### PR TITLE
[fix] Make the format check honour the config's exclude list

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -102,7 +102,13 @@ jobs:
         fi
         sed 's/^/  /' "$changed"
         # NUL-separated: a path with a space would otherwise split into two.
-        if ! tr '\n' '\0' < "$changed" | xargs -0 ruff format --check --; then
+        # --force-exclude is required, not optional: ruff ignores `exclude` for
+        # paths named explicitly on the command line, and this step names every
+        # path explicitly. Without it the config's `exclude` silently stops
+        # applying here -- today that means a pull request touching a notebook-
+        # adjacent or otherwise excluded path gets told to reformat it anyway.
+        if ! tr '\n' '\0' < "$changed" \
+             | xargs -0 ruff format --check --force-exclude --; then
           echo
           echo "To fix, from the repo root:"
           echo "  ruff format \$(git diff --name-only --diff-filter=d \$(git merge-base origin/main HEAD) HEAD -- '*.py')"


### PR DESCRIPTION
One line, one comment. Ruff **ignores `exclude` for paths named explicitly on the command line**, and the format-on-touch step added in 1940869a names every path explicitly — so the config's exclusions silently stop applying inside it. A diff-scoped check and a config `exclude` do not compose without `--force-exclude`.

```
$ ruff format --check fibsem/correlation/pyto/common.py
1 file would be reformatted

$ ruff format --check --force-exclude fibsem/correlation/pyto/common.py
warning: No Python files found under the given path(s)
```

Nothing currently excluded would bite today — `**/*.md` can't reach this step, since the diff is filtered to `*.py`. So this is pre-emptive. It is also exactly the kind of defect that stays invisible until someone adds an exclusion later and it quietly does not work.

Split out of #491, which also proposed excluding the vendored `pyto` tree. That half is dropped: pyto is frozen and effectively ours now, so "keep it diffable against upstream" no longer holds, and the case for linting it is the stronger one — the linter found a real `NameError` in that tree, and excluding it would mean the next one goes unfound.
