### PR TITLE
[fix] Bump the GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,8 @@ jobs:
       # by packaging, rather than re-derived from the tag string in shell.
       prerelease: ${{ steps.check.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
       - run: pip install packaging
@@ -82,8 +82,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip
@@ -99,8 +99,8 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,9 +30,9 @@ jobs:
             python-version: "3.13"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -63,8 +63,8 @@ jobs:
     # same answer eight times. This takes about ten seconds.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v7
+    - uses: actions/setup-python@v7
       with:
         python-version: "3.12"
     # Pinned so a new ruff release cannot turn this red on a commit that changed


### PR DESCRIPTION
Every CI run currently logs:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5.

Both actions declare `using: node20`. Today that is only a warning, but when GitHub finishes removing the Node 20 runtime it becomes a hard failure and every job stops at the checkout step.

## What changed

`actions/checkout@v4` → `@v7` and `actions/setup-python@v5` → `@v7` (the current major of each), in:

- `python-package.yml` — both the `build` matrix and the `lint` job
- `publish.yml` — `check-version`, `test`, and `publish`

`publish.yml` uses the same two actions and would break the same way. Its failure mode is worse, since it only runs on a release tag, so it is bumped here rather than left for later.

Ten `uses:` lines, nothing else.

## Why this is a drop-in bump

Diffing the two `action.yml` manifests directly, rather than assuming:

| | old → new |
|---|---|
| `checkout` v4 → v7 | `using: node20` → `node24`. **Nothing else.** The `allow-unsafe-pr-checkout` input v7 added was backported into v4.4.0, so the input sets are already identical. |
| `setup-python` v5 → v7 | `using: node20` → `node24`, plus one new optional input, `pip-version`. No input removed, no default changed. |

The two inputs used here — `python-version` and `cache: 'pip'` — are unchanged in v7.

Breaking changes in the intervening majors, checked against these workflows:

- **checkout v7** refuses fork-PR checkouts under `pull_request_target` and `workflow_run`. Neither triggers these workflows (`push`, `pull_request`, and tag `push`).
- **checkout v5/v6** and **setup-python v6** require Actions runner ≥ v2.327.1, which GitHub-hosted runners are well past.
- **setup-python v7** removes a `pip-install` input that was introduced and removed within v6 — it never existed in v5, so nothing here referenced it.
- **setup-python v7** also "removed EOL Python versions", which sounds like it might drop the `3.8` end of the build matrix. It does not: that change touches only setup-python's own CI workflows and test fixtures, not the action source. Version resolution still comes from the `actions/python-versions` manifest, which this bump does not affect.

## Verification

Both files parse, and the parsed workflows are structurally identical to the old ones once the version pin is normalised away — confirming the diff really is version strings only. Every `with:` key on the bumped steps was checked against the v7 manifests' declared inputs; all valid.

CI on this PR is itself the end-to-end check: it runs on the bumped actions, and the deprecation warning should be gone from the log.