### PR TITLE
[feature] Box a marked position with the field of view it stands for (FIB-524)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -72,7 +72,10 @@ from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
     MinimapShapesOverlay,
     ShapeSpec,
 )
-from fibsem.ui.widgets.canvas.overlays.point_overlay import PointsOverlay
+from fibsem.ui.widgets.canvas.overlays.point_overlay import (
+    FieldOfViewOverlay,
+    PointsOverlay,
+)
 from fibsem.ui.widgets.canvas.overlays.tile_grid_options_panel import (
     TileGridOptionsPanel,
 )
@@ -412,7 +415,13 @@ class FMOverviewWidget(QWidget):
         # Crosshairs rather than dots: a marked position is a point on the sample, and
         # a filled dot covers the feature it is naming. The gap in the middle is the
         # whole reason -- you can see what you marked.
-        self.position_overlay = PointsOverlay(
+        #
+        # Boxed with the camera's field of view, set in `_refresh_positions` once the
+        # projection is known, so a marker also says how much sample one frame covers.
+        # The current stage position above stays unboxed: it is where you are rather
+        # than something you are sizing up, and boxing it would double every lamella's
+        # box the moment you drove to one.
+        self.position_overlay = FieldOfViewOverlay(
             color=SAVED_POSITION_COLOUR, marker="+", size=11
         )
         self.canvas.canvas.add_overlay(self.position_overlay)
@@ -421,7 +430,7 @@ class FMOverviewWidget(QWidget):
         # one above: `PointsOverlay` paints every point the same, and one selected
         # marker is not worth teaching it per-point colours for. Added last, so it
         # draws over its unselected neighbours where markers crowd together.
-        self.selected_position_overlay = PointsOverlay(
+        self.selected_position_overlay = FieldOfViewOverlay(
             color=SELECTED_POSITION_COLOUR, marker="+", size=15
         )
         self.canvas.canvas.add_overlay(self.selected_position_overlay)
@@ -1625,8 +1634,29 @@ class FMOverviewWidget(QWidget):
         """
         return self.canvas.canvas.metres_to_canvas(*self._grid_offset())
 
+    def _sync_position_fov(self) -> None:
+        """Size the marked positions' boxes to one camera frame.
+
+        Off the kept projection rather than the camera: this runs on every position
+        refresh, and reading `camera.resolution` / `camera.pixel_size` is two
+        `active_channel()` scopes on the shared connection -- see :meth:`_projection`.
+        Neither changes except with binning, which a refresh does not do.
+
+        Leaves the boxes as they are when the camera geometry cannot be had, which
+        before the first read means no box at all: a crosshair with no frame around it
+        is honest, a frame at a guessed size is not.
+        """
+        projection = self._projection()
+        if projection is None:
+            return
+        height, width = projection.shape
+        pixel_size = projection.pixel_size
+        for overlay in (self.position_overlay, self.selected_position_overlay):
+            overlay.set_extent(width * pixel_size, height * pixel_size)
+
     def _refresh_positions(self) -> None:
         """Mark the stage positions in the canvas frame."""
+        self._sync_position_fov()
         frame = self._frame()
         if not self._positions or frame is None:
             self.position_overlay.set_points([])
@@ -1860,8 +1890,16 @@ class FMOverviewWidget(QWidget):
     def _position_at(self, x: float, y: float) -> Optional[str]:
         """The marked position under a canvas point, or None.
 
-        Measured on screen, not in data units: at a wide zoom every marker would be
-        within any sensible micron radius of the click, and at a tight one none would be.
+        A click hits a position if it lands inside that position's field-of-view box
+        **or** within `PICK_RADIUS_PX` of its crosshair. The union rather than either
+        alone, because neither is reliably the bigger target: the box wins once you are
+        zoomed into a region, the fixed radius wins at whole-grid zoom where the box
+        shrinks below it -- see `FieldOfViewOverlay.covers`.
+
+        The radius is measured on screen, not in data units: at a wide zoom every marker
+        would be within any sensible micron radius of the click, and at a tight one none
+        would be. Nearest crosshair wins among the hits, which also settles overlapping
+        boxes -- and lamellae closer together than one camera frame do overlap.
         """
         frame = self._frame()
         ax = getattr(self.canvas.canvas, "_ax", None)
@@ -1874,18 +1912,25 @@ class FMOverviewWidget(QWidget):
             logging.debug(f"Could not resolve the click for picking: {e}")
             return None
 
-        best_name, best_distance = None, float(self.PICK_RADIUS_PX)
+        best_name, best_distance = None, float("inf")
         for position in self._positions:
             name = position.name
             if not name:
                 continue
             try:
-                point = transform.transform(frame.to_canvas(position))
+                centre = frame.to_canvas(position)
+                point = transform.transform(centre)
             except Exception:
                 continue
             distance = (
                 (click[0] - point[0]) ** 2 + (click[1] - point[1]) ** 2
             ) ** 0.5
+            # `centre` is in canvas units and `point` in screen pixels: the box is a
+            # fixed piece of sample, the radius a fixed piece of screen.
+            if distance >= self.PICK_RADIUS_PX and not self.position_overlay.covers(
+                centre, x, y
+            ):
+                continue
             if distance < best_distance:
                 best_name, best_distance = name, distance
         return best_name

--- a/fibsem/ui/widgets/canvas/overlays/__init__.py
+++ b/fibsem/ui/widgets/canvas/overlays/__init__.py
@@ -17,13 +17,18 @@ from fibsem.ui.widgets.canvas.overlays.pattern_overlay import (
     PatternOverlay,
     ScanDirectionArrowOverlay,
 )
-from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay, PointsOverlay
+from fibsem.ui.widgets.canvas.overlays.point_overlay import (
+    FieldOfViewOverlay,
+    PointOverlay,
+    PointsOverlay,
+)
 from fibsem.ui.widgets.canvas.overlays.rect_overlay import RectOverlay
 from fibsem.ui.widgets.canvas.overlays.ruler_overlay import RulerOverlay
 
 __all__ = [
     "CanvasOverlay",
     "PointsOverlay",
+    "FieldOfViewOverlay",
     "PointOverlay",
     "RectOverlay",
     "RulerOverlay",

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -1,6 +1,7 @@
 """Static + interactive scatter-point overlays for FibsemImageCanvas.
 
 ``PointsOverlay`` — non-interactive scatter markers with optional labels.
+``FieldOfViewOverlay`` — the same, plus the field of view each point covers.
 ``PointOverlay`` — interactive points (select / drag / delete / add).
 """
 
@@ -103,36 +104,211 @@ class PointsOverlay(CanvasOverlay):
     def _draw(self):
         if self._ax is None:
             return
-        edge_color, edge_width = self._marker_edge()
-        for i, (x, y) in enumerate(self._points, 1):
-            (line,) = self._ax.plot(
-                x,
-                y,
-                marker=self._marker,
-                markersize=self._size,
-                color=self._color,
-                markeredgecolor=edge_color,
-                markeredgewidth=edge_width,
-                linestyle="none",
-                zorder=8,
-            )
-            self._artists.append(line)
-            label = None
-            if self._labels is not None and i <= len(self._labels):
-                label = self._labels[i - 1]
-            elif self._label_prefix:
-                label = f"{self._label_prefix}{i}"
+        for index, (x, y) in enumerate(self._points):
+            self._draw_marker(x, y)
+            label = self._label_for(index)
             if label:
-                ann = self._ax.annotate(
-                    label,
-                    xy=(x, y),
-                    xytext=(6, 4),
-                    textcoords="offset points",
-                    color=self._color,
-                    fontsize=8,
-                    zorder=9,
-                )
-                self._artists.append(ann)
+                self._draw_label(label, x, y)
+
+    def _label_for(self, index: int) -> Optional[str]:
+        """The text for the point at *index* (0-based), or None for none.
+
+        `labels` takes precedence over `label_prefix` -- see :meth:`set_points`. An
+        empty string is a label that draws nothing, which is how a caller marks a
+        point it wants unnamed without giving up labels for the rest.
+        """
+        if self._labels is not None and index < len(self._labels):
+            return self._labels[index]
+        if self._label_prefix:
+            return f"{self._label_prefix}{index + 1}"
+        return None
+
+    def _draw_marker(self, x: float, y: float) -> None:
+        """Draw the glyph for one point.
+
+        Split out of :meth:`_draw` so a subclass can add to what a point is drawn as
+        without restating the loop or the label rules -- see
+        :class:`FieldOfViewOverlay`.
+        """
+        edge_color, edge_width = self._marker_edge()
+        (line,) = self._ax.plot(
+            x,
+            y,
+            marker=self._marker,
+            markersize=self._size,
+            color=self._color,
+            markeredgecolor=edge_color,
+            markeredgewidth=edge_width,
+            linestyle="none",
+            zorder=8,
+        )
+        self._artists.append(line)
+
+    def _draw_label(self, label: str, x: float, y: float) -> None:
+        """Name the point at *x*, *y* -- beside the glyph, offset clear of it."""
+        ann = self._ax.annotate(
+            label,
+            xy=(x, y),
+            xytext=(6, 4),
+            textcoords="offset points",
+            color=self._color,
+            fontsize=8,
+            zorder=9,
+        )
+        self._artists.append(ann)
+
+
+# How the field-of-view box is drawn. Deliberately light: the box is context for the
+# marker, not the subject. At full weight its edge competes with the magenta lattice
+# behind it -- gridbars on the beam tab, the planned tile grid on either -- and the box
+# reads as part of that grid rather than as one position.
+FOV_BOX_LINEWIDTH = 0.6
+FOV_LABEL_FONTSIZE = 6.5
+
+
+class FieldOfViewOverlay(PointsOverlay):
+    """Points drawn with the field of view each one stands for.
+
+    A crosshair says where a position is. It does not say how much of the sample an
+    image taken there would cover, which on an overview spanning millimetres is the
+    thing actually being judged -- whether two lamellae would land in one frame,
+    whether a marker sits far enough inside a grid square to mill.
+
+    The extent is held in **metres** and converted at draw time rather than stored in
+    canvas units. The canvas scale is not fixed: it arrives with the first image, and
+    the fluorescence tab sets it from the camera before then -- so a box stored in
+    canvas units would silently come to mean a different number of microns. The
+    conversion is `metres_to_canvas`, a straight division by the reference pixel size:
+    the box is a frame in the plane being *displayed*, not a shape lying on the tilted
+    sample, so the surface foreshortening correction must not be applied to it -- doing
+    that to something in this frame is what made an overlay 3.9x too tall (FIB-615).
+
+    With no extent, or before the canvas has a scale, this draws exactly what
+    :class:`PointsOverlay` draws: the crosshair and a label beside it.
+    """
+
+    def __init__(self, *args, extent: Optional[Tuple[float, float]] = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._extent = self._as_extent(extent)
+
+    @staticmethod
+    def _as_extent(extent) -> Optional[Tuple[float, float]]:
+        """*extent* as a positive (width, height) in metres, or None for no box."""
+        if not extent:
+            return None
+        width, height = extent
+        if not width or not height or width <= 0 or height <= 0:
+            return None
+        return (float(width), float(height))
+
+    def set_extent(self, width: Optional[float], height: Optional[float]) -> None:
+        """Set the field of view every point covers, in metres.
+
+        A no-op when it is the size already held. Hosts call this from the same
+        refresh that redraws the markers, which on the fluorescence tab runs on
+        settings changes and stage moves; repainting a canvas to tell it what it
+        already knows is the cost that made the grid drag stutter (FIB-752).
+        """
+        extent = self._as_extent((width, height))
+        if extent == self._extent:
+            return
+        self._extent = extent
+        self._remove_artists()
+        self._draw()
+        if self._canvas is not None:
+            self._canvas.draw_idle()
+
+    def half_extent_canvas(self) -> Optional[Tuple[float, float]]:
+        """Half the box's width and height in canvas units, or None for no box.
+
+        Public because picking needs it. A click inside the box selects the position
+        it belongs to, and the box you can hit has to be the box you can see -- so both
+        come from here rather than from two callers doing the same division.
+        """
+        if self._extent is None or self._canvas is None:
+            return None
+        to_canvas = getattr(self._canvas, "metres_to_canvas", None)
+        if to_canvas is None:  # not a real-space canvas; nothing to scale against
+            return None
+        width, height = to_canvas(*self._extent)
+        # (0, 0) is what `metres_to_canvas` answers before the canvas has a scale.
+        if width <= 0 or height <= 0:
+            return None
+        return width / 2, height / 2
+
+    def covers(self, point: Tuple[float, float], x: float, y: float) -> bool:
+        """Whether the box drawn around *point* contains the canvas point (x, y).
+
+        For picking: clicking anywhere inside a position's field of view should select
+        it. The box tested here is the box drawn -- both come from
+        :meth:`half_extent_canvas` -- so what you can hit cannot drift from what you
+        can see.
+
+        False when there is no box, which leaves a caller's own hit radius as the only
+        target. That is why picking should treat this as a *union* with the radius
+        rather than a replacement for it: the box is not always the bigger target. A
+        100 um box is under 24 px tall past ~2.8 um per screen pixel, which on a
+        ~1000 px canvas is a field of about 2.8 mm -- roughly a whole grid, i.e. the
+        view with the most markers in it. Picking by box alone would make them harder
+        to hit exactly there.
+        """
+        half = self.half_extent_canvas()
+        if half is None:
+            return False
+        half_w, half_h = half
+        return abs(x - point[0]) <= half_w and abs(y - point[1]) <= half_h
+
+    def _draw_marker(self, x: float, y: float) -> None:
+        """The crosshair, and the frame an image taken there would cover."""
+        super()._draw_marker(x, y)
+        half = self.half_extent_canvas()
+        if half is None:
+            return
+        from matplotlib.patches import Rectangle
+
+        half_w, half_h = half
+        box = Rectangle(
+            (x - half_w, y - half_h),
+            2 * half_w,
+            2 * half_h,
+            fill=False,
+            edgecolor=self._color,
+            linewidth=FOV_BOX_LINEWIDTH,
+            # Under the marker so the crosshair stays legible where a neighbouring
+            # box crosses it, and over the stage context (zorder 4) beneath.
+            zorder=7,
+        )
+        self._ax.add_patch(box)
+        self._artists.append(box)
+
+    def _draw_label(self, label: str, x: float, y: float) -> None:
+        """Name the position above the top-left corner of its box.
+
+        Beside the crosshair -- where :class:`PointsOverlay` puts it -- lands the text
+        inside the box, over the sample the box exists to show. Above and outside keeps
+        both readable, and lines the names up along the top edges where several boxes
+        sit at similar heights.
+
+        The y axis is inverted (image convention, origin upper), so the top edge is at
+        the *smaller* y.
+        """
+        half = self.half_extent_canvas()
+        if half is None:
+            super()._draw_label(label, x, y)
+            return
+        half_w, half_h = half
+        ann = self._ax.annotate(
+            label,
+            xy=(x - half_w, y - half_h),
+            xytext=(0, 2),
+            textcoords="offset points",
+            color=self._color,
+            fontsize=FOV_LABEL_FONTSIZE,
+            ha="left",
+            va="bottom",
+            zorder=9,
+        )
+        self._artists.append(ann)
 
 
 _PICK_RADIUS_PX = 12  # screen-space hit radius for point picking

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -60,6 +60,7 @@ from PyQt5.QtWidgets import (
 from superqt import ensure_main_thread
 
 from fibsem import constants
+from fibsem.config import DEFAULT_STANDARD_RESOLUTION_LIST
 from fibsem.fm.composite import auto_clim
 from fibsem.imaging import tiled
 from fibsem.imaging.reduce import downsample, downsample_mask
@@ -105,7 +106,10 @@ from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
     MinimapShapesOverlay,
     ShapeSpec,
 )
-from fibsem.ui.widgets.canvas.overlays.point_overlay import PointsOverlay
+from fibsem.ui.widgets.canvas.overlays.point_overlay import (
+    FieldOfViewOverlay,
+    PointsOverlay,
+)
 from fibsem.ui.widgets.canvas.overlays.tile_grid_options_panel import (
     TileGridOptionsPanel,
 )
@@ -202,6 +206,16 @@ DEFAULT_GRIDBAR_WIDTH_UM = 20.0
 # Screen-space hit radius for picking a marker, matching the FM overview's. In pixels
 # rather than stage microns so how close you have to click does not change with zoom.
 PICK_RADIUS_PX = 12
+
+# The field of view drawn around each marked position, in metres. A fixed size rather
+# than the current imaging settings: the box says how much sample a lamella occupies,
+# which does not change when somebody adjusts the HFW for the next overview -- and a box
+# that resized itself under a settings change would look like the positions had moved.
+# 100 um at the standard resolution's aspect, so it is the frame a normal image is.
+POSITION_FOV_WIDTH = 100e-6
+POSITION_FOV_HEIGHT = POSITION_FOV_WIDTH * (
+    DEFAULT_STANDARD_RESOLUTION_LIST[1] / DEFAULT_STANDARD_RESOLUTION_LIST[0]
+)
 
 
 # How many pixels the contrast limits are taken from. `auto_clim`'s own cap, and for
@@ -632,9 +646,19 @@ class FibsemOverviewWidget(QWidget):
         self.canvas.add_overlay(self.current_position_overlay)
 
         # Crosshairs rather than dots: a marked position is a point on the sample, and a
-        # filled dot covers the feature it is naming.
-        self.position_overlay = PointsOverlay(
-            color=SAVED_POSITION_COLOUR, marker="+", size=11
+        # filled dot covers the feature it is naming. Boxed with the field of view an
+        # image taken there would cover, so the marker carries a sense of scale -- on a
+        # canvas spanning millimetres a bare crosshair gives none, and "would these two
+        # lamellae land in one frame" is a question you cannot answer by eye without it.
+        #
+        # The current stage position above is deliberately left unboxed: it is where you
+        # are rather than something you are sizing up, and boxing it would double every
+        # lamella's box the moment you drove to one.
+        self.position_overlay = FieldOfViewOverlay(
+            color=SAVED_POSITION_COLOUR,
+            marker="+",
+            size=11,
+            extent=(POSITION_FOV_WIDTH, POSITION_FOV_HEIGHT),
         )
         self.canvas.add_overlay(self.position_overlay)
         # Flagged positions, on their own layer for the same reason the selection has
@@ -642,15 +666,21 @@ class FibsemOverviewWidget(QWidget):
         # layer here rather than collapsing it into the others -- a lamella marked
         # defective is one you should not be re-targeting, and the tab this replaces
         # said so in colour.
-        self.flagged_position_overlay = PointsOverlay(
-            color=SEMANTIC_WARNING_COLOR, marker="+", size=11
+        self.flagged_position_overlay = FieldOfViewOverlay(
+            color=SEMANTIC_WARNING_COLOR,
+            marker="+",
+            size=11,
+            extent=(POSITION_FOV_WIDTH, POSITION_FOV_HEIGHT),
         )
         self.canvas.add_overlay(self.flagged_position_overlay)
         # The selected position on its own layer rather than as a colour within the one
         # above: `PointsOverlay` paints every point the same. Added last, so it draws
         # over its unselected neighbours where markers crowd together.
-        self.selected_position_overlay = PointsOverlay(
-            color=SELECTED_POSITION_COLOUR, marker="+", size=15
+        self.selected_position_overlay = FieldOfViewOverlay(
+            color=SELECTED_POSITION_COLOUR,
+            marker="+",
+            size=15,
+            extent=(POSITION_FOV_WIDTH, POSITION_FOV_HEIGHT),
         )
         self.canvas.add_overlay(self.selected_position_overlay)
 
@@ -2414,8 +2444,16 @@ class FibsemOverviewWidget(QWidget):
     def _position_at(self, x: float, y: float) -> Optional[str]:
         """The marked position under a canvas point, or None.
 
-        Measured on screen, not in data units: at a wide zoom every marker would be
-        within any sensible micron radius of the click, and at a tight one none would be.
+        A click hits a position if it lands inside that position's field-of-view box
+        **or** within `PICK_RADIUS_PX` of its crosshair. The union rather than either
+        alone, because neither is reliably the bigger target: the box wins once you are
+        zoomed into a region, the fixed radius wins at whole-grid zoom where the box
+        shrinks below it -- see `FieldOfViewOverlay.covers`.
+
+        The radius is measured on screen, not in data units: at a wide zoom every marker
+        would be within any sensible micron radius of the click, and at a tight one none
+        would be. Nearest crosshair wins among the hits, which also settles overlapping
+        boxes -- and lamellae closer together than the field of view do overlap.
         """
         if not self.overlay_controls.is_visible(_OVERLAY_POSITIONS):
             # Turned off means gone, not merely invisible. `_refresh_position_markers`
@@ -2437,15 +2475,22 @@ class FibsemOverviewWidget(QWidget):
             logger.debug(f"Could not resolve the click for picking: {e}")
             return None
 
-        best_name, best_distance = None, float(PICK_RADIUS_PX)
+        best_name, best_distance = None, float("inf")
         for position in self._positions:
             if not position.name:
                 continue
             try:
-                point = transform.transform(frame.to_canvas(position))
+                centre = frame.to_canvas(position)
+                point = transform.transform(centre)
             except Exception:
                 continue
             distance = ((click[0] - point[0]) ** 2 + (click[1] - point[1]) ** 2) ** 0.5
+            # `centre` is in canvas units and `point` in screen pixels: the box is a
+            # fixed piece of sample, the radius a fixed piece of screen.
+            if distance >= PICK_RADIUS_PX and not self.position_overlay.covers(
+                centre, x, y
+            ):
+                continue
             if distance < best_distance:
                 best_name, best_distance = position.name, distance
         return best_name

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -3979,6 +3979,12 @@ def test_the_pick_radius_is_screen_space(qapp, interactive_widget):
     before = (ax.get_xlim(), ax.get_ylim())
     # 80 um away from the marker, in stage terms
     near = frame.to_canvas(_named("probe", 200e-6, 90e-6))
+    # ...and outside its field-of-view box, or the box would pick it at every zoom and
+    # this would be testing nothing. 80 um clears a 102 um camera frame by 29 um; a
+    # coarser binning would not, and this says so rather than failing further down.
+    assert not widget.position_overlay.covers(
+        frame.to_canvas(_named("Lamella-01", 120e-6, 90e-6)), *near
+    ), "the probe is inside the box, so the radius is not what is being measured"
 
     ax.set_xlim(-50000, 50000)
     ax.set_ylim(-50000, 50000)

--- a/tests/ui/test_position_field_of_view.py
+++ b/tests/ui/test_position_field_of_view.py
@@ -1,0 +1,540 @@
+"""A marked position is drawn with the field of view it stands for, and picked by it.
+
+A crosshair says where a lamella is. On a canvas spanning millimetres it says nothing
+about how much sample one image covers there, which is what you are actually judging --
+whether two markers would land in one frame, whether one sits far enough inside a grid
+square. `FieldOfViewOverlay` draws that box, and a click inside it selects the position
+it belongs to.
+
+The picking is a **union** with the existing screen-space radius rather than a
+replacement for it, and that is the part worth pinning: the box is not always the bigger
+target. A 100 um box is under 24 px tall past ~2.8 um per screen pixel -- on a ~1000 px
+canvas, a field of about 2.8 mm, which is roughly a whole grid and therefore the view
+with the most markers in it. Two tests below hold each half of the union, because either
+one alone passes with the other half deleted.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_position_field_of_view.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+import pytest
+
+# CI installs `.[test]`, not `.[ui]`, so PyQt5 is absent there.
+pytest.importorskip("PyQt5")
+
+from matplotlib.patches import Rectangle  # noqa: E402
+from matplotlib.text import Annotation  # noqa: E402
+from PyQt5.QtWidgets import QApplication  # noqa: E402
+
+from fibsem import utils  # noqa: E402
+from fibsem.structures import (  # noqa: E402
+    BeamType,
+    FibsemImage,
+    FibsemStagePosition,
+    ImageSettings,
+)
+from fibsem.ui.widgets.canvas.overlays.point_overlay import (  # noqa: E402
+    FOV_BOX_LINEWIDTH,
+    FOV_LABEL_FONTSIZE,
+    FieldOfViewOverlay,
+)
+from fibsem.ui.widgets.canvas.real_space_canvas import (  # noqa: E402
+    FibsemRealSpaceCanvas,
+)
+from fibsem.ui.widgets.overview_widget import (  # noqa: E402
+    PICK_RADIUS_PX,
+    POSITION_FOV_HEIGHT,
+    POSITION_FOV_WIDTH,
+    FibsemOverviewWidget,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+PIXEL_SIZE = 1e-6  # 1 um per canvas unit, so metres and canvas units read off directly
+
+
+def _boxes(overlay):
+    return [a for a in overlay._artists if isinstance(a, Rectangle)]
+
+
+def _labels(overlay):
+    return [a for a in overlay._artists if isinstance(a, Annotation)]
+
+
+def _canvas(pixel_size: float = PIXEL_SIZE) -> FibsemRealSpaceCanvas:
+    canvas = FibsemRealSpaceCanvas()
+    canvas.set_reference_pixel_size(pixel_size)
+    return canvas
+
+
+# ── the overlay ──────────────────────────────────────────────────────────────
+
+
+class TestTheBoxIsTheFieldOfView:
+    def test_the_box_is_the_extent_it_was_given(self):
+        overlay = FieldOfViewOverlay(color="#ffffff", marker="+", extent=(100e-6, 60e-6))
+        canvas = _canvas()
+        canvas.add_overlay(overlay)
+
+        overlay.set_points([(0.0, 0.0)])
+
+        (box,) = _boxes(overlay)
+        assert box.get_width() == pytest.approx(100e-6 / PIXEL_SIZE)
+        assert box.get_height() == pytest.approx(60e-6 / PIXEL_SIZE)
+        assert box.get_xy() == pytest.approx((-50.0, -30.0)), "not centred on the point"
+
+    def test_the_extent_is_metres_not_canvas_units(self):
+        """Halving the canvas scale must double the box, not leave it the same size.
+
+        The scale is not fixed -- it arrives with the first image, and the fluorescence
+        tab sets it from the camera before then -- so an extent stored in canvas units
+        would quietly come to mean a different number of microns.
+        """
+        sizes = []
+        for pixel_size in (1e-6, 0.5e-6):
+            overlay = FieldOfViewOverlay(extent=(100e-6, 60e-6))
+            canvas = _canvas(pixel_size)
+            canvas.add_overlay(overlay)
+            overlay.set_points([(0.0, 0.0)])
+            sizes.append(_boxes(overlay)[0].get_width())
+
+        assert sizes[1] == pytest.approx(sizes[0] * 2)
+
+    def test_one_box_per_point(self):
+        overlay = FieldOfViewOverlay(extent=(100e-6, 60e-6))
+        _canvas().add_overlay(overlay)
+
+        overlay.set_points([(0.0, 0.0), (200.0, 0.0), (0.0, 200.0)])
+
+        assert len(_boxes(overlay)) == 3
+
+    def test_it_is_drawn_lightly(self):
+        """The box is context for the marker, not the subject. At full weight its edge
+        competes with the tile grid behind it and reads as part of that lattice."""
+        overlay = FieldOfViewOverlay(color="#26c6da", extent=(100e-6, 60e-6))
+        _canvas().add_overlay(overlay)
+
+        overlay.set_points([(0.0, 0.0)], labels=["Lamella-01"])
+
+        (box,) = _boxes(overlay)
+        assert box.get_linewidth() == FOV_BOX_LINEWIDTH
+        assert box.get_edgecolor()[:3] == pytest.approx((0x26 / 255, 0xC6 / 255, 0xDA / 255), abs=0.01)
+        assert box.get_fill() is False, "a filled box would hide the sample it frames"
+        assert _labels(overlay)[0].get_fontsize() == FOV_LABEL_FONTSIZE
+
+    def test_the_box_sits_under_the_marker(self):
+        """Where a neighbouring box crosses a crosshair, the crosshair stays legible."""
+        overlay = FieldOfViewOverlay(marker="+", extent=(100e-6, 60e-6))
+        _canvas().add_overlay(overlay)
+
+        overlay.set_points([(0.0, 0.0)])
+
+        from matplotlib.lines import Line2D
+
+        marker = next(a for a in overlay._artists if isinstance(a, Line2D))
+        assert _boxes(overlay)[0].get_zorder() < marker.get_zorder()
+
+
+class TestTheLabelIsAboveTheBox:
+    def test_the_label_sits_above_the_top_left_corner(self):
+        """Beside the crosshair -- where `PointsOverlay` puts it -- lands the text
+        inside the box, over the sample the box exists to show.
+
+        The y axis is inverted (origin upper), so the top edge is the *smaller* y.
+        """
+        overlay = FieldOfViewOverlay(extent=(100e-6, 60e-6))
+        _canvas().add_overlay(overlay)
+
+        overlay.set_points([(0.0, 0.0)], labels=["Lamella-01"])
+
+        (label,) = _labels(overlay)
+        assert label.xy == pytest.approx((-50.0, -30.0)), "not the top-left corner"
+        assert label.get_ha() == "left"
+        assert label.get_va() == "bottom", "would put the text inside the box"
+
+    def test_an_empty_label_still_draws_nothing(self):
+        """How a caller marks one point unnamed without giving up labels for the rest."""
+        overlay = FieldOfViewOverlay(extent=(100e-6, 60e-6))
+        _canvas().add_overlay(overlay)
+
+        overlay.set_points([(0.0, 0.0)], labels=[""])
+
+        assert _labels(overlay) == []
+
+
+class TestWithoutABoxItIsTheOverlayItSubclasses:
+    """No extent, or no canvas scale, must degrade to a plain crosshair -- not to a
+    box of some guessed size, and not to nothing."""
+
+    def test_no_extent_draws_no_box(self):
+        overlay = FieldOfViewOverlay(marker="+")
+        _canvas().add_overlay(overlay)
+
+        overlay.set_points([(0.0, 0.0)], labels=["Lamella-01"])
+
+        assert _boxes(overlay) == []
+        assert len(_labels(overlay)) == 1
+
+    def test_no_canvas_scale_draws_no_box(self):
+        """`metres_to_canvas` answers (0, 0) before the canvas has a reference pixel
+        size, which is a real state on the fluorescence tab: the camera geometry has to
+        be read before the box can be sized, and that read can fail."""
+        overlay = FieldOfViewOverlay(marker="+", extent=(100e-6, 60e-6))
+        canvas = FibsemRealSpaceCanvas()  # deliberately no reference pixel size
+        canvas.add_overlay(overlay)
+
+        overlay.set_points([(0.0, 0.0)], labels=["Lamella-01"])
+
+        assert overlay.half_extent_canvas() is None
+        assert _boxes(overlay) == []
+
+    def test_the_label_falls_back_beside_the_marker(self):
+        """With no box there is no corner to hang the name off."""
+        overlay = FieldOfViewOverlay(marker="+")
+        _canvas().add_overlay(overlay)
+
+        overlay.set_points([(3.0, 4.0)], labels=["Lamella-01"])
+
+        (label,) = _labels(overlay)
+        assert label.xy == pytest.approx((3.0, 4.0))
+
+
+class TestSettingTheSameExtentIsNotAnEvent:
+    """Hosts call `set_extent` from the same refresh that redraws the markers.
+
+    Repainting a canvas to tell it what it already knows is the cost that made the grid
+    drag stutter (FIB-752), and here it would also throw away the artists picking is
+    measured against.
+    """
+
+    def test_the_same_extent_does_not_rebuild_the_artists(self):
+        overlay = FieldOfViewOverlay(extent=(100e-6, 60e-6))
+        _canvas().add_overlay(overlay)
+        overlay.set_points([(0.0, 0.0)])
+        before = list(overlay._artists)
+
+        overlay.set_extent(100e-6, 60e-6)
+
+        assert overlay._artists == before, "redrew for a size it already had"
+
+    def test_a_different_extent_does(self):
+        overlay = FieldOfViewOverlay(extent=(100e-6, 60e-6))
+        _canvas().add_overlay(overlay)
+        overlay.set_points([(0.0, 0.0)])
+
+        overlay.set_extent(200e-6, 120e-6)
+
+        assert _boxes(overlay)[0].get_width() == pytest.approx(200.0)
+
+
+class TestCoversIsTheBoxThatIsDrawn:
+    def test_a_point_inside_the_box_is_covered(self):
+        overlay = FieldOfViewOverlay(extent=(100e-6, 60e-6))
+        _canvas().add_overlay(overlay)
+
+        assert overlay.covers((0.0, 0.0), 49.0, 29.0)
+        assert overlay.covers((0.0, 0.0), -49.0, -29.0)
+
+    def test_a_point_outside_it_is_not(self):
+        overlay = FieldOfViewOverlay(extent=(100e-6, 60e-6))
+        _canvas().add_overlay(overlay)
+
+        assert not overlay.covers((0.0, 0.0), 51.0, 0.0)
+        assert not overlay.covers((0.0, 0.0), 0.0, 31.0), "tested the width for both axes"
+
+    def test_it_is_measured_from_the_point_it_is_given(self):
+        overlay = FieldOfViewOverlay(extent=(100e-6, 60e-6))
+        _canvas().add_overlay(overlay)
+
+        assert overlay.covers((500.0, 500.0), 540.0, 520.0)
+        assert not overlay.covers((500.0, 500.0), 40.0, 20.0)
+
+    def test_no_box_covers_nothing(self):
+        """So a caller's own hit radius stays the only target rather than the whole
+        canvas becoming one."""
+        overlay = FieldOfViewOverlay()
+        _canvas().add_overlay(overlay)
+
+        assert not overlay.covers((0.0, 0.0), 0.0, 0.0)
+
+
+# ── the beam tab ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    """The same simulated Arctis `test_overview_widget.py` uses."""
+    import fibsem.config as fibsem_config
+
+    path = os.path.join(
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "sim-arctis-configuration.yaml",
+    )
+    scope, _ = utils.setup_session(manufacturer="Demo", config_path=path)
+    return scope
+
+
+@pytest.fixture
+def widget(microscope):
+    w = FibsemOverviewWidget(microscope)
+    w.resize(900, 700)
+    yield w
+    w.close()
+
+
+def _at(base, dx=0.0, dy=0.0, name=None):
+    p = FibsemStagePosition(x=base.x + dx, y=base.y + dy, z=base.z, r=base.r, t=base.t)
+    p.name = name
+    return p
+
+
+def _tile(microscope, position, shape=(64, 64), hfw=100e-6):
+    image = FibsemImage.generate_blank_image(resolution=(shape[1], shape[0]), hfw=hfw)
+    image.data = (np.random.default_rng(0).random(shape) * 255).astype(np.uint8)
+    state = microscope.get_microscope_state(beam_type=BeamType.ELECTRON)
+    state.stage_position = position
+    image.metadata.image_settings = ImageSettings(hfw=hfw, beam_type=BeamType.ELECTRON)
+    image.metadata.microscope_state = state
+    image.metadata.system_info = microscope.system.info
+    image.metadata.hardware_geometry = microscope.hardware_geometry()
+    return image
+
+
+def _loaded(widget, microscope, *marks):
+    base = microscope.get_stage_position()
+    widget.place_image(_tile(microscope, _at(base)))
+    widget.set_positions([_at(base, dx, dy, name) for name, dx, dy in marks])
+    return base
+
+
+def _screen_distance(widget, a, b):
+    """Distance in screen pixels between two canvas points."""
+    transform = widget.canvas._ax.transData
+    pa, pb = transform.transform(a), transform.transform(b)
+    return ((pa[0] - pb[0]) ** 2 + (pa[1] - pb[1]) ** 2) ** 0.5
+
+
+def _frame_canvas_units(widget, span):
+    """Frame *span* canvas units across, and settle."""
+    ax = widget.canvas._ax
+    ax.set_xlim(-span / 2, span / 2)
+    ax.set_ylim(span / 2, -span / 2)  # inverted, origin upper
+    _app.processEvents()
+
+
+class TestTheBeamTabBoxesItsPositions:
+    def test_the_box_is_a_hundred_microns_at_the_standard_aspect(self, widget, microscope):
+        """Fixed rather than the current imaging settings: the box says how much sample
+        a lamella occupies, and one that resized itself when somebody changed the HFW
+        would look like the positions had moved."""
+        _loaded(widget, microscope, ("Lamella-01", 0.0, 0.0))
+
+        (box,) = _boxes(widget.position_overlay)
+        reference = widget.canvas.reference_pixel_size
+        assert box.get_width() * reference == pytest.approx(100e-6)
+        assert box.get_height() * reference == pytest.approx(100e-6 * 1024 / 1536)
+
+    def test_flagged_and_selected_positions_are_boxed_too(self, widget, microscope):
+        """Three overlays only because `PointsOverlay` paints every point the same
+        colour -- they are the same kind of thing and must be drawn as one."""
+        base = _loaded(
+            widget, microscope, ("Lamella-01", 0.0, 0.0), ("Lamella-02", 400e-6, 0.0)
+        )
+        widget.set_positions(
+            [_at(base, 0.0, 0.0, "Lamella-01"), _at(base, 400e-6, 0.0, "Lamella-02")],
+            flagged=["Lamella-02"],
+        )
+        widget.set_selected_position("Lamella-01")
+        _app.processEvents()
+
+        assert len(_boxes(widget.flagged_position_overlay)) == 1
+        assert len(_boxes(widget.selected_position_overlay)) == 1
+
+    def test_the_current_stage_position_is_not_boxed(self, widget, microscope):
+        """Where you *are*, not something you are sizing up -- and boxing it would
+        double every lamella's box the moment you drove to one."""
+        _loaded(widget, microscope, ("Lamella-01", 0.0, 0.0))
+
+        assert not isinstance(widget.current_position_overlay, FieldOfViewOverlay)
+        assert _boxes(widget.current_position_overlay) == []
+
+
+class TestPickingIsTheUnionOfBoxAndRadius:
+    """Each half is tested against a click the *other* half cannot explain."""
+
+    def test_a_click_inside_the_box_selects_it(self, widget, microscope):
+        base = _loaded(widget, microscope, ("Lamella-01", 0.0, 0.0))
+        _frame_canvas_units(widget, 400)  # zoomed in: the box is far bigger than 12 px
+        frame = widget._frame()
+        centre = frame.to_canvas(_at(base))
+        probe = frame.to_canvas(_at(base, 40e-6, 0.0))  # inside the 100 um box
+
+        assert widget.position_overlay.covers(centre, *probe), "probe missed the box"
+        assert _screen_distance(widget, centre, probe) > PICK_RADIUS_PX, (
+            "the radius alone would explain this hit"
+        )
+        assert widget._position_at(*probe) == "Lamella-01"
+
+    def test_the_same_click_misses_once_the_box_is_taken_away(self, widget, microscope):
+        """The other half of the test above: it must be the box doing the work."""
+        base = _loaded(widget, microscope, ("Lamella-01", 0.0, 0.0))
+        _frame_canvas_units(widget, 400)
+        frame = widget._frame()
+        probe = frame.to_canvas(_at(base, 40e-6, 0.0))
+        assert widget._position_at(*probe) == "Lamella-01"
+
+        for overlay in (
+            widget.position_overlay,
+            widget.flagged_position_overlay,
+            widget.selected_position_overlay,
+        ):
+            overlay.set_extent(None, None)
+
+        assert widget._position_at(*probe) is None
+
+    def test_the_radius_still_picks_where_the_box_is_smaller_than_it(
+        self, widget, microscope
+    ):
+        """The reason this is a union. Zoomed out to a whole grid the 100 um box is a
+        couple of pixels across -- picking by box alone would make markers hardest to
+        hit in the view that has the most of them.
+        """
+        base = _loaded(widget, microscope, ("Lamella-01", 0.0, 0.0))
+        _frame_canvas_units(widget, 100_000)
+        frame = widget._frame()
+        centre = frame.to_canvas(_at(base))
+
+        # A probe 8 screen pixels away, in canvas units at this zoom.
+        transform = widget.canvas._ax.transData
+        per_unit = abs(
+            transform.transform((centre[0] + 1.0, centre[1]))[0]
+            - transform.transform(centre)[0]
+        )
+        probe = (centre[0] + 8.0 / per_unit, centre[1])
+
+        assert not widget.position_overlay.covers(centre, *probe), (
+            "the box is still the bigger target here; zoom out further"
+        )
+        assert _screen_distance(widget, centre, probe) < PICK_RADIUS_PX
+        assert widget._position_at(*probe) == "Lamella-01"
+
+    def test_the_nearest_crosshair_wins_between_overlapping_boxes(
+        self, widget, microscope
+    ):
+        """Lamellae closer together than the field of view overlap, so a click can be
+        inside two boxes. The nearer one is deliberately *first* in the list: keeping a
+        hit without keeping its distance leaves the last match winning, which would
+        agree with the right answer if the nearest happened to come last.
+        """
+        base = _loaded(
+            widget,
+            microscope,
+            ("Lamella-02", 30e-6, 0.0),
+            ("Lamella-01", 0.0, 0.0),
+        )
+        _frame_canvas_units(widget, 400)
+        frame = widget._frame()
+        centre_1 = frame.to_canvas(_at(base))
+        centre_2 = frame.to_canvas(_at(base, 30e-6, 0.0))
+        probe = frame.to_canvas(_at(base, 25e-6, 0.0))
+
+        overlay = widget.position_overlay
+        assert overlay.covers(centre_1, *probe) and overlay.covers(centre_2, *probe), (
+            "the probe is not inside both boxes"
+        )
+        assert widget._position_at(*probe) == "Lamella-02"
+
+    def test_a_click_outside_every_box_and_radius_picks_nothing(self, widget, microscope):
+        base = _loaded(widget, microscope, ("Lamella-01", 0.0, 0.0))
+        frame = widget._frame()
+
+        assert widget._position_at(*frame.to_canvas(_at(base, 900e-6, 900e-6))) is None
+
+    def test_a_hidden_marker_is_not_a_target_through_its_box_either(
+        self, widget, microscope
+    ):
+        """Turned off means gone. The box widens the target, so it would widen this
+        hole too: a click on bare mosaic selecting a lamella nothing on screen names."""
+        base = _loaded(widget, microscope, ("Lamella-01", 0.0, 0.0))
+        _frame_canvas_units(widget, 400)
+        frame = widget._frame()
+        probe = frame.to_canvas(_at(base, 40e-6, 0.0))
+        assert widget._position_at(*probe) == "Lamella-01"
+
+        widget.overlay_controls.set_visible("positions", False)
+
+        assert widget._position_at(*probe) is None
+
+
+# ── the fluorescence tab ─────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def fm_widget(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+    from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+
+    microscope = build_microscope()
+    microscope.fm.objective.insert()
+    w = FMOverviewWidget(microscope)
+    w.resize(1200, 800)
+    w.show()
+    qapp.processEvents()
+    return w
+
+
+def _fm_named(name, x, y):
+    position = FibsemStagePosition(x=x, y=y, z=0.0, r=0.0, t=np.deg2rad(-180.0))
+    position.name = name
+    return position
+
+
+class TestTheFluorescenceTabBoxesItsPositions:
+    def test_the_box_is_one_camera_frame(self, qapp, fm_widget):
+        """Not a constant: on the fluorescence side the field of view *is* the camera,
+        and it moves with binning."""
+        fm_widget.set_positions([_fm_named("Lamella-01", 120e-6, 90e-6)])
+        qapp.processEvents()
+
+        projection = fm_widget._projection()
+        height, width = projection.shape
+        assert fm_widget.position_overlay._extent == pytest.approx(
+            (width * projection.pixel_size, height * projection.pixel_size)
+        )
+
+        fm_widget.set_positions([])
+
+    def test_the_box_is_drawn_and_the_stage_position_is_not_boxed(self, qapp, fm_widget):
+        fm_widget.set_positions([_fm_named("Lamella-01", 120e-6, 90e-6)])
+        qapp.processEvents()
+
+        assert len(_boxes(fm_widget.position_overlay)) == 1
+        assert _boxes(fm_widget.current_position_overlay) == []
+
+        fm_widget.set_positions([])
+
+    def test_a_click_inside_the_box_selects_it(self, qapp, fm_widget):
+        fm_widget.set_positions([_fm_named("Lamella-01", 120e-6, 90e-6)])
+        qapp.processEvents()
+        frame = fm_widget._frame()
+        centre = frame.to_canvas(_fm_named("centre", 120e-6, 90e-6))
+        half_w, _ = fm_widget.position_overlay.half_extent_canvas()
+        probe = (centre[0] + half_w * 0.8, centre[1])
+
+        transform = fm_widget.canvas.canvas._ax.transData
+        pa, pb = transform.transform(centre), transform.transform(probe)
+        distance = ((pa[0] - pb[0]) ** 2 + (pa[1] - pb[1]) ** 2) ** 0.5
+        assert distance > fm_widget.PICK_RADIUS_PX, (
+            "the radius alone would explain this hit"
+        )
+        assert fm_widget._position_at(*probe) == "Lamella-01"
+
+        fm_widget.set_positions([])


### PR DESCRIPTION
A crosshair says where a lamella is. On a canvas spanning millimetres it says nothing about how much sample one image covers there, which is what you are actually judging — whether two markers would land in one frame, whether one sits far enough inside a grid square to mill.

## What it draws

`FieldOfViewOverlay` subclasses `PointsOverlay`. The base's `_draw` is split into `_draw_marker` / `_label_for` / `_draw_label`, so the subclass adds the box and moves the label without restating the loop or the label rules.

- **beam** — a fixed 100 × 66.7 µm, the standard resolution's aspect. Not the current imaging settings: the box says how much sample a lamella occupies, and one that resized itself when somebody changed the HFW for the next overview would look like the positions had moved.
- **fluorescence** — one camera frame, off the *kept* projection rather than the camera, which is two `active_channel()` scopes on the shared connection.
- The name moves from beside the crosshair to above the box's top-left corner. Beside the crosshair puts the text inside the box, over the sample the box exists to show.
- Line 0.6, text 6.5, box under the marker. Deliberately light — at full weight the edge competes with the magenta lattice behind it and reads as part of that grid rather than as one position.
- The **current stage position stays unboxed** on both tabs. It is where you are rather than something you are sizing up, and boxing it would double every lamella's box the moment you drove to one.

The extent is held in **metres** and converted at draw time rather than stored in canvas units. The canvas scale is not fixed — it arrives with the first image, and the fluorescence tab sets it from the camera before then — so a stored canvas-unit box would quietly come to mean a different number of microns. The conversion is `metres_to_canvas`, a straight division by the reference pixel size, with **no surface foreshortening**: the box is a frame in the plane being displayed, not a shape lying on the tilted sample.

With no extent, or before the canvas has a scale, it draws exactly what `PointsOverlay` draws. That is a real state on the fluorescence tab — the camera geometry has to be read before the box can be sized, and that read can fail.

## What it picks

Both tabs picked a marked position by screen-space distance to its crosshair, within 12 px. That is now the **union** of the box and the radius, nearest crosshair winning.

A union rather than either alone, because neither is reliably the bigger target. A 100 µm box is under 24 px tall past ~2.8 µm per screen pixel — on a ~1000 px canvas, a field of about 2.8 mm, which is roughly a whole grid and therefore the view with the most markers in it. Picking by box alone would make them hardest to hit exactly there. Nearest-crosshair also settles overlapping boxes, and lamellae closer together than the field of view do overlap.

Double-click is untouched. It means "drive the stage to this point" and stays literal; snapping it to a box's centre would move the stage somewhere other than where you clicked.

The beam tab's existing "hidden markers are not targets" guard still holds — the box widens the target, so it would have widened that hole too.

## Tests

New `tests/ui/test_position_field_of_view.py` (28), plus the existing overview/FM/overlay modules — 686 green.

Six mutations, each killed by the test it should be. The two that matter are the union proof:

| mutation | killed by |
|---|---|
| picking → box only | `test_the_radius_still_picks_where_the_box_is_smaller_than_it` |
| picking → radius only | `test_a_click_inside_the_box_selects_it` |

Both picking tests assert their own precondition (the probe really is outside the other half's reach), so neither can pass for the wrong reason. `test_the_pick_radius_is_screen_space` in the FM module gains the precondition it now depends on: its 80 µm probe clears the 102 µm camera frame by 29 µm, and says so rather than failing obscurely if binning ever changes that.

## Not in this PR

FIB-756 — recording the FOV *with* a saved position, which FIB-524 also decided. Live is correct today (the binning factors cancel, so the FOV is static for a given camera), and recording it costs a data-model change plus a migration for positions already saved without one. The issue also records the two parts of FIB-524's original scope that were declined rather than deferred: a box on the current position, and the same box on the napari minimap, which is being retired.
