### PR TITLE
[fix] Point the instructions at controls that exist

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -157,7 +157,10 @@ INSTRUCTIONS = {
     "NOT_CONNECTED": "Connect to the microscope to begin.",
     "NO_EXPERIMENT": "Create or load an experiment to begin.",
     "NO_PROTOCOL": "Load a protocol for this experiment (File \u2192 Load Protocol).",
-    "NO_LAMELLA": "Add a lamella position with + in the lamella list.",
+    "NO_LAMELLA": (
+        "Add a lamella position with + in the lamella list, "
+        "or mark one on the Overview tab."
+    ),
     "AUTOLAMELLA_READY": "Ready to run. Choose lamella and tasks in the Workflow tab.",
 }
 

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -149,15 +149,16 @@ except Exception as e:
 
 
 # instructions
+# What to do next, shown in the window's status bar. Each names something visible
+# on screen at the moment it is shown -- three of these used to name menus that do
+# not exist ("Connection ->", "Experiment ->" are not menus; the File entries are
+# "New Experiment" and "Load Experiment"), which is worse than saying nothing.
 INSTRUCTIONS = {
-    "NOT_CONNECTED": "Please connect to the microscope (Connection -> Connect to Microscope).",
-    "NO_EXPERIMENT": "Please create or load an experiment (File -> Create / Load Experiment)",
-    "NO_PROTOCOL": "Please load a protocol (File -> Load Protocol).",
-    "NO_LAMELLA": "Please Add Lamella Positions (Experiment -> Add Lamella).",
-    "TRENCH_READY": "Trench Positions Selected. Ready to Run Waffle Trench.",
-    "UNDERCUT_READY": "Undercut Positions Selected. Ready to Run Waffle Undercut.",
-    "LAMELLA_READY": "Lamella Positions Selected. Ready to Run Setup AutoLamella.",
-    "AUTOLAMELLA_READY": "Lamella Positions Selected. Ready to Run AutoLamella.",
+    "NOT_CONNECTED": "Connect to the microscope to begin.",
+    "NO_EXPERIMENT": "Create or load an experiment to begin.",
+    "NO_PROTOCOL": "Load a protocol for this experiment (File \u2192 Load Protocol).",
+    "NO_LAMELLA": "Add a lamella position with + in the lamella list.",
+    "AUTOLAMELLA_READY": "Ready to run. Choose lamella and tasks in the Workflow tab.",
 }
 
 

