### PR TITLE
[fix] Leave the vendored pyto tree to upstream

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -102,7 +102,12 @@ jobs:
         fi
         sed 's/^/  /' "$changed"
         # NUL-separated: a path with a space would otherwise split into two.
-        if ! tr '\n' '\0' < "$changed" | xargs -0 ruff format --check --; then
+        # --force-exclude is required, not optional: ruff ignores `exclude` for
+        # paths named explicitly on the command line, and this step names every
+        # path explicitly. Without it, editing a vendored or otherwise excluded
+        # file would still be told to reformat it.
+        if ! tr '\n' '\0' < "$changed" \
+             | xargs -0 ruff format --check --force-exclude --; then
           echo
           echo "To fix, from the repo root:"
           echo "  ruff format \$(git diff --name-only --diff-filter=d \$(git merge-base origin/main HEAD) HEAD -- '*.py')"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,12 @@ filterwarnings = [
 # infers py38, so the two can never drift apart.
 extend-exclude = [
     "external",
+    # Vendored upstream: pyto, by Vladan Lucic (MPI of Biochemistry). Linting or
+    # formatting it would make it undiffable against upstream, and its findings
+    # are not ours to fix -- points.py:59 has a live `unitx`/`units` typo that
+    # belongs upstream, not in a local patch. Excluding it drops 14 F401, 17
+    # E701, 11 F841 and 6 F821 that no one here was ever going to action.
+    "fibsem/correlation/pyto",
     # Ruff rewrites notebooks in place, re-sorting imports inside the cell JSON.
     # Whether the notebooks are in scope is a separate question to this config.
     "**/*.ipynb",


### PR DESCRIPTION
`fibsem/correlation/pyto` is vendored from [pyto](https://github.com/vladanl/Pyto) by Vladan Lucic (MPI of Biochemistry) — the author line is still at the top of every file. Linting and formatting it makes it undiffable against upstream, and its findings are not ours to action.

Two files changed. Came out of starting on the `F821` work, where four of the six findings turned out to be in this tree.

## What it drops

| rule | before | after |
|---|---|---|
| `F401` | 391 | 377 |
| `E701` | 19 | **2** |
| `F841` | 61 | 50 |
| `F821` | 24 | 18 |

About 59 parked findings that nobody here was ever going to fix. `E701` in particular goes from a rule with 19 findings to one with 2 — almost all of it was upstream's style.

`points.py:59` has a genuine bug in it (`elif unitx == 'rad':`, a typo for `units`, which raises `NameError` on that branch). The right home for that fix is upstream — a local patch gets silently reverted by the next vendor drop. Worth reporting there; not worth carrying here.

The live code that *uses* pyto — `fibsem/correlation/correlation_v2.py` — is still linted. Only the vendored tree is skipped.

## `--force-exclude` is required, not cosmetic

This is the part worth reviewing. Ruff **ignores `exclude` for paths named explicitly on the command line**, and the format-on-touch step added in 1940869a names every path explicitly. So without this flag, editing a vendored file would still be told to reformat the whole thing, exclusion or not:

```
$ ruff format --check fibsem/correlation/pyto/common.py
1 file would be reformatted

$ ruff format --check --force-exclude fibsem/correlation/pyto/common.py
warning: No Python files found under the given path(s)
```

That applies to any future exclusion too, not just this one — a diff-scoped check and a config `exclude` do not compose without it.

## Verification

Ran the exact script out of the workflow:

| case | result |
|---|---|
| no Python changed (this PR) | passes, reports `0` |
| a PR that edits a **vendored** file | **passes** — correctly exempt |

Plus `ruff check .` clean and the full suite at 5,743 passed, 24 skipped.
