### PR TITLE
[refactor] Say the experiment name once, and the guidance in one place

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1422,12 +1422,18 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         is_connected = self.autolamella_ui.microscope is not None
         experiment = self.autolamella_ui.experiment
         is_experiment_loaded = experiment is not None
+        # Carried here from the panel, which used to render the same ladder into a
+        # label of its own: an experiment with no protocol cannot run anything, and
+        # this was the one rung the status bar did not have.
+        is_protocol_loaded = self.autolamella_ui.protocol is not None
         has_positions = is_experiment_loaded and len(experiment.positions) > 0
 
         if not is_connected:
             msg = INSTRUCTIONS["NOT_CONNECTED"]
         elif not is_experiment_loaded:
             msg = INSTRUCTIONS["NO_EXPERIMENT"]
+        elif not is_protocol_loaded:
+            msg = INSTRUCTIONS["NO_PROTOCOL"]
         elif not has_positions:
             msg = INSTRUCTIONS["NO_LAMELLA"]
         else:

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -19,7 +19,6 @@ from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QGridLayout,
     QLabel,
-    QLineEdit,
     QMainWindow,
     QMessageBox,
     QPushButton,
@@ -241,14 +240,6 @@ class AutoLamellaUI(QMainWindow):
         self.tab = QWidget()
         self.grid_layout_experiment = QGridLayout(self.tab)
 
-        # Experiment name (row 0)
-        self.label_experiment_name = QLabel("Experiment")
-        self.lineEdit_experiment_name = QLineEdit()
-
-        # Protocol name (row 3)
-        self.label_protocol_name = QLabel("Protocol")
-        self.lineEdit_protocol_name = QLineEdit()
-
         self.lamella_list = LamellaNameListWidget()
         self.lamella_list.enable_add_button(True)
         self.lamella_list.enable_defect_button(True)
@@ -257,31 +248,24 @@ class AutoLamellaUI(QMainWindow):
         self.lamella_list.enable_update_action(True)
         self.lamella_list.enable_remove_button(True)
 
-        # --- Selected Lamella panel (row 6, colspan 2) ---
         self.selected_lamella_widget = SelectedLamellaWidget()
 
-        self.grid_layout_experiment.addWidget(self.label_experiment_name, 0, 0)
-        self.grid_layout_experiment.addWidget(self.lineEdit_experiment_name, 0, 1)
-        self.grid_layout_experiment.addWidget(self.label_protocol_name, 1, 0)
-        self.grid_layout_experiment.addWidget(self.lineEdit_protocol_name, 1, 1)
-        self.grid_layout_experiment.addWidget(self.lamella_list, 2, 0, 1, 2)
-        self.grid_layout_experiment.addWidget(self.selected_lamella_widget, 3, 0, 1, 2)
+        self.grid_layout_experiment.addWidget(self.lamella_list, 0, 0, 1, 2)
+        self.grid_layout_experiment.addWidget(self.selected_lamella_widget, 1, 0, 1, 2)
 
-        # Vertical spacer (row 7)
         self.grid_layout_experiment.addItem(
-            QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding), 4, 0, 1, 2
+            QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding), 2, 0, 1, 2
         )
 
         # Add Experiment tab to tabWidget
         self.tabWidget.addTab(self.tab, "Experiment")
 
-        # --- Workflow info (row 2) ---
         self.label_workflow_information = QLabel("Workflow Information")
 
-        # --- Instructions (row 3) ---
+        # The question a running workflow is asking; hidden when it is not asking
+        # one. Idle guidance lives in the window's status bar.
         self.label_instructions = QLabel("Instructions")
 
-        # --- Yes / No buttons (row 4) ---
         self.pushButton_yes = QPushButton("Yes")
         self.pushButton_no = QPushButton("No")
 
@@ -346,12 +330,6 @@ class AutoLamellaUI(QMainWindow):
         self.detection_confirmed_signal.connect(self.handle_confirmed_detection_signal)
         self.workflow_update_signal.connect(self.handle_workflow_update)
         self._workflow_finished_signal.connect(self._workflow_finished)  # type: ignore
-
-        # labels and placeholders
-        self.lineEdit_experiment_name.setPlaceholderText("No Experiment Loaded")
-        self.lineEdit_protocol_name.setPlaceholderText("No Protocol Loaded")
-        self.lineEdit_protocol_name.setReadOnly(True)
-        self.lineEdit_experiment_name.setReadOnly(True)
 
         # workflow info
         self.set_current_workflow_message(msg=None, show=False)
@@ -557,7 +535,9 @@ class AutoLamellaUI(QMainWindow):
             experiment = Experiment.load(Path(experiment_path))
         except Exception as e:
             logging.warning(f"Quickload: unable to load {experiment_path}: {e}")
