### PR TITLE
[refactor] One inverse projection, reached three ways (FIB-500)

### DIFF
--- a/fibsem/imaging/tiling/reprojection.py
+++ b/fibsem/imaging/tiling/reprojection.py
@@ -25,7 +25,9 @@ from fibsem.structures import (
 from fibsem.transformations import inverse_view_corrected_dy
 
 
-def calculate_reprojected_stage_position(image: FibsemImage, pos: FibsemStagePosition) -> Point:
+def calculate_reprojected_stage_position(
+    image: FibsemImage, pos: FibsemStagePosition
+) -> Point:
     """Calculate the reprojected stage position on an image.
     Args:
         image: The image.
@@ -38,8 +40,8 @@ def calculate_reprojected_stage_position(image: FibsemImage, pos: FibsemStagePos
 
     # projection of the positions onto the image
     dx = delta.x
-    dy = np.sqrt(delta.y**2 + delta.z**2) # TODO: correct for perspective here
-    dy = dy if (delta.y<0) else -dy
+    dy = np.sqrt(delta.y**2 + delta.z**2)  # TODO: correct for perspective here
+    dy = dy if (delta.y < 0) else -dy
 
     pt_delta = Point(dx, dy)
     px_delta = pt_delta._to_pixels(image.metadata.pixel_size.x)
@@ -49,16 +51,18 @@ def calculate_reprojected_stage_position(image: FibsemImage, pos: FibsemStagePos
         scan_rotation = image.metadata.microscope_state.electron_beam.scan_rotation
     if beam_type is BeamType.ION:
         scan_rotation = image.metadata.microscope_state.ion_beam.scan_rotation
-    
+
     if np.isclose(scan_rotation, np.pi):
         px_delta.x *= -1.0
         px_delta.y *= -1.0
 
     # account for compustage tilt, when mounted upside down
-    if np.isclose(image.metadata.stage_position.t, np.radians(-180), atol=np.radians(5)):
+    if np.isclose(
+        image.metadata.stage_position.t, np.radians(-180), atol=np.radians(5)
+    ):
         px_delta.y *= -1.0
 
-    image_centre = Point(x=image.data.shape[1]/2, y=image.data.shape[0]/2)
+    image_centre = Point(x=image.data.shape[1] / 2, y=image.data.shape[0] / 2)
     point = image_centre + px_delta
 
     # NB: there is a small reprojection error that grows with distance from centre
@@ -66,10 +70,10 @@ def calculate_reprojected_stage_position(image: FibsemImage, pos: FibsemStagePos
 
     return point
 
+
 def reproject_stage_positions_onto_image(
-        image:FibsemImage, 
-        positions: List[FibsemStagePosition], 
-        bound: bool=False) -> List[Point]:
+    image: FibsemImage, positions: List[FibsemStagePosition], bound: bool = False
+) -> List[Point]:
     """Reproject stage positions onto an image. Assumes image is flat to beam.
     Args:
         image: The image.
@@ -80,8 +84,6 @@ def reproject_stage_positions_onto_image(
     # reprojection of positions onto image coordinates
     points = []
     for pos in positions:
-
-
         # hotfix (pat): demo returns None positions #240
         if image.metadata.microscope_state.stage_position.x is None:
             image.metadata.microscope_state.stage_position.x = 0
@@ -92,27 +94,30 @@ def reproject_stage_positions_onto_image(
         if image.metadata.microscope_state.stage_position.r is None:
             image.metadata.microscope_state.stage_position.r = 0
         if image.metadata.microscope_state.stage_position.t is None:
-            image.metadata.microscope_state.stage_position.t = 0      
-                
+            image.metadata.microscope_state.stage_position.t = 0
+
         # automate logic for transforming positions
-        # assume only two valid positions are when stage is flat to either beam...  
+        # assume only two valid positions are when stage is flat to either beam...
         # r needs to be 180 degrees different
         # currently only one way: Flat to Ion -> Flat to Electron
         dr = abs(np.rad2deg(image.metadata.microscope_state.stage_position.r - pos.r))
-        if np.isclose(dr, 180, atol=2):     
+        if np.isclose(dr, 180, atol=2):
             pos = _transform_position(pos)
 
         pt = calculate_reprojected_stage_position(image, pos)
         pt.name = pos.name
-        
+
         if bound and not is_inside_image_bounds([pt.y, pt.x], image.data.shape):
             continue
-        
+
         points.append(pt)
-    
+
     return points
 
-def calculate_reprojected_stage_position2(image: FibsemImage, pos: FibsemStagePosition) -> Point:
+
+def calculate_reprojected_stage_position2(
+    image: FibsemImage, pos: FibsemStagePosition
+) -> Point:
     """Calculate the reprojected stage position on an image.
     Args:
         image: The image.
@@ -121,28 +126,37 @@ def calculate_reprojected_stage_position2(image: FibsemImage, pos: FibsemStagePo
         The reprojected stage position on the image."""
 
     if image.metadata is None or image.metadata.microscope_state is None:
-        raise ValueError("Image metadata or microscope state is not set. Cannot reproject stage position.")
+        raise ValueError(
+            "Image metadata or microscope state is not set. Cannot reproject stage position."
+        )
 
     if image.metadata.microscope_state.stage_position is None:
-        raise ValueError("Image metadata does not contain a valid stage position. Cannot reproject stage position.")
-
+        raise ValueError(
+            "Image metadata does not contain a valid stage position. Cannot reproject stage position."
+        )
 
     beam_type = image.metadata.image_settings.beam_type
-    base_stage_position = image.metadata.microscope_state.stage_position 
+    base_stage_position = image.metadata.microscope_state.stage_position
     pixel_size = image.metadata.pixel_size.x
 
     scan_rotation = None
     if beam_type is BeamType.ELECTRON:
         if image.metadata.microscope_state.electron_beam is None:
-            raise ValueError("Image metadata does not contain a valid electron beam state. Cannot reproject stage position.")
+            raise ValueError(
+                "Image metadata does not contain a valid electron beam state. Cannot reproject stage position."
+            )
         scan_rotation = image.metadata.microscope_state.electron_beam.scan_rotation
     if beam_type is BeamType.ION:
         if image.metadata.microscope_state.ion_beam is None:
-            raise ValueError("Image metadata does not contain a valid ion beam state. Cannot reproject stage position.")
+            raise ValueError(
+                "Image metadata does not contain a valid ion beam state. Cannot reproject stage position."
+            )
         scan_rotation = image.metadata.microscope_state.ion_beam.scan_rotation
 
     if scan_rotation is None:
-        raise ValueError("Image metadata does not contain a valid scan rotation. Cannot reproject stage position.")
+        raise ValueError(
+            "Image metadata does not contain a valid scan rotation. Cannot reproject stage position."
+        )
 
     # difference between current position and image position
     delta = pos - base_stage_position
@@ -150,7 +164,9 @@ def calculate_reprojected_stage_position2(image: FibsemImage, pos: FibsemStagePo
     # projection of the positions onto the image
     dx = delta.x
     if dx is None:
-        raise ValueError("Stage position x coordinate is None. Cannot reproject stage position.")
+        raise ValueError(
+            "Stage position x coordinate is None. Cannot reproject stage position."
+        )
 
     # Tescan stage x is inverted wrt image coordinates (see TescanMicroscope.stable_move);
     # the y inversion is handled inside _inverse_y_corrected_stage_movement_tescan. Match
@@ -162,7 +178,9 @@ def calculate_reprojected_stage_position2(image: FibsemImage, pos: FibsemStagePo
         dx = -dx
 
     # dy = microscope._inverse_y_corrected_stage_movement(dy=delta.y, dz=delta.z, beam_type=beam_type) # type: ignore
-    dy = _inverse_y_corrected_stage_movement(image, dy=delta.y, dz=delta.z, beam_type=beam_type) # type: ignore
+    dy = _inverse_y_corrected_stage_movement(
+        image, dy=delta.y, dz=delta.z, beam_type=beam_type
+    )  # type: ignore
 
     pt_delta = Point(dx, -dy)
     px_delta = pt_delta._to_pixels(pixel_size)
@@ -171,15 +189,15 @@ def calculate_reprojected_stage_position2(image: FibsemImage, pos: FibsemStagePo
         px_delta.x *= -1.0
         px_delta.y *= -1.0
 
-    image_centre = Point(x=image.data.shape[1]/2, y=image.data.shape[0]/2)
+    image_centre = Point(x=image.data.shape[1] / 2, y=image.data.shape[0] / 2)
     point = image_centre + px_delta
 
     return point
 
+
 def reproject_stage_positions_onto_image2(
-        image:FibsemImage, 
-        positions: List[FibsemStagePosition], 
-        bound: bool=False) -> List[Point]:
+    image: FibsemImage, positions: List[FibsemStagePosition], bound: bool = False
+) -> List[Point]:
     """Reproject stage positions onto an image. Assumes image is flat to beam.
     Args:
         image: The image.
@@ -190,18 +208,27 @@ def reproject_stage_positions_onto_image2(
     # reprojection of positions onto image coordinates
     points = []
     for pos in positions:
-
         # compucentric rotation correction
         if image.metadata is None or image.metadata.microscope_state is None:
-            raise ValueError("Image metadata or microscope state is not set. Cannot reproject stage position.")
+            raise ValueError(
+                "Image metadata or microscope state is not set. Cannot reproject stage position."
+            )
         if image.metadata.microscope_state.stage_position is None:
-            raise ValueError("Image metadata does not contain a valid stage position. Cannot reproject stage position.")
+            raise ValueError(
+                "Image metadata does not contain a valid stage position. Cannot reproject stage position."
+            )
         if image.metadata.microscope_state.stage_position is None:
-            raise ValueError("Image metadata does not contain a valid stage position. Cannot reproject stage position.")
+            raise ValueError(
+                "Image metadata does not contain a valid stage position. Cannot reproject stage position."
+            )
         if image.metadata.microscope_state.stage_position.r is None:
-            raise ValueError("Image metadata does not contain a valid stage position r coordinate. Cannot reproject stage position.")
+            raise ValueError(
+                "Image metadata does not contain a valid stage position r coordinate. Cannot reproject stage position."
+            )
         if pos.r is None:
-            raise ValueError("Stage position r coordinate is None. Cannot reproject stage position.")
+            raise ValueError(
+                "Stage position r coordinate is None. Cannot reproject stage position."
+            )
         # automate logic for transforming positions
         dr = abs(np.rad2deg(image.metadata.microscope_state.stage_position.r - pos.r))
         if np.isclose(dr, 180, atol=2):
@@ -217,24 +244,32 @@ def reproject_stage_positions_onto_image2(
 
     return points
 
-X_OFFSET = -0.0005127403888932854 
+
+X_OFFSET = -0.0005127403888932854
 Y_OFFSET = 0.0007937916666666666
+
 
 def _to_specimen_coordinate_system(pos: FibsemStagePosition):
     """Converts a position in the raw coordinate system to the specimen coordinate system"""
 
-    specimen_offset = FibsemStagePosition(x=X_OFFSET, y=Y_OFFSET, z=0.0, r=0, t=0, coordinate_system="RAW")
+    specimen_offset = FibsemStagePosition(
+        x=X_OFFSET, y=Y_OFFSET, z=0.0, r=0, t=0, coordinate_system="RAW"
+    )
     specimen_position = pos - specimen_offset
 
     return specimen_position
 
+
 def _to_raw_coordinate_system(pos: FibsemStagePosition):
     """Converts a position in the raw coordinate system to the specimen coordinate system"""
 
-    specimen_offset = FibsemStagePosition(x=X_OFFSET, y=Y_OFFSET, z=0.0, r=0, t=0, coordinate_system="RAW")
+    specimen_offset = FibsemStagePosition(
+        x=X_OFFSET, y=Y_OFFSET, z=0.0, r=0, t=0, coordinate_system="RAW"
+    )
     raw_position = pos + specimen_offset
 
     return raw_position
+
 
 def _transform_position(pos: FibsemStagePosition) -> FibsemStagePosition:
     """This function takes in a position flat to a beam, and outputs the position if stage was rotated / tilted flat to the other beam).
@@ -265,6 +300,7 @@ def _transform_position(pos: FibsemStagePosition) -> FibsemStagePosition:
     logging.info(f"Initial position {pos} was transformed to {transformed_position}")
 
     return transformed_position
+
 
 def _inverse_y_corrected_stage_movement(
     image: FibsemImage,
@@ -301,7 +337,9 @@ def _inverse_y_corrected_stage_movement(
         float: expected_y input that would produce the given dy, dz movements
     """
     if image.metadata is None or image.metadata.hardware_geometry is None:
-        raise ValueError("Image metadata or hardware geometry is not set. Cannot calculate inverse y corrected stage movement.")
+        raise ValueError(
+            "Image metadata or hardware geometry is not set. Cannot calculate inverse y corrected stage movement."
+        )
 
     # Tescan stages have a different geometry (z below the tilt axis), so the inverse
     # is a separate derivation, not the compustage-aware path below. Match
@@ -309,7 +347,9 @@ def _inverse_y_corrected_stage_movement(
     # (band-aid string check, tracked in FIB-300)
     system_info = image.metadata.system_info
     if system_info is not None and system_info.manufacturer.upper() == "TESCAN":
-        return _inverse_y_corrected_stage_movement_tescan(image, dy=dy, dz=dz, beam_type=beam_type)
+        return _inverse_y_corrected_stage_movement_tescan(
+            image, dy=dy, dz=dz, beam_type=beam_type
+        )
 
     geometry = image.metadata.hardware_geometry
     position = image.metadata.stage_position
@@ -327,6 +367,7 @@ def _inverse_y_corrected_stage_movement(
         stage_rotation=position.r if position.r is not None else 0.0,
         stage_tilt=position.t if position.t is not None else 0.0,
     )
+
 
 def _inverse_y_corrected_stage_movement_tescan(
     image: FibsemImage,
@@ -350,7 +391,9 @@ def _inverse_y_corrected_stage_movement_tescan(
         float: expected_y input that would produce the given dy, dz movements
     """
     if image.metadata is None or image.metadata.hardware_geometry is None:
-        raise ValueError("Image metadata or hardware geometry is not set. Cannot calculate inverse y corrected stage movement.")
+        raise ValueError(
+            "Image metadata or hardware geometry is not set. Cannot calculate inverse y corrected stage movement."
+        )
 
     return inverse_y_corrected_stage_movement_tescan_from_geometry(
         geometry=image.metadata.hardware_geometry,
@@ -398,13 +441,19 @@ def y_corrected_stage_movement_tescan_from_geometry(
     stage_rotation_flat_to_eb = np.deg2rad(geometry.rotation_reference) % (2 * np.pi)
     stage_rotation_flat_to_ion = np.deg2rad(geometry.rotation_180) % (2 * np.pi)
 
-    stage_rotation = stage_position.r % (2 * np.pi) if stage_position.r is not None else 0.0
+    stage_rotation = (
+        stage_position.r % (2 * np.pi) if stage_position.r is not None else 0.0
+    )
     stage_tilt = stage_position.t if stage_position.t is not None else 0.0
 
     PRETILT_SIGN = 1.0
-    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
+    if movement.rotation_angle_is_smaller(
+        stage_rotation, stage_rotation_flat_to_eb, atol=5
+    ):
         PRETILT_SIGN = 1.0
-    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
+    if movement.rotation_angle_is_smaller(
+        stage_rotation, stage_rotation_flat_to_ion, atol=5
+    ):
         PRETILT_SIGN = -1.0
 
     corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)
@@ -467,14 +516,20 @@ def inverse_y_corrected_stage_movement_tescan_from_geometry(
     stage_rotation_flat_to_ion = np.deg2rad(geometry.rotation_180) % (2 * np.pi)
 
     # stage pose at acquisition
-    stage_rotation = stage_position.r % (2 * np.pi) if stage_position.r is not None else 0.0
+    stage_rotation = (
+        stage_position.r % (2 * np.pi) if stage_position.r is not None else 0.0
+    )
     stage_tilt = stage_position.t if stage_position.t is not None else 0.0
 
     PRETILT_SIGN = 1.0
     # pretilt angle depends on rotation
-    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
+    if movement.rotation_angle_is_smaller(
+        stage_rotation, stage_rotation_flat_to_eb, atol=5
+    ):
         PRETILT_SIGN = 1.0
-    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
+    if movement.rotation_angle_is_smaller(
+        stage_rotation, stage_rotation_flat_to_ion, atol=5
+    ):
         PRETILT_SIGN = -1.0
 
     corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)

--- a/fibsem/imaging/tiling/reprojection.py
+++ b/fibsem/imaging/tiling/reprojection.py
@@ -22,6 +22,7 @@ from fibsem.structures import (
     FibsemStagePosition,
     Point,
 )
+from fibsem.transformations import inverse_view_corrected_dy
 
 
 def calculate_reprojected_stage_position(image: FibsemImage, pos: FibsemStagePosition) -> Point:
@@ -271,113 +272,61 @@ def _inverse_y_corrected_stage_movement(
     dz: float,
     beam_type: BeamType = BeamType.ELECTRON,
 ) -> float:
-        """
-        Calculate the expected_y input from dy, dz stage movements and beam_type.
-        This is the inverse of _y_corrected_stage_movement.
+    """Recover the in-image y-displacement from a y/z stage movement, off an image.
 
-        Args:
-            dy (float): actual y stage movement
-            dz (float): actual z stage movement  
-            beam_type (BeamType, optional): beam_type used. Defaults to BeamType.ELECTRON.
+    The inverse of `_y_corrected_stage_movement`, answered from the image's own
+    metadata rather than a live instrument -- so a saved overview projects as it was
+    taken.
 
-        Returns:
-            float: expected_y input that would produce the given dy, dz movements
-        """
-        if image.metadata is None or image.metadata.hardware_geometry is None:
-            raise ValueError("Image metadata or hardware geometry is not set. Cannot calculate inverse y corrected stage movement.")
+    Deferred to :func:`fibsem.transformations.inverse_view_corrected_dy` rather than
+    derived here. This function used to carry its own copy of the trigonometry, as did
+    `FibsemMicroscope._inverse_view_corrected_stage_movement`, so one decision about the
+    geometry lived in three places and only stayed consistent by everyone editing all
+    three.
 
-        # Tescan stages have a different geometry (z below the tilt axis), so the inverse
-        # is a separate derivation, not the compustage-aware path below. Match
-        # case-insensitively: a live scope reports "TESCAN", config/saved images "Tescan".
-        # (band-aid string check, tracked in FIB-300)
-        system_info = image.metadata.system_info
-        if system_info is not None and system_info.manufacturer.upper() == "TESCAN":
-            return _inverse_y_corrected_stage_movement_tescan(image, dy=dy, dz=dz, beam_type=beam_type)
+    That is also what closes FIB-500. The copy that lived here decided the compustage
+    FIB orientation from tilt alone, where the live path and `fm/reprojection.py` both
+    also require the rotation to match the reference. Sharing one implementation makes
+    all three agree by construction rather than by three edits. The six combinations
+    that change are tilt -128 with a non-zero rotation, where the sign inverts -- and a
+    compustage has no rotation axis, so no acquisition can produce them.
 
-        geometry = image.metadata.hardware_geometry
+    Args:
+        image: the image whose geometry and pose the projection is taken from.
+        dy: actual y stage movement
+        dz: actual z stage movement
+        beam_type: beam the image was acquired with. Defaults to ELECTRON.
 
-        # all angles in radians
-        sem_column_tilt = np.deg2rad(geometry.column_tilt)
-        fib_column_tilt = np.deg2rad(geometry.fib_column_tilt)
+    Returns:
+        float: expected_y input that would produce the given dy, dz movements
+    """
+    if image.metadata is None or image.metadata.hardware_geometry is None:
+        raise ValueError("Image metadata or hardware geometry is not set. Cannot calculate inverse y corrected stage movement.")
 
-        stage_pretilt = np.deg2rad(geometry.shuttle_pre_tilt)
+    # Tescan stages have a different geometry (z below the tilt axis), so the inverse
+    # is a separate derivation, not the compustage-aware path below. Match
+    # case-insensitively: a live scope reports "TESCAN", config/saved images "Tescan".
+    # (band-aid string check, tracked in FIB-300)
+    system_info = image.metadata.system_info
+    if system_info is not None and system_info.manufacturer.upper() == "TESCAN":
+        return _inverse_y_corrected_stage_movement_tescan(image, dy=dy, dz=dz, beam_type=beam_type)
 
-        stage_rotation_flat_to_eb = np.deg2rad(geometry.rotation_reference) % (2 * np.pi)
-        stage_rotation_flat_to_ion = np.deg2rad(geometry.rotation_180) % (2 * np.pi)
-
-        # current stage position
-        current_stage_position = image.metadata.stage_position
-        stage_rotation = current_stage_position.r % (2 * np.pi) if current_stage_position.r is not None else 0.0
-        stage_tilt = current_stage_position.t if current_stage_position.t is not None else 0.0
-
-        # Handle compustage case. This mirrors FibsemMicroscope._view_corrected_stage_movement:
-        # the forward flips expected_y once for compustage, then a second time at the FIB
-        # orientation, so the two cancel there. Determined from metadata rather than a live
-        # microscope; for the compustage the rotation is always 0, so the orientation is
-        # fixed by the tilt alone (FIB sits at column_tilt - pretilt - 180, i.e. ~-128 deg,
-        # and the FM pose at -180 deg).
-        #
-        # NOTE: this differs from the live path and from fm/reprojection.py, which both
-        # also require the rotation to match the reference before calling a pose FIB.
-        # Deliberately left alone here so FIB-481 is a pure restructuring with no
-        # numerical difference; the divergence is FIB-500. It is latent -- a compustage
-        # image cannot carry a non-zero rotation, so the two versions only disagree
-        # about poses no acquisition can produce.
-        compustage_sign = 1.0
-        is_fib_orientation = False
-        if geometry.is_compustage:
-            fib_orientation_tilt = np.deg2rad(
-                geometry.fib_column_tilt - geometry.shuttle_pre_tilt - 180
-            )
-            is_fib_orientation = bool(
-                np.isclose(stage_tilt, fib_orientation_tilt, atol=0.1)
-            )
-            compustage_sign = 1.0 if is_fib_orientation else -1.0
-            stage_tilt += np.pi
-
-        PRETILT_SIGN = 1.0
-        # pretilt angle depends on rotation
-        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
-            PRETILT_SIGN = 1.0
-        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
-            PRETILT_SIGN = -1.0
-
-        if is_fib_orientation:
-            PRETILT_SIGN = -1.0
-
-        corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)
-
-        # perspective tilt adjustment
-        if beam_type == BeamType.ELECTRON:
-            perspective_tilt_adjustment = -corrected_pretilt_angle
-        elif beam_type == BeamType.ION:
-            perspective_tilt_adjustment = (-corrected_pretilt_angle - fib_column_tilt)
-
-        # Reverse the calculations from the forward function:
-        # Forward: y_move = y_sample_move * cos(corrected_pretilt_angle)
-        # Forward: z_move = -y_sample_move * sin(corrected_pretilt_angle)
-        # Therefore: y_sample_move can be calculated from either dy or dz
-
-        # Calculate y_sample_move from dy and dz (should be consistent)
-        cos_pretilt = np.cos(corrected_pretilt_angle)
-        sin_pretilt = np.sin(corrected_pretilt_angle)
-        
-        if abs(cos_pretilt) > abs(sin_pretilt):
-            # Use dy calculation when cos component is larger
-            y_sample_move = dy / cos_pretilt
-        else:
-            # Use dz calculation when sin component is larger
-            y_sample_move = -dz / sin_pretilt
-
-        # Reverse: expected_y = y_sample_move * cos(stage_tilt + perspective_tilt_adjustment)
-        expected_y = y_sample_move * np.cos(stage_tilt + perspective_tilt_adjustment)
-
-        # Apply compustage correction if needed
-        if geometry.is_compustage:
-            expected_y *= compustage_sign
-
-        return expected_y
-
+    geometry = image.metadata.hardware_geometry
+    position = image.metadata.stage_position
+    # The ion column's tilt is the view tilt for a FIB image; the electron column is the
+    # reference axis and so contributes none. Same rule as `_beam_view_tilt` on the live
+    # microscope, read from the image's geometry instead of the instrument.
+    view_tilt = (
+        np.deg2rad(geometry.fib_column_tilt) if beam_type is BeamType.ION else 0.0
+    )
+    return inverse_view_corrected_dy(
+        dy=dy,
+        dz=dz,
+        view_tilt=view_tilt,
+        geometry=geometry,
+        stage_rotation=position.r if position.r is not None else 0.0,
+        stage_tilt=position.t if position.t is not None else 0.0,
+    )
 
 def _inverse_y_corrected_stage_movement_tescan(
     image: FibsemImage,

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -132,7 +132,10 @@ from fibsem.structures import (
     RangeLimit,
     SystemSettings,
 )
-from fibsem.transformations import get_stage_tilt_from_milling_angle
+from fibsem.transformations import (
+    get_stage_tilt_from_milling_angle,
+    inverse_view_corrected_dy,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1418,6 +1421,23 @@ class FibsemMicroscope(ABC):
 
         Inverse of :meth:`_view_corrected_stage_movement`.
 
+        Deferred to :func:`fibsem.transformations.inverse_view_corrected_dy` rather than
+        derived here. This method used to carry its own copy of the trigonometry, as did
+        `imaging/tiling/reprojection.py`, so one decision about the geometry lived in
+        three places and only stayed consistent by everyone editing all three. They now
+        share the one implementation, which is what `transformations` was extracted for.
+
+        Two consequences, both wanted:
+
+        * **No hardware read for the orientation.** The old copy asked
+          `get_stage_orientation()` to decide whether a compustage was at the FIB pose;
+          the shared version derives it from the pose it was handed. The stage position
+          is still read here, because "the current pose" is this method's contract.
+        * **The compustage FIB test gains the rotation term** the live path always had
+          and the tiled copy lacked (FIB-500). Only reachable poses matter and none
+          change: a compustage has no rotation axis, so the combinations that differ --
+          tilt -128 with a non-zero rotation -- cannot be produced by any acquisition.
+
         Args:
             dy: actual y stage movement
             dz: actual z stage movement
@@ -1426,75 +1446,15 @@ class FibsemMicroscope(ABC):
         Returns:
             float: expected_y input that would produce the given dy, dz movements
         """
-
-        # all angles in radians
-        sem_column_tilt = np.deg2rad(self.system.electron.column_tilt)
-
-        stage_pretilt = np.deg2rad(self.system.stage.shuttle_pre_tilt)
-
-        stage_rotation_flat_to_eb = np.deg2rad(
-            self.system.stage.rotation_reference
-        ) % (2 * np.pi)
-        stage_rotation_flat_to_ion = np.deg2rad(
-            self.system.stage.rotation_180
-        ) % (2 * np.pi)
-
-        # current stage position
-        current_stage_position = self.get_stage_position()
-        stage_rotation = current_stage_position.r % (2 * np.pi) if current_stage_position.r is not None else 0.0
-        stage_tilt = current_stage_position.t if current_stage_position.t is not None else 0.0
-
-        # Handle compustage case. This mirrors the forward's sign handling: it flips
-        # expected_y once for compustage, then a second time at the FIB orientation,
-        # so the two flips cancel there. The sign is +/-1, hence self-inverse, and is
-        # applied to the recovered expected_y below.
-        compustage_sign = 1.0
-        if self.stage_is_compustage:
-            compustage_sign = -1.0
-            stage_tilt += np.pi
-
-        PRETILT_SIGN = 1.0
-        # pretilt angle depends on rotation
-        from fibsem import movement
-        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
-            PRETILT_SIGN = 1.0
-        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
-            PRETILT_SIGN = -1.0
-
-        if self.stage_is_compustage and self.get_stage_orientation() == "FIB":
-            compustage_sign = 1.0  # the forward's second flip cancels the first
-            PRETILT_SIGN = -1.0
-
-        corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)
-
-        # perspective tilt adjustment
-        perspective_tilt_adjustment = -corrected_pretilt_angle - view_tilt
-
-        # Reverse the calculations from the forward function:
-        # Forward: y_move = y_sample_move * cos(corrected_pretilt_angle)
-        # Forward: z_move = -y_sample_move * sin(corrected_pretilt_angle)
-        # Therefore: y_sample_move can be calculated from either dy or dz
-
-        # Calculate y_sample_move from dy and dz (should be consistent)
-        cos_pretilt = np.cos(corrected_pretilt_angle)
-        sin_pretilt = np.sin(corrected_pretilt_angle)
-
-        if abs(cos_pretilt) > abs(sin_pretilt):
-            # Use dy calculation when cos component is larger
-            y_sample_move = dy / cos_pretilt
-        else:
-            # Use dz calculation when sin component is larger
-            y_sample_move = -dz / sin_pretilt
-
-        # Reverse: expected_y = y_sample_move * cos(stage_tilt + perspective_tilt_adjustment)
-        expected_y = y_sample_move * np.cos(stage_tilt + perspective_tilt_adjustment)
-
-        # Apply compustage correction if needed
-        if self.stage_is_compustage:
-            expected_y *= compustage_sign
-
-        return expected_y
-
+        position = self.get_stage_position()
+        return inverse_view_corrected_dy(
+            dy=dy,
+            dz=dz,
+            view_tilt=view_tilt,
+            geometry=self.hardware_geometry(),
+            stage_rotation=position.r if position.r is not None else 0.0,
+            stage_tilt=position.t if position.t is not None else 0.0,
+        )
     def _fm_image_to_stage_delta(self, dx: float, dy: float) -> Tuple[float, float]:
         """Map a displacement in the displayed FM image onto stage axes.
 

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -23,15 +23,18 @@ from skimage import transform
 THERMO_API_AVAILABLE = False
 MINIMUM_AUTOSCRIPT_VERSION_4_7 = parse_version("4.7")
 
+
 class AutoScriptException(Exception):
     pass
 
 
 try:
-    sys.path.append(r'C:\Program Files\Thermo Scientific AutoScript')
-    sys.path.append(r'C:\Program Files\Enthought\Python\envs\AutoScript\Lib\site-packages')
-    sys.path.append(r'C:\Program Files\Python36\envs\AutoScript')
-    sys.path.append(r'C:\Program Files\Python36\envs\AutoScript\Lib\site-packages')
+    sys.path.append(r"C:\Program Files\Thermo Scientific AutoScript")
+    sys.path.append(
+        r"C:\Program Files\Enthought\Python\envs\AutoScript\Lib\site-packages"
+    )
+    sys.path.append(r"C:\Program Files\Python36\envs\AutoScript")
+    sys.path.append(r"C:\Program Files\Python36\envs\AutoScript\Lib\site-packages")
     import autoscript_sdb_microscope_client
     from autoscript_sdb_microscope_client import SdbMicroscopeClient
 
@@ -80,6 +83,7 @@ try:
         Rectangle,
         StagePosition,
     )
+
     THERMO_API_AVAILABLE = True
 except AutoScriptException as e:
     logging.warning("Failed to load AutoScript (ThermoFisher): %s", str(e))
@@ -88,7 +92,10 @@ except ImportError as e:
     logging.debug("AutoScript (ThermoFisher) not found: %s", str(e))
     pass
 except Exception:
-    logging.error("Failed to load AutoScript (ThermoFisher) due to unexpected error", exc_info=True)
+    logging.error(
+        "Failed to load AutoScript (ThermoFisher) due to unexpected error",
+        exc_info=True,
+    )
     pass
 
 
@@ -144,8 +151,10 @@ if TYPE_CHECKING:
 
     from fibsem.structures import TFibsemPatternSettings
 
+
 class FibsemMicroscope(ABC):
     """Abstract class containing all the core microscope functionalities"""
+
     # THREADING CONTRACT: these are psygnal Signals — subscribers run synchronously
     # on whatever thread emits (workflow/movement/acquisition workers, not the GUI
     # thread). Any handler that touches Qt or a canvas MUST marshal, e.g. with
@@ -174,7 +183,9 @@ class FibsemMicroscope(ABC):
     _stage_position: FibsemStagePosition = None
 
     @abstractmethod
-    def connect_to_microscope(self, ip_address: str, port: int, reset_beam_shift: bool = True) -> None:
+    def connect_to_microscope(
+        self, ip_address: str, port: int, reset_beam_shift: bool = True
+    ) -> None:
         pass
 
     @abstractmethod
@@ -182,7 +193,11 @@ class FibsemMicroscope(ABC):
         pass
 
     @abstractmethod
-    def acquire_image(self, image_settings: Optional[ImageSettings] = None, beam_type: Optional[BeamType] = None) -> FibsemImage:
+    def acquire_image(
+        self,
+        image_settings: Optional[ImageSettings] = None,
+        beam_type: Optional[BeamType] = None,
+    ) -> FibsemImage:
         pass
 
     @abstractmethod
@@ -208,9 +223,7 @@ class FibsemMicroscope(ABC):
 
         # start acquisition thread
         self._acquisition_thread = threading.Thread(
-            target=self._acquisition_worker,
-            args=(beam_type,),
-            daemon=True
+            target=self._acquisition_worker, args=(beam_type,), daemon=True
         )
         self._acquisition_thread.start()
 
@@ -225,7 +238,7 @@ class FibsemMicroscope(ABC):
             # self.fib_acquisition_signal.disconnect()
 
     def _acquisition_worker(self, beam_type: BeamType) -> None:
-        """The worker function for the acquisition thread. 
+        """The worker function for the acquisition thread.
         Acquires images from the microscope, and emits them as signals."""
         pass
 
@@ -234,11 +247,15 @@ class FibsemMicroscope(ABC):
         pass
 
     @abstractmethod
-    def autocontrast(self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None) -> None:
+    def autocontrast(
+        self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None
+    ) -> None:
         pass
 
     @abstractmethod
-    def auto_focus(self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None) -> None:
+    def auto_focus(
+        self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None
+    ) -> None:
         pass
 
     def reset_beam_shifts(self) -> None:
@@ -280,6 +297,7 @@ class FibsemMicroscope(ABC):
     def _create_sample_stage(self) -> None:
         """Create the sample stage and holder based on the system settings."""
         from fibsem.microscopes._stage import _create_sample_stage
+
         self._stage = _create_sample_stage(self)
 
     def _get_axis_limits(self) -> Dict[str, RangeLimit]:
@@ -293,6 +311,7 @@ class FibsemMicroscope(ABC):
         axes_limits["t"] = RangeLimit(min=-10.0, max=90.0)
 
         return axes_limits
+
     @abstractmethod
     def move_stage_absolute(self, position: FibsemStagePosition) -> FibsemStagePosition:
         pass
@@ -302,7 +321,9 @@ class FibsemMicroscope(ABC):
         pass
 
     @abstractmethod
-    def stable_move(self,dx: float, dy: float, beam_type: BeamType) -> FibsemStagePosition:
+    def stable_move(
+        self, dx: float, dy: float, beam_type: BeamType
+    ) -> FibsemStagePosition:
         pass
 
     @abstractmethod
@@ -319,7 +340,7 @@ class FibsemMicroscope(ABC):
     ) -> FibsemStagePosition:
         pass
 
-    def move_flat_to_beam(self, beam_type: BeamType, _safe:bool = True) -> None:
+    def move_flat_to_beam(self, beam_type: BeamType, _safe: bool = True) -> None:
         """Move the sample surface flat to the electron or ion beam.
 
         .. deprecated::
@@ -355,12 +376,20 @@ class FibsemMicroscope(ABC):
         if self.stage_is_compustage and beam_type is BeamType.ION:
             rotation = 0
             tilt = -np.pi + tilt
-            
+
         # updated safe rotation move
         logging.info(f"moving flat to {beam_type.name}")
-        stage_position = FibsemStagePosition(r=rotation, t=tilt, coordinate_system="Raw")
+        stage_position = FibsemStagePosition(
+            r=rotation, t=tilt, coordinate_system="Raw"
+        )
 
-        logging.debug({"msg": "move_flat_to_beam", "stage_position": stage_position.to_dict(), "beam_type": beam_type.name})
+        logging.debug(
+            {
+                "msg": "move_flat_to_beam",
+                "stage_position": stage_position.to_dict(),
+                "beam_type": beam_type.name,
+            }
+        )
 
         if _safe:
             self.safe_absolute_stage_movement(stage_position)
@@ -408,11 +437,15 @@ class FibsemMicroscope(ABC):
         pass
 
     @abstractmethod
-    def move_manipulator_corrected(self, dx: float, dy: float, beam_type: BeamType) -> None:
+    def move_manipulator_corrected(
+        self, dx: float, dy: float, beam_type: BeamType
+    ) -> None:
         pass
 
     @abstractmethod
-    def move_manipulator_to_position_offset(self, offset: FibsemManipulatorPosition, name: str) -> None:
+    def move_manipulator_to_position_offset(
+        self, offset: FibsemManipulatorPosition, name: str
+    ) -> None:
         pass
 
     @abstractmethod
@@ -424,7 +457,9 @@ class FibsemMicroscope(ABC):
         pass
 
     @abstractmethod
-    def run_milling(self, milling_current: float, milling_voltage: float, asynch: bool = False) -> None:
+    def run_milling(
+        self, milling_current: float, milling_voltage: float, asynch: bool = False
+    ) -> None:
         pass
 
     @abstractmethod
@@ -456,7 +491,7 @@ class FibsemMicroscope(ABC):
 
     @abstractmethod
     def get_milling_state(self) -> MillingState:
-        pass 
+        pass
 
     @abstractmethod
     def estimate_milling_time(self) -> float:
@@ -490,7 +525,7 @@ class FibsemMicroscope(ABC):
 
         elif isinstance(pattern, FibsemBitmapSettings):
             self.draw_bitmap_pattern(pattern)
-        
+
         elif isinstance(pattern, FibsemPolygonSettings):
             self.draw_polygon(pattern)
 
@@ -538,10 +573,14 @@ class FibsemMicroscope(ABC):
         raise NotImplementedError("Sputter coater not implemented for this microscope.")
 
     @abstractmethod
-    def get_available_values(self, key: str, beam_type: Optional[BeamType] = None) -> List[Union[str, float, int]]:
+    def get_available_values(
+        self, key: str, beam_type: Optional[BeamType] = None
+    ) -> List[Union[str, float, int]]:
         pass
 
-    def get_available_values_cached(self, key: str, beam_type: Optional[BeamType] = None) -> List[Union[str, float, int]]:
+    def get_available_values_cached(
+        self, key: str, beam_type: Optional[BeamType] = None
+    ) -> List[Union[str, float, int]]:
         """Get available values with caching to avoid repeated microscope queries.
 
         Args:
@@ -551,24 +590,30 @@ class FibsemMicroscope(ABC):
         Returns:
             List of available values for the given key.
         """
-        if not hasattr(self, '_available_values_cache'):
+        if not hasattr(self, "_available_values_cache"):
             logging.info("Initializing available values cache.")
             self._available_values_cache: Dict[str, List[Union[str, float, int]]] = {}
 
         cache_key = f"{key}_{beam_type.name if beam_type else 'None'}"
         if cache_key not in self._available_values_cache:
-            logging.info(f"Caching available values for key: {key}, beam_type: {beam_type}")
-            self._available_values_cache[cache_key] = self.get_available_values(key, beam_type)
+            logging.info(
+                f"Caching available values for key: {key}, beam_type: {beam_type}"
+            )
+            self._available_values_cache[cache_key] = self.get_available_values(
+                key, beam_type
+            )
         return self._available_values_cache[cache_key]
 
-    def clear_available_values_cache(self, key: Optional[str] = None, beam_type: Optional[BeamType] = None) -> None:
+    def clear_available_values_cache(
+        self, key: Optional[str] = None, beam_type: Optional[BeamType] = None
+    ) -> None:
         """Clear the available values cache.
 
         Args:
             key: If provided, only clear cache for this key. Otherwise clear all.
             beam_type: The beam type (used with key to clear specific entry).
         """
-        if not hasattr(self, '_available_values_cache'):
+        if not hasattr(self, "_available_values_cache"):
             return
 
         if key is None:
@@ -578,25 +623,43 @@ class FibsemMicroscope(ABC):
             self._available_values_cache.pop(cache_key, None)
 
     # TODO: use a decorator instead?
-    def get(self, key: str, beam_type: Optional[BeamType] = None) -> Union[float, int, bool, str, list, tuple, Point]:
+    def get(
+        self, key: str, beam_type: Optional[BeamType] = None
+    ) -> Union[float, int, bool, str, list, tuple, Point]:
         """Get wrapper for logging."""
         value = self._get(key, beam_type)
         beam_name = "None" if beam_type is None else beam_type.name
-        logging.debug({"msg": "get", "key": key, "beam_type": beam_name, "value": value})
+        logging.debug(
+            {"msg": "get", "key": key, "beam_type": beam_name, "value": value}
+        )
         return value
 
-    def set(self, key: str, value: Union[str, float, int, tuple, list, Point], beam_type: Optional[BeamType] = None) -> None:
+    def set(
+        self,
+        key: str,
+        value: Union[str, float, int, tuple, list, Point],
+        beam_type: Optional[BeamType] = None,
+    ) -> None:
         """Set wrapper for logging"""
         self._set(key, value, beam_type)
         beam_name = "None" if beam_type is None else beam_type.name
-        logging.debug({"msg": "set", "key": key, "beam_type": beam_name, "value": value})
+        logging.debug(
+            {"msg": "set", "key": key, "beam_type": beam_name, "value": value}
+        )
 
     @abstractmethod
-    def _get(self, key: str, beam_type: Optional[BeamType] = None) -> Union[float, int, bool, str, list]:
+    def _get(
+        self, key: str, beam_type: Optional[BeamType] = None
+    ) -> Union[float, int, bool, str, list]:
         pass
 
     @abstractmethod
-    def _set(self, key: str, value: Union[str, float, int, list, tuple, Point], beam_type: Optional[BeamType] = None) -> None:
+    def _set(
+        self,
+        key: str,
+        value: Union[str, float, int, list, tuple, Point],
+        beam_type: Optional[BeamType] = None,
+    ) -> None:
         pass
 
     # TODO: i dont think this is needed, you set the beam settings and detector settings separately
@@ -613,7 +676,13 @@ class FibsemMicroscope(ABC):
             path=self._last_imaging_settings.path,
             filename=self._last_imaging_settings.filename,
         )
-        logging.debug({"msg": "get_imaging_settings", "image_settings": image_settings.to_dict(), "beam_type": beam_type.name})
+        logging.debug(
+            {
+                "msg": "get_imaging_settings",
+                "image_settings": image_settings.to_dict(),
+                "beam_type": beam_type.name,
+            }
+        )
         return image_settings
 
     def set_imaging_settings(self, image_settings: ImageSettings) -> None:
@@ -628,13 +697,18 @@ class FibsemMicroscope(ABC):
         # self.set("drift_correction", image_settings.drift_correction, image_settings.beam_type)
 
         # TODO: implement the rest of these settings... @patrick
-        logging.debug({"msg": "set_imaging_settings", "image_settings": image_settings.to_dict(), "beam_type": image_settings.beam_type.name})
+        logging.debug(
+            {
+                "msg": "set_imaging_settings",
+                "image_settings": image_settings.to_dict(),
+                "beam_type": image_settings.beam_type.name,
+            }
+        )
 
-        return 
+        return
 
     def get_beam_settings(self, beam_type: BeamType) -> BeamSettings:
-        """Get the current beam settings for the specified beam type.
-        """
+        """Get the current beam settings for the specified beam type."""
 
         logging.debug(f"Getting {beam_type.name} beam settings...")
         beam_settings = BeamSettings(
@@ -643,21 +717,29 @@ class FibsemMicroscope(ABC):
             beam_current=self.get_beam_current(beam_type),
             voltage=self.get_beam_voltage(beam_type),
             hfw=self.get_field_of_view(beam_type),
-            resolution=self.get_resolution(beam_type),  
+            resolution=self.get_resolution(beam_type),
             dwell_time=self.get_dwell_time(beam_type),
             stigmation=self.get_stigmation(beam_type),
             shift=self.get_beam_shift(beam_type),
             scan_rotation=self.get_scan_rotation(beam_type),
             preset=self.get("preset", beam_type),
         )
-        logging.debug({"msg": "get_beam_settings", "beam_settings": beam_settings.to_dict(), "beam_type": beam_type.name})
+        logging.debug(
+            {
+                "msg": "get_beam_settings",
+                "beam_settings": beam_settings.to_dict(),
+                "beam_type": beam_type.name,
+            }
+        )
 
         return beam_settings
 
     def set_beam_settings(self, beam_settings: BeamSettings) -> None:
         """Set the beam settings for the specified beam type"""
         logging.debug(f"Setting {beam_settings.beam_type.name} beam settings...")
-        self.set_working_distance(beam_settings.working_distance, beam_settings.beam_type)
+        self.set_working_distance(
+            beam_settings.working_distance, beam_settings.beam_type
+        )
         self.set_beam_current(beam_settings.beam_current, beam_settings.beam_type)
         self.set_beam_voltage(beam_settings.voltage, beam_settings.beam_type)
         self.set_field_of_view(beam_settings.hfw, beam_settings.beam_type)
@@ -668,12 +750,17 @@ class FibsemMicroscope(ABC):
         self.set_scan_rotation(beam_settings.scan_rotation, beam_settings.beam_type)
         self.set("preset", beam_settings.preset, beam_settings.beam_type)
 
-        logging.debug({"msg": "set_beam_settings", "beam_settings": beam_settings.to_dict(), "beam_type": beam_settings.beam_type.name})
+        logging.debug(
+            {
+                "msg": "set_beam_settings",
+                "beam_settings": beam_settings.to_dict(),
+                "beam_type": beam_settings.beam_type.name,
+            }
+        )
         return
 
     def get_beam_system_settings(self, beam_type: BeamType) -> BeamSystemSettings:
-        """Get the current beam system settings for the specified beam type.
-        """
+        """Get the current beam system settings for the specified beam type."""
         logging.debug(f"Getting {beam_type.name} beam system settings...")
         beam_system_settings = BeamSystemSettings(
             beam_type=beam_type,
@@ -686,12 +773,17 @@ class FibsemMicroscope(ABC):
             plasma_gas=self.get("plasma_gas", beam_type),
         )
 
-        logging.debug({"msg": "get_beam_system_settings", "settings": beam_system_settings.to_dict(), "beam_type": beam_type.name})
+        logging.debug(
+            {
+                "msg": "get_beam_system_settings",
+                "settings": beam_system_settings.to_dict(),
+                "beam_type": beam_type.name,
+            }
+        )
         return beam_system_settings
 
     def set_beam_system_settings(self, settings: BeamSystemSettings) -> None:
-        """Set the beam system settings for the specified beam type.
-        """
+        """Set the beam system settings for the specified beam type."""
         beam_type = settings.beam_type
         logging.debug(f"Setting {settings.beam_type.name} beam system settings...")
         self.set("beam_enabled", settings.enabled, beam_type)
@@ -704,13 +796,20 @@ class FibsemMicroscope(ABC):
             self.set("plasma_gas", settings.plasma_gas, beam_type)
             self.set("plasma", settings.plasma, beam_type)
 
-        logging.debug( {"msg": "set_beam_system_settings", "settings": settings.to_dict(), "beam_type": beam_type.name})
-    
+        logging.debug(
+            {
+                "msg": "set_beam_system_settings",
+                "settings": settings.to_dict(),
+                "beam_type": beam_type.name,
+            }
+        )
+
         return
 
-    def get_detector_settings(self, beam_type: BeamType = BeamType.ELECTRON) -> FibsemDetectorSettings:
-        """Get the current detector settings for the specified beam type.
-        """
+    def get_detector_settings(
+        self, beam_type: BeamType = BeamType.ELECTRON
+    ) -> FibsemDetectorSettings:
+        """Get the current detector settings for the specified beam type."""
         logging.debug(f"Getting {beam_type.name} detector settings...")
         detector_settings = FibsemDetectorSettings(
             type=self.get_detector_type(beam_type),
@@ -718,21 +817,39 @@ class FibsemMicroscope(ABC):
             brightness=self.get_detector_brightness(beam_type),
             contrast=self.get_detector_contrast(beam_type),
         )
-        logging.debug({"msg": "get_detector_settings", "detector_settings": detector_settings.to_dict(), "beam_type": beam_type.name})
+        logging.debug(
+            {
+                "msg": "get_detector_settings",
+                "detector_settings": detector_settings.to_dict(),
+                "beam_type": beam_type.name,
+            }
+        )
         return detector_settings
-    
-    def set_detector_settings(self, detector_settings: FibsemDetectorSettings, beam_type: BeamType = BeamType.ELECTRON) -> None:
+
+    def set_detector_settings(
+        self,
+        detector_settings: FibsemDetectorSettings,
+        beam_type: BeamType = BeamType.ELECTRON,
+    ) -> None:
         """Set the detector settings for the specified beam type"""
         logging.debug(f"Setting {beam_type.name} detector settings...")
         self.set_detector_type(detector_settings.type, beam_type)
         self.set_detector_mode(detector_settings.mode, beam_type)
         self.set_detector_brightness(detector_settings.brightness, beam_type)
         self.set_detector_contrast(detector_settings.contrast, beam_type)
-        logging.debug({"msg": "set_detector_settings", "detector_settings": detector_settings.to_dict(), "beam_type": beam_type.name})
+        logging.debug(
+            {
+                "msg": "set_detector_settings",
+                "detector_settings": detector_settings.to_dict(),
+                "beam_type": beam_type.name,
+            }
+        )
 
         return
 
-    def get_microscope_state(self, beam_type: Optional[BeamType] = None) -> MicroscopeState:
+    def get_microscope_state(
+        self, beam_type: Optional[BeamType] = None
+    ) -> MicroscopeState:
         """Get the current microscope state."""
 
         # default values
@@ -746,26 +863,28 @@ class FibsemMicroscope(ABC):
         if self.is_available("electron_beam") and get_electron_state:
             electron_beam = self.get_beam_settings(beam_type=BeamType.ELECTRON)
             electron_detector = self.get_detector_settings(beam_type=BeamType.ELECTRON)
- 
-        # get the state of the ion beam        
+
+        # get the state of the ion beam
         if self.is_available("ion_beam") and get_ion_state:
             ion_beam = self.get_beam_settings(beam_type=BeamType.ION)
             ion_detector = self.get_detector_settings(beam_type=BeamType.ION)
 
         # get the state of the stage
         if self.is_available("stage"):
-            stage_position = self.get_stage_position()       
+            stage_position = self.get_stage_position()
 
         current_microscope_state = MicroscopeState(
             timestamp=datetime.datetime.timestamp(datetime.datetime.now()),
-            stage_position=stage_position,                                  # get absolute stage coordinates (RAW)
-            electron_beam=electron_beam,                                    # electron beam state
-            ion_beam=ion_beam,                                              # ion beam state
-            electron_detector=electron_detector,                            # electron beam detector state
-            ion_detector=ion_detector,                                      # ion beam detector state
+            stage_position=stage_position,  # get absolute stage coordinates (RAW)
+            electron_beam=electron_beam,  # electron beam state
+            ion_beam=ion_beam,  # ion beam state
+            electron_detector=electron_detector,  # electron beam detector state
+            ion_detector=ion_detector,  # ion beam detector state
         )
 
-        logging.debug({"msg": "get_microscope_state", "state": current_microscope_state.to_dict()})
+        logging.debug(
+            {"msg": "get_microscope_state", "state": current_microscope_state.to_dict()}
+        )
 
         return deepcopy(current_microscope_state)
 
@@ -776,7 +895,9 @@ class FibsemMicroscope(ABC):
             if microscope_state.electron_beam is not None:
                 self.set_beam_settings(microscope_state.electron_beam)
             if microscope_state.electron_detector is not None:
-                self.set_detector_settings(microscope_state.electron_detector, BeamType.ELECTRON)
+                self.set_detector_settings(
+                    microscope_state.electron_detector, BeamType.ELECTRON
+                )
         if self.is_available("ion_beam"):
             if microscope_state.ion_beam is not None:
                 self.set_beam_settings(microscope_state.ion_beam)
@@ -787,19 +908,43 @@ class FibsemMicroscope(ABC):
         if self.fm is not None and microscope_state.objective_position is not None:
             self.fm.objective.move_absolute(microscope_state.objective_position)
 
-        logging.debug({"msg": "set_microscope_state", "state": microscope_state.to_dict()})
+        logging.debug(
+            {"msg": "set_microscope_state", "state": microscope_state.to_dict()}
+        )
 
         return
 
     def set_milling_settings(self, mill_settings: FibsemMillingSettings) -> None:
-        self.set("active_view", mill_settings.milling_channel, mill_settings.milling_channel)
-        self.set("active_device", mill_settings.milling_channel, mill_settings.milling_channel)
-        self.set("default_patterning_beam_type", mill_settings.milling_channel, mill_settings.milling_channel)
-        self.set("application_file", mill_settings.application_file, mill_settings.milling_channel)
-        self.set("patterning_mode", mill_settings.patterning_mode, mill_settings.milling_channel)
+        self.set(
+            "active_view", mill_settings.milling_channel, mill_settings.milling_channel
+        )
+        self.set(
+            "active_device",
+            mill_settings.milling_channel,
+            mill_settings.milling_channel,
+        )
+        self.set(
+            "default_patterning_beam_type",
+            mill_settings.milling_channel,
+            mill_settings.milling_channel,
+        )
+        self.set(
+            "application_file",
+            mill_settings.application_file,
+            mill_settings.milling_channel,
+        )
+        self.set(
+            "patterning_mode",
+            mill_settings.patterning_mode,
+            mill_settings.milling_channel,
+        )
         self.set("hfw", mill_settings.hfw, mill_settings.milling_channel)
-        self.set("current", mill_settings.milling_current, mill_settings.milling_channel)
-        self.set("voltage", mill_settings.milling_voltage, mill_settings.milling_channel)
+        self.set(
+            "current", mill_settings.milling_current, mill_settings.milling_channel
+        )
+        self.set(
+            "voltage", mill_settings.milling_voltage, mill_settings.milling_channel
+        )
 
     def is_available(self, system: str) -> bool:
 
@@ -857,7 +1002,9 @@ class FibsemMicroscope(ABC):
         elif system == "gis_sputter_coater":
             self.system.gis.sputter_coater = value
 
-    def apply_configuration(self, system_settings: Optional[SystemSettings] = None) -> None:
+    def apply_configuration(
+        self, system_settings: Optional[SystemSettings] = None
+    ) -> None:
         """Apply the system settings to the microscope."""
 
         logging.info("Applying Microscope Configuration...")
@@ -883,10 +1030,14 @@ class FibsemMicroscope(ABC):
 
         # dont update info -> read only
         logging.info("Microscope configuration applied.")
-        logging.debug({"msg": "apply_configuration", "system_settings": system_settings.to_dict()})
+        logging.debug(
+            {"msg": "apply_configuration", "system_settings": system_settings.to_dict()}
+        )
 
     @abstractmethod
-    def check_available_values(self, key:str, values, beam_type: Optional[BeamType] = None) -> bool:
+    def check_available_values(
+        self, key: str, values, beam_type: Optional[BeamType] = None
+    ) -> bool:
         pass
 
     def home(self) -> bool:
@@ -900,7 +1051,7 @@ class FibsemMicroscope(ABC):
         return self.get("stage_linked")
 
     def pump(self) -> str:
-        """"Pump the chamber."""
+        """ "Pump the chamber."""
         self.set("pump_chamber", True)
         return self.get("chamber_state")
 
@@ -908,7 +1059,7 @@ class FibsemMicroscope(ABC):
         """Vent the chamber."""
         self.set("vent_chamber", True)
         return self.get("chamber_state")
-    
+
     def turn_on(self, beam_type: BeamType) -> bool:
         """Turn on the specified beam type."""
         self.set("on", True, beam_type)
@@ -918,25 +1069,25 @@ class FibsemMicroscope(ABC):
         "Turn off the specified beam type."
         self.set("on", False, beam_type)
         return self.get("on", beam_type)
-    
+
     def is_on(self, beam_type: BeamType) -> bool:
         """Check if the specified beam type is on."""
         return self.get("on", beam_type)
-    
+
     def blank(self, beam_type: BeamType) -> bool:
         """Blank the specified beam type."""
         self.set("blanked", True, beam_type)
         return self.get("blanked", beam_type)
-    
+
     def unblank(self, beam_type: BeamType) -> bool:
         """Unblank the specified beam type."""
         self.set("blanked", False, beam_type)
         return self.get("blanked", beam_type)
-    
+
     def is_blanked(self, beam_type: BeamType) -> bool:
         """Check if the specified beam type is blanked."""
         return self.get("blanked", beam_type)
-    
+
     def get_available_beams(self) -> List[BeamType]:
         """Get the available beams for the microscope."""
         available_beams = []
@@ -951,7 +1102,9 @@ class FibsemMicroscope(ABC):
         self.set("spot_mode", point, beam_type)
         return
 
-    def set_reduced_area_scanning_mode(self, reduced_area: FibsemRectangle, beam_type: BeamType) -> None:
+    def set_reduced_area_scanning_mode(
+        self, reduced_area: FibsemRectangle, beam_type: BeamType
+    ) -> None:
         """Set the reduced area scanning mode for the specified beam type."""
         self.set("reduced_area", reduced_area, beam_type)
         return
@@ -979,7 +1132,9 @@ class FibsemMicroscope(ABC):
         self.set("voltage", voltage, beam_type)
         return self.get("voltage", beam_type)
 
-    def set_resolution(self, resolution: Tuple[int, int], beam_type: BeamType) -> List[int]:
+    def set_resolution(
+        self, resolution: Tuple[int, int], beam_type: BeamType
+    ) -> List[int]:
         """Set the resolution for the specified beam type."""
         self.set("resolution", resolution, beam_type)
         return self.get("resolution", beam_type)
@@ -1084,10 +1239,12 @@ class FibsemMicroscope(ABC):
         return self.get("preset", beam_type)
 
     def _get_compucentric_rotation_offset(self) -> FibsemStagePosition:
-        return FibsemStagePosition(x=0, y=0) # assume no offset to rotation centre
+        return FibsemStagePosition(x=0, y=0)  # assume no offset to rotation centre
 
-    def _get_compucentric_rotation_position(self, position: FibsemStagePosition) -> FibsemStagePosition:
-        """Get the compucentric rotation position for the given stage position. 
+    def _get_compucentric_rotation_position(
+        self, position: FibsemStagePosition
+    ) -> FibsemStagePosition:
+        """Get the compucentric rotation position for the given stage position.
         Assumes 180deg rotation. TFS only"""
 
         # compustage does not support compucentric rotation
@@ -1114,11 +1271,15 @@ class FibsemMicroscope(ABC):
 
         return target_position
 
-    def get_target_position(self, stage_position: FibsemStagePosition, target_orientation: str) -> FibsemStagePosition:
+    def get_target_position(
+        self, stage_position: FibsemStagePosition, target_orientation: str
+    ) -> FibsemStagePosition:
         """Convert the stage position to the target position for the given orientation."""
 
         currrent_orientation = self.get_stage_orientation(stage_position)
-        logging.info(f"Getting target position for {target_orientation} from {currrent_orientation}")
+        logging.info(
+            f"Getting target position for {target_orientation} from {currrent_orientation}"
+        )
 
         if currrent_orientation == target_orientation:
             return stage_position
@@ -1150,20 +1311,31 @@ class FibsemMicroscope(ABC):
             target_position = stage_position
             target_position.r = orientation.r
             target_position.t = orientation.t
-        elif ((currrent_orientation in ["SEM", "FIB", "MILLING"] and target_orientation == "FM") or
-              (currrent_orientation == "FM" and target_orientation in ["SEM", "FIB", "MILLING"])):
+        elif (
+            currrent_orientation in ["SEM", "FIB", "MILLING"]
+            and target_orientation == "FM"
+        ) or (
+            currrent_orientation == "FM"
+            and target_orientation in ["SEM", "FIB", "MILLING"]
+        ):
             if not self.stage_is_compustage:
-                raise ValueError("Cannot move to FM position on non-compustage systems.")
+                raise ValueError(
+                    "Cannot move to FM position on non-compustage systems."
+                )
             # Convert from FIB to FM
             target_position = stage_position
             target_position.r = orientation.r
             target_position.t = orientation.t
         else:
-            raise ValueError(f"Cannot convert from {currrent_orientation} to {target_orientation}")
+            raise ValueError(
+                f"Cannot convert from {currrent_orientation} to {target_orientation}"
+            )
 
         return target_position
 
-    def get_stage_orientation(self, stage_position: Optional[FibsemStagePosition] = None) -> str:
+    def get_stage_orientation(
+        self, stage_position: Optional[FibsemStagePosition] = None
+    ) -> str:
         """Get the current stage orientation based on the stage position (r,t).
         Args:
             stage_position (FibsemStagePosition, optional): stage position to use. If None, uses current stage position.
@@ -1176,7 +1348,9 @@ class FibsemMicroscope(ABC):
         if stage_position is None:
             stage_position = self.get_stage_position()
         if stage_position.r is None or stage_position.t is None:
-            raise ValueError("Stage position must have both rotation (r) and tilt (t) defined.")
+            raise ValueError(
+                "Stage position must have both rotation (r) and tilt (t) defined."
+            )
         stage_rotation = stage_position.r % (2 * np.pi)
         stage_tilt = stage_position.t
 
@@ -1188,13 +1362,30 @@ class FibsemMicroscope(ABC):
         milling = self.get_orientation("MILLING")
         fm = self.get_orientation("FM")
         if sem is None or fib is None or milling is None:
-            raise ValueError("SEM, FIB or MILLING orientation not defined in the system.")
-        if sem.r is None or sem.t is None or fib.r is None or fib.t is None or milling.r is None or milling.t is None:
-            raise ValueError("SEM, FIB or MILLING orientation must have both rotation (r) and tilt (t) defined.")
+            raise ValueError(
+                "SEM, FIB or MILLING orientation not defined in the system."
+            )
+        if (
+            sem.r is None
+            or sem.t is None
+            or fib.r is None
+            or fib.t is None
+            or milling.r is None
+            or milling.t is None
+        ):
+            raise ValueError(
+                "SEM, FIB or MILLING orientation must have both rotation (r) and tilt (t) defined."
+            )
 
-        is_sem_rotation = movement.rotation_angle_is_smaller(stage_rotation, sem.r, atol=5) # query: do we need rotation_angle_is_smaller, since we % 2pi the rotation?
-        is_fib_rotation = movement.rotation_angle_is_smaller(stage_rotation, fib.r, atol=5)
-        is_fm_rotation = movement.rotation_angle_is_smaller(stage_rotation, fm.r, atol=5)
+        is_sem_rotation = movement.rotation_angle_is_smaller(
+            stage_rotation, sem.r, atol=5
+        )  # query: do we need rotation_angle_is_smaller, since we % 2pi the rotation?
+        is_fib_rotation = movement.rotation_angle_is_smaller(
+            stage_rotation, fib.r, atol=5
+        )
+        is_fm_rotation = movement.rotation_angle_is_smaller(
+            stage_rotation, fm.r, atol=5
+        )
 
         is_sem_tilt = np.isclose(stage_tilt, sem.t, atol=0.1)
         is_fib_tilt = np.isclose(stage_tilt, fib.t, atol=0.1)
@@ -1219,7 +1410,7 @@ class FibsemMicroscope(ABC):
         # if orientations not initialised, update
         if not hasattr(self, "orientations"):
             self._update_orientations()
-       
+
         if orientation not in self.orientations:
             raise ValueError(f"Orientation {orientation} not supported.")
 
@@ -1230,10 +1421,12 @@ class FibsemMicroscope(ABC):
 
         stage_settings = self.system.stage
         shuttle_pre_tilt = stage_settings.shuttle_pre_tilt  # deg
-        milling_angle = stage_settings.milling_angle        # deg
+        milling_angle = stage_settings.milling_angle  # deg
 
         # needs to be dynmaically updated as it can change.
-        milling_stage_tilt = get_stage_tilt_from_milling_angle(self, np.radians(milling_angle))
+        milling_stage_tilt = get_stage_tilt_from_milling_angle(
+            self, np.radians(milling_angle)
+        )
 
         self.orientations = {
             "SEM": FibsemStagePosition(
@@ -1245,13 +1438,14 @@ class FibsemMicroscope(ABC):
                 t=np.radians(self.system.ion.column_tilt - shuttle_pre_tilt),
             ),
             "MILLING": FibsemStagePosition(
-                r=np.radians(stage_settings.rotation_reference),
-                t=milling_stage_tilt
+                r=np.radians(stage_settings.rotation_reference), t=milling_stage_tilt
             ),
         }
 
         if self.stage_is_compustage:
-            self.orientations["FIB"].r = np.radians(0)  # Compustage is always at 0 rotation
+            self.orientations["FIB"].r = np.radians(
+                0
+            )  # Compustage is always at 0 rotation
             self.orientations["FIB"].t -= np.radians(180)
 
             self.orientations["FM"] = FibsemStagePosition(
@@ -1267,7 +1461,9 @@ class FibsemMicroscope(ABC):
         self.system.stage.milling_angle = milling_angle
         self._update_orientations()
 
-    def get_current_milling_angle(self, stage_position: Optional[FibsemStagePosition] = None) -> float:
+    def get_current_milling_angle(
+        self, stage_position: Optional[FibsemStagePosition] = None
+    ) -> float:
         """Get the current milling angle in degrees based on the current stage tilt."""
 
         from fibsem.transformations import convert_stage_tilt_to_milling_angle
@@ -1282,21 +1478,25 @@ class FibsemMicroscope(ABC):
         stage_tilt = stage_position.t
 
         if stage_tilt is None:
-            raise ValueError("Stage tilt is not available. Cannot calculate milling angle.")
-        
+            raise ValueError(
+                "Stage tilt is not available. Cannot calculate milling angle."
+            )
+
         if self.stage_is_compustage and stage_tilt < np.radians(-90):
             # Compustage stage tilt is inverted, so we need to adjust the angle
             stage_tilt += np.radians(180)
 
         # Calculate the milling angle from the stage tilt
         milling_angle = convert_stage_tilt_to_milling_angle(
-            stage_tilt=stage_tilt, 
-            pretilt=np.radians(self.system.stage.shuttle_pre_tilt), 
-            column_tilt=np.radians(self.system.ion.column_tilt)
+            stage_tilt=stage_tilt,
+            pretilt=np.radians(self.system.stage.shuttle_pre_tilt),
+            column_tilt=np.radians(self.system.ion.column_tilt),
         )
         return float(np.degrees(milling_angle))
 
-    def is_close_to_milling_angle(self, milling_angle: float, atol: float = 2.0) -> bool:
+    def is_close_to_milling_angle(
+        self, milling_angle: float, atol: float = 2.0
+    ) -> bool:
         """Check if the current milling angle is close to the specified milling angle.
         Args:
             milling_angle (float): The target milling angle in degrees.
@@ -1304,11 +1504,13 @@ class FibsemMicroscope(ABC):
         Returns:
             bool: True if the current milling angle is close to the specified milling angle, False otherwise
         """
-        current_milling_angle = self.get_current_milling_angle() # degrees
+        current_milling_angle = self.get_current_milling_angle()  # degrees
 
         return bool(np.isclose(current_milling_angle, milling_angle, atol=atol))
 
-    def move_to_milling_angle(self,milling_angle: float, rotation: Optional[float] = None) -> bool:
+    def move_to_milling_angle(
+        self, milling_angle: float, rotation: Optional[float] = None
+    ) -> bool:
         """Move the stage to the milling angle, based on the current pretilt and column tilt.
         Args:
             milling_angle (float): The target milling angle in radians.
@@ -1365,12 +1567,12 @@ class FibsemMicroscope(ABC):
 
         stage_pretilt = np.deg2rad(self.system.stage.shuttle_pre_tilt)
 
-        stage_rotation_flat_to_eb = np.deg2rad(
-            self.system.stage.rotation_reference
-        ) % (2 * np.pi)
-        stage_rotation_flat_to_ion = np.deg2rad(
-            self.system.stage.rotation_180
-        ) % (2 * np.pi)
+        stage_rotation_flat_to_eb = np.deg2rad(self.system.stage.rotation_reference) % (
+            2 * np.pi
+        )
+        stage_rotation_flat_to_ion = np.deg2rad(self.system.stage.rotation_180) % (
+            2 * np.pi
+        )
 
         # current stage position
         current_stage_position = self.get_stage_position()
@@ -1379,7 +1581,6 @@ class FibsemMicroscope(ABC):
 
         # the compustage does not have pre-tilt, cannot rotate, but tilts 180 deg.
         if self.stage_is_compustage:
-
             # if stage_tilt < 0:
             expected_y *= -1.0
 
@@ -1388,26 +1589,35 @@ class FibsemMicroscope(ABC):
         PRETILT_SIGN = 1.0
         # pretilt angle depends on rotation # TODO: migrate to orientation
         from fibsem import movement
-        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
+
+        if movement.rotation_angle_is_smaller(
+            stage_rotation, stage_rotation_flat_to_eb, atol=5
+        ):
             PRETILT_SIGN = 1.0
-        if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
+        if movement.rotation_angle_is_smaller(
+            stage_rotation, stage_rotation_flat_to_ion, atol=5
+        ):
             PRETILT_SIGN = -1.0
 
         if self.stage_is_compustage and self.get_stage_orientation() == "FIB":
-            expected_y *= -1.0 # use this until rotation_180 is deprecated correctly...
+            expected_y *= -1.0  # use this until rotation_180 is deprecated correctly...
             PRETILT_SIGN = -1.0
 
-        corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt) # electron angle = 0, ion = 52
+        corrected_pretilt_angle = PRETILT_SIGN * (
+            stage_pretilt + sem_column_tilt
+        )  # electron angle = 0, ion = 52
 
         # perspective tilt adjustment (difference between perspective view and sample coordinate system)
         perspective_tilt_adjustment = -corrected_pretilt_angle - view_tilt
 
         # the amount the sample has to move in the y-axis
-        y_sample_move = expected_y  / np.cos(stage_tilt + perspective_tilt_adjustment)
+        y_sample_move = expected_y / np.cos(stage_tilt + perspective_tilt_adjustment)
 
         # the amount the stage has to move in each axis
         y_move = y_sample_move * np.cos(corrected_pretilt_angle)
-        z_move = -y_sample_move * np.sin(corrected_pretilt_angle) #TODO: investigate this
+        z_move = -y_sample_move * np.sin(
+            corrected_pretilt_angle
+        )  # TODO: investigate this
 
         return FibsemStagePosition(x=0, y=y_move, z=z_move)
 
@@ -1455,6 +1665,7 @@ class FibsemMicroscope(ABC):
             stage_rotation=position.r if position.r is not None else 0.0,
             stage_tilt=position.t if position.t is not None else 0.0,
         )
+
     def _fm_image_to_stage_delta(self, dx: float, dy: float) -> Tuple[float, float]:
         """Map a displacement in the displayed FM image onto stage axes.
 
@@ -1646,15 +1857,23 @@ class FibsemMicroscope(ABC):
         # keeps focus because the move stays in the sample plane.
         self.move_stage_relative(stage_position)
 
-        logging.debug({"msg": "fm_stable_move", "dx": dx, "dy": dy,
-                       "camera_tilt": self.fm.camera_tilt,
-                       "position": stage_position.to_dict()})
+        logging.debug(
+            {
+                "msg": "fm_stable_move",
+                "dx": dx,
+                "dy": dy,
+                "camera_tilt": self.fm.camera_tilt,
+                "position": stage_position.to_dict(),
+            }
+        )
 
         return self.get_stage_position()
 
     def move_to_device(self, device: str) -> None:
         """Move the stage to the predefined device position."""
-        logging.warning(f"move_to_device is not implemented for {self.__class__.__name__}.")
+        logging.warning(
+            f"move_to_device is not implemented for {self.__class__.__name__}."
+        )
         pass
 
     def move_to_microscope(self, target: str) -> None:
@@ -1665,25 +1884,29 @@ class FibsemMicroscope(ABC):
         if self.stage_is_compustage:
             self.move_to_microscope_compustage(target)
             return
-        
+
         if not self.fm:
             raise ValueError("FM module is not available. Cannot move to FM position.")
 
         stage_position = self.get_stage_position()
 
         if target == "FM" and self.get_stage_orientation(stage_position) != "FIB":
-            raise ValueError("Cannot move to FM from SEM or MILLING orientation. Please switch to FIB orientation first.")
+            raise ValueError(
+                "Cannot move to FM from SEM or MILLING orientation. Please switch to FIB orientation first."
+            )
 
         # check if we are already at the target position
         # this is for TFS SDB chamber: e.g. piescope, meteor, iflm
         # arctis has same range for FIBSEM/FM (stage is flipped upside down)
-        FM_RANGE  = (40e-3, 60e-3)  # 40 mm to 60 mm
+        FM_RANGE = (40e-3, 60e-3)  # 40 mm to 60 mm
         FIBSEM_RANGE = (-20e-3, 20e-3)  # -20 mm to 20 mm
         if target == "FM" and (FM_RANGE[0] < stage_position.x < FM_RANGE[1]):
             logging.info("Already at FM position, no need to move.")
             return
 
-        if target == "FIBSEM" and (FIBSEM_RANGE[0] < stage_position.x < FIBSEM_RANGE[1]):
+        if target == "FIBSEM" and (
+            FIBSEM_RANGE[0] < stage_position.x < FIBSEM_RANGE[1]
+        ):
             logging.info("Already at FIBSEM position, no need to move.")
             return
 
@@ -1692,7 +1915,9 @@ class FibsemMicroscope(ABC):
         # retract objective (safety precaution)
         self.fm.objective.retract()
 
-        TRANSLATION_DX = 48.8e-3  # 48.8 mm # THIS needs to be configurable for different microscopes
+        TRANSLATION_DX = (
+            48.8e-3  # 48.8 mm # THIS needs to be configurable for different microscopes
+        )
         transf = FibsemStagePosition(x=TRANSLATION_DX)
 
         # move to FIBSEM
@@ -1708,8 +1933,10 @@ class FibsemMicroscope(ABC):
         """Special method to move to the specified microscope (FIBSEM <-> FM) for Compustage microscopes."""
 
         if not self.stage_is_compustage:
-            raise ValueError("This method is only available for Compustage microscopes.")
-        
+            raise ValueError(
+                "This method is only available for Compustage microscopes."
+            )
+
         if not self.fm:
             raise ValueError("FM module is not available. Cannot move to FM position.")
 
@@ -1729,7 +1956,7 @@ class FibsemMicroscope(ABC):
             self.move_stage_absolute(fm_orientation)
             self.fm.objective.insert()  # insert objective
 
-    @property      
+    @property
     def current_grid(self) -> str:
         try:
             grid = self._stage.current_grid
@@ -1742,6 +1969,7 @@ class FibsemMicroscope(ABC):
     @property
     def manufacturer(self) -> str:
         return "ThermoFisher"
+
 
 def _thermo_application_file_wrapper_for_drawing_functions(
     patterning_function: Callable[["ThermoMicroscope", TFibsemPatternSettings], Any],
@@ -1772,24 +2000,24 @@ class ThermoMicroscope(FibsemMicroscope):
         connection (SdbMicroscopeClient): The microscope client connection.
 
     Inherited Methods:
-        connect_to_microscope(self, ip_address: str, port: int = 7520) -> None: 
+        connect_to_microscope(self, ip_address: str, port: int = 7520) -> None:
             Connect to a Thermo Fisher microscope at the specified IP address and port.
 
-        disconnect(self) -> None: 
+        disconnect(self) -> None:
             Disconnects the microscope client connection.
 
-        acquire_image(self, image_settings: ImageSettings) -> FibsemImage: 
+        acquire_image(self, image_settings: ImageSettings) -> FibsemImage:
             Acquire a new image with the specified settings.
 
-        last_image(self, beam_type: BeamType = BeamType.ELECTRON) -> FibsemImage: 
+        last_image(self, beam_type: BeamType = BeamType.ELECTRON) -> FibsemImage:
             Get the last previously acquired image.
 
-        autocontrast(self, beam_type: BeamType) -> None: 
+        autocontrast(self, beam_type: BeamType) -> None:
             Automatically adjust the microscope image contrast for the specified beam type.
 
         auto_focus(self, beam_type: BeamType) -> None:
             Automatically adjust the microscope focus for the specified beam type.
-        
+
         beam_shift(self, dx: float, dy: float,  beam_type: BeamType) -> None:
             Adjusts the beam shift of given beam based on relative values that are provided.
 
@@ -1804,24 +2032,24 @@ class ThermoMicroscope(FibsemMicroscope):
 
         vertical_move(self,  dy: float, dx: float = 0) -> None:
             Move the stage vertically to correct eucentric point
-        
+
         get_manipulator_position(self) -> FibsemManipulatorPosition:
             Get the current manipulator position.
-        
+
         insert_manipulator(self, name: str) -> None:
             Insert the manipulator into the sample.
-        
+
         retract_manipulator(self) -> None:
             Retract the manipulator from the sample.
 
         move_manipulator_relative(self, position: FibsemManipulatorPosition) -> None:
             Move the manipulator by the specified relative move.
-        
+
         move_manipulator_absolute(self, position: FibsemManipulatorPosition) -> None:
             Move the manipulator to the specified coordinates.
 
         move_manipulator_corrected(self, dx: float, dy: float, beam_type: BeamType) -> None:
-            Move the manipulator by the specified relative move, correcting for the beam type.      
+            Move the manipulator by the specified relative move, correcting for the beam type.
 
         move_manipulator_to_position_offset(self, offset: FibsemManipulatorPosition, name: str) -> None:
             Move the manipulator to the specified position offset.
@@ -1852,7 +2080,7 @@ class ThermoMicroscope(FibsemMicroscope):
 
         set_microscope_state(self, microscope_state: MicroscopeState) -> None:
             Reset the microscope state to the provided state.
-        
+
         get(self, key:str, beam_type: BeamType = None):
             Returns the value of the specified key.
 
@@ -1860,7 +2088,7 @@ class ThermoMicroscope(FibsemMicroscope):
             Sets the value of the specified key.
 
     New methods:
-        __init__(self): 
+        __init__(self):
             Initializes a new instance of the class.
 
         _y_corrected_stage_movement(self, expected_y: float, beam_type: BeamType = BeamType.ELECTRON) -> FibsemStagePosition:
@@ -1869,9 +2097,11 @@ class ThermoMicroscope(FibsemMicroscope):
 
     def __init__(self, system_settings: SystemSettings):
         if not THERMO_API_AVAILABLE:
-            raise Exception("Autoscript (ThermoFisher) not installed. Please see the user guide for installation instructions.")            
+            raise Exception(
+                "Autoscript (ThermoFisher) not installed. Please see the user guide for installation instructions."
+            )
 
-        # create microscope client 
+        # create microscope client
         self.connection = SdbMicroscopeClient()
 
         # initialise system settings
@@ -1886,7 +2116,12 @@ class ThermoMicroscope(FibsemMicroscope):
         self._current_application_file = self._default_application_file
 
         # logging
-        logging.debug({"msg": "create_microscope_client", "system_settings": system_settings.to_dict()})
+        logging.debug(
+            {
+                "msg": "create_microscope_client",
+                "system_settings": system_settings.to_dict(),
+            }
+        )
 
     def reconnect(self):
         """Attempt to reconnect to the microscope client."""
@@ -1906,7 +2141,9 @@ class ThermoMicroscope(FibsemMicroscope):
         del self.connection
         self.connection = None
 
-    def connect_to_microscope(self, ip_address: str, port: int = 7520, reset_beam_shift: bool = True) -> None:
+    def connect_to_microscope(
+        self, ip_address: str, port: int = 7520, reset_beam_shift: bool = True
+    ) -> None:
         """
         Connect to a Thermo Fisher microscope at the specified IP address and port.
 
@@ -1939,13 +2176,21 @@ class ThermoMicroscope(FibsemMicroscope):
         self.system.info.model = self.connection.service.system.name
         self.system.info.serial_number = self.connection.service.system.serial_number
         self.system.info.hardware_version = self.connection.service.system.version
-        self.system.info.software_version = self.connection.service.autoscript.client.version
+        self.system.info.software_version = (
+            self.connection.service.autoscript.client.version
+        )
         info = self.system.info
-        logging.info(f"Microscope client connected to model {info.model} with serial number {info.serial_number} and software version {info.software_version}.")
+        logging.info(
+            f"Microscope client connected to model {info.model} with serial number {info.serial_number} and software version {info.software_version}."
+        )
 
         # autoscript information
-        logging.info(f"Autoscript Client: {self.connection.service.autoscript.client.version}")
-        logging.info(f"Autoscript Server: {self.connection.service.autoscript.server.version}")
+        logging.info(
+            f"Autoscript Client: {self.connection.service.autoscript.client.version}"
+        )
+        logging.info(
+            f"Autoscript Server: {self.connection.service.autoscript.server.version}"
+        )
 
         if reset_beam_shift:
             self.reset_beam_shifts()
@@ -1960,7 +2205,9 @@ class ThermoMicroscope(FibsemMicroscope):
             self.stage_is_compustage = False
             self._default_stage_coordinate_system = CoordinateSystem.RAW
         else:
-            raise Exception("No stage installed. Please check the microscope configuration.")
+            raise Exception(
+                "No stage installed. Please check the microscope configuration."
+            )
 
         # set default coordinate system
         self.stage.set_default_coordinate_system(self._default_stage_coordinate_system)
@@ -1972,19 +2219,26 @@ class ThermoMicroscope(FibsemMicroscope):
 
         try:
             if not self.stage_is_compustage:
-                logging.warning("Fluorescence microscope module is currently only implemented for compustage systems. FM will not be available.")
+                logging.warning(
+                    "Fluorescence microscope module is currently only implemented for compustage systems. FM will not be available."
+                )
                 self.fm = None
                 self.set_channel(BeamType.ELECTRON)
             else:
                 from fibsem.fm.autoscript import ThermoFisherFluorescenceMicroscope
+
                 self.fm = ThermoFisherFluorescenceMicroscope(self, self.connection)
-                self.fm.set_active_channel() # this will fail if no fm available
-                logging.info("Thermo Fisher Fluorescence Microscope initialized successfully.")
+                self.fm.set_active_channel()  # this will fail if no fm available
+                logging.info(
+                    "Thermo Fisher Fluorescence Microscope initialized successfully."
+                )
         except Exception as e:
-            logging.error(f"Failed to initialize Thermo Fisher Fluorescence Microscope: {e}")
+            logging.error(
+                f"Failed to initialize Thermo Fisher Fluorescence Microscope: {e}"
+            )
             self.fm = None
             self.set_channel(BeamType.ELECTRON)
-        
+
         try:
             self._create_sample_stage()
         except Exception as e:
@@ -2001,8 +2255,12 @@ class ThermoMicroscope(FibsemMicroscope):
         self.connection.imaging.set_active_view(channel.value)
         self.connection.imaging.set_active_device(channel.value)
         logging.debug(f"Set active channel to {channel.name}")
-        
-    def acquire_image(self, image_settings: Optional[ImageSettings] = None, beam_type: Optional[BeamType] = None) -> FibsemImage:
+
+    def acquire_image(
+        self,
+        image_settings: Optional[ImageSettings] = None,
+        beam_type: Optional[BeamType] = None,
+    ) -> FibsemImage:
         """
         Acquire a new image with the specified settings.
 
@@ -2018,19 +2276,25 @@ class ThermoMicroscope(FibsemMicroscope):
             return self.acquire_image3(image_settings=None, beam_type=beam_type)
 
         if image_settings is None:
-            raise ValueError("Must provide image_settings to acquire a new image if beam_type is not specified.")
+            raise ValueError(
+                "Must provide image_settings to acquire a new image if beam_type is not specified."
+            )
 
         # set reduced area settings
         if image_settings.reduced_area is not None:
             rect = image_settings.reduced_area
             reduced_area = Rectangle(rect.left, rect.top, rect.width, rect.height)
-            logging.debug(f"Set reduced are: {reduced_area} for beam type {image_settings.beam_type}")
+            logging.debug(
+                f"Set reduced are: {reduced_area} for beam type {image_settings.beam_type}"
+            )
         else:
             reduced_area = None
             self.set_full_frame_scanning_mode(image_settings.beam_type)
 
         # set the imaging hfw
-        self.set_field_of_view(hfw=image_settings.hfw, beam_type=image_settings.beam_type)
+        self.set_field_of_view(
+            hfw=image_settings.hfw, beam_type=image_settings.beam_type
+        )
 
         logging.info(f"acquiring new {image_settings.beam_type.name} image.")
 
@@ -2079,11 +2343,17 @@ class ThermoMicroscope(FibsemMicroscope):
         # store last imaging settings
         self._last_imaging_settings = image_settings
 
-        logging.debug({"msg": "acquire_image", "metadata": fibsem_image.metadata.to_dict()})
+        logging.debug(
+            {"msg": "acquire_image", "metadata": fibsem_image.metadata.to_dict()}
+        )
 
         return fibsem_image
 
-    def acquire_image3(self, image_settings: Optional[ImageSettings] = None, beam_type: Optional[BeamType] = None) -> FibsemImage:
+    def acquire_image3(
+        self,
+        image_settings: Optional[ImageSettings] = None,
+        beam_type: Optional[BeamType] = None,
+    ) -> FibsemImage:
         """
         Acquire a new image with the specified settings or current settings for the given beam type.
 
@@ -2137,7 +2407,9 @@ class ThermoMicroscope(FibsemMicroscope):
         # the path every `beam_type=`-only call takes, including the live worker's.
         with self._threading_lock:
             self.set_channel(effective_beam_type)
-            adorned_image: AdornedImage = self.connection.imaging.grab_frame(frame_settings)
+            adorned_image: AdornedImage = self.connection.imaging.grab_frame(
+                frame_settings
+            )
 
         # QUERY: is this required, reduced area is only set for the grab_frame?
         # Restore full frame if reduced area was used (same as acquire_image)
@@ -2239,7 +2511,9 @@ class ThermoMicroscope(FibsemMicroscope):
 
         self._set_additional_metadata(fibsem_image)
 
-        logging.debug({"msg": "acquire_image", "metadata": fibsem_image.metadata.to_dict()})
+        logging.debug(
+            {"msg": "acquire_image", "metadata": fibsem_image.metadata.to_dict()}
+        )
 
         return fibsem_image
 
@@ -2303,7 +2577,9 @@ class ThermoMicroscope(FibsemMicroscope):
                     break
                 with self._threading_lock:
                     self.set_channel(channel=beam_type)  # re-force active channel...?
-                    adorned_image = self.connection.imaging.get_image(GetImageSettings(wait_for_frame=True))
+                    adorned_image = self.connection.imaging.get_image(
+                        GetImageSettings(wait_for_frame=True)
+                    )
                     image = self._construct_image(adorned_image, beam_type=beam_type)
 
                     logging.info(f"Acquired Image: {image.data.shape}")
@@ -2313,11 +2589,13 @@ class ThermoMicroscope(FibsemMicroscope):
                     if beam_type is BeamType.ION:
                         self.fib_acquisition_signal.emit(image)
         except Exception as e:
-                logging.error(f"Exception occurred during fast acquisition: {e}")
+            logging.error(f"Exception occurred during fast acquisition: {e}")
         finally:
             self.connection.imaging.stop_acquisition()
 
-    def _construct_image(self, adorned_image: AdornedImage, beam_type: BeamType) -> FibsemImage:
+    def _construct_image(
+        self, adorned_image: AdornedImage, beam_type: BeamType
+    ) -> FibsemImage:
         """Construct a FibsemImage from an AdornedImage and the current microscope state."""
         # get the required metadata, convert to FibsemImage
         state = self.get_microscope_state(beam_type=beam_type)
@@ -2333,7 +2611,9 @@ class ThermoMicroscope(FibsemMicroscope):
 
         return image
 
-    def autocontrast(self, beam_type: BeamType, reduced_area: FibsemRectangle = None) -> None:
+    def autocontrast(
+        self, beam_type: BeamType, reduced_area: FibsemRectangle = None
+    ) -> None:
         """
         Automatically adjust the microscope image contrast for the specified beam type.
 
@@ -2364,7 +2644,9 @@ class ThermoMicroscope(FibsemMicroscope):
 
         logging.debug({"msg": "autocontrast", "beam_type": beam_type.name})
 
-    def auto_focus(self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None) -> None:
+    def auto_focus(
+        self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None
+    ) -> None:
         """Automatically focus the specified beam type.
 
         Args:
@@ -2389,7 +2671,9 @@ class ThermoMicroscope(FibsemMicroscope):
             self.set_full_frame_scanning_mode(beam_type)
         logging.debug({"msg": "auto_focus", "beam_type": beam_type.name})
 
-    def beam_shift(self, dx: float, dy: float, beam_type: BeamType = BeamType.ION) -> Point:
+    def beam_shift(
+        self, dx: float, dy: float, beam_type: BeamType = BeamType.ION
+    ) -> Point:
         """
         Adjusts the beam shift based on relative values that are provided.
 
@@ -2401,23 +2685,29 @@ class ThermoMicroscope(FibsemMicroscope):
             Point: the current beam shift of the requested beam_type, as this can now be clipped.
         """
         # beam shift limits
-        beam= self._get_beam(beam_type=beam_type)
+        beam = self._get_beam(beam_type=beam_type)
         limits: Limits2d = beam.beam_shift.limits
 
         # check if requested shift is outside limits
         current_shift = self.get_beam_shift(beam_type=beam_type)
         new_shift = Point(x=current_shift.x + dx, y=current_shift.y + dy)
         if new_shift.x < limits.limits_x.min or new_shift.x > limits.limits_x.max:
-            logging.warning(f"Beam shift x value {new_shift.x} is out of bounds: {limits.limits_x}")
+            logging.warning(
+                f"Beam shift x value {new_shift.x} is out of bounds: {limits.limits_x}"
+            )
         if new_shift.y < limits.limits_y.min or new_shift.y > limits.limits_y.max:
-            logging.warning(f"Beam shift y value {new_shift.y} is out of bounds: {limits.limits_y}")
+            logging.warning(
+                f"Beam shift y value {new_shift.y} is out of bounds: {limits.limits_y}"
+            )
 
         # clip the requested shift to the limits
         new_shift.x = np.clip(new_shift.x, limits.limits_x.min, limits.limits_x.max)
         new_shift.y = np.clip(new_shift.y, limits.limits_y.min, limits.limits_y.max)
         self.set_beam_shift(shift=new_shift, beam_type=beam_type)
 
-        logging.debug({"msg": "beam_shift", "dx": dx, "dy": dy, "beam_type": beam_type.name})
+        logging.debug(
+            {"msg": "beam_shift", "dx": dx, "dy": dy, "beam_type": beam_type.name}
+        )
 
         return self.get_beam_shift(beam_type=beam_type)
 
@@ -2436,14 +2726,20 @@ class ThermoMicroscope(FibsemMicroscope):
         wd = self.get_working_distance(BeamType.ELECTRON)
 
         # convert to autoscript position
-        autoscript_position = stage_position_to_autoscript(position, compustage=self.stage_is_compustage) # TODO: apply compucentric/raw coordinate offset here?
+        autoscript_position = stage_position_to_autoscript(
+            position, compustage=self.stage_is_compustage
+        )  # TODO: apply compucentric/raw coordinate offset here?
 
-        if self.get_stage_orientation() == "FM" or (self.fm is not None and self.fm.objective.state == "Inserted"): # ONLY when restrictions are on
+        if self.get_stage_orientation() == "FM" or (
+            self.fm is not None and self.fm.objective.state == "Inserted"
+        ):  # ONLY when restrictions are on
             autoscript_position.z = None
             autoscript_position.r = None
 
         logging.info(f"Moving stage to {position}.")
-        self.stage.absolute_move(autoscript_position, MoveSettings(rotate_compucentric=True)) # TODO: This needs at least an optional safe move to prevent collision?
+        self.stage.absolute_move(
+            autoscript_position, MoveSettings(rotate_compucentric=True)
+        )  # TODO: This needs at least an optional safe move to prevent collision?
 
         # restore working distance to adjust for microscope compenstation
         if not self.stage_is_compustage:
@@ -2464,7 +2760,9 @@ class ThermoMicroscope(FibsemMicroscope):
         logging.info(f"Moving stage by {position}.")
 
         # convert to autoscript position
-        thermo_position = stage_position_to_autoscript(position, self.stage_is_compustage)
+        thermo_position = stage_position_to_autoscript(
+            position, self.stage_is_compustage
+        )
 
         # move stage
         self.stage.relative_move(thermo_position)
@@ -2474,9 +2772,11 @@ class ThermoMicroscope(FibsemMicroscope):
         return self.get_stage_position()
 
     # TODO: migrate from stable_move vocab to sample_stage
-    def stable_move(self, dx: float, dy: float, beam_type: BeamType, static_wd: bool = False) -> FibsemStagePosition:
+    def stable_move(
+        self, dx: float, dy: float, beam_type: BeamType, static_wd: bool = False
+    ) -> FibsemStagePosition:
         """
-        Calculate the corrected stage movements based on the beam_type stage tilt, shuttle pre-tilt, 
+        Calculate the corrected stage movements based on the beam_type stage tilt, shuttle pre-tilt,
         and then move the stage relatively.
 
         Args:
@@ -2498,8 +2798,9 @@ class ThermoMicroscope(FibsemMicroscope):
             expected_y=dy,
             beam_type=beam_type,
         )
-        stage_position = FibsemStagePosition(x=dx, y=yz_move.y, z=yz_move.z, 
-                                             r=0, t=0, coordinate_system="RAW")
+        stage_position = FibsemStagePosition(
+            x=dx, y=yz_move.y, z=yz_move.z, r=0, t=0, coordinate_system="RAW"
+        )
 
         # move stage
         self.move_stage_relative(stage_position)
@@ -2508,14 +2809,22 @@ class ThermoMicroscope(FibsemMicroscope):
         if static_wd:
             wd = self.system.electron.eucentric_height
 
-        if not self.stage_is_compustage: # TODO: can replace with self.stage.is_linked
+        if not self.stage_is_compustage:  # TODO: can replace with self.stage.is_linked
             self.set_working_distance(wd, BeamType.ELECTRON)
 
         # logging
-        logging.debug({"msg": "stable_move", "dx": dx, "dy": dy, 
-                "beam_type": beam_type.name, "static_wd": static_wd,
-                "working_distance": wd, "scan_rotation": scan_rotation, 
-                "position": stage_position.to_dict()})
+        logging.debug(
+            {
+                "msg": "stable_move",
+                "dx": dx,
+                "dy": dy,
+                "beam_type": beam_type.name,
+                "static_wd": static_wd,
+                "working_distance": wd,
+                "scan_rotation": scan_rotation,
+                "position": stage_position.to_dict(),
+            }
+        )
 
         return self.get_stage_position()
 
@@ -2524,7 +2833,7 @@ class ThermoMicroscope(FibsemMicroscope):
         dy: float,
         dx: float = 0.0,
     ) -> FibsemStagePosition:
-        """ Move the stage vertically to correct coincidence point
+        """Move the stage vertically to correct coincidence point
 
         Args:
             dy (float): distance along the y-axis (image coordinates)
@@ -2550,16 +2859,22 @@ class ThermoMicroscope(FibsemMicroscope):
         # TODO: implement perspective correction
         PERSPECTIVE_CORRECTION = 0.9
         z_move = dy
-        if True: #use_perspective: 
-            z_move = dy / np.cos(np.deg2rad(90 - self.system.ion.column_tilt)) * PERSPECTIVE_CORRECTION  # TODO: MAGIC NUMBER, 90 - fib tilt
+        if True:  # use_perspective:
+            z_move = (
+                dy
+                / np.cos(np.deg2rad(90 - self.system.ion.column_tilt))
+                * PERSPECTIVE_CORRECTION
+            )  # TODO: MAGIC NUMBER, 90 - fib tilt
 
-        # manually calculate the dx, dy, dz 
-        theta = self.get_stage_position().t # rad
+        # manually calculate the dx, dy, dz
+        theta = self.get_stage_position().t  # rad
         dy = z_move * np.sin(theta)
         dz = z_move / np.cos(theta)
         stage_position = FibsemStagePosition(x=dx, y=dy, z=dz, coordinate_system="RAW")
         logging.info(f"Vertical movement: {stage_position}")
-        self.move_stage_relative(stage_position) # NOTE: this seems to be a bit less than previous... -> perspective correction?
+        self.move_stage_relative(
+            stage_position
+        )  # NOTE: this seems to be a bit less than previous... -> perspective correction?
 
         # Vertical moves re-establish the coincidence plane. Always restore the
         # pre-move SEM (electron) working distance so fine corrections keep their
@@ -2569,13 +2884,21 @@ class ThermoMicroscope(FibsemMicroscope):
         EUCENTRIC_RESET_THRESHOLD = 100e-6  # m (stage-z travel)
         self.set_working_distance(wd=wd, beam_type=BeamType.ELECTRON)
         if abs(dz) > EUCENTRIC_RESET_THRESHOLD:
-            self.set_working_distance(wd=self.system.ion.eucentric_height, beam_type=BeamType.ION)
+            self.set_working_distance(
+                wd=self.system.ion.eucentric_height, beam_type=BeamType.ION
+            )
 
         # logging
-        logging.debug({"msg": "vertical_move", "dy": dy, "dx": dx,
+        logging.debug(
+            {
+                "msg": "vertical_move",
+                "dy": dy,
+                "dx": dx,
                 "wd": wd,
                 "scan_rotation": scan_rotation,
-                "position": stage_position.to_dict()})
+                "position": stage_position.to_dict(),
+            }
+        )
 
         return self.get_stage_position()
 
@@ -2596,9 +2919,9 @@ class ThermoMicroscope(FibsemMicroscope):
         dz = position_after_sem_move.z - base_position.z
 
         # correct for the stage tilt and milling angle
-        if self.get_stage_orientation() in ["SEM","MILLING"]:
-            theta = np.radians(self.get_current_milling_angle()) # deg
-            dy = dy*np.sin(theta)
+        if self.get_stage_orientation() in ["SEM", "MILLING"]:
+            theta = np.radians(self.get_current_milling_angle())  # deg
+            dy = dy * np.sin(theta)
 
         # NOTE: vertical move also corrects for scan rotation, so we need to adjust dy accordingly
         # if the scan rotation is 0, we need to invert the dy value
@@ -2607,7 +2930,9 @@ class ThermoMicroscope(FibsemMicroscope):
             dy *= -1.0
 
         # apply the vertical move to correct the position
-        self.vertical_move(dx=0, dy=dy*1.11) # TODO: MAGIC_NUMBER To correct for perspective correction...
+        self.vertical_move(
+            dx=0, dy=dy * 1.11
+        )  # TODO: MAGIC_NUMBER To correct for perspective correction...
 
         return self.get_stage_position()
 
@@ -2660,17 +2985,16 @@ class ThermoMicroscope(FibsemMicroscope):
             view_tilt=self._beam_view_tilt(beam_type),
         )
 
-
-
     def _get_axis_limits(self) -> Dict[str, RangeLimit]:
         """Get the stage axis limits for x, y, z, t, r."""
         from fibsem.microscopes.simulator import (
             STAGE_LIMITS_COMPUSTAGE,
             STAGE_LIMITS_DEFAULT,
         )
+
         if self.stage_is_compustage:
             return STAGE_LIMITS_COMPUSTAGE
-        
+
         if not hasattr(self.stage, "get_axis_limits"):
             return STAGE_LIMITS_DEFAULT
 
@@ -2680,9 +3004,8 @@ class ThermoMicroscope(FibsemMicroscope):
             # t is in radians -> degrees
             if axis == "t":
                 limits[axis] = RangeLimit(
-                    min=np.degrees(axis_limit.min),
-                    max=np.degrees(axis_limit.max)
-                )                
+                    min=np.degrees(axis_limit.min), max=np.degrees(axis_limit.max)
+                )
                 continue
 
             limits[axis] = RangeLimit(
@@ -2698,9 +3021,7 @@ class ThermoMicroscope(FibsemMicroscope):
             )
         return limits
 
-    def _safe_rotation_movement(
-        self, stage_position: FibsemStagePosition
-    ):
+    def _safe_rotation_movement(self, stage_position: FibsemStagePosition):
         """Tilt the stage flat when performing a large rotation to prevent collision.
 
         Args:
@@ -2710,8 +3031,8 @@ class ThermoMicroscope(FibsemMicroscope):
 
         # tilt flat for large rotations to prevent collisions
         from fibsem import movement
-        if movement.rotation_angle_is_larger(stage_position.r, current_position.r):
 
+        if movement.rotation_angle_is_larger(stage_position.r, current_position.r):
             self.move_stage_absolute(FibsemStagePosition(t=0))
             logging.info("tilting to flat for large rotation.")
 
@@ -2723,12 +3044,13 @@ class ThermoMicroscope(FibsemMicroscope):
         """
         # safe movements are not required on the compustage, because it doesn't rotate
         if not self.stage_is_compustage:
-
             # tilt flat for large rotations to prevent collisions
             self._safe_rotation_movement(stage_position)
 
             # move to compucentric rotation
-            self.move_stage_absolute(FibsemStagePosition(r=stage_position.r, coordinate_system="RAW")) # TODO: support compucentric rotation directly
+            self.move_stage_absolute(
+                FibsemStagePosition(r=stage_position.r, coordinate_system="RAW")
+            )  # TODO: support compucentric rotation directly
 
         logging.debug(f"safe moving to {stage_position}")
         self.move_stage_absolute(stage_position)
@@ -2737,10 +3059,13 @@ class ThermoMicroscope(FibsemMicroscope):
 
         return
 
-    def project_stable_move(self, 
-        dx:float, dy:float, 
-        beam_type:BeamType, 
-        base_position:FibsemStagePosition) -> FibsemStagePosition:
+    def project_stable_move(
+        self,
+        dx: float,
+        dy: float,
+        beam_type: BeamType,
+        base_position: FibsemStagePosition,
+    ) -> FibsemStagePosition:
 
         scan_rotation = self.get_scan_rotation(beam_type=beam_type)
         if np.isclose(scan_rotation, np.pi):
@@ -2768,10 +3093,16 @@ class ThermoMicroscope(FibsemMicroscope):
         if name not in ["PARK", "EUCENTRIC"]:
             raise ValueError(f"insert position {name} not supported.")
         if AUTOSCRIPT_VERSION < MINIMUM_AUTOSCRIPT_VERSION_4_7:
-            raise NotImplementedError("Manipulator saved positions not supported in this version. Please upgrade to 4.7 or higher")
+            raise NotImplementedError(
+                "Manipulator saved positions not supported in this version. Please upgrade to 4.7 or higher"
+            )
 
         # get the saved position name
-        saved_position = ManipulatorSavedPosition.PARK if name == "PARK" else ManipulatorSavedPosition.EUCENTRIC
+        saved_position = (
+            ManipulatorSavedPosition.PARK
+            if name == "PARK"
+            else ManipulatorSavedPosition.EUCENTRIC
+        )
 
         # get the insert position
         insert_position = self.connection.specimen.manipulator.get_saved_position(
@@ -2784,14 +3115,22 @@ class ThermoMicroscope(FibsemMicroscope):
 
         # return the manipulator position
         manipulator_position = self.get_manipulator_position()
-        logging.debug({"msg": "insert_manipulator", "name": name, "position": manipulator_position.to_dict()})                      
+        logging.debug(
+            {
+                "msg": "insert_manipulator",
+                "name": name,
+                "position": manipulator_position.to_dict(),
+            }
+        )
         return manipulator_position
 
     def retract_manipulator(self):
-        """Retract the manipulator"""        
+        """Retract the manipulator"""
 
         if AUTOSCRIPT_VERSION < MINIMUM_AUTOSCRIPT_VERSION_4_7:
-            raise NotImplementedError("Manipulator saved positions not supported in this version. Please upgrade to 4.7 or higher")
+            raise NotImplementedError(
+                "Manipulator saved positions not supported in this version. Please upgrade to 4.7 or higher"
+            )
 
         if not self.is_available("manipulator"):
             raise NotImplementedError("Manipulator not available.")
@@ -2816,7 +3155,9 @@ class ThermoMicroscope(FibsemMicroscope):
         autoscript_position = manipulator_position_to_autoscript(position)
         # move manipulator relative
         self.connection.specimen.manipulator.relative_move(autoscript_position)
-        logging.debug({"msg": "move_manipulator_relative", "position": position.to_dict()})
+        logging.debug(
+            {"msg": "move_manipulator_relative", "position": position.to_dict()}
+        )
 
     def move_manipulator_absolute(self, position: FibsemManipulatorPosition):
         """Move the manipulator to the specified coordinates."""
@@ -2827,9 +3168,13 @@ class ThermoMicroscope(FibsemMicroscope):
 
         # move manipulator
         self.connection.specimen.manipulator.absolute_move(autoscript_position)
-        logging.debug({"msg": "move_manipulator_absolute", "position": position.to_dict()})
+        logging.debug(
+            {"msg": "move_manipulator_absolute", "position": position.to_dict()}
+        )
 
-    def _x_corrected_needle_movement(self, expected_x: float) -> FibsemManipulatorPosition:
+    def _x_corrected_needle_movement(
+        self, expected_x: float
+    ) -> FibsemManipulatorPosition:
         """Calculate the corrected needle movement to move in the x-axis.
 
         Args:
@@ -2839,8 +3184,8 @@ class ThermoMicroscope(FibsemMicroscope):
         """
         return FibsemManipulatorPosition(x=expected_x, y=0, z=0)  # no adjustment needed
 
-    def _y_corrected_needle_movement(self, 
-        expected_y: float, stage_tilt: float
+    def _y_corrected_needle_movement(
+        self, expected_y: float, stage_tilt: float
     ) -> FibsemManipulatorPosition:
         """Calculate the corrected needle movement to move in the y-axis.
 
@@ -2855,8 +3200,8 @@ class ThermoMicroscope(FibsemMicroscope):
         z_move = +np.sin(stage_tilt) * expected_y
         return FibsemManipulatorPosition(x=0, y=y_move, z=z_move)
 
-    def _z_corrected_needle_movement(self, 
-        expected_z: float, stage_tilt: float
+    def _z_corrected_needle_movement(
+        self, expected_z: float, stage_tilt: float
     ) -> FibsemManipulatorPosition:
         """Calculate the corrected needle movement to move in the z-axis.
 
@@ -2871,20 +3216,21 @@ class ThermoMicroscope(FibsemMicroscope):
         z_move = +np.cos(stage_tilt) * expected_z
         return FibsemManipulatorPosition(x=0, y=y_move, z=z_move)
 
-    def move_manipulator_corrected(self, 
+    def move_manipulator_corrected(
+        self,
         dx: float = 0,
         dy: float = 0,
         beam_type: BeamType = BeamType.ELECTRON,
     ) -> None:
         """Calculate the required corrected needle movements based on the BeamType to move in the desired image coordinates.
-        Then move the needle relatively. Manipulator movement axis is based on stage tilt, so we need to adjust for that 
+        Then move the needle relatively. Manipulator movement axis is based on stage tilt, so we need to adjust for that
         with corrected movements, depending on the stage tilt and imaging perspective.
 
         BeamType.ELECTRON:  move in x, y (raw coordinates)
         BeamType.ION:       move in x, z (raw coordinates)
 
         Args:
-            microscope (FibsemMicroscope) 
+            microscope (FibsemMicroscope)
             dx (float): distance along the x-axis (image coordinates)
             dy (float): distance along the y-axis (image corodinates)
             beam_type (BeamType, optional): the beam type to move in. Defaults to BeamType.ELECTRON.
@@ -2898,25 +3244,28 @@ class ThermoMicroscope(FibsemMicroscope):
 
         # xz,
         if beam_type is BeamType.ION:
-
             x_move = self._x_corrected_needle_movement(expected_x=dx)
-            yz_move = self._z_corrected_needle_movement(expected_z=dy, stage_tilt=stage_tilt)
+            yz_move = self._z_corrected_needle_movement(
+                expected_z=dy, stage_tilt=stage_tilt
+            )
 
         # explicitly set the coordinate system
         self.connection.specimen.manipulator.set_default_coordinate_system(
             ManipulatorCoordinateSystem.STAGE
         )
-        manipulator_position = FibsemManipulatorPosition(x=x_move.x, y=yz_move.y, 
-                                                    z=yz_move.z, 
-                                                    r = 0.0 ,coordinate_system="STAGE")
+        manipulator_position = FibsemManipulatorPosition(
+            x=x_move.x, y=yz_move.y, z=yz_move.z, r=0.0, coordinate_system="STAGE"
+        )
 
         # move manipulator
         self.move_manipulator_relative(manipulator_position)
 
         return self.get_manipulator_position()
 
-    def move_manipulator_to_position_offset(self, offset: FibsemManipulatorPosition, name: str = None) -> None:
-        """Move the manipulator to the specified coordinates, offset by the provided offset."""        
+    def move_manipulator_to_position_offset(
+        self, offset: FibsemManipulatorPosition, name: str = None
+    ) -> None:
+        """Move the manipulator to the specified coordinates, offset by the provided offset."""
         saved_position = self._get_saved_manipulator_position(name)
 
         # calculate corrected manipulator movement
@@ -2929,31 +3278,51 @@ class ThermoMicroscope(FibsemMicroscope):
         saved_position.z += yz_move.z  # RAW, up = negative, STAGE: down = negative
         saved_position.r = None  # rotation is not supported
 
-        logging.debug({"msg": "move_manipulator_to_position_offset", 
-                       "name": name, "offset": offset.to_dict(), 
-                       "saved_position": saved_position.to_dict()})
+        logging.debug(
+            {
+                "msg": "move_manipulator_to_position_offset",
+                "name": name,
+                "offset": offset.to_dict(),
+                "saved_position": saved_position.to_dict(),
+            }
+        )
 
         # move manipulator absolute
         self.move_manipulator_absolute(saved_position)
 
-    def _get_saved_manipulator_position(self, name: str = "PARK") -> FibsemManipulatorPosition:
+    def _get_saved_manipulator_position(
+        self, name: str = "PARK"
+    ) -> FibsemManipulatorPosition:
 
         if name not in ["PARK", "EUCENTRIC"]:
             raise ValueError(f"saved position {name} not supported.")
         if AUTOSCRIPT_VERSION < MINIMUM_AUTOSCRIPT_VERSION_4_7:
-            raise NotImplementedError("Manipulator saved positions not supported in this version. Please upgrade to 4.7 or higher")
-
-        named_position = ManipulatorSavedPosition.PARK if name == "PARK" else ManipulatorSavedPosition.EUCENTRIC
-        autoscript_position = self.connection.specimen.manipulator.get_saved_position(
-                named_position, ManipulatorCoordinateSystem.STAGE # TODO: why is this STAGE not RAW?
+            raise NotImplementedError(
+                "Manipulator saved positions not supported in this version. Please upgrade to 4.7 or higher"
             )
+
+        named_position = (
+            ManipulatorSavedPosition.PARK
+            if name == "PARK"
+            else ManipulatorSavedPosition.EUCENTRIC
+        )
+        autoscript_position = self.connection.specimen.manipulator.get_saved_position(
+            named_position,
+            ManipulatorCoordinateSystem.STAGE,  # TODO: why is this STAGE not RAW?
+        )
 
         # convert to FibsemManipulatorPosition
         manipulator_position = manipulator_position_from_autoscript(autoscript_position)
 
-        logging.debug({"msg": "get_saved_manipulator_position", "name": name, "position": manipulator_position.to_dict()})
+        logging.debug(
+            {
+                "msg": "get_saved_manipulator_position",
+                "name": name,
+                "position": manipulator_position.to_dict(),
+            }
+        )
 
-        return manipulator_position 
+        return manipulator_position
 
     def setup_milling(
         self,
@@ -2972,24 +3341,32 @@ class ThermoMicroscope(FibsemMicroscope):
         self.set_patterning_mode(mill_settings.patterning_mode)
         self.clear_patterns()  # clear any existing patterns
         self.set_field_of_view(hfw=mill_settings.hfw, beam_type=self.milling_channel)
-        self.set_beam_current(current=mill_settings.milling_current, beam_type=self.milling_channel)
-        self.set_beam_voltage(voltage=mill_settings.milling_voltage, beam_type=self.milling_channel)
+        self.set_beam_current(
+            current=mill_settings.milling_current, beam_type=self.milling_channel
+        )
+        self.set_beam_voltage(
+            voltage=mill_settings.milling_voltage, beam_type=self.milling_channel
+        )
 
         # TODO: migrate to _set_milling_settings():
         # self.milling_channel = mill_settings.milling_channel
         # self.set_milling_settings(mill_settings)
         # self.clear_patterns()
 
-        logging.debug({"msg": "setup_milling", "mill_settings": mill_settings.to_dict()})
+        logging.debug(
+            {"msg": "setup_milling", "mill_settings": mill_settings.to_dict()}
+        )
 
-    def run_milling(self, milling_current: float, milling_voltage: float, asynch: bool = False):
+    def run_milling(
+        self, milling_current: float, milling_voltage: float, asynch: bool = False
+    ):
         """
         Run ion beam milling using the specified milling current.
 
         Args:
             milling_current (float): The current to use for milling in amps.
             milling_voltage (float): The voltage to use for milling in volts.
-            asynch (bool, optional): If True, the milling will be run asynchronously. 
+            asynch (bool, optional): If True, the milling will be run asynchronously.
                                      Defaults to False, in which case it will run synchronously.
         """
         if not self.is_available("ion_beam"):
@@ -2998,11 +3375,17 @@ class ThermoMicroscope(FibsemMicroscope):
         try:
             # change to milling current, voltage # TODO: do this in a more standard way (there are other settings)
             if self.get_beam_voltage(beam_type=self.milling_channel) != milling_voltage:
-                self.set_beam_voltage(voltage=milling_voltage, beam_type=self.milling_channel)
+                self.set_beam_voltage(
+                    voltage=milling_voltage, beam_type=self.milling_channel
+                )
             if self.get_beam_current(beam_type=self.milling_channel) != milling_current:
-                self.set_beam_current(current=milling_current, beam_type=self.milling_channel)
+                self.set_beam_current(
+                    current=milling_current, beam_type=self.milling_channel
+                )
         except Exception as e:
-            logging.warning(f"Failed to set voltage or current: {e}, voltage={milling_voltage}, current={milling_current}")
+            logging.warning(
+                f"Failed to set voltage or current: {e}, voltage={milling_voltage}, current={milling_current}"
+            )
 
         # run milling (asynchronously)
         self.set_channel(channel=self.milling_channel)  # the ion beam view
@@ -3014,32 +3397,45 @@ class ThermoMicroscope(FibsemMicroscope):
         remaining_time = estimated_time
 
         if asynch:
-            return # return immediately, up to the caller to handle the milling process
+            return  # return immediately, up to the caller to handle the milling process
 
         MILLING_SLEEP_TIME = 1
-        while self.get_milling_state() is MillingState.IDLE: # giving time to start 
+        while self.get_milling_state() is MillingState.IDLE:  # giving time to start
             time.sleep(0.5)
         while self.get_milling_state() in ACTIVE_MILLING_STATES:
             # logging.info(f"Patterning State: {self.connection.patterning.state}")
             # TODO: add drift correction support here... generically
             if self.get_milling_state() is MillingState.RUNNING:
-                remaining_time -= MILLING_SLEEP_TIME # TODO: investigate if this is a good estimate
+                remaining_time -= (
+                    MILLING_SLEEP_TIME  # TODO: investigate if this is a good estimate
+                )
             time.sleep(MILLING_SLEEP_TIME)
             # TODO: refresh the remaining time by getting the milling time from the patterning API as user can change the patterns on xtUI
 
             # update milling progress via signal
-            self.milling_progress_signal.emit({"progress": {
-                    "state": "update", 
-                    "start_time": start_time,
-                    "milling_state": self.get_milling_state(),
-                    "estimated_time": estimated_time, 
-                    "remaining_time": remaining_time}
-                    })
+            self.milling_progress_signal.emit(
+                {
+                    "progress": {
+                        "state": "update",
+                        "start_time": start_time,
+                        "milling_state": self.get_milling_state(),
+                        "estimated_time": estimated_time,
+                        "remaining_time": remaining_time,
+                    }
+                }
+            )
 
         # milling complete
         self.clear_patterns()
-                
-        logging.debug({"msg": "run_milling", "milling_current": milling_current, "milling_voltage": milling_voltage, "asynch": asynch})
+
+        logging.debug(
+            {
+                "msg": "run_milling",
+                "milling_current": milling_current,
+                "milling_voltage": milling_voltage,
+                "asynch": asynch,
+            }
+        )
 
     def finish_milling(self, imaging_current: float, imaging_voltage: float):
         """
@@ -3052,9 +3448,15 @@ class ThermoMicroscope(FibsemMicroscope):
         self.set_beam_current(current=imaging_current, beam_type=self.milling_channel)
         self.set_beam_voltage(voltage=imaging_voltage, beam_type=self.milling_channel)
         self.set_patterning_mode("Serial")
-         # TODO: store initial imaging settings in setup_milling, restore here, rather than hybrid
+        # TODO: store initial imaging settings in setup_milling, restore here, rather than hybrid
 
-        logging.debug({"msg": "finish_milling", "imaging_current": imaging_current, "imaging_voltage": imaging_voltage})
+        logging.debug(
+            {
+                "msg": "finish_milling",
+                "imaging_current": imaging_current,
+                "imaging_voltage": imaging_voltage,
+            }
+        )
 
     # def setup_milling2(
     #     self,
@@ -3062,7 +3464,7 @@ class ThermoMicroscope(FibsemMicroscope):
     # ):
     #     """
     #     Configure the microscope for milling using the ion beam.
-        
+
     #     Args:
     #         milling_stage (FibsemMillingStage): Milling stage.
     #     """
@@ -3079,7 +3481,9 @@ class ThermoMicroscope(FibsemMicroscope):
     def set_default_patterning_beam_type(self, beam_type: BeamType):
         """Set the default beam type for patterning."""
         if beam_type not in BeamType:
-            raise ValueError(f"Beam type {beam_type} not supported. Supported types: {list(BeamType)}")
+            raise ValueError(
+                f"Beam type {beam_type} not supported. Supported types: {list(BeamType)}"
+            )
 
         self.connection.patterning.set_default_beam_type(beam_type.value)
         return beam_type
@@ -3159,11 +3563,16 @@ class ThermoMicroscope(FibsemMicroscope):
         application_files = self.get_available_values("application_file")
         if application_file not in application_files:
             if strict:
-                raise ValueError(f"Application file {application_file} not available. Available files: {application_files}")
+                raise ValueError(
+                    f"Application file {application_file} not available. Available files: {application_files}"
+                )
             from difflib import get_close_matches
+
             closest_match = get_close_matches(application_file, application_files, n=1)
             if not closest_match:
-                raise ValueError(f"Application file {application_file} not available. Available files: {application_files}")
+                raise ValueError(
+                    f"Application file {application_file} not available. Available files: {application_files}"
+                )
             application_file = str(closest_match[0])
 
         return application_file
@@ -3205,8 +3614,10 @@ class ThermoMicroscope(FibsemMicroscope):
             mode (str): The patterning mode to set. Can be "Serial" or "Parallel".
         """
         if mode not in ["Serial", "Parallel"]:
-            raise ValueError(f"Patterning mode {mode} not supported. Supported modes: Serial, Parallel")
-        
+            raise ValueError(
+                f"Patterning mode {mode} not supported. Supported modes: Serial, Parallel"
+            )
+
         self.connection.patterning.mode = mode
         logging.debug({"msg": "set_patterning_mode", "mode": mode})
         return mode
@@ -3228,16 +3639,20 @@ class ThermoMicroscope(FibsemMicroscope):
         Raises:
             AutoscriptError: if an error occurs while creating the pattern.
         """
-        
+
         # get patterning api
         patterning_api = self.connection.patterning
         if pattern_settings.cross_section is CrossSectionPattern.RegularCrossSection:
             create_pattern_function = patterning_api.create_regular_cross_section
-            self.set_patterning_mode("Serial") # parallel mode not supported for regular cross section
+            self.set_patterning_mode(
+                "Serial"
+            )  # parallel mode not supported for regular cross section
             self.set_application_file("Si-multipass", strict=False)
         elif pattern_settings.cross_section is CrossSectionPattern.CleaningCrossSection:
             create_pattern_function = patterning_api.create_cleaning_cross_section
-            self.set_patterning_mode("Serial") # parallel mode not supported for cleaning cross section
+            self.set_patterning_mode(
+                "Serial"
+            )  # parallel mode not supported for cleaning cross section
             self.set_application_file("Si-ccs", strict=False)
         else:
             create_pattern_function = patterning_api.create_rectangle
@@ -3266,29 +3681,36 @@ class ThermoMicroscope(FibsemMicroscope):
         pattern.is_exclusion_zone = pattern_settings.is_exclusion
 
         # set scan direction
-        available_scan_directions = self.get_available_values("scan_direction")        
-    
+        available_scan_directions = self.get_available_values("scan_direction")
+
         if pattern_settings.scan_direction in available_scan_directions:
             pattern.scan_direction = pattern_settings.scan_direction
         else:
             pattern.scan_direction = "TopToBottom"
-            logging.warning(f"Scan direction {pattern_settings.scan_direction} not supported. Using TopToBottom instead.")
-            logging.warning(f"Supported scan directions are: {available_scan_directions}")        
+            logging.warning(
+                f"Scan direction {pattern_settings.scan_direction} not supported. Using TopToBottom instead."
+            )
+            logging.warning(
+                f"Supported scan directions are: {available_scan_directions}"
+            )
 
-        # set passes       
-        if pattern_settings.passes: # not zero
+        # set passes
+        if pattern_settings.passes:  # not zero
             if isinstance(pattern, RegularCrossSectionPattern):
                 pattern.multi_scan_pass_count = pattern_settings.passes
-                pattern.scan_method = 1 # multi scan
+                pattern.scan_method = 1  # multi scan
             else:
-                pattern.dwell_time = pattern.dwell_time * (pattern.pass_count / pattern_settings.passes)
-                
+                pattern.dwell_time = pattern.dwell_time * (
+                    pattern.pass_count / pattern_settings.passes
+                )
+
                 # NB: passes, time, dwell time are all interlinked, therefore can only adjust passes indirectly
                 # if we adjust passes directly, it just reduces the total time to compensate, rather than increasing the dwell_time
                 # NB: the current must be set before doing this, otherwise it will be out of range
 
-
-        logging.debug({"msg": "draw_rectangle", "pattern_settings": pattern_settings.to_dict()})
+        logging.debug(
+            {"msg": "draw_rectangle", "pattern_settings": pattern_settings.to_dict()}
+        )
 
         self._patterns.append(pattern)
 
@@ -3317,7 +3739,9 @@ class ThermoMicroscope(FibsemMicroscope):
             end_y=pattern_settings.end_y,
             depth=pattern_settings.depth,
         )
-        logging.debug({"msg": "draw_line", "pattern_settings": pattern_settings.to_dict()})
+        logging.debug(
+            {"msg": "draw_line", "pattern_settings": pattern_settings.to_dict()}
+        )
         self._patterns.append(pattern)
         return pattern
 
@@ -3340,8 +3764,8 @@ class ThermoMicroscope(FibsemMicroscope):
 
         outer_diameter = 2 * pattern_settings.radius
         inner_diameter = 0
-        if  pattern_settings.thickness != 0:       
-            inner_diameter = outer_diameter - 2*pattern_settings.thickness
+        if pattern_settings.thickness != 0:
+            inner_diameter = outer_diameter - 2 * pattern_settings.thickness
 
         fallback_application_file = "Si"
         try:
@@ -3371,7 +3795,9 @@ class ThermoMicroscope(FibsemMicroscope):
         # set exclusion
         pattern.is_exclusion_zone = pattern_settings.is_exclusion
 
-        logging.debug({"msg": "draw_circle", "pattern_settings": pattern_settings.to_dict()})
+        logging.debug(
+            {"msg": "draw_circle", "pattern_settings": pattern_settings.to_dict()}
+        )
         self._patterns.append(pattern)
         return pattern
 
@@ -3395,9 +3821,7 @@ class ThermoMicroscope(FibsemMicroscope):
         fallback_application_file = "Si"
         try:
             if pattern_settings.interpolate is not None:
-                points = self._resize_bitmap_to_pattern(
-                    pattern_settings
-                )
+                points = self._resize_bitmap_to_pattern(pattern_settings)
             bitmap_pattern.points = points
             pattern = self.connection.patterning.create_bitmap(
                 center_x=pattern_settings.centre_x,
@@ -3418,9 +3842,7 @@ class ThermoMicroscope(FibsemMicroscope):
             self.set_application_file(fallback_application_file)
 
             if pattern_settings.interpolate is not None:
-                points = self._resize_bitmap_to_pattern(
-                    pattern_settings
-                )
+                points = self._resize_bitmap_to_pattern(pattern_settings)
             bitmap_pattern.points = points
             pattern = self.connection.patterning.create_bitmap(
                 center_x=pattern_settings.centre_x,
@@ -3449,7 +3871,8 @@ class ThermoMicroscope(FibsemMicroscope):
         else:
             pattern.scan_direction = "TopToBottom"
             logging.warning(
-                "Scan direction %s not supported. Using TopToBottom instead.", pattern_settings.scan_direction
+                "Scan direction %s not supported. Using TopToBottom instead.",
+                pattern_settings.scan_direction,
             )
             logging.warning(
                 "Supported scan directions are: %s", str(available_scan_directions)
@@ -3515,7 +3938,9 @@ class ThermoMicroscope(FibsemMicroscope):
         resized_points = np.empty((*new_shape, 2), dtype=object)
 
         resized_points[:, :, 0] = transform.resize(
-            points[:, :, 0].reshape(points.shape[0], points.shape[1]).astype(np.float64),
+            points[:, :, 0]
+            .reshape(points.shape[0], points.shape[1])
+            .astype(np.float64),
             output_shape=new_shape,
             order=order,
             preserve_range=True,
@@ -3534,21 +3959,24 @@ class ThermoMicroscope(FibsemMicroscope):
         """Draw a polygon pattern on the current imaging view of the microscope."""
 
         if AUTOSCRIPT_VERSION < parse_version("4.12"):
-            raise NotImplementedError("Polygon patterning is only supported in Autoscript 4.12 or higher.")
+            raise NotImplementedError(
+                "Polygon patterning is only supported in Autoscript 4.12 or higher."
+            )
 
         pattern = self.connection.patterning.create_polygon(
-            pattern_settings.vertices,
-            depth=pattern_settings.depth
+            pattern_settings.vertices, depth=pattern_settings.depth
         )
         pattern.is_exclusion_zone = pattern_settings.is_exclusion
 
-        logging.debug({"msg": "draw_polygon", "pattern_settings": pattern_settings.to_dict()})
+        logging.debug(
+            {"msg": "draw_polygon", "pattern_settings": pattern_settings.to_dict()}
+        )
         self._patterns.append(pattern)
         return pattern
 
     def get_gis(self, port: str = None):
         use_multichem = self.is_available("gis_multichem")
-        
+
         if use_multichem:
             gis = self.connection.gas.get_multichem()
         else:
@@ -3571,7 +3999,9 @@ class ThermoMicroscope(FibsemMicroscope):
     def retract_gis(self):
         """Retract the gis"""
         self.gis.retract()
-        logging.debug({"msg": "retract_gis", "use_multichem": self.is_available("gis_multichem")})
+        logging.debug(
+            {"msg": "retract_gis", "use_multichem": self.is_available("gis_multichem")}
+        )
 
     def gis_turn_heater_on(self, gas: str = None) -> None:
         """Turn the heater on and wait for it to get to temperature"""
@@ -3580,33 +4010,42 @@ class ThermoMicroscope(FibsemMicroscope):
             self.gis.turn_heater_on(gas)
         else:
             self.gis.turn_heater_on()
-        
+
         logging.info("Waiting for heater to get to temperature...")
-        time.sleep(3) # we need to wait a bit
+        time.sleep(3)  # we need to wait a bit
 
         wait_time = 0
         max_wait_time = 15
-        target_temp = 300 # validate this somehow?
+        target_temp = 300  # validate this somehow?
         while True:
             if gas is not None:
-                temp = self.gis.get_temperature(gas) # multi-chem requires gas name
+                temp = self.gis.get_temperature(gas)  # multi-chem requires gas name
             else:
                 temp = self.gis.get_temperature()
-            logging.info(f"Waiting for heater: {temp}K, target={target_temp}, wait_time={wait_time}/{max_wait_time} sec")
+            logging.info(
+                f"Waiting for heater: {temp}K, target={target_temp}, wait_time={wait_time}/{max_wait_time} sec"
+            )
 
             if temp >= target_temp:
                 break
 
-            time.sleep(1) # wait for the heat
+            time.sleep(1)  # wait for the heat
 
             wait_time += 1
             if wait_time > max_wait_time:
                 raise TimeoutError("Gas Injection Failed to heat within time...")
-        
-        logging.debug({"msg": "gis_turn_heater_on", "temp": temp, "target_temp": target_temp, 
-                                "wait_time": wait_time, "max_wait_time": max_wait_time})
 
-        return 
+        logging.debug(
+            {
+                "msg": "gis_turn_heater_on",
+                "temp": temp,
+                "target_temp": target_temp,
+                "wait_time": wait_time,
+                "max_wait_time": max_wait_time,
+            }
+        )
+
+        return
 
     def cryo_deposition_v2(self, gis_settings: FibsemGasInjectionSettings) -> None:
         """Run non-specific cryo deposition protocol.
@@ -3621,7 +4060,7 @@ class ThermoMicroscope(FibsemMicroscope):
         insert_position = gis_settings.insert_position
 
         logging.debug({"msg": "cryo_depositon_v2", "settings": gis_settings.to_dict()})
-        
+
         # get gis subsystem
         self.get_gis(port)
 
@@ -3634,11 +4073,11 @@ class ThermoMicroscope(FibsemMicroscope):
         # turn heater on
         gas = gas if use_multichem else None
         self.gis_turn_heater_on(gas)
-        
+
         # run deposition
         logging.info(f"Running deposition for {duration} seconds")
         self.gis.open()
-        time.sleep(duration) 
+        time.sleep(duration)
         # TODO: provide more feedback to user
         self.gis.close()
 
@@ -3649,7 +4088,7 @@ class ThermoMicroscope(FibsemMicroscope):
         # retract gis / multichem
         logging.info("Retracting Gas Injection System")
         self.retract_gis()
-            
+
         return
 
     def setup_sputter(self, protocol: dict):
@@ -3666,9 +4105,9 @@ class ThermoMicroscope(FibsemMicroscope):
             None
 
         Notes:
-            This function sets up the sputter coating process on the microscope. 
-            It sets the active view to the electron beam, clears any existing patterns, and sets the default beam type to the electron beam. 
-            It then inserts the multichem and turns on the heater for the specified gas according to the given protocol. 
+            This function sets up the sputter coating process on the microscope.
+            It sets the active view to the electron beam, clears any existing patterns, and sets the default beam type to the electron beam.
+            It then inserts the multichem and turns on the heater for the specified gas according to the given protocol.
             This function also waits for 3 seconds to allow the heater to warm up.
         """
         self.original_active_view = self.connection.imaging.get_active_view()
@@ -3683,7 +4122,9 @@ class ThermoMicroscope(FibsemMicroscope):
 
         logging.debug({"msg": "setup_sputter", "protocol": protocol})
 
-    def draw_sputter_pattern(self, hfw: float, line_pattern_length: float, sputter_time: float):
+    def draw_sputter_pattern(
+        self, hfw: float, line_pattern_length: float, sputter_time: float
+    ):
         """
         Draws a line pattern for sputtering with the given parameters.
 
@@ -3710,8 +4151,15 @@ class ThermoMicroscope(FibsemMicroscope):
             2e-6,
         )  # milling depth
         pattern.time = sputter_time + 0.1
-        
-        logging.debug({"msg": "draw_sputter_pattern", "hfw": hfw, "line_pattern_length": line_pattern_length, "sputter_time": sputter_time})
+
+        logging.debug(
+            {
+                "msg": "draw_sputter_pattern",
+                "hfw": hfw,
+                "line_pattern_length": line_pattern_length,
+                "sputter_time": sputter_time,
+            }
+        )
 
     def run_sputter(self, **kwargs):
         """
@@ -3719,7 +4167,7 @@ class ThermoMicroscope(FibsemMicroscope):
 
         Args:
             **kwargs: Optional keyword arguments for the sputter function. The required argument for
-        the Thermo version is "sputter_time" (int), which specifies the time to sputter in seconds. 
+        the Thermo version is "sputter_time" (int), which specifies the time to sputter in seconds.
 
         Returns:
             None
@@ -3737,7 +4185,9 @@ class ThermoMicroscope(FibsemMicroscope):
 
         self.connection.beams.electron_beam.blank()
         if self.connection.patterning.state == "Idle":
-            logging.info("Sputtering with platinum for {} seconds...".format(sputter_time))
+            logging.info(
+                "Sputtering with platinum for {} seconds...".format(sputter_time)
+            )
             self.connection.patterning.start()  # asynchronous patterning
             time.sleep(sputter_time + 5)
         else:
@@ -3745,7 +4195,9 @@ class ThermoMicroscope(FibsemMicroscope):
         if self.connection.patterning.state == "Running":
             self.connection.patterning.stop()
         else:
-            logging.warning("Patterning state is {}".format(self.connection.patterning.state))
+            logging.warning(
+                "Patterning state is {}".format(self.connection.patterning.state)
+            )
             logging.warning("Consider adjusting the patterning line depth.")
 
     def finish_sputter(self, application_file: str) -> None:
@@ -3773,13 +4225,17 @@ class ThermoMicroscope(FibsemMicroscope):
         self.connection.beams.electron_beam.unblank()
         self.set_application_file(application_file)
         self.connection.imaging.set_active_view(self.original_active_view)
-        self.connection.patterning.set_default_beam_type(BeamType.ION.value)  # set ion beam
+        self.connection.patterning.set_default_beam_type(
+            BeamType.ION.value
+        )  # set ion beam
         self.multichem.retract()
 
         # Log that the sputtering process has finished
         logging.info("Platinum sputtering process completed.")
 
-    def get_available_values(self, key: str, beam_type: Optional[BeamType] = None)-> Tuple:
+    def get_available_values(
+        self, key: str, beam_type: Optional[BeamType] = None
+    ) -> Tuple:
         """Get a list of available values for a given key.
         Keys: application_file, plasma_gas, current, detector_type, detector_mode
         """
@@ -3790,7 +4246,9 @@ class ThermoMicroscope(FibsemMicroscope):
 
         if beam_type is BeamType.ION and self.system.ion.plasma:
             if key == "plasma_gas":
-                values = self.connection.beams.ion_beam.source.plasma_gas.available_values
+                values = (
+                    self.connection.beams.ion_beam.source.plasma_gas.available_values
+                )
 
         if key == "current":
             if beam_type is BeamType.ION and self.is_available("ion_beam"):
@@ -3813,17 +4271,17 @@ class ThermoMicroscope(FibsemMicroscope):
             if beam_type is BeamType.ION:
                 VALUES = (500, 1000, 2000, 8000, 16000, 30000)
             if beam_type is BeamType.ELECTRON:
-                VALUES =  (1000, 2000, 3000, 5000, 10000, 20000, 30000)
+                VALUES = (1000, 2000, 3000, 5000, 10000, 20000, 30000)
             # filter values to be within limits
             values = [v for v in VALUES if limits.min <= v <= limits.max]
             return values
-        
+
         if key == "detector_type":
             values = self.connection.detector.type.available_values
-        
+
         if key == "detector_mode":
             values = self.connection.detector.mode.available_values
-        
+
         if key == "scan_direction":
             TFS_SCAN_DIRECTIONS = [
                 "BottomToTop",
@@ -3838,7 +4296,7 @@ class ThermoMicroscope(FibsemMicroscope):
                 "TopToBottom",
             ]
             values = TFS_SCAN_DIRECTIONS
-        
+
         if key == "gis_ports":
             if self.is_available("gis"):
                 values = self.connection.gas.list_all_gis_ports()
@@ -3846,12 +4304,23 @@ class ThermoMicroscope(FibsemMicroscope):
                 values = self.connection.gas.list_all_multichem_ports()
             else:
                 values = []
-                        
+
         logging.debug({"msg": "get_available_values", "key": key, "values": values})
 
         return values
 
-    def _get(self, key: str, beam_type: Optional[BeamType] = None) -> Union[int, float, str, list, Point, FibsemStagePosition, FibsemManipulatorPosition, None]:
+    def _get(
+        self, key: str, beam_type: Optional[BeamType] = None
+    ) -> Union[
+        int,
+        float,
+        str,
+        list,
+        Point,
+        FibsemStagePosition,
+        FibsemManipulatorPosition,
+        None,
+    ]:
         """Get a property of the microscope."""
         # TODO: make the list of get and set keys available to the user
         if beam_type is not None:
@@ -3863,7 +4332,7 @@ class ThermoMicroscope(FibsemMicroscope):
             return self.connection.imaging.get_active_device()
 
         # beam properties
-        if key == "on": 
+        if key == "on":
             return beam.is_on
         if key == "blanked":
             return beam.is_blanked
@@ -3883,13 +4352,16 @@ class ThermoMicroscope(FibsemMicroscope):
             return beam.high_voltage.limits
         if key == "voltage_controllable":
             return beam.high_voltage.is_controllable
-        if key == "shift": # beam shift
+        if key == "shift":  # beam shift
             return Point(beam.beam_shift.value.x, beam.beam_shift.value.y)
-        if key == "stigmation": 
+        if key == "stigmation":
             return Point(beam.stigmator.value.x, beam.stigmator.value.y)
         if key == "resolution":
             resolution = beam.scanning.resolution.value
-            width, height = int(resolution.split("x")[0]), int(resolution.split("x")[-1])
+            width, height = (
+                int(resolution.split("x")[0]),
+                int(resolution.split("x")[-1]),
+            )
             return [width, height]
 
         # system properties
@@ -3923,17 +4395,23 @@ class ThermoMicroscope(FibsemMicroscope):
 
         if key == "plasma_gas":
             if beam_type is BeamType.ION and self.system.ion.plasma:
-                return beam.source.plasma_gas.value # might need to check if this is available?
+                return (
+                    beam.source.plasma_gas.value
+                )  # might need to check if this is available?
             else:
                 return None
 
         # stage properties
         if key == "stage_position":
-            # get stage position in raw coordinates 
-            self.stage.set_default_coordinate_system(self._default_stage_coordinate_system) # TODO: remove this once testing is done
-            stage_position = stage_position_from_autoscript(self.stage.current_position) # TODO: apply compucentric/raw coordinate system conversion here
+            # get stage position in raw coordinates
+            self.stage.set_default_coordinate_system(
+                self._default_stage_coordinate_system
+            )  # TODO: remove this once testing is done
+            stage_position = stage_position_from_autoscript(
+                self.stage.current_position
+            )  # TODO: apply compucentric/raw coordinate system conversion here
             return stage_position
-        
+
         if key == "stage_homed":
             return self.stage.is_homed
         if key == "stage_linked":
@@ -3942,13 +4420,17 @@ class ThermoMicroscope(FibsemMicroscope):
         # chamber properties
         if key == "chamber_state":
             return self.connection.vacuum.chamber_state
-        
+
         if key == "chamber_pressure":
             return self.connection.vacuum.chamber_pressure.value
 
         # detector mode and type
-        if key in ["detector_mode", "detector_type", "detector_brightness", "detector_contrast"]:
-            
+        if key in [
+            "detector_mode",
+            "detector_type",
+            "detector_brightness",
+            "detector_contrast",
+        ]:
             # set beam active view and device
             self.set_channel(beam_type)
 
@@ -3963,10 +4445,10 @@ class ThermoMicroscope(FibsemMicroscope):
 
         # manipulator properties
         if key == "manipulator_position":
-            position = self.connection.specimen.manipulator.current_position   
+            position = self.connection.specimen.manipulator.current_position
             return manipulator_position_from_autoscript(position)
         if key == "manipulator_state":
-            state = self.connection.specimen.manipulator.state                 
+            state = self.connection.specimen.manipulator.state
             return True if state == ManipulatorState.INSERTED else False
 
         # manufacturer properties
@@ -3982,9 +4464,14 @@ class ThermoMicroscope(FibsemMicroscope):
             return self.system.info.hardware_version
 
         # logging.warning(f"Unknown key: {key} ({beam_type})")
-        return None    
+        return None
 
-    def _set(self, key: str, value: Union[str, int, float, BeamType, Point, FibsemRectangle], beam_type: Optional[BeamType] = None) -> None:
+    def _set(
+        self,
+        key: str,
+        value: Union[str, int, float, BeamType, Point, FibsemRectangle],
+        beam_type: Optional[BeamType] = None,
+    ) -> None:
         """Set a property of the microscope."""
         # required for setting shift, stigmation
         from autoscript_sdb_microscope_client.structures import Point as ThermoPoint
@@ -3994,7 +4481,9 @@ class ThermoMicroscope(FibsemMicroscope):
             beam = self._get_beam(beam_type)
 
         if key == "active_view":
-            self.connection.imaging.set_active_view(value.value)  # the beam type is the active view (in ui)
+            self.connection.imaging.set_active_view(
+                value.value
+            )  # the beam type is the active view (in ui)
             return
         if key == "active_device":
             self.connection.imaging.set_active_device(value.value)
@@ -4004,7 +4493,7 @@ class ThermoMicroscope(FibsemMicroscope):
         if key == "working_distance":
             beam.working_distance.value = value
             logging.info(f"{beam_type.name} working distance set to {value} m.")
-            return 
+            return
         if key == "current":
             beam.beam_current.value = value
             logging.info(f"{beam_type.name} current set to {value} A.")
@@ -4015,10 +4504,10 @@ class ThermoMicroscope(FibsemMicroscope):
             return
         if key == "hfw":
             limits = beam.horizontal_field_width.limits
-            value = np.clip(value, limits.min, limits.max-10e-6)
+            value = np.clip(value, limits.min, limits.max - 10e-6)
             beam.horizontal_field_width.value = value
             logging.info(f"{beam_type.name} HFW set to {value} m.")
-            return 
+            return
         if key == "dwell_time":
             beam.scanning.dwell_time.value = value
             logging.info(f"{beam_type.name} dwell time set to {value} s.")
@@ -4028,7 +4517,9 @@ class ThermoMicroscope(FibsemMicroscope):
             logging.info(f"{beam_type.name} scan rotation set to {value} radians.")
             return
         if key == "shift":
-            beam.beam_shift.value = ThermoPoint(value.x, value.y) # TODO: resolve this coordinate system
+            beam.beam_shift.value = ThermoPoint(
+                value.x, value.y
+            )  # TODO: resolve this coordinate system
             logging.info(f"{beam_type.name} shift set to {value}.")
             return
         if key == "stigmation":
@@ -4039,14 +4530,13 @@ class ThermoMicroscope(FibsemMicroscope):
         if key == "resolution":
             resolution = f"{value[0]}x{value[1]}"  # WidthxHeight e.g. 1536x1024
             beam.scanning.resolution.value = resolution
-            return 
+            return
 
         # scanning modes
         if key == "reduced_area":
-            beam.scanning.mode.set_reduced_area(left=value.left, 
-                                                top=value.top, 
-                                                width=value.width, 
-                                                height=value.height)
+            beam.scanning.mode.set_reduced_area(
+                left=value.left, top=value.top, width=value.width, height=value.height
+            )
             return
 
         if key == "spot_mode":
@@ -4065,11 +4555,18 @@ class ThermoMicroscope(FibsemMicroscope):
             return
         if key == "blanked":
             beam.blank() if value else beam.unblank()
-            logging.info(f"{beam_type.name} beam {'blanked' if value else 'unblanked'}.")
+            logging.info(
+                f"{beam_type.name} beam {'blanked' if value else 'unblanked'}."
+            )
             return
 
         # detector properties
-        if key in ["detector_mode", "detector_type", "detector_brightness", "detector_contrast"]:
+        if key in [
+            "detector_mode",
+            "detector_type",
+            "detector_brightness",
+            "detector_contrast",
+        ]:
             self.set_channel(beam_type)
 
             if key == "detector_mode":
@@ -4087,25 +4584,29 @@ class ThermoMicroscope(FibsemMicroscope):
                     logging.warning(f"Detector type {value} not available.")
                 return
             if key == "detector_brightness":
-                if 0 < value <= 1 :
+                if 0 < value <= 1:
                     self.connection.detector.brightness.value = value
                     logging.info(f"Detector brightness set to {value}.")
                 else:
-                    logging.warning(f"Detector brightness {value} not available, must be between 0 and 1.")
+                    logging.warning(
+                        f"Detector brightness {value} not available, must be between 0 and 1."
+                    )
                 return
             if key == "detector_contrast":
-                if 0 < value <= 1 :
+                if 0 < value <= 1:
                     self.connection.detector.contrast.value = value
                     logging.info(f"Detector contrast set to {value}.")
                 else:
-                    logging.warning(f"Detector contrast {value} not available, mut be between 0 and 1.")
+                    logging.warning(
+                        f"Detector contrast {value} not available, mut be between 0 and 1."
+                    )
                 return
 
         # system properties
         if key == "beam_enabled":
             if beam_type is BeamType.ELECTRON:
                 self.system.electron.beam.enabled = value
-                return 
+                return
             elif beam_type is BeamType.ION:
                 self.system.ion.beam.enabled = value
                 return
@@ -4119,17 +4620,17 @@ class ThermoMicroscope(FibsemMicroscope):
                 return
             elif beam_type is BeamType.ION:
                 self.system.ion.eucentric_height = value
-                return 
+                return
             else:
                 raise ValueError(f"Unknown beam type: {beam_type} for {key}")
 
-        if key =="column_tilt":
+        if key == "column_tilt":
             if beam_type is BeamType.ELECTRON:
                 self.system.electron.column_tilt = value
                 return
             elif beam_type is BeamType.ION:
                 self.system.ion.column_tilt = value
-                return 
+                return
             else:
                 raise ValueError(f"Unknown beam type: {beam_type} for {key}")
 
@@ -4149,7 +4650,7 @@ class ThermoMicroscope(FibsemMicroscope):
             if key == "angular_correction_tilt_correction":
                 beam.angular_correction.tilt_correction.turn_on() if value else beam.angular_correction.tilt_correction.turn_off()
                 return
-    
+
         # ion beam properties
         if beam_type is BeamType.ION:
             if key == "plasma_gas":
@@ -4157,9 +4658,13 @@ class ThermoMicroscope(FibsemMicroscope):
                     logging.debug("Plasma gas cannot be set on this microscope.")
                     return
                 if not self.check_available_values("plasma_gas", [value], beam_type):
-                    logging.warning(f"Plasma gas {value} not available. Available values: {self.get_available_values('plasma_gas', beam_type)}")
-                
-                logging.info(f"Setting plasma gas to {value}... this may take some time...")
+                    logging.warning(
+                        f"Plasma gas {value} not available. Available values: {self.get_available_values('plasma_gas', beam_type)}"
+                    )
+
+                logging.info(
+                    f"Setting plasma gas to {value}... this may take some time..."
+                )
                 beam.source.plasma_gas.value = value
                 logging.info(f"Plasma gas set to {value}.")
 
@@ -4179,7 +4684,7 @@ class ThermoMicroscope(FibsemMicroscope):
 
             logging.info("Linking stage...")
             self.stage.link() if value else self.stage.unlink()
-            logging.info(f"Stage {'linked' if value else 'unlinked'}.")    
+            logging.info(f"Stage {'linked' if value else 'unlinked'}.")
             return
 
         # chamber properties
@@ -4187,7 +4692,7 @@ class ThermoMicroscope(FibsemMicroscope):
             if value:
                 logging.info("Pumping chamber...")
                 self.connection.vacuum.pump()
-                logging.info("Chamber pumped.") 
+                logging.info("Chamber pumped.")
                 return
             else:
                 logging.warning(f"Invalid value for pump_chamber: {value}.")
@@ -4197,7 +4702,7 @@ class ThermoMicroscope(FibsemMicroscope):
             if value:
                 logging.info("Venting chamber...")
                 self.connection.vacuum.vent()
-                logging.info("Chamber vented.") 
+                logging.info("Chamber vented.")
                 return
             else:
                 logging.warning(f"Invalid value for vent_chamber: {value}.")
@@ -4214,7 +4719,9 @@ class ThermoMicroscope(FibsemMicroscope):
 
         return
 
-    def check_available_values(self, key:str, values: list, beam_type: Optional[BeamType] = None) -> bool:
+    def check_available_values(
+        self, key: str, values: list, beam_type: Optional[BeamType] = None
+    ) -> bool:
         """Check if the given values are available for the given key."""
 
         available_values = self.get_available_values(key, beam_type)
@@ -4231,7 +4738,7 @@ class ThermoMicroscope(FibsemMicroscope):
                     return False
         return True
 
-    def _get_beam(self, beam_type: BeamType) -> Union['ElectronBeam', 'IonBeam']:
+    def _get_beam(self, beam_type: BeamType) -> Union["ElectronBeam", "IonBeam"]:
         """Get the beam connection api for the given beam type.
         Args:
             beam_type (BeamType): The type of beam to get (ELECTRON or ION).
@@ -4250,22 +4757,24 @@ class ThermoMicroscope(FibsemMicroscope):
         if self.stage_is_compustage:
             return FibsemStagePosition(x=0, y=0)
 
-        # get stage position in speciemn coordinates 
+        # get stage position in speciemn coordinates
         self.stage.set_default_coordinate_system(CoordinateSystem.SPECIMEN)
-        specimen_stage_position = stage_position_from_autoscript(self.stage.current_position)
+        specimen_stage_position = stage_position_from_autoscript(
+            self.stage.current_position
+        )
 
         # get stage position in raw coordinates
         self.stage.set_default_coordinate_system(CoordinateSystem.RAW)
         raw_stage_position = stage_position_from_autoscript(self.stage.current_position)
 
         # calculate the offset
-        offset = specimen_stage_position - raw_stage_position # XY only
+        offset = specimen_stage_position - raw_stage_position  # XY only
 
         # restore stage coordinate system
         self.stage.set_default_coordinate_system(self._default_stage_coordinate_system)
 
         return offset
-    
+
     def run_sputter_coater(self, time_seconds: int) -> None:
         """Run the sputter coater for a given time in seconds.
         Args:
@@ -4277,7 +4786,9 @@ class ThermoMicroscope(FibsemMicroscope):
         """
 
         if not hasattr(self.connection.specimen, "sputter_coater"):
-            raise NotImplementedError("Sputter coater not available on this microscope.")
+            raise NotImplementedError(
+                "Sputter coater not available on this microscope."
+            )
 
         # check if system is Arctis
         if "Arctis" not in self.system.info.model:

--- a/tests/test_projection_paths_agree.py
+++ b/tests/test_projection_paths_agree.py
@@ -1,0 +1,213 @@
+"""One implementation of the inverse projection, reached three ways.
+
+`FibsemMicroscope._inverse_view_corrected_stage_movement` and
+`imaging/tiling/reprojection._inverse_y_corrected_stage_movement` each used to carry
+their own copy of the trigonometry that recovers an in-image y-displacement from a y/z
+stage movement. Three copies of one decision, kept consistent only by everyone
+remembering to edit all three -- and they had already drifted (FIB-500).
+
+Both now defer to `transformations.inverse_view_corrected_dy`. These tests are what makes
+that worth having: they fail if a copy ever comes back, and they pin the reachability
+argument that lets the drift be closed without a hardware check.
+
+Run directly:
+    python -m pytest tests/test_projection_paths_agree.py
+"""
+from __future__ import annotations
+
+import ast
+import io
+import os
+
+import numpy as np
+import pytest
+
+from fibsem import utils
+from fibsem.imaging.tiling.reprojection import _inverse_y_corrected_stage_movement
+from fibsem.structures import (
+    BeamType,
+    FibsemImage,
+    FibsemStagePosition,
+    ImageSettings,
+)
+from fibsem.transformations import inverse_view_corrected_dy
+
+# Poses worth asking about, in degrees. The configured orientations plus the two the
+# geometry is exact at, because a sweep of round numbers misses -128 and -23 entirely.
+TILTS = (-180.0, -160.0, -128.0, -90.0, -23.0, 0.0, 20.0, 38.0)
+DELTAS = ((12e-6, -5e-6), (-40e-6, 22e-6), (0.0, 30e-6), (30e-6, 0.0), (0.0, 0.0))
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    """A simulated Arctis -- a compustage, which is where the three paths differed."""
+    import fibsem.config as fibsem_config
+
+    path = os.path.join(
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "sim-arctis-configuration.yaml",
+    )
+    scope, _ = utils.setup_session(manufacturer="Demo", config_path=path)
+    assert scope.stage_is_compustage, "the config stopped being a compustage"
+    return scope
+
+
+def _image_at(microscope, beam_type: BeamType, pose: FibsemStagePosition) -> FibsemImage:
+    """An image carrying *pose* and the instrument's geometry, for the metadata path."""
+    image = FibsemImage.generate_blank_image(resolution=(64, 64), hfw=100e-6)
+    image.data = np.zeros((64, 64), dtype=np.uint8)
+    state = microscope.get_microscope_state(beam_type=beam_type)
+    state.stage_position = pose
+    image.metadata.image_settings = ImageSettings(hfw=100e-6, beam_type=beam_type)
+    image.metadata.microscope_state = state
+    image.metadata.system_info = microscope.system.info
+    image.metadata.hardware_geometry = microscope.hardware_geometry()
+    return image
+
+
+def _shared(microscope, beam_type, pose, dy, dz) -> float:
+    """The one implementation, called directly."""
+    return inverse_view_corrected_dy(
+        dy=dy,
+        dz=dz,
+        view_tilt=microscope._beam_view_tilt(beam_type),
+        geometry=microscope.hardware_geometry(),
+        stage_rotation=pose.r if pose.r is not None else 0.0,
+        stage_tilt=pose.t if pose.t is not None else 0.0,
+    )
+
+
+class TestTheThreePathsAgree:
+    """The contract the delegation exists to make unbreakable.
+
+    Not "they happen to agree today" -- these run the full pose matrix, so a
+    reintroduced copy that is right at the flat poses and wrong at the tilted ones
+    (which is what both geometry defects here looked like) fails rather than passing.
+    """
+
+    @pytest.mark.parametrize("tilt_deg", TILTS)
+    @pytest.mark.parametrize("beam_type", [BeamType.ELECTRON, BeamType.ION])
+    def test_the_image_metadata_path_matches(self, microscope, beam_type, tilt_deg):
+        pose = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(tilt_deg))
+        image = _image_at(microscope, beam_type, pose)
+        for dy, dz in DELTAS:
+            assert _inverse_y_corrected_stage_movement(
+                image, dy=dy, dz=dz, beam_type=beam_type
+            ) == pytest.approx(
+                _shared(microscope, beam_type, pose, dy, dz), abs=1e-15
+            ), f"tiled path differs at t={tilt_deg}, {beam_type.name}, ({dy}, {dz})"
+
+    @pytest.mark.parametrize("tilt_deg", TILTS)
+    @pytest.mark.parametrize("beam_type", [BeamType.ELECTRON, BeamType.ION])
+    def test_the_live_microscope_path_matches(self, microscope, beam_type, tilt_deg):
+        """The live path reads the pose off the instrument, so the stage has to be there."""
+        pose = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(tilt_deg))
+        microscope.move_stage_absolute(pose)
+        live = microscope.get_stage_position()
+        for dy, dz in DELTAS:
+            assert microscope._inverse_y_corrected_stage_movement(
+                dy=dy, dz=dz, beam_type=beam_type
+            ) == pytest.approx(
+                _shared(microscope, beam_type, live, dy, dz), abs=1e-15
+            ), f"live path differs at t={tilt_deg}, {beam_type.name}, ({dy}, {dz})"
+
+    def test_the_live_path_does_not_read_the_orientation_from_hardware(self, microscope):
+        """It used to ask `get_stage_orientation()` to decide the compustage FIB pose.
+
+        The shared implementation derives that from the pose it is handed, which is one
+        fewer instrument round trip on a path the canvas calls per marker.
+        """
+        calls = []
+        original = type(microscope).get_stage_orientation
+
+        def counted(self, *args, **kwargs):
+            calls.append(1)
+            return original(self, *args, **kwargs)
+
+        type(microscope).get_stage_orientation = counted
+        try:
+            microscope._inverse_y_corrected_stage_movement(
+                dy=10e-6, dz=5e-6, beam_type=BeamType.ELECTRON
+            )
+        finally:
+            type(microscope).get_stage_orientation = original
+        assert calls == [], "the orientation is being read from the instrument again"
+
+
+class TestTheCompustageFibDivergenceIsClosed:
+    """FIB-500. The tiled copy decided the FIB orientation from tilt alone, where the
+    other two also require the rotation to match the reference -- so at tilt -128 with a
+    non-zero rotation the sign inverted between them."""
+
+    @pytest.mark.parametrize("rotation_deg", [90.0, 180.0, 270.0])
+    @pytest.mark.parametrize("beam_type", [BeamType.ELECTRON, BeamType.ION])
+    def test_the_paths_agree_at_a_rotated_fib_pose(
+        self, microscope, beam_type, rotation_deg
+    ):
+        pose = FibsemStagePosition(
+            x=0.0, y=0.0, z=0.0,
+            r=np.deg2rad(rotation_deg), t=np.deg2rad(-128.0),
+        )
+        image = _image_at(microscope, beam_type, pose)
+        assert _inverse_y_corrected_stage_movement(
+            image, dy=12e-6, dz=-5e-6, beam_type=beam_type
+        ) == pytest.approx(_shared(microscope, beam_type, pose, 12e-6, -5e-6), abs=1e-15)
+
+
+class TestARotatedCompustagePoseIsUnreachable:
+    """Why closing that divergence needed no hardware confirmation.
+
+    The poses that changed cannot be produced: a compustage has no rotation axis. That
+    argument is the whole justification, so it is pinned here rather than left in a
+    comment where it can quietly expire.
+    """
+
+    def test_a_compustage_has_no_rotation_axis(self):
+        from fibsem.microscopes.simulator import STAGE_LIMITS_COMPUSTAGE
+
+        assert "r" not in STAGE_LIMITS_COMPUSTAGE
+        assert set(STAGE_LIMITS_COMPUSTAGE) == {"x", "y", "z", "t"}
+
+    def test_a_compustage_position_is_converted_with_rotation_hardcoded_to_zero(self):
+        """Asserted through the AST, not by calling it.
+
+        `stage_position_from_autoscript` raises without the AutoScript libraries, which
+        neither CI nor a development machine has -- so the only way to hold this is to
+        read the source. Located through the module rather than by relative path, which
+        would depend on pytest's working directory.
+        """
+        from fibsem.microscopes import autoscript as autoscript_module
+
+        with io.open(autoscript_module.__file__, encoding="utf-8") as handle:
+            source = handle.read()
+        tree = ast.parse(source)
+        function = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "stage_position_from_autoscript"
+        )
+        # The CompustagePosition branch is the one guarded by an isinstance check.
+        branch = next(
+            node
+            for node in ast.walk(function)
+            if isinstance(node, ast.If)
+            and isinstance(node.test, ast.Call)
+            and getattr(node.test.func, "id", None) == "isinstance"
+            and any(
+                getattr(arg, "id", None) == "CompustagePosition" for arg in node.test.args
+            )
+        )
+        call = next(
+            node
+            for node in ast.walk(branch)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", None) == "FibsemStagePosition"
+        )
+        rotation = next(kw.value for kw in call.keywords if kw.arg == "r")
+        assert isinstance(rotation, ast.Constant), (
+            "rotation is no longer a literal -- a compustage may now carry one, and the "
+            "FIB-500 reachability argument no longer holds"
+        )
+        assert rotation.value == 0.0

--- a/tests/test_projection_paths_agree.py
+++ b/tests/test_projection_paths_agree.py
@@ -13,6 +13,7 @@ argument that lets the drift be closed without a hardware check.
 Run directly:
     python -m pytest tests/test_projection_paths_agree.py
 """
+
 from __future__ import annotations
 
 import ast
@@ -53,7 +54,9 @@ def microscope():
     return scope
 
 
-def _image_at(microscope, beam_type: BeamType, pose: FibsemStagePosition) -> FibsemImage:
+def _image_at(
+    microscope, beam_type: BeamType, pose: FibsemStagePosition
+) -> FibsemImage:
     """An image carrying *pose* and the instrument's geometry, for the metadata path."""
     image = FibsemImage.generate_blank_image(resolution=(64, 64), hfw=100e-6)
     image.data = np.zeros((64, 64), dtype=np.uint8)
@@ -112,7 +115,9 @@ class TestTheThreePathsAgree:
                 _shared(microscope, beam_type, live, dy, dz), abs=1e-15
             ), f"live path differs at t={tilt_deg}, {beam_type.name}, ({dy}, {dz})"
 
-    def test_the_live_path_does_not_read_the_orientation_from_hardware(self, microscope):
+    def test_the_live_path_does_not_read_the_orientation_from_hardware(
+        self, microscope
+    ):
         """It used to ask `get_stage_orientation()` to decide the compustage FIB pose.
 
         The shared implementation derives that from the pose it is handed, which is one
@@ -146,13 +151,18 @@ class TestTheCompustageFibDivergenceIsClosed:
         self, microscope, beam_type, rotation_deg
     ):
         pose = FibsemStagePosition(
-            x=0.0, y=0.0, z=0.0,
-            r=np.deg2rad(rotation_deg), t=np.deg2rad(-128.0),
+            x=0.0,
+            y=0.0,
+            z=0.0,
+            r=np.deg2rad(rotation_deg),
+            t=np.deg2rad(-128.0),
         )
         image = _image_at(microscope, beam_type, pose)
         assert _inverse_y_corrected_stage_movement(
             image, dy=12e-6, dz=-5e-6, beam_type=beam_type
-        ) == pytest.approx(_shared(microscope, beam_type, pose, 12e-6, -5e-6), abs=1e-15)
+        ) == pytest.approx(
+            _shared(microscope, beam_type, pose, 12e-6, -5e-6), abs=1e-15
+        )
 
 
 class TestARotatedCompustagePoseIsUnreachable:
@@ -196,7 +206,8 @@ class TestARotatedCompustagePoseIsUnreachable:
             and isinstance(node.test, ast.Call)
             and getattr(node.test.func, "id", None) == "isinstance"
             and any(
-                getattr(arg, "id", None) == "CompustagePosition" for arg in node.test.args
+                getattr(arg, "id", None) == "CompustagePosition"
+                for arg in node.test.args
             )
         )
         call = next(


### PR DESCRIPTION
> **Read the first commit; skip the second.**
>
> `5e15f424` is the refactor — 294 insertions, 172 deletions, and the whole of what this PR does.
> `c8832c1e` is `ruff format` on the same three files, which the lint job now requires of anything a PR touches (#489). `microscope.py` had never been formatted, so doing it inline would have buried a hundred-line refactor under thirteen hundred lines of reflowed argument lists.
>
> The formatting commit is verified to change no code: the parsed trees are identical once string constants are compared with whitespace normalised. 14 of 1001 string constants differ and all fourteen are docstrings whose trailing spaces ruff strips.

Groundwork for FIB-766, which needs a term added to the inverse projection. Today that would be three edits in three files that could silently disagree; after this it is one.

**No behaviour is changed on any reachable pose.**

## What it does

`FibsemMicroscope._inverse_view_corrected_stage_movement` and `imaging/tiling/reprojection._inverse_y_corrected_stage_movement` each carried their own copy of the trigonometry that recovers an in-image y-displacement from a y/z stage movement. Three copies of one decision, held consistent only by everyone remembering to edit all three — and they had already drifted.

Both now defer to `transformations.inverse_view_corrected_dy`, which is what that module was extracted for. **Net 91 lines fewer.**

The Tescan paths are untouched: those are a genuinely different derivation (z below the tilt axis), not a copy.

## Identical, verified before the change rather than assumed

All three implementations already agreed to **0.000 pm** across the configured orientations, both beams, and 40 deltas. So there was no hidden drift to preserve, and the delegation is a straight substitution.

## It closes FIB-500

The tiled copy decided the compustage FIB orientation from **tilt alone**, where the live path and `fm/reprojection.py` both also require the rotation to match the reference. At tilt −128 with a non-zero rotation the sign inverted between them — **6 of 32 combinations**, reproducing the table on FIB-500 exactly:

```
tilt=-128  rot= 90  ELEC   tiled  +7.3879u   shared  -7.3879u
tilt=-128  rot= 90  ION    tiled +12.0000u   shared -12.0000u
   ... 90 / 180 / 270, both beams
```

Sharing one implementation makes the three agree **by construction** rather than by three edits, which is FIB-500's stated acceptance criterion.

Those poses are unreachable — a compustage has no rotation axis — so nothing an acquisition can produce changes. FIB-500 asks for hardware confirmation before shipping; note that hardware cannot exercise the difference, precisely because the divergent poses can't be reached. What hardware *would* show is that every reachable pose is unchanged, which the identity check above already establishes. Flagging it so the call is a conscious one.

## One side effect worth naming

The live path called `get_stage_orientation()` to decide the compustage FIB pose, which reads the stage position a **second** time on top of the read the method already does:

```python
current_stage_position = self.get_stage_position()          # read 1
...
if self.stage_is_compustage and self.get_stage_orientation() == "FIB":   # read 2
```

That's gone — same answer, half the round trips, on a path the canvas calls once per marker. It also removes an error path, since `get_stage_orientation()` raises when the rotation is `None`.

## Tests

New `tests/test_projection_paths_agree.py`, 41 tests. It sweeps the **full pose matrix** rather than a few round numbers, because a reintroduced copy that is right at the flat poses and wrong at the tilted ones is exactly the shape the defects in this area take — the informative poses are −128 and −23, which nobody picks by hand.

Four mutations, each killed by the test that should catch it **and no other**:

| mutation | killed by |
| -- | -- |
| tiled path diverges | the metadata-path agreement tests |
| tiled path drops the rotation term (FIB-500 reintroduced) | only the 6 rotated-FIB-pose tests |
| live path diverges | the live-path agreement tests |
| live path reads the orientation from hardware again | only the hardware-read test |

It also picks up the three reachability tests FIB-500 set aside, so "a compustage cannot rotate" fails loudly rather than expiring in a comment: `STAGE_LIMITS_COMPUSTAGE` has no `r` axis, and `stage_position_from_autoscript` writes `r=0.0` as a literal — asserted through the AST, since that function raises without the AutoScript libraries neither CI nor a dev machine has.

1191 tests pass across the geometry, tiling, movement, correlation and overview suites. Ruff clean.

