### PR TITLE
[refactor] Remove unused imports from imaging, milling, fm, segmentation, alignment

### DIFF
--- a/fibsem/alignment/plotting.py
+++ b/fibsem/alignment/plotting.py
@@ -11,7 +11,6 @@ from fibsem.structures import ImageSettings
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
-    from matplotlib.figure import Figure
 
     from fibsem.alignment import AlignmentDifferential, AlignmentIteration
     from fibsem.structures import FibsemImage
@@ -29,7 +28,6 @@ def _plot_image_with_crosshair(ax: Axes, data: np.ndarray, title: str) -> None:
 
 def _alignment_save_path(ref_image: FibsemImage) -> tuple:
     """Return (ref_path, prefix, ts) for saving alignment plots."""
-    from datetime import datetime
 
     from fibsem.alignment import ALIGNMENT_SUBDIR
 

--- a/fibsem/alignment/plotting.py
+++ b/fibsem/alignment/plotting.py
@@ -98,15 +98,23 @@ def plot_multi_step_alignment(
         dy_px = r.shift.y / pixel_size
         colour = "lime" if r.score >= 0.7 else ("orange" if r.score >= 0.5 else "red")
         axes[0, 1 + i].text(
-            0.04, 0.04,
+            0.04,
+            0.04,
             f"dx={dx_px:.1f}px  dy={dy_px:.1f}px",
             transform=axes[0, 1 + i].transAxes,
-            color=colour, fontsize=7, va="bottom", fontfamily="monospace",
-            bbox=dict(boxstyle="round,pad=0.2", facecolor="black", alpha=0.6, edgecolor="none"),
+            color=colour,
+            fontsize=7,
+            va="bottom",
+            fontfamily="monospace",
+            bbox=dict(
+                boxstyle="round,pad=0.2", facecolor="black", alpha=0.6, edgecolor="none"
+            ),
         )
         cx, cy = r.image.data.shape[1] // 2, r.image.data.shape[0] // 2
         axes[0, 1 + i].annotate(
-            "", xy=(cx + dx_px, cy + dy_px), xytext=(cx, cy),
+            "",
+            xy=(cx + dx_px, cy + dy_px),
+            xytext=(cx, cy),
             arrowprops=dict(arrowstyle="->", color=colour, lw=2),
         )
 
@@ -155,12 +163,24 @@ def plot_multi_step_alignment(
             lines = []
             for method_name, shift_pt in validation.shifts_px.items():
                 mag = np.hypot(shift_pt.x, shift_pt.y)
-                lines.append(f"{method_name}: dx={shift_pt.x:.1f}  dy={shift_pt.y:.1f}  |{mag:.1f}|px")
+                lines.append(
+                    f"{method_name}: dx={shift_pt.x:.1f}  dy={shift_pt.y:.1f}  |{mag:.1f}|px"
+                )
             axes[2, n_cols - 1].text(
-                0.04, 0.04, "\n".join(lines),
+                0.04,
+                0.04,
+                "\n".join(lines),
                 transform=axes[2, n_cols - 1].transAxes,
-                color=colour, fontsize=7, va="bottom", fontfamily="monospace",
-                bbox=dict(boxstyle="round,pad=0.3", facecolor="black", alpha=0.6, edgecolor="none"),
+                color=colour,
+                fontsize=7,
+                va="bottom",
+                fontfamily="monospace",
+                bbox=dict(
+                    boxstyle="round,pad=0.3",
+                    facecolor="black",
+                    alpha=0.6,
+                    edgecolor="none",
+                ),
             )
 
     fig.tight_layout()

--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -42,6 +42,7 @@ from fibsem.structures import BeamType, FibsemStagePosition, TileOrderStrategy
 if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
 
+
 def acquire_channels(
     microscope: FluorescenceMicroscope,
     channel_settings: Union[ChannelSettings, List[ChannelSettings]],
@@ -57,13 +58,15 @@ def acquire_channels(
         # Same payload shape `acquire_z_stack` emits, minus the z fields. Without it a
         # multi-channel acquisition was silent, so anything watching progress within a
         # tile had nothing to show unless a z-stack happened to be enabled.
-        microscope.acquisition_progress_signal.emit({
-            "state": "acquiring",
-            "task": "channels",
-            "channel": channel.name,
-            "channel_index": i + 1,
-            "total_channels": len(channel_settings),
-        })
+        microscope.acquisition_progress_signal.emit(
+            {
+                "state": "acquiring",
+                "task": "channels",
+                "channel": channel.name,
+                "channel_index": i + 1,
+                "total_channels": len(channel_settings),
+            }
+        )
 
         # Check for cancellation before each channel
         if stop_event and stop_event.is_set():
@@ -101,24 +104,30 @@ def acquire_z_stack(
             z_level_images: List[List[FluorescenceImage]] = []
             for j, z in enumerate(z_positions):
                 if stop_event and stop_event.is_set():
-                    logging.info("Z-stack acquisition cancelled before z-level acquisition")
+                    logging.info(
+                        "Z-stack acquisition cancelled before z-level acquisition"
+                    )
                     microscope.objective.move_absolute(z_init)
                     return None
 
                 microscope.objective.move_absolute(z)
                 ch_images: List[FluorescenceImage] = []
                 for i, ch in enumerate(channel_settings):
-                    microscope.acquisition_progress_signal.emit({
-                        "state": "acquiring",
-                        "task": "z-stack",
-                        "channel": ch.name,
-                        "channel_index": i + 1,
-                        "total_channels": len(channel_settings),
-                        "zlevel": j + 1,
-                        "total_zlevels": len(z_positions),
-                    })
+                    microscope.acquisition_progress_signal.emit(
+                        {
+                            "state": "acquiring",
+                            "task": "z-stack",
+                            "channel": ch.name,
+                            "channel_index": i + 1,
+                            "total_channels": len(channel_settings),
+                            "zlevel": j + 1,
+                            "total_zlevels": len(z_positions),
+                        }
+                    )
                     if stop_event and stop_event.is_set():
-                        logging.info("Z-stack acquisition cancelled during z-level acquisition")
+                        logging.info(
+                            "Z-stack acquisition cancelled during z-level acquisition"
+                        )
                         microscope.objective.move_absolute(z_init)
                         return None
                     ch_images.append(microscope.acquire_image(channel_settings=ch))
@@ -132,21 +141,25 @@ def acquire_z_stack(
             # Channel-wise (default): for each channel, acquire all z-planes
             for i, ch in enumerate(channel_settings):
                 if stop_event and stop_event.is_set():
-                    logging.info("Z-stack acquisition cancelled before channel acquisition")
+                    logging.info(
+                        "Z-stack acquisition cancelled before channel acquisition"
+                    )
                     microscope.objective.move_absolute(z_init)
                     return None
 
                 ch_images = []
                 for j, z in enumerate(z_positions):
-                    microscope.acquisition_progress_signal.emit({
-                        "state": "acquiring",
-                        "task": "z-stack",
-                        "channel": ch.name,
-                        "channel_index": i + 1,
-                        "total_channels": len(channel_settings),
-                        "zlevel": j + 1,
-                        "total_zlevels": len(z_positions),
-                    })
+                    microscope.acquisition_progress_signal.emit(
+                        {
+                            "state": "acquiring",
+                            "task": "z-stack",
+                            "channel": ch.name,
+                            "channel_index": i + 1,
+                            "total_channels": len(channel_settings),
+                            "zlevel": j + 1,
+                            "total_zlevels": len(z_positions),
+                        }
+                    )
                     if stop_event and stop_event.is_set():
                         logging.info("Z-stack acquisition cancelled during z-stack")
                         microscope.objective.move_absolute(z_init)
@@ -184,7 +197,9 @@ def acquire_image(
         raise ValueError("Microscope parent is not set. Cannot start acquisition.")
 
     if not microscope.has_valid_orientation():
-        raise ValueError(f"Stage is not in valid orientation ({microscope.parent.get_stage_orientation()!r}). Cannot start acquisition.")
+        raise ValueError(
+            f"Stage is not in valid orientation ({microscope.parent.get_stage_orientation()!r}). Cannot start acquisition."
+        )
 
     if zparams is not None:
         # Acquire Z-stack if zparams is provided
@@ -209,8 +224,9 @@ def acquire_image(
 
     return image
 
+
 def acquire_at_positions(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     positions: List[FMStagePosition],
     channel_settings: Union[ChannelSettings, List[ChannelSettings]],
     zparams: Optional[ZParameters] = None,
@@ -249,7 +265,9 @@ def acquire_at_positions(
             "Fluorescence microscope not initialized in the FibsemMicroscope instance"
         )
     if not microscope.fm.has_valid_orientation():
-        raise ValueError(f"Stage is not in valid orientation ({microscope.get_stage_orientation()!r}). Cannot start acquisition.")
+        raise ValueError(
+            f"Stage is not in valid orientation ({microscope.get_stage_orientation()!r}). Cannot start acquisition."
+        )
 
     if not positions:
         raise ValueError("Positions list cannot be empty")
@@ -264,17 +282,20 @@ def acquire_at_positions(
     acquisition_start_time = time.time()
 
     # Emit initial acquisition progress signal
-    microscope.fm.acquisition_progress_signal.emit({"state": "acquiring", 
-                                                    "task": "multi-position",
-                                                    "position": "null",
-                                                    "current": 1,
-                                                    "total": len(positions),
-                                                    "estimated_total_time": total_estimated_time,
-                                                    "estimated_remaining_time": total_estimated_time,})
+    microscope.fm.acquisition_progress_signal.emit(
+        {
+            "state": "acquiring",
+            "task": "multi-position",
+            "position": "null",
+            "current": 1,
+            "total": len(positions),
+            "estimated_total_time": total_estimated_time,
+            "estimated_remaining_time": total_estimated_time,
+        }
+    )
 
     images: List[FluorescenceImage] = []
     for i, fm_pos in enumerate(positions):
-
         # Check for cancellation before each position
         if stop_event and stop_event.is_set():
             logging.info("Multi-position acquisition cancelled")
@@ -286,26 +307,35 @@ def acquire_at_positions(
         current_position = i + 1
         total_positions = len(positions)
         # Emit progress signal before starting position acquisition
-        microscope.fm.acquisition_progress_signal.emit({"state": "acquiring", 
-                                                        "task": "multi-position",
-                                                       "position": fm_pos.name,
-                                                       "current": current_position,
-                                                       "total": total_positions,
-                                                    #    "estimated_total_time": total_estimated_time,
-                                                    #    "estimated_remaining_time": estimated_remaining_time,
-                                                    #    "elapsed_time": elapsed_time,
-                                                       })
+        microscope.fm.acquisition_progress_signal.emit(
+            {
+                "state": "acquiring",
+                "task": "multi-position",
+                "position": fm_pos.name,
+                "current": current_position,
+                "total": total_positions,
+                #    "estimated_total_time": total_estimated_time,
+                #    "estimated_remaining_time": estimated_remaining_time,
+                #    "elapsed_time": elapsed_time,
+            }
+        )
 
         # Move stage to the saved stage position and objective position
         if microscope.get_stage_orientation(fm_pos.stage_position) not in ["SEM", "FM"]:
-            raise ValueError(f"Stage Position {fm_pos.name} is not in valid orientation: {fm_pos.stage_position}")
-        microscope.fm.acquisition_progress_signal.emit({"state": "moving", "task": "multi-position"})
+            raise ValueError(
+                f"Stage Position {fm_pos.name} is not in valid orientation: {fm_pos.stage_position}"
+            )
+        microscope.fm.acquisition_progress_signal.emit(
+            {"state": "moving", "task": "multi-position"}
+        )
         microscope.safe_absolute_stage_movement(fm_pos.stage_position)
         microscope.fm.objective.move_absolute(fm_pos.objective_position)
 
         # Run autofocus if requested
         if use_autofocus:
-            result = run_autofocus(microscope.fm, channel_settings[0], stop_event=stop_event)
+            result = run_autofocus(
+                microscope.fm, channel_settings[0], stop_event=stop_event
+            )
             if result is None:
                 logging.info("Multi-position acquisition cancelled during autofocus")
                 return images
@@ -324,15 +354,19 @@ def acquire_at_positions(
             filename = os.path.join(position_dir, basename)
 
         # Acquire image
-        image = acquire_image(microscope=microscope.fm,
-                              channel_settings=channel_settings,
-                              zparams=zparams,
-                              stop_event=stop_event,
-                              filename=filename)
+        image = acquire_image(
+            microscope=microscope.fm,
+            channel_settings=channel_settings,
+            zparams=zparams,
+            stop_event=stop_event,
+            filename=filename,
+        )
 
         # Check if acquisition was cancelled
         if image is None:
-            logging.info("Multi-position acquisition cancelled during image acquisition")
+            logging.info(
+                "Multi-position acquisition cancelled during image acquisition"
+            )
             return images
 
         image.metadata.description = f"{fm_pos.name}-{image.metadata.acquisition_date}"
@@ -342,25 +376,32 @@ def acquire_at_positions(
         elapsed_time = time.time() - acquisition_start_time
         if current_position > 1:
             time_per_position = elapsed_time / (current_position - 1)
-            estimated_remaining_time = time_per_position * (total_positions - current_position)
+            estimated_remaining_time = time_per_position * (
+                total_positions - current_position
+            )
         else:
             estimated_remaining_time = total_estimated_time
 
-        microscope.fm.acquisition_progress_signal.emit({"state": "acquiring", 
-                                                        "task": "multi-position",
-                                                       "position": fm_pos.name,
-                                                       "current": current_position,
-                                                       "total": total_positions,
-                                                       "estimated_total_time": total_estimated_time,
-                                                       "estimated_remaining_time": estimated_remaining_time,
-                                                       "elapsed_time": elapsed_time,})
+        microscope.fm.acquisition_progress_signal.emit(
+            {
+                "state": "acquiring",
+                "task": "multi-position",
+                "position": fm_pos.name,
+                "current": current_position,
+                "total": total_positions,
+                "estimated_total_time": total_estimated_time,
+                "estimated_remaining_time": estimated_remaining_time,
+                "elapsed_time": elapsed_time,
+            }
+        )
 
     microscope.fm.acquisition_progress_signal.emit({"state": "finished"})
 
     return images
 
+
 def run_tileset_autofocus(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     channel_settings: Optional[ChannelSettings],
     autofocus_settings: AutoFocusSettings,
     stop_event: Optional[threading.Event] = None,
@@ -401,8 +442,6 @@ def run_tileset_autofocus(
     except Exception as e:
         logging.warning(f"Auto-focus failed: {e}")
         return False
-
-
 
 
 def _to_channel_planes(data: np.ndarray, n_channels: int) -> np.ndarray:
@@ -526,7 +565,7 @@ class FMTiledAcquisitionRunner:
 
     def __init__(
         self,
-        microscope: 'FibsemMicroscope',
+        microscope: "FibsemMicroscope",
         channel_settings: Union[ChannelSettings, List[ChannelSettings]],
         overview_parameters: OverviewParameters,
         zparams: Optional[ZParameters] = None,
@@ -661,10 +700,14 @@ class FMTiledAcquisitionRunner:
         # A spiral revisits rows non-sequentially, so "autofocus on each new row" would
         # fire almost every tile and still leave stale focus in between. Promote it, as
         # the beam runner does.
-        if (self._autofocus_mode is AutoFocusMode.EACH_ROW
-                and self._tile_order is TileOrderStrategy.SPIRAL):
+        if (
+            self._autofocus_mode is AutoFocusMode.EACH_ROW
+            and self._tile_order is TileOrderStrategy.SPIRAL
+        ):
             self._autofocus_mode = AutoFocusMode.EACH_TILE
-            logging.info("EACH_ROW autofocus upgraded to EACH_TILE for SPIRAL tile order")
+            logging.info(
+                "EACH_ROW autofocus upgraded to EACH_TILE for SPIRAL tile order"
+            )
 
         # Full grid, holes included: the canvas is the whole grid whatever the mask.
         self.tileset = [[None] * self._cols for _ in range(self._rows)]
@@ -704,8 +747,11 @@ class FMTiledAcquisitionRunner:
         self._setup_autofocus()
 
         time_estimates = estimate_tileset_acquisition_time(
-            self.channel_settings, (self._rows, self._cols), self.zparams,
-            self._autofocus_mode, tile_mask=self._tile_mask,
+            self.channel_settings,
+            (self._rows, self._cols),
+            self.zparams,
+            self._autofocus_mode,
+            tile_mask=self._tile_mask,
         )
         self._total_estimated_time = time_estimates["total_time"]
         self._acquisition_start_time = time.time()
@@ -889,12 +935,16 @@ class FMTiledAcquisitionRunner:
         #
         # `total` counts tiles that will actually be acquired, not grid cells -- a
         # progress bar that stops at 9/25 on a successful sparse run reads as a failure.
-        self._emit({
-            "state": "acquiring", "task": "tileset",
-            "counter": 0, "total": len(self._ordered),
-            "estimated_total_time": self._total_estimated_time,
-            "estimated_remaining_time": self._total_estimated_time,
-        })
+        self._emit(
+            {
+                "state": "acquiring",
+                "task": "tileset",
+                "counter": 0,
+                "total": len(self._ordered),
+                "estimated_total_time": self._total_estimated_time,
+                "estimated_remaining_time": self._total_estimated_time,
+            }
+        )
 
     def _init_preview_canvas(self) -> None:
         """Allocate the live mosaic that tiles are painted into as they arrive.
@@ -932,7 +982,9 @@ class FMTiledAcquisitionRunner:
                 data = data[: self._preview.canvas.shape[0]]
             self._preview.paint(data, tile.canvas_x, tile.canvas_y)
         except Exception as e:  # pragma: no cover - preview is never load-bearing
-            logging.debug(f"Could not paint tile ({tile.row}, {tile.col}) into preview: {e}")
+            logging.debug(
+                f"Could not paint tile ({tile.row}, {tile.col}) into preview: {e}"
+            )
 
     def _autofocus_if_mode(self, mode: AutoFocusMode) -> None:
         """Run autofocus when the configured mode matches.
@@ -978,7 +1030,9 @@ class FMTiledAcquisitionRunner:
         self._n_acquired = 0
         for tile in self._ordered:
             # Check before moving, so a cancel skips the travel entirely.
-            raise_if_cancelled(self.stop_event, "Tileset acquisition cancelled by user.")
+            raise_if_cancelled(
+                self.stop_event, "Tileset acquisition cancelled by user."
+            )
 
             if tile.row != prev_row:
                 prev_row = tile.row
@@ -1054,7 +1108,8 @@ class FMTiledAcquisitionRunner:
             "zparameters": self.zparams.to_dict() if self.zparams is not None else None,
             "autofocus_settings": (
                 self.autofocus_settings.to_dict()
-                if self.autofocus_settings is not None else None
+                if self.autofocus_settings is not None
+                else None
             ),
             "channel_settings": [ch.to_dict() for ch in self.channel_settings],
         }
@@ -1109,26 +1164,32 @@ class FMTiledAcquisitionRunner:
         copy does not show.
         """
         estimated_total, estimated_remaining, elapsed = self._time_estimate()
-        self._emit({
-            "state": "tile", "task": "tileset",
-            "row": tile.row, "col": tile.col,
-            "total_rows": self._rows, "total_cols": self._cols,
-            # **Tiles completed**, which is what `counter` means on this signal -- the
-            # beam tiler increments and then emits, so its count has always meant this.
-            # The fluorescence side used to say it twice per tile with two meanings: the
-            # tile *starting* before the acquisition and the tally after. One key cannot
-            # be both, and a consumer choosing between them got a bar that changed scale
-            # at every boundary (FIB-736, FIB-739).
-            "counter": self._n_acquired, "total": len(self._ordered),
-            # The estimate rides with the count rather than with the announcement below,
-            # so one payload carries the whole picture and a consumer never has to
-            # assemble progress from two.
-            "estimated_total_time": estimated_total,
-            "estimated_remaining_time": estimated_remaining,
-            "elapsed_time": elapsed,
-            "image": self._preview.canvas.copy(),
-            "preview_stride": self._preview.stride,
-        })
+        self._emit(
+            {
+                "state": "tile",
+                "task": "tileset",
+                "row": tile.row,
+                "col": tile.col,
+                "total_rows": self._rows,
+                "total_cols": self._cols,
+                # **Tiles completed**, which is what `counter` means on this signal -- the
+                # beam tiler increments and then emits, so its count has always meant this.
+                # The fluorescence side used to say it twice per tile with two meanings: the
+                # tile *starting* before the acquisition and the tally after. One key cannot
+                # be both, and a consumer choosing between them got a bar that changed scale
+                # at every boundary (FIB-736, FIB-739).
+                "counter": self._n_acquired,
+                "total": len(self._ordered),
+                # The estimate rides with the count rather than with the announcement below,
+                # so one payload carries the whole picture and a consumer never has to
+                # assemble progress from two.
+                "estimated_total_time": estimated_total,
+                "estimated_remaining_time": estimated_remaining,
+                "elapsed_time": elapsed,
+                "image": self._preview.canvas.copy(),
+                "preview_stride": self._preview.stride,
+            }
+        )
 
     def _time_estimate(self):
         """`(total, remaining, elapsed)` for the run, from what it has done so far.
@@ -1160,15 +1221,20 @@ class FMTiledAcquisitionRunner:
         "Moving stage…" label the previous payload put up. The progress arrives after
         the tile, with the preview.
         """
-        self._emit({
-            "state": "acquiring", "task": "tileset",
-            "row": row + 1, "col": col + 1,
-            "total_rows": self._rows, "total_cols": self._cols,
-        })
+        self._emit(
+            {
+                "state": "acquiring",
+                "task": "tileset",
+                "row": row + 1,
+                "col": col + 1,
+                "total_rows": self._rows,
+                "total_cols": self._cols,
+            }
+        )
 
 
 def acquire_tileset(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     channel_settings: Union[ChannelSettings, List[ChannelSettings]],
     overview_parameters: OverviewParameters,
     zparams: Optional[ZParameters] = None,
@@ -1318,7 +1384,9 @@ def stitch_tileset(
     mosaic_width = effective_tile_width * (cols - 1) + tile_width
     mosaic_height = effective_tile_height * (rows - 1) + tile_height
 
-    logging.info(f"Tile size: {tile_height}x{tile_width}, Mosaic size: {mosaic_height}x{mosaic_width}")
+    logging.info(
+        f"Tile size: {tile_height}x{tile_width}, Mosaic size: {mosaic_height}x{mosaic_width}"
+    )
     logging.info(f"Channels: {nc_channels}, Z-planes: {nz_planes}")
 
     # Initialize mosaic array with proper dimensions (C, Z, Y, X)
@@ -1395,8 +1463,9 @@ def stitch_tileset(
     logging.info(f"Stitching complete: {mosaic_height}x{mosaic_width} mosaic created")
     return stitched_image
 
+
 def acquire_and_stitch_tileset(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     channel_settings: Union[ChannelSettings, List[ChannelSettings]],
     overview_parameters: OverviewParameters,
     zparams: Optional[ZParameters] = None,
@@ -1430,14 +1499,17 @@ def acquire_and_stitch_tileset(
         channel_settings = [channel_settings]
 
     destination = (
-        OverviewDestination.create(save_directory) if save_directory is not None else None
+        OverviewDestination.create(save_directory)
+        if save_directory is not None
+        else None
     )
     tiles_directory = destination.tiles_directory if destination is not None else None
 
-
     # Check if zparams is provided when z-stack is requested
     if zparams is None and overview_parameters.use_zstack:
-        raise ValueError("Z-stack requested in overview parameters but no zparams provided")
+        raise ValueError(
+            "Z-stack requested in overview parameters but no zparams provided"
+        )
 
     # acquire the tileset
     # A cancel is now signalled explicitly rather than inferred from the result. The
@@ -1468,7 +1540,7 @@ def acquire_and_stitch_tileset(
 
 
 def acquire_multiple_overviews(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     positions: List[FMStagePosition],
     channel_settings: Union[ChannelSettings, List[ChannelSettings]],
     overview_parameters: OverviewParameters,
@@ -1511,7 +1583,7 @@ def acquire_multiple_overviews(
         >>> pos2 = FMStagePosition(name="Region2", stage_position=stage_pos2, objective_position=0.013)
         >>> positions = [pos1, pos2]
         >>>
-        >>> # Define channel settings and overview parameters  
+        >>> # Define channel settings and overview parameters
         >>> channel = ChannelSettings(name="DAPI", excitation_wavelength=365,
         ...                          emission_wavelength=450, power=50, exposure_time=0.1)
         >>> overview_params = OverviewParameters(rows=3, cols=3, overlap=0.1)
@@ -1606,7 +1678,7 @@ def acquire_multiple_overviews(
 
 
 def convert_grid_positions_to_stage_positions(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     positions: List[Tuple[float, float]],
     beam_type: BeamType = BeamType.ELECTRON,
     base_position: Optional[FibsemStagePosition] = None,

--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -1,14 +1,11 @@
 import logging
-import math
 import os
 import threading
 import time
 from copy import deepcopy
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
-import matplotlib.patches as patches
-import matplotlib.pyplot as plt
 import numpy as np
 
 from fibsem import utils
@@ -31,9 +28,7 @@ from fibsem.fm.timing import (
     estimate_tileset_acquisition_time,
 )
 from fibsem.imaging.reduce import (
-    PREVIEW_MAX_DIMENSION,
     PreviewMosaic,
-    downsample,
 )
 from fibsem.imaging.tiling.geometry import (
     TilePosition,

--- a/fibsem/fm/autoscript.py
+++ b/fibsem/fm/autoscript.py
@@ -64,7 +64,7 @@ ARCTIS_LWD_CONFIGURATION = {
     "magnification": 50.0,
     "numerical_aperture": 0.75,
     "working_distance": 4e-3,
-    "pixel_size": (2.74822695035461e-08*2, 2.74822695035461e-08*2),
+    "pixel_size": (2.74822695035461e-08 * 2, 2.74822695035461e-08 * 2),
     "resolution": (4512, 4512),
     "focus_position": 7.6e-3,  # 7600 microns
     "limit_position": 8.6e-3,  # 8600 microns
@@ -104,7 +104,9 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
         self._numerical_aperture = DEFAULT_CONFIGURATION["numerical_aperture"]
         self._working_distance = DEFAULT_CONFIGURATION["working_distance"]
         self._focus_position = DEFAULT_CONFIGURATION["focus_position"]
-        self._limit_position: float = DEFAULT_CONFIGURATION.get("limit_position", 8.6e-3)
+        self._limit_position: float = DEFAULT_CONFIGURATION.get(
+            "limit_position", 8.6e-3
+        )
 
     @property
     def magnification(self) -> float:
@@ -169,7 +171,9 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
 
         # clip to user-defined limits
         if not position <= self._limit_position:
-            logging.warning(f"Clipping position {position} to user-defined limits {self._limit_position}")
+            logging.warning(
+                f"Clipping position {position} to user-defined limits {self._limit_position}"
+            )
             position = np.clip(position, 0, self._limit_position)
         with self.parent.active_channel():
             self.parent.fm_settings.focus.value = position
@@ -295,8 +299,8 @@ class ThermoFisherCamera(Camera):
                     self.parent.set_active_channel()  # re-force active channel...?
                     image = self.parent.connection.imaging.get_image()
                     # if image.data.shape != self.resolution: # if shape doesn't match expected resolution, skip (likely acquired wrong channel)
-                        # logging.warning(f"Acquired image shape {image.shape} does not match expected resolution {self.resolution}")
-                        # continue
+                    # logging.warning(f"Acquired image shape {image.shape} does not match expected resolution {self.resolution}")
+                    # continue
                     self.parent._construct_image(image.data)
 
         except Exception as e:
@@ -408,7 +412,7 @@ class ThermoFisherCamera(Camera):
         """
         with self.parent.active_channel():
             return self.parent.connection.detector.contrast.value
-    
+
     @gain.setter
     def gain(self, value: float) -> None:
         """Set the gain of the camera.
@@ -617,7 +621,9 @@ class ThermoFisherFilterSet(FilterSet):
             if value is None:
                 self.parent.fm_settings.filter.type.value = CameraFilterType.REFLECTION
             else:
-                self.parent.fm_settings.filter.type.value = CameraFilterType.FLUORESCENCE
+                self.parent.fm_settings.filter.type.value = (
+                    CameraFilterType.FLUORESCENCE
+                )
 
 
 class ThermoFisherFluorescenceMicroscope(FluorescenceMicroscope):

--- a/fibsem/fm/autoscript.py
+++ b/fibsem/fm/autoscript.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 from contextlib import contextmanager
-from typing import Any, Dict, Literal, Optional, Tuple, Union
+from typing import Literal, Optional, Tuple, Union
 
 import numpy as np
 from autoscript_sdb_microscope_client.enumerations import (
@@ -9,10 +9,8 @@ from autoscript_sdb_microscope_client.enumerations import (
     CameraFilterType,
     ImagingDevice,
     ImagingState,
-    RetractableDeviceState,
 )
 from autoscript_sdb_microscope_client.structures import (
-    GetImageSettings,
     GrabFrameSettings,
 )
 

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime
 from enum import Enum
-from typing import Any, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import tifffile as tff

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -71,8 +71,9 @@ from fibsem.structures import (  # noqa: F401
 
 class ZStackOrder(Enum):
     """Acquisition order for z-stack."""
-    CHANNEL = "channel"   # default: for each channel, acquire all z-planes
-    Z_LEVEL = "z_level"   # for each z-plane, acquire all channels
+
+    CHANNEL = "channel"  # default: for each channel, acquire all z-planes
+    Z_LEVEL = "z_level"  # for each z-plane, acquire all channels
 
 
 BINNING_MAP = {
@@ -89,11 +90,15 @@ _UNIT_TO_METERS = {
     UnitsLength.METER: 1.0,
 }
 
-def _convert_length_to_meters(value: Optional[float], unit: Optional[UnitsLength]) -> Optional[float]:
+
+def _convert_length_to_meters(
+    value: Optional[float], unit: Optional[UnitsLength]
+) -> Optional[float]:
     """Convert an OME length value to meters if both value and unit are present."""
     if value is None:
         return None
     return value * _UNIT_TO_METERS.get(unit, 1.0)
+
 
 def _color_to_hex(color: Optional[Color]) -> str:
     """Convert OME Color to a hex string understood by the FM viewer."""
@@ -104,6 +109,7 @@ def _color_to_hex(color: Optional[Color]) -> str:
         return f"#{r:02X}{g:02X}{b:02X}"
     except Exception:
         return "gray"
+
 
 def safe_ome_from_tiff(filename: str) -> OMEMetadata:
     """Parse OME metadata from TIFF file, handling potential known issues with the OME XML.
@@ -128,6 +134,7 @@ def safe_ome_from_tiff(filename: str) -> OMEMetadata:
         ome_xml = re.sub(r"<Filter\b[^>]*/>", "", ome_xml)
         ome = from_xml(ome_xml)
     return ome
+
 
 @dataclass
 class FMStagePosition:
@@ -218,7 +225,7 @@ class ChannelSettings:
     name: str = "Channel-01"
     excitation_wavelength: float = 550  # nm
     emission_wavelength: Optional[Union[str, float]] = None  # nm
-    power: float = 0.01 # %
+    power: float = 0.01  # %
     exposure_time: float = 0.001  # seconds
     color: str = "gray"
     gain: float = 0.0
@@ -237,9 +244,13 @@ class ChannelSettings:
         if self.emission_wavelength is None:
             emission_str = "Reflection"
         else:
-            emission_str = f"{self.emission_wavelength}nm" if isinstance(self.emission_wavelength, float) else self.emission_wavelength
+            emission_str = (
+                f"{self.emission_wavelength}nm"
+                if isinstance(self.emission_wavelength, float)
+                else self.emission_wavelength
+            )
 
-        return f"{self.name} ({self.excitation_wavelength:.0f}nm → {emission_str}) P:{self.power*100:.1f}%, EXP:{self.exposure_time * 1000:.1f}ms"
+        return f"{self.name} ({self.excitation_wavelength:.0f}nm → {emission_str}) P:{self.power * 100:.1f}%, EXP:{self.exposure_time * 1000:.1f}ms"
 
     @property
     def pretty(self) -> str:
@@ -285,7 +296,7 @@ class ZParameters:
         z_positions = np.arange(
             start=z_init + self.zmin,
             stop=z_init + self.zmax + self.zstep * 0.5,
-            step=self.zstep
+            step=self.zstep,
         )
 
         return z_positions.tolist()
@@ -314,7 +325,9 @@ class ZParameters:
         if num_planes <= 1:
             return "Z-Stack: Single plane acquisition"
 
-        order_str = "channel-wise" if self.order == ZStackOrder.CHANNEL else "z-level-wise"
+        order_str = (
+            "channel-wise" if self.order == ZStackOrder.CHANNEL else "z-level-wise"
+        )
         return f"Z-Stack: {num_planes} planes ({self.zmin * 1e6:.1f}μm to {self.zmax * 1e6:.1f}μm, step {self.zstep * 1e6:.1f}μm, {order_str})"
 
 
@@ -1142,7 +1155,9 @@ class FluorescenceImage:
             pixel_size_y=pixel_size,
             resolution=resolution,
             channels=channels,
-            z_positions=[i * pixel_size for i in range(zlevels)] if zlevels > 1 else None,
+            z_positions=[i * pixel_size for i in range(zlevels)]
+            if zlevels > 1
+            else None,
         )
 
         return FluorescenceImage(data=data, metadata=metadata)
@@ -1387,9 +1402,9 @@ class FluorescenceImageMetadata:
                 else None
             ),
         )
-    
+
     @classmethod
-    def from_ome(cls, ome: OMEMetadata) -> 'FluorescenceImageMetadata':
+    def from_ome(cls, ome: OMEMetadata) -> "FluorescenceImageMetadata":
         """Convert OME metadata to FluorescenceImageMetadata with availability checks.
 
         For importing images from **external software**. `load` prefers the
@@ -1411,10 +1426,11 @@ class FluorescenceImageMetadata:
 
         if pixels_md is None:
             raise ValueError("OME metadata contains no pixel information")
-        
+
         # Pixel sizes (convert to meters where possible)
         pixel_size_x = _convert_length_to_meters(
-            pixels_md.physical_size_x, pixels_md.physical_size_x_unit)
+            pixels_md.physical_size_x, pixels_md.physical_size_x_unit
+        )
         pixel_size_y = _convert_length_to_meters(
             pixels_md.physical_size_y, pixels_md.physical_size_y_unit
         )
@@ -1465,9 +1481,7 @@ class FluorescenceImageMetadata:
             )
 
         # Use z positions only if we have at least two valid entries
-        valid_z_positions = (
-            z_positions if len(z_positions) >= 2 else None
-        )
+        valid_z_positions = z_positions if len(z_positions) >= 2 else None
 
         # Build channel metadata with fallbacks
         channels_md: List[FluorescenceChannelMetadata] = []
@@ -1584,7 +1598,8 @@ class OverviewParameters:
             "tile_order": self.tile_order.value,
             "objective_start": self.objective_start.value,
             # plain bools: np.bool_ does not survive yaml.safe_dump
-            "tile_mask": None if self.tile_mask is None
+            "tile_mask": None
+            if self.tile_mask is None
             else [[bool(v) for v in row] for row in self.tile_mask],
         }
 
@@ -1597,11 +1612,15 @@ class OverviewParameters:
             cols=ddict.get("cols", 3),
             overlap=ddict.get("overlap", 0.1),
             use_zstack=ddict.get("use_zstack", False),
-            autofocus_mode=AutoFocusMode(ddict.get("autofocus_mode", AutoFocusMode.NONE.value)),
+            autofocus_mode=AutoFocusMode(
+                ddict.get("autofocus_mode", AutoFocusMode.NONE.value)
+            ),
             tile_order=TileOrderStrategy(
                 ddict.get("tile_order", TileOrderStrategy.TYPEWRITER.value)
             ),
-            tile_mask=None if mask is None else [[bool(v) for v in row] for row in mask],
+            tile_mask=None
+            if mask is None
+            else [[bool(v) for v in row] for row in mask],
             # Defaulted, not required: every overview saved before this existed started
             # from wherever the objective was, so that is what its parameters mean.
             objective_start=ObjectiveStartPosition(
@@ -1620,7 +1639,8 @@ class OverviewParameters:
 @dataclass
 class CameraSettings:
     """Camera settings for fluorescence microscopy acquisition."""
-    gain: float = 0.01 # 1%
+
+    gain: float = 0.01  # 1%
     offset: float = 0.0
     binning: int = 1
     transform: CameraImageTransform = CameraImageTransform.NONE
@@ -1682,9 +1702,7 @@ class FluorescenceConfiguration:
                 ddict["autofocus_settings"]
             )
         if ddict.get("camera_settings"):
-            camera_settings = CameraSettings.from_dict(
-                ddict["camera_settings"]
-            )
+            camera_settings = CameraSettings.from_dict(ddict["camera_settings"])
         else:
             camera_settings = CameraSettings()
 
@@ -1722,9 +1740,7 @@ class FluorescenceConfiguration:
         # Write to YAML file
         with open(filename, "w") as f:
             yaml.dump(
-                config_dict, f, 
-                default_flow_style=False, 
-                indent=4, sort_keys=False
+                config_dict, f, default_flow_style=False, indent=4, sort_keys=False
             )
 
         logging.info(f"FM configuration exported to: {filename}")

--- a/fibsem/imaging/masks.py
+++ b/fibsem/imaging/masks.py
@@ -113,11 +113,13 @@ def create_rect_mask(
 
     mask = np.zeros_like(img)
 
-    y_min, y_max = int(np.clip(pt.y - h / 2, 0, img.shape[1])), int(
-        np.clip(pt.y + h / 2, 0, img.shape[1])
+    y_min, y_max = (
+        int(np.clip(pt.y - h / 2, 0, img.shape[1])),
+        int(np.clip(pt.y + h / 2, 0, img.shape[1])),
     )
-    x_min, x_max = int(np.clip(pt.x - w / 2, 0, img.shape[1])), int(
-        np.clip(pt.x + w / 2, 0, img.shape[1])
+    x_min, x_max = (
+        int(np.clip(pt.x - w / 2, 0, img.shape[1])),
+        int(np.clip(pt.x + w / 2, 0, img.shape[1])),
     )
 
     mask[y_min:y_max, x_min:x_max] = 1
@@ -227,7 +229,6 @@ def create_vertical_mask(arr, width=128):
     return mask
 
 
-
 def create_mask(arr: np.ndarray, mask_info: dict) -> np.ndarray:
 
     # mask_info = {
@@ -238,10 +239,18 @@ def create_mask(arr: np.ndarray, mask_info: dict) -> np.ndarray:
     # }
 
     if mask_info["type"] == "circle":
-        mask = create_circle_mask(arr.shape, radius=mask_info["radius"], sigma=mask_info["sigma"])
+        mask = create_circle_mask(
+            arr.shape, radius=mask_info["radius"], sigma=mask_info["sigma"]
+        )
 
     if mask_info["type"] == "rect":
-        mask = create_rect_mask(arr, pt=mask_info["pt"], w=mask_info["w"], h=mask_info["h"], sigma=mask_info["sigma"])
+        mask = create_rect_mask(
+            arr,
+            pt=mask_info["pt"],
+            w=mask_info["w"],
+            h=mask_info["h"],
+            sigma=mask_info["sigma"],
+        )
 
     if mask_info["invert"]:
         mask = np.logical_not(mask)

--- a/fibsem/imaging/masks.py
+++ b/fibsem/imaging/masks.py
@@ -1,6 +1,5 @@
 import numpy as np
 import scipy.ndimage as ndi
-from PIL import Image, ImageDraw
 
 from fibsem import conversions
 from fibsem.imaging import utils as image_utils

--- a/fibsem/imaging/tests/test_drawing_widget.py
+++ b/fibsem/imaging/tests/test_drawing_widget.py
@@ -26,7 +26,9 @@ def _make_test_image(width: int = 512, height: int = 384) -> np.ndarray:
     img = ((np.sin(x / 30.0) * np.cos(y / 30.0) + 1) * 60 + 40).astype(np.uint8)
     # add some noise
     rng = np.random.default_rng(42)
-    img = np.clip(img.astype(np.int16) + rng.integers(-10, 10, img.shape), 0, 255).astype(np.uint8)
+    img = np.clip(
+        img.astype(np.int16) + rng.integers(-10, 10, img.shape), 0, 255
+    ).astype(np.uint8)
     return img
 
 
@@ -53,7 +55,7 @@ def main():
         row_layout = QHBoxLayout(row_widget)
         row_layout.setSpacing(16)
 
-        for title, pixel_size, kwargs in test_cases[i:i + 3]:
+        for title, pixel_size, kwargs in test_cases[i : i + 3]:
             img = _make_test_image()
 
             if pixel_size is not None:
@@ -65,7 +67,9 @@ def main():
             col_layout.setSpacing(4)
 
             title_label = QLabel(title)
-            title_label.setStyleSheet("color: #e0e0e0; font-size: 11px; font-weight: bold;")
+            title_label.setStyleSheet(
+                "color: #e0e0e0; font-size: 11px; font-weight: bold;"
+            )
             title_label.setAlignment(Qt.AlignCenter)
             col_layout.addWidget(title_label)
 

--- a/fibsem/imaging/tests/test_drawing_widget.py
+++ b/fibsem/imaging/tests/test_drawing_widget.py
@@ -7,7 +7,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QImage, QPixmap
 from PyQt5.QtWidgets import QApplication, QHBoxLayout, QLabel, QVBoxLayout, QWidget
 
-from fibsem.imaging.drawing import draw_crosshair, draw_image_overlays, draw_scalebar
+from fibsem.imaging.drawing import draw_image_overlays
 
 
 def _arr_to_pixmap(arr: np.ndarray) -> QPixmap:

--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -2,25 +2,20 @@ from __future__ import annotations
 
 import datetime
 import logging
-import math
 import os
 import threading
 from copy import deepcopy
-from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
-import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.figure import Figure
 
 from fibsem import acquire, conversions
 from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
 from fibsem.constants import DATETIME_FILE
-from fibsem.conversions import is_inside_image_bounds
 
 # Moved to the `tiling` package (FIB-390); re-exported so existing importers and the
 # public API are unaffected. `fibsem/imaging/__init__.py` star-imports this module.
-from fibsem.imaging.reduce import PreviewMosaic, downsample
+from fibsem.imaging.reduce import PreviewMosaic
 from fibsem.imaging.tiling.geometry import (  # noqa: E402,F401
     TilePosition,
     _spiral_order,  # noqa: E402,F401
@@ -50,7 +45,6 @@ from fibsem.imaging.tiling.reprojection import (  # noqa: E402,F401
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import (
     AutoFocusMode,
-    BeamType,
     FibsemImage,
     FibsemImageMetadata,
     FibsemStagePosition,

--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -70,6 +70,7 @@ def _check_cancelled(stop_event: Optional[threading.Event]) -> None:
 
 ##### TILED ACQUISITION
 
+
 class TiledAcquisitionRunner:
     """Orchestrates a tiled image acquisition as a series of discrete phases.
 
@@ -161,14 +162,16 @@ class TiledAcquisitionRunner:
         terminal *outcome* would collide on "finished" while meaning something else.
         """
         total_tiles = self.settings.n_enabled_tiles
-        self.microscope.tiled_acquisition_signal.emit({
-            "modality": MODALITY_BEAM,
-            "msg": message,
-            "counter": getattr(self, "_n_tiles_acquired", 0),
-            "total": total_tiles,
-            "finished": True,
-            "outcome": outcome,
-        })
+        self.microscope.tiled_acquisition_signal.emit(
+            {
+                "modality": MODALITY_BEAM,
+                "msg": message,
+                "counter": getattr(self, "_n_tiles_acquired", 0),
+                "total": total_tiles,
+                "finished": True,
+                "outcome": outcome,
+            }
+        )
 
     def run_and_stitch(self) -> FibsemImage:
         """Acquire all tiles and return the stitched FibsemImage."""
@@ -197,12 +200,14 @@ class TiledAcquisitionRunner:
         self._image_settings = image_settings
 
         # notify the UI immediately so the progress bar appears before the first move
-        self.microscope.tiled_acquisition_signal.emit({
-            "modality": MODALITY_BEAM,
-            "msg": "Computing Tile Positions",
-            "counter": 0,
-            "total": self.settings.n_enabled_tiles,
-        })
+        self.microscope.tiled_acquisition_signal.emit(
+            {
+                "modality": MODALITY_BEAM,
+                "msg": "Computing Tile Positions",
+                "counter": 0,
+                "total": self.settings.n_enabled_tiles,
+            }
+        )
 
     def _compute_grid(self) -> None:
         """Compute tile order and pre-project every stage position from the grid centre.
@@ -255,7 +260,7 @@ class TiledAcquisitionRunner:
         grid_offset_y = (settings.nrows - 1) * self._dy_step / 2
 
         # stitched canvas
-        eff_w = max(1, int(round(image_width  * (1 - overlap))))
+        eff_w = max(1, int(round(image_width * (1 - overlap))))
         eff_h = max(1, int(round(image_height * (1 - overlap))))
         full_w = eff_w * (settings.ncols - 1) + image_width
         full_h = eff_h * (settings.nrows - 1) + image_height
@@ -263,7 +268,9 @@ class TiledAcquisitionRunner:
         self._mosaic_metadata = self._build_mosaic_metadata(full_w, full_h)
         self._init_preview(full_w, full_h)
 
-        logging.info(f"Tiled acquisition centre position: {self._centre_position.pretty}")
+        logging.info(
+            f"Tiled acquisition centre position: {self._centre_position.pretty}"
+        )
 
         self._tile_stage_positions = [
             self.microscope.project_stable_move(
@@ -283,9 +290,14 @@ class TiledAcquisitionRunner:
 
         # EACH_ROW is not well-defined for SPIRAL (rows are revisited non-sequentially),
         # so promote it to EACH_TILE so focus is always fresh.
-        if self._af_mode is AutoFocusMode.EACH_ROW and settings.tile_order is TileOrderStrategy.SPIRAL:
+        if (
+            self._af_mode is AutoFocusMode.EACH_ROW
+            and settings.tile_order is TileOrderStrategy.SPIRAL
+        ):
             self._af_mode = AutoFocusMode.EACH_TILE
-            logging.info("EACH_ROW autofocus upgraded to EACH_TILE for SPIRAL tile order")
+            logging.info(
+                "EACH_ROW autofocus upgraded to EACH_TILE for SPIRAL tile order"
+            )
 
     def _build_mosaic_metadata(self, full_w: int, full_h: int) -> FibsemImageMetadata:
         """The mosaic's metadata, built before the first tile rather than after the last.
@@ -372,7 +384,8 @@ class TiledAcquisitionRunner:
         )
         metadata.image_settings = deepcopy(self._mosaic_metadata.image_settings)
         metadata.image_settings.resolution = (
-            self._preview.canvas.shape[1], self._preview.canvas.shape[0],
+            self._preview.canvas.shape[1],
+            self._preview.canvas.shape[0],
         )
         return FibsemImage(data=self._preview.canvas.copy(), metadata=metadata)
 
@@ -393,7 +406,9 @@ class TiledAcquisitionRunner:
 
             logging.info(f"Tile ({tile.row}, {tile.col}) — target: {stage_pos.pretty}")
             self.microscope.safe_absolute_stage_movement(stage_pos)
-            logging.info(f"Tile ({tile.row}, {tile.col}) — actual: {self.microscope.get_stage_position().pretty}")
+            logging.info(
+                f"Tile ({tile.row}, {tile.col}) — actual: {self.microscope.get_stage_position().pretty}"
+            )
 
             # check after moving in case cancel was requested during the move
             _check_cancelled(self.stop_event)
@@ -416,33 +431,35 @@ class TiledAcquisitionRunner:
 
             # stitch tile into canvas (overlapping regions are overwritten by later tiles)
             self._canvas[
-                tile.canvas_y:tile.canvas_y + image_height,
-                tile.canvas_x:tile.canvas_x + image_width,
+                tile.canvas_y : tile.canvas_y + image_height,
+                tile.canvas_x : tile.canvas_x + image_width,
             ] = image.filtered_data
 
             self._paint_preview(tile, image)
             self._n_tiles_acquired += 1
-            self.microscope.tiled_acquisition_signal.emit({
-                "modality": MODALITY_BEAM,
-                "msg": "Tile Collected",
-                "i": tile.row,
-                "j": tile.col,
-                "n_rows": self.settings.nrows,
-                "n_cols": self.settings.ncols,
-                "image": self._canvas,
-                # The mosaic so far, decimated, and carrying metadata -- so a
-                # real-space display can place it as one image rather than assembling
-                # tiles of its own. One artist per run instead of one per tile, which
-                # is what stops the canvas slowing down as tilesets accumulate
-                # (FIB-627).
-                #
-                # Additive, and `image` above is deliberately untouched: the napari
-                # minimap assigns it straight into a layer, so it has to stay a bare
-                # array until that tab goes.
-                "preview": self._preview_image(),
-                "counter": self._n_tiles_acquired,
-                "total": total_tiles,
-            })
+            self.microscope.tiled_acquisition_signal.emit(
+                {
+                    "modality": MODALITY_BEAM,
+                    "msg": "Tile Collected",
+                    "i": tile.row,
+                    "j": tile.col,
+                    "n_rows": self.settings.nrows,
+                    "n_cols": self.settings.ncols,
+                    "image": self._canvas,
+                    # The mosaic so far, decimated, and carrying metadata -- so a
+                    # real-space display can place it as one image rather than assembling
+                    # tiles of its own. One artist per run instead of one per tile, which
+                    # is what stops the canvas slowing down as tilesets accumulate
+                    # (FIB-627).
+                    #
+                    # Additive, and `image` above is deliberately untouched: the napari
+                    # minimap assigns it straight into a layer, so it has to stay a bare
+                    # array until that tab goes.
+                    "preview": self._preview_image(),
+                    "counter": self._n_tiles_acquired,
+                    "total": total_tiles,
+                }
+            )
 
     def _acquire_tile(self, tile: TilePosition) -> FibsemImage:
         """Acquire one tile — focus-stack or plain image."""
@@ -462,7 +479,9 @@ class TiledAcquisitionRunner:
 
         signal = self.microscope.tiled_acquisition_signal
         total_tiles = self.settings.n_enabled_tiles
-        signal.emit({"msg": "Stitching Tiles", "counter": total_tiles, "total": total_tiles})
+        signal.emit(
+            {"msg": "Stitching Tiles", "counter": total_tiles, "total": total_tiles}
+        )
         # The metadata `_compute_grid` built, not a patched copy of the first tile's.
         # deepcopy so the stitched image gets its own snapshot rather than sharing the
         # runner's, which the preview also hands out.
@@ -481,7 +500,14 @@ class TiledAcquisitionRunner:
         filename = os.path.join(image.metadata.image_settings.path, self._prev_label)  # type: ignore
         image.save(filename)
 
-        signal.emit({"msg": "Done", "counter": total_tiles, "total": total_tiles, "finished": True})
+        signal.emit(
+            {
+                "msg": "Done",
+                "counter": total_tiles,
+                "total": total_tiles,
+                "finished": True,
+            }
+        )
         return image
 
     # ── helpers ──────────────────────────────────────────────────────────
@@ -541,6 +567,7 @@ def tiled_image_acquisition_and_stitch(
         microscope, settings, stop_event, centre_position=centre_position
     ).run_and_stitch()
 
+
 ##### REPROJECTION
 # TODO: move these to fibsem.imaging.reprojection?
 
@@ -572,6 +599,7 @@ def convert_image_coord_to_stage_position(
 
     return stage_position
 
+
 def convert_image_coordinates_to_stage_positions(
     microscope: FibsemMicroscope, image: FibsemImage, coords: List[Tuple[float, float]]
 ) -> List[FibsemStagePosition]:
@@ -592,6 +620,5 @@ def convert_image_coordinates_to_stage_positions(
         stage_positions.append(stage_position)
     return stage_positions
 
+
 ##### THERMO ONLY
-
-

--- a/fibsem/imaging/tiling/progress.py
+++ b/fibsem/imaging/tiling/progress.py
@@ -32,7 +32,6 @@ it was before this existed.
 
 from __future__ import annotations
 
-from typing import Optional
 
 # The beam tiler: SEM or FIB, since no consumer distinguishes them -- both draw into the
 # same overview.

--- a/fibsem/imaging/tiling/progress.py
+++ b/fibsem/imaging/tiling/progress.py
@@ -32,7 +32,6 @@ it was before this existed.
 
 from __future__ import annotations
 
-
 # The beam tiler: SEM or FIB, since no consumer distinguishes them -- both draw into the
 # same overview.
 MODALITY_BEAM = "beam"

--- a/fibsem/imaging/transforms.py
+++ b/fibsem/imaging/transforms.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 import cv2

--- a/fibsem/milling/base.py
+++ b/fibsem/milling/base.py
@@ -70,6 +70,7 @@ class MillingStrategyConfig(ABC):
 
 class MillingStrategy(ABC, Generic[TMillingStrategyConfig]):
     """Abstract base class for different milling strategies"""
+
     name: str = "Milling Strategy"
     config_class: Type[TMillingStrategyConfig]
     selectable: bool = True
@@ -88,9 +89,13 @@ class MillingStrategy(ABC, Generic[TMillingStrategyConfig]):
     def summary(self) -> str:
         """Return a multi-line human-readable summary of the strategy and its config."""
         from fibsem.utils import format_value
+
         lines = [f"    Strategy: {self.name}"]
         for attr in self.config.required_attributes:
-            if attr in self.config._hidden_attributes or attr in self.config.advanced_attributes:
+            if (
+                attr in self.config._hidden_attributes
+                or attr in self.config.advanced_attributes
+            ):
                 continue
             val = getattr(self.config, attr)
             meta = self.config.field_metadata.get(attr, {})
@@ -99,12 +104,23 @@ class MillingStrategy(ABC, Generic[TMillingStrategyConfig]):
             if isinstance(val, float) and unit:
                 val_str = format_value(val, unit=unit, precision=1)
             else:
-                val_str = val.name if hasattr(val, "name") and not isinstance(val, float) else str(val)
+                val_str = (
+                    val.name
+                    if hasattr(val, "name") and not isinstance(val, float)
+                    else str(val)
+                )
             lines.append(f"        {label}: {val_str}")
         return "\n".join(lines)
 
     @abstractmethod
-    def run(self, microscope: FibsemMicroscope, stage: "FibsemMillingStage", asynch: bool = False, parent_ui = None, stop_event: Optional[threading.Event] = None) -> None:
+    def run(
+        self,
+        microscope: FibsemMicroscope,
+        stage: "FibsemMillingStage",
+        asynch: bool = False,
+        parent_ui=None,
+        stop_event: Optional[threading.Event] = None,
+    ) -> None:
         pass
 
 
@@ -127,14 +143,16 @@ class FibsemMillingStage:
     enabled: bool = True
     milling: FibsemMillingSettings = field(default_factory=FibsemMillingSettings)
     pattern: BasePattern = field(default_factory=DEFAULT_MILLING_PATTERN)
-    patterns: Optional[List[BasePattern]] = None # unused
+    patterns: Optional[List[BasePattern]] = None  # unused
     strategy: MillingStrategy[Any] = field(default_factory=get_strategy)
     alignment: MillingAlignment = field(default_factory=MillingAlignment)
-    imaging: ImageSettings = field(default_factory=ImageSettings) # settings for post-milling acquisition
+    imaging: ImageSettings = field(
+        default_factory=ImageSettings
+    )  # settings for post-milling acquisition
     reference_image: Optional[FibsemImage] = None
 
     def __post_init__(self):
-        
+
         if self.imaging.resolution is None:
             self.imaging.resolution = [1536, 1024]  # default resolution for imaging
         if self.imaging.hfw is None:
@@ -172,7 +190,7 @@ class FibsemMillingStage:
         alignment = data.get("alignment", {})
         imaging: dict = data.get("imaging", {})
         if imaging == {} or imaging.get("path", None) is None:
-            imaging["path"] = None # set to None if not explicitly set
+            imaging["path"] = None  # set to None if not explicitly set
         return cls(
             name=data["name"],
             num=data.get("num", 0),
@@ -188,24 +206,31 @@ class FibsemMillingStage:
     def estimated_time(self) -> float:
         return estimate_milling_time(self.pattern, self.milling.milling_current)
 
-    def run(self, microscope: FibsemMicroscope, asynch: bool = False, parent_ui = None) -> None:
+    def run(
+        self, microscope: FibsemMicroscope, asynch: bool = False, parent_ui=None
+    ) -> None:
         """Run the milling stage strategy on the given microscope."""
-        self.strategy.run(microscope=microscope, stage=self, asynch=asynch, parent_ui=parent_ui)
+        self.strategy.run(
+            microscope=microscope, stage=self, asynch=asynch, parent_ui=parent_ui
+        )
 
     @property
     def summary(self) -> str:
         """Return a multi-line human-readable summary of the milling stage parameters."""
-        return "\n".join([
-            self.name,
-            self.milling.summary(),
-            self.pattern.summary(),
-            self.strategy.summary(),
-        ])
+        return "\n".join(
+            [
+                self.name,
+                self.milling.summary(),
+                self.pattern.summary(),
+                self.strategy.summary(),
+            ]
+        )
 
     @property
     def pretty_name(self) -> str:
         """Return a pretty name for the milling stage, including the milling current."""
         from fibsem.utils import format_value
+
         milling_current = self.milling.milling_current
         mc = format_value(val=milling_current, unit="A", precision=1)
 
@@ -240,7 +265,9 @@ class FibsemMillingStage:
         return self.strategy.config == other.strategy.config
 
 
-def get_milling_stages(key: str, protocol: Dict[str, List[Dict[str, Any]]]) -> List[FibsemMillingStage]:
+def get_milling_stages(
+    key: str, protocol: Dict[str, List[Dict[str, Any]]]
+) -> List[FibsemMillingStage]:
     """Get the milling stages for specific key from the protocol.
     Args:
         key: the key to get the milling stages for
@@ -248,15 +275,20 @@ def get_milling_stages(key: str, protocol: Dict[str, List[Dict[str, Any]]]) -> L
     Returns:
         List[FibsemMillingStage]: the milling stages for the given key"""
     if key not in protocol:
-        raise ValueError(f"Key {key} not found in protocol. Available keys: {list(protocol.keys())}")
-    
+        raise ValueError(
+            f"Key {key} not found in protocol. Available keys: {list(protocol.keys())}"
+        )
+
     stages = []
     for stage_config in protocol[key]:
         stage = FibsemMillingStage.from_dict(stage_config)
         stages.append(stage)
     return stages
 
-def get_protocol_from_stages(stages: Union[FibsemMillingStage, List[FibsemMillingStage]]) -> List[Dict[str, Any]]:
+
+def get_protocol_from_stages(
+    stages: Union[FibsemMillingStage, List[FibsemMillingStage]],
+) -> List[Dict[str, Any]]:
     """Convert a list of milling stages to a protocol dictionary.
     Args:
         stages: the list of milling stages to convert
@@ -264,14 +296,14 @@ def get_protocol_from_stages(stages: Union[FibsemMillingStage, List[FibsemMillin
         List[Dict[str, Any]]: the protocol dictionary"""
     if not isinstance(stages, list):
         stages = [stages]
-    
+
     return deepcopy([stage.to_dict() for stage in stages])
 
 
 def estimate_milling_time(pattern: BasePattern, milling_current: float) -> float:
-    """Estimate the milling time for a given pattern and milling current. 
+    """Estimate the milling time for a given pattern and milling current.
     The time is calculated as the volume of the pattern divided by the sputter rate at the given current.
-    The sputter rate is taken from the microscope application files. 
+    The sputter rate is taken from the microscope application files.
     This is a rough estimate, as the actual milling time is calculated at milling time.
 
     Args:
@@ -289,20 +321,29 @@ def estimate_milling_time(pattern: BasePattern, milling_current: float) -> float
     sp_keys.sort(key=lambda x: abs(x - milling_current))
 
     # get the sputter rate for the closest key
-    sputter_rate = MILLING_SPUTTER_RATE[sp_keys[0]] # um3/s 
+    sputter_rate = MILLING_SPUTTER_RATE[sp_keys[0]]  # um3/s
 
     # scale the sputter rate based on the expected current
     sputter_rate = sputter_rate * (milling_current / sp_keys[0])
-    volume = pattern.volume # m3
+    volume = pattern.volume  # m3
 
-    if hasattr(pattern, "cross_section") and pattern.cross_section is CrossSectionPattern.CleaningCrossSection:
-        volume *= 0.66 # ccs is approx 2/3 of the volume of a rectangle
+    if (
+        hasattr(pattern, "cross_section")
+        and pattern.cross_section is CrossSectionPattern.CleaningCrossSection
+    ):
+        volume *= 0.66  # ccs is approx 2/3 of the volume of a rectangle
 
-    time = (volume *1e6**3) / sputter_rate
-    return time * 0.75 # QUERY: accuracy of this estimate?
+    time = (volume * 1e6**3) / sputter_rate
+    return time * 0.75  # QUERY: accuracy of this estimate?
+
 
 def estimate_total_milling_time(stages: List[FibsemMillingStage]) -> float:
     """Estimate the total milling time for a list of milling stages"""
     if not isinstance(stages, list):
         stages = [stages]
-    return sum([estimate_milling_time(stage.pattern, stage.milling.milling_current) for stage in stages])
+    return sum(
+        [
+            estimate_milling_time(stage.pattern, stage.milling.milling_current)
+            for stage in stages
+        ]
+    )

--- a/fibsem/milling/base.py
+++ b/fibsem/milling/base.py
@@ -5,7 +5,6 @@ from dataclasses import asdict, dataclass, field, fields
 from functools import cached_property
 from typing import (
     Any,
-    ClassVar,
     Dict,
     Generic,
     List,

--- a/fibsem/milling/patterning/patterns2.py
+++ b/fibsem/milling/patterning/patterns2.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from copy import deepcopy
 from dataclasses import asdict, dataclass, field, fields
 from functools import cached_property
 from typing import (

--- a/fibsem/milling/patterning/patterns2.py
+++ b/fibsem/milling/patterning/patterns2.py
@@ -46,6 +46,7 @@ TPattern = TypeVar("TPattern", bound="BasePattern")
 
 ####### Combo Patterns
 
+
 @dataclass
 class BasePattern(ABC, Generic[TFibsemPatternSettings]):
     name: ClassVar[str] = field(init=False)
@@ -54,16 +55,18 @@ class BasePattern(ABC, Generic[TFibsemPatternSettings]):
     # `"type": Point` *before* spreading DEFAULT_DISTANCE_METADATA, so the
     # spread's `float` silently won and the declaration was a lie -- which is
     # why the row had to be special-cased on the field being named "point".
-    point: Point = field(default_factory=Point,
-                         metadata=field_meta(
-                            DEFAULT_DISTANCE_METADATA,
-                            label="Point",
-                            type=Point,
-                            minimum=-1000.0,
-                            maximum=1000.0,
-                            tooltip="Point coordinates for the milling pattern.",
-                            advanced=True,
-                         ))
+    point: Point = field(
+        default_factory=Point,
+        metadata=field_meta(
+            DEFAULT_DISTANCE_METADATA,
+            label="Point",
+            type=Point,
+            minimum=-1000.0,
+            maximum=1000.0,
+            tooltip="Point coordinates for the milling pattern.",
+            advanced=True,
+        ),
+    )
     # Computed by define(), never edited: the form skips it on `hidden` rather
     # than on a hardcoded field name, so a plugin can hide its own fields too.
     shapes: Optional[List[TFibsemPatternSettings]] = field(
@@ -138,6 +141,7 @@ class BasePattern(ABC, Generic[TFibsemPatternSettings]):
     def summary(self) -> str:
         """Return a multi-line human-readable summary of key pattern parameters."""
         from fibsem.utils import format_value
+
         lines = [f"    Pattern: {self.name}"]
         for attr in self.required_attributes:
             if attr in self.advanced_attributes:
@@ -439,13 +443,16 @@ class RectanglePattern(BasePattern[FibsemRectangleSettings]):
 
     def summary(self) -> str:
         from fibsem.utils import format_value
-        return "\n".join([
-            f"    Pattern: {self.name}",
-            f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
-            f"        Width: {format_value(self.width, unit='m', precision=1)}",
-            f"        Height: {format_value(self.height, unit='m', precision=1)}",
-            f"        Cross Section: {self.cross_section.name}",
-        ])
+
+        return "\n".join(
+            [
+                f"    Pattern: {self.name}",
+                f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
+                f"        Width: {format_value(self.width, unit='m', precision=1)}",
+                f"        Height: {format_value(self.height, unit='m', precision=1)}",
+                f"        Cross Section: {self.cross_section.name}",
+            ]
+        )
 
     def define(self) -> List[FibsemRectangleSettings]:
 
@@ -516,10 +523,13 @@ class LinePattern(BasePattern[FibsemLineSettings]):
 
     def summary(self) -> str:
         from fibsem.utils import format_value
-        return "\n".join([
-            f"    Pattern: {self.name}",
-            f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
-        ])
+
+        return "\n".join(
+            [
+                f"    Pattern: {self.name}",
+                f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
+            ]
+        )
 
     def define(self) -> List[FibsemLineSettings]:
         shape = FibsemLineSettings(
@@ -565,14 +575,17 @@ class CirclePattern(BasePattern[FibsemCircleSettings]):
 
     def summary(self) -> str:
         from fibsem.utils import format_value
-        return "\n".join([
-            f"    Pattern: {self.name}",
-            f"        Radius: {format_value(self.radius, unit='m', precision=1)}",
-            f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
-        ])
+
+        return "\n".join(
+            [
+                f"    Pattern: {self.name}",
+                f"        Radius: {format_value(self.radius, unit='m', precision=1)}",
+                f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
+            ]
+        )
 
     def define(self) -> List[FibsemCircleSettings]:
-        
+
         shape = FibsemCircleSettings(
             radius=self.radius,
             depth=self.depth,
@@ -649,16 +662,19 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
 
     def summary(self) -> str:
         from fibsem.utils import format_value
-        return "\n".join([
-            f"    Pattern: {self.name}",
-            f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
-            f"        Width: {format_value(self.width, unit='m', precision=1)}",
-            f"        Spacing: {format_value(self.spacing, unit='m', precision=1)}",
-            f"        Upper Trench Height: {format_value(self.upper_trench_height, unit='m', precision=1)}",
-            f"        Lower Trench Height: {format_value(self.lower_trench_height, unit='m', precision=1)}",
-            f"        Passes: {format_value(self.passes, precision=0)}",
-            f"        Cross Section: {self.cross_section.name}",
-        ])
+
+        return "\n".join(
+            [
+                f"    Pattern: {self.name}",
+                f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
+                f"        Width: {format_value(self.width, unit='m', precision=1)}",
+                f"        Spacing: {format_value(self.spacing, unit='m', precision=1)}",
+                f"        Upper Trench Height: {format_value(self.upper_trench_height, unit='m', precision=1)}",
+                f"        Lower Trench Height: {format_value(self.lower_trench_height, unit='m', precision=1)}",
+                f"        Passes: {format_value(self.passes, precision=0)}",
+                f"        Cross Section: {self.cross_section.name}",
+            ]
+        )
 
     def define(self) -> List[Union[FibsemRectangleSettings, FibsemCircleSettings]]:
 
@@ -679,7 +695,7 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
         # fillet radius on the corners
         fillet = np.clip(fillet, 0, upper_trench_height / 2)
         if fillet > 0:
-            width = max(0, width - 2 * fillet) # ensure width is not negative
+            width = max(0, width - 2 * fillet)  # ensure width is not negative
 
         # mill settings
         lower_trench_settings = FibsemRectangleSettings(
@@ -709,23 +725,27 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
         self.shapes = [upper_trench_settings, lower_trench_settings]
 
         # add fillet to the corners
-        if fillet > 0:            
+        if fillet > 0:
             left_x_pos = point.x - width / 2
             right_x_pos = point.x + width / 2
 
             fillet_offset = 1.5
-            lower_y_pos = centre_lower_y + lower_trench_height / 2 - fillet * fillet_offset
-            top_y_pos = centre_upper_y - upper_trench_height / 2 + fillet * fillet_offset
+            lower_y_pos = (
+                centre_lower_y + lower_trench_height / 2 - fillet * fillet_offset
+            )
+            top_y_pos = (
+                centre_upper_y - upper_trench_height / 2 + fillet * fillet_offset
+            )
 
             lower_left_fillet = FibsemCircleSettings(
                 radius=fillet,
-                depth=depth/2,
+                depth=depth / 2,
                 centre_x=point.x - width / 2,
                 centre_y=lower_y_pos,
             )
             lower_right_fillet = FibsemCircleSettings(
                 radius=fillet,
-                depth=depth/2,
+                depth=depth / 2,
                 centre_x=point.x + width / 2,
                 centre_y=lower_y_pos,
             )
@@ -737,7 +757,7 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
                 depth=depth,
                 centre_x=left_x_pos - fillet / 2,
                 centre_y=centre_lower_y - fillet / 2,
-                cross_section = cross_section,
+                cross_section=cross_section,
                 scan_direction="BottomToTop",
                 passes=self.passes,
             )
@@ -747,7 +767,7 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
                 depth=depth,
                 centre_x=right_x_pos + fillet / 2,
                 centre_y=centre_lower_y - fillet / 2,
-                cross_section = cross_section,
+                cross_section=cross_section,
                 scan_direction="BottomToTop",
                 passes=self.passes,
             )
@@ -771,7 +791,7 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
                 depth=depth,
                 centre_x=left_x_pos - fillet / 2,
                 centre_y=centre_upper_y + fillet / 2,
-                cross_section = cross_section,
+                cross_section=cross_section,
                 scan_direction="TopToBottom",
                 passes=self.passes,
             )
@@ -781,15 +801,23 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
                 depth=depth,
                 centre_x=right_x_pos + fillet / 2,
                 centre_y=centre_upper_y + fillet / 2,
-                cross_section = cross_section,
+                cross_section=cross_section,
                 scan_direction="TopToBottom",
                 passes=self.passes,
             )
 
-            self.shapes.extend([lower_left_fill, lower_right_fill, 
-                                top_left_fill, top_right_fill, 
-                                lower_left_fillet, lower_right_fillet, 
-                                top_left_fillet, top_right_fillet])
+            self.shapes.extend(
+                [
+                    lower_left_fill,
+                    lower_right_fill,
+                    top_left_fill,
+                    top_right_fill,
+                    lower_left_fillet,
+                    lower_right_fillet,
+                    top_left_fillet,
+                    top_right_fillet,
+                ]
+            )
 
         return self.shapes
 
@@ -894,7 +922,7 @@ class HorseshoePattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x,
             centre_y=centre_lower_y,
             scan_direction="BottomToTop",
-            cross_section = cross_section
+            cross_section=cross_section,
         )
 
         upper_pattern = FibsemRectangleSettings(
@@ -904,7 +932,7 @@ class HorseshoePattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x,
             centre_y=centre_upper_y,
             scan_direction="TopToBottom",
-            cross_section = cross_section
+            cross_section=cross_section,
         )
 
         side_pattern = FibsemRectangleSettings(
@@ -914,7 +942,7 @@ class HorseshoePattern(BasePattern[FibsemRectangleSettings]):
             centre_x=side_x,
             centre_y=side_y,
             scan_direction=self.scan_direction,
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         self.shapes = [upper_pattern, lower_pattern, side_pattern]
@@ -1001,7 +1029,7 @@ class HorseshoePatternVertical(BasePattern):
             centre_x=point.x - (width / 2) - (trench_width / 2),
             centre_y=point.y,
             scan_direction="LeftToRight",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         right_pattern = FibsemRectangleSettings(
@@ -1011,7 +1039,7 @@ class HorseshoePatternVertical(BasePattern):
             centre_x=point.x + (width / 2) + (trench_width / 2),
             centre_y=point.y,
             scan_direction="RightToLeft",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
         y_offset = (height / 2) + (upper_trench_height / 2)
         if inverted:
@@ -1023,10 +1051,10 @@ class HorseshoePatternVertical(BasePattern):
             centre_x=point.x,
             centre_y=point.y + y_offset,
             scan_direction=scan_direction,
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
-        self.shapes = [upper_pattern, left_pattern,right_pattern]
+        self.shapes = [upper_pattern, left_pattern, right_pattern]
         return self.shapes
 
 
@@ -1120,11 +1148,13 @@ class SerialSectionPattern(BasePattern[FibsemLineSettings]):
             side_height *= -1.0
 
         # main section pattern
-        section_pattern = FibsemLineSettings(start_x=point.x - section_width / 2, 
-                                             end_x=point.x + section_width / 2, 
-                                             start_y=point.y + section_y, 
-                                             end_y=point.y + section_y, 
-                                             depth=section_depth)
+        section_pattern = FibsemLineSettings(
+            start_x=point.x - section_width / 2,
+            end_x=point.x + section_width / 2,
+            start_y=point.y + section_y,
+            end_y=point.y + section_y,
+            depth=section_depth,
+        )
 
         self.shapes = [section_pattern]
 
@@ -1162,10 +1192,15 @@ class SerialSectionPattern(BasePattern[FibsemLineSettings]):
                 depth=side_depth,
             )
 
-            self.shapes.extend([left_side_pattern, right_side_pattern, 
-                            left_side_pattern_vertical, 
-                            right_side_pattern_vertical])
-            
+            self.shapes.extend(
+                [
+                    left_side_pattern,
+                    right_side_pattern,
+                    left_side_pattern_vertical,
+                    right_side_pattern_vertical,
+                ]
+            )
+
         return self.shapes
 
 
@@ -1226,7 +1261,6 @@ class FiducialPattern(BasePattern[FibsemRectangleSettings]):
         rotation = self.rotation * constants.DEGREES_TO_RADIANS
         cross_section = self.cross_section
 
-
         # def calculate_angles(num_steps, start_angle=0):
         #     angles = []
         #     step_size = 180 / num_steps
@@ -1279,8 +1313,8 @@ class FiducialPattern(BasePattern[FibsemRectangleSettings]):
         )
         if self.asymmetric:
             left_pattern.height *= 0.5
-            left_pattern.centre_x -= left_pattern.height*0.5*np.cos(rotation)
-            left_pattern.centre_y += left_pattern.height*0.5*np.sin(rotation)
+            left_pattern.centre_x -= left_pattern.height * 0.5 * np.cos(rotation)
+            left_pattern.centre_y += left_pattern.height * 0.5 * np.sin(rotation)
 
         self.shapes = [left_pattern, right_pattern]
         return self.shapes
@@ -1343,7 +1377,7 @@ class UndercutPattern(BasePattern[FibsemRectangleSettings]):
     name: ClassVar[str] = "Undercut"
 
     def define(self) -> List[FibsemRectangleSettings]:
-        
+
         point = self.point
         jcut_rhs_height = self.rhs_height
         jcut_lamella_height = self.height
@@ -1367,7 +1401,7 @@ class UndercutPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x,
             centre_y=point.y,
             scan_direction="TopToBottom",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
         # rhs jcut
         jcut_rhs_centre_x = point.x + (jcut_width / 2) - jcut_trench_thickness / 2
@@ -1383,7 +1417,7 @@ class UndercutPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=jcut_rhs_centre_x,
             centre_y=jcut_rhs_centre_y,
             scan_direction="TopToBottom",
-            cross_section = cross_section
+            cross_section=cross_section,
         )
 
         self.shapes = [top_pattern, rhs_pattern]
@@ -1441,7 +1475,7 @@ class MicroExpansionPattern(BasePattern[FibsemRectangleSettings]):
             width=width,
             height=height,
             depth=depth,
-            centre_x=point.x -  distance,
+            centre_x=point.x - distance,
             centre_y=point.y,
             scan_direction="TopToBottom",
         )
@@ -1557,7 +1591,7 @@ class ArrayPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSettin
     # ref: weld cross-section/ passes: https://www.nature.com/articles/s41592-023-02113-5
 
     def define(self) -> List[Union[FibsemRectangleSettings, FibsemCircleSettings]]:
-        
+
         point = self.point
         width = self.width
         height = self.height
@@ -1598,7 +1632,7 @@ class ArrayPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSettin
                     height=height,
                     depth=depth,
                     centre_x=pt.x,
-                    centre_y=pt.y,  
+                    centre_y=pt.y,
                     scan_direction=scan_direction,
                     rotation=rotation,
                     passes=passes,
@@ -1606,7 +1640,7 @@ class ArrayPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSettin
                 )
             self.shapes.append(pattern_settings)
 
-        return self.shapes # type: ignore
+        return self.shapes  # type: ignore
 
 
 @dataclass
@@ -1693,7 +1727,7 @@ class WaffleNotchPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x,
             centre_y=point.y - distance / 2 - vheight / 2 + hheight / 2,
             scan_direction="TopToBottom",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         bottom_vertical_pattern = FibsemRectangleSettings(
@@ -1703,7 +1737,7 @@ class WaffleNotchPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x,
             centre_y=point.y + distance / 2 + vheight / 2 - hheight / 2,
             scan_direction="BottomToTop",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         top_horizontal_pattern = FibsemRectangleSettings(
@@ -1713,7 +1747,7 @@ class WaffleNotchPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x + (hwidth / 2 + vwidth / 2) * inverted,
             centre_y=point.y - distance / 2,
             scan_direction="TopToBottom",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         bottom_horizontal_pattern = FibsemRectangleSettings(
@@ -1723,7 +1757,7 @@ class WaffleNotchPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x + (hwidth / 2 + vwidth / 2) * inverted,
             centre_y=point.y + distance / 2,
             scan_direction="BottomToTop",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         centre_vertical_pattern = FibsemRectangleSettings(
@@ -1733,7 +1767,7 @@ class WaffleNotchPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x + (hwidth + vwidth) * inverted,
             centre_y=point.y,
             scan_direction="TopToBottom",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         self.shapes = [
@@ -1769,7 +1803,7 @@ class CloverPattern(BasePattern[Union[FibsemCircleSettings, FibsemRectangleSetti
     name: ClassVar[str] = "Clover"
 
     def define(self) -> List[Union[FibsemCircleSettings, FibsemRectangleSettings]]:
-        
+
         point = self.point
         radius = self.radius
         depth = self.depth
@@ -1856,14 +1890,11 @@ class TriForcePattern(BasePattern[FibsemRectangleSettings]):
         ]
 
         for point in points:
-
-            triangle_shapes =  create_triangle_patterns(width=width, 
-                                                        height=height, 
-                                                        depth=depth, 
-                                                        point=point, 
-                                                        angle=angle)
+            triangle_shapes = create_triangle_patterns(
+                width=width, height=height, depth=depth, point=point, angle=angle
+            )
             self.shapes.extend(triangle_shapes)
-            
+
         return self.shapes
 
 
@@ -1912,7 +1943,7 @@ class TrenchTrapezoidPattern(BasePattern):
     name: ClassVar[str] = "TrapezoidTrench"
 
     # ref: https://www.researchsquare.com/article/rs-6497420/v1
-    
+
     def define(self):
 
         width = self.trench_width
@@ -1934,7 +1965,7 @@ class TrenchTrapezoidPattern(BasePattern):
 
         # create mirrored polygon (mirror over y-axis)
         mirrored_points = points.copy()
-        mirrored_points[:, 1] = -mirrored_points[:, 1] #- spacing /2
+        mirrored_points[:, 1] = -mirrored_points[:, 1]  # - spacing /2
 
         top_trench = FibsemPolygonSettings(vertices=points, depth=depth)
         bottom_trench = FibsemPolygonSettings(vertices=mirrored_points, depth=depth)
@@ -1952,7 +1983,9 @@ class TrenchTrapezoidPattern(BasePattern):
 
 @dataclass
 class PolygonPattern(BasePattern):
-    vertices: np.ndarray[float] = field(default_factory=lambda: np.array([]), metadata={"hidden": True})    # type: ignore[type-arg]
+    vertices: np.ndarray[float] = field(
+        default_factory=lambda: np.array([]), metadata={"hidden": True}
+    )  # type: ignore[type-arg]
     depth: float = field(
         default=1.0e-6,
         metadata={
@@ -1973,14 +2006,16 @@ class PolygonPattern(BasePattern):
 
     def define(self) -> List[FibsemPolygonSettings]:
         """Define a polygon milling pattern based on the provided vertices."""
-        
+
         if self.vertices.ndim != 2 or self.vertices.shape[1] != 2:
             raise ValueError("Vertices must be a 2D array with shape (n, 2)")
 
         # Create a polygon milling pattern
-        polygon = FibsemPolygonSettings(vertices=np.array(self.vertices, copy=True), 
-                                        depth=self.depth,
-                                        is_exclusion=self.is_exclusion)
+        polygon = FibsemPolygonSettings(
+            vertices=np.array(self.vertices, copy=True),
+            depth=self.depth,
+            is_exclusion=self.is_exclusion,
+        )
 
         # Offset the vertices by the point
         polygon.vertices[:, 0] += self.point.x

--- a/fibsem/milling/strategy/coincidence.py
+++ b/fibsem/milling/strategy/coincidence.py
@@ -105,7 +105,9 @@ class CoincidenceMillingStrategyConfig(MillingStrategyConfig):
     )
     bbox: Optional[FibsemRectangle] = field(
         default=None,
-        metadata=field_meta(hidden=True),  # set interactively via the FM ROI, not a form control
+        metadata=field_meta(
+            hidden=True
+        ),  # set interactively via the FM ROI, not a form control
     )  # reduced area for intensity monitoring
     # oscillation parameters
 
@@ -359,9 +361,7 @@ class CoincidenceMillingStrategy(MillingStrategy[CoincidenceMillingStrategyConfi
 
             # unsupervised runs: automatically stop on intensity drop
             if not self.config.supervised and self._drop_detected:
-                logging.info(
-                    "Unsupervised: intensity drop detected. Stopping milling."
-                )
+                logging.info("Unsupervised: intensity drop detected. Stopping milling.")
                 self.microscope.stop_milling()
                 break
 

--- a/fibsem/milling/strategy/coincidence.py
+++ b/fibsem/milling/strategy/coincidence.py
@@ -5,15 +5,13 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
-from queue import Queue
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
-import tifffile as tff
 from psygnal import Signal
 
 from fibsem import constants
-from fibsem.fm.structures import ChannelSettings, FluorescenceImage, ZParameters
+from fibsem.fm.structures import FluorescenceImage
 from fibsem.microscope import FibsemMicroscope
 from fibsem.microscopes.simulator import DemoMicroscope
 from fibsem.milling import (

--- a/fibsem/segmentation/_nnunet.py
+++ b/fibsem/segmentation/_nnunet.py
@@ -3,7 +3,6 @@ import json
 import os
 import shutil
 
-import matplotlib.pyplot as plt
 import numpy as np
 import PIL.Image
 import torch

--- a/fibsem/segmentation/_nnunet.py
+++ b/fibsem/segmentation/_nnunet.py
@@ -85,12 +85,11 @@ def load_from_checkpoint(
 
     # load the model parameters
     parameters = []
-    checkpoint_name = "final" # always use final checkpoint for now
-    for i, k in enumerate(sorted(model_checkpoint['folds'])):
+    checkpoint_name = "final"  # always use final checkpoint for now
+    for i, k in enumerate(sorted(model_checkpoint["folds"])):
+        checkpoint = model_checkpoint["folds"][k][checkpoint_name]
 
-        checkpoint = model_checkpoint['folds'][k][checkpoint_name]
-        
-        if i == 0: # use first fold to get trainer and configuration name
+        if i == 0:  # use first fold to get trainer and configuration name
             trainer_name = checkpoint["trainer_name"]
             configuration_name = checkpoint["init_args"]["configuration"]
             inference_allowed_mirroring_axes = (

--- a/fibsem/segmentation/adaptive_model.py
+++ b/fibsem/segmentation/adaptive_model.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 from adaptive_polish.dl_segmentation import sem_lamella_segmentor as sgm
 
-from fibsem.segmentation.utils import decode_segmap_v2, download_checkpoint
+from fibsem.segmentation.utils import decode_segmap_v2
 
 
 class AdaptiveSegmentationModel:

--- a/fibsem/segmentation/dataset.py
+++ b/fibsem/segmentation/dataset.py
@@ -18,7 +18,6 @@ PROB = 0.1
 
 transformations_input = transforms.Compose(
     [
-
         transforms.RandomRotation(ROT_ANGLE),
         transforms.RandomHorizontalFlip(p=PROB),
         transforms.RandomVerticalFlip(p=PROB),
@@ -34,28 +33,39 @@ transformations_target = transforms.Compose(
         transforms.RandomRotation(ROT_ANGLE),
         transforms.RandomHorizontalFlip(p=PROB),
         transforms.RandomVerticalFlip(p=PROB),
-
     ]
 )
 
 
 class SegmentationDataset(Dataset):
-    def __init__(self, images, masks, num_classes: int, transforms_input=None, transforms_target=None):
+    def __init__(
+        self,
+        images,
+        masks,
+        num_classes: int,
+        transforms_input=None,
+        transforms_target=None,
+    ):
         self.images = images
         self.masks = masks
         self.num_classes = num_classes
         self.transforms_input = transforms_input
         self.transforms_target = transforms_target
 
-        assert len(self.images) == len(self.masks), "Images and masks are not the same length"
-        assert self.transforms_target is not None if self.transforms_input is not None else True, "transforms_target must be provided if transforms_input is provided"
+        assert len(self.images) == len(self.masks), (
+            "Images and masks are not the same length"
+        )
+        assert (
+            self.transforms_target is not None
+            if self.transforms_input is not None
+            else True
+        ), "transforms_target must be provided if transforms_input is provided"
 
     def _set_seed(self, seed):
         random.seed(seed)
         torch.manual_seed(seed)
 
     def __getitem__(self, idx):
-
 
         image = np.asarray(self.images[idx])
         mask = np.asarray(self.masks[idx])
@@ -66,10 +76,9 @@ class SegmentationDataset(Dataset):
         # need to to transformation manually
         # mask = torch.tensor(mask).unsqueeze(0)
 
-        image = torch.tensor(image).unsqueeze(0) # TODO: validate this behaviour
+        image = torch.tensor(image).unsqueeze(0)  # TODO: validate this behaviour
         mask = torch.tensor(mask).unsqueeze(0)
-        
-    
+
         image_max_val = torch.iinfo(image.dtype).max
         if image.dtype not in [torch.uint8, torch.int16]:
             raise ValueError(f"Image dtype {image.dtype} not supported")
@@ -83,11 +92,12 @@ class SegmentationDataset(Dataset):
 
         # convert image to float32 scaled between 0-1
         image = image.float() / image_max_val
-                        
+
         return image, mask
 
     def __len__(self):
         return len(self.images)
+
 
 from pathlib import Path
 
@@ -112,12 +122,18 @@ def load_dask_dataset_v2(data_paths: List[Path], label_paths: List[Path]):
     return images, masks
 
 
-def preprocess_data(data_paths: List[Path], label_paths: List[Path], num_classes: int = 3, 
-                    batch_size: int = 1, val_split: float = 0.15, 
-                    _validate_dataset:bool = True, apply_transforms: bool = False):
-    
+def preprocess_data(
+    data_paths: List[Path],
+    label_paths: List[Path],
+    num_classes: int = 3,
+    batch_size: int = 1,
+    val_split: float = 0.15,
+    _validate_dataset: bool = True,
+    apply_transforms: bool = False,
+):
+
     # if _validate_dataset:
-        # validate_dataset(data_path, label_path)
+    # validate_dataset(data_path, label_path)
 
     if not isinstance(data_paths, list):
         data_paths = [data_paths]
@@ -125,7 +141,6 @@ def preprocess_data(data_paths: List[Path], label_paths: List[Path], num_classes
         label_paths = [label_paths]
 
     images, masks = load_dask_dataset_v2(data_paths, label_paths)
-
 
     print(f"Loading dataset from {len(data_paths)} paths: {images.shape[0]}")
     for path in data_paths:
@@ -139,14 +154,15 @@ def preprocess_data(data_paths: List[Path], label_paths: List[Path], num_classes
 
     transformations_input = transforms.Compose(
         [
-
             transforms.RandomRotation(ROT_ANGLE),
             transforms.RandomHorizontalFlip(p=PROB),
             transforms.RandomVerticalFlip(p=PROB),
             transforms.RandomAutocontrast(p=PROB),
             transforms.RandomEqualize(p=PROB),
             transforms.GaussianBlur(kernel_size=3, sigma=(0.1, 2.0)),
-            transforms.ColorJitter(brightness=0.1, contrast=0.1, saturation=0.1, hue=0.1),
+            transforms.ColorJitter(
+                brightness=0.1, contrast=0.1, saturation=0.1, hue=0.1
+            ),
         ]
     )
 
@@ -155,15 +171,16 @@ def preprocess_data(data_paths: List[Path], label_paths: List[Path], num_classes
             transforms.RandomRotation(ROT_ANGLE),
             transforms.RandomHorizontalFlip(p=PROB),
             transforms.RandomVerticalFlip(p=PROB),
-
         ]
     )
 
     # load dataset
     seg_dataset = SegmentationDataset(
-        images, masks, num_classes, 
-        transforms_input=transformations_input, 
-        transforms_target=transformations_target
+        images,
+        masks,
+        num_classes,
+        transforms_input=transformations_input,
+        transforms_target=transformations_target,
     )
 
     # train/validation splits
@@ -192,12 +209,13 @@ def preprocess_data(data_paths: List[Path], label_paths: List[Path], num_classes
 
 # ref: https://towardsdatascience.com/pytorch-basics-sampling-samplers-2a0f29f0bf2a
 
+
 # Helper functions
 def validate_dataset(data_path: str, label_path: str):
     print("validating dataset...")
     # get data
     filenames = sorted(glob.glob(os.path.join(data_path, "*.tif*")))
-    labels = sorted(glob.glob(os.path.join(label_path,  "*.tif*")))
+    labels = sorted(glob.glob(os.path.join(label_path, "*.tif*")))
 
     # check length
     assert len(filenames) == len(labels), "Images and labels are not the same length"
@@ -208,7 +226,6 @@ def validate_dataset(data_path: str, label_path: str):
         img, label = tff.imread(fname), tff.imread(lfname)
 
         if (img.shape[0:2] != label.shape[0:2]) or (img.shape[0:2] != base_shape[0:2]):
-
             raise ValueError(
                 "invalid data, image shape is different to label shape",
                 i,
@@ -221,7 +238,6 @@ def validate_dataset(data_path: str, label_path: str):
             )
 
         if (img.ndim > 2) or (label.ndim > 2):
-
             raise ValueError(
                 "Image has too many dimensions, must be in 2D grayscale format.",
                 i,

--- a/fibsem/segmentation/dataset.py
+++ b/fibsem/segmentation/dataset.py
@@ -9,7 +9,6 @@ import dask.array as da
 import numpy as np
 import tifffile as tff
 import torch
-from PIL import Image
 from torch.utils.data import DataLoader, Dataset, SubsetRandomSampler
 from torchvision import transforms
 

--- a/fibsem/segmentation/inference.py
+++ b/fibsem/segmentation/inference.py
@@ -3,7 +3,6 @@
 import argparse
 import glob
 import os
-import time
 
 # import matplotlib.pyplot as plt
 import numpy as np
@@ -15,7 +14,7 @@ import yaml
 import zarr
 from PIL import Image
 
-from fibsem.segmentation import dataset, utils, validate_config
+from fibsem.segmentation import utils, validate_config
 
 
 def inference(images, output_dir, model, model_path, device, WANDB=False):

--- a/fibsem/segmentation/inference.py
+++ b/fibsem/segmentation/inference.py
@@ -25,8 +25,10 @@ def inference(images, output_dir, model, model_path, device, WANDB=False):
     # model.eval()
 
     # Inference
-    with torch.no_grad(): # TODO: move this down to only wrap the model inference
-        vol = tff.imread(os.path.join(images, "*.tif*"), aszarr=True) # loading folder of .tif into zarr array)
+    with torch.no_grad():  # TODO: move this down to only wrap the model inference
+        vol = tff.imread(
+            os.path.join(images, "*.tif*"), aszarr=True
+        )  # loading folder of .tif into zarr array)
         zarr_set = zarr.open(vol)
 
         filenames = sorted(glob.glob(os.path.join(images, "*.tif*")))
@@ -36,13 +38,13 @@ def inference(images, output_dir, model, model_path, device, WANDB=False):
             img = img.to(device)
             outputs = model(img[None, :, :, :].float())
             output_mask = utils.decode_output(outputs)
-            
-            output = Image.fromarray(output_mask) 
+
+            output = Image.fromarray(output_mask)
             path = os.path.join(output_dir, os.path.basename(fname).split(".")[0])
-            
+
             # if not os.path.exists(path):
             os.makedirs(path, exist_ok=True)
-            
+
             input_img = Image.fromarray(img.detach().cpu().squeeze().numpy())
             input_img.save(os.path.join(path, "input.tif"))
             output.save(os.path.join(path, "output.tif"))  # or 'test.tif'
@@ -56,6 +58,7 @@ def inference(images, output_dir, model, model_path, device, WANDB=False):
                 wandb.log({"image": wb_img, "mask": wb_mask})
 
         return outputs, output_mask
+
 
 if __name__ == "__main__":
     # command line arguments
@@ -71,7 +74,7 @@ if __name__ == "__main__":
     config_dir = args.config
 
     # NOTE: Setup your config.yml file
-    with open(config_dir, 'r') as f:
+    with open(config_dir, "r") as f:
         config = yaml.safe_load(f)
 
     print("Validating config file.")
@@ -86,19 +89,20 @@ if __name__ == "__main__":
     cuda = config["inference"]["cuda"]
     WANDB = config["inference"]["wandb"]
 
-
     model = smp.Unet(
-            encoder_name=config["inference"]["encoder"],
-            encoder_weights="imagenet",
-            in_channels=1,  # grayscale images
-            classes=config["inference"]["num_classes"],  # background, needle, lamella
-        )
+        encoder_name=config["inference"]["encoder"],
+        encoder_weights="imagenet",
+        in_channels=1,  # grayscale images
+        classes=config["inference"]["num_classes"],  # background, needle, lamella
+    )
 
     if WANDB:
         # weights and biases setup
-        wandb.init(project=config["inference"]["wandb_project"], entity=config["inference"]["wandb_entity"])
+        wandb.init(
+            project=config["inference"]["wandb_project"],
+            entity=config["inference"]["wandb_entity"],
+        )
 
     device = torch.device("cuda:0" if torch.cuda.is_available() and cuda else "cpu")
 
     inference(data_path, output_dir, model, model_weights, device, WANDB)
-    

--- a/fibsem/segmentation/nnunet_model.py
+++ b/fibsem/segmentation/nnunet_model.py
@@ -1,5 +1,3 @@
-
-
 # TODO: actually implement this
 
 import numpy as np
@@ -13,17 +11,17 @@ from fibsem.segmentation.utils import decode_segmap_v2
 def SegmentationModelBase(ABC):
 
     def __init__(self, checkpoint: str):
-        pass 
-
+        pass
 
     def load_model(self, checkpoint: str) -> SegmentationModelBase:
         """Load the model, and optionally load a checkpoint"""
         raise NotImplementedError
-    
+
     def inference(self, img: np.ndarray, rgb: bool = True) -> np.ndarray:
         """Run model inference on the input image"""
         raise NotImplementedError
-    
+
+
 class SegmentationModelNNUnet:
     def __init__(
         self,
@@ -33,14 +31,14 @@ class SegmentationModelNNUnet:
 
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self.colormap = scfg.get_colormap()
-       
+
         self.checkpoint = checkpoint
         if checkpoint is not None:
             self.load_model(checkpoint=checkpoint)
 
     def load_model(self, checkpoint: str) -> None:
         """Load the model, and optionally load a checkpoint"""
-        
+
         self.model = nnunet.load_model(path=checkpoint, device=self.device)
 
         return self.model
@@ -57,7 +55,7 @@ class SegmentationModelNNUnet:
             img = img[:, :, :, :]
         else:
             raise ValueError(f"Invalid image shape: {img.shape}")
-        
+
         # TODO: also do dtype conversions
         if not isinstance(img.dtype, np.float32):
             img = img.astype(np.float32)
@@ -66,17 +64,17 @@ class SegmentationModelNNUnet:
 
     def inference(self, img: np.ndarray, rgb: bool = True) -> np.ndarray:
         """Run model inference on the input image"""
-        
+
         img = self.pre_process(img)
-        
+
         masks, scores = nnunet.inference(self.model, img)
-        
+
         # convert to rgb image
         if rgb:
-            masks = decode_segmap_v2(masks[0], self.colormap) # 2d only
+            masks = decode_segmap_v2(masks[0], self.colormap)  # 2d only
         else:
-            if masks.ndim>=3:
-                masks = masks[0] # return 2d
+            if masks.ndim >= 3:
+                masks = masks[0]  # return 2d
         return masks
 
     def postprocess(self, masks):
@@ -84,5 +82,3 @@ class SegmentationModelNNUnet:
         if masks.ndim == 3:
             masks = masks[0]
         return decode_segmap_v2(masks, self.colormap)
-
-     

--- a/fibsem/segmentation/nnunet_model.py
+++ b/fibsem/segmentation/nnunet_model.py
@@ -1,14 +1,9 @@
 
-import os
 
 # TODO: actually implement this
-from abc import ABC
-from pathlib import Path
-from typing import List, Optional
 
 import numpy as np
 import torch
-from huggingface_hub import hf_hub_download
 
 from fibsem.segmentation import _nnunet as nnunet
 from fibsem.segmentation import config as scfg

--- a/fibsem/segmentation/nnunet_model_v2.py
+++ b/fibsem/segmentation/nnunet_model_v2.py
@@ -1,6 +1,5 @@
 
 import os
-from typing import List, Optional
 
 import numpy as np
 import torch

--- a/fibsem/segmentation/nnunet_model_v2.py
+++ b/fibsem/segmentation/nnunet_model_v2.py
@@ -1,4 +1,3 @@
-
 import os
 
 import numpy as np
@@ -9,25 +8,25 @@ from fibsem.segmentation import config as scfg
 from fibsem.segmentation.utils import decode_segmap_v2
 
 
-class SegmentationModelNNUnetV2():
+class SegmentationModelNNUnetV2:
     def __init__(self, checkpoint: str):
         """Initialize the NNUnet model for segmentation inference using nnunetv2.
         Args:
             checkpoint (str): Path to the model checkpoint file.
-                Note: this should be the full path to the checkpoint file, not just the directory. 
+                Note: this should be the full path to the checkpoint file, not just the directory.
                 The directory will be inferred from the checkpoint path, and needs to be in nnunet format...
         """
 
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self.checkpoint = checkpoint
         self._image_properties: dict = {
-                "sitk_stuff": {
-                    "spacing": (1.0, 1.0),
-                    "origin": (0.0, 0.0),
-                    "direction": (1.0, 0.0, 0.0, 1.0),
-                },
-                "spacing": [999.0, 1.0, 1.0],
-            }
+            "sitk_stuff": {
+                "spacing": (1.0, 1.0),
+                "origin": (0.0, 0.0),
+                "direction": (1.0, 0.0, 0.0, 1.0),
+            },
+            "spacing": [999.0, 1.0, 1.0],
+        }
 
         self.predictor = nnunet_predict.nnUNetPredictor(
             perform_everything_on_device=bool(self.device.type == "cuda"),
@@ -45,7 +44,7 @@ class SegmentationModelNNUnetV2():
         self.predictor.initialize_from_trained_model_folder(
             model_training_output_dir=model_directory,
             use_folds=(0,),
-            checkpoint_name=checkpoint_name
+            checkpoint_name=checkpoint_name,
         )
 
     def pre_process(self, img: np.ndarray) -> np.ndarray:
@@ -68,9 +67,9 @@ class SegmentationModelNNUnetV2():
 
     def inference(self, img: np.ndarray, rgb: bool = True) -> np.ndarray:
         """Run model inference on the input image"""
-        
-        img = self.pre_process(img) # requires (C, 1, H, W) or (1, 1, H, W)
-        mask, scores = self.predictor.predict_single_npy_array( #  type: ignore
+
+        img = self.pre_process(img)  # requires (C, 1, H, W) or (1, 1, H, W)
+        mask, scores = self.predictor.predict_single_npy_array(  #  type: ignore
             img, self._image_properties, None, None, True
         )
         if rgb:

--- a/fibsem/segmentation/onnx_model.py
+++ b/fibsem/segmentation/onnx_model.py
@@ -19,7 +19,6 @@ from fibsem.segmentation.utils import decode_segmap_v2, download_checkpoint
 
 
 class SegmentationModelONNX:
-
     def __init__(self, checkpoint: str = None):
         if checkpoint is not None:
             self.load_model(checkpoint)
@@ -31,8 +30,9 @@ class SegmentationModelONNX:
         self.checkpoint = os.path.basename(checkpoint)
 
         # load inference session
-        self.session = onnxruntime.InferenceSession(checkpoint, providers=["CPUExecutionProvider"])
-
+        self.session = onnxruntime.InferenceSession(
+            checkpoint, providers=["CPUExecutionProvider"]
+        )
 
     def inference(self, img: np.ndarray, rgb: bool = True):
         # preprocess
@@ -45,20 +45,20 @@ class SegmentationModelONNX:
         ort_inputs = {self.session.get_inputs()[0].name: imgt}
         ort_outs = self.session.run(None, ort_inputs)
 
-
         # softmax
-        outputs = ort_outs[0] # TODO: support batch size > 1
+        outputs = ort_outs[0]  # TODO: support batch size > 1
         outputs = np.exp(outputs) / np.sum(np.exp(outputs), axis=1, keepdims=True)
         masks = np.argmax(outputs, axis=1)
         mask = masks[0, :, :]
 
         # convert to rgb
-        if rgb: 
+        if rgb:
             mask = decode_segmap_v2(mask)
         return mask
 
+
 def export_model_to_onnx(checkpoint: str, onnx_path: str):
-    
+
     import torch
 
     from fibsem.segmentation.model import load_model
@@ -74,26 +74,35 @@ def export_model_to_onnx(checkpoint: str, onnx_path: str):
     torch_out = model.model(x)
 
     # Export the model
-    torch.onnx.export(model.model,               # model being run
-                    x,                         # model input (or a tuple for multiple inputs)
-                    onnx_path,   # where to save the model (can be a file or file-like object)
-                    export_params=True,        # store the trained parameter weights inside the model file
-                    do_constant_folding=True,  # whether to execute constant folding for optimization
-                    input_names = ['input'],   # the model's input names
-                    output_names = ['output'], # the model's output names
-                    dynamic_axes={'input' : {0 : 'batch_size'},    # variable length axes
-                                    'output' : {0 : 'batch_size'}})
-
+    torch.onnx.export(
+        model.model,  # model being run
+        x,  # model input (or a tuple for multiple inputs)
+        onnx_path,  # where to save the model (can be a file or file-like object)
+        export_params=True,  # store the trained parameter weights inside the model file
+        do_constant_folding=True,  # whether to execute constant folding for optimization
+        input_names=["input"],  # the model's input names
+        output_names=["output"],  # the model's output names
+        dynamic_axes={
+            "input": {0: "batch_size"},  # variable length axes
+            "output": {0: "batch_size"},
+        },
+    )
 
     # load onnx model
     onnx_model = onnx.load(onnx_path)
     onnx.checker.check_model(onnx_model)
 
     # load inference session
-    ort_session = onnxruntime.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+    ort_session = onnxruntime.InferenceSession(
+        onnx_path, providers=["CPUExecutionProvider"]
+    )
 
     def to_numpy(tensor):
-        return tensor.detach().cpu().numpy() if tensor.requires_grad else tensor.cpu().numpy()
+        return (
+            tensor.detach().cpu().numpy()
+            if tensor.requires_grad
+            else tensor.cpu().numpy()
+        )
 
     # compute ONNX Runtime output prediction
     ort_inputs = {ort_session.get_inputs()[0].name: to_numpy(x)}
@@ -104,7 +113,9 @@ def export_model_to_onnx(checkpoint: str, onnx_path: str):
 
     print("Exported model has been tested with ONNXRuntime, and the result looks good!")
 
+
 # export_model_to_onnx("autolamella-mega-latest.pt", "autolamella-mega-20231230.onnx")
+
 
 ## PPLITESEG WINDOWED MODEL
 def load_windowed_onnx_model(model_path: str) -> tuple:
@@ -127,6 +138,7 @@ def load_windowed_onnx_model(model_path: str) -> tuple:
     num_output_classes = session.get_outputs()[0].shape[1]
 
     return session, input_name, window_shape, output_name, num_output_classes
+
 
 def standardize(img: object, sigma: float = 24.0) -> np.ndarray:
     """
@@ -154,12 +166,13 @@ class SegmentationModelWindowONNX:
     ONNX model for windowed inference.
     This code refactor enables multi-threaded inference and Gaussian weighted windows
     Improves model inference, inference time and window edge effects"""
+
     def __init__(self, checkpoint: str = None):
         if checkpoint is not None:
             self.load_model(checkpoint)
         self.device = None
         self.num_workers = min(8, os.cpu_count())
-    
+
     def load_model(self, checkpoint="autolamella-mega.onnx"):
         # download checkpoint if needed
         # checkpoint = download_checkpoint(checkpoint)
@@ -167,8 +180,14 @@ class SegmentationModelWindowONNX:
 
         # load inference session
         session = load_windowed_onnx_model(checkpoint)
-        self.session, self.input_name, self.window_shape, self.output_name, self.num_output_classes = session
-    
+        (
+            self.session,
+            self.input_name,
+            self.window_shape,
+            self.output_name,
+            self.num_output_classes,
+        ) = session
+
     def GaussianWeightMatrix(self, window_shape: tuple[int, int]) -> np.ndarray:
         """
         Generate a Gaussian weight matrix for the sliding window."""
@@ -182,7 +201,7 @@ class SegmentationModelWindowONNX:
         w_matrix = w_matrix[np.newaxis, ...]
         del ksize
         return w_matrix
-    
+
     def pre_process(self, img: np.ndarray) -> np.ndarray:
         """Pre-process the image for inference, calculate window parameters"""
         ##### PREPROCESSING
@@ -208,16 +227,25 @@ class SegmentationModelWindowONNX:
         img = np.pad(img, ((0, 0), (0, pad_h), (0, pad_w)), mode="constant")
         _, pad_h, pad_w = img.shape
 
-        #   window input image 
+        #   window input image
         windows = view_as_windows(
-        img, (3, self.window_shape[0], self.window_shape[1]), step=stride
+            img, (3, self.window_shape[0], self.window_shape[1]), step=stride
         ).reshape(-1, 3, self.window_shape[0], self.window_shape[1])
 
-        logging.debug(f"pre_process: {img.shape}, {windows.shape}, {h}, {w}, {pad_h}, {pad_w}, {stride}")
+        logging.debug(
+            f"pre_process: {img.shape}, {windows.shape}, {h}, {w}, {pad_h}, {pad_w}, {stride}"
+        )
 
         return img, windows, h, w, pad_h, pad_w, stride
-    
-    def window_indices(self,pad_h: int, pad_w: int, window_shape: tuple[int, int], stride: int, windows: np.ndarray) -> None:
+
+    def window_indices(
+        self,
+        pad_h: int,
+        pad_w: int,
+        window_shape: tuple[int, int],
+        stride: int,
+        windows: np.ndarray,
+    ) -> None:
         #   determine the i and j indices for each window
         num_windows_h = ((pad_h - window_shape[0]) / stride) + 1
         num_windows_w = ((pad_w - window_shape[1]) / stride) + 1
@@ -229,7 +257,7 @@ class SegmentationModelWindowONNX:
         return indices
 
     def worker_process(
-    self,session: InferenceSession, window: np.ndarray, index: tuple[int, int]
+        self, session: InferenceSession, window: np.ndarray, index: tuple[int, int]
     ) -> tuple[np.ndarray, tuple[int, int]]:
         """
         Worker process for multi-threaded ONNX inference.
@@ -249,7 +277,7 @@ class SegmentationModelWindowONNX:
         )[0].squeeze()
 
         return logits, index
-    
+
     def inference(self, img: np.ndarray, rgb: bool = True) -> np.ndarray:
         """Perform inference on the provided image.
         Args:
@@ -258,7 +286,7 @@ class SegmentationModelWindowONNX:
         Returns:
             np.ndarray: The segmented image."""
         pass
-        
+
         w_matrix = self.GaussianWeightMatrix(self.window_shape)
 
         img, windows, h, w, pad_h, pad_w, stride = self.pre_process(img)
@@ -267,9 +295,14 @@ class SegmentationModelWindowONNX:
 
         container = np.zeros([1, self.num_output_classes, pad_h, pad_w])
         count = np.zeros([1, 1, pad_h, pad_w])
-        with concurrent.futures.ThreadPoolExecutor(max_workers=self.num_workers) as executor:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.num_workers
+        ) as executor:
             jobs = {
-                executor.submit(self.worker_process, self.session, window, idx): (window, idx)
+                executor.submit(self.worker_process, self.session, window, idx): (
+                    window,
+                    idx,
+                )
                 for (window, idx) in zip(windows, indices)
             }
             for job in concurrent.futures.as_completed(jobs):
@@ -279,9 +312,7 @@ class SegmentationModelWindowONNX:
                     :,
                     idx[0] : idx[0] + logits.shape[1],
                     idx[1] : idx[1] + logits.shape[2],
-                ] += (
-                    logits * w_matrix
-                )
+                ] += logits * w_matrix
                 count[
                     :,
                     :,
@@ -290,7 +321,6 @@ class SegmentationModelWindowONNX:
                 ] = w_matrix
         del w_matrix, executor, jobs, logits, idx
 
-        
         mask = np.argmax(container / count, axis=1).squeeze()  # 2d class map
         del container, count
         # crop image to remove padding
@@ -299,6 +329,7 @@ class SegmentationModelWindowONNX:
         if rgb:
             mask = decode_segmap_v2(mask)
         return mask
+
 
 class SegmentationModelWindowONNX_OLD:
     def __init__(self, checkpoint: str = None):
@@ -313,7 +344,13 @@ class SegmentationModelWindowONNX_OLD:
 
         # load inference session
         session = load_windowed_onnx_model(checkpoint)
-        self.session, self.input_name, self.window_shape, self.output_name, self.num_output_classes = session
+        (
+            self.session,
+            self.input_name,
+            self.window_shape,
+            self.output_name,
+            self.num_output_classes,
+        ) = session
 
     def pre_process(self, img: np.ndarray) -> np.ndarray:
         """Pre-process the image for inference, calculate window parameters"""
@@ -345,7 +382,9 @@ class SegmentationModelWindowONNX_OLD:
             img, (3, self.window_shape[0], self.window_shape[1]), step=stride
         ).squeeze()
 
-        logging.debug(f"pre_process: {img.shape}, {windows.shape}, {h}, {w}, {pad_h}, {pad_w}, {stride}")
+        logging.debug(
+            f"pre_process: {img.shape}, {windows.shape}, {h}, {w}, {pad_h}, {pad_w}, {stride}"
+        )
 
         return img, windows, h, w, pad_h, pad_w, stride
 
@@ -373,8 +412,7 @@ class SegmentationModelWindowONNX_OLD:
 
                 # add batch dimension to window
                 logits = self.session.run(
-                    [self.output_name], 
-                    {self.input_name: window[np.newaxis, ...]}
+                    [self.output_name], {self.input_name: window[np.newaxis, ...]}
                 )[0].squeeze()
                 del window
 
@@ -385,9 +423,9 @@ class SegmentationModelWindowONNX_OLD:
                 count[:, :, h_start:h_end, w_start:w_end] += 1
                 del h_start, w_start, h_end, w_end, logits
 
-        assert (
-            np.min(count) == 1
-        ), "There are pixels not predicted. Check window and stride size."
+        assert np.min(count) == 1, (
+            "There are pixels not predicted. Check window and stride size."
+        )
 
         # post-process
         # average the predictions across windows

--- a/fibsem/segmentation/onnx_model.py
+++ b/fibsem/segmentation/onnx_model.py
@@ -12,7 +12,6 @@ import onnxruntime
 import PIL.Image
 from onnxruntime import InferenceSession
 from skimage.util.shape import view_as_windows
-from tqdm import tqdm
 
 from fibsem.segmentation.utils import decode_segmap_v2, download_checkpoint
 

--- a/fibsem/segmentation/utils.py
+++ b/fibsem/segmentation/utils.py
@@ -1,6 +1,3 @@
-
-
-
 import logging
 import os
 from pathlib import Path
@@ -26,7 +23,6 @@ def decode_output(output):
 
 
 def decode_segmap(image, nc=5):
-
     """
     Decode segmentation class mask into an RGB image mask
     ref: https://learnopencv.com/pytorch-for-beginners-semantic-segmentation-using-torchvision/
@@ -37,10 +33,10 @@ def decode_segmap(image, nc=5):
     label_colors[1, :] = (255, 0, 0)
     label_colors[2, :] = (0, 255, 0)
     label_colors[3, :] = (0, 255, 255)
-    label_colors[4, :] = (255, 255, 0)    
+    label_colors[4, :] = (255, 255, 0)
     label_colors[5, :] = (255, 0, 255)
     label_colors[6, :] = (0, 0, 255)
-    label_colors[7, :] = (128, 0, 0) # TODO: convert this to use CLASS_COLORS
+    label_colors[7, :] = (128, 0, 0)  # TODO: convert this to use CLASS_COLORS
 
     # pre-allocate r, g, b channels as zero
     r = np.zeros_like(image, dtype=np.uint8)
@@ -49,7 +45,7 @@ def decode_segmap(image, nc=5):
 
     # TODO: make this more efficient
     # apply the class label colours to each pixel
-    for class_idx in range(1, nc+1):
+    for class_idx in range(1, nc + 1):
         idx = image == class_idx
         # class_idx = class_idx % len(label_colors)
         r[idx] = label_colors[class_idx, 0]
@@ -59,7 +55,8 @@ def decode_segmap(image, nc=5):
     # stack rgb channels to form an image
     rgb_mask = np.stack([r, g, b], axis=-1).squeeze()
     return rgb_mask
-   
+
+
 def decode_segmap_v2(image, colormap: List[tuple] = None) -> np.ndarray:
     """
     Decode segmentation class mask into an RGB image mask
@@ -68,6 +65,7 @@ def decode_segmap_v2(image, colormap: List[tuple] = None) -> np.ndarray:
 
     if colormap is None:
         from fibsem.segmentation.config import CLASS_COLORS_RGB
+
         colormap = CLASS_COLORS_RGB
 
     # convert class masks to rgb values
@@ -79,6 +77,7 @@ def decode_segmap_v2(image, colormap: List[tuple] = None) -> np.ndarray:
 
     return rgb_mask
 
+
 def show_img_and_mask(imgs, gts, mask, title="Image, Ground Truth and Mask"):
     """Show a plot of the image, ground truth mask, and predicted mask"""
     n_imgs = len(imgs)
@@ -88,7 +87,6 @@ def show_img_and_mask(imgs, gts, mask, title="Image, Ground Truth and Mask"):
     fig.suptitle(title)
 
     for i in range(len(imgs)):
-
         img = imgs[i].permute(1, 2, 0).squeeze()
         gt = decode_segmap(gts[i].permute(1, 2, 0).squeeze())  # convert to rgb mask
 
@@ -109,7 +107,7 @@ def show_memory_usage():
     f = r - a  # free inside reserved
     if r == 0:
         r = 0.00001
-    print("GPU memory", t, r, a, f, f"{f/r:.3}")
+    print("GPU memory", t, r, a, f, f"{f / r:.3}")
 
 
 def show_values(ten):
@@ -118,15 +116,19 @@ def show_values(ten):
     print(ten.shape, ten.min(), ten.max(), ten.mean(), ten.std(), unq)
 
 
-def validate_config(config:dict):
+def validate_config(config: dict):
     if "data_paths" not in config:
-        raise ValueError("data_path is missing. Should point to path containing labelled images.")
+        raise ValueError(
+            "data_path is missing. Should point to path containing labelled images."
+        )
     else:
         for path in config["data_paths"]:
             if not os.path.exists(path):
                 raise ValueError(f"{path} directory does not exist. (data_path)")
     if "label_paths" not in config:
-        raise ValueError("label_path is missing. Should point to path containing labelled images.")
+        raise ValueError(
+            "label_path is missing. Should point to path containing labelled images."
+        )
     else:
         for path in config["label_paths"]:
             if not os.path.exists(path):
@@ -137,67 +139,87 @@ def validate_config(config:dict):
         path = config["save_path"]
         os.makedirs(path, exist_ok=True)
     if "wandb" not in config:
-        raise ValueError("wandb is missing. Used to enable/disable wandb logging in training loop. Should be a boolean value.")
+        raise ValueError(
+            "wandb is missing. Used to enable/disable wandb logging in training loop. Should be a boolean value."
+        )
     else:
         val = config["wandb"]
         if type(val) != bool:
             raise TypeError(f"{val} is not a boolean (True/False). (wandb)")
     if "checkpoint" not in config:
-        raise ValueError("checkpoint is missing. Either a path leading to the desired saved model, or None value.")
+        raise ValueError(
+            "checkpoint is missing. Either a path leading to the desired saved model, or None value."
+        )
     else:
         path = config["checkpoint"]
         if path is not None and not os.path.exists(path):
             raise ValueError(f"{path} directory does not exist. (checkpoint)")
     if "encoder" not in config:
-        raise ValueError("encoder is missing. Used to specify which model architecture to use. Default is resnet18.")
+        raise ValueError(
+            "encoder is missing. Used to specify which model architecture to use. Default is resnet18."
+        )
     else:
         val = config["encoder"]
         if type(val) != str:
             raise TypeError(f"{val} must be a string. (encoder)")
         elif val not in unet_encoders:
-            raise ValueError(f"{val} not a valid encoder. Check readme for full list. (encoder)")
+            raise ValueError(
+                f"{val} not a valid encoder. Check readme for full list. (encoder)"
+            )
     if "epochs" not in config:
-        raise ValueError("epochs is missing. Integer value used to determine number of epochs model trains for.")
+        raise ValueError(
+            "epochs is missing. Integer value used to determine number of epochs model trains for."
+        )
     else:
         val = config["epochs"]
         if type(val) != int or val <= 0:
-            raise TypeError(f"{val} is not a positive integer. (epochs)")  
+            raise TypeError(f"{val} is not a positive integer. (epochs)")
     if "batch_size" not in config:
-        raise ValueError("batch_size is missing. Integer value used to determine batch size of dataset.")
+        raise ValueError(
+            "batch_size is missing. Integer value used to determine batch size of dataset."
+        )
     else:
         val = config["batch_size"]
         if type(val) != int or val <= 0:
-            raise TypeError(f"{val} is not a positive integer. (batch_size)")    
+            raise TypeError(f"{val} is not a positive integer. (batch_size)")
     if "num_classes" not in config:
-        raise ValueError("num_classes is missing. Integer value used to determine number of classes model classifies.")
+        raise ValueError(
+            "num_classes is missing. Integer value used to determine number of classes model classifies."
+        )
     else:
         val = config["num_classes"]
         if type(val) != int or val <= 0:
-            raise TypeError(f"{val} is not a positive integer. (num_classes)")  
+            raise TypeError(f"{val} is not a positive integer. (num_classes)")
     if "lr" not in config:
-        raise ValueError("lr is missing. Float value indicating the learning rate of the model.")
+        raise ValueError(
+            "lr is missing. Float value indicating the learning rate of the model."
+        )
     else:
         val = config["lr"]
         if type(val) == float:
             if val <= 0:
                 raise ValueError(f"{val} must be a positive float value (lr).")
         else:
-            raise TypeError(f"{val} is not a float. (lr)")  
+            raise TypeError(f"{val} is not a float. (lr)")
     if "wandb_project" not in config:
-        raise ValueError("wandb_project is missing. String indicating the wandb project title for login.")
+        raise ValueError(
+            "wandb_project is missing. String indicating the wandb project title for login."
+        )
     else:
         val = config["wandb_project"]
         if type(val) != str:
             raise TypeError(f"{val} is not a string. (wandb_project)")
     if "wandb_entity" not in config:
-        raise ValueError("wandb_entity is missing. String indicating the wandb login credentials.")
+        raise ValueError(
+            "wandb_entity is missing. String indicating the wandb login credentials."
+        )
     else:
         val = config["wandb_entity"]
         if type(val) != str:
             raise TypeError(f"{val} is not a string. (wandb_project)")
     return
-    
-        
+
+
 # All UNet encoders that work with Imagenet weights
 unet_encoders = [
     "resnet18",
@@ -240,14 +262,19 @@ unet_encoders = [
     "efficientnet-b7",
     "mobilenet_v2",
     "efficientnet-b0",
-    "xception"
+    "xception",
 ]
-        
 
-def plot_segmentations(images: List[np.ndarray], masks: List[np.ndarray], 
-    alpha=0.5, legend: bool = True, show: bool = True) -> plt.Figure:
+
+def plot_segmentations(
+    images: List[np.ndarray],
+    masks: List[np.ndarray],
+    alpha=0.5,
+    legend: bool = True,
+    show: bool = True,
+) -> plt.Figure:
     """Plot the image and mask overlaid with a class legend."""
-    
+
     if not isinstance(images, list):
         images = [images]
     if not isinstance(masks, list):
@@ -255,12 +282,11 @@ def plot_segmentations(images: List[np.ndarray], masks: List[np.ndarray],
 
     if len(images) != len(masks):
         raise ValueError("images and masks must be the same length")
-    
-    n_cols = len(images)
-    fig, ax = plt.subplots(1, len(images), figsize=(10*n_cols/2, 10*n_cols/2))
-    for i, (image, mask) in enumerate(zip(images, masks)):
 
-        # convert to rgb mask        
+    n_cols = len(images)
+    fig, ax = plt.subplots(1, len(images), figsize=(10 * n_cols / 2, 10 * n_cols / 2))
+    for i, (image, mask) in enumerate(zip(images, masks)):
+        # convert to rgb mask
         rgb = decode_segmap_v2(mask)
 
         if len(images) == 1:
@@ -268,34 +294,42 @@ def plot_segmentations(images: List[np.ndarray], masks: List[np.ndarray],
         else:
             axes = ax[i]
         # plot
-        axes.imshow(image.data, cmap='gray')
+        axes.imshow(image.data, cmap="gray")
         axes.imshow(rgb, alpha=0.4)
 
         # filter legend to only include classes present in mask
         class_ids = np.unique(mask)
-        
+
         colors, labels = [], []
         for idx in class_ids:
             colors.append(CLASS_COLORS[idx])
             labels.append(CLASS_LABELS[idx])
 
         # Create a patch for each class color
-        patches = [mpatches.Patch(color=color, label=label) 
-                for color, label in zip(colors, labels)]
+        patches = [
+            mpatches.Patch(color=color, label=label)
+            for color, label in zip(colors, labels)
+        ]
 
         # Add the patches to the legend
         if legend:
-            axes.legend(handles=patches, loc="best", prop={'size': 6})
-    
+            axes.legend(handles=patches, loc="best", prop={"size": 6})
+
     if show:
         plt.show()
 
     return fig
 
+
 ## Huggingface Utils
 
+
 def list_available_checkpoints():
-    logging.warning(DeprecationWarning("list_available_checkpoints is deprecated. Please update to v2 to supported cached checkpoints..."))
+    logging.warning(
+        DeprecationWarning(
+            "list_available_checkpoints is deprecated. Please update to v2 to supported cached checkpoints..."
+        )
+    )
     api = HfApi()
     files = api.list_repo_files(cfg.HUGGINFACE_REPO)
     checkpoints = []
@@ -305,6 +339,7 @@ def list_available_checkpoints():
 
     return checkpoints
 
+
 def download_checkpoint(checkpoint: str):
     if os.path.exists(checkpoint):
         checkpoint = checkpoint
@@ -312,36 +347,44 @@ def download_checkpoint(checkpoint: str):
         checkpoint = hf_hub_download(repo_id=cfg.HUGGINFACE_REPO, filename=checkpoint)
     return checkpoint
 
+
 def list_available_checkpoints_v2():
     """List available model checkpoints from either Hugging Face API or local cache if offline."""
-    
+
     # try to use the API if we have internet access
     try:
         api = HfApi()
         files = api.list_repo_files(cfg.HUGGINFACE_REPO)
-        checkpoints = [file for file in files if file.endswith(".pt") and "archive" not in file]
+        checkpoints = [
+            file for file in files if file.endswith(".pt") and "archive" not in file
+        ]
         return checkpoints
     except Exception as e:
         # if api fails, fall back to local cache
         logging.warning(f"Couldn't connect to Hugging Face API: {e}")
         logging.debug("Searching local cache for available checkpoints...")
-        
+
         checkpoints = _get_cached_huggingface_checkpoints()
 
         if not checkpoints:
-            logging.warning("No cached checkpoints found. You might need to download models first when online.")
+            logging.warning(
+                "No cached checkpoints found. You might need to download models first when online."
+            )
 
         return checkpoints
-    
+
+
 def _get_cached_huggingface_checkpoints() -> List[str]:
     """Get cached huggingface model checkpoints"""
     # TODO: de-duplicate checkpoints from the cache
     checkpoints = []
 
-    # get cached repositories    
-    cache_dir = os.environ.get("HF_HUB_CACHE", os.path.expanduser("~/.cache/huggingface/hub"))
+    # get cached repositories
+    cache_dir = os.environ.get(
+        "HF_HUB_CACHE", os.path.expanduser("~/.cache/huggingface/hub")
+    )
     cached_repos = scan_cache_dir(cache_dir)
-    
+
     latest_revision_date = None
     latest_revision_hash = None
 
@@ -354,10 +397,9 @@ def _get_cached_huggingface_checkpoints() -> List[str]:
     if selected_repo is None:
         logging.warning(f"Cannot find repoistory {cfg.HUGGINFACE_REPO} in cache.")
         return checkpoints
-    
+
     # get info about each revision
     for revision in selected_repo.revisions:
-
         # get datetime of last modified
         revision_date = revision.last_modified
         if latest_revision_date is None:
@@ -365,7 +407,9 @@ def _get_cached_huggingface_checkpoints() -> List[str]:
             latest_revision_hash = revision.commit_hash
 
         if revision_date < latest_revision_date:
-            logging.debug(f"Skipping revision {revision.commit_hash} as it is older than the latest revision {latest_revision_hash}.")
+            logging.debug(
+                f"Skipping revision {revision.commit_hash} as it is older than the latest revision {latest_revision_hash}."
+            )
             continue
 
         snapshot_path = Path(revision.snapshot_path)
@@ -374,5 +418,5 @@ def _get_cached_huggingface_checkpoints() -> List[str]:
             if "archive" not in str(file_path):
                 # Get the basename of the file (e.g., "model.pt")
                 checkpoints.append(str(file_path))
-    
+
     return checkpoints

--- a/fibsem/segmentation/utils.py
+++ b/fibsem/segmentation/utils.py
@@ -14,7 +14,7 @@ import torch.nn.functional as F
 from huggingface_hub import HfApi, hf_hub_download, scan_cache_dir
 
 from fibsem import config as cfg
-from fibsem.segmentation.config import CLASS_COLORS, CLASS_COLORS_RGB, CLASS_LABELS
+from fibsem.segmentation.config import CLASS_COLORS, CLASS_LABELS
 
 
 # helper functions

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -32,6 +32,7 @@ from fibsem.fm.structures import (
     ZParameters,
     ZStackOrder,
 )
+from fibsem.imaging.reduce import PREVIEW_MAX_DIMENSION
 from fibsem.structures import FibsemStagePosition, TileOrderStrategy
 
 
@@ -41,6 +42,7 @@ def demo_microscope():
     microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
     return microscope
 
+
 @pytest.fixture
 def fm_microscope(demo_microscope):
     """Fixture providing a demo microscope configured for FM operations."""
@@ -49,6 +51,7 @@ def fm_microscope(demo_microscope):
     microscope.stage_is_compustage = True
     microscope.move_to_microscope("FM")
     return microscope
+
 
 def _lattice(ncols, nrows, fov_x, fov_y, overlap):
     """A grid of (x, y) positions, the shape the `calculate_grid_*` helpers consume.
@@ -93,6 +96,7 @@ def test_calculate_grid_overlap():
 
     assert overlap_x == 0.0
     assert overlap_y == 0.0
+
 
 def test_calculate_grid_dimensions():
     """Test grid dimension calculation from positions."""
@@ -144,6 +148,7 @@ def test_calculate_grid_dimensions():
 
     assert ncols == 4
     assert nrows == 3
+
 
 def test_calculate_grid_coverage_area():
     """Test calculation of total area covered by a grid."""
@@ -206,6 +211,7 @@ def test_calculate_grid_coverage_area():
     assert width == 12.0
     assert height == 11.0
 
+
 # Tests for acquire_at_positions function
 def test_acquire_at_positions_single_position(fm_microscope):
     """Test acquire_at_positions with a single position using demo microscope."""
@@ -214,9 +220,7 @@ def test_acquire_at_positions_single_position(fm_microscope):
     # Create test position
     stage_pos = FibsemStagePosition(x=0.001, y=0.002, z=0.003, r=0, t=np.radians(-180))
     fm_position = FMStagePosition(
-        name="test_pos_1",
-        stage_position=stage_pos,
-        objective_position=0.012
+        name="test_pos_1", stage_position=stage_pos, objective_position=0.012
     )
 
     # Create test channel settings
@@ -225,19 +229,18 @@ def test_acquire_at_positions_single_position(fm_microscope):
         excitation_wavelength=358,
         emission_wavelength=461,
         power=0.1,
-        exposure_time=0.5
+        exposure_time=0.5,
     )
 
     # Call function
     result = acquire_at_positions(
-        microscope=microscope,
-        positions=[fm_position],
-        channel_settings=channel
+        microscope=microscope, positions=[fm_position], channel_settings=channel
     )
 
     # Verify result
     assert len(result) == 1
     assert isinstance(result[0], FluorescenceImage)
+
 
 def test_acquire_at_positions_multiple_positions(fm_microscope):
     """Test acquire_at_positions with multiple positions using demo microscope."""
@@ -247,14 +250,18 @@ def test_acquire_at_positions_multiple_positions(fm_microscope):
     positions = [
         FMStagePosition(
             name="pos_1",
-            stage_position=FibsemStagePosition(x=0.001, y=0.002, z=0.003, r=0, t=np.radians(-180)),
-            objective_position=0.010
+            stage_position=FibsemStagePosition(
+                x=0.001, y=0.002, z=0.003, r=0, t=np.radians(-180)
+            ),
+            objective_position=0.010,
         ),
         FMStagePosition(
-            name="pos_2", 
-            stage_position=FibsemStagePosition(x=0.004, y=0.005, z=0.006, r=0, t=np.radians(-180)),
-            objective_position=0.015
-        )
+            name="pos_2",
+            stage_position=FibsemStagePosition(
+                x=0.004, y=0.005, z=0.006, r=0, t=np.radians(-180)
+            ),
+            objective_position=0.015,
+        ),
     ]
 
     # Create test channel
@@ -263,20 +270,19 @@ def test_acquire_at_positions_multiple_positions(fm_microscope):
         excitation_wavelength=488,
         emission_wavelength=509,
         power=0.2,
-        exposure_time=0.3
+        exposure_time=0.3,
     )
 
     # Call function
     result = acquire_at_positions(
-        microscope=microscope,
-        positions=positions,
-        channel_settings=channel
+        microscope=microscope, positions=positions, channel_settings=channel
     )
 
     # Verify result
     assert len(result) == 2
     for image in result:
         assert isinstance(image, FluorescenceImage)
+
 
 def test_acquire_at_positions_with_z_stack(fm_microscope):
     """Test acquire_at_positions with Z-stack parameters using demo microscope."""
@@ -285,8 +291,10 @@ def test_acquire_at_positions_with_z_stack(fm_microscope):
     # Create test position
     position = FMStagePosition(
         name="z_stack_pos",
-        stage_position=FibsemStagePosition(x=0.001, y=0.002, z=0.003, r=0, t=np.radians(-180)),
-        objective_position=0.012
+        stage_position=FibsemStagePosition(
+            x=0.001, y=0.002, z=0.003, r=0, t=np.radians(-180)
+        ),
+        objective_position=0.012,
     )
 
     # Create test channel
@@ -295,27 +303,24 @@ def test_acquire_at_positions_with_z_stack(fm_microscope):
         excitation_wavelength=358,
         emission_wavelength=461,
         power=0.1,
-        exposure_time=0.5
+        exposure_time=0.5,
     )
 
     # Create Z-stack parameters
-    z_params = ZParameters(
-        zmin=-0.005,
-        zmax=0.005,
-        zstep=0.001
-    )
+    z_params = ZParameters(zmin=-0.005, zmax=0.005, zstep=0.001)
 
     # Call function
     result = acquire_at_positions(
         microscope=microscope,
         positions=[position],
         channel_settings=channel,
-        zparams=z_params
+        zparams=z_params,
     )
 
     # Verify result
     assert len(result) == 1
     assert isinstance(result[0], FluorescenceImage)
+
 
 def test_acquire_at_positions_empty_list(fm_microscope):
     """Test acquire_at_positions with empty positions list raises ValueError."""
@@ -327,16 +332,15 @@ def test_acquire_at_positions_empty_list(fm_microscope):
         excitation_wavelength=358,
         emission_wavelength=461,
         power=0.1,
-        exposure_time=0.5
+        exposure_time=0.5,
     )
 
     # Call function with empty list should raise ValueError
     with pytest.raises(ValueError, match="Positions list cannot be empty"):
         acquire_at_positions(
-            microscope=microscope,
-            positions=[],
-            channel_settings=channel
+            microscope=microscope, positions=[], channel_settings=channel
         )
+
 
 def test_acquire_channels(demo_microscope):
     """Test acquire_channels with multiple channels using demo microscope."""
@@ -349,22 +353,19 @@ def test_acquire_channels(demo_microscope):
             excitation_wavelength=358,
             emission_wavelength=461,
             power=0.1,
-            exposure_time=0.5
+            exposure_time=0.5,
         ),
         ChannelSettings(
             name="GFP",
             excitation_wavelength=488,
             emission_wavelength=509,
             power=0.2,
-            exposure_time=0.3
-        )
+            exposure_time=0.3,
+        ),
     ]
 
     # Call function
-    result = acquire_channels(
-        microscope=microscope.fm,
-        channel_settings=channels
-    )
+    result = acquire_channels(microscope=microscope.fm, channel_settings=channels)
 
     # Verify result
     assert isinstance(result, FluorescenceImage)
@@ -389,6 +390,7 @@ def test_acquire_channels(demo_microscope):
     # Check that acquisition date is set
     assert result.metadata.acquisition_date is not None
 
+
 def test_acquire_z_stack(demo_microscope):
     """Test acquire_z_stack with Z-stack parameters using demo microscope."""
     microscope = demo_microscope
@@ -399,21 +401,15 @@ def test_acquire_z_stack(demo_microscope):
         excitation_wavelength=358,
         emission_wavelength=461,
         power=0.1,
-        exposure_time=0.1
+        exposure_time=0.1,
     )
 
     # Create Z-stack parameters
-    z_params = ZParameters(
-        zmin=-0.005,
-        zmax=0.005,
-        zstep=0.001
-    )
+    z_params = ZParameters(zmin=-0.005, zmax=0.005, zstep=0.001)
 
     # Call function
     result = acquire_z_stack(
-        microscope=microscope.fm,
-        channel_settings=channel,
-        zparams=z_params
+        microscope=microscope.fm, channel_settings=channel, zparams=z_params
     )
 
     # Verify result
@@ -434,7 +430,9 @@ def test_acquire_z_stack(demo_microscope):
     assert len(result.metadata.z_positions) == expected_nz
 
     # Check image data has correct Z dimension
-    assert result.data.shape[1] == expected_nz  # Z dimension should match expected slices (CZYX format)
+    assert (
+        result.data.shape[1] == expected_nz
+    )  # Z dimension should match expected slices (CZYX format)
 
     # Check that acquisition date is set
     assert result.metadata.acquisition_date is not None
@@ -448,12 +446,27 @@ def test_acquire_z_stack(demo_microscope):
 # volume is required to come out identical either way.
 
 Z_ORDER_CHANNELS = [
-    ChannelSettings(name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-                    power=0.1, exposure_time=0.01),
-    ChannelSettings(name="GFP", excitation_wavelength=488, emission_wavelength=509,
-                    power=0.2, exposure_time=0.01),
-    ChannelSettings(name="RFP", excitation_wavelength=555, emission_wavelength=580,
-                    power=0.3, exposure_time=0.01),
+    ChannelSettings(
+        name="DAPI",
+        excitation_wavelength=358,
+        emission_wavelength=461,
+        power=0.1,
+        exposure_time=0.01,
+    ),
+    ChannelSettings(
+        name="GFP",
+        excitation_wavelength=488,
+        emission_wavelength=509,
+        power=0.2,
+        exposure_time=0.01,
+    ),
+    ChannelSettings(
+        name="RFP",
+        excitation_wavelength=555,
+        emission_wavelength=580,
+        power=0.3,
+        exposure_time=0.01,
+    ),
 ]
 # 3 planes, the smallest stack that can be mis-transposed without it being a no-op.
 Z_ORDER_PARAMS = dict(zmin=-1e-6, zmax=1e-6, zstep=1e-6)
@@ -508,7 +521,9 @@ def test_z_level_order_acquires_every_channel_before_moving_the_objective(
     # The three frames of each plane share one objective position, and the plane
     # advances only between groups.
     positions = [round(pos, 12) for _, pos in sequence]
-    per_plane = [positions[i:i + N_CHANNELS] for i in range(0, len(positions), N_CHANNELS)]
+    per_plane = [
+        positions[i : i + N_CHANNELS] for i in range(0, len(positions), N_CHANNELS)
+    ]
     assert all(len(set(group)) == 1 for group in per_plane)
     assert [group[0] for group in per_plane] == sorted(set(positions))
 
@@ -597,9 +612,11 @@ def test_acquisition_order_does_not_change_the_assembled_stack(fm_microscope):
     by_channel, by_z_level = results[ZStackOrder.CHANNEL], results[ZStackOrder.Z_LEVEL]
 
     assert by_z_level.data.shape == by_channel.data.shape
-    assert [ch.name for ch in by_z_level.metadata.channels] == [
-        ch.name for ch in by_channel.metadata.channels
-    ] == ["DAPI", "GFP", "RFP"]
+    assert (
+        [ch.name for ch in by_z_level.metadata.channels]
+        == [ch.name for ch in by_channel.metadata.channels]
+        == ["DAPI", "GFP", "RFP"]
+    )
     assert by_z_level.metadata.z_positions == by_channel.metadata.z_positions
     assert len(by_z_level.metadata.z_positions) == N_PLANES
 
@@ -959,12 +976,18 @@ def _run_tileset(microscope, rows, cols, overlap=0.1):
     acquisition.acquire_tileset(
         microscope=microscope,
         channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
+            name="DAPI",
+            excitation_wavelength=358,
+            emission_wavelength=461,
+            power=0.1,
+            exposure_time=0.1,
         ),
         overview_parameters=OverviewParameters(
-            rows=rows, cols=cols, overlap=overlap,
-            use_zstack=False, autofocus_mode=AutoFocusMode.NONE,
+            rows=rows,
+            cols=cols,
+            overlap=overlap,
+            use_zstack=False,
+            autofocus_mode=AutoFocusMode.NONE,
         ),
     )
 
@@ -979,11 +1002,13 @@ def _by_tile(positions, rows, cols):
         f"expected one move per tile plus the restore, got {len(positions)} "
         f"for a {rows}x{cols} grid"
     )
-    return {(k // cols, k % cols): p for k, p in enumerate(positions[:rows * cols])}
+    return {(k // cols, k % cols): p for k, p in enumerate(positions[: rows * cols])}
 
 
 @pytest.mark.parametrize("rows,cols", [(2, 2), (3, 2), (1, 4), (4, 1)])
-def test_acquire_tileset_visits_rows_top_to_bottom(fm_microscope, monkeypatch, rows, cols):
+def test_acquire_tileset_visits_rows_top_to_bottom(
+    fm_microscope, monkeypatch, rows, cols
+):
     """Row 0 is the top of the mosaic, so it sits at the highest stage y."""
     microscope = fm_microscope
     positions = _record_tile_positions(microscope, monkeypatch)
@@ -1021,7 +1046,9 @@ def test_acquire_tileset_uses_absolute_positions_not_accumulated_steps(
     )
 
 
-def test_acquire_tileset_row_direction_matches_the_beam_tiler(fm_microscope, monkeypatch):
+def test_acquire_tileset_row_direction_matches_the_beam_tiler(
+    fm_microscope, monkeypatch
+):
     """The FM tiler and the beam tiler must agree on the direction of each axis.
 
     Pins the two against each other rather than against a hard-coded sign, so the
@@ -1039,7 +1066,9 @@ def test_acquire_tileset_row_direction_matches_the_beam_tiler(fm_microscope, mon
     beam_tiles = compute_tile_grid(
         OverviewAcquisitionSettings(
             image_settings=ImageSettings(hfw=100e-6, resolution=[1024, 1024]),
-            nrows=rows, ncols=cols, overlap=0.1,
+            nrows=rows,
+            ncols=cols,
+            overlap=0.1,
         )
     )
 
@@ -1090,12 +1119,18 @@ def _runner(microscope, rows, cols, stop_event=None, overlap=0.1):
     return acquisition.FMTiledAcquisitionRunner(
         microscope=microscope,
         channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
+            name="DAPI",
+            excitation_wavelength=358,
+            emission_wavelength=461,
+            power=0.1,
+            exposure_time=0.1,
         ),
         overview_parameters=OverviewParameters(
-            rows=rows, cols=cols, overlap=overlap,
-            use_zstack=False, autofocus_mode=AutoFocusMode.NONE,
+            rows=rows,
+            cols=cols,
+            overlap=overlap,
+            use_zstack=False,
+            autofocus_mode=AutoFocusMode.NONE,
         ),
         stop_event=stop_event,
     )
@@ -1200,12 +1235,18 @@ def test_stitching_reports_a_cancel_as_none_not_an_error(fm_microscope, monkeypa
     result = acquire_and_stitch_tileset(
         microscope=microscope,
         channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
+            name="DAPI",
+            excitation_wavelength=358,
+            emission_wavelength=461,
+            power=0.1,
+            exposure_time=0.1,
         ),
         overview_parameters=OverviewParameters(
-            rows=2, cols=2, overlap=0.1,
-            use_zstack=False, autofocus_mode=AutoFocusMode.NONE,
+            rows=2,
+            cols=2,
+            overlap=0.1,
+            use_zstack=False,
+            autofocus_mode=AutoFocusMode.NONE,
         ),
     )
 
@@ -1242,7 +1283,10 @@ def _sparse_runner(microscope, rows, cols, mask=None, order=None, stop_event=Non
         microscope=microscope,
         channel_settings=ChannelSettings(name="DAPI", exposure_time=0.1),
         overview_parameters=OverviewParameters(
-            rows=rows, cols=cols, overlap=0.1, use_zstack=False,
+            rows=rows,
+            cols=cols,
+            overlap=0.1,
+            use_zstack=False,
             autofocus_mode=AutoFocusMode.NONE,
             tile_order=order or TileOrderStrategy.TYPEWRITER,
             tile_mask=mask,
@@ -1268,7 +1312,9 @@ def test_a_masked_run_visits_only_the_enabled_tiles(fm_microscope, monkeypatch):
     assert len(positions) == 9 + 1
 
 
-def test_skipped_tiles_stay_none_and_the_grid_keeps_its_shape(fm_microscope, monkeypatch):
+def test_skipped_tiles_stay_none_and_the_grid_keeps_its_shape(
+    fm_microscope, monkeypatch
+):
     _record_tile_positions(fm_microscope, monkeypatch)
     mask = _plus_mask(5)
 
@@ -1281,20 +1327,20 @@ def test_skipped_tiles_stay_none_and_the_grid_keeps_its_shape(fm_microscope, mon
             assert (tileset[r][c] is not None) is mask[r][c], f"tile ({r}, {c})"
 
 
-def test_masking_changes_which_tiles_are_acquired_never_where(fm_microscope, monkeypatch):
+def test_masking_changes_which_tiles_are_acquired_never_where(
+    fm_microscope, monkeypatch
+):
     """The headline property, at runner level."""
     dense = _record_tile_positions(fm_microscope, monkeypatch)
     _sparse_runner(fm_microscope, 5, 5).run()
-    dense_by_tile = {
-        (k // 5, k % 5): p for k, p in enumerate(list(dense)[:25])
-    }
+    dense_by_tile = {(k // 5, k % 5): p for k, p in enumerate(list(dense)[:25])}
 
     sparse = _record_tile_positions(fm_microscope, monkeypatch)
     mask = _plus_mask(5)
     _sparse_runner(fm_microscope, 5, 5, mask=mask).run()
 
     enabled = [(r, c) for r in range(5) for c in range(5) if mask[r][c]]
-    for (row, col), position in zip(enabled, list(sparse)[:len(enabled)]):
+    for (row, col), position in zip(enabled, list(sparse)[: len(enabled)]):
         expected = dense_by_tile[(row, col)]
         assert position.x == pytest.approx(expected.x), f"tile ({row}, {col}) x"
         assert position.y == pytest.approx(expected.y), f"tile ({row}, {col}) y"
@@ -1338,20 +1384,28 @@ def test_tile_order_drives_the_visit_sequence(fm_microscope, monkeypatch):
     _sparse_runner(fm_microscope, 3, 3, order=TileOrderStrategy.SERPENTINE).run()
 
     # Row 1 runs right-to-left under serpentine, so tiles 3..5 are reversed.
-    assert [p.x for p in list(serpentine)[3:6]] == [p.x for p in list(typewriter)[3:6]][::-1]
+    assert [p.x for p in list(serpentine)[3:6]] == [p.x for p in list(typewriter)[3:6]][
+        ::-1
+    ]
     # Same set of positions either way -- only the order differs.
-    assert sorted(round(p.x, 12) for p in list(typewriter)[:9]) == \
-           sorted(round(p.x, 12) for p in list(serpentine)[:9])
+    assert sorted(round(p.x, 12) for p in list(typewriter)[:9]) == sorted(
+        round(p.x, 12) for p in list(serpentine)[:9]
+    )
 
 
-def test_each_row_autofocus_is_promoted_to_each_tile_for_a_spiral(fm_microscope, monkeypatch):
+def test_each_row_autofocus_is_promoted_to_each_tile_for_a_spiral(
+    fm_microscope, monkeypatch
+):
     """A spiral revisits rows non-sequentially, so "on each new row" is meaningless."""
     _record_tile_positions(fm_microscope, monkeypatch)
     runner = acquisition.FMTiledAcquisitionRunner(
         microscope=fm_microscope,
         channel_settings=ChannelSettings(name="DAPI", exposure_time=0.1),
         overview_parameters=OverviewParameters(
-            rows=3, cols=3, overlap=0.1, use_zstack=False,
+            rows=3,
+            cols=3,
+            overlap=0.1,
+            use_zstack=False,
             autofocus_mode=AutoFocusMode.EACH_ROW,
             tile_order=TileOrderStrategy.SPIRAL,
         ),
@@ -1371,7 +1425,10 @@ def test_each_row_autofocus_survives_a_row_wise_order(fm_microscope, monkeypatch
         microscope=fm_microscope,
         channel_settings=ChannelSettings(name="DAPI", exposure_time=0.1),
         overview_parameters=OverviewParameters(
-            rows=3, cols=3, overlap=0.1, use_zstack=False,
+            rows=3,
+            cols=3,
+            overlap=0.1,
+            use_zstack=False,
             autofocus_mode=AutoFocusMode.EACH_ROW,
             tile_order=TileOrderStrategy.SERPENTINE,
         ),
@@ -1393,13 +1450,18 @@ def test_stitching_leaves_skipped_tiles_as_zeros_at_full_canvas_size(fm_microsco
     sparse = acquire_and_stitch_tileset(
         microscope=fm_microscope,
         channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
-        overview_parameters=OverviewParameters(rows=3, cols=3, overlap=0.1, tile_mask=mask),
+        overview_parameters=OverviewParameters(
+            rows=3, cols=3, overlap=0.1, tile_mask=mask
+        ),
     )
 
     assert sparse.data.shape == dense.data.shape
     # The corners are skipped, so the canvas there was never written.
-    tile_h, tile_w = fm_microscope.fm.camera.resolution[1], fm_microscope.fm.camera.resolution[0]
-    assert not sparse.data[0, 0, :tile_h // 2, :tile_w // 2].any(), "top-left corner"
+    tile_h, tile_w = (
+        fm_microscope.fm.camera.resolution[1],
+        fm_microscope.fm.camera.resolution[0],
+    )
+    assert not sparse.data[0, 0, : tile_h // 2, : tile_w // 2].any(), "top-left corner"
     assert sparse.data[0, 0].any(), "the enabled tiles were written"
 
 
@@ -1435,14 +1497,19 @@ def test_the_mosaic_centre_is_the_run_centre_whatever_was_acquired(
     centred on the starting stage position, so that position is the answer, exactly,
     and independently of the mask.
     """
-    mask = (None if predicate is None
-            else [[predicate(i, j) for j in range(3)] for i in range(3)])
+    mask = (
+        None
+        if predicate is None
+        else [[predicate(i, j) for j in range(3)] for i in range(3)]
+    )
     centre = fm_microscope.get_stage_position()
 
     mosaic = acquire_and_stitch_tileset(
         microscope=fm_microscope,
         channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
-        overview_parameters=OverviewParameters(rows=3, cols=3, overlap=0.1, tile_mask=mask),
+        overview_parameters=OverviewParameters(
+            rows=3, cols=3, overlap=0.1, tile_mask=mask
+        ),
     )
 
     assert mosaic.metadata.stage_position.x == pytest.approx(centre.x, abs=1e-12)
@@ -1461,13 +1528,17 @@ def test_the_mosaic_records_the_objective_the_run_used(fm_microscope):
         overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
     )
 
-    assert all(ch.objective_position == pytest.approx(objective)
-               for ch in mosaic.metadata.channels)
+    assert all(
+        ch.objective_position == pytest.approx(objective)
+        for ch in mosaic.metadata.channels
+    )
 
 
 def test_the_mosaic_carries_the_same_metadata_as_a_single_image(fm_microscope):
     """Only the resolution differs. It is a large image, not a different kind of thing."""
-    channel = ChannelSettings(name="DAPI", excitation_wavelength=358, exposure_time=0.001)
+    channel = ChannelSettings(
+        name="DAPI", excitation_wavelength=358, exposure_time=0.001
+    )
     single = acquire_image(fm_microscope.fm, channel)
 
     mosaic = acquire_and_stitch_tileset(
@@ -1476,8 +1547,9 @@ def test_the_mosaic_carries_the_same_metadata_as_a_single_image(fm_microscope):
         overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
     )
 
-    assert [ch.name for ch in mosaic.metadata.channels] == \
-           [ch.name for ch in single.metadata.channels]
+    assert [ch.name for ch in mosaic.metadata.channels] == [
+        ch.name for ch in single.metadata.channels
+    ]
     assert mosaic.metadata.pixel_size_x == single.metadata.pixel_size_x
     assert mosaic.metadata.pixel_size_y == single.metadata.pixel_size_y
     assert mosaic.metadata.resolution[0] > single.metadata.resolution[0]
@@ -1558,7 +1630,7 @@ def test_the_preview_is_decimated(fm_microscope):
     frames = _preview_frames(fm_microscope, 5, 5)
 
     image = frames[-1]["image"]
-    assert max(image.shape[-2:]) <= acquisition.PREVIEW_MAX_DIMENSION
+    assert max(image.shape[-2:]) <= PREVIEW_MAX_DIMENSION
     assert frames[-1]["preview_stride"] > 1
 
 
@@ -1571,7 +1643,7 @@ def test_the_preview_leaves_skipped_tiles_blank(fm_microscope):
     image = frames[-1]["image"][0]
     h, w = image.shape
     assert not image[: h // 4, : w // 4].any(), "top-left corner was never acquired"
-    assert image[h // 3: 2 * h // 3, w // 3: 2 * w // 3].any(), "the centre tile was"
+    assert image[h // 3 : 2 * h // 3, w // 3 : 2 * w // 3].any(), "the centre tile was"
 
 
 def test_the_preview_has_one_plane_per_channel(fm_microscope):
@@ -1583,10 +1655,10 @@ def test_the_preview_has_one_plane_per_channel(fm_microscope):
 @pytest.mark.parametrize(
     ("shape", "n_channels", "expected"),
     [
-        ((8, 8), 1, (1, 8, 8)),            # plain 2D
-        ((3, 8, 8), 1, (1, 8, 8)),         # single channel z-stack -> projected
-        ((3, 8, 8), 3, (3, 8, 8)),         # three channels, no z -> kept
-        ((2, 4, 8, 8), 2, (2, 8, 8)),      # channels + z -> projected
+        ((8, 8), 1, (1, 8, 8)),  # plain 2D
+        ((3, 8, 8), 1, (1, 8, 8)),  # single channel z-stack -> projected
+        ((3, 8, 8), 3, (3, 8, 8)),  # three channels, no z -> kept
+        ((2, 4, 8, 8), 2, (2, 8, 8)),  # channels + z -> projected
     ],
     ids=["2d", "single-channel-zstack", "multi-channel", "channels-and-z"],
 )
@@ -1603,10 +1675,12 @@ def test_tile_data_is_normalised_to_channel_planes(shape, n_channels, expected):
 def _sweep_settings():
     from fibsem.autofunctions.autofocus import FocusSweepPass
 
-    return AutoFocusSettings(passes=[
-        FocusSweepPass(search_range=20e-6, step_size=5e-6),   # coarse: 5 positions
-        FocusSweepPass(search_range=6e-6, step_size=1e-6),    # fine:   7 positions
-    ])
+    return AutoFocusSettings(
+        passes=[
+            FocusSweepPass(search_range=20e-6, step_size=5e-6),  # coarse: 5 positions
+            FocusSweepPass(search_range=6e-6, step_size=1e-6),  # fine:   7 positions
+        ]
+    )
 
 
 def _autofocus_payloads(microscope, monkeypatch, mode):
@@ -1618,8 +1692,9 @@ def _autofocus_payloads(microscope, monkeypatch, mode):
     acquisition.FMTiledAcquisitionRunner(
         microscope=microscope,
         channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
-        overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1,
-                                               autofocus_mode=mode),
+        overview_parameters=OverviewParameters(
+            rows=2, cols=2, overlap=0.1, autofocus_mode=mode
+        ),
         autofocus_settings=_sweep_settings(),
     ).run()
     return seen
@@ -1633,8 +1708,9 @@ def test_focusing_once_runs_every_enabled_pass(fm_microscope, monkeypatch):
     """
     seen = _autofocus_payloads(fm_microscope, monkeypatch, AutoFocusMode.ONCE)
 
-    passes = sorted({(d["pass_index"], d["total_passes"], d["total_zlevels"])
-                     for d in seen})
+    passes = sorted(
+        {(d["pass_index"], d["total_passes"], d["total_zlevels"]) for d in seen}
+    )
     assert passes == [(1, 2, 5), (2, 2, 7)]
 
 
@@ -1643,8 +1719,8 @@ def test_per_tile_focusing_runs_only_the_narrowest_pass(fm_microscope, monkeypat
     seen = _autofocus_payloads(fm_microscope, monkeypatch, AutoFocusMode.EACH_TILE)
 
     assert sorted({(d["pass_index"], d["total_passes"]) for d in seen}) == [(1, 1)]
-    assert {d["total_zlevels"] for d in seen} == {7}          # the fine pass
-    assert len([d for d in seen if d["zlevel"] == 1]) == 4    # once per tile
+    assert {d["total_zlevels"] for d in seen} == {7}  # the fine pass
+    assert len([d for d in seen if d["zlevel"] == 1]) == 4  # once per tile
 
 
 def test_the_sweep_reports_progress_per_position(fm_microscope, monkeypatch):
@@ -1676,8 +1752,9 @@ def test_a_cancelled_sweep_does_not_start_the_next_pass(fm_microscope, monkeypat
         acquisition.FMTiledAcquisitionRunner(
             microscope=fm_microscope,
             channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
-            overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1,
-                                                   autofocus_mode=AutoFocusMode.ONCE),
+            overview_parameters=OverviewParameters(
+                rows=2, cols=2, overlap=0.1, autofocus_mode=AutoFocusMode.ONCE
+            ),
             autofocus_settings=_sweep_settings(),
             stop_event=stop_event,
         ).run()
@@ -1835,7 +1912,9 @@ def test_a_saved_mosaic_is_stamped_with_the_run_it_came_from(fm_microscope, tmp_
     assert FluorescenceImage.load(path).metadata.description == destination.basename
 
 
-def test_a_cancelled_run_still_records_what_it_was_trying_to_do(fm_microscope, tmp_path):
+def test_a_cancelled_run_still_records_what_it_was_trying_to_do(
+    fm_microscope, tmp_path
+):
     """The parameters describe what was *requested*, so they are known before the first
     tile. Written at the end instead, a cancelled run left its tiles on disk with
     nothing saying what grid they belonged to."""
@@ -1859,8 +1938,12 @@ def test_two_runs_in_the_same_second_do_not_collide(tmp_path):
     """The timestamp only resolves to the second, and a single-tile overview at a short
     exposure takes far less. Sharing the name would let the second run overwrite the
     first tile for tile, silently."""
-    first = acquisition.OverviewDestination.create(str(tmp_path), basename="overview-12-00-00")
-    second = acquisition.OverviewDestination.create(str(tmp_path), basename="overview-12-00-00")
+    first = acquisition.OverviewDestination.create(
+        str(tmp_path), basename="overview-12-00-00"
+    )
+    second = acquisition.OverviewDestination.create(
+        str(tmp_path), basename="overview-12-00-00"
+    )
 
     assert first.tiles_directory != second.tiles_directory
     assert first.mosaic_path != second.mosaic_path
@@ -1953,8 +2036,10 @@ def test_masking_off_the_unreachable_tiles_makes_a_grid_acquirable(fm_microscope
     _narrow_limits(fm_microscope, 10e-6)
 
     parameters = OverviewParameters(
-        rows=1, cols=3, overlap=0.1,
-        tile_mask=[[False, True, False]],   # keep only the reachable centre tile
+        rows=1,
+        cols=3,
+        overlap=0.1,
+        tile_mask=[[False, True, False]],  # keep only the reachable centre tile
     )
     runner = FMTiledAcquisitionRunner(
         microscope=fm_microscope,
@@ -2019,15 +2104,22 @@ def _acquired_at(monkeypatch, microscope, mode, rows=1, cols=2, order=None):
     monkeypatch.setattr(acquisition, "acquire_image", spy)
 
     parameters = OverviewParameters(
-        rows=rows, cols=cols, overlap=0.1, use_zstack=False, autofocus_mode=mode,
+        rows=rows,
+        cols=cols,
+        overlap=0.1,
+        use_zstack=False,
+        autofocus_mode=mode,
     )
     if order is not None:
         parameters.tile_order = order
     runner = acquisition.FMTiledAcquisitionRunner(
         microscope=microscope,
         channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
+            name="DAPI",
+            excitation_wavelength=358,
+            emission_wavelength=461,
+            power=0.1,
+            exposure_time=0.1,
         ),
         overview_parameters=parameters,
         autofocus_settings=AutoFocusSettings(),
@@ -2125,19 +2217,28 @@ def _start_from(monkeypatch, microscope, start, focus=SAVED_FOCUS):
     runner = acquisition.FMTiledAcquisitionRunner(
         microscope=microscope,
         channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
+            name="DAPI",
+            excitation_wavelength=358,
+            emission_wavelength=461,
+            power=0.1,
+            exposure_time=0.1,
         ),
         overview_parameters=OverviewParameters(
-            rows=1, cols=2, overlap=0.1, use_zstack=False,
-            autofocus_mode=AutoFocusMode.NONE, objective_start=start,
+            rows=1,
+            cols=2,
+            overlap=0.1,
+            use_zstack=False,
+            autofocus_mode=AutoFocusMode.NONE,
+            objective_start=start,
         ),
     )
     runner.run()
     return positions, runner
 
 
-def test_by_default_an_overview_starts_where_the_objective_is(fm_microscope, monkeypatch):
+def test_by_default_an_overview_starts_where_the_objective_is(
+    fm_microscope, monkeypatch
+):
     """Unchanged behaviour, and still the default: an overview is usually taken of
     whatever you have just been looking at."""
     started_at = fm_microscope.fm.objective.position
@@ -2157,7 +2258,9 @@ def test_it_can_start_from_the_saved_focus_position(fm_microscope, monkeypatch):
     assert positions == [pytest.approx(SAVED_FOCUS)] * 2
 
 
-def test_the_objective_still_goes_back_where_the_user_left_it(fm_microscope, monkeypatch):
+def test_the_objective_still_goes_back_where_the_user_left_it(
+    fm_microscope, monkeypatch
+):
     """Choosing where to start is not moving house."""
     started_at = fm_microscope.fm.objective.position
 
@@ -2173,19 +2276,30 @@ def test_the_objective_is_moved_before_a_sweep_would_search(fm_microscope, monke
     swept_at = []
     fm_microscope.fm.objective.focus_position = SAVED_FOCUS
     monkeypatch.setattr(
-        acquisition, "run_tileset_autofocus",
-        lambda microscope, *a, **k: swept_at.append(microscope.fm.objective.position) or True,
+        acquisition,
+        "run_tileset_autofocus",
+        lambda microscope, *a, **k: (
+            swept_at.append(microscope.fm.objective.position) or True
+        ),
     )
-    monkeypatch.setattr(acquisition, "acquire_image", lambda *a, **k: acquisition.acquire_image)
+    monkeypatch.setattr(
+        acquisition, "acquire_image", lambda *a, **k: acquisition.acquire_image
+    )
 
     runner = acquisition.FMTiledAcquisitionRunner(
         microscope=fm_microscope,
         channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
+            name="DAPI",
+            excitation_wavelength=358,
+            emission_wavelength=461,
+            power=0.1,
+            exposure_time=0.1,
         ),
         overview_parameters=OverviewParameters(
-            rows=1, cols=1, overlap=0.1, use_zstack=False,
+            rows=1,
+            cols=1,
+            overlap=0.1,
+            use_zstack=False,
             autofocus_mode=AutoFocusMode.ONCE,
             objective_start=ObjectiveStartPosition.FOCUS,
         ),
@@ -2210,7 +2324,9 @@ def test_asking_for_a_focus_position_that_was_never_saved_is_refused(
         )
 
 
-def test_an_overview_will_not_run_with_the_objective_retracted(fm_microscope, monkeypatch):
+def test_an_overview_will_not_run_with_the_objective_retracted(
+    fm_microscope, monkeypatch
+):
     """Nothing an overview does works without it -- the tiles would be whatever a
     retracted objective sees, and a sweep would search for a focus that cannot exist."""
     fm_microscope.fm.objective.retract()
@@ -2346,7 +2462,8 @@ def test_the_announcement_carries_no_progress(fm_microscope):
     ).run()
 
     announcements = [
-        p for p in emitted
+        p
+        for p in emitted
         if p.get("state") == "acquiring" and p.get("task") == "tileset" and "row" in p
     ]
     assert announcements, "nothing announces the tile being acquired"


### PR DESCRIPTION
First slice of the `F401` burn-down. 50 unused imports removed across 20 files. **F401 goes 389 → 339** repo-wide; in these five areas, 82 → 32, and all 32 that remain are in `__init__.py`, where the imports *are* the re-export idiom and ruff correctly refuses to touch them.

## `ruff --fix` alone is not safe here, and here is the proof

Ruff answers "is this name used inside this file". That is a different question from "is it safe to delete". Every flagged name was checked against the whole repo, three ways, **before** touching anything:

| reachable how | findings at risk |
|---|---|
| `from M import X` elsewhere | **15** |
| `import M` then `M.X` | 0 |
| `from M import *` | 2 (nobody actually imports them) |

Fourteen of the fifteen are in `__init__.py`, which ruff leaves alone. **One is not:** `fibsem/microscopes/tescan.py` re-exports `tescanautomation`, [scripts/test_installation.py:60](https://github.com/fibsem-os/fibsem-os/blob/main/scripts/test_installation.py#L60) imports it, and **ruff rates that removal `safe`**. So `ruff check --fix` on `main` today silently breaks that script. None of the fifteen is in this slice; the tescan one is flagged for whichever slice reaches `fibsem/microscopes`.

Then the same check ran **after** the edit, against what was actually removed: zero of the 50 are imported anywhere else.

## The check still had a hole, and the suite found it

`tests/fm/test_acquisition.py` asserted against `acquisition.PREVIEW_MAX_DIMENSION` — a constant that lives in `fibsem.imaging.reduce` and was reachable there only because `acquisition.py` imported it and never used it. Removing the import broke the test.

That is a **fourth** path, and the one my pre-checks missed: `from fibsem.fm import acquisition` binds a *module* via `ImportFrom`, so it never appears in an `import M` alias map, and `acquisition.PREVIEW_MAX_DIMENSION` reaches straight through it.

Detector fixed and re-run over the remaining 339: one other instance, `fibsem.milling.setup_milling` used by `example/example_milling.py`, in an `__init__.py` ruff will not auto-fix anyway.

Fixed by pointing the test at the constant's real home, rather than restoring an accidental re-export.

## Why these five areas

Reformatting a file is mandatory once it is touched, and the cost per finding spans two orders of magnitude:

| area | findings | format lines | lines per finding |
|---|---|---|---|
| `fibsem/imaging` | 18 | 165 | **9** |
| `fibsem/milling` | 18 | 345 | 19 |
| `fibsem/fm` | 27 | 405 | 15 |
| `fibsem/segmentation` | 15 | 474 | 32 |
| `fibsem/alignment` | 4 | 48 | 12 |
| — for contrast — | | | |
| `fibsem/structures.py` | 3 | 1,045 | **348** |
| `fibsem/microscope.py` | 11 | 1,364 | 124 |

Doing all 146 files at once would be an 18,406-line diff. This is the cheap end.

## Commits

- `a638b2c2` — the 50 removals, nothing else
- `8dd1af5f` — the mandatory reformat, plus the one-line test repoint, called out in the message rather than buried

## Verification

`ruff check .` clean, all touched files formatted, full suite **5,752 passed, 24 skipped**.