--- a/tests/ui/test_instructions.py
+++ b/tests/ui/test_instructions.py
@@ -1,0 +1,113 @@
+"""Every instruction names something that exists, and nothing names nothing.
+
+Three of the five used to point at menus that were never there — "Connection ->
+Connect to Microscope" and "Experiment -> Add Lamella" name no menu at all, and the
+File entries are "New Experiment" and "Load Experiment", not "Create / Load
+Experiment". Guidance that sends someone hunting for a menu is worse than silence,
+and nothing failed when it drifted, because a string cannot be wrong on its own.
+
+So the menu paths are checked against the menus the window actually builds, and the
+table is checked against the states that actually render it. Both read the source:
+`AutoLamellaSingleWindowUI` builds a napari viewer and a vispy quad view and cannot
+be constructed under the offscreen platform.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import os
+import re
+import textwrap
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (  # noqa: E402
+    AutoLamellaSingleWindowUI,
+)
+from fibsem.applications.autolamella.ui.AutoLamellaUI import INSTRUCTIONS  # noqa: E402
+
+# "(File -> Load Protocol)" / "(File → Load Protocol)" -- the menu, then the entry.
+MENU_PATH = re.compile(r"\(([A-Z][A-Za-z ]*?)\s*(?:->|→)\s*([^)]+)\)")
+
+
+def _source(func) -> ast.Module:
+    return ast.parse(textwrap.dedent(inspect.getsource(func)))
+
+
+def _first_string_args(func, name: str) -> set[str]:
+    """Every literal first argument to `name(...)` or `.name(...)` in the source.
+
+    Both call shapes matter here: menus are added with `menu_bar.addMenu("File")`
+    (an attribute) and actions are built with `QAction("Load Protocol", self)`
+    (a plain name).
+    """
+    out = set()
+    for node in ast.walk(_source(func)):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        called = (
+            node.func.attr
+            if isinstance(node.func, ast.Attribute)
+            else getattr(node.func, "id", None)
+        )
+        arg = node.args[0]
+        if (
+            called == name
+            and isinstance(arg, ast.Constant)
+            and isinstance(arg.value, str)
+        ):
+            out.add(arg.value)
+    return out
+
+
+def test_every_menu_path_names_a_real_menu():
+    menus = _first_string_args(AutoLamellaSingleWindowUI._create_menu_bar, "addMenu")
+    actions = _first_string_args(AutoLamellaSingleWindowUI._create_menu_bar, "QAction")
+    assert "File" in menus, "sanity: the menu bar builder was not read correctly"
+    assert actions, "sanity: no QAction labels found in the menu bar builder"
+
+    for key, msg in INSTRUCTIONS.items():
+        for menu, entry in MENU_PATH.findall(msg):
+            assert menu in menus, (
+                f"INSTRUCTIONS[{key!r}] sends the user to a {menu!r} menu; "
+                f"the window builds {sorted(menus)}"
+            )
+            assert entry.strip() in actions, (
+                f"INSTRUCTIONS[{key!r}] names a {entry.strip()!r} entry that no "
+                f"QAction in the menu bar is called"
+            )
+
+
+def test_no_instruction_goes_unused():
+    """A message no state can reach is a message nobody maintains.
+
+    Three ready-state entries outlived the code that showed them, still describing
+    a Waffle-method flow that no longer renders them.
+    """
+    used = {
+        node.slice.value
+        for node in ast.walk(_source(AutoLamellaSingleWindowUI._update_instructions))
+        if isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "INSTRUCTIONS"
+        and isinstance(node.slice, ast.Constant)
+    }
+
+    assert used, "sanity: no INSTRUCTIONS lookups found in _update_instructions"
+    assert set(INSTRUCTIONS) == used, (
+        f"unused: {sorted(set(INSTRUCTIONS) - used)}; "
+        f"missing: {sorted(used - set(INSTRUCTIONS))}"
+    )
+
+
+def test_instructions_say_what_to_do_without_asking_permission():
+    """House style: the UI is not requesting a favour, and it is not shouting."""
+    for key, msg in INSTRUCTIONS.items():
+        assert not msg.lower().startswith("please"), f"INSTRUCTIONS[{key!r}]"
+        assert msg == msg[0] + msg[1:].replace("  ", " "), f"INSTRUCTIONS[{key!r}]"
+        assert msg.endswith("."), f"INSTRUCTIONS[{key!r}] should be a sentence"


### PR DESCRIPTION
Three of the five status-bar instructions told the user to use a menu that is not there.

| said | actual |
|---|---|
| `Connection -> Connect to Microscope` | no Connection **menu** — it is a tab, and the button is on screen |
| `File -> Create / Load Experiment` | File has "New Experiment" and "Load Experiment"; there is also a header button since #490 |
| `Experiment -> Add Lamella` | there is no Experiment menu at all |

The window builds File, Edit, View, Imaging, Tools, Help and Development. Guidance that sends someone hunting for a menu is worse than silence.

## What they say now

Each names something visible at the moment it is shown, and drops the "Please" that opened every one.

```
NOT_CONNECTED      Connect to the microscope to begin.
NO_EXPERIMENT      Create or load an experiment to begin.
NO_PROTOCOL        Load a protocol for this experiment (File → Load Protocol).
NO_LAMELLA         Add a lamella position with + in the lamella list.
AUTOLAMELLA_READY  Ready to run. Choose lamella and tasks in the Workflow tab.
```

`NO_PROTOCOL` keeps its menu path because that one is real, and it is the only state whose action has no on-screen control.

`AUTOLAMELLA_READY` no longer claims readiness outright: the Run Workflow button also needs a lamella **and** a task selected, so "Ready to Run AutoLamella" overstated it. It now points at the tab where that choice is made.

## Three entries that had outlived their code

`TRENCH_READY`, `UNDERCUT_READY` and `LAMELLA_READY` are gone. Nothing has looked them up since the Waffle flow that displayed them stopped rendering; after #495 the only reader is `_update_instructions`, which reaches five states.

## Tests

Nothing failed when any of this drifted, because a string cannot be wrong on its own. So `tests/ui/test_instructions.py` gives it something to be wrong against:

- **every `(Menu → Entry)` is checked against the menus and QActions the window actually builds** — read from `_create_menu_bar` by AST, since `AutoLamellaSingleWindowUI` builds a napari viewer and a vispy quad view and cannot be constructed offscreen;
- **the table is checked against the states that render it**, so an entry nothing can reach fails rather than lingering;
- house style: no "Please", no double spaces, ends in a full stop.

Mutation-checked: restoring `"Please Add Lamella Positions (Experiment -> Add Lamella)."` fails two of the three.

Full `tests/ui` green. Files formatted per #489, AST-identical.
