### PR TITLE
[refactor] Remove unused imports from fm, and stop a test reaching through one

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -1,14 +1,11 @@
 import logging
-import math
 import os
 import threading
 import time
 from copy import deepcopy
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
-import matplotlib.patches as patches
-import matplotlib.pyplot as plt
 import numpy as np
 
 from fibsem import utils
@@ -31,9 +28,7 @@ from fibsem.fm.timing import (
     estimate_tileset_acquisition_time,
 )
 from fibsem.imaging.reduce import (
-    PREVIEW_MAX_DIMENSION,
     PreviewMosaic,
-    downsample,
 )
 from fibsem.imaging.tiling.geometry import (
     TilePosition,
@@ -46,6 +41,7 @@ from fibsem.structures import BeamType, FibsemStagePosition, TileOrderStrategy
 
 if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
+
 
 def acquire_channels(
     microscope: FluorescenceMicroscope,
@@ -62,13 +58,15 @@ def acquire_channels(
         # Same payload shape `acquire_z_stack` emits, minus the z fields. Without it a
         # multi-channel acquisition was silent, so anything watching progress within a
         # tile had nothing to show unless a z-stack happened to be enabled.
-        microscope.acquisition_progress_signal.emit({
-            "state": "acquiring",
-            "task": "channels",
-            "channel": channel.name,
-            "channel_index": i + 1,
-            "total_channels": len(channel_settings),
-        })
+        microscope.acquisition_progress_signal.emit(
+            {
+                "state": "acquiring",
+                "task": "channels",
+                "channel": channel.name,
+                "channel_index": i + 1,
+                "total_channels": len(channel_settings),
+            }
+        )
 
         # Check for cancellation before each channel
         if stop_event and stop_event.is_set():
@@ -106,24 +104,30 @@ def acquire_z_stack(
             z_level_images: List[List[FluorescenceImage]] = []
             for j, z in enumerate(z_positions):
                 if stop_event and stop_event.is_set():
-                    logging.info("Z-stack acquisition cancelled before z-level acquisition")
+                    logging.info(
+                        "Z-stack acquisition cancelled before z-level acquisition"
+                    )
                     microscope.objective.move_absolute(z_init)
                     return None
 
                 microscope.objective.move_absolute(z)
                 ch_images: List[FluorescenceImage] = []
                 for i, ch in enumerate(channel_settings):
-                    microscope.acquisition_progress_signal.emit({
-                        "state": "acquiring",
-                        "task": "z-stack",
-                        "channel": ch.name,
-                        "channel_index": i + 1,
-                        "total_channels": len(channel_settings),
-                        "zlevel": j + 1,
-                        "total_zlevels": len(z_positions),
-                    })
+                    microscope.acquisition_progress_signal.emit(
+                        {
+                            "state": "acquiring",
+                            "task": "z-stack",
+                            "channel": ch.name,
+                            "channel_index": i + 1,
+                            "total_channels": len(channel_settings),
+                            "zlevel": j + 1,
+                            "total_zlevels": len(z_positions),
+                        }
+                    )
                     if stop_event and stop_event.is_set():
-                        logging.info("Z-stack acquisition cancelled during z-level acquisition")
+                        logging.info(
+                            "Z-stack acquisition cancelled during z-level acquisition"
+                        )
                         microscope.objective.move_absolute(z_init)
                         return None
                     ch_images.append(microscope.acquire_image(channel_settings=ch))
@@ -137,21 +141,25 @@ def acquire_z_stack(
             # Channel-wise (default): for each channel, acquire all z-planes
             for i, ch in enumerate(channel_settings):
                 if stop_event and stop_event.is_set():
-                    logging.info("Z-stack acquisition cancelled before channel acquisition")
+                    logging.info(
+                        "Z-stack acquisition cancelled before channel acquisition"
+                    )
                     microscope.objective.move_absolute(z_init)
                     return None
 
                 ch_images = []
                 for j, z in enumerate(z_positions):
-                    microscope.acquisition_progress_signal.emit({
-                        "state": "acquiring",
-                        "task": "z-stack",
-                        "channel": ch.name,
-                        "channel_index": i + 1,
-                        "total_channels": len(channel_settings),
-                        "zlevel": j + 1,
-                        "total_zlevels": len(z_positions),
-                    })
+                    microscope.acquisition_progress_signal.emit(
+                        {
+                            "state": "acquiring",
+                            "task": "z-stack",
+                            "channel": ch.name,
+                            "channel_index": i + 1,
+                            "total_channels": len(channel_settings),
+                            "zlevel": j + 1,
+                            "total_zlevels": len(z_positions),
+                        }
+                    )
                     if stop_event and stop_event.is_set():
                         logging.info("Z-stack acquisition cancelled during z-stack")
                         microscope.objective.move_absolute(z_init)
@@ -189,7 +197,9 @@ def acquire_image(
         raise ValueError("Microscope parent is not set. Cannot start acquisition.")
 
     if not microscope.has_valid_orientation():
-        raise ValueError(f"Stage is not in valid orientation ({microscope.parent.get_stage_orientation()!r}). Cannot start acquisition.")
+        raise ValueError(
+            f"Stage is not in valid orientation ({microscope.parent.get_stage_orientation()!r}). Cannot start acquisition."
+        )
 
     if zparams is not None:
         # Acquire Z-stack if zparams is provided
@@ -214,8 +224,9 @@ def acquire_image(
 
     return image
 
+
 def acquire_at_positions(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     positions: List[FMStagePosition],
     channel_settings: Union[ChannelSettings, List[ChannelSettings]],
     zparams: Optional[ZParameters] = None,
@@ -254,7 +265,9 @@ def acquire_at_positions(
             "Fluorescence microscope not initialized in the FibsemMicroscope instance"
         )
     if not microscope.fm.has_valid_orientation():
-        raise ValueError(f"Stage is not in valid orientation ({microscope.get_stage_orientation()!r}). Cannot start acquisition.")
+        raise ValueError(
+            f"Stage is not in valid orientation ({microscope.get_stage_orientation()!r}). Cannot start acquisition."
+        )
 
     if not positions:
         raise ValueError("Positions list cannot be empty")
@@ -269,17 +282,20 @@ def acquire_at_positions(
     acquisition_start_time = time.time()
 
     # Emit initial acquisition progress signal
-    microscope.fm.acquisition_progress_signal.emit({"state": "acquiring", 
-                                                    "task": "multi-position",
-                                                    "position": "null",
-                                                    "current": 1,
-                                                    "total": len(positions),
-                                                    "estimated_total_time": total_estimated_time,
-                                                    "estimated_remaining_time": total_estimated_time,})
+    microscope.fm.acquisition_progress_signal.emit(
+        {
+            "state": "acquiring",
+            "task": "multi-position",
+            "position": "null",
+            "current": 1,
+            "total": len(positions),
+            "estimated_total_time": total_estimated_time,
+            "estimated_remaining_time": total_estimated_time,
+        }
+    )
 
     images: List[FluorescenceImage] = []
     for i, fm_pos in enumerate(positions):
-
         # Check for cancellation before each position
         if stop_event and stop_event.is_set():
             logging.info("Multi-position acquisition cancelled")
@@ -291,26 +307,35 @@ def acquire_at_positions(
         current_position = i + 1
         total_positions = len(positions)
         # Emit progress signal before starting position acquisition
-        microscope.fm.acquisition_progress_signal.emit({"state": "acquiring", 
-                                                        "task": "multi-position",
-                                                       "position": fm_pos.name,
-                                                       "current": current_position,
-                                                       "total": total_positions,
-                                                    #    "estimated_total_time": total_estimated_time,
-                                                    #    "estimated_remaining_time": estimated_remaining_time,
-                                                    #    "elapsed_time": elapsed_time,
-                                                       })
+        microscope.fm.acquisition_progress_signal.emit(
+            {
+                "state": "acquiring",
+                "task": "multi-position",
+                "position": fm_pos.name,
+                "current": current_position,
+                "total": total_positions,
+                #    "estimated_total_time": total_estimated_time,
+                #    "estimated_remaining_time": estimated_remaining_time,
+                #    "elapsed_time": elapsed_time,
+            }
+        )
 
         # Move stage to the saved stage position and objective position
         if microscope.get_stage_orientation(fm_pos.stage_position) not in ["SEM", "FM"]:
-            raise ValueError(f"Stage Position {fm_pos.name} is not in valid orientation: {fm_pos.stage_position}")
-        microscope.fm.acquisition_progress_signal.emit({"state": "moving", "task": "multi-position"})
+            raise ValueError(
+                f"Stage Position {fm_pos.name} is not in valid orientation: {fm_pos.stage_position}"
+            )
+        microscope.fm.acquisition_progress_signal.emit(
+            {"state": "moving", "task": "multi-position"}
+        )
         microscope.safe_absolute_stage_movement(fm_pos.stage_position)
         microscope.fm.objective.move_absolute(fm_pos.objective_position)
 
         # Run autofocus if requested
         if use_autofocus:
-            result = run_autofocus(microscope.fm, channel_settings[0], stop_event=stop_event)
+            result = run_autofocus(
+                microscope.fm, channel_settings[0], stop_event=stop_event
+            )
             if result is None:
                 logging.info("Multi-position acquisition cancelled during autofocus")
                 return images
@@ -329,15 +354,19 @@ def acquire_at_positions(
             filename = os.path.join(position_dir, basename)
 
         # Acquire image
-        image = acquire_image(microscope=microscope.fm,
-                              channel_settings=channel_settings,
-                              zparams=zparams,
-                              stop_event=stop_event,
-                              filename=filename)
+        image = acquire_image(
+            microscope=microscope.fm,
+            channel_settings=channel_settings,
+            zparams=zparams,
+            stop_event=stop_event,
+            filename=filename,
+        )
 
         # Check if acquisition was cancelled
         if image is None:
-            logging.info("Multi-position acquisition cancelled during image acquisition")
+            logging.info(
+                "Multi-position acquisition cancelled during image acquisition"
+            )
             return images
 
         image.metadata.description = f"{fm_pos.name}-{image.metadata.acquisition_date}"
@@ -347,25 +376,32 @@ def acquire_at_positions(
         elapsed_time = time.time() - acquisition_start_time
         if current_position > 1:
             time_per_position = elapsed_time / (current_position - 1)
-            estimated_remaining_time = time_per_position * (total_positions - current_position)
+            estimated_remaining_time = time_per_position * (
+                total_positions - current_position
+            )
         else:
             estimated_remaining_time = total_estimated_time
 
-        microscope.fm.acquisition_progress_signal.emit({"state": "acquiring", 
-                                                        "task": "multi-position",
-                                                       "position": fm_pos.name,
-                                                       "current": current_position,
-                                                       "total": total_positions,
-                                                       "estimated_total_time": total_estimated_time,
-                                                       "estimated_remaining_time": estimated_remaining_time,
-                                                       "elapsed_time": elapsed_time,})
+        microscope.fm.acquisition_progress_signal.emit(
+            {
+                "state": "acquiring",
+                "task": "multi-position",
+                "position": fm_pos.name,
+                "current": current_position,
+                "total": total_positions,
+                "estimated_total_time": total_estimated_time,
+                "estimated_remaining_time": estimated_remaining_time,
+                "elapsed_time": elapsed_time,
+            }
+        )
 
     microscope.fm.acquisition_progress_signal.emit({"state": "finished"})
 
     return images
 
+
 def run_tileset_autofocus(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     channel_settings: Optional[ChannelSettings],
     autofocus_settings: AutoFocusSettings,
     stop_event: Optional[threading.Event] = None,
@@ -406,8 +442,6 @@ def run_tileset_autofocus(
     except Exception as e:
         logging.warning(f"Auto-focus failed: {e}")
         return False
-
-
 
 
 def _to_channel_planes(data: np.ndarray, n_channels: int) -> np.ndarray:
@@ -531,7 +565,7 @@ class FMTiledAcquisitionRunner:
 
     def __init__(
         self,
-        microscope: 'FibsemMicroscope',
+        microscope: "FibsemMicroscope",
         channel_settings: Union[ChannelSettings, List[ChannelSettings]],
         overview_parameters: OverviewParameters,
         zparams: Optional[ZParameters] = None,
@@ -666,10 +700,14 @@ class FMTiledAcquisitionRunner:
         # A spiral revisits rows non-sequentially, so "autofocus on each new row" would
         # fire almost every tile and still leave stale focus in between. Promote it, as
         # the beam runner does.
-        if (self._autofocus_mode is AutoFocusMode.EACH_ROW
-                and self._tile_order is TileOrderStrategy.SPIRAL):
+        if (
+            self._autofocus_mode is AutoFocusMode.EACH_ROW
+            and self._tile_order is TileOrderStrategy.SPIRAL
+        ):
             self._autofocus_mode = AutoFocusMode.EACH_TILE
-            logging.info("EACH_ROW autofocus upgraded to EACH_TILE for SPIRAL tile order")
+            logging.info(
+                "EACH_ROW autofocus upgraded to EACH_TILE for SPIRAL tile order"
+            )
 
         # Full grid, holes included: the canvas is the whole grid whatever the mask.
         self.tileset = [[None] * self._cols for _ in range(self._rows)]
@@ -709,8 +747,11 @@ class FMTiledAcquisitionRunner:
         self._setup_autofocus()
 
         time_estimates = estimate_tileset_acquisition_time(
-            self.channel_settings, (self._rows, self._cols), self.zparams,
-            self._autofocus_mode, tile_mask=self._tile_mask,
+            self.channel_settings,
+            (self._rows, self._cols),
+            self.zparams,
+            self._autofocus_mode,
+            tile_mask=self._tile_mask,
         )
         self._total_estimated_time = time_estimates["total_time"]
         self._acquisition_start_time = time.time()
@@ -894,12 +935,16 @@ class FMTiledAcquisitionRunner:
         #
         # `total` counts tiles that will actually be acquired, not grid cells -- a
         # progress bar that stops at 9/25 on a successful sparse run reads as a failure.
-        self._emit({
-            "state": "acquiring", "task": "tileset",
-            "counter": 0, "total": len(self._ordered),
-            "estimated_total_time": self._total_estimated_time,
-            "estimated_remaining_time": self._total_estimated_time,
-        })
+        self._emit(
+            {
+                "state": "acquiring",
+                "task": "tileset",
+                "counter": 0,
+                "total": len(self._ordered),
+                "estimated_total_time": self._total_estimated_time,
+                "estimated_remaining_time": self._total_estimated_time,
+            }
+        )
 
     def _init_preview_canvas(self) -> None:
         """Allocate the live mosaic that tiles are painted into as they arrive.
@@ -937,7 +982,9 @@ class FMTiledAcquisitionRunner:
                 data = data[: self._preview.canvas.shape[0]]
             self._preview.paint(data, tile.canvas_x, tile.canvas_y)
         except Exception as e:  # pragma: no cover - preview is never load-bearing
-            logging.debug(f"Could not paint tile ({tile.row}, {tile.col}) into preview: {e}")
+            logging.debug(
+                f"Could not paint tile ({tile.row}, {tile.col}) into preview: {e}"
+            )
 
     def _autofocus_if_mode(self, mode: AutoFocusMode) -> None:
         """Run autofocus when the configured mode matches.
@@ -983,7 +1030,9 @@ class FMTiledAcquisitionRunner:
         self._n_acquired = 0
         for tile in self._ordered:
             # Check before moving, so a cancel skips the travel entirely.
-            raise_if_cancelled(self.stop_event, "Tileset acquisition cancelled by user.")
+            raise_if_cancelled(
+                self.stop_event, "Tileset acquisition cancelled by user."
+            )
 
             if tile.row != prev_row:
                 prev_row = tile.row
@@ -1059,7 +1108,8 @@ class FMTiledAcquisitionRunner:
             "zparameters": self.zparams.to_dict() if self.zparams is not None else None,
             "autofocus_settings": (
                 self.autofocus_settings.to_dict()
-                if self.autofocus_settings is not None else None
+                if self.autofocus_settings is not None
+                else None
             ),
             "channel_settings": [ch.to_dict() for ch in self.channel_settings],
         }
@@ -1114,26 +1164,32 @@ class FMTiledAcquisitionRunner:
         copy does not show.
         """
         estimated_total, estimated_remaining, elapsed = self._time_estimate()
-        self._emit({
-            "state": "tile", "task": "tileset",
-            "row": tile.row, "col": tile.col,
-            "total_rows": self._rows, "total_cols": self._cols,
-            # **Tiles completed**, which is what `counter` means on this signal -- the
-            # beam tiler increments and then emits, so its count has always meant this.
-            # The fluorescence side used to say it twice per tile with two meanings: the
-            # tile *starting* before the acquisition and the tally after. One key cannot
-            # be both, and a consumer choosing between them got a bar that changed scale
-            # at every boundary (FIB-736, FIB-739).
-            "counter": self._n_acquired, "total": len(self._ordered),
-            # The estimate rides with the count rather than with the announcement below,
-            # so one payload carries the whole picture and a consumer never has to
-            # assemble progress from two.
-            "estimated_total_time": estimated_total,
-            "estimated_remaining_time": estimated_remaining,
-            "elapsed_time": elapsed,
-            "image": self._preview.canvas.copy(),
-            "preview_stride": self._preview.stride,
-        })
+        self._emit(
+            {
+                "state": "tile",
+                "task": "tileset",
+                "row": tile.row,
+                "col": tile.col,
+                "total_rows": self._rows,
+                "total_cols": self._cols,
+                # **Tiles completed**, which is what `counter` means on this signal -- the
+                # beam tiler increments and then emits, so its count has always meant this.
+                # The fluorescence side used to say it twice per tile with two meanings: the
+                # tile *starting* before the acquisition and the tally after. One key cannot
+                # be both, and a consumer choosing between them got a bar that changed scale
+                # at every boundary (FIB-736, FIB-739).
+                "counter": self._n_acquired,
+                "total": len(self._ordered),
+                # The estimate rides with the count rather than with the announcement below,
+                # so one payload carries the whole picture and a consumer never has to
+                # assemble progress from two.
+                "estimated_total_time": estimated_total,
+                "estimated_remaining_time": estimated_remaining,
+                "elapsed_time": elapsed,
+                "image": self._preview.canvas.copy(),
+                "preview_stride": self._preview.stride,
+            }
+        )
 
     def _time_estimate(self):
         """`(total, remaining, elapsed)` for the run, from what it has done so far.
@@ -1165,15 +1221,20 @@ class FMTiledAcquisitionRunner:
         "Moving stage…" label the previous payload put up. The progress arrives after
         the tile, with the preview.
         """
-        self._emit({
-            "state": "acquiring", "task": "tileset",
-            "row": row + 1, "col": col + 1,
-            "total_rows": self._rows, "total_cols": self._cols,
-        })
+        self._emit(
+            {
+                "state": "acquiring",
+                "task": "tileset",
+                "row": row + 1,
+                "col": col + 1,
+                "total_rows": self._rows,
+                "total_cols": self._cols,
+            }
+        )
 
 
 def acquire_tileset(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     channel_settings: Union[ChannelSettings, List[ChannelSettings]],
     overview_parameters: OverviewParameters,
     zparams: Optional[ZParameters] = None,
@@ -1323,7 +1384,9 @@ def stitch_tileset(
     mosaic_width = effective_tile_width * (cols - 1) + tile_width
     mosaic_height = effective_tile_height * (rows - 1) + tile_height
 
-    logging.info(f"Tile size: {tile_height}x{tile_width}, Mosaic size: {mosaic_height}x{mosaic_width}")
+    logging.info(
+        f"Tile size: {tile_height}x{tile_width}, Mosaic size: {mosaic_height}x{mosaic_width}"
+    )
     logging.info(f"Channels: {nc_channels}, Z-planes: {nz_planes}")
 
     # Initialize mosaic array with proper dimensions (C, Z, Y, X)
@@ -1400,8 +1463,9 @@ def stitch_tileset(
     logging.info(f"Stitching complete: {mosaic_height}x{mosaic_width} mosaic created")
     return stitched_image
 
+
 def acquire_and_stitch_tileset(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     channel_settings: Union[ChannelSettings, List[ChannelSettings]],
     overview_parameters: OverviewParameters,
     zparams: Optional[ZParameters] = None,
@@ -1435,14 +1499,17 @@ def acquire_and_stitch_tileset(
         channel_settings = [channel_settings]
 
     destination = (
-        OverviewDestination.create(save_directory) if save_directory is not None else None
+        OverviewDestination.create(save_directory)
+        if save_directory is not None
+        else None
     )
     tiles_directory = destination.tiles_directory if destination is not None else None
 
-
     # Check if zparams is provided when z-stack is requested
     if zparams is None and overview_parameters.use_zstack:
-        raise ValueError("Z-stack requested in overview parameters but no zparams provided")
+        raise ValueError(
+            "Z-stack requested in overview parameters but no zparams provided"
+        )
 
     # acquire the tileset
     # A cancel is now signalled explicitly rather than inferred from the result. The
@@ -1473,7 +1540,7 @@ def acquire_and_stitch_tileset(
 
 
 def acquire_multiple_overviews(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     positions: List[FMStagePosition],
     channel_settings: Union[ChannelSettings, List[ChannelSettings]],
     overview_parameters: OverviewParameters,
@@ -1516,7 +1583,7 @@ def acquire_multiple_overviews(
         >>> pos2 = FMStagePosition(name="Region2", stage_position=stage_pos2, objective_position=0.013)
         >>> positions = [pos1, pos2]
         >>>
-        >>> # Define channel settings and overview parameters  
+        >>> # Define channel settings and overview parameters
         >>> channel = ChannelSettings(name="DAPI", excitation_wavelength=365,
         ...                          emission_wavelength=450, power=50, exposure_time=0.1)
         >>> overview_params = OverviewParameters(rows=3, cols=3, overlap=0.1)
@@ -1611,7 +1678,7 @@ def acquire_multiple_overviews(
 
 
 def convert_grid_positions_to_stage_positions(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     positions: List[Tuple[float, float]],
     beam_type: BeamType = BeamType.ELECTRON,
     base_position: Optional[FibsemStagePosition] = None,

--- a/fibsem/fm/autoscript.py
+++ b/fibsem/fm/autoscript.py
@@ -1,7 +1,7 @@
 import logging
 import threading
 from contextlib import contextmanager
-from typing import Any, Dict, Literal, Optional, Tuple, Union
+from typing import Literal, Optional, Tuple, Union
 
 import numpy as np
 from autoscript_sdb_microscope_client.enumerations import (
@@ -9,10 +9,8 @@ from autoscript_sdb_microscope_client.enumerations import (
     CameraFilterType,
     ImagingDevice,
     ImagingState,
-    RetractableDeviceState,
 )
 from autoscript_sdb_microscope_client.structures import (
-    GetImageSettings,
     GrabFrameSettings,
 )
 
@@ -66,7 +64,7 @@ ARCTIS_LWD_CONFIGURATION = {
     "magnification": 50.0,
     "numerical_aperture": 0.75,
     "working_distance": 4e-3,
-    "pixel_size": (2.74822695035461e-08*2, 2.74822695035461e-08*2),
+    "pixel_size": (2.74822695035461e-08 * 2, 2.74822695035461e-08 * 2),
     "resolution": (4512, 4512),
     "focus_position": 7.6e-3,  # 7600 microns
     "limit_position": 8.6e-3,  # 8600 microns
@@ -106,7 +104,9 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
         self._numerical_aperture = DEFAULT_CONFIGURATION["numerical_aperture"]
         self._working_distance = DEFAULT_CONFIGURATION["working_distance"]
         self._focus_position = DEFAULT_CONFIGURATION["focus_position"]
-        self._limit_position: float = DEFAULT_CONFIGURATION.get("limit_position", 8.6e-3)
+        self._limit_position: float = DEFAULT_CONFIGURATION.get(
+            "limit_position", 8.6e-3
+        )
 
     @property
     def magnification(self) -> float:
@@ -171,7 +171,9 @@ class ThermoFisherObjectiveLens(ObjectiveLens):
 
         # clip to user-defined limits
         if not position <= self._limit_position:
-            logging.warning(f"Clipping position {position} to user-defined limits {self._limit_position}")
+            logging.warning(
+                f"Clipping position {position} to user-defined limits {self._limit_position}"
+            )
             position = np.clip(position, 0, self._limit_position)
         with self.parent.active_channel():
             self.parent.fm_settings.focus.value = position
@@ -297,8 +299,8 @@ class ThermoFisherCamera(Camera):
                     self.parent.set_active_channel()  # re-force active channel...?
                     image = self.parent.connection.imaging.get_image()
                     # if image.data.shape != self.resolution: # if shape doesn't match expected resolution, skip (likely acquired wrong channel)
-                        # logging.warning(f"Acquired image shape {image.shape} does not match expected resolution {self.resolution}")
-                        # continue
+                    # logging.warning(f"Acquired image shape {image.shape} does not match expected resolution {self.resolution}")
+                    # continue
                     self.parent._construct_image(image.data)
 
         except Exception as e:
@@ -410,7 +412,7 @@ class ThermoFisherCamera(Camera):
         """
         with self.parent.active_channel():
             return self.parent.connection.detector.contrast.value
-    
+
     @gain.setter
     def gain(self, value: float) -> None:
         """Set the gain of the camera.
@@ -619,7 +621,9 @@ class ThermoFisherFilterSet(FilterSet):
             if value is None:
                 self.parent.fm_settings.filter.type.value = CameraFilterType.REFLECTION
             else:
-                self.parent.fm_settings.filter.type.value = CameraFilterType.FLUORESCENCE
+                self.parent.fm_settings.filter.type.value = (
+                    CameraFilterType.FLUORESCENCE
+                )
 
 
 class ThermoFisherFluorescenceMicroscope(FluorescenceMicroscope):

--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime
 from enum import Enum
-from typing import Any, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import tifffile as tff
@@ -71,8 +71,9 @@ from fibsem.structures import (  # noqa: F401
 
 class ZStackOrder(Enum):
     """Acquisition order for z-stack."""
-    CHANNEL = "channel"   # default: for each channel, acquire all z-planes
-    Z_LEVEL = "z_level"   # for each z-plane, acquire all channels
+
+    CHANNEL = "channel"  # default: for each channel, acquire all z-planes
+    Z_LEVEL = "z_level"  # for each z-plane, acquire all channels
 
 
 BINNING_MAP = {
@@ -89,11 +90,15 @@ _UNIT_TO_METERS = {
     UnitsLength.METER: 1.0,
 }
 
-def _convert_length_to_meters(value: Optional[float], unit: Optional[UnitsLength]) -> Optional[float]:
+
+def _convert_length_to_meters(
+    value: Optional[float], unit: Optional[UnitsLength]
+) -> Optional[float]:
     """Convert an OME length value to meters if both value and unit are present."""
     if value is None:
         return None
     return value * _UNIT_TO_METERS.get(unit, 1.0)
+
 
 def _color_to_hex(color: Optional[Color]) -> str:
     """Convert OME Color to a hex string understood by the FM viewer."""
@@ -104,6 +109,7 @@ def _color_to_hex(color: Optional[Color]) -> str:
         return f"#{r:02X}{g:02X}{b:02X}"
     except Exception:
         return "gray"
+
 
 def safe_ome_from_tiff(filename: str) -> OMEMetadata:
     """Parse OME metadata from TIFF file, handling potential known issues with the OME XML.
@@ -128,6 +134,7 @@ def safe_ome_from_tiff(filename: str) -> OMEMetadata:
         ome_xml = re.sub(r"<Filter\b[^>]*/>", "", ome_xml)
         ome = from_xml(ome_xml)
     return ome
+
 
 @dataclass
 class FMStagePosition:
@@ -218,7 +225,7 @@ class ChannelSettings:
     name: str = "Channel-01"
     excitation_wavelength: float = 550  # nm
     emission_wavelength: Optional[Union[str, float]] = None  # nm
-    power: float = 0.01 # %
+    power: float = 0.01  # %
     exposure_time: float = 0.001  # seconds
     color: str = "gray"
     gain: float = 0.0
@@ -237,9 +244,13 @@ class ChannelSettings:
         if self.emission_wavelength is None:
             emission_str = "Reflection"
         else:
-            emission_str = f"{self.emission_wavelength}nm" if isinstance(self.emission_wavelength, float) else self.emission_wavelength
+            emission_str = (
+                f"{self.emission_wavelength}nm"
+                if isinstance(self.emission_wavelength, float)
+                else self.emission_wavelength
+            )
 
-        return f"{self.name} ({self.excitation_wavelength:.0f}nm → {emission_str}) P:{self.power*100:.1f}%, EXP:{self.exposure_time * 1000:.1f}ms"
+        return f"{self.name} ({self.excitation_wavelength:.0f}nm → {emission_str}) P:{self.power * 100:.1f}%, EXP:{self.exposure_time * 1000:.1f}ms"
 
     @property
     def pretty(self) -> str:
@@ -285,7 +296,7 @@ class ZParameters:
         z_positions = np.arange(
             start=z_init + self.zmin,
             stop=z_init + self.zmax + self.zstep * 0.5,
-            step=self.zstep
+            step=self.zstep,
         )
 
         return z_positions.tolist()
@@ -314,7 +325,9 @@ class ZParameters:
         if num_planes <= 1:
             return "Z-Stack: Single plane acquisition"
 
-        order_str = "channel-wise" if self.order == ZStackOrder.CHANNEL else "z-level-wise"
+        order_str = (
+            "channel-wise" if self.order == ZStackOrder.CHANNEL else "z-level-wise"
+        )
         return f"Z-Stack: {num_planes} planes ({self.zmin * 1e6:.1f}μm to {self.zmax * 1e6:.1f}μm, step {self.zstep * 1e6:.1f}μm, {order_str})"
 
 
@@ -1142,7 +1155,9 @@ class FluorescenceImage:
             pixel_size_y=pixel_size,
             resolution=resolution,
             channels=channels,
-            z_positions=[i * pixel_size for i in range(zlevels)] if zlevels > 1 else None,
+            z_positions=[i * pixel_size for i in range(zlevels)]
+            if zlevels > 1
+            else None,
         )
 
         return FluorescenceImage(data=data, metadata=metadata)
@@ -1387,9 +1402,9 @@ class FluorescenceImageMetadata:
                 else None
             ),
         )
-    
+
     @classmethod
-    def from_ome(cls, ome: OMEMetadata) -> 'FluorescenceImageMetadata':
+    def from_ome(cls, ome: OMEMetadata) -> "FluorescenceImageMetadata":
         """Convert OME metadata to FluorescenceImageMetadata with availability checks.
 
         For importing images from **external software**. `load` prefers the
@@ -1411,10 +1426,11 @@ class FluorescenceImageMetadata:
 
         if pixels_md is None:
             raise ValueError("OME metadata contains no pixel information")
-        
+
         # Pixel sizes (convert to meters where possible)
         pixel_size_x = _convert_length_to_meters(
-            pixels_md.physical_size_x, pixels_md.physical_size_x_unit)
+            pixels_md.physical_size_x, pixels_md.physical_size_x_unit
+        )
         pixel_size_y = _convert_length_to_meters(
             pixels_md.physical_size_y, pixels_md.physical_size_y_unit
         )
@@ -1465,9 +1481,7 @@ class FluorescenceImageMetadata:
             )
 
         # Use z positions only if we have at least two valid entries
-        valid_z_positions = (
-            z_positions if len(z_positions) >= 2 else None
-        )
+        valid_z_positions = z_positions if len(z_positions) >= 2 else None
 
         # Build channel metadata with fallbacks
         channels_md: List[FluorescenceChannelMetadata] = []
@@ -1584,7 +1598,8 @@ class OverviewParameters:
             "tile_order": self.tile_order.value,
             "objective_start": self.objective_start.value,
             # plain bools: np.bool_ does not survive yaml.safe_dump
-            "tile_mask": None if self.tile_mask is None
+            "tile_mask": None
+            if self.tile_mask is None
             else [[bool(v) for v in row] for row in self.tile_mask],
         }
 
@@ -1597,11 +1612,15 @@ class OverviewParameters:
             cols=ddict.get("cols", 3),
             overlap=ddict.get("overlap", 0.1),
             use_zstack=ddict.get("use_zstack", False),
-            autofocus_mode=AutoFocusMode(ddict.get("autofocus_mode", AutoFocusMode.NONE.value)),
+            autofocus_mode=AutoFocusMode(
+                ddict.get("autofocus_mode", AutoFocusMode.NONE.value)
+            ),
             tile_order=TileOrderStrategy(
                 ddict.get("tile_order", TileOrderStrategy.TYPEWRITER.value)
             ),
-            tile_mask=None if mask is None else [[bool(v) for v in row] for row in mask],
+            tile_mask=None
+            if mask is None
+            else [[bool(v) for v in row] for row in mask],
             # Defaulted, not required: every overview saved before this existed started
             # from wherever the objective was, so that is what its parameters mean.
             objective_start=ObjectiveStartPosition(
@@ -1620,7 +1639,8 @@ class OverviewParameters:
 @dataclass
 class CameraSettings:
     """Camera settings for fluorescence microscopy acquisition."""
-    gain: float = 0.01 # 1%
+
+    gain: float = 0.01  # 1%
     offset: float = 0.0
     binning: int = 1
     transform: CameraImageTransform = CameraImageTransform.NONE
@@ -1682,9 +1702,7 @@ class FluorescenceConfiguration:
                 ddict["autofocus_settings"]
             )
         if ddict.get("camera_settings"):
-            camera_settings = CameraSettings.from_dict(
-                ddict["camera_settings"]
-            )
+            camera_settings = CameraSettings.from_dict(ddict["camera_settings"])
         else:
             camera_settings = CameraSettings()
 
@@ -1722,9 +1740,7 @@ class FluorescenceConfiguration:
         # Write to YAML file
         with open(filename, "w") as f:
             yaml.dump(
-                config_dict, f, 
-                default_flow_style=False, 
-                indent=4, sort_keys=False
+                config_dict, f, default_flow_style=False, indent=4, sort_keys=False
             )
 
         logging.info(f"FM configuration exported to: {filename}")

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -32,6 +32,7 @@ from fibsem.fm.structures import (
     ZParameters,
     ZStackOrder,
 )
+from fibsem.imaging.reduce import PREVIEW_MAX_DIMENSION
 from fibsem.structures import FibsemStagePosition, TileOrderStrategy
 
 
@@ -41,6 +42,7 @@ def demo_microscope():
     microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
     return microscope
 
+
 @pytest.fixture
 def fm_microscope(demo_microscope):
     """Fixture providing a demo microscope configured for FM operations."""
@@ -49,6 +51,7 @@ def fm_microscope(demo_microscope):
     microscope.stage_is_compustage = True
     microscope.move_to_microscope("FM")
     return microscope
+
 
 def _lattice(ncols, nrows, fov_x, fov_y, overlap):
     """A grid of (x, y) positions, the shape the `calculate_grid_*` helpers consume.
@@ -93,6 +96,7 @@ def test_calculate_grid_overlap():
 
     assert overlap_x == 0.0
     assert overlap_y == 0.0
+
 
 def test_calculate_grid_dimensions():
     """Test grid dimension calculation from positions."""
@@ -144,6 +148,7 @@ def test_calculate_grid_dimensions():
 
     assert ncols == 4
     assert nrows == 3
+
 
 def test_calculate_grid_coverage_area():
     """Test calculation of total area covered by a grid."""
@@ -206,6 +211,7 @@ def test_calculate_grid_coverage_area():
     assert width == 12.0
     assert height == 11.0
 
+
 # Tests for acquire_at_positions function
 def test_acquire_at_positions_single_position(fm_microscope):
     """Test acquire_at_positions with a single position using demo microscope."""
@@ -214,9 +220,7 @@ def test_acquire_at_positions_single_position(fm_microscope):
     # Create test position
     stage_pos = FibsemStagePosition(x=0.001, y=0.002, z=0.003, r=0, t=np.radians(-180))
     fm_position = FMStagePosition(
-        name="test_pos_1",
-        stage_position=stage_pos,
-        objective_position=0.012
+        name="test_pos_1", stage_position=stage_pos, objective_position=0.012
     )
 
     # Create test channel settings
@@ -225,19 +229,18 @@ def test_acquire_at_positions_single_position(fm_microscope):
         excitation_wavelength=358,
         emission_wavelength=461,
         power=0.1,
-        exposure_time=0.5
+        exposure_time=0.5,
     )
 
     # Call function
     result = acquire_at_positions(
-        microscope=microscope,
-        positions=[fm_position],
-        channel_settings=channel
+        microscope=microscope, positions=[fm_position], channel_settings=channel
     )
 
     # Verify result
     assert len(result) == 1
     assert isinstance(result[0], FluorescenceImage)
+
 
 def test_acquire_at_positions_multiple_positions(fm_microscope):
     """Test acquire_at_positions with multiple positions using demo microscope."""
@@ -247,14 +250,18 @@ def test_acquire_at_positions_multiple_positions(fm_microscope):
     positions = [
         FMStagePosition(
             name="pos_1",
-            stage_position=FibsemStagePosition(x=0.001, y=0.002, z=0.003, r=0, t=np.radians(-180)),
-            objective_position=0.010
+            stage_position=FibsemStagePosition(
+                x=0.001, y=0.002, z=0.003, r=0, t=np.radians(-180)
+            ),
+            objective_position=0.010,
         ),
         FMStagePosition(
-            name="pos_2", 
-            stage_position=FibsemStagePosition(x=0.004, y=0.005, z=0.006, r=0, t=np.radians(-180)),
-            objective_position=0.015
-        )
+            name="pos_2",
+            stage_position=FibsemStagePosition(
+                x=0.004, y=0.005, z=0.006, r=0, t=np.radians(-180)
+            ),
+            objective_position=0.015,
+        ),
     ]
 
     # Create test channel
@@ -263,20 +270,19 @@ def test_acquire_at_positions_multiple_positions(fm_microscope):
         excitation_wavelength=488,
         emission_wavelength=509,
         power=0.2,
-        exposure_time=0.3
+        exposure_time=0.3,
     )
 
     # Call function
     result = acquire_at_positions(
-        microscope=microscope,
-        positions=positions,
-        channel_settings=channel
+        microscope=microscope, positions=positions, channel_settings=channel
     )
 
     # Verify result
     assert len(result) == 2
     for image in result:
         assert isinstance(image, FluorescenceImage)
+
 
 def test_acquire_at_positions_with_z_stack(fm_microscope):
     """Test acquire_at_positions with Z-stack parameters using demo microscope."""
@@ -285,8 +291,10 @@ def test_acquire_at_positions_with_z_stack(fm_microscope):
     # Create test position
     position = FMStagePosition(
         name="z_stack_pos",
-        stage_position=FibsemStagePosition(x=0.001, y=0.002, z=0.003, r=0, t=np.radians(-180)),
-        objective_position=0.012
+        stage_position=FibsemStagePosition(
+            x=0.001, y=0.002, z=0.003, r=0, t=np.radians(-180)
+        ),
+        objective_position=0.012,
     )
 
     # Create test channel
@@ -295,27 +303,24 @@ def test_acquire_at_positions_with_z_stack(fm_microscope):
         excitation_wavelength=358,
         emission_wavelength=461,
         power=0.1,
-        exposure_time=0.5
+        exposure_time=0.5,
     )
 
     # Create Z-stack parameters
-    z_params = ZParameters(
-        zmin=-0.005,
-        zmax=0.005,
-        zstep=0.001
-    )
+    z_params = ZParameters(zmin=-0.005, zmax=0.005, zstep=0.001)
 
     # Call function
     result = acquire_at_positions(
         microscope=microscope,
         positions=[position],
         channel_settings=channel,
-        zparams=z_params
+        zparams=z_params,
     )
 
     # Verify result
     assert len(result) == 1
     assert isinstance(result[0], FluorescenceImage)
+
 
 def test_acquire_at_positions_empty_list(fm_microscope):
     """Test acquire_at_positions with empty positions list raises ValueError."""
@@ -327,16 +332,15 @@ def test_acquire_at_positions_empty_list(fm_microscope):
         excitation_wavelength=358,
         emission_wavelength=461,
         power=0.1,
-        exposure_time=0.5
+        exposure_time=0.5,
     )
 
     # Call function with empty list should raise ValueError
     with pytest.raises(ValueError, match="Positions list cannot be empty"):
         acquire_at_positions(
-            microscope=microscope,
-            positions=[],
-            channel_settings=channel
+            microscope=microscope, positions=[], channel_settings=channel
         )
+
 
 def test_acquire_channels(demo_microscope):
     """Test acquire_channels with multiple channels using demo microscope."""
@@ -349,22 +353,19 @@ def test_acquire_channels(demo_microscope):
             excitation_wavelength=358,
             emission_wavelength=461,
             power=0.1,
-            exposure_time=0.5
+            exposure_time=0.5,
         ),
         ChannelSettings(
             name="GFP",
             excitation_wavelength=488,
             emission_wavelength=509,
             power=0.2,
-            exposure_time=0.3
-        )
+            exposure_time=0.3,
+        ),
     ]
 
     # Call function
-    result = acquire_channels(
-        microscope=microscope.fm,
-        channel_settings=channels
-    )
+    result = acquire_channels(microscope=microscope.fm, channel_settings=channels)
 
     # Verify result
     assert isinstance(result, FluorescenceImage)
@@ -389,6 +390,7 @@ def test_acquire_channels(demo_microscope):
     # Check that acquisition date is set
     assert result.metadata.acquisition_date is not None
 
+
 def test_acquire_z_stack(demo_microscope):
     """Test acquire_z_stack with Z-stack parameters using demo microscope."""
     microscope = demo_microscope
@@ -399,21 +401,15 @@ def test_acquire_z_stack(demo_microscope):
         excitation_wavelength=358,
         emission_wavelength=461,
         power=0.1,
-        exposure_time=0.1
+        exposure_time=0.1,
     )
 
     # Create Z-stack parameters
-    z_params = ZParameters(
-        zmin=-0.005,
-        zmax=0.005,
-        zstep=0.001
-    )
+    z_params = ZParameters(zmin=-0.005, zmax=0.005, zstep=0.001)
 
     # Call function
     result = acquire_z_stack(
-        microscope=microscope.fm,
-        channel_settings=channel,
-        zparams=z_params
+        microscope=microscope.fm, channel_settings=channel, zparams=z_params
     )
 
     # Verify result
@@ -434,7 +430,9 @@ def test_acquire_z_stack(demo_microscope):
     assert len(result.metadata.z_positions) == expected_nz
 
     # Check image data has correct Z dimension
-    assert result.data.shape[1] == expected_nz  # Z dimension should match expected slices (CZYX format)
+    assert (
+        result.data.shape[1] == expected_nz
+    )  # Z dimension should match expected slices (CZYX format)
 
     # Check that acquisition date is set
     assert result.metadata.acquisition_date is not None
@@ -448,12 +446,27 @@ def test_acquire_z_stack(demo_microscope):
 # volume is required to come out identical either way.
 
 Z_ORDER_CHANNELS = [
-    ChannelSettings(name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-                    power=0.1, exposure_time=0.01),
-    ChannelSettings(name="GFP", excitation_wavelength=488, emission_wavelength=509,
-                    power=0.2, exposure_time=0.01),
-    ChannelSettings(name="RFP", excitation_wavelength=555, emission_wavelength=580,
-                    power=0.3, exposure_time=0.01),
+    ChannelSettings(
+        name="DAPI",
+        excitation_wavelength=358,
+        emission_wavelength=461,
+        power=0.1,
+        exposure_time=0.01,
+    ),
+    ChannelSettings(
+        name="GFP",
+        excitation_wavelength=488,
+        emission_wavelength=509,
+        power=0.2,
+        exposure_time=0.01,
+    ),
+    ChannelSettings(
+        name="RFP",
+        excitation_wavelength=555,
+        emission_wavelength=580,
+        power=0.3,
+        exposure_time=0.01,
+    ),
 ]
 # 3 planes, the smallest stack that can be mis-transposed without it being a no-op.
 Z_ORDER_PARAMS = dict(zmin=-1e-6, zmax=1e-6, zstep=1e-6)
@@ -508,7 +521,9 @@ def test_z_level_order_acquires_every_channel_before_moving_the_objective(
     # The three frames of each plane share one objective position, and the plane
     # advances only between groups.
     positions = [round(pos, 12) for _, pos in sequence]
-    per_plane = [positions[i:i + N_CHANNELS] for i in range(0, len(positions), N_CHANNELS)]
+    per_plane = [
+        positions[i : i + N_CHANNELS] for i in range(0, len(positions), N_CHANNELS)
+    ]
     assert all(len(set(group)) == 1 for group in per_plane)
     assert [group[0] for group in per_plane] == sorted(set(positions))
 
@@ -597,9 +612,11 @@ def test_acquisition_order_does_not_change_the_assembled_stack(fm_microscope):
     by_channel, by_z_level = results[ZStackOrder.CHANNEL], results[ZStackOrder.Z_LEVEL]
 
     assert by_z_level.data.shape == by_channel.data.shape
-    assert [ch.name for ch in by_z_level.metadata.channels] == [
-        ch.name for ch in by_channel.metadata.channels
-    ] == ["DAPI", "GFP", "RFP"]
+    assert (
+        [ch.name for ch in by_z_level.metadata.channels]
+        == [ch.name for ch in by_channel.metadata.channels]
+        == ["DAPI", "GFP", "RFP"]
+    )
     assert by_z_level.metadata.z_positions == by_channel.metadata.z_positions
     assert len(by_z_level.metadata.z_positions) == N_PLANES
 
@@ -959,12 +976,18 @@ def _run_tileset(microscope, rows, cols, overlap=0.1):
     acquisition.acquire_tileset(
         microscope=microscope,
         channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
+            name="DAPI",
+            excitation_wavelength=358,
+            emission_wavelength=461,
+            power=0.1,
+            exposure_time=0.1,
         ),
         overview_parameters=OverviewParameters(
-            rows=rows, cols=cols, overlap=overlap,
-            use_zstack=False, autofocus_mode=AutoFocusMode.NONE,
+            rows=rows,
+            cols=cols,
+            overlap=overlap,
+            use_zstack=False,
+            autofocus_mode=AutoFocusMode.NONE,
         ),
     )
 
@@ -979,11 +1002,13 @@ def _by_tile(positions, rows, cols):
         f"expected one move per tile plus the restore, got {len(positions)} "
         f"for a {rows}x{cols} grid"
     )
-    return {(k // cols, k % cols): p for k, p in enumerate(positions[:rows * cols])}
+    return {(k // cols, k % cols): p for k, p in enumerate(positions[: rows * cols])}
 
 
 @pytest.mark.parametrize("rows,cols", [(2, 2), (3, 2), (1, 4), (4, 1)])
-def test_acquire_tileset_visits_rows_top_to_bottom(fm_microscope, monkeypatch, rows, cols):
+def test_acquire_tileset_visits_rows_top_to_bottom(
+    fm_microscope, monkeypatch, rows, cols
+):
     """Row 0 is the top of the mosaic, so it sits at the highest stage y."""
     microscope = fm_microscope
     positions = _record_tile_positions(microscope, monkeypatch)
@@ -1021,7 +1046,9 @@ def test_acquire_tileset_uses_absolute_positions_not_accumulated_steps(
     )
 
 
-def test_acquire_tileset_row_direction_matches_the_beam_tiler(fm_microscope, monkeypatch):
+def test_acquire_tileset_row_direction_matches_the_beam_tiler(
+    fm_microscope, monkeypatch
+):
     """The FM tiler and the beam tiler must agree on the direction of each axis.
 
     Pins the two against each other rather than against a hard-coded sign, so the
@@ -1039,7 +1066,9 @@ def test_acquire_tileset_row_direction_matches_the_beam_tiler(fm_microscope, mon
     beam_tiles = compute_tile_grid(
         OverviewAcquisitionSettings(
             image_settings=ImageSettings(hfw=100e-6, resolution=[1024, 1024]),
-            nrows=rows, ncols=cols, overlap=0.1,
+            nrows=rows,
+            ncols=cols,
+            overlap=0.1,
         )
     )
 
@@ -1090,12 +1119,18 @@ def _runner(microscope, rows, cols, stop_event=None, overlap=0.1):
     return acquisition.FMTiledAcquisitionRunner(
         microscope=microscope,
         channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
+            name="DAPI",
+            excitation_wavelength=358,
+            emission_wavelength=461,
+            power=0.1,
+            exposure_time=0.1,
         ),
         overview_parameters=OverviewParameters(
-            rows=rows, cols=cols, overlap=overlap,
-            use_zstack=False, autofocus_mode=AutoFocusMode.NONE,
+            rows=rows,
+            cols=cols,
+            overlap=overlap,
+            use_zstack=False,
+            autofocus_mode=AutoFocusMode.NONE,
         ),
         stop_event=stop_event,
     )
@@ -1200,12 +1235,18 @@ def test_stitching_reports_a_cancel_as_none_not_an_error(fm_microscope, monkeypa
     result = acquire_and_stitch_tileset(
         microscope=microscope,
         channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
+            name="DAPI",
+            excitation_wavelength=358,
+            emission_wavelength=461,
+            power=0.1,
+            exposure_time=0.1,
         ),
         overview_parameters=OverviewParameters(
-            rows=2, cols=2, overlap=0.1,
-            use_zstack=False, autofocus_mode=AutoFocusMode.NONE,
+            rows=2,
+            cols=2,
+            overlap=0.1,
+            use_zstack=False,
+            autofocus_mode=AutoFocusMode.NONE,
         ),
     )
 
@@ -1242,7 +1283,10 @@ def _sparse_runner(microscope, rows, cols, mask=None, order=None, stop_event=Non
         microscope=microscope,
         channel_settings=ChannelSettings(name="DAPI", exposure_time=0.1),
         overview_parameters=OverviewParameters(
-            rows=rows, cols=cols, overlap=0.1, use_zstack=False,
+            rows=rows,
+            cols=cols,
+            overlap=0.1,
+            use_zstack=False,
             autofocus_mode=AutoFocusMode.NONE,
             tile_order=order or TileOrderStrategy.TYPEWRITER,
             tile_mask=mask,
@@ -1268,7 +1312,9 @@ def test_a_masked_run_visits_only_the_enabled_tiles(fm_microscope, monkeypatch):
     assert len(positions) == 9 + 1
 
 
-def test_skipped_tiles_stay_none_and_the_grid_keeps_its_shape(fm_microscope, monkeypatch):
+def test_skipped_tiles_stay_none_and_the_grid_keeps_its_shape(
+    fm_microscope, monkeypatch
+):
     _record_tile_positions(fm_microscope, monkeypatch)
     mask = _plus_mask(5)
 
@@ -1281,20 +1327,20 @@ def test_skipped_tiles_stay_none_and_the_grid_keeps_its_shape(fm_microscope, mon
             assert (tileset[r][c] is not None) is mask[r][c], f"tile ({r}, {c})"
 
 
-def test_masking_changes_which_tiles_are_acquired_never_where(fm_microscope, monkeypatch):
+def test_masking_changes_which_tiles_are_acquired_never_where(
+    fm_microscope, monkeypatch
+):
     """The headline property, at runner level."""
     dense = _record_tile_positions(fm_microscope, monkeypatch)
     _sparse_runner(fm_microscope, 5, 5).run()
-    dense_by_tile = {
-        (k // 5, k % 5): p for k, p in enumerate(list(dense)[:25])
-    }
+    dense_by_tile = {(k // 5, k % 5): p for k, p in enumerate(list(dense)[:25])}
 
     sparse = _record_tile_positions(fm_microscope, monkeypatch)
     mask = _plus_mask(5)
     _sparse_runner(fm_microscope, 5, 5, mask=mask).run()
 
     enabled = [(r, c) for r in range(5) for c in range(5) if mask[r][c]]
-    for (row, col), position in zip(enabled, list(sparse)[:len(enabled)]):
+    for (row, col), position in zip(enabled, list(sparse)[: len(enabled)]):
         expected = dense_by_tile[(row, col)]
         assert position.x == pytest.approx(expected.x), f"tile ({row}, {col}) x"
         assert position.y == pytest.approx(expected.y), f"tile ({row}, {col}) y"
@@ -1338,20 +1384,28 @@ def test_tile_order_drives_the_visit_sequence(fm_microscope, monkeypatch):
     _sparse_runner(fm_microscope, 3, 3, order=TileOrderStrategy.SERPENTINE).run()
 
     # Row 1 runs right-to-left under serpentine, so tiles 3..5 are reversed.
-    assert [p.x for p in list(serpentine)[3:6]] == [p.x for p in list(typewriter)[3:6]][::-1]
+    assert [p.x for p in list(serpentine)[3:6]] == [p.x for p in list(typewriter)[3:6]][
+        ::-1
+    ]
     # Same set of positions either way -- only the order differs.
-    assert sorted(round(p.x, 12) for p in list(typewriter)[:9]) == \
-           sorted(round(p.x, 12) for p in list(serpentine)[:9])
+    assert sorted(round(p.x, 12) for p in list(typewriter)[:9]) == sorted(
+        round(p.x, 12) for p in list(serpentine)[:9]
+    )
 
 
-def test_each_row_autofocus_is_promoted_to_each_tile_for_a_spiral(fm_microscope, monkeypatch):
+def test_each_row_autofocus_is_promoted_to_each_tile_for_a_spiral(
+    fm_microscope, monkeypatch
+):
     """A spiral revisits rows non-sequentially, so "on each new row" is meaningless."""
     _record_tile_positions(fm_microscope, monkeypatch)
     runner = acquisition.FMTiledAcquisitionRunner(
         microscope=fm_microscope,
         channel_settings=ChannelSettings(name="DAPI", exposure_time=0.1),
         overview_parameters=OverviewParameters(
-            rows=3, cols=3, overlap=0.1, use_zstack=False,
+            rows=3,
+            cols=3,
+            overlap=0.1,
+            use_zstack=False,
             autofocus_mode=AutoFocusMode.EACH_ROW,
             tile_order=TileOrderStrategy.SPIRAL,
         ),
@@ -1371,7 +1425,10 @@ def test_each_row_autofocus_survives_a_row_wise_order(fm_microscope, monkeypatch
         microscope=fm_microscope,
         channel_settings=ChannelSettings(name="DAPI", exposure_time=0.1),
         overview_parameters=OverviewParameters(
-            rows=3, cols=3, overlap=0.1, use_zstack=False,
+            rows=3,
+            cols=3,
+            overlap=0.1,
+            use_zstack=False,
             autofocus_mode=AutoFocusMode.EACH_ROW,
             tile_order=TileOrderStrategy.SERPENTINE,
         ),
@@ -1393,13 +1450,18 @@ def test_stitching_leaves_skipped_tiles_as_zeros_at_full_canvas_size(fm_microsco
     sparse = acquire_and_stitch_tileset(
         microscope=fm_microscope,
         channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
-        overview_parameters=OverviewParameters(rows=3, cols=3, overlap=0.1, tile_mask=mask),
+        overview_parameters=OverviewParameters(
+            rows=3, cols=3, overlap=0.1, tile_mask=mask
+        ),
     )
 
     assert sparse.data.shape == dense.data.shape
     # The corners are skipped, so the canvas there was never written.
-    tile_h, tile_w = fm_microscope.fm.camera.resolution[1], fm_microscope.fm.camera.resolution[0]
-    assert not sparse.data[0, 0, :tile_h // 2, :tile_w // 2].any(), "top-left corner"
+    tile_h, tile_w = (
+        fm_microscope.fm.camera.resolution[1],
+        fm_microscope.fm.camera.resolution[0],
+    )
+    assert not sparse.data[0, 0, : tile_h // 2, : tile_w // 2].any(), "top-left corner"
     assert sparse.data[0, 0].any(), "the enabled tiles were written"
 
 
@@ -1435,14 +1497,19 @@ def test_the_mosaic_centre_is_the_run_centre_whatever_was_acquired(
     centred on the starting stage position, so that position is the answer, exactly,
     and independently of the mask.
     """
-    mask = (None if predicate is None
-            else [[predicate(i, j) for j in range(3)] for i in range(3)])
+    mask = (
+        None
+        if predicate is None
+        else [[predicate(i, j) for j in range(3)] for i in range(3)]
+    )
     centre = fm_microscope.get_stage_position()
 
     mosaic = acquire_and_stitch_tileset(
         microscope=fm_microscope,
         channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
-        overview_parameters=OverviewParameters(rows=3, cols=3, overlap=0.1, tile_mask=mask),
+        overview_parameters=OverviewParameters(
+            rows=3, cols=3, overlap=0.1, tile_mask=mask
+        ),
     )
 
     assert mosaic.metadata.stage_position.x == pytest.approx(centre.x, abs=1e-12)
@@ -1461,13 +1528,17 @@ def test_the_mosaic_records_the_objective_the_run_used(fm_microscope):
         overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
     )
 
-    assert all(ch.objective_position == pytest.approx(objective)
-               for ch in mosaic.metadata.channels)
+    assert all(
+        ch.objective_position == pytest.approx(objective)
+        for ch in mosaic.metadata.channels
+    )
 
 
 def test_the_mosaic_carries_the_same_metadata_as_a_single_image(fm_microscope):
     """Only the resolution differs. It is a large image, not a different kind of thing."""
-    channel = ChannelSettings(name="DAPI", excitation_wavelength=358, exposure_time=0.001)
+    channel = ChannelSettings(
+        name="DAPI", excitation_wavelength=358, exposure_time=0.001
+    )
     single = acquire_image(fm_microscope.fm, channel)
 
     mosaic = acquire_and_stitch_tileset(
@@ -1476,8 +1547,9 @@ def test_the_mosaic_carries_the_same_metadata_as_a_single_image(fm_microscope):
         overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
     )
 
-    assert [ch.name for ch in mosaic.metadata.channels] == \
-           [ch.name for ch in single.metadata.channels]
+    assert [ch.name for ch in mosaic.metadata.channels] == [
+        ch.name for ch in single.metadata.channels
+    ]
     assert mosaic.metadata.pixel_size_x == single.metadata.pixel_size_x
     assert mosaic.metadata.pixel_size_y == single.metadata.pixel_size_y
     assert mosaic.metadata.resolution[0] > single.metadata.resolution[0]
@@ -1558,7 +1630,7 @@ def test_the_preview_is_decimated(fm_microscope):
     frames = _preview_frames(fm_microscope, 5, 5)
 
     image = frames[-1]["image"]
-    assert max(image.shape[-2:]) <= acquisition.PREVIEW_MAX_DIMENSION
+    assert max(image.shape[-2:]) <= PREVIEW_MAX_DIMENSION
     assert frames[-1]["preview_stride"] > 1
 
 
@@ -1571,7 +1643,7 @@ def test_the_preview_leaves_skipped_tiles_blank(fm_microscope):
     image = frames[-1]["image"][0]
     h, w = image.shape
     assert not image[: h // 4, : w // 4].any(), "top-left corner was never acquired"
-    assert image[h // 3: 2 * h // 3, w // 3: 2 * w // 3].any(), "the centre tile was"
+    assert image[h // 3 : 2 * h // 3, w // 3 : 2 * w // 3].any(), "the centre tile was"
 
 
 def test_the_preview_has_one_plane_per_channel(fm_microscope):
@@ -1583,10 +1655,10 @@ def test_the_preview_has_one_plane_per_channel(fm_microscope):
 @pytest.mark.parametrize(
     ("shape", "n_channels", "expected"),
     [
-        ((8, 8), 1, (1, 8, 8)),            # plain 2D
-        ((3, 8, 8), 1, (1, 8, 8)),         # single channel z-stack -> projected
-        ((3, 8, 8), 3, (3, 8, 8)),         # three channels, no z -> kept
-        ((2, 4, 8, 8), 2, (2, 8, 8)),      # channels + z -> projected
+        ((8, 8), 1, (1, 8, 8)),  # plain 2D
+        ((3, 8, 8), 1, (1, 8, 8)),  # single channel z-stack -> projected
+        ((3, 8, 8), 3, (3, 8, 8)),  # three channels, no z -> kept
+        ((2, 4, 8, 8), 2, (2, 8, 8)),  # channels + z -> projected
     ],
     ids=["2d", "single-channel-zstack", "multi-channel", "channels-and-z"],
 )
@@ -1603,10 +1675,12 @@ def test_tile_data_is_normalised_to_channel_planes(shape, n_channels, expected):
 def _sweep_settings():
     from fibsem.autofunctions.autofocus import FocusSweepPass
 
-    return AutoFocusSettings(passes=[
-        FocusSweepPass(search_range=20e-6, step_size=5e-6),   # coarse: 5 positions
-        FocusSweepPass(search_range=6e-6, step_size=1e-6),    # fine:   7 positions
-    ])
+    return AutoFocusSettings(
+        passes=[
+            FocusSweepPass(search_range=20e-6, step_size=5e-6),  # coarse: 5 positions
+            FocusSweepPass(search_range=6e-6, step_size=1e-6),  # fine:   7 positions
+        ]
+    )
 
 
 def _autofocus_payloads(microscope, monkeypatch, mode):
@@ -1618,8 +1692,9 @@ def _autofocus_payloads(microscope, monkeypatch, mode):
     acquisition.FMTiledAcquisitionRunner(
         microscope=microscope,
         channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
-        overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1,
-                                               autofocus_mode=mode),
+        overview_parameters=OverviewParameters(
+            rows=2, cols=2, overlap=0.1, autofocus_mode=mode
+        ),
         autofocus_settings=_sweep_settings(),
     ).run()
     return seen
@@ -1633,8 +1708,9 @@ def test_focusing_once_runs_every_enabled_pass(fm_microscope, monkeypatch):
     """
     seen = _autofocus_payloads(fm_microscope, monkeypatch, AutoFocusMode.ONCE)
 
-    passes = sorted({(d["pass_index"], d["total_passes"], d["total_zlevels"])
-                     for d in seen})
+    passes = sorted(
+        {(d["pass_index"], d["total_passes"], d["total_zlevels"]) for d in seen}
+    )
     assert passes == [(1, 2, 5), (2, 2, 7)]
 
 
@@ -1643,8 +1719,8 @@ def test_per_tile_focusing_runs_only_the_narrowest_pass(fm_microscope, monkeypat
     seen = _autofocus_payloads(fm_microscope, monkeypatch, AutoFocusMode.EACH_TILE)
 
     assert sorted({(d["pass_index"], d["total_passes"]) for d in seen}) == [(1, 1)]
-    assert {d["total_zlevels"] for d in seen} == {7}          # the fine pass
-    assert len([d for d in seen if d["zlevel"] == 1]) == 4    # once per tile
+    assert {d["total_zlevels"] for d in seen} == {7}  # the fine pass
+    assert len([d for d in seen if d["zlevel"] == 1]) == 4  # once per tile
 
 
 def test_the_sweep_reports_progress_per_position(fm_microscope, monkeypatch):
@@ -1676,8 +1752,9 @@ def test_a_cancelled_sweep_does_not_start_the_next_pass(fm_microscope, monkeypat
         acquisition.FMTiledAcquisitionRunner(
             microscope=fm_microscope,
             channel_settings=ChannelSettings(name="DAPI", exposure_time=0.001),
-            overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1,
-                                                   autofocus_mode=AutoFocusMode.ONCE),
+            overview_parameters=OverviewParameters(
+                rows=2, cols=2, overlap=0.1, autofocus_mode=AutoFocusMode.ONCE
+            ),
             autofocus_settings=_sweep_settings(),
             stop_event=stop_event,
         ).run()
@@ -1835,7 +1912,9 @@ def test_a_saved_mosaic_is_stamped_with_the_run_it_came_from(fm_microscope, tmp_
     assert FluorescenceImage.load(path).metadata.description == destination.basename
 
 
-def test_a_cancelled_run_still_records_what_it_was_trying_to_do(fm_microscope, tmp_path):
+def test_a_cancelled_run_still_records_what_it_was_trying_to_do(
+    fm_microscope, tmp_path
+):
     """The parameters describe what was *requested*, so they are known before the first
     tile. Written at the end instead, a cancelled run left its tiles on disk with
     nothing saying what grid they belonged to."""
@@ -1859,8 +1938,12 @@ def test_two_runs_in_the_same_second_do_not_collide(tmp_path):
     """The timestamp only resolves to the second, and a single-tile overview at a short
     exposure takes far less. Sharing the name would let the second run overwrite the
     first tile for tile, silently."""
-    first = acquisition.OverviewDestination.create(str(tmp_path), basename="overview-12-00-00")
-    second = acquisition.OverviewDestination.create(str(tmp_path), basename="overview-12-00-00")
+    first = acquisition.OverviewDestination.create(
+        str(tmp_path), basename="overview-12-00-00"
+    )
+    second = acquisition.OverviewDestination.create(
+        str(tmp_path), basename="overview-12-00-00"
+    )
 
     assert first.tiles_directory != second.tiles_directory
     assert first.mosaic_path != second.mosaic_path
@@ -1953,8 +2036,10 @@ def test_masking_off_the_unreachable_tiles_makes_a_grid_acquirable(fm_microscope
     _narrow_limits(fm_microscope, 10e-6)
 
     parameters = OverviewParameters(
-        rows=1, cols=3, overlap=0.1,
-        tile_mask=[[False, True, False]],   # keep only the reachable centre tile
+        rows=1,
+        cols=3,
+        overlap=0.1,
+        tile_mask=[[False, True, False]],  # keep only the reachable centre tile
     )
     runner = FMTiledAcquisitionRunner(
         microscope=fm_microscope,
@@ -2019,15 +2104,22 @@ def _acquired_at(monkeypatch, microscope, mode, rows=1, cols=2, order=None):
     monkeypatch.setattr(acquisition, "acquire_image", spy)
 
     parameters = OverviewParameters(
-        rows=rows, cols=cols, overlap=0.1, use_zstack=False, autofocus_mode=mode,
+        rows=rows,
+        cols=cols,
+        overlap=0.1,
+        use_zstack=False,
+        autofocus_mode=mode,
     )
     if order is not None:
         parameters.tile_order = order
     runner = acquisition.FMTiledAcquisitionRunner(
         microscope=microscope,
         channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
+            name="DAPI",
+            excitation_wavelength=358,
+            emission_wavelength=461,
+            power=0.1,
+            exposure_time=0.1,
         ),
         overview_parameters=parameters,
         autofocus_settings=AutoFocusSettings(),
@@ -2125,19 +2217,28 @@ def _start_from(monkeypatch, microscope, start, focus=SAVED_FOCUS):
     runner = acquisition.FMTiledAcquisitionRunner(
         microscope=microscope,
         channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
+            name="DAPI",
+            excitation_wavelength=358,
+            emission_wavelength=461,
+            power=0.1,
+            exposure_time=0.1,
         ),
         overview_parameters=OverviewParameters(
-            rows=1, cols=2, overlap=0.1, use_zstack=False,
-            autofocus_mode=AutoFocusMode.NONE, objective_start=start,
+            rows=1,
+            cols=2,
+            overlap=0.1,
+            use_zstack=False,
+            autofocus_mode=AutoFocusMode.NONE,
+            objective_start=start,
         ),
     )
     runner.run()
     return positions, runner
 
 
-def test_by_default_an_overview_starts_where_the_objective_is(fm_microscope, monkeypatch):
+def test_by_default_an_overview_starts_where_the_objective_is(
+    fm_microscope, monkeypatch
+):
     """Unchanged behaviour, and still the default: an overview is usually taken of
     whatever you have just been looking at."""
     started_at = fm_microscope.fm.objective.position
@@ -2157,7 +2258,9 @@ def test_it_can_start_from_the_saved_focus_position(fm_microscope, monkeypatch):
     assert positions == [pytest.approx(SAVED_FOCUS)] * 2
 
 
-def test_the_objective_still_goes_back_where_the_user_left_it(fm_microscope, monkeypatch):
+def test_the_objective_still_goes_back_where_the_user_left_it(
+    fm_microscope, monkeypatch
+):
     """Choosing where to start is not moving house."""
     started_at = fm_microscope.fm.objective.position
 
@@ -2173,19 +2276,30 @@ def test_the_objective_is_moved_before_a_sweep_would_search(fm_microscope, monke
     swept_at = []
     fm_microscope.fm.objective.focus_position = SAVED_FOCUS
     monkeypatch.setattr(
-        acquisition, "run_tileset_autofocus",
-        lambda microscope, *a, **k: swept_at.append(microscope.fm.objective.position) or True,
+        acquisition,
+        "run_tileset_autofocus",
+        lambda microscope, *a, **k: (
+            swept_at.append(microscope.fm.objective.position) or True
+        ),
     )
-    monkeypatch.setattr(acquisition, "acquire_image", lambda *a, **k: acquisition.acquire_image)
+    monkeypatch.setattr(
+        acquisition, "acquire_image", lambda *a, **k: acquisition.acquire_image
+    )
 
     runner = acquisition.FMTiledAcquisitionRunner(
         microscope=fm_microscope,
         channel_settings=ChannelSettings(
-            name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-            power=0.1, exposure_time=0.1,
+            name="DAPI",
+            excitation_wavelength=358,
+            emission_wavelength=461,
+            power=0.1,
+            exposure_time=0.1,
         ),
         overview_parameters=OverviewParameters(
-            rows=1, cols=1, overlap=0.1, use_zstack=False,
+            rows=1,
+            cols=1,
+            overlap=0.1,
+            use_zstack=False,
             autofocus_mode=AutoFocusMode.ONCE,
             objective_start=ObjectiveStartPosition.FOCUS,
         ),
@@ -2210,7 +2324,9 @@ def test_asking_for_a_focus_position_that_was_never_saved_is_refused(
         )
 
 
-def test_an_overview_will_not_run_with_the_objective_retracted(fm_microscope, monkeypatch):
+def test_an_overview_will_not_run_with_the_objective_retracted(
+    fm_microscope, monkeypatch
+):
     """Nothing an overview does works without it -- the tiles would be whatever a
     retracted objective sees, and a sweep would search for a focus that cannot exist."""
     fm_microscope.fm.objective.retract()
@@ -2346,7 +2462,8 @@ def test_the_announcement_carries_no_progress(fm_microscope):
     ).run()
 
     announcements = [
-        p for p in emitted
+        p
+        for p in emitted
         if p.get("state") == "acquiring" and p.get("task") == "tileset" and "row" in p
     ]
     assert announcements, "nothing announces the tile being acquired"


### PR DESCRIPTION
12 unused imports removed from `fibsem/fm`, plus the reformat format-on-touch requires. Four files — three source, one test.

## One of them was load-bearing, invisibly

`fibsem/fm/acquisition.py` imported `PREVIEW_MAX_DIMENSION` from `fibsem.imaging.reduce` and never used it. `tests/fm/test_acquisition.py` asserted against `acquisition.PREVIEW_MAX_DIMENSION` — reaching the constant through a module that re-exported it purely by accident. Removing the import broke the test.

This is a fourth way an unused import can matter, and the one static analysis misses: `from fibsem.fm import acquisition` binds a **module** via `ImportFrom`, so it never appears in an `import M` alias map, and the dotted access reaches straight through. **Only running the suite caught it.**

Re-scanned all 339 remaining findings for the same shape — one more, `fibsem.milling.setup_milling` used by `example/example_milling.py`, in an `__init__.py` ruff will not auto-fix anyway.

Fixed by pointing the test at the constant's real home, rather than restoring an accidental re-export. That is why the test change is in this PR rather than a separate one: the removal and the fix are the same change.

## Safety

Checked before and after against the whole repo — `from M import X`, `import M` + `M.X`, `from pkg import mod` + `mod.X`, `from M import *`. Zero of the 12 are reachable from anywhere else once the test is repointed.

`ruff check --fix` alone is not safe on this codebase; see the closed #496 for the case where it rates as `safe` a removal that breaks `scripts/test_installation.py`.

## Verification

Full suite **5,752 passed, 24 skipped**; `ruff check .` clean; all four files formatted.
