### PR TITLE
[feature] Format the files a pull request touches, rather than the whole tree

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -89,16 +89,20 @@ jobs:
       run: |
         set -euo pipefail
         base=$(git merge-base origin/main HEAD)
-        git diff --name-only --diff-filter=d "$base" HEAD -- '*.py' > changed.txt
-        count=$(wc -l < changed.txt | tr -d ' ')
+        # mktemp, not a file in the repo root: this script is meant to be
+        # runnable locally too, and it should not leave anything behind.
+        changed=$(mktemp)
+        trap 'rm -f "$changed"' EXIT
+        git diff --name-only --diff-filter=d "$base" HEAD -- '*.py' > "$changed"
+        count=$(wc -l < "$changed" | tr -d ' ')
         echo "python files changed against $base: $count"
         if [ "$count" -eq 0 ]; then
           echo "no python files changed; nothing to check"
           exit 0
         fi
-        sed 's/^/  /' changed.txt
+        sed 's/^/  /' "$changed"
         # NUL-separated: a path with a space would otherwise split into two.
-        if ! tr '\n' '\0' < changed.txt | xargs -0 ruff format --check --; then
+        if ! tr '\n' '\0' < "$changed" | xargs -0 ruff format --check --; then
           echo
           echo "To fix, from the repo root:"
           echo "  ruff format \$(git diff --name-only --diff-filter=d \$(git merge-base origin/main HEAD) HEAD -- '*.py')"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -64,6 +64,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        # The formatting step below diffs against the merge base, which does not
+        # exist in the default shallow clone.
+        fetch-depth: 0
     - uses: actions/setup-python@v7
       with:
         python-version: "3.12"
@@ -72,3 +76,31 @@ jobs:
     - run: python -m pip install ruff==0.16.3
     # --output-format=github annotates the diff instead of only failing the job.
     - run: ruff check --output-format=github .
+    - name: Check formatting of the files this PR changes
+      # Format-on-touch rather than a whole-tree flag day: a file has to be
+      # formatted once something in it is edited, so the tree converts fastest
+      # where the work actually happens. `main` stays mixed for a while, which
+      # is the accepted cost.
+      #
+      # The count is echoed on purpose. The failure mode of a diff-scoped check
+      # is that the diff comes back empty -- wrong base, shallow clone -- and
+      # the job passes green having checked nothing, so the number has to be
+      # visible in the log to be disbelieved.
+      run: |
+        set -euo pipefail
+        base=$(git merge-base origin/main HEAD)
+        git diff --name-only --diff-filter=d "$base" HEAD -- '*.py' > changed.txt
+        count=$(wc -l < changed.txt | tr -d ' ')
+        echo "python files changed against $base: $count"
+        if [ "$count" -eq 0 ]; then
+          echo "no python files changed; nothing to check"
+          exit 0
+        fi
+        sed 's/^/  /' changed.txt
+        # NUL-separated: a path with a space would otherwise split into two.
+        if ! tr '\n' '\0' < changed.txt | xargs -0 ruff format --check --; then
+          echo
+          echo "To fix, from the repo root:"
+          echo "  ruff format \$(git diff --name-only --diff-filter=d \$(git merge-base origin/main HEAD) HEAD -- '*.py')"
+          exit 1
+        fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,14 @@ extend-exclude = [
     "**/*.ipynb",
 ]
 
+[tool.ruff.format]
+# Ruff formats Python inside fenced code blocks in Markdown. Documentation
+# snippets are written to be read, not to satisfy a line-length rule: it wanted
+# to wrap a three-argument call in README.md across three lines, and to rewrite
+# 84 lines of docs/design/autofocus.md. Whether the docs get formatted is its
+# own decision, and not one a formatter should make on the way past.
+exclude = ["**/*.md"]
+
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I"]
 # E501 (line-length) is deliberately absent. A formatter is what wraps code, and


### PR DESCRIPTION
Adopts `ruff format` incrementally instead of as a flag day. A file has to be formatted once something in it is edited. Two files changed here; no reformatting, nothing for the eleven open pull requests to rebase over.

Replaces #488, which reformatted 599 files in one commit. That is closed.

## The trade

Touching one line of a file means reformatting all of it, and the hot files are the unformatted ones:

| file | lines of format diff | file lines |
|---|---|---|
| `fibsem/structures.py` | 1,044 | 3,376 |
| `fibsem/ui/FibsemMinimapWidget.py` | 605 | 1,542 |
| `fibsem/applications/autolamella/structures.py` | 420 | 1,656 |
| `fibsem/config.py` | 142 | 667 |

So a one-line fix in `structures.py` arrives as a four-figure diff. **Keep the reformat as its own commit inside the PR** — the feature commit then reads on its own, and the reviewer skips the other one.

What it buys: the tree converts fastest exactly where the work happens. `fibsem/ui` saw 375 commits in the last 180 days, `tests` 288, `fibsem/applications` 232 — so the files people actually read get formatted first. A directory-by-directory ratchet would have reached those last. `main` stays mixed-state for a while; that is the accepted cost of not doing a flag day, not an oversight.

## The CI step

```bash
base=$(git merge-base origin/main HEAD)
git diff --name-only --diff-filter=d "$base" HEAD -- '*.py' > changed.txt
```

Two details that are load-bearing:

- **`fetch-depth: 0`** on the checkout. The step diffs against the merge base, which is not in the default shallow clone.
- **The file count is echoed.** The failure mode of any diff-scoped check is that the diff comes back empty — wrong base, shallow clone — and the job passes green having checked nothing. The number has to be visible for anyone to disbelieve it. Same reasoning as `FIBSEM_REQUIRE_PLUGIN_FIXTURE` in the test job.

`--diff-filter=d` drops deleted paths, which would otherwise make ruff error on a file that is not there. Paths are passed NUL-separated so a filename with a space cannot split into two arguments.

On failure it prints the exact command to fix it.

## Verification

Exercised locally against all three cases, since a check that cannot fail is worse than no check:

| case | result |
|---|---|
| no Python files changed | passes, reports `0` |
| a formatted Python file changed | passes |
| an unformatted Python file changed | **fails**, prints the fix command |

## Markdown is excluded

Ruff formats Python inside fenced code blocks. It wanted to wrap a three-argument `setup_session(...)` call in `README.md` across three lines and rewrite 84 lines of `docs/design/autofocus.md`. Documentation snippets are written to be read; whether they get formatted is a separate decision, and not one a formatter should make on the way past.