-            notification_service.show_toast(f"Quickload: could not load experiment: {e}", "error")
+            notification_service.show_toast(
+                f"Quickload: could not load experiment: {e}", "error"
+            )
             return
 
         # The same bar the load dialog sets. An experiment with no protocol has
@@ -569,7 +549,9 @@ class AutoLamellaUI(QMainWindow):
             return
 
         self._adopt_experiment(experiment)
-        logging.info(f"Quickload: loaded experiment {experiment.name} from {experiment_path}")
+        logging.info(
+            f"Quickload: loaded experiment {experiment.name} from {experiment_path}"
+        )
 
     def _adopt_experiment(self, experiment: Experiment) -> None:
         """Make ``experiment`` the current one, and point logging at its logfile.
@@ -1015,7 +997,9 @@ class AutoLamellaUI(QMainWindow):
             # capture the per-run summary before the manager is torn down
             if self._task_manager is not None:
                 try:
-                    self._last_run_summary = self._task_manager.build_run_summary_dataframe()
+                    self._last_run_summary = (
+                        self._task_manager.build_run_summary_dataframe()
+                    )
                 except Exception as e:
                     logging.warning(f"Failed to build workflow run summary: {e}")
                     self._last_run_summary = None
@@ -1107,17 +1091,8 @@ class AutoLamellaUI(QMainWindow):
             idx = self.tabWidget.indexOf(self.det_widget)
             self.tabWidget.setTabVisible(idx, False)  # hide detection tab for now
 
-        # labels
-        self.lineEdit_experiment_name.setToolTip("No Experiment Loaded")
         if is_experiment_loaded and self.experiment is not None:
-            self.lineEdit_experiment_name.setText(f"{self.experiment.name}")
-            self.lineEdit_experiment_name.setToolTip(
-                f"Experiment Directory: {self.experiment.path}"
-            )
             self.lamella_list.setEnabled(has_lamella)
-
-        if self.protocol is not None:
-            self.lineEdit_protocol_name.setText(f"{self.protocol.name}")
 
         # buttons
         self.lamella_list.setEnabled(is_experiment_ready)
@@ -1137,16 +1112,11 @@ class AutoLamellaUI(QMainWindow):
         if self.is_workflow_running:
             return
 
-        if not is_microscope_connected:
-            self.set_instructions_msg(INSTRUCTIONS["NOT_CONNECTED"])
-        elif not is_experiment_loaded:
-            self.set_instructions_msg(INSTRUCTIONS["NO_EXPERIMENT"])
-        elif not is_protocol_loaded:
-            self.set_instructions_msg(INSTRUCTIONS["NO_PROTOCOL"])
-        elif not has_lamella:
-            self.set_instructions_msg(INSTRUCTIONS["NO_LAMELLA"])
-        elif has_lamella:
-            self.set_instructions_msg(INSTRUCTIONS["AUTOLAMELLA_READY"])
+        # Nothing to say while idle. The same guidance is in the window's status
+        # bar, which is where it belongs -- shown in both places it read as two
+        # different messages that happened to agree. This label is for the question
+        # a running workflow is asking, which the Yes/No buttons below it answer.
+        self.set_instructions_msg("")
 
     def _on_workflow_config_changed(self, wcfg: AutoLamellaWorkflowConfig):
         if self.experiment is None or self.experiment.task_protocol is None:
@@ -1483,7 +1453,9 @@ class AutoLamellaUI(QMainWindow):
                 )
 
         self.experiment.save()
-        self.selected_lamella_widget.refresh_pose(pose_name, state.stage_position.pretty)
+        self.selected_lamella_widget.refresh_pose(
+            pose_name, state.stage_position.pretty
+        )
         # The FM overview canvas draws these positions itself rather than reading them
         # back, so a pose that moved here is one it only hears about by being told.
         self.experiment.positions.events.changed.emit()
@@ -1554,14 +1526,17 @@ class AutoLamellaUI(QMainWindow):
         else:
             value_m = obj.focus_position
         if value_m is None:
-            notification_service.show_toast("Objective position unavailable.", "warning")
+            notification_service.show_toast(
+                "Objective position unavailable.", "warning"
+            )
             return
         lamella.fluorescence_pose.objective_position = value_m
         self.experiment.save()
         # full refresh so the objective value shows and "Apply to All" re-enables
         self.selected_lamella_widget.set_lamella(lamella)
         notification_service.show_toast(
-            f"Set objective position to {value_m * METRE_TO_MICRON:.1f} µm for {lamella.name}.", "info"
+            f"Set objective position to {value_m * METRE_TO_MICRON:.1f} µm for {lamella.name}.",
+            "info",
         )
 
     def _move_objective_to_lamella_position(self):
@@ -1645,7 +1620,8 @@ class AutoLamellaUI(QMainWindow):
         if count:
             self.experiment.save()
             notification_service.show_toast(
-                f"Applied objective position ({value_um:.1f} µm) to {count} lamella.", "info"
+                f"Applied objective position ({value_um:.1f} µm) to {count} lamella.",
+                "info",
             )
 
     def get_selected_lamella(self) -> Optional[Lamella]:
@@ -1744,6 +1720,9 @@ class AutoLamellaUI(QMainWindow):
             neg: The negative button text.
         """
         self.label_instructions.setText(msg)
