### PR TITLE
[refactor] Remove unused imports from segmentation (1/2)

### DIFF
--- a/fibsem/segmentation/_nnunet.py
+++ b/fibsem/segmentation/_nnunet.py
@@ -3,7 +3,6 @@ import json
 import os
 import shutil
 
-import matplotlib.pyplot as plt
 import numpy as np
 import PIL.Image
 import torch
@@ -86,12 +85,11 @@ def load_from_checkpoint(
 
     # load the model parameters
     parameters = []
-    checkpoint_name = "final" # always use final checkpoint for now
-    for i, k in enumerate(sorted(model_checkpoint['folds'])):
+    checkpoint_name = "final"  # always use final checkpoint for now
+    for i, k in enumerate(sorted(model_checkpoint["folds"])):
+        checkpoint = model_checkpoint["folds"][k][checkpoint_name]
 
-        checkpoint = model_checkpoint['folds'][k][checkpoint_name]
-        
-        if i == 0: # use first fold to get trainer and configuration name
+        if i == 0:  # use first fold to get trainer and configuration name
             trainer_name = checkpoint["trainer_name"]
             configuration_name = checkpoint["init_args"]["configuration"]
             inference_allowed_mirroring_axes = (

--- a/fibsem/segmentation/adaptive_model.py
+++ b/fibsem/segmentation/adaptive_model.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 from adaptive_polish.dl_segmentation import sem_lamella_segmentor as sgm
 
-from fibsem.segmentation.utils import decode_segmap_v2, download_checkpoint
+from fibsem.segmentation.utils import decode_segmap_v2
 
 
 class AdaptiveSegmentationModel:

--- a/fibsem/segmentation/dataset.py
+++ b/fibsem/segmentation/dataset.py
@@ -9,7 +9,6 @@ import dask.array as da
 import numpy as np
 import tifffile as tff
 import torch
-from PIL import Image
 from torch.utils.data import DataLoader, Dataset, SubsetRandomSampler
 from torchvision import transforms
 
@@ -19,7 +18,6 @@ PROB = 0.1
 
 transformations_input = transforms.Compose(
     [
-
         transforms.RandomRotation(ROT_ANGLE),
         transforms.RandomHorizontalFlip(p=PROB),
         transforms.RandomVerticalFlip(p=PROB),
@@ -35,28 +33,39 @@ transformations_target = transforms.Compose(
         transforms.RandomRotation(ROT_ANGLE),
         transforms.RandomHorizontalFlip(p=PROB),
         transforms.RandomVerticalFlip(p=PROB),
-
     ]
 )
 
 
 class SegmentationDataset(Dataset):
-    def __init__(self, images, masks, num_classes: int, transforms_input=None, transforms_target=None):
+    def __init__(
+        self,
+        images,
+        masks,
+        num_classes: int,
+        transforms_input=None,
+        transforms_target=None,
+    ):
         self.images = images
         self.masks = masks
         self.num_classes = num_classes
         self.transforms_input = transforms_input
         self.transforms_target = transforms_target
 
-        assert len(self.images) == len(self.masks), "Images and masks are not the same length"
-        assert self.transforms_target is not None if self.transforms_input is not None else True, "transforms_target must be provided if transforms_input is provided"
+        assert len(self.images) == len(self.masks), (
+            "Images and masks are not the same length"
+        )
+        assert (
+            self.transforms_target is not None
+            if self.transforms_input is not None
+            else True
+        ), "transforms_target must be provided if transforms_input is provided"
 
     def _set_seed(self, seed):
         random.seed(seed)
         torch.manual_seed(seed)
 
     def __getitem__(self, idx):
-
 
         image = np.asarray(self.images[idx])
         mask = np.asarray(self.masks[idx])
@@ -67,10 +76,9 @@ class SegmentationDataset(Dataset):
         # need to to transformation manually
         # mask = torch.tensor(mask).unsqueeze(0)
 
-        image = torch.tensor(image).unsqueeze(0) # TODO: validate this behaviour
+        image = torch.tensor(image).unsqueeze(0)  # TODO: validate this behaviour
         mask = torch.tensor(mask).unsqueeze(0)
-        
-    
+
         image_max_val = torch.iinfo(image.dtype).max
         if image.dtype not in [torch.uint8, torch.int16]:
             raise ValueError(f"Image dtype {image.dtype} not supported")
@@ -84,11 +92,12 @@ class SegmentationDataset(Dataset):
 
         # convert image to float32 scaled between 0-1
         image = image.float() / image_max_val
-                        
+
         return image, mask
 
     def __len__(self):
         return len(self.images)
+
 
 from pathlib import Path
 
@@ -113,12 +122,18 @@ def load_dask_dataset_v2(data_paths: List[Path], label_paths: List[Path]):
     return images, masks
 
 
-def preprocess_data(data_paths: List[Path], label_paths: List[Path], num_classes: int = 3, 
-                    batch_size: int = 1, val_split: float = 0.15, 
-                    _validate_dataset:bool = True, apply_transforms: bool = False):
-    
+def preprocess_data(
+    data_paths: List[Path],
+    label_paths: List[Path],
+    num_classes: int = 3,
+    batch_size: int = 1,
+    val_split: float = 0.15,
+    _validate_dataset: bool = True,
+    apply_transforms: bool = False,
+):
+
     # if _validate_dataset:
-        # validate_dataset(data_path, label_path)
+    # validate_dataset(data_path, label_path)
 
     if not isinstance(data_paths, list):
         data_paths = [data_paths]
@@ -126,7 +141,6 @@ def preprocess_data(data_paths: List[Path], label_paths: List[Path], num_classes
         label_paths = [label_paths]
 
     images, masks = load_dask_dataset_v2(data_paths, label_paths)
-
 
     print(f"Loading dataset from {len(data_paths)} paths: {images.shape[0]}")
     for path in data_paths:
@@ -140,14 +154,15 @@ def preprocess_data(data_paths: List[Path], label_paths: List[Path], num_classes
 
     transformations_input = transforms.Compose(
         [
-
             transforms.RandomRotation(ROT_ANGLE),
             transforms.RandomHorizontalFlip(p=PROB),
             transforms.RandomVerticalFlip(p=PROB),
             transforms.RandomAutocontrast(p=PROB),
             transforms.RandomEqualize(p=PROB),
             transforms.GaussianBlur(kernel_size=3, sigma=(0.1, 2.0)),
-            transforms.ColorJitter(brightness=0.1, contrast=0.1, saturation=0.1, hue=0.1),
+            transforms.ColorJitter(
+                brightness=0.1, contrast=0.1, saturation=0.1, hue=0.1
+            ),
         ]
     )
 
@@ -156,15 +171,16 @@ def preprocess_data(data_paths: List[Path], label_paths: List[Path], num_classes
             transforms.RandomRotation(ROT_ANGLE),
             transforms.RandomHorizontalFlip(p=PROB),
             transforms.RandomVerticalFlip(p=PROB),
-
         ]
     )
 
     # load dataset
     seg_dataset = SegmentationDataset(
-        images, masks, num_classes, 
-        transforms_input=transformations_input, 
-        transforms_target=transformations_target
+        images,
+        masks,
+        num_classes,
+        transforms_input=transformations_input,
+        transforms_target=transformations_target,
     )
 
     # train/validation splits
@@ -193,12 +209,13 @@ def preprocess_data(data_paths: List[Path], label_paths: List[Path], num_classes
 
 # ref: https://towardsdatascience.com/pytorch-basics-sampling-samplers-2a0f29f0bf2a
 
+
 # Helper functions
 def validate_dataset(data_path: str, label_path: str):
     print("validating dataset...")
     # get data
     filenames = sorted(glob.glob(os.path.join(data_path, "*.tif*")))
-    labels = sorted(glob.glob(os.path.join(label_path,  "*.tif*")))
+    labels = sorted(glob.glob(os.path.join(label_path, "*.tif*")))
 
     # check length
     assert len(filenames) == len(labels), "Images and labels are not the same length"
@@ -209,7 +226,6 @@ def validate_dataset(data_path: str, label_path: str):
         img, label = tff.imread(fname), tff.imread(lfname)
 
         if (img.shape[0:2] != label.shape[0:2]) or (img.shape[0:2] != base_shape[0:2]):
-
             raise ValueError(
                 "invalid data, image shape is different to label shape",
                 i,
@@ -222,7 +238,6 @@ def validate_dataset(data_path: str, label_path: str):
             )
 
         if (img.ndim > 2) or (label.ndim > 2):
-
             raise ValueError(
                 "Image has too many dimensions, must be in 2D grayscale format.",
                 i,

--- a/fibsem/segmentation/inference.py
+++ b/fibsem/segmentation/inference.py
@@ -3,7 +3,6 @@
 import argparse
 import glob
 import os
-import time
 
 # import matplotlib.pyplot as plt
 import numpy as np
@@ -15,7 +14,7 @@ import yaml
 import zarr
 from PIL import Image
 
-from fibsem.segmentation import dataset, utils, validate_config
+from fibsem.segmentation import utils, validate_config
 
 
 def inference(images, output_dir, model, model_path, device, WANDB=False):
@@ -26,8 +25,10 @@ def inference(images, output_dir, model, model_path, device, WANDB=False):
     # model.eval()
 
     # Inference
-    with torch.no_grad(): # TODO: move this down to only wrap the model inference
-        vol = tff.imread(os.path.join(images, "*.tif*"), aszarr=True) # loading folder of .tif into zarr array)
+    with torch.no_grad():  # TODO: move this down to only wrap the model inference
+        vol = tff.imread(
+            os.path.join(images, "*.tif*"), aszarr=True
+        )  # loading folder of .tif into zarr array)
         zarr_set = zarr.open(vol)
 
         filenames = sorted(glob.glob(os.path.join(images, "*.tif*")))
@@ -37,13 +38,13 @@ def inference(images, output_dir, model, model_path, device, WANDB=False):
             img = img.to(device)
             outputs = model(img[None, :, :, :].float())
             output_mask = utils.decode_output(outputs)
-            
-            output = Image.fromarray(output_mask) 
+
+            output = Image.fromarray(output_mask)
             path = os.path.join(output_dir, os.path.basename(fname).split(".")[0])
-            
+
             # if not os.path.exists(path):
             os.makedirs(path, exist_ok=True)
-            
+
             input_img = Image.fromarray(img.detach().cpu().squeeze().numpy())
             input_img.save(os.path.join(path, "input.tif"))
             output.save(os.path.join(path, "output.tif"))  # or 'test.tif'
@@ -57,6 +58,7 @@ def inference(images, output_dir, model, model_path, device, WANDB=False):
                 wandb.log({"image": wb_img, "mask": wb_mask})
 
         return outputs, output_mask
+
 
 if __name__ == "__main__":
     # command line arguments
@@ -72,7 +74,7 @@ if __name__ == "__main__":
     config_dir = args.config
 
     # NOTE: Setup your config.yml file
-    with open(config_dir, 'r') as f:
+    with open(config_dir, "r") as f:
         config = yaml.safe_load(f)
 
     print("Validating config file.")
@@ -87,19 +89,20 @@ if __name__ == "__main__":
     cuda = config["inference"]["cuda"]
     WANDB = config["inference"]["wandb"]
 
-
     model = smp.Unet(
-            encoder_name=config["inference"]["encoder"],
-            encoder_weights="imagenet",
-            in_channels=1,  # grayscale images
-            classes=config["inference"]["num_classes"],  # background, needle, lamella
-        )
+        encoder_name=config["inference"]["encoder"],
+        encoder_weights="imagenet",
+        in_channels=1,  # grayscale images
+        classes=config["inference"]["num_classes"],  # background, needle, lamella
+    )
 
     if WANDB:
         # weights and biases setup
-        wandb.init(project=config["inference"]["wandb_project"], entity=config["inference"]["wandb_entity"])
+        wandb.init(
+            project=config["inference"]["wandb_project"],
+            entity=config["inference"]["wandb_entity"],
+        )
 
     device = torch.device("cuda:0" if torch.cuda.is_available() and cuda else "cpu")
 
     inference(data_path, output_dir, model, model_weights, device, WANDB)
-    


### PR DESCRIPTION
5 unused imports removed from this area, plus the reformat format-on-touch requires. Four files; the other half of segmentation is a separate PR.

## Safety

Every removed name was checked against the whole repo, before and after the edit, for four ways an "unused" import can still be load-bearing:

| reachable how | at risk here |
|---|---|
| `from M import X` elsewhere | 0 |
| `import M` then `M.X` | 0 |
| `from pkg import mod` then `mod.X` | 0 |
| `from M import *` | 0 |

`ruff check --fix` alone is **not** safe on this codebase — it rates as `safe` a removal that breaks `scripts/test_installation.py`. Full rationale and the dangerous case are recorded on the closed #496; that one is in `fibsem/microscopes`, not in this slice.

Second commit is the reformat that format-on-touch requires. Nothing in it is worth reading line by line.
