### PR TITLE
[refactor] Say what the autolamella config shim is, in a way tools can read

### DIFF
--- a/fibsem/applications/autolamella/config.py
+++ b/fibsem/applications/autolamella/config.py
@@ -1,18 +1,19 @@
-from fibsem.config import (
-    AUTOLAMELLA_BASE_PATH as BASE_PATH,
-)
-from fibsem.config import (
-    AUTOLAMELLA_CONFIG_PATH as CONFIG_PATH,
-)
-from fibsem.config import (
-    AUTOLAMELLA_EXPERIMENT_NAME as EXPERIMENT_NAME,
-)
-from fibsem.config import (
-    AUTOLAMELLA_LOG_PATH as LOG_PATH,
-)
-from fibsem.config import (
-    AUTOLAMELLA_PROTOCOL_PATH as PROTOCOL_PATH,
-)
-from fibsem.config import (
-    AUTOLAMELLA_TASK_PROTOCOL_PATH as TASK_PROTOCOL_PATH,
-)
+"""AutoLamella's short names for the AUTOLAMELLA_* paths in fibsem.config.
+
+Assignments rather than `from fibsem.config import AUTOLAMELLA_X as X`. The two
+are equivalent at runtime, but an aliased import means "deliberate re-export" to
+a reader and "unused import" to every tool: ruff rates deleting these as a *safe*
+fix, which empties this module and takes `import ...autolamella.structures` down
+with it. Its isort rule also splits a multi-alias import into one statement per
+name, which is how six constants came to occupy eighteen lines. Assignment says
+the same thing unambiguously to both audiences.
+"""
+
+from fibsem import config as _cfg
+
+BASE_PATH = _cfg.AUTOLAMELLA_BASE_PATH
+CONFIG_PATH = _cfg.AUTOLAMELLA_CONFIG_PATH
+EXPERIMENT_NAME = _cfg.AUTOLAMELLA_EXPERIMENT_NAME
+LOG_PATH = _cfg.AUTOLAMELLA_LOG_PATH
+PROTOCOL_PATH = _cfg.AUTOLAMELLA_PROTOCOL_PATH
+TASK_PROTOCOL_PATH = _cfg.AUTOLAMELLA_TASK_PROTOCOL_PATH


### PR DESCRIPTION
`fibsem/applications/autolamella/config.py` exists to give autolamella's code short names for six `AUTOLAMELLA_*` paths defined in `fibsem.config`. It expressed that as aliased imports, which read as a deliberate re-export to a person and as an unused import to every tool.

Concretely: ruff rates deleting them as a **safe** fix. It honours a redundant `X as X` alias as an explicit re-export, but a *renaming* alias has no such marker, so `ruff check --fix` empties this file to zero bytes and `import fibsem.applications.autolamella.structures` then dies with `AttributeError: module '...config' has no attribute 'EXPERIMENT_NAME'`. Confirmed by AST that this is the only import-only module in the repo, so it is also the only place this can happen — which is why the fix is one file rather than a policy.

Ruff's isort also splits a multi-alias import into one statement per name; that is how six constants came to occupy eighteen lines after #484. This restores it to ten.

```python
from fibsem import config as _cfg

BASE_PATH = _cfg.AUTOLAMELLA_BASE_PATH
CONFIG_PATH = _cfg.AUTOLAMELLA_CONFIG_PATH
...
```

Equivalent at runtime, unambiguous to both audiences: nothing for `F401` to report and nothing for a `--fix` to remove.

## Why not delete the shim instead

Considered. It has ~38 call sites across 7 files, and removing it rewrites every one of them from `cfg.CONFIG_PATH` to `cfg.AUTOLAMELLA_CONFIG_PATH` — strictly more verbose at each site, to delete a module that costs nothing once it stops using aliased imports. It is also importable API that user scripts may rely on. The problem was the construct, not the module.

## Verification

- All six names resolve to the same objects as `fibsem.config.AUTOLAMELLA_*` — asserted, no mismatches
- The one direct `from ...config import PROTOCOL_PATH` still works
- `ruff check .` clean, and clean again with `F401` explicitly un-ignored, which is the point
- Byte-identical after `ruff check --select F401,I --fix`
- Full suite: 5,743 passed, 24 skipped

## Follow-on

Unblocks the `F401` burn-down: this was the only finding whose autofix was dangerous rather than merely wrong. The remaining ~339 are ordinary unused imports, plus 56 in `__init__.py` that ruff already refuses to autofix and that a `per-file-ignores` line will silence when the rule comes out of `ignore`.