+        # An empty prompt is not a blank line: with no message there is no question,
+        # so the label goes away rather than reserving space for one.
+        self.label_instructions.setVisible(bool(msg))
         self.pushButton_yes.setText(pos)
         self.pushButton_no.setText(neg)
 
@@ -1998,15 +1977,21 @@ class AutoLamellaUI(QMainWindow):
         controller.set_overlay(
             BeamType.ION,
             PointsSpec(
-                id="poi", points=[(col, row)],
+                id="poi",
+                points=[(col, row)],
                 # Matches the protocol editor's POI, down to the legend entry: same
                 # concept, same marker. Left to the defaults this drew at size 18 with
                 # PointOverlay's 2.0 edge, a cross visibly fatter than the thin one the
                 # editor and the config preview draw, and absent from the legend
                 # (FIB-582). 1.2 keeps it reading like the centre crosshair.
-                color="magenta", selected_color="magenta", marker="+",
-                size=14, edge_width=1.2, legend_label="Point of Interest",
-                add_on_right_click=False, removable=False,
+                color="magenta",
+                selected_color="magenta",
+                marker="+",
+                size=14,
+                edge_width=1.2,
+                legend_label="Point of Interest",
+                add_on_right_click=False,
+                removable=False,
             ),
         )
         # POI owns FIB-canvas input: stage-move + milling menu stand down. The toolbar

