### PR TITLE
[feature] Make the experiment name the control, not a label beside two spent buttons

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -16,8 +16,8 @@ import warnings
 from datetime import datetime
 
 import napari
-from PyQt5.QtCore import QSize, Qt, QTimer
-from PyQt5.QtGui import QIcon, QKeySequence, QPainter, QPixmap
+from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtGui import QKeySequence
 from PyQt5.QtWidgets import (
     QAction,
     QApplication,
@@ -125,9 +125,6 @@ warnings.filterwarnings(
 # the point of the button is to say which experiment is open.
 EXPERIMENT_MENU_MAX_WIDTH = 360
 
-# Icons sat on a button, rather than in a menu, are drawn at this size.
-BUTTON_ICON_SIZE = 16
-
 
 def experiment_tooltip(experiment: Experiment) -> str:
     """The hover card for the tab-corner experiment button.
@@ -172,28 +169,6 @@ def experiment_tooltip(experiment: Experiment) -> str:
         f"<div style='color: {TEXT_MUTED_COLOR}; margin-top: 4px;'>"
         f"{html.escape(str(experiment.path))}</div>"
     )
-
-
-def set_button_icon(button: QPushButton, key: str, gap: int = 5) -> None:
-    """Put an icon on a button with breathing room between it and the text.
-
-    Qt spaces a button's icon from its label by about four pixels and offers no way
-    to ask for more, which next to a name reads as the two being squashed together.
-    Padding the pixmap on its right buys the rest -- and the icon size has to grow
-    with the padding, or Qt scales the wider pixmap back into the old box and
-    shrinks the glyph instead of moving the text.
-    """
-    pixmap = fibsem_icon(key, color=GRAY_ICON_COLOR).pixmap(BUTTON_ICON_SIZE, BUTTON_ICON_SIZE)
-    ratio = pixmap.devicePixelRatio() or 1.0
-    padded = QPixmap(pixmap.width() + round(gap * ratio), pixmap.height())
-    padded.setDevicePixelRatio(ratio)
-    padded.fill(Qt.transparent)
-    painter = QPainter(padded)
-    painter.drawPixmap(0, 0, pixmap)
-    painter.end()
-
-    button.setIcon(QIcon(padded))
-    button.setIconSize(QSize(BUTTON_ICON_SIZE + gap, BUTTON_ICON_SIZE))
 
 
 def set_menu_icon(action: QAction, key: str) -> None:
@@ -1851,7 +1826,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # The experiment name, once there is one, is itself the control that reaches
         # the create/load actions -- see _update_experiment_header.
         self.btn_experiment_menu = QPushButton()
-        set_button_icon(self.btn_experiment_menu, "mdi:flask-outline")
         self.btn_experiment_menu.setStyleSheet(MENU_BUTTON_STYLESHEET)
         self.btn_experiment_menu.setMaximumWidth(EXPERIMENT_MENU_MAX_WIDTH)
         # Hug the name. A QPushButton's default policy lets it grow to fill the

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import html
 import logging
 import sys
 import time
@@ -12,6 +13,7 @@ except Exception:
     pass
 
 import warnings
+from datetime import datetime
 
 import napari
 from PyQt5.QtCore import Qt, QTimer
@@ -24,10 +26,12 @@ from PyQt5.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QMainWindow,
+    QMenu,
     QMessageBox,
     QProgressBar,
     QPushButton,
     QScrollArea,
+    QSizePolicy,
     QSplitter,
     QTabWidget,
     QTextEdit,
@@ -85,6 +89,7 @@ from fibsem.ui.qt.gc import install_main_thread_gc
 from fibsem.ui.stylesheets import (
     DANGER_BUTTON_STYLESHEET,
     GRAY_ICON_COLOR,
+    MENU_BUTTON_STYLESHEET,
     NAPARI_STYLE,
     PRIMARY_BUTTON_STYLESHEET,
     PROGRESS_BAR_STYLESHEET,
@@ -96,8 +101,9 @@ from fibsem.ui.stylesheets import (
     border_stylesheet,
 )
 from fibsem.ui.tokens import (
+    ERROR_COLOR,
     SURFACE_COLOR,
-    TEXT_COLOR,
+    TEXT_MUTED_COLOR,
 )
 from fibsem.ui.widgets import preflight
 from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
@@ -113,6 +119,66 @@ warnings.filterwarnings(
     category=UserWarning,
     module=r"napari\.layers\.shapes\._shapes_utils",
 )
+
+# How wide the experiment name button in the tab corner is allowed to grow. Wide
+# enough that a default name -- "AutoLamella-" plus a date stamp -- is never elided;
+# the point of the button is to say which experiment is open.
+EXPERIMENT_MENU_MAX_WIDTH = 360
+
+
+def experiment_tooltip(experiment: Experiment) -> str:
+    """The hover card for the tab-corner experiment button.
+
+    Rich text, because Qt renders a tooltip as HTML the moment it contains a tag:
+    that is what lines the rows up and keeps the directory on a line of its own
+    instead of letting it set the width of everything above it.
+
+    Every row here is a fact the experiment already holds. Rows whose fact is
+    missing are dropped rather than rendered empty -- a protocol is set after
+    construction and `created_at` is absent from experiments written before it was
+    recorded, so both are genuinely unknown rather than blank.
+    """
+    rows: List[Tuple[str, str]] = []
+
+    if experiment.created_at:
+        created = datetime.fromtimestamp(experiment.created_at)
+        rows.append(("Created", html.escape(created.strftime("%d %b %Y, %H:%M"))))
+
+    lamella = str(len(experiment.positions))
+    # `is_failure` is a human's judgement that a lamella is defective, not a record
+    # of a task that failed, so the count says defective. See Lamella.is_failure.
+    defective = len(experiment.at_failure())
+    if defective:
+        lamella += (
+            f"&nbsp;&nbsp;<span style='color: {ERROR_COLOR}'>"
+            f"{defective} defective</span>"
+        )
+    rows.append(("Lamella", lamella))
+
+    if experiment.task_protocol is not None:
+        rows.append(("Protocol", html.escape(experiment.task_protocol.name)))
+
+    body = "".join(
+        f"<tr><td style='color: {TEXT_MUTED_COLOR}; padding-right: 10px;'>{label}</td>"
+        f"<td>{value}</td></tr>"
+        for label, value in rows
+    )
+    return (
+        f"<b>{html.escape(experiment.name)}</b>"
+        f"<table cellspacing='0' cellpadding='0'>{body}</table>"
+        f"<div style='color: {TEXT_MUTED_COLOR}; margin-top: 4px;'>"
+        f"{html.escape(str(experiment.path))}</div>"
+    )
+
+
+def set_menu_icon(action: QAction, key: str) -> None:
+    """Give a menu action an icon that actually renders.
+
+    Qt turns menu icons off wholesale on macOS (AA_DontShowIconsInMenus), so an
+    icon set the usual way shows on Windows and Linux and silently vanishes here.
+    """
+    action.setIcon(fibsem_icon(key, color=GRAY_ICON_COLOR))
+    action.setIconVisibleInMenu(True)
 
 
 def play_notification_sound():
@@ -368,15 +434,22 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if view_menu is None:
             raise RuntimeError("Failed to create View menu in AutoLamella UI.")
 
+        # These three carry icons because they are also the tab-corner experiment
+        # menu (see create_notification_button), where the icons do the work of
+        # telling create from load at a glance. Qt hides action icons in menus on
+        # macOS unless each action asks for them, hence set_menu_icon.
         self.action_new_experiment = QAction("New Experiment", self)
+        set_menu_icon(self.action_new_experiment, "mdi:plus")
         self.action_new_experiment.triggered.connect(self._on_new_experiment)
 
         self.action_load_experiment = QAction("Load Experiment", self)
+        set_menu_icon(self.action_load_experiment, "mdi:folder-open")
         self.action_load_experiment.triggered.connect(self._on_load_experiment)
 
         self.action_open_experiment_directory = QAction(
             "Open Experiment Directory", self
         )
+        set_menu_icon(self.action_open_experiment_directory, "mdi:folder")
         self.action_open_experiment_directory.triggered.connect(
             self._on_open_experiment_directory
         )
@@ -1366,8 +1439,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.autolamella_ui.microscope.spot_burn_progress_signal.connect(
                 self._on_spot_burn_progress
             )
-        self.btn_create_experiment.setEnabled(True)
-        self.btn_load_experiment.setEnabled(True)
+        self._update_experiment_header()
         self._update_instructions()
 
     @ensure_main_thread
@@ -1617,12 +1689,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.lamella_widget.setMinimumWidth(500)
         self.lamella_workflow_widget.setMinimumWidth(600)
 
-        # Update experiment name label
-        self.experiment_name_label.setText(
-            f"Experiment: {self.autolamella_ui.experiment.name}"
-        )
-        self.btn_create_experiment.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
-        self.btn_load_experiment.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
+        # Update the experiment name button
+        self._update_experiment_header()
 
         # Show run workflow button when experiment is loaded
         self.run_workflow_btn.show()
@@ -1695,6 +1763,45 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             events.changed.connect(self._refresh_overview_positions)
         self._lamella_list_experiment = experiment
 
+    def _update_experiment_header(self):
+        """Show either the create/load buttons or the experiment menu, never both.
+
+        Until an experiment exists those two buttons are the only thing to do, so they
+        stay primary-coloured and take the room. Once one is loaded the experiment name
+        replaces them, and opens a menu holding the same actions: the greyed-out pair
+        cost a third of the tab bar to say nothing.
+        """
+        autolamella_ui = getattr(self, "autolamella_ui", None)
+        experiment = autolamella_ui.experiment if autolamella_ui else None
+        is_connected = autolamella_ui is not None and autolamella_ui.microscope is not None
+
+        self.btn_create_experiment.setEnabled(is_connected)
+        self.btn_load_experiment.setEnabled(is_connected)
+        self.btn_create_experiment.setVisible(experiment is None)
+        self.btn_load_experiment.setVisible(experiment is None)
+
+        self.btn_experiment_menu.setVisible(experiment is not None)
+        if experiment is None:
+            return
+
+        # Experiment names carry a date stamp and run long; elided here rather than
+        # left to stretch the corner widget back to the width this change reclaims.
+        # Measured off the button rather than against a guessed allowance for the
+        # icon, padding and chevron -- an allowance set too generously elides names
+        # that would have fitted.
+        self.btn_experiment_menu.setText(experiment.name)
+        overflow = self.btn_experiment_menu.sizeHint().width() - EXPERIMENT_MENU_MAX_WIDTH
+        if overflow > 0:
+            metrics = self.btn_experiment_menu.fontMetrics()
+            self.btn_experiment_menu.setText(
+                metrics.elidedText(
+                    experiment.name,
+                    Qt.ElideMiddle,
+                    metrics.horizontalAdvance(experiment.name) - overflow,
+                )
+            )
+        self.btn_experiment_menu.setToolTip(experiment_tooltip(experiment))
+
     def create_notification_button(self):
         """Add buttons to the tab bar for adding Protocol Editor, Lamella, and Minimap tabs."""
         # Create button container widget
@@ -1716,16 +1823,34 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.btn_load_experiment.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         self.btn_load_experiment.clicked.connect(self._on_load_experiment)
 
-        # Experiment name label
-        self.experiment_name_label = QLabel("No Experiment")
-        self.experiment_name_label.setStyleSheet(f"color: {TEXT_COLOR}; font-size: 12px;")
+        # The experiment name, once there is one, is itself the control that reaches
+        # the create/load actions -- see _update_experiment_header.
+        self.btn_experiment_menu = QPushButton()
+        self.btn_experiment_menu.setIcon(
+            fibsem_icon("mdi:flask-outline", color=GRAY_ICON_COLOR)
+        )
+        self.btn_experiment_menu.setStyleSheet(MENU_BUTTON_STYLESHEET)
+        self.btn_experiment_menu.setMaximumWidth(EXPERIMENT_MENU_MAX_WIDTH)
+        # Hug the name. A QPushButton's default policy lets it grow to fill the
+        # layout, which here means straight back out to the maximum width above --
+        # the corner widget would be no narrower than the pair it replaces.
+        self.btn_experiment_menu.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+        self.btn_experiment_menu.setVisible(False)
+        experiment_menu = QMenu(self.btn_experiment_menu)
+        # The File menu's own QAction objects, not copies of them, so the two places
+        # that offer these actions cannot drift apart.
+        experiment_menu.addAction(self.action_new_experiment)
+        experiment_menu.addAction(self.action_load_experiment)
+        experiment_menu.addSeparator()
+        experiment_menu.addAction(self.action_open_experiment_directory)
+        self.btn_experiment_menu.setMenu(experiment_menu)
 
         # Notification bell
         self.notification_bell = NotificationBell(self)
         self.toast_manager.set_notification_bell(self.notification_bell)
 
         # Add widgets to layout
-        button_layout.addWidget(self.experiment_name_label)
+        button_layout.addWidget(self.btn_experiment_menu)
         button_layout.addWidget(self.btn_create_experiment)
         button_layout.addWidget(self.btn_load_experiment)
         button_layout.addWidget(self.notification_bell)

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -16,8 +16,8 @@ import warnings
 from datetime import datetime
 
 import napari
-from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtGui import QKeySequence
+from PyQt5.QtCore import QSize, Qt, QTimer
+from PyQt5.QtGui import QIcon, QKeySequence, QPainter, QPixmap
 from PyQt5.QtWidgets import (
     QAction,
     QApplication,
@@ -125,6 +125,9 @@ warnings.filterwarnings(
 # the point of the button is to say which experiment is open.
 EXPERIMENT_MENU_MAX_WIDTH = 360
 
+# Icons sat on a button, rather than in a menu, are drawn at this size.
+BUTTON_ICON_SIZE = 16
+
 
 def experiment_tooltip(experiment: Experiment) -> str:
     """The hover card for the tab-corner experiment button.
@@ -169,6 +172,33 @@ def experiment_tooltip(experiment: Experiment) -> str:
         f"<div style='color: {TEXT_MUTED_COLOR}; margin-top: 4px;'>"
         f"{html.escape(str(experiment.path))}</div>"
     )
+
+
+def set_button_icon(
+    button: QPushButton, key: str, gap: int = 5, color: str = TEXT_MUTED_COLOR
+) -> None:
+    """Put an icon on a button with breathing room between it and the text.
+
+    Qt spaces a button's icon from its label by about four pixels and offers no way
+    to ask for more, which next to a name reads as the two being squashed together.
+    Padding the pixmap on its right buys the rest -- and the icon size has to grow
+    with the padding, or Qt scales the wider pixmap back into the old box and
+    shrinks the glyph instead of moving the text.
+
+    Muted by default: at the label's own weight the icon competes with the name
+    rather than introducing it.
+    """
+    pixmap = fibsem_icon(key, color=color).pixmap(BUTTON_ICON_SIZE, BUTTON_ICON_SIZE)
+    ratio = pixmap.devicePixelRatio() or 1.0
+    padded = QPixmap(pixmap.width() + round(gap * ratio), pixmap.height())
+    padded.setDevicePixelRatio(ratio)
+    padded.fill(Qt.transparent)
+    painter = QPainter(padded)
+    painter.drawPixmap(0, 0, pixmap)
+    painter.end()
+
+    button.setIcon(QIcon(padded))
+    button.setIconSize(QSize(BUTTON_ICON_SIZE + gap, BUTTON_ICON_SIZE))
 
 
 def set_menu_icon(action: QAction, key: str) -> None:
@@ -1826,6 +1856,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # The experiment name, once there is one, is itself the control that reaches
         # the create/load actions -- see _update_experiment_header.
         self.btn_experiment_menu = QPushButton()
+        set_button_icon(self.btn_experiment_menu, "mdi:flask-outline")
         self.btn_experiment_menu.setStyleSheet(MENU_BUTTON_STYLESHEET)
         self.btn_experiment_menu.setMaximumWidth(EXPERIMENT_MENU_MAX_WIDTH)
         # Hug the name. A QPushButton's default policy lets it grow to fill the

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -16,8 +16,8 @@ import warnings
 from datetime import datetime
 
 import napari
-from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtGui import QKeySequence
+from PyQt5.QtCore import QSize, Qt, QTimer
+from PyQt5.QtGui import QIcon, QKeySequence, QPainter, QPixmap
 from PyQt5.QtWidgets import (
     QAction,
     QApplication,
@@ -125,6 +125,9 @@ warnings.filterwarnings(
 # the point of the button is to say which experiment is open.
 EXPERIMENT_MENU_MAX_WIDTH = 360
 
+# Icons sat on a button, rather than in a menu, are drawn at this size.
+BUTTON_ICON_SIZE = 16
+
 
 def experiment_tooltip(experiment: Experiment) -> str:
     """The hover card for the tab-corner experiment button.
@@ -169,6 +172,28 @@ def experiment_tooltip(experiment: Experiment) -> str:
         f"<div style='color: {TEXT_MUTED_COLOR}; margin-top: 4px;'>"
         f"{html.escape(str(experiment.path))}</div>"
     )
+
+
+def set_button_icon(button: QPushButton, key: str, gap: int = 5) -> None:
+    """Put an icon on a button with breathing room between it and the text.
+
+    Qt spaces a button's icon from its label by about four pixels and offers no way
+    to ask for more, which next to a name reads as the two being squashed together.
+    Padding the pixmap on its right buys the rest -- and the icon size has to grow
+    with the padding, or Qt scales the wider pixmap back into the old box and
+    shrinks the glyph instead of moving the text.
+    """
+    pixmap = fibsem_icon(key, color=GRAY_ICON_COLOR).pixmap(BUTTON_ICON_SIZE, BUTTON_ICON_SIZE)
+    ratio = pixmap.devicePixelRatio() or 1.0
+    padded = QPixmap(pixmap.width() + round(gap * ratio), pixmap.height())
+    padded.setDevicePixelRatio(ratio)
+    padded.fill(Qt.transparent)
+    painter = QPainter(padded)
+    painter.drawPixmap(0, 0, pixmap)
+    painter.end()
+
+    button.setIcon(QIcon(padded))
+    button.setIconSize(QSize(BUTTON_ICON_SIZE + gap, BUTTON_ICON_SIZE))
 
 
 def set_menu_icon(action: QAction, key: str) -> None:
@@ -1826,9 +1851,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # The experiment name, once there is one, is itself the control that reaches
         # the create/load actions -- see _update_experiment_header.
         self.btn_experiment_menu = QPushButton()
-        self.btn_experiment_menu.setIcon(
-            fibsem_icon("mdi:flask-outline", color=GRAY_ICON_COLOR)
-        )
+        set_button_icon(self.btn_experiment_menu, "mdi:flask-outline")
         self.btn_experiment_menu.setStyleSheet(MENU_BUTTON_STYLESHEET)
         self.btn_experiment_menu.setMaximumWidth(EXPERIMENT_MENU_MAX_WIDTH)
         # Hug the name. A QPushButton's default policy lets it grow to fill the

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -295,11 +295,15 @@ def confirm_add_to_queue_dialog(
         )
         layout.addLayout(metrics)
 
-    layout.addWidget(preflight.detail_block([
-        ("Position", "Run next" if run_next else "At the end of the queue"),
-        ("Lamella", ", ".join(lamella_names)),
-        ("Tasks", ", ".join(task_names)),
-    ]))
+    layout.addWidget(
+        preflight.detail_block(
+            [
+                ("Position", "Run next" if run_next else "At the end of the queue"),
+                ("Lamella", ", ".join(lamella_names)),
+                ("Tasks", ", ".join(task_names)),
+            ]
+        )
+    )
 
     absorbed = _absorbed_note(estimate)
     if absorbed:
@@ -378,8 +382,10 @@ def _absorbed_note(estimate: Optional[AdditionEstimate]) -> str:
     ):
         return ""
     if estimate.delay_seconds <= 0:
-        return ("The workflow is already waiting for a scheduled task, and this work "
-                "fits inside that wait — so it costs no extra time overall.")
+        return (
+            "The workflow is already waiting for a scheduled task, and this work "
+            "fits inside that wait — so it costs no extra time overall."
+        )
     return (
         f"Only {preflight.format_duration(estimate.delay_seconds)} of this lands after "
         "the workflow's scheduled wait; the rest fits inside it."
@@ -1244,8 +1250,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # same rule — there is nothing to add until something is ticked.
         if hasattr(self, "workflow_timeline"):
             if valid:
-                tip = (f"Add to queue: {n_lam} lamella, "
-                       f"{n_task} task{'s' if n_task != 1 else ''}")
+                tip = (
+                    f"Add to queue: {n_lam} lamella, "
+                    f"{n_task} task{'s' if n_task != 1 else ''}"
+                )
             else:
                 tip = f"Select {' and '.join(missing)} to add to the queue"
             self.workflow_timeline.set_add_enabled(valid, tip)
@@ -1803,7 +1811,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         """
         autolamella_ui = getattr(self, "autolamella_ui", None)
         experiment = autolamella_ui.experiment if autolamella_ui else None
-        is_connected = autolamella_ui is not None and autolamella_ui.microscope is not None
+        is_connected = (
+            autolamella_ui is not None and autolamella_ui.microscope is not None
+        )
 
         self.btn_create_experiment.setEnabled(is_connected)
         self.btn_load_experiment.setEnabled(is_connected)
@@ -1820,7 +1830,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # icon, padding and chevron -- an allowance set too generously elides names
         # that would have fitted.
         self.btn_experiment_menu.setText(experiment.name)
-        overflow = self.btn_experiment_menu.sizeHint().width() - EXPERIMENT_MENU_MAX_WIDTH
+        overflow = (
+            self.btn_experiment_menu.sizeHint().width() - EXPERIMENT_MENU_MAX_WIDTH
+        )
         if overflow > 0:
             metrics = self.btn_experiment_menu.fontMetrics()
             self.btn_experiment_menu.setText(
@@ -2173,14 +2185,21 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         task_names = [t.name for t in tasks]
 
         pending = {(i.lamella_name, i.task_name) for i in manager.queue.pending}
-        already = [f"{t} for {ln}" for t in task_names for ln in lamella_names
-                   if (ln, t) in pending]
+        already = [
+            f"{t} for {ln}"
+            for t in task_names
+            for ln in lamella_names
+            if (ln, t) in pending
+        ]
 
         # Task-outer, lamella-inner: the order the items are really inserted in below,
         # so what is priced is what will be queued.
         pairs = [(ln, tn) for tn in task_names for ln in lamella_names]
         if not confirm_add_to_queue_dialog(
-            lamella_names, task_names, run_next, already,
+            lamella_names,
+            task_names,
+            run_next,
+            already,
             estimate=self._estimate_addition(manager, pairs, run_next),
             parent=self,
         ):
@@ -2189,8 +2208,11 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # A lamella created before a task joined the protocol has no config for
         # it, and run_task raises on that. Backfill from the base protocol first.
         experiment = self.autolamella_ui.experiment
-        missing = [ln for ln, lam in zip(lamella_names, lamellae)
-                   if any(t not in lam.task_config for t in task_names)]
+        missing = [
+            ln
+            for ln, lam in zip(lamella_names, lamellae)
+            if any(t not in lam.task_config for t in task_names)
+        ]
         if missing and experiment is not None:
             experiment.apply_lamella_config(missing, task_names)
 
@@ -2256,8 +2278,12 @@ class AutoLamellaSingleWindowUI(QMainWindow):
                 # `estimated_time` divides by the sputter rate (milling/base.py:292), so
                 # a hand-edited protocol can raise. Losing the figure is a great deal
                 # better than losing the dialog that queues the work.
-                logging.warning("Could not estimate duration for %s on %s.",
-                                item.task_name, item.lamella_name, exc_info=True)
+                logging.warning(
+                    "Could not estimate duration for %s on %s.",
+                    item.task_name,
+                    item.lamella_name,
+                    exc_info=True,
+                )
                 return None
 
         schedule = {}
@@ -2282,8 +2308,12 @@ class AutoLamellaSingleWindowUI(QMainWindow):
                 )
 
         return estimate_addition(
-            manager.queue.items, pairs, seconds_for,
-            run_next=run_next, schedule=schedule, active_elapsed=active_elapsed,
+            manager.queue.items,
+            pairs,
+            seconds_for,
+            run_next=run_next,
+            schedule=schedule,
+            active_elapsed=active_elapsed,
         )
 
     def _push_timeline_estimates(self, pairs: list) -> None:
@@ -2322,7 +2352,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
                 # to offer" state, so degrading into it is the graceful failure.
                 logging.warning(
                     "Could not estimate duration for %s on %s; the timeline will show "
-                    "no estimate for it.", task_name, lamella_name, exc_info=True,
+                    "no estimate for it.",
+                    task_name,
+                    lamella_name,
+                    exc_info=True,
                 )
         self.workflow_timeline.set_estimates(estimates)
 
@@ -2386,14 +2419,17 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             # A fresh item rather than a rewind: the original attempt still
             # happened and stays in the run record.
             added = queue.add(item.lamella_name, item.task_name, front=True)
-            message = (f"Queued {label} to run next." if added is not None
-                       else f"Could not queue {label}.")
+            message = (
+                f"Queued {label} to run next."
+                if added is not None
+                else f"Could not queue {label}."
+            )
         else:
             call = {
-                "move_up":   lambda: queue.nudge(item_id, -1),
+                "move_up": lambda: queue.nudge(item_id, -1),
                 "move_down": lambda: queue.nudge(item_id, +1),
-                "run_next":  lambda: queue.move_to_front(item_id),
-                "remove":    lambda: queue.remove(item_id),
+                "run_next": lambda: queue.move_to_front(item_id),
+                "remove": lambda: queue.remove(item_id),
             }.get(action)
             if call is None:
                 logging.warning(f"Unknown queue action from the timeline: {action}")
@@ -2418,10 +2454,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if not result.ok:
             return f"{label} is no longer in the queue."
         return {
-            "move_up":   f"Moved {label} up.",
+            "move_up": f"Moved {label} up.",
             "move_down": f"Moved {label} down.",
-            "run_next":  f"{label} will run next.",
-            "remove":    f"Removed {label} from the queue.",
+            "run_next": f"{label} will run next.",
+            "remove": f"Removed {label} from the queue.",
         }.get(action, "")
 
     def _show_queue_message(self, message: str) -> None:
@@ -2725,12 +2761,16 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.fm_overview_tab.availability_changed.connect(
             self._on_fm_overview_availability
         )
-        self.fm_overview_tab.lamella_selected.connect(self._on_fm_overview_lamella_selected)
+        self.fm_overview_tab.lamella_selected.connect(
+            self._on_fm_overview_lamella_selected
+        )
         self.fm_overview_tab.acquiring_changed.connect(self._apply_overview_locks)
 
         self.tab_widget.insertTab(
-            2, self.fm_overview_tab,
-            fibsem_icon("mdi:microscope", color=GRAY_ICON_COLOR), "FM Overview",
+            2,
+            self.fm_overview_tab,
+            fibsem_icon("mdi:microscope", color=GRAY_ICON_COLOR),
+            "FM Overview",
         )
         self.tab_widget.setTabEnabled(
             self.tab_widget.indexOf(self.fm_overview_tab), False
@@ -2761,7 +2801,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.overview_canvas_tab.acquiring_changed.connect(self._apply_overview_locks)
 
         self.tab_widget.insertTab(
-            3, self.overview_canvas_tab,
+            3,
+            self.overview_canvas_tab,
             fibsem_icon("mdi:map-search-outline", color=GRAY_ICON_COLOR),
             "Overview (Canvas)",
         )
@@ -2937,9 +2978,14 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             try:
                 self.lamella_widget.flush_pending_save()
             except Exception as e:
-                logging.warning(f"Could not flush a pending experiment save on close: {e}")
+                logging.warning(
+                    f"Could not flush a pending experiment save on close: {e}"
+                )
         # persist the FM working state (channels / camera transform / objective)
-        if self.autolamella_ui is not None and self.autolamella_ui.fm_control_widget is not None:
+        if (
+            self.autolamella_ui is not None
+            and self.autolamella_ui.fm_control_widget is not None
+        ):
             try:
                 self.autolamella_ui.fm_control_widget.save_fm_configuration()
             except Exception as e:
@@ -2995,13 +3041,13 @@ def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         "--quickstart",
         action="store_true",
         help="Connect to the microscope with the default configuration as soon as the "
-             "window is up, instead of waiting for the Connection tab.",
+        "window is up, instead of waiting for the Connection tab.",
     )
     parser.add_argument(
         "--quickload",
         action="store_true",
         help="Connect as --quickstart does, then reopen the most recent experiment. "
-             "Implies --quickstart -- the experiment tabs are built at connection time.",
+        "Implies --quickstart -- the experiment tabs are built at connection time.",
     )
     return parser.parse_args(argv)
 

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -254,7 +254,9 @@ SECONDARY_BUTTON_STYLESHEET = f"""
 # or not a stylesheet draws its own. Padding chosen to clear the chevron therefore
 # pays for that gutter twice, which put 30px between the label and the arrow against
 # 12px on the other side. 16 leaves 8 before the chevron and 8 after it.
-MENU_BUTTON_STYLESHEET = SECONDARY_BUTTON_STYLESHEET + """
+MENU_BUTTON_STYLESHEET = (
+    SECONDARY_BUTTON_STYLESHEET
+    + """
     QPushButton {
         text-align: left;
         padding-right: 16px;
@@ -268,6 +270,7 @@ MENU_BUTTON_STYLESHEET = SECONDARY_BUTTON_STYLESHEET + """
         right: 8px;
     }
 """.replace("__ICONS_DIR__", _ICONS_DIR)
+)
 
 MESSAGE_BOX_STYLESHEET = f"""
     QMessageBox {{

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -248,10 +248,16 @@ SECONDARY_BUTTON_STYLESHEET = f"""
 # The contents are left-aligned because the chevron is pinned to the right edge:
 # centred, a button wider than its label splits the slack evenly and pushes the
 # label away from the left padding, which reads as a gap rather than as balance.
+#
+# padding-right is 16 rather than the chevron's own 18 because Qt has *already*
+# reserved room for a menu indicator inside the contents rect -- about 10px, whether
+# or not a stylesheet draws its own. Padding chosen to clear the chevron therefore
+# pays for that gutter twice, which put 30px between the label and the arrow against
+# 12px on the other side. 16 leaves 8 before the chevron and 8 after it.
 MENU_BUTTON_STYLESHEET = SECONDARY_BUTTON_STYLESHEET + """
     QPushButton {
         text-align: left;
-        padding-right: 20px;
+        padding-right: 16px;
     }
     QPushButton::menu-indicator {
         image: url("__ICONS_DIR__/chevron_down.svg");

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -241,6 +241,23 @@ SECONDARY_BUTTON_STYLESHEET = f"""
     }}
 """
 
+# A QPushButton that opens a menu. Qt stops drawing the native menu arrow as soon
+# as the button carries a stylesheet, so the chevron has to be put back by hand --
+# without it the control looks like a plain button and nothing says it opens.
+MENU_BUTTON_STYLESHEET = SECONDARY_BUTTON_STYLESHEET + """
+    QPushButton {
+        padding-right: 24px;
+    }
+    QPushButton::menu-indicator {
+        image: url("__ICONS_DIR__/chevron_down.svg");
+        subcontrol-origin: padding;
+        subcontrol-position: center right;
+        width: 10px;
+        height: 10px;
+        right: 8px;
+    }
+""".replace("__ICONS_DIR__", _ICONS_DIR)
+
 MESSAGE_BOX_STYLESHEET = f"""
     QMessageBox {{
         background-color: {SURFACE_COLOR};

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -244,9 +244,14 @@ SECONDARY_BUTTON_STYLESHEET = f"""
 # A QPushButton that opens a menu. Qt stops drawing the native menu arrow as soon
 # as the button carries a stylesheet, so the chevron has to be put back by hand --
 # without it the control looks like a plain button and nothing says it opens.
+#
+# The contents are left-aligned because the chevron is pinned to the right edge:
+# centred, a button wider than its label splits the slack evenly and pushes the
+# label away from the left padding, which reads as a gap rather than as balance.
 MENU_BUTTON_STYLESHEET = SECONDARY_BUTTON_STYLESHEET + """
     QPushButton {
-        padding-right: 24px;
+        text-align: left;
+        padding-right: 20px;
     }
     QPushButton::menu-indicator {
         image: url("__ICONS_DIR__/chevron_down.svg");

--- a/tests/ui/test_experiment_header_button.py
+++ b/tests/ui/test_experiment_header_button.py
@@ -35,9 +35,11 @@ from fibsem.applications.autolamella.structures import (  # noqa: E402
     Lamella,
 )
 from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (  # noqa: E402
+    BUTTON_ICON_SIZE,
     EXPERIMENT_MENU_MAX_WIDTH,
     AutoLamellaSingleWindowUI,
     experiment_tooltip,
+    set_button_icon,
 )
 
 
@@ -229,3 +231,24 @@ class TestExperimentTooltip:
 
         assert "a&lt;b&gt;&amp;c" in tip
         assert "<b>&c" not in tip
+
+
+def test_button_icon_size_grows_with_its_padding(qapp):
+    """The icon box has to widen by the gap, or the glyph shrinks instead.
+
+    Qt scales a button's icon into `iconSize`, so padding the pixmap without
+    widening that box squeezes the drawing back down rather than pushing the text
+    across -- a failure that looks like a slightly small icon and nothing else.
+    """
+    button = QPushButton("Experiment")
+
+    set_button_icon(button, "mdi:flask-outline", gap=5)
+
+    assert button.iconSize().width() == BUTTON_ICON_SIZE + 5
+    assert button.iconSize().height() == BUTTON_ICON_SIZE
+    # The glyph itself keeps its square, with the gap as transparent padding.
+    drawn = button.icon().pixmap(button.iconSize())
+    ratio = drawn.devicePixelRatio() or 1.0
+    assert round(drawn.width() / ratio) == BUTTON_ICON_SIZE + 5
+    assert round(drawn.height() / ratio) == BUTTON_ICON_SIZE
+    button.deleteLater()

--- a/tests/ui/test_experiment_header_button.py
+++ b/tests/ui/test_experiment_header_button.py
@@ -12,6 +12,7 @@ borrowed onto a host carrying the three real buttons, the same way
 `test_status_bar_tile_outcome.py` does. The buttons are the real ones and so is the
 Experiment; only the widget that owns them is stood in for.
 """
+
 from __future__ import annotations
 
 import ast
@@ -150,9 +151,11 @@ def test_menu_reuses_the_file_menu_actions():
     place would silently miss the other. The constructor cannot be run here, so the
     source is read for which actions it adds.
     """
-    tree = ast.parse(textwrap.dedent(inspect.getsource(
-        AutoLamellaSingleWindowUI.create_notification_button
-    )))
+    tree = ast.parse(
+        textwrap.dedent(
+            inspect.getsource(AutoLamellaSingleWindowUI.create_notification_button)
+        )
+    )
     added = {
         node.args[0].attr
         for node in ast.walk(tree)

--- a/tests/ui/test_experiment_header_button.py
+++ b/tests/ui/test_experiment_header_button.py
@@ -35,9 +35,11 @@ from fibsem.applications.autolamella.structures import (  # noqa: E402
     Lamella,
 )
 from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (  # noqa: E402
+    BUTTON_ICON_SIZE,
     EXPERIMENT_MENU_MAX_WIDTH,
     AutoLamellaSingleWindowUI,
     experiment_tooltip,
+    set_button_icon,
 )
 
 
@@ -230,3 +232,23 @@ class TestExperimentTooltip:
         assert "a&lt;b&gt;&amp;c" in tip
         assert "<b>&c" not in tip
 
+
+def test_button_icon_size_grows_with_its_padding(qapp):
+    """The icon box has to widen by the gap, or the glyph shrinks instead.
+
+    Qt scales a button's icon into `iconSize`, so padding the pixmap without
+    widening that box squeezes the drawing back down rather than pushing the text
+    across -- a failure that looks like a slightly small icon and nothing else.
+    """
+    button = QPushButton("Experiment")
+
+    set_button_icon(button, "mdi:flask-outline", gap=5)
+
+    assert button.iconSize().width() == BUTTON_ICON_SIZE + 5
+    assert button.iconSize().height() == BUTTON_ICON_SIZE
+    # The glyph itself keeps its square, with the gap as transparent padding.
+    drawn = button.icon().pixmap(button.iconSize())
+    ratio = drawn.devicePixelRatio() or 1.0
+    assert round(drawn.width() / ratio) == BUTTON_ICON_SIZE + 5
+    assert round(drawn.height() / ratio) == BUTTON_ICON_SIZE
+    button.deleteLater()

--- a/tests/ui/test_experiment_header_button.py
+++ b/tests/ui/test_experiment_header_button.py
@@ -35,11 +35,9 @@ from fibsem.applications.autolamella.structures import (  # noqa: E402
     Lamella,
 )
 from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (  # noqa: E402
-    BUTTON_ICON_SIZE,
     EXPERIMENT_MENU_MAX_WIDTH,
     AutoLamellaSingleWindowUI,
     experiment_tooltip,
-    set_button_icon,
 )
 
 
@@ -232,23 +230,3 @@ class TestExperimentTooltip:
         assert "a&lt;b&gt;&amp;c" in tip
         assert "<b>&c" not in tip
 
-
-def test_button_icon_size_grows_with_its_padding(qapp):
-    """The icon box has to widen by the gap, or the glyph shrinks instead.
-
-    Qt scales a button's icon into `iconSize`, so padding the pixmap without
-    widening that box squeezes the drawing back down rather than pushing the text
-    across -- a failure that looks like a slightly small icon and nothing else.
-    """
-    button = QPushButton("Experiment")
-
-    set_button_icon(button, "mdi:flask-outline", gap=5)
-
-    assert button.iconSize().width() == BUTTON_ICON_SIZE + 5
-    assert button.iconSize().height() == BUTTON_ICON_SIZE
-    # The glyph itself keeps its square, with the gap as transparent padding.
-    drawn = button.icon().pixmap(button.iconSize())
-    ratio = drawn.devicePixelRatio() or 1.0
-    assert round(drawn.width() / ratio) == BUTTON_ICON_SIZE + 5
-    assert round(drawn.height() / ratio) == BUTTON_ICON_SIZE
-    button.deleteLater()

--- a/tests/ui/test_experiment_header_button.py
+++ b/tests/ui/test_experiment_header_button.py
@@ -1,0 +1,231 @@
+"""The tab-corner header swaps its create/load buttons for the experiment name.
+
+Before an experiment exists, "Create Experiment" and "Load Experiment" are the only
+thing to do and are shown in the primary colour. Once one is loaded they used to stay
+put, greyed out, next to a label repeating the name -- three controls and roughly a
+third of the tab bar spent on actions the File menu already carries. Now the name
+itself becomes the button, and it holds those actions in a menu.
+
+The window cannot be constructed offscreen -- it builds a napari viewer and a vispy
+quad view, neither of which survives `QT_QPA_PLATFORM=offscreen` -- so its handler is
+borrowed onto a host carrying the three real buttons, the same way
+`test_status_bar_tile_outcome.py` does. The buttons are the real ones and so is the
+Experiment; only the widget that owns them is stood in for.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import os
+import textwrap
+from datetime import datetime
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QPushButton  # noqa: E402
+
+from fibsem.applications.autolamella.structures import (  # noqa: E402
+    AutoLamellaTaskProtocol,
+    DefectType,
+    Experiment,
+    Lamella,
+)
+from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (  # noqa: E402
+    EXPERIMENT_MENU_MAX_WIDTH,
+    AutoLamellaSingleWindowUI,
+    experiment_tooltip,
+)
+
+
+class _UIStub:
+    """Stands in for AutoLamellaUI: the header reads exactly these two attributes."""
+
+    def __init__(self, experiment=None, microscope=None):
+        self.experiment = experiment
+        self.microscope = microscope
+
+
+class _HeaderHost:
+    _update_experiment_header = AutoLamellaSingleWindowUI._update_experiment_header
+
+    def __init__(self):
+        self.btn_create_experiment = QPushButton("Create Experiment")
+        self.btn_load_experiment = QPushButton("Load Experiment")
+        self.btn_experiment_menu = QPushButton()
+        self.autolamella_ui = _UIStub()
+
+    def close(self):
+        for btn in (
+            self.btn_create_experiment,
+            self.btn_load_experiment,
+            self.btn_experiment_menu,
+        ):
+            btn.deleteLater()
+
+
+@pytest.fixture
+def host(qapp):
+    host = _HeaderHost()
+    yield host
+    host.close()
+
+
+@pytest.fixture
+def experiment(tmp_path):
+    return Experiment(path=str(tmp_path), name="AutoLamella-2026-08-21-headers")
+
+
+def test_buttons_shown_and_disabled_before_connecting(host):
+    host._update_experiment_header()
+
+    assert not host.btn_create_experiment.isHidden()
+    assert not host.btn_load_experiment.isHidden()
+    assert not host.btn_create_experiment.isEnabled()
+    assert not host.btn_load_experiment.isEnabled()
+    # Nothing to name yet, so the name button stays out of the way.
+    assert host.btn_experiment_menu.isHidden()
+
+
+def test_buttons_enabled_once_connected(host):
+    host.autolamella_ui.microscope = object()
+
+    host._update_experiment_header()
+
+    assert host.btn_create_experiment.isEnabled()
+    assert host.btn_load_experiment.isEnabled()
+    assert host.btn_experiment_menu.isHidden()
+
+
+def test_name_button_replaces_the_pair_once_loaded(host, experiment):
+    host.autolamella_ui.microscope = object()
+    host.autolamella_ui.experiment = experiment
+
+    host._update_experiment_header()
+
+    assert host.btn_create_experiment.isHidden()
+    assert host.btn_load_experiment.isHidden()
+    assert not host.btn_experiment_menu.isHidden()
+    assert experiment.name in host.btn_experiment_menu.text()
+    assert experiment.name in host.btn_experiment_menu.toolTip()
+
+
+def test_default_length_name_is_not_elided(host, tmp_path):
+    """A date-stamped default name has to fit whole -- naming the experiment is the
+    button's entire job, and an allowance guessed for the icon, padding and chevron
+    once cut one short."""
+    name = "AutoLamella-2026-08-21-11-04"
+    host.autolamella_ui.microscope = object()
+    host.autolamella_ui.experiment = Experiment(path=str(tmp_path), name=name)
+
+    host._update_experiment_header()
+
+    assert host.btn_experiment_menu.text() == name
+
+
+def test_long_name_is_elided_not_stretched(host, tmp_path):
+    long_name = "AutoLamella-2026-08-21-" + "grid" * 20
+    host.autolamella_ui.microscope = object()
+    host.autolamella_ui.experiment = Experiment(path=str(tmp_path), name=long_name)
+
+    host._update_experiment_header()
+
+    text = host.btn_experiment_menu.text()
+    assert text != long_name
+    assert "…" in text
+    # The full name is still reachable, just not at the cost of the tab bar.
+    assert long_name in host.btn_experiment_menu.toolTip()
+    assert host.btn_experiment_menu.sizeHint().width() <= EXPERIMENT_MENU_MAX_WIDTH
+
+
+def test_menu_reuses_the_file_menu_actions():
+    """The header menu must add the File menu's own QActions, not rebuild them.
+
+    Two separate sets would drift: a shortcut, a rename or a new guard added in one
+    place would silently miss the other. The constructor cannot be run here, so the
+    source is read for which actions it adds.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(
+        AutoLamellaSingleWindowUI.create_notification_button
+    )))
+    added = {
+        node.args[0].attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "addAction"
+        and node.args
+        and isinstance(node.args[0], ast.Attribute)
+    }
+    assert added == {
+        "action_new_experiment",
+        "action_load_experiment",
+        "action_open_experiment_directory",
+    }
+
+
+class TestExperimentTooltip:
+    """What the hover card over the experiment name says.
+
+    Rows come off the experiment, and a row whose fact is missing is dropped rather
+    than rendered blank: a protocol is attached after construction, and `created_at`
+    is absent from experiments written before it was recorded.
+    """
+
+    def test_names_dates_counts_and_path(self, tmp_path):
+        experiment = Experiment(path=str(tmp_path), name="AutoLamella-2026-08-21-11-04")
+        experiment.created_at = datetime(2026, 8, 21, 11, 4).timestamp()
+        experiment.task_protocol = AutoLamellaTaskProtocol(name="Waffle Method")
+        for i in range(3):
+            experiment.positions.append(
+                Lamella(petname=f"{i:02d}-lam", path=str(tmp_path / str(i)), number=i)
+            )
+
+        tip = experiment_tooltip(experiment)
+
+        assert "AutoLamella-2026-08-21-11-04" in tip
+        assert "21 Aug 2026, 11:04" in tip
+        assert ">3<" in tip
+        assert "Waffle Method" in tip
+        assert str(experiment.path) in tip
+
+    def test_defective_count_only_when_there_is_one(self, tmp_path):
+        experiment = Experiment(path=str(tmp_path), name="defects")
+        for i in range(2):
+            experiment.positions.append(
+                Lamella(petname=f"{i:02d}-lam", path=str(tmp_path / str(i)), number=i)
+            )
+        # Matched with the closing tag: pytest's own tmp_path is named after this
+        # test, and the path is one of the rows.
+        assert "defective</span>" not in experiment_tooltip(experiment)
+
+        experiment.positions[0].defect.state = DefectType.FAILURE
+
+        tip = experiment_tooltip(experiment)
+        # "defective", not "failed": is_failure is a human's judgement about the
+        # lamella, not a record of a task that failed.
+        assert "1 defective</span>" in tip
+        assert "failed" not in tip
+
+    def test_missing_facts_drop_out(self, tmp_path):
+        experiment = Experiment(path=str(tmp_path), name="fresh")
+        experiment.task_protocol = None
+        experiment.created_at = None
+
+        tip = experiment_tooltip(experiment)
+
+        assert "Protocol" not in tip
+        assert "Created" not in tip
+        assert "Lamella" in tip
+
+    def test_name_is_escaped(self, tmp_path):
+        """The name is user-supplied and lands in a rich-text tooltip."""
+        experiment = Experiment(path=str(tmp_path), name="a<b>&c")
+
+        tip = experiment_tooltip(experiment)
+
+        assert "a&lt;b&gt;&amp;c" in tip
+        assert "<b>&c" not in tip


### PR DESCRIPTION
Once an experiment is loaded, the tab corner keeps the two buttons that put it there — greyed out, permanently parked next to a label repeating the name. Roughly 600px of tab bar, most of it spent restating what happened and offering two actions the File menu already carries.

## What the header does now

The name becomes the button, and it opens a menu holding Create / Load / Open experiment directory. The pair disappears.

Before an experiment exists nothing changes: those two buttons are the only thing to do, so they stay primary-coloured and take the room. `_update_experiment_header` is the single place that decides which state is showing, replacing the two `setEnabled` calls in `_on_microscope_connected` and the label-text-plus-grey-stylesheet block in `_on_experiment_update`. Enablement is still keyed to the microscope connection, as before.

The loaded-state corner widget measures **~320px against ~600px**.

The menu adds the File menu's **own `QAction` objects** rather than rebuilding them, so a shortcut, a rename or a new guard added in one place cannot miss the other. A test reads the source for which actions get added, since the window itself cannot be constructed offscreen.

Those three actions gain icons — which means they show icons in the File menu too, where the other five entries have none. Each one opts in explicitly via `set_menu_icon`, because Qt turns menu icons off wholesale on macOS (`AA_DontShowIconsInMenus`) and an icon set the usual way would render on Windows and Linux and silently vanish here.

`MENU_BUTTON_STYLESHEET` is secondary plus a `::menu-indicator` rule pointing at the existing `chevron_down.svg`. Needed because a stylesheet on a `QPushButton` suppresses the native menu arrow, and a menu button with no chevron looks exactly like the unclickable control this change is removing.

## What the hover says

`experiment_tooltip` — created date, lamella count, protocol, then the directory. A module-level function rather than a method, so it is testable without a window.

The count of lamellae marked defective appears only when there is one, and says **defective, not failed**: `at_failure()` filters on `Lamella.is_failure`, which its own docstring pins as a human's judgement about the lamella rather than a record of a task that failed. Calling it "failed" here would read as a workflow outcome.

Rows whose fact is missing drop out rather than render blank — `task_protocol` is `None` until set after construction, and `created_at` is absent from experiments written before it was recorded. Both are genuinely unknown, not empty. The name is HTML-escaped: it is user-supplied and lands in rich text.

Rich text rather than plain, because that is what lines the rows up and keeps the directory on a line of its own instead of letting it set the width of everything above it. Renders at 409 × 94px.

## Two things only measurement caught

Both were green-looking code that reclaimed nothing.

| symptom | cause | fix |
|---|---|---|
| corner widget no narrower than before | a `QPushButton`'s default policy lets it grow to fill the layout, so the name button stretched straight back out to its maximum width | `QSizePolicy.Maximum` — hug the text |
| a 30-character name elided when it would have fitted | eliding against a guessed allowance for the icon, padding and chevron | measure the overflow off the button's own `sizeHint` and trim only the excess |

The second has a regression test of its own: a date-stamped default name has to survive whole, since naming the experiment is the button's entire job.

## Tests

New `tests/ui/test_experiment_header_button.py` — 10, five of them on the tooltip. The window builds a napari viewer and a vispy quad view and cannot be constructed under the offscreen platform, so the handler is borrowed onto a host carrying the three real buttons, the same way `test_status_bar_tile_outcome.py` does. The buttons and the `Experiment` are real; only the widget owning them is stood in for.

Full `tests/ui`: 2050 passed, 1 skipped. `ruff check fibsem tests` clean.

Verified by rendering the real corner widget and the real tooltip offscreen and looking at the pixels — the chevron, the icons and the menu all draw.
