### PR TITLE
[refactor] Give a task's dependency its own column

### DIFF
--- a/fibsem/applications/autolamella/ui/workflow_config_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_config_widget.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import html
 from typing import Dict, List, Optional
 
 from PyQt5.QtCore import QSize, Qt, pyqtSignal
+from PyQt5.QtGui import QFont, QFontMetrics
 from PyQt5.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
@@ -36,6 +38,11 @@ from fibsem.ui.tokens import (
 from fibsem.ui.widgets.custom_widgets import IconToolButton
 
 _NAME_MIN_WIDTH = 180
+# The dependency suffix: present, but never competing with the name it follows,
+# and never wider than this -- past it the row clips the text mid-word.
+REQUIRES_COLOUR = NEUTRAL_700
+REQUIRES_FONT_PX = 10
+REQUIRES_MAX_WIDTH = 190
 _BTN_SIZE = QSize(32, 32)
 _ROW_HEIGHT = 40
 _BTN_SPACER_WIDTH = (
@@ -70,6 +77,30 @@ def _supervise_icon(task: AutoLamellaTaskDescription) -> tuple[str, str, str]:
     return "mdi:lightning-bolt-circle", stylesheets.AUTOMATED_COLOR, "Automated"
 
 
+def _name_markup(task: AutoLamellaTaskDescription, font: QFont) -> str:
+    """The task's name, and what it waits for, on one line.
+
+    Nothing where a task has no dependency: "No requirements" under every row was
+    what buried the two or three that have one.
+
+    The dependency list is elided to a fixed budget rather than left to run: a task
+    waiting on four others produced a label wider than the row, which Qt then cut
+    off mid-word. The row's tooltip carries the full list either way. Escaped
+    because task names come from the protocol and this is rich text.
+    """
+    name = html.escape(task.name)
+    if not task.requires:
+        return name
+
+    small = QFont(font)
+    small.setPixelSize(REQUIRES_FONT_PX)
+    after = QFontMetrics(small).elidedText(
+        ", ".join(task.requires), Qt.ElideRight, REQUIRES_MAX_WIDTH
+    )
+    style = f"color: {REQUIRES_COLOUR}; font-size: {REQUIRES_FONT_PX}px;"
+    return f'{name} <span style="{style}">after {html.escape(after)}</span>'
+
+
 class WorkflowTaskRowWidget(QWidget):
     supervised_changed = pyqtSignal(object)  # AutoLamellaTaskDescription
     edit_clicked = pyqtSignal(object)  # AutoLamellaTaskDescription
@@ -95,22 +126,14 @@ class WorkflowTaskRowWidget(QWidget):
         self.checkbox.setStyleSheet("background: transparent;")
         layout.addWidget(self.checkbox)
 
-        name_col = QVBoxLayout()
-        name_col.setSpacing(1)
-        # name_col.setContentsMargins(0, 0, 0, 0)
-
+        # One line, not a name over a requirements line. The second line was blank
+        # on most rows -- every task without a dependency -- and a name sitting at
+        # the top of a two-line block reads as floating above a gap. Inline, every
+        # name shares a baseline and the dependency stays attached to its task.
         self.name_label = QLabel()
         self.name_label.setMinimumWidth(_NAME_MIN_WIDTH)
         self.name_label.setStyleSheet("background: transparent;")
-        name_col.addWidget(self.name_label)
-
-        self.requires_label = QLabel()
-        self.requires_label.setStyleSheet(
-            "background: transparent; color: #707070; font-size: 10px;"
-        )
-        name_col.addWidget(self.requires_label)
-
-        layout.addLayout(name_col)
+        layout.addWidget(self.name_label)
 
         layout.addStretch(1)
 
@@ -170,10 +193,10 @@ class WorkflowTaskRowWidget(QWidget):
     def refresh(self) -> None:
         """Re-read all display fields from the stored task."""
         self.name_label.setText(self.task.name)
-        # Blank, not "No requirements": restating an absence on every row is what
-        # buries the few rows that do declare a dependency. The label keeps its line
-        # rather than being hidden, so rows stay the same height down the list.
-        self.requires_label.setText(", ".join(self.task.requires))
+        self.name_label.setText(_name_markup(self.task, self.name_label.font()))
+        self.setToolTip(
+            "Requires: " + ", ".join(self.task.requires) if self.task.requires else ""
+        )
         icon_name, icon_color, tooltip = _supervise_icon(self.task)
         self.btn_supervise.setIcon(fibsem_icon(icon_name, color=icon_color))
         self.btn_supervise.setToolTip(tooltip)

--- a/fibsem/applications/autolamella/ui/workflow_config_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_config_widget.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import html
 from typing import Dict, List, Optional
 
 from PyQt5.QtCore import QSize, Qt, pyqtSignal
@@ -38,11 +37,12 @@ from fibsem.ui.tokens import (
 from fibsem.ui.widgets.custom_widgets import IconToolButton
 
 _NAME_MIN_WIDTH = 180
-# The dependency suffix: present, but never competing with the name it follows,
-# and never wider than this -- past it the row clips the text mid-word.
+# The dependency column: present, but never competing with the name it belongs to.
+# Fixed width, so the entries line up down the list and the text elides inside it
+# rather than the row clipping it mid-word.
 REQUIRES_COLOUR = NEUTRAL_700
 REQUIRES_FONT_PX = 10
-REQUIRES_MAX_WIDTH = 190
+REQUIRES_MAX_WIDTH = 170
 _BTN_SIZE = QSize(32, 32)
 _ROW_HEIGHT = 40
 _BTN_SPACER_WIDTH = (
@@ -77,28 +77,21 @@ def _supervise_icon(task: AutoLamellaTaskDescription) -> tuple[str, str, str]:
     return "mdi:lightning-bolt-circle", stylesheets.AUTOMATED_COLOR, "Automated"
 
 
-def _name_markup(task: AutoLamellaTaskDescription, font: QFont) -> str:
-    """The task's name, and what it waits for, on one line.
+def _requires_text(task: AutoLamellaTaskDescription, font: QFont) -> str:
+    """What the task waits for, sized to the column that holds it.
 
-    Nothing where a task has no dependency: "No requirements" under every row was
-    what buried the two or three that have one.
+    Empty where a task has no dependency: "No requirements" on every row was what
+    buried the two or three that have one.
 
-    The dependency list is elided to a fixed budget rather than left to run: a task
-    waiting on four others produced a label wider than the row, which Qt then cut
-    off mid-word. The row's tooltip carries the full list either way. Escaped
-    because task names come from the protocol and this is rich text.
+    Elided rather than left to run. A task waiting on four others produced a label
+    wider than the row, and Qt cut it off mid-word; the row's tooltip carries the
+    full list.
     """
-    name = html.escape(task.name)
     if not task.requires:
-        return name
-
-    small = QFont(font)
-    small.setPixelSize(REQUIRES_FONT_PX)
-    after = QFontMetrics(small).elidedText(
-        ", ".join(task.requires), Qt.ElideRight, REQUIRES_MAX_WIDTH
+        return ""
+    return QFontMetrics(font).elidedText(
+        "after " + ", ".join(task.requires), Qt.ElideRight, REQUIRES_MAX_WIDTH
     )
-    style = f"color: {REQUIRES_COLOUR}; font-size: {REQUIRES_FONT_PX}px;"
-    return f'{name} <span style="{style}">after {html.escape(after)}</span>'
 
 
 class WorkflowTaskRowWidget(QWidget):
@@ -128,14 +121,29 @@ class WorkflowTaskRowWidget(QWidget):
 
         # One line, not a name over a requirements line. The second line was blank
         # on most rows -- every task without a dependency -- and a name sitting at
-        # the top of a two-line block reads as floating above a gap. Inline, every
-        # name shares a baseline and the dependency stays attached to its task.
+        # the top of a two-line block reads as floating above a gap.
         self.name_label = QLabel()
         self.name_label.setMinimumWidth(_NAME_MIN_WIDTH)
+        # Task names come from the protocol, and a QLabel left on AutoText renders
+        # anything that looks like markup as markup.
+        self.name_label.setTextFormat(Qt.PlainText)
         self.name_label.setStyleSheet("background: transparent;")
         layout.addWidget(self.name_label)
 
         layout.addStretch(1)
+
+        # Its own column, right-aligned at a fixed width, so the dependencies line
+        # up down the list and can be read as a column rather than hunted for at
+        # whatever point each name happens to end.
+        self.requires_label = QLabel()
+        self.requires_label.setFixedWidth(REQUIRES_MAX_WIDTH)
+        self.requires_label.setTextFormat(Qt.PlainText)
+        self.requires_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        self.requires_label.setStyleSheet(
+            f"background: transparent; color: {REQUIRES_COLOUR}; "
+            f"font-size: {REQUIRES_FONT_PX}px;"
+        )
+        layout.addWidget(self.requires_label)
 
         self.btn_schedule = QToolButton()
         self.btn_schedule.setFixedSize(_BTN_SIZE)
@@ -193,7 +201,9 @@ class WorkflowTaskRowWidget(QWidget):
     def refresh(self) -> None:
         """Re-read all display fields from the stored task."""
         self.name_label.setText(self.task.name)
-        self.name_label.setText(_name_markup(self.task, self.name_label.font()))
+        self.requires_label.setText(
+            _requires_text(self.task, self.requires_label.font())
+        )
         self.setToolTip(
             "Requires: " + ", ".join(self.task.requires) if self.task.requires else ""
         )

--- a/fibsem/applications/autolamella/ui/workflow_config_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_config_widget.py
@@ -38,8 +38,11 @@ from fibsem.ui.widgets.custom_widgets import IconToolButton
 _NAME_MIN_WIDTH = 180
 _BTN_SIZE = QSize(32, 32)
 _ROW_HEIGHT = 40
-_BTN_SPACER_WIDTH = _BTN_SIZE.width() * 4 + 8 * 3  # schedule + supervise + edit + remove + 3 gaps
+_BTN_SPACER_WIDTH = (
+    _BTN_SIZE.width() * 4 + 8 * 3
+)  # schedule + supervise + edit + remove + 3 gaps
 _BTN_STYLE = stylesheets.TOOLBUTTON_ICON_STYLESHEET
+
 
 class _DraggableTaskList(QListWidget):
     """QListWidget with InternalMove drag-and-drop that emits the new task order after each drop.
@@ -68,9 +71,9 @@ def _supervise_icon(task: AutoLamellaTaskDescription) -> tuple[str, str, str]:
 
 
 class WorkflowTaskRowWidget(QWidget):
-    supervised_changed = pyqtSignal(object)       # AutoLamellaTaskDescription
-    edit_clicked = pyqtSignal(object)             # AutoLamellaTaskDescription
-    remove_clicked = pyqtSignal(object)           # AutoLamellaTaskDescription
+    supervised_changed = pyqtSignal(object)  # AutoLamellaTaskDescription
+    edit_clicked = pyqtSignal(object)  # AutoLamellaTaskDescription
+    remove_clicked = pyqtSignal(object)  # AutoLamellaTaskDescription
     selection_changed = pyqtSignal(object, bool)  # AutoLamellaTaskDescription, checked
 
     def __init__(
@@ -102,7 +105,9 @@ class WorkflowTaskRowWidget(QWidget):
         name_col.addWidget(self.name_label)
 
         self.requires_label = QLabel()
-        self.requires_label.setStyleSheet("background: transparent; color: #707070; font-size: 10px;")
+        self.requires_label.setStyleSheet(
+            "background: transparent; color: #707070; font-size: 10px;"
+        )
         name_col.addWidget(self.requires_label)
 
         layout.addLayout(name_col)
@@ -119,10 +124,14 @@ class WorkflowTaskRowWidget(QWidget):
         self.btn_supervise.setStyleSheet(_BTN_STYLE)
         layout.addWidget(self.btn_supervise)
 
-        self.btn_edit = IconToolButton(icon="mdi:pencil", tooltip="Edit", size=_BTN_SIZE.width())
+        self.btn_edit = IconToolButton(
+            icon="mdi:pencil", tooltip="Edit", size=_BTN_SIZE.width()
+        )
         layout.addWidget(self.btn_edit)
 
-        self.btn_remove = IconToolButton(icon="mdi:trash-can-outline", tooltip="Remove", size=_BTN_SIZE.width())
+        self.btn_remove = IconToolButton(
+            icon="mdi:trash-can-outline", tooltip="Remove", size=_BTN_SIZE.width()
+        )
         layout.addWidget(self.btn_remove)
 
         drag_icon = QLabel()
@@ -161,18 +170,24 @@ class WorkflowTaskRowWidget(QWidget):
     def refresh(self) -> None:
         """Re-read all display fields from the stored task."""
         self.name_label.setText(self.task.name)
-        requires_text = ", ".join(self.task.requires) if self.task.requires else "No requirements"
-        self.requires_label.setText(requires_text)
+        # Blank, not "No requirements": restating an absence on every row is what
+        # buries the few rows that do declare a dependency. The label keeps its line
+        # rather than being hidden, so rows stay the same height down the list.
+        self.requires_label.setText(", ".join(self.task.requires))
         icon_name, icon_color, tooltip = _supervise_icon(self.task)
         self.btn_supervise.setIcon(fibsem_icon(icon_name, color=icon_color))
         self.btn_supervise.setToolTip(tooltip)
         if self.task.scheduled_at is not None:
-            self.btn_schedule.setIcon(fibsem_icon("mdi:clock", color=stylesheets.WHITE_ICON_COLOR))
+            self.btn_schedule.setIcon(
+                fibsem_icon("mdi:clock", color=stylesheets.WHITE_ICON_COLOR)
+            )
             self.btn_schedule.setToolTip(
                 f"Scheduled: {self.task.scheduled_at.strftime(DATETIME_DISPLAY_AMPM)}"
             )
         else:
-            self.btn_schedule.setIcon(fibsem_icon("mdi:clock-outline", color=NEUTRAL_700))
+            self.btn_schedule.setIcon(
+                fibsem_icon("mdi:clock-outline", color=NEUTRAL_700)
+            )
             self.btn_schedule.setToolTip("Not scheduled — click to set")
 
 
@@ -202,7 +217,9 @@ class _WorkflowTaskListHeader(QWidget):
         spacer.setStyleSheet("background: transparent;")
         layout.addWidget(spacer)
 
-        self.btn_add = IconToolButton(icon="mdi:plus", tooltip="Add Task", size=_BTN_SIZE.width())
+        self.btn_add = IconToolButton(
+            icon="mdi:plus", tooltip="Add Task", size=_BTN_SIZE.width()
+        )
         layout.addWidget(self.btn_add)
 
         self.checkbox_all.stateChanged.connect(
@@ -215,10 +232,10 @@ class WorkflowConfigWidget(QWidget):
     """List widget displaying AutoLamellaWorkflowConfig tasks with name, supervised, edit and remove actions."""
 
     supervised_changed = pyqtSignal(object)  # AutoLamellaTaskDescription
-    edit_requested = pyqtSignal(object)      # AutoLamellaTaskDescription
-    remove_requested = pyqtSignal(object)    # AutoLamellaTaskDescription
-    selection_changed = pyqtSignal(list)     # List[AutoLamellaTaskDescription]
-    order_changed = pyqtSignal(list)         # List[AutoLamellaTaskDescription]
+    edit_requested = pyqtSignal(object)  # AutoLamellaTaskDescription
+    remove_requested = pyqtSignal(object)  # AutoLamellaTaskDescription
+    selection_changed = pyqtSignal(list)  # List[AutoLamellaTaskDescription]
+    order_changed = pyqtSignal(list)  # List[AutoLamellaTaskDescription]
     add_task_clicked = pyqtSignal()
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
@@ -268,7 +285,9 @@ class WorkflowConfigWidget(QWidget):
         for task in config.tasks:
             self.add_task(task)
 
-    def add_task(self, task: AutoLamellaTaskDescription, checked: bool = False) -> WorkflowTaskRowWidget:
+    def add_task(
+        self, task: AutoLamellaTaskDescription, checked: bool = False
+    ) -> WorkflowTaskRowWidget:
         self._checked[id(task)] = checked
         row = WorkflowTaskRowWidget(task, checked)
         item = QListWidgetItem()
@@ -379,7 +398,9 @@ class WorkflowConfigWidget(QWidget):
         self.remove_task(task)
         self.remove_requested.emit(task)
 
-    def _on_row_selection_changed(self, task: AutoLamellaTaskDescription, checked: bool) -> None:
+    def _on_row_selection_changed(
+        self, task: AutoLamellaTaskDescription, checked: bool
+    ) -> None:
         self._checked[id(task)] = checked
         self._sync_select_all()
         self.selection_changed.emit(self.get_selected())
@@ -407,10 +428,7 @@ class WorkflowConfigWidget(QWidget):
         count = self._list.count()
         if count == 0:
             return
-        n_checked = sum(
-            self._row(i).checkbox.isChecked()
-            for i in range(count)
-        )
+        n_checked = sum(self._row(i).checkbox.isChecked() for i in range(count))
         cb = self._header.checkbox_all
         cb.blockSignals(True)
         if n_checked == 0:

--- a/tests/ui/test_workflow_task_requires.py
+++ b/tests/ui/test_workflow_task_requires.py
@@ -1,0 +1,74 @@
+"""A task row states its requirements, and says nothing when it has none.
+
+Every row used to carry a second line, and on most of them it read "No
+requirements" — an absence restated once per task, which is what buried the two or
+three rows that actually declare a dependency. Blank leaves those standing alone.
+
+The line is emptied rather than hidden, so every row keeps the same height and the
+list does not go ragged wherever a dependency happens to fall. Both halves are
+pinned here, because the obvious "tidy-up" is to hide the label.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.structures import (  # noqa: E402
+    AutoLamellaTaskDescription,
+)
+from fibsem.applications.autolamella.ui.workflow_config_widget import (  # noqa: E402
+    WorkflowTaskRowWidget,
+)
+
+
+def _row(qapp, name: str, requires: list[str]) -> WorkflowTaskRowWidget:
+    task = AutoLamellaTaskDescription(
+        name=name, supervise=False, required=True, requires=requires
+    )
+    return WorkflowTaskRowWidget(task)
+
+
+def test_a_task_with_no_requirements_says_nothing(qapp):
+    row = _row(qapp, "Mill Fiducial", [])
+
+    assert row.requires_label.text() == ""
+
+    row.deleteLater()
+
+
+def test_a_task_with_requirements_names_them(qapp):
+    row = _row(qapp, "Rough Milling", ["Mill Fiducial"])
+
+    assert row.requires_label.text() == "Mill Fiducial"
+
+    row.deleteLater()
+
+
+def test_several_requirements_are_listed(qapp):
+    row = _row(qapp, "Polishing", ["Mill Fiducial", "Rough Milling"])
+
+    assert row.requires_label.text() == "Mill Fiducial, Rough Milling"
+
+    row.deleteLater()
+
+
+def test_rows_keep_the_same_height_either_way(qapp):
+    """Emptied, not hidden. Hiding the label shortens the row it is on.
+
+    A list whose rows change height depending on whether a task declares a
+    dependency is harder to read than the repeated text this removes.
+    """
+    without = _row(qapp, "Mill Fiducial", [])
+    with_one = _row(qapp, "Rough Milling", ["Mill Fiducial"])
+
+    assert without.requires_label.isVisibleTo(without)
+    assert without.sizeHint().height() == with_one.sizeHint().height()
+
+    without.deleteLater()
+    with_one.deleteLater()

--- a/tests/ui/test_workflow_task_requires.py
+++ b/tests/ui/test_workflow_task_requires.py
@@ -1,26 +1,27 @@
-"""A task row states what it waits for, on the same line as its name.
+"""A task row states what it waits for, in a column of its own.
 
 Every row used to carry a second line, and on most it read "No requirements" — an
 absence restated once per task, which buried the two or three rows that actually
 declare a dependency. Blanking that line was not enough on its own: the name sits
 at the top of a two-line block, so a row without a sub-line reads as a name
-floating above a gap. One line puts every name on the same baseline.
+floating above a gap.
 
-The dependency list is elided to a fixed budget, because a task waiting on four
-others produced a label wider than the row and Qt cut it off mid-word. The row's
-tooltip carries the full list.
+One line each, and the dependency in a fixed-width right-aligned column, so the
+entries end on the same edge and read downwards as a column rather than being
+hunted for wherever each name happens to stop.
 """
 
 from __future__ import annotations
 
 import os
-import re
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 import pytest
 
 pytest.importorskip("PyQt5")
+
+from PyQt5.QtCore import Qt  # noqa: E402
 
 from fibsem.applications.autolamella.structures import (  # noqa: E402
     AutoLamellaTaskDescription,
@@ -29,8 +30,6 @@ from fibsem.applications.autolamella.ui.workflow_config_widget import (  # noqa:
     REQUIRES_MAX_WIDTH,
     WorkflowTaskRowWidget,
 )
-
-TAGS = re.compile(r"<[^>]+>")
 
 
 def _row(name: str, requires: list[str]) -> WorkflowTaskRowWidget:
@@ -41,23 +40,20 @@ def _row(name: str, requires: list[str]) -> WorkflowTaskRowWidget:
     )
 
 
-def _rendered(row: WorkflowTaskRowWidget) -> str:
-    """What the label actually reads, with the markup stripped."""
-    return TAGS.sub("", row.name_label.text())
-
-
-def test_a_task_with_no_requirements_says_only_its_name(qapp):
+def test_a_task_with_no_requirements_leaves_the_column_empty(qapp):
     row = _row("Mill Fiducial", [])
 
-    assert _rendered(row) == "Mill Fiducial"
+    assert row.name_label.text() == "Mill Fiducial"
+    assert row.requires_label.text() == ""
 
     row.deleteLater()
 
 
-def test_a_task_with_a_requirement_names_it_after_the_task(qapp):
+def test_a_task_with_a_requirement_names_it(qapp):
     row = _row("Rough Milling", ["Mill Fiducial"])
 
-    assert _rendered(row) == "Rough Milling after Mill Fiducial"
+    assert row.name_label.text() == "Rough Milling"
+    assert row.requires_label.text() == "after Mill Fiducial"
 
     row.deleteLater()
 
@@ -65,30 +61,34 @@ def test_a_task_with_a_requirement_names_it_after_the_task(qapp):
 def test_several_requirements_are_listed(qapp):
     row = _row("Polishing", ["Mill Fiducial", "Rough Milling"])
 
-    assert _rendered(row) == "Polishing after Mill Fiducial, Rough Milling"
+    assert row.requires_label.text() == "after Mill Fiducial, Rough Milling"
 
     row.deleteLater()
 
 
-def test_rows_sit_on_one_baseline_either_way(qapp):
-    """The point of the single line: no row is taller, and no name is higher.
+def test_the_column_is_the_same_width_and_edge_on_every_row(qapp):
+    """The point of the column: entries end on one edge, so they read downwards.
 
-    Two labels stacked would put the name at the top of the block on every row
-    that has no dependency, which is most of them.
+    A suffix that simply followed the name would start and end wherever that name
+    happened to stop, which is what makes a list of them hard to scan.
     """
-    without = _row("Mill Fiducial", [])
-    with_one = _row("Rough Milling", ["Mill Fiducial"])
+    rows = [
+        _row("Mill Fiducial", []),
+        _row("Rough Milling", ["Mill Fiducial"]),
+        _row("A Considerably Longer Task Name", ["Rough Milling"]),
+    ]
 
-    assert without.sizeHint().height() == with_one.sizeHint().height()
-    # One label, so there is no second line for the name to sit above.
-    assert not hasattr(without, "requires_label")
+    assert {r.requires_label.width() for r in rows} == {REQUIRES_MAX_WIDTH}
+    assert all(r.requires_label.alignment() & Qt.AlignRight for r in rows)
+    # And no row is taller than another for having something in the column.
+    assert len({r.sizeHint().height() for r in rows}) == 1
 
-    without.deleteLater()
-    with_one.deleteLater()
+    for r in rows:
+        r.deleteLater()
 
 
 def test_a_long_dependency_list_is_elided_not_clipped(qapp):
-    """Four dependencies made the label wider than the row, and Qt cut it mid-word."""
+    """Four dependencies overflowed the row, and Qt cut the text off mid-word."""
     requires = [
         "Setup Lamella Position",
         "Spot Burn Fiducial",
@@ -97,27 +97,20 @@ def test_a_long_dependency_list_is_elided_not_clipped(qapp):
     ]
     row = _row("Final Polishing Pass", requires)
 
-    rendered = _rendered(row)
-    assert "…" in rendered
-    assert rendered.startswith("Final Polishing Pass after Setup Lamella Position")
-    # Bounded by the budget plus the name, rather than by however long the list is.
-    name_only = _row("Final Polishing Pass", [])
-    assert (
-        row.name_label.sizeHint().width()
-        <= name_only.sizeHint().width() + REQUIRES_MAX_WIDTH
-    )
+    text = row.requires_label.text()
+    assert "…" in text
+    assert text.startswith("after Setup Lamella Position")
     # Nothing is lost: the whole list is one hover away.
     assert row.toolTip() == "Requires: " + ", ".join(requires)
 
     row.deleteLater()
-    name_only.deleteLater()
 
 
-def test_a_task_name_cannot_inject_markup(qapp):
-    """Names come from the protocol, and the label is rich text."""
+def test_a_task_name_cannot_render_as_markup(qapp):
+    """Names come from the protocol, and QLabel on AutoText would interpret them."""
     row = _row("Mill <b>Fiducial</b> & Co", [])
 
-    assert "&lt;b&gt;" in row.name_label.text()
-    assert "<b>" not in row.name_label.text()
+    assert row.name_label.textFormat() == Qt.PlainText
+    assert row.name_label.text() == "Mill <b>Fiducial</b> & Co"
 
     row.deleteLater()

--- a/tests/ui/test_workflow_task_requires.py
+++ b/tests/ui/test_workflow_task_requires.py
@@ -1,17 +1,20 @@
-"""A task row states its requirements, and says nothing when it has none.
+"""A task row states what it waits for, on the same line as its name.
 
-Every row used to carry a second line, and on most of them it read "No
-requirements" — an absence restated once per task, which is what buried the two or
-three rows that actually declare a dependency. Blank leaves those standing alone.
+Every row used to carry a second line, and on most it read "No requirements" — an
+absence restated once per task, which buried the two or three rows that actually
+declare a dependency. Blanking that line was not enough on its own: the name sits
+at the top of a two-line block, so a row without a sub-line reads as a name
+floating above a gap. One line puts every name on the same baseline.
 
-The line is emptied rather than hidden, so every row keeps the same height and the
-list does not go ragged wherever a dependency happens to fall. Both halves are
-pinned here, because the obvious "tidy-up" is to hide the label.
+The dependency list is elided to a fixed budget, because a task waiting on four
+others produced a label wider than the row and Qt cut it off mid-word. The row's
+tooltip carries the full list.
 """
 
 from __future__ import annotations
 
 import os
+import re
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
@@ -23,52 +26,98 @@ from fibsem.applications.autolamella.structures import (  # noqa: E402
     AutoLamellaTaskDescription,
 )
 from fibsem.applications.autolamella.ui.workflow_config_widget import (  # noqa: E402
+    REQUIRES_MAX_WIDTH,
     WorkflowTaskRowWidget,
 )
 
+TAGS = re.compile(r"<[^>]+>")
 
-def _row(qapp, name: str, requires: list[str]) -> WorkflowTaskRowWidget:
-    task = AutoLamellaTaskDescription(
-        name=name, supervise=False, required=True, requires=requires
+
+def _row(name: str, requires: list[str]) -> WorkflowTaskRowWidget:
+    return WorkflowTaskRowWidget(
+        AutoLamellaTaskDescription(
+            name=name, supervise=False, required=True, requires=requires
+        )
     )
-    return WorkflowTaskRowWidget(task)
 
 
-def test_a_task_with_no_requirements_says_nothing(qapp):
-    row = _row(qapp, "Mill Fiducial", [])
+def _rendered(row: WorkflowTaskRowWidget) -> str:
+    """What the label actually reads, with the markup stripped."""
+    return TAGS.sub("", row.name_label.text())
 
-    assert row.requires_label.text() == ""
+
+def test_a_task_with_no_requirements_says_only_its_name(qapp):
+    row = _row("Mill Fiducial", [])
+
+    assert _rendered(row) == "Mill Fiducial"
 
     row.deleteLater()
 
 
-def test_a_task_with_requirements_names_them(qapp):
-    row = _row(qapp, "Rough Milling", ["Mill Fiducial"])
+def test_a_task_with_a_requirement_names_it_after_the_task(qapp):
+    row = _row("Rough Milling", ["Mill Fiducial"])
 
-    assert row.requires_label.text() == "Mill Fiducial"
+    assert _rendered(row) == "Rough Milling after Mill Fiducial"
 
     row.deleteLater()
 
 
 def test_several_requirements_are_listed(qapp):
-    row = _row(qapp, "Polishing", ["Mill Fiducial", "Rough Milling"])
+    row = _row("Polishing", ["Mill Fiducial", "Rough Milling"])
 
-    assert row.requires_label.text() == "Mill Fiducial, Rough Milling"
+    assert _rendered(row) == "Polishing after Mill Fiducial, Rough Milling"
 
     row.deleteLater()
 
 
-def test_rows_keep_the_same_height_either_way(qapp):
-    """Emptied, not hidden. Hiding the label shortens the row it is on.
+def test_rows_sit_on_one_baseline_either_way(qapp):
+    """The point of the single line: no row is taller, and no name is higher.
 
-    A list whose rows change height depending on whether a task declares a
-    dependency is harder to read than the repeated text this removes.
+    Two labels stacked would put the name at the top of the block on every row
+    that has no dependency, which is most of them.
     """
-    without = _row(qapp, "Mill Fiducial", [])
-    with_one = _row(qapp, "Rough Milling", ["Mill Fiducial"])
+    without = _row("Mill Fiducial", [])
+    with_one = _row("Rough Milling", ["Mill Fiducial"])
 
-    assert without.requires_label.isVisibleTo(without)
     assert without.sizeHint().height() == with_one.sizeHint().height()
+    # One label, so there is no second line for the name to sit above.
+    assert not hasattr(without, "requires_label")
 
     without.deleteLater()
     with_one.deleteLater()
+
+
+def test_a_long_dependency_list_is_elided_not_clipped(qapp):
+    """Four dependencies made the label wider than the row, and Qt cut it mid-word."""
+    requires = [
+        "Setup Lamella Position",
+        "Spot Burn Fiducial",
+        "Mill Fiducial",
+        "Rough Milling",
+    ]
+    row = _row("Final Polishing Pass", requires)
+
+    rendered = _rendered(row)
+    assert "…" in rendered
+    assert rendered.startswith("Final Polishing Pass after Setup Lamella Position")
+    # Bounded by the budget plus the name, rather than by however long the list is.
+    name_only = _row("Final Polishing Pass", [])
+    assert (
+        row.name_label.sizeHint().width()
+        <= name_only.sizeHint().width() + REQUIRES_MAX_WIDTH
+    )
+    # Nothing is lost: the whole list is one hover away.
+    assert row.toolTip() == "Requires: " + ", ".join(requires)
+
+    row.deleteLater()
+    name_only.deleteLater()
+
+
+def test_a_task_name_cannot_inject_markup(qapp):
+    """Names come from the protocol, and the label is rich text."""
+    row = _row("Mill <b>Fiducial</b> & Co", [])
+
+    assert "&lt;b&gt;" in row.name_label.text()
+    assert "<b>" not in row.name_label.text()
+
+    row.deleteLater()


### PR DESCRIPTION
Every task row in the workflow list carried a second line under its name. On a default protocol, four of six read **"No requirements"** — an absence restated once per task, which is what buried the two that actually declare a dependency.

Two revisions on the way to this, both driven by looking at the rendered result:

1. **Blanking the line was not enough.** The name sits at the top of a two-line block, so a row with no sub-line reads as a name floating above a gap — and that is most rows. Row *height* was unchanged, which is what I measured, and why the first check missed it.
2. **A suffix after the name was not enough either.** `Rough Milling  after Mill Fiducial` puts every name on one baseline, but the dependency then starts and ends wherever that name happens to stop, so a list of them cannot be read downwards.

## The column

One line per row; the dependency in a **fixed-width, right-aligned column** before the buttons. Every entry ends on the same edge (measured: right edge at the same x on every row), so the column scans vertically.

```
Setup Lamella Position
Spot Burn Fiducial
Mill Fiducial
Rough Milling                    after Mill Fiducial
Polishing                        after Rough Milling
Example AutoLamella Task
Final Polishing Pass   after Setup Lamella Position, S…
```

Rows are 38px whether or not the column has anything in it.

## What fell out of it

- **Plain text again.** The suffix version appended markup to the name label, which meant escaping; a separate label needs none.
- **Both labels are pinned to `Qt.PlainText`.** A `QLabel` left on `AutoText` renders a task named `<b>Polish</b>` as markup — true on this widget before this branch as well.
- **Elision moved into the column**, which is what bounds the width now. Four dependencies produced a label wider than the row, and Qt cut it off mid-word; the row's tooltip carries the full list.

## Tests

`tests/ui/test_workflow_task_requires.py` — 6: empty column when there is no dependency; one and several named; the column is the same width and edge on every row and no row is taller for having content in it; a four-dependency list elides with the whole list in the tooltip; and a task named `Mill <b>Fiducial</b> & Co` renders literally.

Full `tests/ui`: 2061 passed, 1 skipped. Formatted per #489, AST-identical.