--- a/tests/ui/test_experiment_panel_chrome.py
+++ b/tests/ui/test_experiment_panel_chrome.py
@@ -1,0 +1,145 @@
+"""The experiment panel says each thing once, and the status bar owns the guidance.
+
+The panel used to carry the experiment name and the protocol name in two read-only
+line edits -- boxes that look like inputs and refuse to be typed in -- above a
+label repeating whichever rung of the same guidance ladder the window's status bar
+was already showing. The name now lives in the tab-corner button (see
+`test_experiment_header_button.py`) and the guidance in the status bar.
+
+What the label is actually for survives, and is pinned here: the question a running
+workflow asks, which the Yes/No buttons underneath it answer.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QMainWindow  # noqa: E402
+
+from fibsem.applications.autolamella.structures import (  # noqa: E402
+    AutoLamellaTaskProtocol,
+    Experiment,
+    Lamella,
+)
+from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (  # noqa: E402
+    AutoLamellaSingleWindowUI,
+)
+from fibsem.applications.autolamella.ui.AutoLamellaUI import (  # noqa: E402
+    INSTRUCTIONS,
+    AutoLamellaUI,
+)
+
+
+@pytest.fixture
+def panel(qapp):
+    """The real panel. It constructs offscreen; the window that embeds it does not.
+
+    Shown on purpose: a child of a hidden window reports `isVisible() == False`
+    whatever its own flag says, so every "the label is gone" assertion here would
+    pass without the code doing anything.
+    """
+    ui = AutoLamellaUI(parent_ui=None)
+    ui.show()
+    yield ui
+    ui.deleteLater()
+
+
+def test_idle_says_nothing_in_the_panel(panel, tmp_path):
+    experiment = Experiment(path=str(tmp_path), name="AutoLamella-2026-08-21-11-04")
+    experiment.positions.append(
+        Lamella(petname="01-test", path=str(tmp_path / "01-test"), number=1)
+    )
+    panel.experiment = experiment
+
+    panel.update_ui()
+
+    # Not merely empty -- gone. An empty label still reserves its line.
+    assert not panel.label_instructions.isVisible()
+    assert panel.label_instructions.text() == ""
+
+
+def test_a_workflow_prompt_still_shows_with_its_buttons(panel):
+    panel.set_instructions_msg("Move to the milling position?", "Yes", "No")
+
+    assert panel.label_instructions.text() == "Move to the milling position?"
+    assert panel.label_instructions.isVisible()
+    assert panel.pushButton_yes.isVisible()
+    assert panel.pushButton_no.isVisible()
+
+    # And clears again when the workflow stops asking.
+    panel.set_instructions_msg("")
+
+    assert not panel.label_instructions.isVisible()
+    assert not panel.pushButton_yes.isVisible()
+
+
+def test_the_name_boxes_are_gone(panel):
+    """They were read-only QLineEdits: they read as inputs and were not.
+
+    Pinned because the obvious way to restore a name to the panel is to put the
+    box back, and the tab-corner button already carries it.
+    """
+    assert not hasattr(panel, "lineEdit_experiment_name")
+    assert not hasattr(panel, "lineEdit_protocol_name")
+
+
+class _UIStub:
+    """The two attributes `_update_instructions` reads, plus the protocol."""
+
+    def __init__(self, microscope=None, experiment=None, protocol=None):
+        self.microscope = microscope
+        self.experiment = experiment
+        self.protocol = protocol
+
+
+class _StatusHost(QMainWindow):
+    _update_instructions = AutoLamellaSingleWindowUI._update_instructions
+
+    def __init__(self):
+        super().__init__()
+        self.status_bar = self.statusBar()
+        self.autolamella_ui = _UIStub()
+
+
+@pytest.fixture
+def host(qapp):
+    host = _StatusHost()
+    yield host
+    host.deleteLater()
+
+
+def test_status_bar_walks_the_whole_ladder(host, tmp_path):
+    """Every rung, including the protocol -- the one only the panel used to have.
+
+    Dropping the panel's copy would otherwise have deleted that state outright:
+    an experiment with no protocol can run nothing, and the status bar would have
+    said "add a lamella".
+    """
+    assert host.autolamella_ui.microscope is None
+    host._update_instructions()
+    assert host.status_bar.currentMessage() == INSTRUCTIONS["NOT_CONNECTED"]
+
+    host.autolamella_ui.microscope = object()
+    host._update_instructions()
+    assert host.status_bar.currentMessage() == INSTRUCTIONS["NO_EXPERIMENT"]
+
+    experiment = Experiment(path=str(tmp_path), name="ladder")
+    host.autolamella_ui.experiment = experiment
+    host._update_instructions()
+    assert host.status_bar.currentMessage() == INSTRUCTIONS["NO_PROTOCOL"]
+
+    host.autolamella_ui.protocol = AutoLamellaTaskProtocol()
+    host._update_instructions()
+    assert host.status_bar.currentMessage() == INSTRUCTIONS["NO_LAMELLA"]
+
+    experiment.positions.append(
+        Lamella(petname="01-test", path=str(tmp_path / "01-test"), number=1)
+    )
+    host._update_instructions()
+    assert host.status_bar.currentMessage() == INSTRUCTIONS["AUTOLAMELLA_READY"]


### PR DESCRIPTION
Two duplications in the microscope panel, from the audit that followed #490.

## The name boxes

The Experiment tab opened with `Experiment: <name>` and `Protocol: <name>` in two **read-only `QLineEdit`s** — controls that look like inputs and refuse to be typed in. They were the only two in the codebase used that way; the third, in the report widget, is a genuine output path.

The name is the tab-corner button now (#490) and the protocol name is in its tooltip, so both rows go. That is the top ~70px of the panel back, and the lamella list starts where the tab does.

## The guidance

`INSTRUCTIONS` rendered in two places at once: the window's status bar via `_update_instructions`, and a label at the bottom of the panel via `set_instructions_msg`. Same dict, both live. Disconnected, the user was told so **four times** — the blue button, the status card beneath it, this label, and the status bar.

The label stays, because `set_instructions_msg` has a second caller that is not duplicated: a running workflow's question, which the Yes/No buttons underneath it answer. That is the label's real job. It now hides when there is no question rather than reserving a blank line for one.

## The rung that would have gone missing

The status bar's ladder had **no `NO_PROTOCOL` state** — only the panel did. Dropping the panel's copy without noticing would have left an experiment with no protocol being told to "add a lamella", when it can run nothing at all. `_update_instructions` gains that rung, and the test walks all five.

## Tests

New `tests/ui/test_experiment_panel_chrome.py` — 4. The panel constructs offscreen (`AutoLamellaUI(parent_ui=None)`); the window that embeds it does not, so the status-bar half borrows `_update_instructions` onto a host with a real `QStatusBar`.

The fixture **shows** the panel on purpose. A child of a hidden window reports `isVisible() == False` whatever its own flag says, so the first version of these assertions passed without the code doing anything. Mutation-checked after fixing it: forcing `setVisible(True)` fails both visibility tests.

Full `tests/ui`: 2055 passed, 1 skipped. Files formatted per #489, AST-identical.
