### PR TITLE
[refactor] Remove unused imports from segmentation (2/2)

### DIFF
--- a/fibsem/segmentation/nnunet_model.py
+++ b/fibsem/segmentation/nnunet_model.py
@@ -1,14 +1,7 @@
-
-import os
-
 # TODO: actually implement this
-from abc import ABC
-from pathlib import Path
-from typing import List, Optional
 
 import numpy as np
 import torch
-from huggingface_hub import hf_hub_download
 
 from fibsem.segmentation import _nnunet as nnunet
 from fibsem.segmentation import config as scfg
@@ -18,17 +11,17 @@ from fibsem.segmentation.utils import decode_segmap_v2
 def SegmentationModelBase(ABC):
 
     def __init__(self, checkpoint: str):
-        pass 
-
+        pass
 
     def load_model(self, checkpoint: str) -> SegmentationModelBase:
         """Load the model, and optionally load a checkpoint"""
         raise NotImplementedError
-    
+
     def inference(self, img: np.ndarray, rgb: bool = True) -> np.ndarray:
         """Run model inference on the input image"""
         raise NotImplementedError
-    
+
+
 class SegmentationModelNNUnet:
     def __init__(
         self,
@@ -38,14 +31,14 @@ class SegmentationModelNNUnet:
 
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self.colormap = scfg.get_colormap()
-       
+
         self.checkpoint = checkpoint
         if checkpoint is not None:
             self.load_model(checkpoint=checkpoint)
 
     def load_model(self, checkpoint: str) -> None:
         """Load the model, and optionally load a checkpoint"""
-        
+
         self.model = nnunet.load_model(path=checkpoint, device=self.device)
 
         return self.model
@@ -62,7 +55,7 @@ class SegmentationModelNNUnet:
             img = img[:, :, :, :]
         else:
             raise ValueError(f"Invalid image shape: {img.shape}")
-        
+
         # TODO: also do dtype conversions
         if not isinstance(img.dtype, np.float32):
             img = img.astype(np.float32)
@@ -71,17 +64,17 @@ class SegmentationModelNNUnet:
 
     def inference(self, img: np.ndarray, rgb: bool = True) -> np.ndarray:
         """Run model inference on the input image"""
-        
+
         img = self.pre_process(img)
-        
+
         masks, scores = nnunet.inference(self.model, img)
-        
+
         # convert to rgb image
         if rgb:
-            masks = decode_segmap_v2(masks[0], self.colormap) # 2d only
+            masks = decode_segmap_v2(masks[0], self.colormap)  # 2d only
         else:
-            if masks.ndim>=3:
-                masks = masks[0] # return 2d
+            if masks.ndim >= 3:
+                masks = masks[0]  # return 2d
         return masks
 
     def postprocess(self, masks):
@@ -89,5 +82,3 @@ class SegmentationModelNNUnet:
         if masks.ndim == 3:
             masks = masks[0]
         return decode_segmap_v2(masks, self.colormap)
-
-     

--- a/fibsem/segmentation/nnunet_model_v2.py
+++ b/fibsem/segmentation/nnunet_model_v2.py
@@ -1,6 +1,4 @@
-
 import os
-from typing import List, Optional
 
 import numpy as np
 import torch
@@ -10,25 +8,25 @@ from fibsem.segmentation import config as scfg
 from fibsem.segmentation.utils import decode_segmap_v2
 
 
-class SegmentationModelNNUnetV2():
+class SegmentationModelNNUnetV2:
     def __init__(self, checkpoint: str):
         """Initialize the NNUnet model for segmentation inference using nnunetv2.
         Args:
             checkpoint (str): Path to the model checkpoint file.
-                Note: this should be the full path to the checkpoint file, not just the directory. 
+                Note: this should be the full path to the checkpoint file, not just the directory.
                 The directory will be inferred from the checkpoint path, and needs to be in nnunet format...
         """
 
         self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self.checkpoint = checkpoint
         self._image_properties: dict = {
-                "sitk_stuff": {
-                    "spacing": (1.0, 1.0),
-                    "origin": (0.0, 0.0),
-                    "direction": (1.0, 0.0, 0.0, 1.0),
-                },
-                "spacing": [999.0, 1.0, 1.0],
-            }
+            "sitk_stuff": {
+                "spacing": (1.0, 1.0),
+                "origin": (0.0, 0.0),
+                "direction": (1.0, 0.0, 0.0, 1.0),
+            },
+            "spacing": [999.0, 1.0, 1.0],
+        }
 
         self.predictor = nnunet_predict.nnUNetPredictor(
             perform_everything_on_device=bool(self.device.type == "cuda"),
@@ -46,7 +44,7 @@ class SegmentationModelNNUnetV2():
         self.predictor.initialize_from_trained_model_folder(
             model_training_output_dir=model_directory,
             use_folds=(0,),
-            checkpoint_name=checkpoint_name
+            checkpoint_name=checkpoint_name,
         )
 
     def pre_process(self, img: np.ndarray) -> np.ndarray:
@@ -69,9 +67,9 @@ class SegmentationModelNNUnetV2():
 
     def inference(self, img: np.ndarray, rgb: bool = True) -> np.ndarray:
         """Run model inference on the input image"""
-        
-        img = self.pre_process(img) # requires (C, 1, H, W) or (1, 1, H, W)
-        mask, scores = self.predictor.predict_single_npy_array( #  type: ignore
+
+        img = self.pre_process(img)  # requires (C, 1, H, W) or (1, 1, H, W)
+        mask, scores = self.predictor.predict_single_npy_array(  #  type: ignore
             img, self._image_properties, None, None, True
         )
         if rgb:

--- a/fibsem/segmentation/onnx_model.py
+++ b/fibsem/segmentation/onnx_model.py
@@ -12,7 +12,6 @@ import onnxruntime
 import PIL.Image
 from onnxruntime import InferenceSession
 from skimage.util.shape import view_as_windows
-from tqdm import tqdm
 
 from fibsem.segmentation.utils import decode_segmap_v2, download_checkpoint
 
@@ -20,7 +19,6 @@ from fibsem.segmentation.utils import decode_segmap_v2, download_checkpoint
 
 
 class SegmentationModelONNX:
-
     def __init__(self, checkpoint: str = None):
         if checkpoint is not None:
             self.load_model(checkpoint)
@@ -32,8 +30,9 @@ class SegmentationModelONNX:
         self.checkpoint = os.path.basename(checkpoint)
 
         # load inference session
-        self.session = onnxruntime.InferenceSession(checkpoint, providers=["CPUExecutionProvider"])
-
+        self.session = onnxruntime.InferenceSession(
+            checkpoint, providers=["CPUExecutionProvider"]
+        )
 
     def inference(self, img: np.ndarray, rgb: bool = True):
         # preprocess
@@ -46,20 +45,20 @@ class SegmentationModelONNX:
         ort_inputs = {self.session.get_inputs()[0].name: imgt}
         ort_outs = self.session.run(None, ort_inputs)
 
-
         # softmax
-        outputs = ort_outs[0] # TODO: support batch size > 1
+        outputs = ort_outs[0]  # TODO: support batch size > 1
         outputs = np.exp(outputs) / np.sum(np.exp(outputs), axis=1, keepdims=True)
         masks = np.argmax(outputs, axis=1)
         mask = masks[0, :, :]
 
         # convert to rgb
-        if rgb: 
+        if rgb:
             mask = decode_segmap_v2(mask)
         return mask
 
+
 def export_model_to_onnx(checkpoint: str, onnx_path: str):
-    
+
     import torch
 
     from fibsem.segmentation.model import load_model
@@ -75,26 +74,35 @@ def export_model_to_onnx(checkpoint: str, onnx_path: str):
     torch_out = model.model(x)
 
     # Export the model
-    torch.onnx.export(model.model,               # model being run
-                    x,                         # model input (or a tuple for multiple inputs)
-                    onnx_path,   # where to save the model (can be a file or file-like object)
-                    export_params=True,        # store the trained parameter weights inside the model file
-                    do_constant_folding=True,  # whether to execute constant folding for optimization
-                    input_names = ['input'],   # the model's input names
-                    output_names = ['output'], # the model's output names
-                    dynamic_axes={'input' : {0 : 'batch_size'},    # variable length axes
-                                    'output' : {0 : 'batch_size'}})
-
+    torch.onnx.export(
+        model.model,  # model being run
+        x,  # model input (or a tuple for multiple inputs)
+        onnx_path,  # where to save the model (can be a file or file-like object)
+        export_params=True,  # store the trained parameter weights inside the model file
+        do_constant_folding=True,  # whether to execute constant folding for optimization
+        input_names=["input"],  # the model's input names
+        output_names=["output"],  # the model's output names
+        dynamic_axes={
+            "input": {0: "batch_size"},  # variable length axes
+            "output": {0: "batch_size"},
+        },
+    )
 
     # load onnx model
     onnx_model = onnx.load(onnx_path)
     onnx.checker.check_model(onnx_model)
 
     # load inference session
-    ort_session = onnxruntime.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+    ort_session = onnxruntime.InferenceSession(
+        onnx_path, providers=["CPUExecutionProvider"]
+    )
 
     def to_numpy(tensor):
-        return tensor.detach().cpu().numpy() if tensor.requires_grad else tensor.cpu().numpy()
+        return (
+            tensor.detach().cpu().numpy()
+            if tensor.requires_grad
+            else tensor.cpu().numpy()
+        )
 
     # compute ONNX Runtime output prediction
     ort_inputs = {ort_session.get_inputs()[0].name: to_numpy(x)}
@@ -105,7 +113,9 @@ def export_model_to_onnx(checkpoint: str, onnx_path: str):
 
     print("Exported model has been tested with ONNXRuntime, and the result looks good!")
 
+
 # export_model_to_onnx("autolamella-mega-latest.pt", "autolamella-mega-20231230.onnx")
+
 
 ## PPLITESEG WINDOWED MODEL
 def load_windowed_onnx_model(model_path: str) -> tuple:
@@ -128,6 +138,7 @@ def load_windowed_onnx_model(model_path: str) -> tuple:
     num_output_classes = session.get_outputs()[0].shape[1]
 
     return session, input_name, window_shape, output_name, num_output_classes
+
 
 def standardize(img: object, sigma: float = 24.0) -> np.ndarray:
     """
@@ -155,12 +166,13 @@ class SegmentationModelWindowONNX:
     ONNX model for windowed inference.
     This code refactor enables multi-threaded inference and Gaussian weighted windows
     Improves model inference, inference time and window edge effects"""
+
     def __init__(self, checkpoint: str = None):
         if checkpoint is not None:
             self.load_model(checkpoint)
         self.device = None
         self.num_workers = min(8, os.cpu_count())
-    
+
     def load_model(self, checkpoint="autolamella-mega.onnx"):
         # download checkpoint if needed
         # checkpoint = download_checkpoint(checkpoint)
@@ -168,8 +180,14 @@ class SegmentationModelWindowONNX:
 
         # load inference session
         session = load_windowed_onnx_model(checkpoint)
-        self.session, self.input_name, self.window_shape, self.output_name, self.num_output_classes = session
-    
+        (
+            self.session,
+            self.input_name,
+            self.window_shape,
+            self.output_name,
+            self.num_output_classes,
+        ) = session
+
     def GaussianWeightMatrix(self, window_shape: tuple[int, int]) -> np.ndarray:
         """
         Generate a Gaussian weight matrix for the sliding window."""
@@ -183,7 +201,7 @@ class SegmentationModelWindowONNX:
         w_matrix = w_matrix[np.newaxis, ...]
         del ksize
         return w_matrix
-    
+
     def pre_process(self, img: np.ndarray) -> np.ndarray:
         """Pre-process the image for inference, calculate window parameters"""
         ##### PREPROCESSING
@@ -209,16 +227,25 @@ class SegmentationModelWindowONNX:
         img = np.pad(img, ((0, 0), (0, pad_h), (0, pad_w)), mode="constant")
         _, pad_h, pad_w = img.shape
 
-        #   window input image 
+        #   window input image
         windows = view_as_windows(
-        img, (3, self.window_shape[0], self.window_shape[1]), step=stride
+            img, (3, self.window_shape[0], self.window_shape[1]), step=stride
         ).reshape(-1, 3, self.window_shape[0], self.window_shape[1])
 
-        logging.debug(f"pre_process: {img.shape}, {windows.shape}, {h}, {w}, {pad_h}, {pad_w}, {stride}")
+        logging.debug(
+            f"pre_process: {img.shape}, {windows.shape}, {h}, {w}, {pad_h}, {pad_w}, {stride}"
+        )
 
         return img, windows, h, w, pad_h, pad_w, stride
-    
-    def window_indices(self,pad_h: int, pad_w: int, window_shape: tuple[int, int], stride: int, windows: np.ndarray) -> None:
+
+    def window_indices(
+        self,
+        pad_h: int,
+        pad_w: int,
+        window_shape: tuple[int, int],
+        stride: int,
+        windows: np.ndarray,
+    ) -> None:
         #   determine the i and j indices for each window
         num_windows_h = ((pad_h - window_shape[0]) / stride) + 1
         num_windows_w = ((pad_w - window_shape[1]) / stride) + 1
@@ -230,7 +257,7 @@ class SegmentationModelWindowONNX:
         return indices
 
     def worker_process(
-    self,session: InferenceSession, window: np.ndarray, index: tuple[int, int]
+        self, session: InferenceSession, window: np.ndarray, index: tuple[int, int]
     ) -> tuple[np.ndarray, tuple[int, int]]:
         """
         Worker process for multi-threaded ONNX inference.
@@ -250,7 +277,7 @@ class SegmentationModelWindowONNX:
         )[0].squeeze()
 
         return logits, index
-    
+
     def inference(self, img: np.ndarray, rgb: bool = True) -> np.ndarray:
         """Perform inference on the provided image.
         Args:
@@ -259,7 +286,7 @@ class SegmentationModelWindowONNX:
         Returns:
             np.ndarray: The segmented image."""
         pass
-        
+
         w_matrix = self.GaussianWeightMatrix(self.window_shape)
 
         img, windows, h, w, pad_h, pad_w, stride = self.pre_process(img)
@@ -268,9 +295,14 @@ class SegmentationModelWindowONNX:
 
         container = np.zeros([1, self.num_output_classes, pad_h, pad_w])
         count = np.zeros([1, 1, pad_h, pad_w])
-        with concurrent.futures.ThreadPoolExecutor(max_workers=self.num_workers) as executor:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.num_workers
+        ) as executor:
             jobs = {
-                executor.submit(self.worker_process, self.session, window, idx): (window, idx)
+                executor.submit(self.worker_process, self.session, window, idx): (
+                    window,
+                    idx,
+                )
                 for (window, idx) in zip(windows, indices)
             }
             for job in concurrent.futures.as_completed(jobs):
@@ -280,9 +312,7 @@ class SegmentationModelWindowONNX:
                     :,
                     idx[0] : idx[0] + logits.shape[1],
                     idx[1] : idx[1] + logits.shape[2],
-                ] += (
-                    logits * w_matrix
-                )
+                ] += logits * w_matrix
                 count[
                     :,
                     :,
@@ -291,7 +321,6 @@ class SegmentationModelWindowONNX:
                 ] = w_matrix
         del w_matrix, executor, jobs, logits, idx
 
-        
         mask = np.argmax(container / count, axis=1).squeeze()  # 2d class map
         del container, count
         # crop image to remove padding
@@ -300,6 +329,7 @@ class SegmentationModelWindowONNX:
         if rgb:
             mask = decode_segmap_v2(mask)
         return mask
+
 
 class SegmentationModelWindowONNX_OLD:
     def __init__(self, checkpoint: str = None):
@@ -314,7 +344,13 @@ class SegmentationModelWindowONNX_OLD:
 
         # load inference session
         session = load_windowed_onnx_model(checkpoint)
-        self.session, self.input_name, self.window_shape, self.output_name, self.num_output_classes = session
+        (
+            self.session,
+            self.input_name,
+            self.window_shape,
+            self.output_name,
+            self.num_output_classes,
+        ) = session
 
     def pre_process(self, img: np.ndarray) -> np.ndarray:
         """Pre-process the image for inference, calculate window parameters"""
@@ -346,7 +382,9 @@ class SegmentationModelWindowONNX_OLD:
             img, (3, self.window_shape[0], self.window_shape[1]), step=stride
         ).squeeze()
 
-        logging.debug(f"pre_process: {img.shape}, {windows.shape}, {h}, {w}, {pad_h}, {pad_w}, {stride}")
+        logging.debug(
+            f"pre_process: {img.shape}, {windows.shape}, {h}, {w}, {pad_h}, {pad_w}, {stride}"
+        )
 
         return img, windows, h, w, pad_h, pad_w, stride
 
@@ -374,8 +412,7 @@ class SegmentationModelWindowONNX_OLD:
 
                 # add batch dimension to window
                 logits = self.session.run(
-                    [self.output_name], 
-                    {self.input_name: window[np.newaxis, ...]}
+                    [self.output_name], {self.input_name: window[np.newaxis, ...]}
                 )[0].squeeze()
                 del window
 
@@ -386,9 +423,9 @@ class SegmentationModelWindowONNX_OLD:
                 count[:, :, h_start:h_end, w_start:w_end] += 1
                 del h_start, w_start, h_end, w_end, logits
 
-        assert (
-            np.min(count) == 1
-        ), "There are pixels not predicted. Check window and stride size."
+        assert np.min(count) == 1, (
+            "There are pixels not predicted. Check window and stride size."
+        )
 
         # post-process
         # average the predictions across windows

--- a/fibsem/segmentation/utils.py
+++ b/fibsem/segmentation/utils.py
@@ -1,6 +1,3 @@
-
-
-
 import logging
 import os
 from pathlib import Path
@@ -14,7 +11,7 @@ import torch.nn.functional as F
 from huggingface_hub import HfApi, hf_hub_download, scan_cache_dir
 
 from fibsem import config as cfg
-from fibsem.segmentation.config import CLASS_COLORS, CLASS_COLORS_RGB, CLASS_LABELS
+from fibsem.segmentation.config import CLASS_COLORS, CLASS_LABELS
 
 
 # helper functions
@@ -26,7 +23,6 @@ def decode_output(output):
 
 
 def decode_segmap(image, nc=5):
-
     """
     Decode segmentation class mask into an RGB image mask
     ref: https://learnopencv.com/pytorch-for-beginners-semantic-segmentation-using-torchvision/
@@ -37,10 +33,10 @@ def decode_segmap(image, nc=5):
     label_colors[1, :] = (255, 0, 0)
     label_colors[2, :] = (0, 255, 0)
     label_colors[3, :] = (0, 255, 255)
-    label_colors[4, :] = (255, 255, 0)    
+    label_colors[4, :] = (255, 255, 0)
     label_colors[5, :] = (255, 0, 255)
     label_colors[6, :] = (0, 0, 255)
-    label_colors[7, :] = (128, 0, 0) # TODO: convert this to use CLASS_COLORS
+    label_colors[7, :] = (128, 0, 0)  # TODO: convert this to use CLASS_COLORS
 
     # pre-allocate r, g, b channels as zero
     r = np.zeros_like(image, dtype=np.uint8)
@@ -49,7 +45,7 @@ def decode_segmap(image, nc=5):
 
     # TODO: make this more efficient
     # apply the class label colours to each pixel
-    for class_idx in range(1, nc+1):
+    for class_idx in range(1, nc + 1):
         idx = image == class_idx
         # class_idx = class_idx % len(label_colors)
         r[idx] = label_colors[class_idx, 0]
@@ -59,7 +55,8 @@ def decode_segmap(image, nc=5):
     # stack rgb channels to form an image
     rgb_mask = np.stack([r, g, b], axis=-1).squeeze()
     return rgb_mask
-   
+
+
 def decode_segmap_v2(image, colormap: List[tuple] = None) -> np.ndarray:
     """
     Decode segmentation class mask into an RGB image mask
@@ -68,6 +65,7 @@ def decode_segmap_v2(image, colormap: List[tuple] = None) -> np.ndarray:
 
     if colormap is None:
         from fibsem.segmentation.config import CLASS_COLORS_RGB
+
         colormap = CLASS_COLORS_RGB
 
     # convert class masks to rgb values
@@ -79,6 +77,7 @@ def decode_segmap_v2(image, colormap: List[tuple] = None) -> np.ndarray:
 
     return rgb_mask
 
+
 def show_img_and_mask(imgs, gts, mask, title="Image, Ground Truth and Mask"):
     """Show a plot of the image, ground truth mask, and predicted mask"""
     n_imgs = len(imgs)
@@ -88,7 +87,6 @@ def show_img_and_mask(imgs, gts, mask, title="Image, Ground Truth and Mask"):
     fig.suptitle(title)
 
     for i in range(len(imgs)):
-
         img = imgs[i].permute(1, 2, 0).squeeze()
         gt = decode_segmap(gts[i].permute(1, 2, 0).squeeze())  # convert to rgb mask
 
@@ -109,7 +107,7 @@ def show_memory_usage():
     f = r - a  # free inside reserved
     if r == 0:
         r = 0.00001
-    print("GPU memory", t, r, a, f, f"{f/r:.3}")
+    print("GPU memory", t, r, a, f, f"{f / r:.3}")
 
 
 def show_values(ten):
@@ -118,15 +116,19 @@ def show_values(ten):
     print(ten.shape, ten.min(), ten.max(), ten.mean(), ten.std(), unq)
 
 
-def validate_config(config:dict):
+def validate_config(config: dict):
     if "data_paths" not in config:
-        raise ValueError("data_path is missing. Should point to path containing labelled images.")
+        raise ValueError(
+            "data_path is missing. Should point to path containing labelled images."
+        )
     else:
         for path in config["data_paths"]:
             if not os.path.exists(path):
                 raise ValueError(f"{path} directory does not exist. (data_path)")
     if "label_paths" not in config:
-        raise ValueError("label_path is missing. Should point to path containing labelled images.")
+        raise ValueError(
+            "label_path is missing. Should point to path containing labelled images."
+        )
     else:
         for path in config["label_paths"]:
             if not os.path.exists(path):
@@ -137,67 +139,87 @@ def validate_config(config:dict):
         path = config["save_path"]
         os.makedirs(path, exist_ok=True)
     if "wandb" not in config:
-        raise ValueError("wandb is missing. Used to enable/disable wandb logging in training loop. Should be a boolean value.")
+        raise ValueError(
+            "wandb is missing. Used to enable/disable wandb logging in training loop. Should be a boolean value."
+        )
     else:
         val = config["wandb"]
         if type(val) != bool:
             raise TypeError(f"{val} is not a boolean (True/False). (wandb)")
     if "checkpoint" not in config:
-        raise ValueError("checkpoint is missing. Either a path leading to the desired saved model, or None value.")
+        raise ValueError(
+            "checkpoint is missing. Either a path leading to the desired saved model, or None value."
+        )
     else:
         path = config["checkpoint"]
         if path is not None and not os.path.exists(path):
             raise ValueError(f"{path} directory does not exist. (checkpoint)")
     if "encoder" not in config:
-        raise ValueError("encoder is missing. Used to specify which model architecture to use. Default is resnet18.")
+        raise ValueError(
+            "encoder is missing. Used to specify which model architecture to use. Default is resnet18."
+        )
     else:
         val = config["encoder"]
         if type(val) != str:
             raise TypeError(f"{val} must be a string. (encoder)")
         elif val not in unet_encoders:
-            raise ValueError(f"{val} not a valid encoder. Check readme for full list. (encoder)")
+            raise ValueError(
+                f"{val} not a valid encoder. Check readme for full list. (encoder)"
+            )
     if "epochs" not in config:
-        raise ValueError("epochs is missing. Integer value used to determine number of epochs model trains for.")
+        raise ValueError(
+            "epochs is missing. Integer value used to determine number of epochs model trains for."
+        )
     else:
         val = config["epochs"]
         if type(val) != int or val <= 0:
-            raise TypeError(f"{val} is not a positive integer. (epochs)")  
+            raise TypeError(f"{val} is not a positive integer. (epochs)")
     if "batch_size" not in config:
-        raise ValueError("batch_size is missing. Integer value used to determine batch size of dataset.")
+        raise ValueError(
+            "batch_size is missing. Integer value used to determine batch size of dataset."
+        )
     else:
         val = config["batch_size"]
         if type(val) != int or val <= 0:
-            raise TypeError(f"{val} is not a positive integer. (batch_size)")    
+            raise TypeError(f"{val} is not a positive integer. (batch_size)")
     if "num_classes" not in config:
-        raise ValueError("num_classes is missing. Integer value used to determine number of classes model classifies.")
+        raise ValueError(
+            "num_classes is missing. Integer value used to determine number of classes model classifies."
+        )
     else:
         val = config["num_classes"]
         if type(val) != int or val <= 0:
-            raise TypeError(f"{val} is not a positive integer. (num_classes)")  
+            raise TypeError(f"{val} is not a positive integer. (num_classes)")
     if "lr" not in config:
-        raise ValueError("lr is missing. Float value indicating the learning rate of the model.")
+        raise ValueError(
+            "lr is missing. Float value indicating the learning rate of the model."
+        )
     else:
         val = config["lr"]
         if type(val) == float:
             if val <= 0:
                 raise ValueError(f"{val} must be a positive float value (lr).")
         else:
-            raise TypeError(f"{val} is not a float. (lr)")  
+            raise TypeError(f"{val} is not a float. (lr)")
     if "wandb_project" not in config:
-        raise ValueError("wandb_project is missing. String indicating the wandb project title for login.")
+        raise ValueError(
+            "wandb_project is missing. String indicating the wandb project title for login."
+        )
     else:
         val = config["wandb_project"]
         if type(val) != str:
             raise TypeError(f"{val} is not a string. (wandb_project)")
     if "wandb_entity" not in config:
-        raise ValueError("wandb_entity is missing. String indicating the wandb login credentials.")
+        raise ValueError(
+            "wandb_entity is missing. String indicating the wandb login credentials."
+        )
     else:
         val = config["wandb_entity"]
         if type(val) != str:
             raise TypeError(f"{val} is not a string. (wandb_project)")
     return
-    
-        
+
+
 # All UNet encoders that work with Imagenet weights
 unet_encoders = [
     "resnet18",
@@ -240,14 +262,19 @@ unet_encoders = [
     "efficientnet-b7",
     "mobilenet_v2",
     "efficientnet-b0",
-    "xception"
+    "xception",
 ]
-        
 
-def plot_segmentations(images: List[np.ndarray], masks: List[np.ndarray], 
-    alpha=0.5, legend: bool = True, show: bool = True) -> plt.Figure:
+
+def plot_segmentations(
+    images: List[np.ndarray],
+    masks: List[np.ndarray],
+    alpha=0.5,
+    legend: bool = True,
+    show: bool = True,
+) -> plt.Figure:
     """Plot the image and mask overlaid with a class legend."""
-    
+
     if not isinstance(images, list):
         images = [images]
     if not isinstance(masks, list):
@@ -255,12 +282,11 @@ def plot_segmentations(images: List[np.ndarray], masks: List[np.ndarray],
 
     if len(images) != len(masks):
         raise ValueError("images and masks must be the same length")
-    
-    n_cols = len(images)
-    fig, ax = plt.subplots(1, len(images), figsize=(10*n_cols/2, 10*n_cols/2))
-    for i, (image, mask) in enumerate(zip(images, masks)):
 
-        # convert to rgb mask        
+    n_cols = len(images)
+    fig, ax = plt.subplots(1, len(images), figsize=(10 * n_cols / 2, 10 * n_cols / 2))
+    for i, (image, mask) in enumerate(zip(images, masks)):
+        # convert to rgb mask
         rgb = decode_segmap_v2(mask)
 
         if len(images) == 1:
@@ -268,34 +294,42 @@ def plot_segmentations(images: List[np.ndarray], masks: List[np.ndarray],
         else:
             axes = ax[i]
         # plot
-        axes.imshow(image.data, cmap='gray')
+        axes.imshow(image.data, cmap="gray")
         axes.imshow(rgb, alpha=0.4)
 
         # filter legend to only include classes present in mask
         class_ids = np.unique(mask)
-        
+
         colors, labels = [], []
         for idx in class_ids:
             colors.append(CLASS_COLORS[idx])
             labels.append(CLASS_LABELS[idx])
 
         # Create a patch for each class color
-        patches = [mpatches.Patch(color=color, label=label) 
-                for color, label in zip(colors, labels)]
+        patches = [
+            mpatches.Patch(color=color, label=label)
+            for color, label in zip(colors, labels)
+        ]
 
         # Add the patches to the legend
         if legend:
-            axes.legend(handles=patches, loc="best", prop={'size': 6})
-    
+            axes.legend(handles=patches, loc="best", prop={"size": 6})
+
     if show:
         plt.show()
 
     return fig
 
+
 ## Huggingface Utils
 
+
 def list_available_checkpoints():
-    logging.warning(DeprecationWarning("list_available_checkpoints is deprecated. Please update to v2 to supported cached checkpoints..."))
+    logging.warning(
+        DeprecationWarning(
+            "list_available_checkpoints is deprecated. Please update to v2 to supported cached checkpoints..."
+        )
+    )
     api = HfApi()
     files = api.list_repo_files(cfg.HUGGINFACE_REPO)
     checkpoints = []
@@ -305,6 +339,7 @@ def list_available_checkpoints():
 
     return checkpoints
 
+
 def download_checkpoint(checkpoint: str):
     if os.path.exists(checkpoint):
         checkpoint = checkpoint
@@ -312,36 +347,44 @@ def download_checkpoint(checkpoint: str):
         checkpoint = hf_hub_download(repo_id=cfg.HUGGINFACE_REPO, filename=checkpoint)
     return checkpoint
 
+
 def list_available_checkpoints_v2():
     """List available model checkpoints from either Hugging Face API or local cache if offline."""
-    
+
     # try to use the API if we have internet access
     try:
         api = HfApi()
         files = api.list_repo_files(cfg.HUGGINFACE_REPO)
-        checkpoints = [file for file in files if file.endswith(".pt") and "archive" not in file]
+        checkpoints = [
+            file for file in files if file.endswith(".pt") and "archive" not in file
+        ]
         return checkpoints
     except Exception as e:
         # if api fails, fall back to local cache
         logging.warning(f"Couldn't connect to Hugging Face API: {e}")
         logging.debug("Searching local cache for available checkpoints...")
-        
+
         checkpoints = _get_cached_huggingface_checkpoints()
 
         if not checkpoints:
-            logging.warning("No cached checkpoints found. You might need to download models first when online.")
+            logging.warning(
+                "No cached checkpoints found. You might need to download models first when online."
+            )
 
         return checkpoints
-    
+
+
 def _get_cached_huggingface_checkpoints() -> List[str]:
     """Get cached huggingface model checkpoints"""
     # TODO: de-duplicate checkpoints from the cache
     checkpoints = []
 
-    # get cached repositories    
-    cache_dir = os.environ.get("HF_HUB_CACHE", os.path.expanduser("~/.cache/huggingface/hub"))
+    # get cached repositories
+    cache_dir = os.environ.get(
+        "HF_HUB_CACHE", os.path.expanduser("~/.cache/huggingface/hub")
+    )
     cached_repos = scan_cache_dir(cache_dir)
-    
+
     latest_revision_date = None
     latest_revision_hash = None
 
@@ -354,10 +397,9 @@ def _get_cached_huggingface_checkpoints() -> List[str]:
     if selected_repo is None:
         logging.warning(f"Cannot find repoistory {cfg.HUGGINFACE_REPO} in cache.")
         return checkpoints
-    
+
     # get info about each revision
     for revision in selected_repo.revisions:
-
         # get datetime of last modified
         revision_date = revision.last_modified
         if latest_revision_date is None:
@@ -365,7 +407,9 @@ def _get_cached_huggingface_checkpoints() -> List[str]:
             latest_revision_hash = revision.commit_hash
 
         if revision_date < latest_revision_date:
-            logging.debug(f"Skipping revision {revision.commit_hash} as it is older than the latest revision {latest_revision_hash}.")
+            logging.debug(
+                f"Skipping revision {revision.commit_hash} as it is older than the latest revision {latest_revision_hash}."
+            )
             continue
 
         snapshot_path = Path(revision.snapshot_path)
@@ -374,5 +418,5 @@ def _get_cached_huggingface_checkpoints() -> List[str]:
             if "archive" not in str(file_path):
                 # Get the basename of the file (e.g., "model.pt")
                 checkpoints.append(str(file_path))
-    
+
     return checkpoints


### PR DESCRIPTION
10 unused imports removed from this area, plus the reformat format-on-touch requires. Four files; the first half is a separate PR.

## Safety

Every removed name was checked against the whole repo, before and after the edit, for four ways an "unused" import can still be load-bearing:

| reachable how | at risk here |
|---|---|
| `from M import X` elsewhere | 0 |
| `import M` then `M.X` | 0 |
| `from pkg import mod` then `mod.X` | 0 |
| `from M import *` | 0 |

`ruff check --fix` alone is **not** safe on this codebase — it rates as `safe` a removal that breaks `scripts/test_installation.py`. Full rationale and the dangerous case are recorded on the closed #496; that one is in `fibsem/microscopes`, not in this slice.

Second commit is the reformat that format-on-touch requires. Nothing in it is worth reading line by line.
