### PR TITLE
[refactor] Remove unused imports from alignment and milling

### DIFF
--- a/fibsem/alignment/plotting.py
+++ b/fibsem/alignment/plotting.py
@@ -11,7 +11,6 @@ from fibsem.structures import ImageSettings
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
-    from matplotlib.figure import Figure
 
     from fibsem.alignment import AlignmentDifferential, AlignmentIteration
     from fibsem.structures import FibsemImage
@@ -29,7 +28,6 @@ def _plot_image_with_crosshair(ax: Axes, data: np.ndarray, title: str) -> None:
 
 def _alignment_save_path(ref_image: FibsemImage) -> tuple:
     """Return (ref_path, prefix, ts) for saving alignment plots."""
-    from datetime import datetime
 
     from fibsem.alignment import ALIGNMENT_SUBDIR
 
@@ -100,15 +98,23 @@ def plot_multi_step_alignment(
         dy_px = r.shift.y / pixel_size
         colour = "lime" if r.score >= 0.7 else ("orange" if r.score >= 0.5 else "red")
         axes[0, 1 + i].text(
-            0.04, 0.04,
+            0.04,
+            0.04,
             f"dx={dx_px:.1f}px  dy={dy_px:.1f}px",
             transform=axes[0, 1 + i].transAxes,
-            color=colour, fontsize=7, va="bottom", fontfamily="monospace",
-            bbox=dict(boxstyle="round,pad=0.2", facecolor="black", alpha=0.6, edgecolor="none"),
+            color=colour,
+            fontsize=7,
+            va="bottom",
+            fontfamily="monospace",
+            bbox=dict(
+                boxstyle="round,pad=0.2", facecolor="black", alpha=0.6, edgecolor="none"
+            ),
         )
         cx, cy = r.image.data.shape[1] // 2, r.image.data.shape[0] // 2
         axes[0, 1 + i].annotate(
-            "", xy=(cx + dx_px, cy + dy_px), xytext=(cx, cy),
+            "",
+            xy=(cx + dx_px, cy + dy_px),
+            xytext=(cx, cy),
             arrowprops=dict(arrowstyle="->", color=colour, lw=2),
         )
 
@@ -157,12 +163,24 @@ def plot_multi_step_alignment(
             lines = []
             for method_name, shift_pt in validation.shifts_px.items():
                 mag = np.hypot(shift_pt.x, shift_pt.y)
-                lines.append(f"{method_name}: dx={shift_pt.x:.1f}  dy={shift_pt.y:.1f}  |{mag:.1f}|px")
+                lines.append(
+                    f"{method_name}: dx={shift_pt.x:.1f}  dy={shift_pt.y:.1f}  |{mag:.1f}|px"
+                )
             axes[2, n_cols - 1].text(
-                0.04, 0.04, "\n".join(lines),
+                0.04,
+                0.04,
+                "\n".join(lines),
                 transform=axes[2, n_cols - 1].transAxes,
-                color=colour, fontsize=7, va="bottom", fontfamily="monospace",
-                bbox=dict(boxstyle="round,pad=0.3", facecolor="black", alpha=0.6, edgecolor="none"),
+                color=colour,
+                fontsize=7,
+                va="bottom",
+                fontfamily="monospace",
+                bbox=dict(
+                    boxstyle="round,pad=0.3",
+                    facecolor="black",
+                    alpha=0.6,
+                    edgecolor="none",
+                ),
             )
 
     fig.tight_layout()

--- a/fibsem/milling/base.py
+++ b/fibsem/milling/base.py
@@ -5,7 +5,6 @@ from dataclasses import asdict, dataclass, field, fields
 from functools import cached_property
 from typing import (
     Any,
-    ClassVar,
     Dict,
     Generic,
     List,
@@ -71,6 +70,7 @@ class MillingStrategyConfig(ABC):
 
 class MillingStrategy(ABC, Generic[TMillingStrategyConfig]):
     """Abstract base class for different milling strategies"""
+
     name: str = "Milling Strategy"
     config_class: Type[TMillingStrategyConfig]
     selectable: bool = True
@@ -89,9 +89,13 @@ class MillingStrategy(ABC, Generic[TMillingStrategyConfig]):
     def summary(self) -> str:
         """Return a multi-line human-readable summary of the strategy and its config."""
         from fibsem.utils import format_value
+
         lines = [f"    Strategy: {self.name}"]
         for attr in self.config.required_attributes:
-            if attr in self.config._hidden_attributes or attr in self.config.advanced_attributes:
+            if (
+                attr in self.config._hidden_attributes
+                or attr in self.config.advanced_attributes
+            ):
                 continue
             val = getattr(self.config, attr)
             meta = self.config.field_metadata.get(attr, {})
@@ -100,12 +104,23 @@ class MillingStrategy(ABC, Generic[TMillingStrategyConfig]):
             if isinstance(val, float) and unit:
                 val_str = format_value(val, unit=unit, precision=1)
             else:
-                val_str = val.name if hasattr(val, "name") and not isinstance(val, float) else str(val)
+                val_str = (
+                    val.name
+                    if hasattr(val, "name") and not isinstance(val, float)
+                    else str(val)
+                )
             lines.append(f"        {label}: {val_str}")
         return "\n".join(lines)
 
     @abstractmethod
-    def run(self, microscope: FibsemMicroscope, stage: "FibsemMillingStage", asynch: bool = False, parent_ui = None, stop_event: Optional[threading.Event] = None) -> None:
+    def run(
+        self,
+        microscope: FibsemMicroscope,
+        stage: "FibsemMillingStage",
+        asynch: bool = False,
+        parent_ui=None,
+        stop_event: Optional[threading.Event] = None,
+    ) -> None:
         pass
 
 
@@ -128,14 +143,16 @@ class FibsemMillingStage:
     enabled: bool = True
     milling: FibsemMillingSettings = field(default_factory=FibsemMillingSettings)
     pattern: BasePattern = field(default_factory=DEFAULT_MILLING_PATTERN)
-    patterns: Optional[List[BasePattern]] = None # unused
+    patterns: Optional[List[BasePattern]] = None  # unused
     strategy: MillingStrategy[Any] = field(default_factory=get_strategy)
     alignment: MillingAlignment = field(default_factory=MillingAlignment)
-    imaging: ImageSettings = field(default_factory=ImageSettings) # settings for post-milling acquisition
+    imaging: ImageSettings = field(
+        default_factory=ImageSettings
+    )  # settings for post-milling acquisition
     reference_image: Optional[FibsemImage] = None
 
     def __post_init__(self):
-        
+
         if self.imaging.resolution is None:
             self.imaging.resolution = [1536, 1024]  # default resolution for imaging
         if self.imaging.hfw is None:
@@ -173,7 +190,7 @@ class FibsemMillingStage:
         alignment = data.get("alignment", {})
         imaging: dict = data.get("imaging", {})
         if imaging == {} or imaging.get("path", None) is None:
-            imaging["path"] = None # set to None if not explicitly set
+            imaging["path"] = None  # set to None if not explicitly set
         return cls(
             name=data["name"],
             num=data.get("num", 0),
@@ -189,24 +206,31 @@ class FibsemMillingStage:
     def estimated_time(self) -> float:
         return estimate_milling_time(self.pattern, self.milling.milling_current)
 
-    def run(self, microscope: FibsemMicroscope, asynch: bool = False, parent_ui = None) -> None:
+    def run(
+        self, microscope: FibsemMicroscope, asynch: bool = False, parent_ui=None
+    ) -> None:
         """Run the milling stage strategy on the given microscope."""
-        self.strategy.run(microscope=microscope, stage=self, asynch=asynch, parent_ui=parent_ui)
+        self.strategy.run(
+            microscope=microscope, stage=self, asynch=asynch, parent_ui=parent_ui
+        )
 
     @property
     def summary(self) -> str:
         """Return a multi-line human-readable summary of the milling stage parameters."""
-        return "\n".join([
-            self.name,
-            self.milling.summary(),
-            self.pattern.summary(),
-            self.strategy.summary(),
-        ])
+        return "\n".join(
+            [
+                self.name,
+                self.milling.summary(),
+                self.pattern.summary(),
+                self.strategy.summary(),
+            ]
+        )
 
     @property
     def pretty_name(self) -> str:
         """Return a pretty name for the milling stage, including the milling current."""
         from fibsem.utils import format_value
+
         milling_current = self.milling.milling_current
         mc = format_value(val=milling_current, unit="A", precision=1)
 
@@ -241,7 +265,9 @@ class FibsemMillingStage:
         return self.strategy.config == other.strategy.config
 
 
-def get_milling_stages(key: str, protocol: Dict[str, List[Dict[str, Any]]]) -> List[FibsemMillingStage]:
+def get_milling_stages(
+    key: str, protocol: Dict[str, List[Dict[str, Any]]]
+) -> List[FibsemMillingStage]:
     """Get the milling stages for specific key from the protocol.
     Args:
         key: the key to get the milling stages for
@@ -249,15 +275,20 @@ def get_milling_stages(key: str, protocol: Dict[str, List[Dict[str, Any]]]) -> L
     Returns:
         List[FibsemMillingStage]: the milling stages for the given key"""
     if key not in protocol:
-        raise ValueError(f"Key {key} not found in protocol. Available keys: {list(protocol.keys())}")
-    
+        raise ValueError(
+            f"Key {key} not found in protocol. Available keys: {list(protocol.keys())}"
+        )
+
     stages = []
     for stage_config in protocol[key]:
         stage = FibsemMillingStage.from_dict(stage_config)
         stages.append(stage)
     return stages
 
-def get_protocol_from_stages(stages: Union[FibsemMillingStage, List[FibsemMillingStage]]) -> List[Dict[str, Any]]:
+
+def get_protocol_from_stages(
+    stages: Union[FibsemMillingStage, List[FibsemMillingStage]],
+) -> List[Dict[str, Any]]:
     """Convert a list of milling stages to a protocol dictionary.
     Args:
         stages: the list of milling stages to convert
@@ -265,14 +296,14 @@ def get_protocol_from_stages(stages: Union[FibsemMillingStage, List[FibsemMillin
         List[Dict[str, Any]]: the protocol dictionary"""
     if not isinstance(stages, list):
         stages = [stages]
-    
+
     return deepcopy([stage.to_dict() for stage in stages])
 
 
 def estimate_milling_time(pattern: BasePattern, milling_current: float) -> float:
-    """Estimate the milling time for a given pattern and milling current. 
+    """Estimate the milling time for a given pattern and milling current.
     The time is calculated as the volume of the pattern divided by the sputter rate at the given current.
-    The sputter rate is taken from the microscope application files. 
+    The sputter rate is taken from the microscope application files.
     This is a rough estimate, as the actual milling time is calculated at milling time.
 
     Args:
@@ -290,20 +321,29 @@ def estimate_milling_time(pattern: BasePattern, milling_current: float) -> float
     sp_keys.sort(key=lambda x: abs(x - milling_current))
 
     # get the sputter rate for the closest key
-    sputter_rate = MILLING_SPUTTER_RATE[sp_keys[0]] # um3/s 
+    sputter_rate = MILLING_SPUTTER_RATE[sp_keys[0]]  # um3/s
 
     # scale the sputter rate based on the expected current
     sputter_rate = sputter_rate * (milling_current / sp_keys[0])
-    volume = pattern.volume # m3
+    volume = pattern.volume  # m3
 
-    if hasattr(pattern, "cross_section") and pattern.cross_section is CrossSectionPattern.CleaningCrossSection:
-        volume *= 0.66 # ccs is approx 2/3 of the volume of a rectangle
+    if (
+        hasattr(pattern, "cross_section")
+        and pattern.cross_section is CrossSectionPattern.CleaningCrossSection
+    ):
+        volume *= 0.66  # ccs is approx 2/3 of the volume of a rectangle
 
-    time = (volume *1e6**3) / sputter_rate
-    return time * 0.75 # QUERY: accuracy of this estimate?
+    time = (volume * 1e6**3) / sputter_rate
+    return time * 0.75  # QUERY: accuracy of this estimate?
+
 
 def estimate_total_milling_time(stages: List[FibsemMillingStage]) -> float:
     """Estimate the total milling time for a list of milling stages"""
     if not isinstance(stages, list):
         stages = [stages]
-    return sum([estimate_milling_time(stage.pattern, stage.milling.milling_current) for stage in stages])
+    return sum(
+        [
+            estimate_milling_time(stage.pattern, stage.milling.milling_current)
+            for stage in stages
+        ]
+    )

--- a/fibsem/milling/patterning/patterns2.py
+++ b/fibsem/milling/patterning/patterns2.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from copy import deepcopy
 from dataclasses import asdict, dataclass, field, fields
 from functools import cached_property
 from typing import (
@@ -47,6 +46,7 @@ TPattern = TypeVar("TPattern", bound="BasePattern")
 
 ####### Combo Patterns
 
+
 @dataclass
 class BasePattern(ABC, Generic[TFibsemPatternSettings]):
     name: ClassVar[str] = field(init=False)
@@ -55,16 +55,18 @@ class BasePattern(ABC, Generic[TFibsemPatternSettings]):
     # `"type": Point` *before* spreading DEFAULT_DISTANCE_METADATA, so the
     # spread's `float` silently won and the declaration was a lie -- which is
     # why the row had to be special-cased on the field being named "point".
-    point: Point = field(default_factory=Point,
-                         metadata=field_meta(
-                            DEFAULT_DISTANCE_METADATA,
-                            label="Point",
-                            type=Point,
-                            minimum=-1000.0,
-                            maximum=1000.0,
-                            tooltip="Point coordinates for the milling pattern.",
-                            advanced=True,
-                         ))
+    point: Point = field(
+        default_factory=Point,
+        metadata=field_meta(
+            DEFAULT_DISTANCE_METADATA,
+            label="Point",
+            type=Point,
+            minimum=-1000.0,
+            maximum=1000.0,
+            tooltip="Point coordinates for the milling pattern.",
+            advanced=True,
+        ),
+    )
     # Computed by define(), never edited: the form skips it on `hidden` rather
     # than on a hardcoded field name, so a plugin can hide its own fields too.
     shapes: Optional[List[TFibsemPatternSettings]] = field(
@@ -139,6 +141,7 @@ class BasePattern(ABC, Generic[TFibsemPatternSettings]):
     def summary(self) -> str:
         """Return a multi-line human-readable summary of key pattern parameters."""
         from fibsem.utils import format_value
+
         lines = [f"    Pattern: {self.name}"]
         for attr in self.required_attributes:
             if attr in self.advanced_attributes:
@@ -440,13 +443,16 @@ class RectanglePattern(BasePattern[FibsemRectangleSettings]):
 
     def summary(self) -> str:
         from fibsem.utils import format_value
-        return "\n".join([
-            f"    Pattern: {self.name}",
-            f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
-            f"        Width: {format_value(self.width, unit='m', precision=1)}",
-            f"        Height: {format_value(self.height, unit='m', precision=1)}",
-            f"        Cross Section: {self.cross_section.name}",
-        ])
+
+        return "\n".join(
+            [
+                f"    Pattern: {self.name}",
+                f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
+                f"        Width: {format_value(self.width, unit='m', precision=1)}",
+                f"        Height: {format_value(self.height, unit='m', precision=1)}",
+                f"        Cross Section: {self.cross_section.name}",
+            ]
+        )
 
     def define(self) -> List[FibsemRectangleSettings]:
 
@@ -517,10 +523,13 @@ class LinePattern(BasePattern[FibsemLineSettings]):
 
     def summary(self) -> str:
         from fibsem.utils import format_value
-        return "\n".join([
-            f"    Pattern: {self.name}",
-            f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
-        ])
+
+        return "\n".join(
+            [
+                f"    Pattern: {self.name}",
+                f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
+            ]
+        )
 
     def define(self) -> List[FibsemLineSettings]:
         shape = FibsemLineSettings(
@@ -566,14 +575,17 @@ class CirclePattern(BasePattern[FibsemCircleSettings]):
 
     def summary(self) -> str:
         from fibsem.utils import format_value
-        return "\n".join([
-            f"    Pattern: {self.name}",
-            f"        Radius: {format_value(self.radius, unit='m', precision=1)}",
-            f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
-        ])
+
+        return "\n".join(
+            [
+                f"    Pattern: {self.name}",
+                f"        Radius: {format_value(self.radius, unit='m', precision=1)}",
+                f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
+            ]
+        )
 
     def define(self) -> List[FibsemCircleSettings]:
-        
+
         shape = FibsemCircleSettings(
             radius=self.radius,
             depth=self.depth,
@@ -650,16 +662,19 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
 
     def summary(self) -> str:
         from fibsem.utils import format_value
-        return "\n".join([
-            f"    Pattern: {self.name}",
-            f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
-            f"        Width: {format_value(self.width, unit='m', precision=1)}",
-            f"        Spacing: {format_value(self.spacing, unit='m', precision=1)}",
-            f"        Upper Trench Height: {format_value(self.upper_trench_height, unit='m', precision=1)}",
-            f"        Lower Trench Height: {format_value(self.lower_trench_height, unit='m', precision=1)}",
-            f"        Passes: {format_value(self.passes, precision=0)}",
-            f"        Cross Section: {self.cross_section.name}",
-        ])
+
+        return "\n".join(
+            [
+                f"    Pattern: {self.name}",
+                f"        Depth: {format_value(self.depth, unit='m', precision=1)}",
+                f"        Width: {format_value(self.width, unit='m', precision=1)}",
+                f"        Spacing: {format_value(self.spacing, unit='m', precision=1)}",
+                f"        Upper Trench Height: {format_value(self.upper_trench_height, unit='m', precision=1)}",
+                f"        Lower Trench Height: {format_value(self.lower_trench_height, unit='m', precision=1)}",
+                f"        Passes: {format_value(self.passes, precision=0)}",
+                f"        Cross Section: {self.cross_section.name}",
+            ]
+        )
 
     def define(self) -> List[Union[FibsemRectangleSettings, FibsemCircleSettings]]:
 
@@ -680,7 +695,7 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
         # fillet radius on the corners
         fillet = np.clip(fillet, 0, upper_trench_height / 2)
         if fillet > 0:
-            width = max(0, width - 2 * fillet) # ensure width is not negative
+            width = max(0, width - 2 * fillet)  # ensure width is not negative
 
         # mill settings
         lower_trench_settings = FibsemRectangleSettings(
@@ -710,23 +725,27 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
         self.shapes = [upper_trench_settings, lower_trench_settings]
 
         # add fillet to the corners
-        if fillet > 0:            
+        if fillet > 0:
             left_x_pos = point.x - width / 2
             right_x_pos = point.x + width / 2
 
             fillet_offset = 1.5
-            lower_y_pos = centre_lower_y + lower_trench_height / 2 - fillet * fillet_offset
-            top_y_pos = centre_upper_y - upper_trench_height / 2 + fillet * fillet_offset
+            lower_y_pos = (
+                centre_lower_y + lower_trench_height / 2 - fillet * fillet_offset
+            )
+            top_y_pos = (
+                centre_upper_y - upper_trench_height / 2 + fillet * fillet_offset
+            )
 
             lower_left_fillet = FibsemCircleSettings(
                 radius=fillet,
-                depth=depth/2,
+                depth=depth / 2,
                 centre_x=point.x - width / 2,
                 centre_y=lower_y_pos,
             )
             lower_right_fillet = FibsemCircleSettings(
                 radius=fillet,
-                depth=depth/2,
+                depth=depth / 2,
                 centre_x=point.x + width / 2,
                 centre_y=lower_y_pos,
             )
@@ -738,7 +757,7 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
                 depth=depth,
                 centre_x=left_x_pos - fillet / 2,
                 centre_y=centre_lower_y - fillet / 2,
-                cross_section = cross_section,
+                cross_section=cross_section,
                 scan_direction="BottomToTop",
                 passes=self.passes,
             )
@@ -748,7 +767,7 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
                 depth=depth,
                 centre_x=right_x_pos + fillet / 2,
                 centre_y=centre_lower_y - fillet / 2,
-                cross_section = cross_section,
+                cross_section=cross_section,
                 scan_direction="BottomToTop",
                 passes=self.passes,
             )
@@ -772,7 +791,7 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
                 depth=depth,
                 centre_x=left_x_pos - fillet / 2,
                 centre_y=centre_upper_y + fillet / 2,
-                cross_section = cross_section,
+                cross_section=cross_section,
                 scan_direction="TopToBottom",
                 passes=self.passes,
             )
@@ -782,15 +801,23 @@ class TrenchPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSetti
                 depth=depth,
                 centre_x=right_x_pos + fillet / 2,
                 centre_y=centre_upper_y + fillet / 2,
-                cross_section = cross_section,
+                cross_section=cross_section,
                 scan_direction="TopToBottom",
                 passes=self.passes,
             )
 
-            self.shapes.extend([lower_left_fill, lower_right_fill, 
-                                top_left_fill, top_right_fill, 
-                                lower_left_fillet, lower_right_fillet, 
-                                top_left_fillet, top_right_fillet])
+            self.shapes.extend(
+                [
+                    lower_left_fill,
+                    lower_right_fill,
+                    top_left_fill,
+                    top_right_fill,
+                    lower_left_fillet,
+                    lower_right_fillet,
+                    top_left_fillet,
+                    top_right_fillet,
+                ]
+            )
 
         return self.shapes
 
@@ -895,7 +922,7 @@ class HorseshoePattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x,
             centre_y=centre_lower_y,
             scan_direction="BottomToTop",
-            cross_section = cross_section
+            cross_section=cross_section,
         )
 
         upper_pattern = FibsemRectangleSettings(
@@ -905,7 +932,7 @@ class HorseshoePattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x,
             centre_y=centre_upper_y,
             scan_direction="TopToBottom",
-            cross_section = cross_section
+            cross_section=cross_section,
         )
 
         side_pattern = FibsemRectangleSettings(
@@ -915,7 +942,7 @@ class HorseshoePattern(BasePattern[FibsemRectangleSettings]):
             centre_x=side_x,
             centre_y=side_y,
             scan_direction=self.scan_direction,
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         self.shapes = [upper_pattern, lower_pattern, side_pattern]
@@ -1002,7 +1029,7 @@ class HorseshoePatternVertical(BasePattern):
             centre_x=point.x - (width / 2) - (trench_width / 2),
             centre_y=point.y,
             scan_direction="LeftToRight",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         right_pattern = FibsemRectangleSettings(
@@ -1012,7 +1039,7 @@ class HorseshoePatternVertical(BasePattern):
             centre_x=point.x + (width / 2) + (trench_width / 2),
             centre_y=point.y,
             scan_direction="RightToLeft",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
         y_offset = (height / 2) + (upper_trench_height / 2)
         if inverted:
@@ -1024,10 +1051,10 @@ class HorseshoePatternVertical(BasePattern):
             centre_x=point.x,
             centre_y=point.y + y_offset,
             scan_direction=scan_direction,
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
-        self.shapes = [upper_pattern, left_pattern,right_pattern]
+        self.shapes = [upper_pattern, left_pattern, right_pattern]
         return self.shapes
 
 
@@ -1121,11 +1148,13 @@ class SerialSectionPattern(BasePattern[FibsemLineSettings]):
             side_height *= -1.0
 
         # main section pattern
-        section_pattern = FibsemLineSettings(start_x=point.x - section_width / 2, 
-                                             end_x=point.x + section_width / 2, 
-                                             start_y=point.y + section_y, 
-                                             end_y=point.y + section_y, 
-                                             depth=section_depth)
+        section_pattern = FibsemLineSettings(
+            start_x=point.x - section_width / 2,
+            end_x=point.x + section_width / 2,
+            start_y=point.y + section_y,
+            end_y=point.y + section_y,
+            depth=section_depth,
+        )
 
         self.shapes = [section_pattern]
 
@@ -1163,10 +1192,15 @@ class SerialSectionPattern(BasePattern[FibsemLineSettings]):
                 depth=side_depth,
             )
 
-            self.shapes.extend([left_side_pattern, right_side_pattern, 
-                            left_side_pattern_vertical, 
-                            right_side_pattern_vertical])
-            
+            self.shapes.extend(
+                [
+                    left_side_pattern,
+                    right_side_pattern,
+                    left_side_pattern_vertical,
+                    right_side_pattern_vertical,
+                ]
+            )
+
         return self.shapes
 
 
@@ -1227,7 +1261,6 @@ class FiducialPattern(BasePattern[FibsemRectangleSettings]):
         rotation = self.rotation * constants.DEGREES_TO_RADIANS
         cross_section = self.cross_section
 
-
         # def calculate_angles(num_steps, start_angle=0):
         #     angles = []
         #     step_size = 180 / num_steps
@@ -1280,8 +1313,8 @@ class FiducialPattern(BasePattern[FibsemRectangleSettings]):
         )
         if self.asymmetric:
             left_pattern.height *= 0.5
-            left_pattern.centre_x -= left_pattern.height*0.5*np.cos(rotation)
-            left_pattern.centre_y += left_pattern.height*0.5*np.sin(rotation)
+            left_pattern.centre_x -= left_pattern.height * 0.5 * np.cos(rotation)
+            left_pattern.centre_y += left_pattern.height * 0.5 * np.sin(rotation)
 
         self.shapes = [left_pattern, right_pattern]
         return self.shapes
@@ -1344,7 +1377,7 @@ class UndercutPattern(BasePattern[FibsemRectangleSettings]):
     name: ClassVar[str] = "Undercut"
 
     def define(self) -> List[FibsemRectangleSettings]:
-        
+
         point = self.point
         jcut_rhs_height = self.rhs_height
         jcut_lamella_height = self.height
@@ -1368,7 +1401,7 @@ class UndercutPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x,
             centre_y=point.y,
             scan_direction="TopToBottom",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
         # rhs jcut
         jcut_rhs_centre_x = point.x + (jcut_width / 2) - jcut_trench_thickness / 2
@@ -1384,7 +1417,7 @@ class UndercutPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=jcut_rhs_centre_x,
             centre_y=jcut_rhs_centre_y,
             scan_direction="TopToBottom",
-            cross_section = cross_section
+            cross_section=cross_section,
         )
 
         self.shapes = [top_pattern, rhs_pattern]
@@ -1442,7 +1475,7 @@ class MicroExpansionPattern(BasePattern[FibsemRectangleSettings]):
             width=width,
             height=height,
             depth=depth,
-            centre_x=point.x -  distance,
+            centre_x=point.x - distance,
             centre_y=point.y,
             scan_direction="TopToBottom",
         )
@@ -1558,7 +1591,7 @@ class ArrayPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSettin
     # ref: weld cross-section/ passes: https://www.nature.com/articles/s41592-023-02113-5
 
     def define(self) -> List[Union[FibsemRectangleSettings, FibsemCircleSettings]]:
-        
+
         point = self.point
         width = self.width
         height = self.height
@@ -1599,7 +1632,7 @@ class ArrayPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSettin
                     height=height,
                     depth=depth,
                     centre_x=pt.x,
-                    centre_y=pt.y,  
+                    centre_y=pt.y,
                     scan_direction=scan_direction,
                     rotation=rotation,
                     passes=passes,
@@ -1607,7 +1640,7 @@ class ArrayPattern(BasePattern[Union[FibsemRectangleSettings, FibsemCircleSettin
                 )
             self.shapes.append(pattern_settings)
 
-        return self.shapes # type: ignore
+        return self.shapes  # type: ignore
 
 
 @dataclass
@@ -1694,7 +1727,7 @@ class WaffleNotchPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x,
             centre_y=point.y - distance / 2 - vheight / 2 + hheight / 2,
             scan_direction="TopToBottom",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         bottom_vertical_pattern = FibsemRectangleSettings(
@@ -1704,7 +1737,7 @@ class WaffleNotchPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x,
             centre_y=point.y + distance / 2 + vheight / 2 - hheight / 2,
             scan_direction="BottomToTop",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         top_horizontal_pattern = FibsemRectangleSettings(
@@ -1714,7 +1747,7 @@ class WaffleNotchPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x + (hwidth / 2 + vwidth / 2) * inverted,
             centre_y=point.y - distance / 2,
             scan_direction="TopToBottom",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         bottom_horizontal_pattern = FibsemRectangleSettings(
@@ -1724,7 +1757,7 @@ class WaffleNotchPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x + (hwidth / 2 + vwidth / 2) * inverted,
             centre_y=point.y + distance / 2,
             scan_direction="BottomToTop",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         centre_vertical_pattern = FibsemRectangleSettings(
@@ -1734,7 +1767,7 @@ class WaffleNotchPattern(BasePattern[FibsemRectangleSettings]):
             centre_x=point.x + (hwidth + vwidth) * inverted,
             centre_y=point.y,
             scan_direction="TopToBottom",
-            cross_section=cross_section
+            cross_section=cross_section,
         )
 
         self.shapes = [
@@ -1770,7 +1803,7 @@ class CloverPattern(BasePattern[Union[FibsemCircleSettings, FibsemRectangleSetti
     name: ClassVar[str] = "Clover"
 
     def define(self) -> List[Union[FibsemCircleSettings, FibsemRectangleSettings]]:
-        
+
         point = self.point
         radius = self.radius
         depth = self.depth
@@ -1857,14 +1890,11 @@ class TriForcePattern(BasePattern[FibsemRectangleSettings]):
         ]
 
         for point in points:
-
-            triangle_shapes =  create_triangle_patterns(width=width, 
-                                                        height=height, 
-                                                        depth=depth, 
-                                                        point=point, 
-                                                        angle=angle)
+            triangle_shapes = create_triangle_patterns(
+                width=width, height=height, depth=depth, point=point, angle=angle
+            )
             self.shapes.extend(triangle_shapes)
-            
+
         return self.shapes
 
 
@@ -1913,7 +1943,7 @@ class TrenchTrapezoidPattern(BasePattern):
     name: ClassVar[str] = "TrapezoidTrench"
 
     # ref: https://www.researchsquare.com/article/rs-6497420/v1
-    
+
     def define(self):
 
         width = self.trench_width
@@ -1935,7 +1965,7 @@ class TrenchTrapezoidPattern(BasePattern):
 
         # create mirrored polygon (mirror over y-axis)
         mirrored_points = points.copy()
-        mirrored_points[:, 1] = -mirrored_points[:, 1] #- spacing /2
+        mirrored_points[:, 1] = -mirrored_points[:, 1]  # - spacing /2
 
         top_trench = FibsemPolygonSettings(vertices=points, depth=depth)
         bottom_trench = FibsemPolygonSettings(vertices=mirrored_points, depth=depth)
@@ -1953,7 +1983,9 @@ class TrenchTrapezoidPattern(BasePattern):
 
 @dataclass
 class PolygonPattern(BasePattern):
-    vertices: np.ndarray[float] = field(default_factory=lambda: np.array([]), metadata={"hidden": True})    # type: ignore[type-arg]
+    vertices: np.ndarray[float] = field(
+        default_factory=lambda: np.array([]), metadata={"hidden": True}
+    )  # type: ignore[type-arg]
     depth: float = field(
         default=1.0e-6,
         metadata={
@@ -1974,14 +2006,16 @@ class PolygonPattern(BasePattern):
 
     def define(self) -> List[FibsemPolygonSettings]:
         """Define a polygon milling pattern based on the provided vertices."""
-        
+
         if self.vertices.ndim != 2 or self.vertices.shape[1] != 2:
             raise ValueError("Vertices must be a 2D array with shape (n, 2)")
 
         # Create a polygon milling pattern
-        polygon = FibsemPolygonSettings(vertices=np.array(self.vertices, copy=True), 
-                                        depth=self.depth,
-                                        is_exclusion=self.is_exclusion)
+        polygon = FibsemPolygonSettings(
+            vertices=np.array(self.vertices, copy=True),
+            depth=self.depth,
+            is_exclusion=self.is_exclusion,
+        )
 
         # Offset the vertices by the point
         polygon.vertices[:, 0] += self.point.x

--- a/fibsem/milling/strategy/coincidence.py
+++ b/fibsem/milling/strategy/coincidence.py
@@ -5,15 +5,13 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
-from queue import Queue
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
-import tifffile as tff
 from psygnal import Signal
 
 from fibsem import constants
-from fibsem.fm.structures import ChannelSettings, FluorescenceImage, ZParameters
+from fibsem.fm.structures import FluorescenceImage
 from fibsem.microscope import FibsemMicroscope
 from fibsem.microscopes.simulator import DemoMicroscope
 from fibsem.milling import (
@@ -107,7 +105,9 @@ class CoincidenceMillingStrategyConfig(MillingStrategyConfig):
     )
     bbox: Optional[FibsemRectangle] = field(
         default=None,
-        metadata=field_meta(hidden=True),  # set interactively via the FM ROI, not a form control
+        metadata=field_meta(
+            hidden=True
+        ),  # set interactively via the FM ROI, not a form control
     )  # reduced area for intensity monitoring
     # oscillation parameters
 
@@ -361,9 +361,7 @@ class CoincidenceMillingStrategy(MillingStrategy[CoincidenceMillingStrategyConfi
 
             # unsupervised runs: automatically stop on intensity drop
             if not self.config.supervised and self._drop_detected:
-                logging.info(
-                    "Unsupervised: intensity drop detected. Stopping milling."
-                )
+                logging.info("Unsupervised: intensity drop detected. Stopping milling.")
                 self.microscope.stop_milling()
                 break
 


### PR DESCRIPTION
9 unused imports removed from this area, plus the reformat format-on-touch requires. Four files.

## Safety

Every removed name was checked against the whole repo, before and after the edit, for four ways an "unused" import can still be load-bearing:

| reachable how | at risk here |
|---|---|
| `from M import X` elsewhere | 0 |
| `import M` then `M.X` | 0 |
| `from pkg import mod` then `mod.X` | 0 |
| `from M import *` | 0 |

`ruff check --fix` alone is **not** safe on this codebase — it rates as `safe` a removal that breaks `scripts/test_installation.py`. Full rationale and the dangerous case are recorded on the closed #496; that one is in `fibsem/microscopes`, not in this slice.

Second commit is the reformat that format-on-touch requires. Nothing in it is worth reading line by line.
