### PR TITLE
[fix] Export the Tescan SDK version, instead of re-exporting the SDK module

### DIFF
--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -14,6 +14,10 @@ import fibsem.constants as constants
 from fibsem.microscope import FibsemMicroscope
 
 TESCAN_API_AVAILABLE = False
+# Read through this rather than importing tescanautomation yourself: the guarded
+# import below is also what strips the SDK's PySide6 GUI modules out of
+# sys.modules, and that has to have happened first.
+TESCAN_API_VERSION: Optional[str] = None
 TESCAN_BEAM_READY_TIMEOUT = 60                     # Max time in seconds to wait for the beam to become ready (busy-wait when using Tescanautomation API)
 TESCAN_PRESERVE_SETTINGS_ON_PRESET_CHANGE = True   # Restore rotation/FOV/shift across preset changes, if false, use the values stored in the preset
 SPOT_BURN_POLL_INTERVAL = 1                        # Seconds between DrawBeam status polls while a spot is exposing
@@ -37,6 +41,10 @@ try:
     sys.modules.pop("tescanautomation.pyside6gui.workflow_private")
     sys.modules.pop("PySide6.QtCore")
     TESCAN_API_AVAILABLE = True
+    # getattr, not attribute access: this runs inside the try, so an SDK build
+    # without __version__ would otherwise be caught below and disable the whole
+    # Tescan backend over a missing version string.
+    TESCAN_API_VERSION = getattr(tescanautomation, "__version__", None)
 except Exception as e:
     logging.debug(f"Automation (TESCAN) not installed. {e}")
 

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -18,11 +18,15 @@ TESCAN_API_AVAILABLE = False
 # import below is also what strips the SDK's PySide6 GUI modules out of
 # sys.modules, and that has to have happened first.
 TESCAN_API_VERSION: Optional[str] = None
-TESCAN_BEAM_READY_TIMEOUT = 60                     # Max time in seconds to wait for the beam to become ready (busy-wait when using Tescanautomation API)
-TESCAN_PRESERVE_SETTINGS_ON_PRESET_CHANGE = True   # Restore rotation/FOV/shift across preset changes, if false, use the values stored in the preset
-SPOT_BURN_POLL_INTERVAL = 1                        # Seconds between DrawBeam status polls while a spot is exposing
-SPOT_BURN_PRESET = "30 keV; 100 pA"                # Beam conditions used for spot burning
-DEFAULT_IMAGING_PRESET = "30 keV; 10 pA"           # Fallback for finish_milling when no preset was snapshotted
+TESCAN_BEAM_READY_TIMEOUT = 60  # Max time in seconds to wait for the beam to become ready (busy-wait when using Tescanautomation API)
+TESCAN_PRESERVE_SETTINGS_ON_PRESET_CHANGE = True  # Restore rotation/FOV/shift across preset changes, if false, use the values stored in the preset
+SPOT_BURN_POLL_INTERVAL = (
+    1  # Seconds between DrawBeam status polls while a spot is exposing
+)
+SPOT_BURN_PRESET = "30 keV; 100 pA"  # Beam conditions used for spot burning
+DEFAULT_IMAGING_PRESET = (
+    "30 keV; 10 pA"  # Fallback for finish_milling when no preset was snapshotted
+)
 
 try:
     import tescanautomation
@@ -48,7 +52,7 @@ try:
 except Exception as e:
     logging.debug(f"Automation (TESCAN) not installed. {e}")
 
-from fibsem.structures import ( #noqa
+from fibsem.structures import (  # noqa
     BeamSettings,
     BeamSystemSettings,
     BeamType,
@@ -76,6 +80,7 @@ from fibsem.structures import ( #noqa
     ACTIVE_MILLING_STATES,
 )
 
+
 def _get_beam_settings_from_tescan_md(md: dict, beam_type: BeamType) -> BeamSettings:
     """Parse metadata from Tescan image header to get beam settings."""
     return BeamSettings(
@@ -85,13 +90,12 @@ def _get_beam_settings_from_tescan_md(md: dict, beam_type: BeamType) -> BeamSett
         beam_current=float(md["PredictedBeamCurrent"]),
         dwell_time=float(md["DwellTime"]),
         scan_rotation=float(md["ScanRotation"]) * constants.DEGREES_TO_RADIANS,
-        stigmation=Point(x=float(md["StigmatorX"]), 
-                            y=float(md["StigmatorY"])),
-        shift=Point(x=float(md["ImageShiftX"]), 
-                    y=float(md["ImageShiftY"])),
+        stigmation=Point(x=float(md["StigmatorX"]), y=float(md["StigmatorY"])),
+        shift=Point(x=float(md["ImageShiftX"]), y=float(md["ImageShiftY"])),
         preset=md.get("LastPreset", None),
     )
-    
+
+
 def _get_detector_settings_from_tescan_md(md: dict) -> FibsemDetectorSettings:
     """Parse metadata from Tescan image header to get detector settings."""
     return FibsemDetectorSettings(
@@ -100,13 +104,16 @@ def _get_detector_settings_from_tescan_md(md: dict) -> FibsemDetectorSettings:
         contrast=float(md["Detector0Offset"]) / 100.0,
     )
 
+
 def _get_pixel_size_from_tescan_md(md: dict) -> Point:
     """Parse metadata from Tescan image header to get pixel size."""
-    pixelsize = Point(float(md["MAIN"]["PixelSizeX"]), 
-                    float(md["MAIN"]["PixelSizeY"]))
+    pixelsize = Point(float(md["MAIN"]["PixelSizeX"]), float(md["MAIN"]["PixelSizeY"]))
     return pixelsize
 
-def _get_microscope_state_from_tescan_md(md: dict, image_shape: Tuple[int, int]) -> MicroscopeState:
+
+def _get_microscope_state_from_tescan_md(
+    md: dict, image_shape: Tuple[int, int]
+) -> MicroscopeState:
     """Parse metadata from Tescan image header to create a MicroscopeState object."""
     ddict = {}
     SUPPORTED_KEYS = ["MAIN", "FIB", "SEM"]
@@ -136,14 +143,14 @@ def _get_microscope_state_from_tescan_md(md: dict, image_shape: Tuple[int, int])
     pixelsize = _get_pixel_size_from_tescan_md(ddict)
     resolution = image_shape[1], image_shape[0]
     hfw = pixelsize.x * resolution[0]
-   
+
     # default values
     electron_beam = BeamSettings(beam_type=BeamType.ELECTRON)
     ion_beam = BeamSettings(beam_type=BeamType.ION)
     electron_detector = FibsemDetectorSettings()
     ion_detector = FibsemDetectorSettings()
 
-    # beam settings 
+    # beam settings
     if beam_type is BeamType.ION:
         ion_detector = _get_detector_settings_from_tescan_md(ddict[k])
         ion_beam = _get_beam_settings_from_tescan_md(ddict[k], BeamType.ION)
@@ -157,7 +164,9 @@ def _get_microscope_state_from_tescan_md(md: dict, image_shape: Tuple[int, int])
 
     # acquisition timestamp
     acquisition_time = ddict["MAIN"]["Date"] + " " + ddict["MAIN"]["Time"]
-    timestamp = datetime.datetime.strptime(acquisition_time, "%Y-%m-%d %H:%M:%S").timestamp()
+    timestamp = datetime.datetime.strptime(
+        acquisition_time, "%Y-%m-%d %H:%M:%S"
+    ).timestamp()
 
     ms = MicroscopeState(
         timestamp=timestamp,
@@ -169,12 +178,16 @@ def _get_microscope_state_from_tescan_md(md: dict, image_shape: Tuple[int, int])
     )
     return ms
 
-def fromTescanImage(image: 'Document', image_settings: ImageSettings = None) -> FibsemImage:
+
+def fromTescanImage(
+    image: "Document", image_settings: ImageSettings = None
+) -> FibsemImage:
     """Create a FibsemImage object from a Tescan image document."""
     image_data = np.array(image.Image)
     pixelsize = _get_pixel_size_from_tescan_md(image.Header)
-    ms = _get_microscope_state_from_tescan_md(image.Header, 
-                                              image_shape=image_data.shape)
+    ms = _get_microscope_state_from_tescan_md(
+        image.Header, image_shape=image_data.shape
+    )
     if image_settings is None:
         image_settings = ImageSettings()
 
@@ -186,7 +199,10 @@ def fromTescanImage(image: 'Document', image_settings: ImageSettings = None) -> 
 
     return FibsemImage(data=image_data, metadata=deepcopy(md))
 
-def to_tescan_image_roi(rect: FibsemRectangle, image_shape: Tuple[int, int]) -> Tuple[int, int, int, int]:
+
+def to_tescan_image_roi(
+    rect: FibsemRectangle, image_shape: Tuple[int, int]
+) -> Tuple[int, int, int, int]:
     """Convert a FibsemRectangle to a Tescan image ROI (left, top, right, bottom)."""
     image_width, image_height = image_shape
     left = int(rect.left * image_width)
@@ -195,19 +211,21 @@ def to_tescan_image_roi(rect: FibsemRectangle, image_shape: Tuple[int, int]) -> 
     bottom = int(top + rect.height * image_height - 1)
     return left, top, right, bottom
 
+
 def from_tescan_stage_position(position: Tuple[float]) -> FibsemStagePosition:
     """Convert a Tescan stage position to a FibsemStagePosition object."""
-    x, y, z, r, t = position[:5] # stage can be up to 6D
+    x, y, z, r, t = position[:5]  # stage can be up to 6D
 
     stage_position = FibsemStagePosition(
-        x = x * constants.MILLIMETRE_TO_METRE,
-        y = y * constants.MILLIMETRE_TO_METRE,
-        z = z * constants.MILLIMETRE_TO_METRE,
-        r = r * constants.DEGREES_TO_RADIANS,
-        t = t * constants.DEGREES_TO_RADIANS,
-        coordinate_system= "RAW",
+        x=x * constants.MILLIMETRE_TO_METRE,
+        y=y * constants.MILLIMETRE_TO_METRE,
+        z=z * constants.MILLIMETRE_TO_METRE,
+        r=r * constants.DEGREES_TO_RADIANS,
+        t=t * constants.DEGREES_TO_RADIANS,
+        coordinate_system="RAW",
     )
     return stage_position
+
 
 def to_tescan_stage_position(position: FibsemStagePosition) -> Tuple[float]:
     """Convert a FibsemStagePosition object to a Tescan stage position."""
@@ -217,6 +235,7 @@ def to_tescan_stage_position(position: FibsemStagePosition) -> Tuple[float]:
     r = position.r * constants.RADIANS_TO_DEGREES if position.r is not None else None
     t = position.t * constants.RADIANS_TO_DEGREES if position.t is not None else None
     return x, y, z, r, t
+
 
 FibsemStagePosition.from_tescan_stage_position = from_tescan_stage_position
 FibsemImage.fromTescanImage = fromTescanImage
@@ -245,10 +264,10 @@ except Exception as e:
 
 
 SEM_LIMITS: Dict[str, Tuple] = {
-    "hfw":  (1.0e-6, 2580.0e-6),
+    "hfw": (1.0e-6, 2580.0e-6),
 }
 FIB_LIMITS: Dict[str, Tuple] = {
-    "hfw":  (1.0e-6, 450.0e-6),
+    "hfw": (1.0e-6, 450.0e-6),
 }
 
 LIMITS = {
@@ -268,7 +287,9 @@ class TescanMicroscope(FibsemMicroscope):
 
     def __init__(self, system_settings: SystemSettings):
         if not TESCAN_API_AVAILABLE:
-            raise ImportError("The TESCAN Automation API is not available. Please see the user guide for installation instructions.")
+            raise ImportError(
+                "The TESCAN Automation API is not available. Please see the user guide for installation instructions."
+            )
 
         # create microscope client
         self.connection: Automation
@@ -284,7 +305,9 @@ class TescanMicroscope(FibsemMicroscope):
         self.system: SystemSettings = system_settings
         self.milling_channel: BeamType = BeamType.ION
         self.stage_is_compustage: bool = False
-        self._preserve_settings_on_preset_change: bool = TESCAN_PRESERVE_SETTINGS_ON_PRESET_CHANGE
+        self._preserve_settings_on_preset_change: bool = (
+            TESCAN_PRESERVE_SETTINGS_ON_PRESET_CHANGE
+        )
         self._last_imaging_settings: ImageSettings = ImageSettings()
         # preset active before milling started, restored by finish_milling
         self._preset_before_milling: Optional[str] = None
@@ -309,21 +332,31 @@ class TescanMicroscope(FibsemMicroscope):
         }
 
         # logging
-        logging.debug({"msg": "create_microscope_client", "system_settings": system_settings.to_dict()})
+        logging.debug(
+            {
+                "msg": "create_microscope_client",
+                "system_settings": system_settings.to_dict(),
+            }
+        )
 
     def disconnect(self) -> None:
         self.connection.Disconnect()
         del self.connection
         self.connection = None
 
-    def connect_to_microscope(self, ip_address: str = "localhost", port: int = 8300, reset_beam_shift: bool = True) -> None:
+    def connect_to_microscope(
+        self,
+        ip_address: str = "localhost",
+        port: int = 8300,
+        reset_beam_shift: bool = True,
+    ) -> None:
         """
-            Connects to a microscope with the specified IP address and port.
+        Connects to a microscope with the specified IP address and port.
 
-            Args:
-                ip_address: ip address of the microscope server (default: localhost).
-                port: port of the microscope server (default 8300).
-                reset_beam_shift: Whether to reset beam shifts on connect (default: True).
+        Args:
+            ip_address: ip address of the microscope server (default: localhost).
+            port: port of the microscope server (default 8300).
+            reset_beam_shift: Whether to reset beam shifts on connect (default: True).
         """
         logging.info(f"Microscope client connecting to [{ip_address}:{port}]")
         self.connection = Automation(ip_address, port)
@@ -333,15 +366,21 @@ class TescanMicroscope(FibsemMicroscope):
         self._default_detector_names = {BeamType.ELECTRON: "SE", BeamType.ION: "SE"}
         self._active_detector: Dict[BeamType, Detector] = {}
         available_detectors = self._get_available_detectors(BeamType.ELECTRON)
-        if self._default_detector_names[BeamType.ELECTRON] not in [d.name for d in available_detectors]:
+        if self._default_detector_names[BeamType.ELECTRON] not in [
+            d.name for d in available_detectors
+        ]:
             self._default_detector_names[BeamType.ELECTRON] = "E-T"
-        self.set_detector_type(self._default_detector_names[BeamType.ELECTRON], BeamType.ELECTRON)
+        self.set_detector_type(
+            self._default_detector_names[BeamType.ELECTRON], BeamType.ELECTRON
+        )
         self.set_detector_type(self._default_detector_names[BeamType.ION], BeamType.ION)
 
         # system info
-        self.system.info.manufacturer = "TESCAN" # only available from image
+        self.system.info.manufacturer = "TESCAN"  # only available from image
         info = self.system.info
-        logging.info(f"Microscope client connected to model {info.model} with serial number {info.serial_number} and software version {info.software_version}.")
+        logging.info(
+            f"Microscope client connected to model {info.model} with serial number {info.serial_number} and software version {info.software_version}."
+        )
 
         # reset beam shifts
         if reset_beam_shift:
@@ -353,20 +392,31 @@ class TescanMicroscope(FibsemMicroscope):
         except Exception as e:
             logging.warning(f"Could not create sample stage: {e}")
 
-        logging.debug({"msg": "connect_to_microscope", "ip_address": ip_address, "port": port, "system_info": self.system.info.to_dict()})
+        logging.debug(
+            {
+                "msg": "connect_to_microscope",
+                "ip_address": ip_address,
+                "port": port,
+                "system_info": self.system.info.to_dict(),
+            }
+        )
 
     @property
     def manufacturer(self) -> str:
         return "Tescan"
 
-    def acquire_image(self, image_settings: Optional[ImageSettings] = None, beam_type: Optional[BeamType] = None) -> FibsemImage:
+    def acquire_image(
+        self,
+        image_settings: Optional[ImageSettings] = None,
+        beam_type: Optional[BeamType] = None,
+    ) -> FibsemImage:
         """
         Acquire a new image with the specified settings or current settings for the given beam type.
 
         Args:
-            image_settings (ImageSettings, optional): The settings for the new image. 
+            image_settings (ImageSettings, optional): The settings for the new image.
                 Takes precedence if both parameters are provided.
-            beam_type (BeamType, optional): The beam type to use with current settings. 
+            beam_type (BeamType, optional): The beam type to use with current settings.
                 Used only if image_settings is not provided.
 
         Returns:
@@ -389,7 +439,9 @@ class TescanMicroscope(FibsemMicroscope):
 
         # Validate parameters - at least one must be provided
         if image_settings is None and beam_type is None:
-            raise ValueError("Must provide either image_settings (to acquire with specific settings) or beam_type (to acquire with current microscope settings for that beam type).")
+            raise ValueError(
+                "Must provide either image_settings (to acquire with specific settings) or beam_type (to acquire with current microscope settings for that beam type)."
+            )
         # Determine which beam type and settings to use (image_settings takes precedence)
         elif image_settings is not None:
             # Use provided image settings
@@ -398,7 +450,9 @@ class TescanMicroscope(FibsemMicroscope):
         elif beam_type is not None:
             # Use current settings for the specified beam type
             effective_beam_type = beam_type
-            effective_image_settings = self.get_imaging_settings(beam_type=effective_beam_type)
+            effective_image_settings = self.get_imaging_settings(
+                beam_type=effective_beam_type
+            )
 
         logging.info(f"acquiring new {effective_beam_type.name} image.")
 
@@ -412,16 +466,19 @@ class TescanMicroscope(FibsemMicroscope):
 
         # Only apply settings if image_settings was provided
         if image_settings is not None:
-            hfw = self.get_field_of_view(beam_type=effective_beam_type)  # update hfw if required
+            hfw = self.get_field_of_view(
+                beam_type=effective_beam_type
+            )  # update hfw if required
             if not np.isclose(hfw, effective_image_settings.hfw, atol=1e-6):
-                self.set_field_of_view(effective_image_settings.hfw, effective_beam_type)
+                self.set_field_of_view(
+                    effective_image_settings.hfw, effective_beam_type
+                )
 
-        image_roi = effective_image_settings.reduced_area   
+        image_roi = effective_image_settings.reduced_area
 
         if image_roi is not None:
             left, top, right, bottom = to_tescan_image_roi(
-                rect=image_roi, 
-                image_shape=(image_width, image_height)
+                rect=image_roi, image_shape=(image_width, image_height)
             )
             image: Document = beam.Scan.AcquireROI(
                 Detector=self._active_detector[effective_beam_type],
@@ -460,12 +517,16 @@ class TescanMicroscope(FibsemMicroscope):
             raise ValueError(f"Unknown beam type: {effective_beam_type}")
 
         # cache beam metadata parameters
-        self._beam_parameters[effective_beam_type].dwell_time = effective_image_settings.dwell_time
-        self._beam_parameters[effective_beam_type].resolution = effective_image_settings.resolution
+        self._beam_parameters[
+            effective_beam_type
+        ].dwell_time = effective_image_settings.dwell_time
+        self._beam_parameters[
+            effective_beam_type
+        ].resolution = effective_image_settings.resolution
         self._beam_parameters[effective_beam_type].stigmation = beam_state.stigmation
         self._beam_parameters[effective_beam_type].preset = beam_state.preset
 
-        # Store last imaging settings only if image_settings was provided  
+        # Store last imaging settings only if image_settings was provided
         if image_settings is not None:
             self._last_imaging_settings = image_settings
 
@@ -507,7 +568,7 @@ class TescanMicroscope(FibsemMicroscope):
             logging.error(f"Error in TESCAN acquisition worker: {e}")
 
     def last_image(self, beam_type: BeamType) -> FibsemImage:
-        """    
+        """
         Returns the last acquired image for the specified beam type.
 
         Args:
@@ -534,9 +595,11 @@ class TescanMicroscope(FibsemMicroscope):
         return NotImplemented
         image = self.connection.Camera.AcquireImage()
         logging.debug({"msg": "acquire_chamber_image"})
-        return FibsemImage(data=np.array(image.Image), metadata=None)   
+        return FibsemImage(data=np.array(image.Image), metadata=None)
 
-    def autocontrast(self, beam_type: BeamType, reduced_area: FibsemRectangle = None) -> None:
+    def autocontrast(
+        self, beam_type: BeamType, reduced_area: FibsemRectangle = None
+    ) -> None:
         """Automatically adjust the microscope image contrast for the specified beam type.
 
         Args:
@@ -547,17 +610,23 @@ class TescanMicroscope(FibsemMicroscope):
         beam.Detector.AutoSignal(Detector=self._active_detector[beam_type])
         return
 
-    def auto_focus(self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None) -> None:        
+    def auto_focus(
+        self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None
+    ) -> None:
         if beam_type is BeamType.ION:
-            logging.warning(f"Auto focus is not supported for {beam_type.name} in Tescan API")
+            logging.warning(
+                f"Auto focus is not supported for {beam_type.name} in Tescan API"
+            )
             return
         beam = self._prepare_beam(beam_type=beam_type)
         beam.AutoWDFine(self._active_detector[beam_type])
-        return 
+        return
 
-    def beam_shift(self, dx: float, dy: float, beam_type: BeamType = BeamType.ION) -> None:
+    def beam_shift(
+        self, dx: float, dy: float, beam_type: BeamType = BeamType.ION
+    ) -> None:
         """Adjusts the beam shift based on relative values that are provided.
-        
+
         Args:
             self (FibsemMicroscope): Fibsem microscope object
             dx (float): the relative x term
@@ -571,10 +640,11 @@ class TescanMicroscope(FibsemMicroscope):
         logging.info(f"{beam_type.name} shifting by ({dx}, {dy})")
         new_beam_shift = self.get_beam_shift(beam_type) + Point(dx, dy)
         self.set_beam_shift(new_beam_shift, beam_type)
-        logging.debug({"msg": "beam_shift", "dx": dx, "dy": dy, "beam_type": beam_type.name})
+        logging.debug(
+            {"msg": "beam_shift", "dx": dx, "dy": dy, "beam_type": beam_type.name}
+        )
 
-    def safe_absolute_stage_movement(self, stage_position: FibsemStagePosition
-        ) -> None:
+    def safe_absolute_stage_movement(self, stage_position: FibsemStagePosition) -> None:
 
         # TODO: implement if required.
         self.move_stage_absolute(stage_position)
@@ -687,16 +757,21 @@ class TescanMicroscope(FibsemMicroscope):
         # coordinates). It is applied after the trig so the z sign stays independent.
         # Verify on hardware: a stable_move at non-zero sample inclination should
         # keep the feature centered AND in focus (wrong z sign -> focus error).
-        stage_position = FibsemStagePosition(
-            x=-dx, y=-yz_move.y, z=yz_move.z, r=0, t=0
-        )
+        stage_position = FibsemStagePosition(x=-dx, y=-yz_move.y, z=yz_move.z, r=0, t=0)
         logging.info(f"moving stage ({beam_type.name}): {stage_position}")
         self.move_stage_relative(stage_position)
 
-        logging.debug({"msg": "stable_move", "dx": dx, "dy": dy,
-                       "beam_type": beam_type.name, "static_wd": static_wd,
-                       "scan_rotation": scan_rotation,
-                       "position": stage_position.to_dict()})
+        logging.debug(
+            {
+                "msg": "stable_move",
+                "dx": dx,
+                "dy": dy,
+                "beam_type": beam_type.name,
+                "static_wd": static_wd,
+                "scan_rotation": scan_rotation,
+                "position": stage_position.to_dict(),
+            }
+        )
 
         return self.get_stage_position()
 
@@ -767,12 +842,12 @@ class TescanMicroscope(FibsemMicroscope):
 
         stage_pretilt = np.deg2rad(self.system.stage.shuttle_pre_tilt)
 
-        stage_rotation_flat_to_eb = np.deg2rad(
-            self.system.stage.rotation_reference
-        ) % (2 * np.pi)
-        stage_rotation_flat_to_ion = np.deg2rad(
-            self.system.stage.rotation_180
-        ) % (2 * np.pi)
+        stage_rotation_flat_to_eb = np.deg2rad(self.system.stage.rotation_reference) % (
+            2 * np.pi
+        )
+        stage_rotation_flat_to_ion = np.deg2rad(self.system.stage.rotation_180) % (
+            2 * np.pi
+        )
 
         # current stage position
         current_stage_position = self.get_stage_position()
@@ -782,6 +857,7 @@ class TescanMicroscope(FibsemMicroscope):
         # pre-tilt sign flips when the stage is rotated 180 deg to face the ion beam
         PRETILT_SIGN = 1.0
         from fibsem import movement
+
         if movement.rotation_angle_is_smaller(
             stage_rotation, stage_rotation_flat_to_eb, atol=5
         ):
@@ -799,7 +875,9 @@ class TescanMicroscope(FibsemMicroscope):
         # toward the FIB (same sense as ThermoFisher). If opposite, negate stage_tilt here.
         sample_inclination = stage_tilt - corrected_pretilt_angle
 
-        beam_tilt = sem_column_tilt if beam_type is BeamType.ELECTRON else fib_column_tilt
+        beam_tilt = (
+            sem_column_tilt if beam_type is BeamType.ELECTRON else fib_column_tilt
+        )
 
         # perspective: image-projected dy -> true distance along the sample plane
         y_sample_move = expected_y / np.cos(sample_inclination - beam_tilt)
@@ -812,16 +890,23 @@ class TescanMicroscope(FibsemMicroscope):
         # right. Keep _inverse_y_corrected_stage_movement's sin branch in sync.
         z_move = -y_sample_move * np.sin(sample_inclination)
 
-        logging.debug({"msg": "_y_corrected_stage_movement",
-                       "stage_tilt": stage_tilt,
-                       "corrected_pretilt_angle": corrected_pretilt_angle,
-                       "sample_inclination": sample_inclination,
-                       "expected_y": expected_y,
-                       "y_move": y_move, "z_move": z_move})
+        logging.debug(
+            {
+                "msg": "_y_corrected_stage_movement",
+                "stage_tilt": stage_tilt,
+                "corrected_pretilt_angle": corrected_pretilt_angle,
+                "sample_inclination": sample_inclination,
+                "expected_y": expected_y,
+                "y_move": y_move,
+                "z_move": z_move,
+            }
+        )
 
         return FibsemStagePosition(x=0, y=y_move, z=z_move)
 
-    def _inverse_y_corrected_stage_movement(self, dy: float, dz: float, beam_type: BeamType = BeamType.ELECTRON) -> float:
+    def _inverse_y_corrected_stage_movement(
+        self, dy: float, dz: float, beam_type: BeamType = BeamType.ELECTRON
+    ) -> float:
         """
         Calculate the expected_y input from dy, dz stage movements and beam_type.
         This is the inverse of stable_move's y/z calculation: it takes actual (raw)
@@ -855,7 +940,6 @@ class TescanMicroscope(FibsemMicroscope):
         )
 
     def get_manipulator_state(self) -> bool:
-
         """returns true if nanomanipulator is inserted. Manipulator positions must be calibrated and stored in system.yaml file if not done so
 
         Raises:
@@ -883,7 +967,6 @@ class TescanMicroscope(FibsemMicroscope):
         # check_compare = np.isclose(current_position_array, [retracted_position_x, retracted_position_y, retracted_position_z], atol=0.1)
 
         # return True if False in check_compare else False
-            
 
     def get_manipulator_position(self) -> FibsemManipulatorPosition:
         index = 0
@@ -892,15 +975,19 @@ class TescanMicroscope(FibsemMicroscope):
         # GetPosition returns tuple in the form (x, y, z, r)
         # x,y,z in mm and r in degrees, no tilt information
 
-        x = output_position[0]*constants.MILLIMETRE_TO_METRE
-        y = output_position[1]*constants.MILLIMETRE_TO_METRE
-        z = output_position[2]*constants.MILLIMETRE_TO_METRE
-        r = output_position[3]*constants.DEGREES_TO_RADIANS
+        x = output_position[0] * constants.MILLIMETRE_TO_METRE
+        y = output_position[1] * constants.MILLIMETRE_TO_METRE
+        z = output_position[2] * constants.MILLIMETRE_TO_METRE
+        r = output_position[3] * constants.DEGREES_TO_RADIANS
 
         return FibsemManipulatorPosition(x=x, y=y, z=z, r=r)
 
     def insert_manipulator(self, name: str = "Standby"):
-        preset_positions = ["Parking","Standby","Working",]
+        preset_positions = [
+            "Parking",
+            "Standby",
+            "Working",
+        ]
 
         if name == "PARK":
             name = "Parking"
@@ -910,17 +997,21 @@ class TescanMicroscope(FibsemMicroscope):
                 name = position
 
         if name not in preset_positions:
-            raise ValueError(f"Position {name} is not a valid preset position. Valid positions are {preset_positions}.")
+            raise ValueError(
+                f"Position {name} is not a valid preset position. Valid positions are {preset_positions}."
+            )
 
-        insert_position = getattr(self.connection.Nanomanipulator.Position,name)
+        insert_position = getattr(self.connection.Nanomanipulator.Position, name)
 
         index = 0
         logging.info(f"Inserting Nanomanipulator to {name} position")
-        self.connection.Nanomanipulator.MoveToPosition(Index=index,Position=insert_position)
+        self.connection.Nanomanipulator.MoveToPosition(
+            Index=index, Position=insert_position
+        )
 
-    def _check_manipulator_limits(self,x,y,z,r):
+    def _check_manipulator_limits(self, x, y, z, r):
 
-        limits = self.connection.Nanomanipulator.GetLimits(Index=0,Type=0)
+        limits = self.connection.Nanomanipulator.GetLimits(Index=0, Type=0)
 
         xmin = limits[0]
         xmax = limits[1]
@@ -931,17 +1022,29 @@ class TescanMicroscope(FibsemMicroscope):
         rmin = limits[6]
         rmax = limits[7]
 
-        assert x >= xmin and x <= xmax, f"X position {x} is outside of manipulator limits {xmin} to {xmax}"
-        assert y >= ymin and y <= ymax, f"Y position {y} is outside of manipulator limits {ymin} to {ymax}"
-        assert z >= zmin and z <= zmax, f"Z position {z} is outside of manipulator limits {zmin} to {zmax}"
-        assert r >= rmin and r <= rmax, f"R position {r} is outside of manipulator limits {rmin} to {rmax}"
+        assert x >= xmin and x <= xmax, (
+            f"X position {x} is outside of manipulator limits {xmin} to {xmax}"
+        )
+        assert y >= ymin and y <= ymax, (
+            f"Y position {y} is outside of manipulator limits {ymin} to {ymax}"
+        )
+        assert z >= zmin and z <= zmax, (
+            f"Z position {z} is outside of manipulator limits {zmin} to {zmax}"
+        )
+        assert r >= rmin and r <= rmax, (
+            f"R position {r} is outside of manipulator limits {rmin} to {rmax}"
+        )
 
     def retract_manipulator(self):
-        retract_position = getattr(self.connection.Nanomanipulator.Position,"Parking")
+        retract_position = getattr(self.connection.Nanomanipulator.Position, "Parking")
         index = 0
-        self.connection.Nanomanipulator.MoveToPosition(Index=index,Position=retract_position)
-    
-    def move_manipulator_relative(self,position: FibsemManipulatorPosition, name: str = None):
+        self.connection.Nanomanipulator.MoveToPosition(
+            Index=index, Position=retract_position
+        )
+
+    def move_manipulator_relative(
+        self, position: FibsemManipulatorPosition, name: str = None
+    ):
 
         if self.connection.Nanomanipulator.IsCalibrated(0) is False:
             logging.info("Calibrating manipulator")
@@ -949,31 +1052,33 @@ class TescanMicroscope(FibsemMicroscope):
 
         current_position = self.get_manipulator_position()
 
-        x = (current_position.x + position.x)*constants.METRE_TO_MILLIMETRE
-        y = (current_position.y + position.y)*constants.METRE_TO_MILLIMETRE
-        z = (current_position.z + position.z)*constants.METRE_TO_MILLIMETRE
-        r = (current_position.r + position.r)*constants.RADIANS_TO_DEGREES
+        x = (current_position.x + position.x) * constants.METRE_TO_MILLIMETRE
+        y = (current_position.y + position.y) * constants.METRE_TO_MILLIMETRE
+        z = (current_position.z + position.z) * constants.METRE_TO_MILLIMETRE
+        r = (current_position.r + position.r) * constants.RADIANS_TO_DEGREES
         index = 0
 
         # self._check_manipulator_limits(x,y,z,r)
 
         logging.info(f"moving manipulator by {position}")
         try:
-            self.connection.Nanomanipulator.MoveTo(Index=index,X=x, Y=y, Z=z, Rot=r)
+            self.connection.Nanomanipulator.MoveTo(Index=index, X=x, Y=y, Z=z, Rot=r)
         except Exception as e:
             logging.error(e)
             return e
 
-    def move_manipulator_absolute(self, position: FibsemManipulatorPosition, name: str = None):
+    def move_manipulator_absolute(
+        self, position: FibsemManipulatorPosition, name: str = None
+    ):
 
         if self.connection.Nanomanipulator.IsCalibrated(0) is False:
             logging.info("Calibrating manipulator")
             self.connection.Nanomanipulator.Calibrate(0)
 
-        x = position.x*constants.METRE_TO_MILLIMETRE
-        y = position.y*constants.METRE_TO_MILLIMETRE
-        z = position.z*constants.METRE_TO_MILLIMETRE
-        r = position.r*constants.RADIANS_TO_DEGREES
+        x = position.x * constants.METRE_TO_MILLIMETRE
+        y = position.y * constants.METRE_TO_MILLIMETRE
+        z = position.z * constants.METRE_TO_MILLIMETRE
+        r = position.r * constants.RADIANS_TO_DEGREES
         index = 0
 
         # self._check_manipulator_limits(x,y,z,r)
@@ -986,7 +1091,9 @@ class TescanMicroscope(FibsemMicroscope):
         logging.info("Calibrating manipulator")
         self.connection.Nanomanipulator.Calibrate(0)
 
-    def _x_corrected_needle_movement(self, expected_x: float) -> FibsemManipulatorPosition:
+    def _x_corrected_needle_movement(
+        self, expected_x: float
+    ) -> FibsemManipulatorPosition:
         """Calculate the corrected needle movement to move in the x-axis.
 
         Args:
@@ -996,8 +1103,8 @@ class TescanMicroscope(FibsemMicroscope):
         """
         return FibsemManipulatorPosition(x=expected_x, y=0, z=0)  # no adjustment needed
 
-    def _y_corrected_needle_movement(self, 
-        expected_y: float, stage_tilt: float
+    def _y_corrected_needle_movement(
+        self, expected_y: float, stage_tilt: float
     ) -> FibsemManipulatorPosition:
         """Calculate the corrected needle movement to move in the y-axis.
 
@@ -1012,8 +1119,8 @@ class TescanMicroscope(FibsemMicroscope):
         z_move = +np.sin(stage_tilt) * expected_y
         return FibsemManipulatorPosition(x=0, y=y_move, z=z_move)
 
-    def _z_corrected_needle_movement(self, 
-        expected_z: float, stage_tilt: float
+    def _z_corrected_needle_movement(
+        self, expected_z: float, stage_tilt: float
     ) -> FibsemManipulatorPosition:
         """Calculate the corrected needle movement to move in the z-axis.
 
@@ -1028,7 +1135,8 @@ class TescanMicroscope(FibsemMicroscope):
         z_move = +np.cos(stage_tilt) * expected_z
         return FibsemManipulatorPosition(x=0, y=y_move, z=z_move)
 
-    def move_manipulator_corrected(self, 
+    def move_manipulator_corrected(
+        self,
         dx: float = 0,
         dy: float = 0,
         beam_type: BeamType = BeamType.ELECTRON,
@@ -1063,12 +1171,14 @@ class TescanMicroscope(FibsemMicroscope):
         #     yz_move = self._z_corrected_needle_movement(expected_z=dy, stage_tilt=stage_tilt)
 
         # move needle (relative)
-        #self.connection.Nanomanipulator.MoveTo(Index=0, X=x_move.x, Y=yz_move.y, Z=yz_move.z)
+        # self.connection.Nanomanipulator.MoveTo(Index=0, X=x_move.x, Y=yz_move.y, Z=yz_move.z)
         self.move_manipulator_relative(FibsemManipulatorPosition(x=dx, y=dy, z=0))
 
         return
 
-    def move_manipulator_to_position_offset(self, offset: FibsemManipulatorPosition, name: str = None) -> None:
+    def move_manipulator_to_position_offset(
+        self, offset: FibsemManipulatorPosition, name: str = None
+    ) -> None:
         logging.warning("Not supported by TESCAN API")
         # raise NotImplementedError("Not supported by TESCAN API")
         pass
@@ -1090,7 +1200,7 @@ class TescanMicroscope(FibsemMicroscope):
         """
         if mill_settings.milling_channel is not BeamType.ION:
             raise ValueError("Only FIB milling is currently supported.")
-        
+
         self._prepare_beam(mill_settings.milling_channel)
 
         self.clear_patterns()
@@ -1103,9 +1213,13 @@ class TescanMicroscope(FibsemMicroscope):
         # would otherwise overwrite the snapshot with the milling preset.
         if getattr(self, "_preset_before_milling", None) is None:
             self._preset_before_milling = self.get("preset", BeamType.ION)
-            logging.debug(f"Snapshot preset before milling: {self._preset_before_milling}")
+            logging.debug(
+                f"Snapshot preset before milling: {self._preset_before_milling}"
+            )
 
-        self.set("preset", mill_settings.preset, BeamType.ION)  # QUERY: do we need to set this here as it is also set in IEtching?
+        self.set(
+            "preset", mill_settings.preset, BeamType.ION
+        )  # QUERY: do we need to set this here as it is also set in IEtching?
 
         layer_settings = IEtching(
             syncWriteField=False,
@@ -1121,16 +1235,17 @@ class TescanMicroscope(FibsemMicroscope):
 
         # TODO: change the layer name to milling stage name
         self.layer = self.connection.DrawBeam.Layer("Layer1", layer_settings)
-        
 
-    def run_milling(self, milling_current: float, milling_voltage: float, asynch: bool = False) -> None:
+    def run_milling(
+        self, milling_current: float, milling_voltage: float, asynch: bool = False
+    ) -> None:
         """
         Run ion beam milling using the specified milling current.
 
-        Args: 
+        Args:
             milling_current: float (unused, use preset instead)
             milling_voltage: float (unused, use preset instead)
-            asynch (bool, optional): If True, the milling will be run asynchronously. 
+            asynch (bool, optional): If True, the milling will be run asynchronously.
                             Defaults to False, in which case it will run synchronously.
         """
         self._prepare_beam(self.milling_channel)
@@ -1148,21 +1263,22 @@ class TescanMicroscope(FibsemMicroscope):
 
         # display progress bar in tescan ui
         self.connection.Progress.Show(
-            Title="DrawBeam Milling (OpenFIBSEM)", 
-            Text="Layer 1 in progress", 
-            HideButton=True, 
-            Marquee=False, 
-            ProgressMin=0, ProgressMax=100
+            Title="DrawBeam Milling (OpenFIBSEM)",
+            Text="Layer 1 in progress",
+            HideButton=True,
+            Marquee=False,
+            ProgressMin=0,
+            ProgressMax=100,
         )
 
         if asynch:
-            return # up to the user to monitor the milling process/progress
+            return  # up to the user to monitor the milling process/progress
 
         MILLING_SLEEP_TIME = 1
         err = None
         try:
             while self.get_milling_state() in ACTIVE_MILLING_STATES:
-                status = self.connection.DrawBeam.GetStatus() # status, total, elapsed
+                status = self.connection.DrawBeam.GetStatus()  # status, total, elapsed
                 milling_status, total_time, elapsed_time = status
                 if self.get_milling_state() is MillingState.RUNNING:
                     progress = 0
@@ -1173,13 +1289,17 @@ class TescanMicroscope(FibsemMicroscope):
                 time.sleep(MILLING_SLEEP_TIME)
 
                 # update milling progress via signal
-                self.milling_progress_signal.emit({"progress": {
-                        "state": "update",
-                        "milling_state": self.get_milling_state(),
-                        "start_time": start_time, 
-                        "estimated_time": estimated_time, 
-                        "remaining_time": remaining_time}
-                        })
+                self.milling_progress_signal.emit(
+                    {
+                        "progress": {
+                            "state": "update",
+                            "milling_state": self.get_milling_state(),
+                            "start_time": start_time,
+                            "estimated_time": estimated_time,
+                            "remaining_time": remaining_time,
+                        }
+                    }
+                )
 
         except Exception as err:
             logging.error(f"Error in run_milling: {err}")
@@ -1190,9 +1310,9 @@ class TescanMicroscope(FibsemMicroscope):
                 self.connection.DrawBeam.Stop()
                 self.clear_patterns()
 
-    # def run_milling_drift_corrected(self, milling_current: float,  
-    #     image_settings: ImageSettings, 
-    #     ref_image: FibsemImage, 
+    # def run_milling_drift_corrected(self, milling_current: float,
+    #     image_settings: ImageSettings,
+    #     ref_image: FibsemImage,
     #     reduced_area: FibsemRectangle = None,
     #     asynch: bool = False
     #     ):
@@ -1201,7 +1321,7 @@ class TescanMicroscope(FibsemMicroscope):
 
     #     Args:
     #         milling_current (float): The current to use for milling in amps.
-    #         asynch (bool, optional): If True, the milling will be run asynchronously. 
+    #         asynch (bool, optional): If True, the milling will be run asynchronously.
     #                                  Defaults to False, in which case it will run synchronously.
 
     #     Returns:
@@ -1261,13 +1381,15 @@ class TescanMicroscope(FibsemMicroscope):
     #     print()  # new line on complete
     #     self.connection.Progress.Hide()
 
-    def finish_milling(self, imaging_current: float = None, imaging_voltage: float = None):
+    def finish_milling(
+        self, imaging_current: float = None, imaging_voltage: float = None
+    ):
         """
         Finalises the milling process by clearing the microscope of any patterns and returning the current to the imaging current.
 
         Args:
             imaging_current (float): The current to use for imaging in amps.
-        # """
+        #"""
         # Restore the preset that was active before milling, so the column goes back to the
         # imaging conditions the user was working at. Falls back to the module default when
         # no snapshot was taken (get("preset") can be None if no image has been acquired and
@@ -1292,7 +1414,10 @@ class TescanMicroscope(FibsemMicroscope):
         # TODO: improve thread safety to stop from another thread
         try:
             thread_connection = Automation(self.system.info.ip_address, port=8300)
-            if thread_connection.DrawBeam.GetStatus()[0] == DBStatus.ProjectLoadedExpositionInProgress:
+            if (
+                thread_connection.DrawBeam.GetStatus()[0]
+                == DBStatus.ProjectLoadedExpositionInProgress
+            ):
                 logging.info("Milling is in progress, stopping now...")
                 thread_connection.DrawBeam.Stop()
         except Exception as e:
@@ -1326,7 +1451,9 @@ class TescanMicroscope(FibsemMicroscope):
         return DrawBeamStatusToPatterningState[state]
 
     @staticmethod
-    def _spot_burn_point_to_metres(point: Point, hfw: float, resolution: Tuple[int, int]) -> Point:
+    def _spot_burn_point_to_metres(
+        point: Point, hfw: float, resolution: Tuple[int, int]
+    ) -> Point:
         """Convert a normalised (0-1, top-left origin) image coordinate to DrawBeam coordinates.
 
         DrawBeam objects are positioned in metres from the image centre with +y up, the same
@@ -1358,7 +1485,7 @@ class TescanMicroscope(FibsemMicroscope):
         exposure_time: float,
         hfw: float,
         resolution: Tuple[int, int],
-    ) -> 'Automation.DrawBeam.Layer':
+    ) -> "Automation.DrawBeam.Layer":
         """Build a DrawBeam layer holding one timed dot per coordinate.
 
         The layer runs at SPOT_BURN_PRESET; the remaining IEtching fields are mandatory, so
@@ -1381,7 +1508,9 @@ class TescanMicroscope(FibsemMicroscope):
         # DepthUnit.Second makes Depth an exposure time rather than a depth, which is
         # exactly a spot burn -- park on the point and expose for this long.
         for point in coordinates:
-            centre = self._spot_burn_point_to_metres(point, hfw=hfw, resolution=resolution)
+            centre = self._spot_burn_point_to_metres(
+                point, hfw=hfw, resolution=resolution
+            )
             logging.info(
                 f"spot burn point: {point} -> ({centre.x:.3e}, {centre.y:.3e}) m, "
                 f"exposure time: {exposure_time}s"
@@ -1422,7 +1551,9 @@ class TescanMicroscope(FibsemMicroscope):
             stop_event: set to cancel the exposition.
         """
         if beam_type is not BeamType.ION:
-            raise ValueError(f"Spot burn is only supported on the ion beam, got {beam_type.name}.")
+            raise ValueError(
+                f"Spot burn is only supported on the ion beam, got {beam_type.name}."
+            )
 
         exposure_time = float(exposure_time)
         if exposure_time <= 0:
@@ -1482,13 +1613,17 @@ class TescanMicroscope(FibsemMicroscope):
                 time.sleep(SPOT_BURN_POLL_INTERVAL)
                 remaining_time = max(0.0, estimated_time - (time.time() - start_time))
 
-                self.milling_progress_signal.emit({"progress": {
-                        "state": "update",
-                        "milling_state": self.get_milling_state(),
-                        "start_time": start_time,
-                        "estimated_time": estimated_time,
-                        "remaining_time": remaining_time}
-                        })
+                self.milling_progress_signal.emit(
+                    {
+                        "progress": {
+                            "state": "update",
+                            "milling_state": self.get_milling_state(),
+                            "start_time": start_time,
+                            "estimated_time": estimated_time,
+                            "remaining_time": remaining_time,
+                        }
+                    }
+                )
         except Exception as e:
             logging.error(f"Error in run_spot_burn: {e}")
             raise
@@ -1544,7 +1679,9 @@ class TescanMicroscope(FibsemMicroscope):
             scanning_path = pattern_settings.scan_direction
         else:
             scanning_path = "Flyback"
-            logging.warning(f"Scan direction {pattern_settings.scan_direction} not supported. Using Flyback instead.")
+            logging.warning(
+                f"Scan direction {pattern_settings.scan_direction} not supported. Using Flyback instead."
+            )
         self.connection.DrawBeam.ScanningPath = scanning_path
 
         if pattern_settings.cross_section is CrossSectionPattern.CleaningCrossSection:
@@ -1553,15 +1690,15 @@ class TescanMicroscope(FibsemMicroscope):
             add_pattern_fn = self.layer.addRectangleFilled
 
         add_pattern_fn(
-                CenterX=pattern_settings.centre_x,
-                CenterY= pattern_settings.centre_y,
-                Depth=pattern_settings.depth,
-                DepthUnit='m',
-                Width=pattern_settings.width,
-                Height=pattern_settings.height,
-                Angle=pattern_settings.rotation * constants.RADIANS_TO_DEGREES,
-                ScanningPath=scanning_path,
-                # ExpositionFactor=passes
+            CenterX=pattern_settings.centre_x,
+            CenterY=pattern_settings.centre_y,
+            Depth=pattern_settings.depth,
+            DepthUnit="m",
+            Width=pattern_settings.width,
+            Height=pattern_settings.height,
+            Angle=pattern_settings.rotation * constants.RADIANS_TO_DEGREES,
+            ScanningPath=scanning_path,
+            # ExpositionFactor=passes
         )
 
         pattern = self.layer
@@ -1587,7 +1724,12 @@ class TescanMicroscope(FibsemMicroscope):
         depth = pattern_settings.depth
 
         self.layer.addLine(
-            BeginX=start_x, BeginY=start_y, EndX=end_x, EndY=end_y, Depth=depth, DepthUnit='m',
+            BeginX=start_x,
+            BeginY=start_y,
+            EndX=end_x,
+            EndY=end_y,
+            Depth=depth,
+            DepthUnit="m",
         )
 
         pattern = self.layer
@@ -1612,15 +1754,15 @@ class TescanMicroscope(FibsemMicroscope):
             RadiusA=pattern_settings.radius,
             RadiusB=0,
             Depth=pattern_settings.depth,
-            DepthUnit='m',
+            DepthUnit="m",
         )
 
         return pattern
 
-    def draw_annulus(self,pattern_settings: FibsemCircleSettings):
+    def draw_annulus(self, pattern_settings: FibsemCircleSettings):
         """Draws an annulus (donut) pattern on the current imaging view of the microscope.
 
-        Args: 
+        Args:
             pattern_settings (FibsemCircleSettings): A data class object specifying the pattern parameters,
             including the centre point, outer radius and thickness of the annulus, and the depth of the pattern.
 
@@ -1636,7 +1778,7 @@ class TescanMicroscope(FibsemMicroscope):
             RadiusA=outer_radius,
             RadiusB=inner_radius,
             Depth=pattern_settings.depth,
-            DepthUnit='m',
+            DepthUnit="m",
         )
 
         return pattern
@@ -1655,11 +1797,13 @@ class TescanMicroscope(FibsemMicroscope):
 
     def run_sputter(self, *args, **kwargs):
         pass
-        
+
     def finish_sputter(self, *args, **kwargs):
         pass
 
-    def _get_beam(self, beam_type: BeamType) -> Union['Automation.SEM', 'Automation.FIB']:
+    def _get_beam(
+        self, beam_type: BeamType
+    ) -> Union["Automation.SEM", "Automation.FIB"]:
         """Get the beam object for the given beam type."""
         if not isinstance(beam_type, BeamType):
             raise ValueError(f"Invalid beam type: {beam_type}")
@@ -1669,11 +1813,18 @@ class TescanMicroscope(FibsemMicroscope):
         if beam_type is BeamType.ION:
             return self.connection.FIB
 
-    def _wait_for_beam_ready(self, beam: Union['Automation.SEM', 'Automation.FIB'], beam_type: BeamType, operation: str = "operation") -> None:
+    def _wait_for_beam_ready(
+        self,
+        beam: Union["Automation.SEM", "Automation.FIB"],
+        beam_type: BeamType,
+        operation: str = "operation",
+    ) -> None:
         """Wait for the beam to become ready (not busy)."""
         start_time = time.monotonic()
         while beam.IsBusy():
-            logging.debug(f"Waiting for the {beam_type.name} beam to become ready after {operation}.")
+            logging.debug(
+                f"Waiting for the {beam_type.name} beam to become ready after {operation}."
+            )
             if time.monotonic() - start_time > TESCAN_BEAM_READY_TIMEOUT:
                 raise TimeoutError(
                     f"{beam_type.name} beam is not ready after {operation}. "
@@ -1681,7 +1832,9 @@ class TescanMicroscope(FibsemMicroscope):
                 )
             time.sleep(1)
 
-    def _prepare_beam(self, beam_type: BeamType) -> Union['Automation.SEM', 'Automation.FIB']:
+    def _prepare_beam(
+        self, beam_type: BeamType
+    ) -> Union["Automation.SEM", "Automation.FIB"]:
         """Prepare the beam for imaging, milling, or other operations."""
         beam = self._get_beam(beam_type)
 
@@ -1698,7 +1851,7 @@ class TescanMicroscope(FibsemMicroscope):
         return beam
 
     def _get_presets(self, beam_type: BeamType) -> List[str]:
-        presets = self._get_beam(beam_type=beam_type).Preset.Enum()	
+        presets = self._get_beam(beam_type=beam_type).Preset.Enum()
         return sorted(presets)
 
     def _get_available_detectors(self, beam_type: BeamType) -> List[str]:
@@ -1710,7 +1863,9 @@ class TescanMicroscope(FibsemMicroscope):
             detectors = self.connection.FIB.Detector.Enum()
         return detectors
 
-    def _get_detector(self, detector_type: Union['Detector', str], beam_type: BeamType) -> Optional[str]:
+    def _get_detector(
+        self, detector_type: Union["Detector", str], beam_type: BeamType
+    ) -> Optional[str]:
         """Get the detector object for the given detector type and beam type."""
         if isinstance(detector_type, Detector):
             detector_type = detector_type.name
@@ -1723,7 +1878,9 @@ class TescanMicroscope(FibsemMicroscope):
                 return detector
         return None
 
-    def get_available_values(self, key: str, beam_type: Optional[BeamType] = None)-> List[Union[str, float]]:
+    def get_available_values(
+        self, key: str, beam_type: Optional[BeamType] = None
+    ) -> List[Union[str, float]]:
         """Get a list of available values for a given key.
         Keys: plasma_gas, current, detector_type
         """
@@ -1733,7 +1890,16 @@ class TescanMicroscope(FibsemMicroscope):
             if beam_type == BeamType.ELECTRON:
                 values = [1.0e-12]
             elif beam_type == BeamType.ION:
-                values = [20e-12, 60e-12, 0.2e-9, 0.74e-9, 2.0e-9, 7.6e-9, 28.0e-9, 120e-9]
+                values = [
+                    20e-12,
+                    60e-12,
+                    0.2e-9,
+                    0.74e-9,
+                    2.0e-9,
+                    7.6e-9,
+                    28.0e-9,
+                    120e-9,
+                ]
 
         if key == "detector_type":
             detectors = self._get_available_detectors(beam_type=beam_type)
@@ -1747,30 +1913,26 @@ class TescanMicroscope(FibsemMicroscope):
 
         return values
 
-    def _get(self, key: str, beam_type: Optional[BeamType] = None) -> Union[float,
-                                                                  str,
-                                                                  List[str],
-                                                                  Tuple[int, int],
-                                                                  Point,
-                                                                  FibsemStagePosition,
-                                                                  None]:
+    def _get(
+        self, key: str, beam_type: Optional[BeamType] = None
+    ) -> Union[
+        float, str, List[str], Tuple[int, int], Point, FibsemStagePosition, None
+    ]:
         """Get a property of the microscope (serialised on the connection lock)."""
         with self._connection_lock:
             return self._get_impl(key, beam_type)
 
-    def _get_impl(self, key: str, beam_type: Optional[BeamType] = None) -> Union[float,
-                                                                  str,
-                                                                  List[str],
-                                                                  Tuple[int, int],
-                                                                  Point,
-                                                                  FibsemStagePosition,
-                                                                  None]:
+    def _get_impl(
+        self, key: str, beam_type: Optional[BeamType] = None
+    ) -> Union[
+        float, str, List[str], Tuple[int, int], Point, FibsemStagePosition, None
+    ]:
         """Get a property of the microscope."""
         if beam_type is not None:
             beam: Union[Automation.SEM, Automation.FIB] = self._get_beam(beam_type)
 
-        # beam properties 
-        if key == "on": 
+        # beam properties
+        if key == "on":
             return beam.Beam.GetStatus()
         if key == "working_distance" and beam_type == BeamType.ELECTRON:
             return beam.Optics.GetWD() * constants.MILLIMETRE_TO_METRE
@@ -1780,7 +1942,7 @@ class TescanMicroscope(FibsemMicroscope):
             else:
                 return beam.Beam.ReadProbeCurrent() * constants.PICO_TO_SI
         if key == "voltage":
-            return beam.Beam.GetVoltage() 
+            return beam.Beam.GetVoltage()
         if key == "hfw":
             return beam.Optics.GetViewfield() * constants.MILLIMETRE_TO_METRE
         if key == "resolution":
@@ -1790,7 +1952,9 @@ class TescanMicroscope(FibsemMicroscope):
         if key == "stigmation":
             return self._beam_parameters[beam_type].stigmation
         if key == "scan_rotation":
-            scan_rotation = beam.Optics.GetImageRotation()  # DEGREES, can be nan on simulator
+            scan_rotation = (
+                beam.Optics.GetImageRotation()
+            )  # DEGREES, can be nan on simulator
             if np.isnan(scan_rotation):
                 scan_rotation = 0.0
             # return radians to match the codebase-wide convention (Thermo, image
@@ -1848,13 +2012,15 @@ class TescanMicroscope(FibsemMicroscope):
 
         # detector properties
         if key == "detector_type":
-            detector = beam.Detector.Get(Channel = 0) 
-            if detector is None: # QUERY: can this be None?
+            detector = beam.Detector.Get(Channel=0)
+            if detector is None:  # QUERY: can this be None?
                 return None
             return detector.name
 
         if key in ["detector_contrast", "detector_brightness"]:
-            contrast, brightness = beam.Detector.GetGainBlack(Detector=self._active_detector[beam_type])
+            contrast, brightness = beam.Detector.GetGainBlack(
+                Detector=self._active_detector[beam_type]
+            )
 
             if key == "detector_contrast":
                 return contrast / 100
@@ -1867,7 +2033,7 @@ class TescanMicroscope(FibsemMicroscope):
         if key == "manipulator_calibrated":
             return self.connection.Nanomanipulator.IsCalibrated(0)
         if key == "manipulator_state":
-            return NotImplemented # self.connection.Nanomanipulator.GetStatus(0)
+            return NotImplemented  # self.connection.Nanomanipulator.GetStatus(0)
 
         if key == "presets":
             return self._get_presets(beam_type=beam_type)
@@ -1884,62 +2050,83 @@ class TescanMicroscope(FibsemMicroscope):
         if key == "hardware_version":
             return self.system.info.hardware_version
 
-        NOT_SUPPORTED_KEYS = ["resolution", "dwell_time", "stigmation", "preset", "detector_mode"]
+        NOT_SUPPORTED_KEYS = [
+            "resolution",
+            "dwell_time",
+            "stigmation",
+            "preset",
+            "detector_mode",
+        ]
         if key in NOT_SUPPORTED_KEYS:
             logging.debug(f"Key {key} directly not supported by Tescan API.")
             return None
 
         logging.warning(f"Unknown key: {key} ({beam_type})")
-        return None   
+        return None
 
-    def _activate_preset(self, beam: Union['Automation.SEM', 'Automation.FIB'], beam_type: BeamType, preset_name: str) -> None:
+    def _activate_preset(
+        self,
+        beam: Union["Automation.SEM", "Automation.FIB"],
+        beam_type: BeamType,
+        preset_name: str,
+    ) -> None:
         """Activate a preset, preserving rotation/FOV/shift when self._preserve_settings_on_preset_change is set."""
         # Check if preset is available
         if not beam.Preset.IsAvailable(preset_name):
             logging.warning(f"Preset {preset_name} not available for {beam_type}.")
             return
-        
+
         preserve_settings = self._preserve_settings_on_preset_change
-        
+
         # Save current settings if they should be preserved
         image_rotation = None
         view_field = None
         image_shift_x = None
         image_shift_y = None
-        
+
         if preserve_settings:
             image_rotation = beam.Optics.GetImageRotation()
             logging.debug(f"Image rotation before changing preset: {image_rotation}.")
             view_field = beam.Optics.GetViewfield()
             logging.debug(f"FOV before changing preset: {view_field}.")
             image_shift_x, image_shift_y = beam.Optics.GetImageShift()
-            logging.debug(f"XY shift before changing preset: {image_shift_x}, {image_shift_y}.")
+            logging.debug(
+                f"XY shift before changing preset: {image_shift_x}, {image_shift_y}."
+            )
 
         try:
             # Activate preset
             beam.Preset.Activate(preset_name)
             logging.info(f"Preset {preset_name} activated for {beam_type}.")
-            
+
             # Wait for preset to fully apply
             self._wait_for_beam_ready(beam, beam_type, operation="preset activation")
-            
+
             # Update internal state
             self._beam_parameters[beam_type].preset = preset_name
-            
+
         except Exception as e:
-            logging.error(f"Failed to activate preset {preset_name} for {beam_type}: {e}")
+            logging.error(
+                f"Failed to activate preset {preset_name} for {beam_type}: {e}"
+            )
             raise  # Re-raise to ensure finally block runs and then propagate error
-            
+
         finally:
             # Restore settings if requested
             if preserve_settings:
                 try:
                     beam.Optics.SetImageRotation(image_rotation)
-                    logging.debug(f"Restored image rotation after changing preset to {image_rotation}.")
+                    logging.debug(
+                        f"Restored image rotation after changing preset to {image_rotation}."
+                    )
                     beam.Optics.SetViewfield(view_field)
-                    logging.debug(f"Restored FOV after changing preset to {view_field}.")
+                    logging.debug(
+                        f"Restored FOV after changing preset to {view_field}."
+                    )
                     beam.Optics.SetImageShift(image_shift_x, image_shift_y)
-                    logging.debug(f"Restored XY shift after changing preset to {image_shift_x}, {image_shift_y}.")
+                    logging.debug(
+                        f"Restored XY shift after changing preset to {image_shift_x}, {image_shift_y}."
+                    )
                 except Exception as restore_error:
                     logging.error(f"Failed to restore beam settings: {restore_error}")
 
@@ -1956,7 +2143,9 @@ class TescanMicroscope(FibsemMicroscope):
 
         if key == "working_distance":
             if beam_type is BeamType.ION:
-                logging.info(f"Setting working distance directly for {beam_type} is not supported by Tescan API")
+                logging.info(
+                    f"Setting working distance directly for {beam_type} is not supported by Tescan API"
+                )
                 return
             if beam_type is BeamType.ELECTRON:
                 beam.Optics.SetWD(value * constants.METRE_TO_MILLIMETRE)
@@ -1964,7 +2153,9 @@ class TescanMicroscope(FibsemMicroscope):
             return
         if key == "current":
             if beam_type is BeamType.ION:
-                logging.info(f"Setting current directly for {beam_type} is not supported by Tescan API, please use presets instead.") 
+                logging.info(
+                    f"Setting current directly for {beam_type} is not supported by Tescan API, please use presets instead."
+                )
                 return
             if beam_type is BeamType.ELECTRON:
                 beam.Beam.SetCurrent(value * constants.SI_TO_PICO)
@@ -1972,7 +2163,9 @@ class TescanMicroscope(FibsemMicroscope):
             return
         if key == "voltage":
             if beam_type is BeamType.ION:
-                logging.warning(f"Setting voltage directly for {beam_type} is not supported by Tescan API, please use presets instead.") 
+                logging.warning(
+                    f"Setting voltage directly for {beam_type} is not supported by Tescan API, please use presets instead."
+                )
                 return
             if beam_type is BeamType.ELECTRON:
                 beam.Beam.SetVoltage(value)
@@ -1997,7 +2190,10 @@ class TescanMicroscope(FibsemMicroscope):
             logging.info(f"{beam_type.name} beam turned {'on' if value else 'off'}.")
             return
         if key == "shift":
-            point = Point(value.x*constants.METRE_TO_MILLIMETRE, value.y*constants.METRE_TO_MILLIMETRE)
+            point = Point(
+                value.x * constants.METRE_TO_MILLIMETRE,
+                value.y * constants.METRE_TO_MILLIMETRE,
+            )
             beam.Optics.SetImageShift(point.x, point.y)
             logging.info(f"{beam_type.name} beam shift set to {value}.")
             return
@@ -2008,7 +2204,7 @@ class TescanMicroscope(FibsemMicroscope):
             if detector is None:
                 logging.warning(f"Detector {value} not found for {beam_type}.")
                 return
-            beam.Detector.Set(Channel = 0, Detector = detector)
+            beam.Detector.Set(Channel=0, Detector=detector)
             self._active_detector[beam_type] = detector
             logging.debug(f"{beam_type.name} detector type set to {value}.")
             return
@@ -2018,29 +2214,32 @@ class TescanMicroscope(FibsemMicroscope):
             return
 
         if key in ["detector_brightness", "detector_contrast"]:
-
             # check if value is between 0 and 1
             if not (0 <= value <= 1):
-                logging.warning(f"Invalid value for {beam_type} {key}: {value}. Must be between 0 and 1.")
+                logging.warning(
+                    f"Invalid value for {beam_type} {key}: {value}. Must be between 0 and 1."
+                )
                 return
 
-            # get active detector 
-            active_detector =  self._active_detector[beam_type]
+            # get active detector
+            active_detector = self._active_detector[beam_type]
             if active_detector is None:
-                logging.warning(f"No active detector for {beam_type}. Please set detector type first.")
+                logging.warning(
+                    f"No active detector for {beam_type}. Please set detector type first."
+                )
                 return
 
             # get current gain and black level
-            contrast, brightness = beam.Detector.GetGainBlack(Detector= active_detector)
+            contrast, brightness = beam.Detector.GetGainBlack(Detector=active_detector)
             if key == "detector_contrast":
                 contrast = value * 100
             if key == "detector_brightness":
                 brightness = value * 100
 
             # set new gain and black level
-            beam.Detector.SetGainBlack(Detector= active_detector, 
-                                        Gain = contrast, 
-                                        Black = brightness)
+            beam.Detector.SetGainBlack(
+                Detector=active_detector, Gain=contrast, Black=brightness
+            )
             logging.info(f"{beam_type.name} {key} set to {value}.")
             return
 

--- a/scripts/test_installation.py
+++ b/scripts/test_installation.py
@@ -8,6 +8,7 @@ def main():
     print("\n\nOpenFIBSEM API:\n")
     try:
         import fibsem
+
         FIBSEM_AVAILABLE = True
     except ImportError:
         FIBSEM_AVAILABLE = False
@@ -19,23 +20,25 @@ def main():
         if branch:
             print(f"Branch: {branch}")
         print(f"Installed at: {fibsem.__path__}")
-    
+
     print("-" * 80)
-    
+
     print("Applications:\n")
-    try: 
+    try:
         from fibsem.applications import autolamella
+
         AUTOLAMELLA_AVAILABLE = True
-    except ImportError: 
+    except ImportError:
         AUTOLAMELLA_AVAILABLE = False
     if AUTOLAMELLA_AVAILABLE:
         # getattr rather than direct access: this script exists to report what is
         # installed, so a package that omits __version__ must not abort the report.
         print(f"AutoLamella v{getattr(autolamella, '__version__', 'unknown')}")
         print(f"Installed at: {autolamella.__path__}")
-    
-    try: 
+
+    try:
         import salami
+
         SALAMI_AVAILABLE = True
     except ImportError:
         SALAMI_AVAILABLE = False
@@ -43,14 +46,17 @@ def main():
         print(f"SALAMI v{getattr(salami, '__version__', 'unknown')}")
         print(f"Installed at: {salami.__path__}")
     print("-" * 80)
-    
+
     # Hardware APIs
     print("Hardware APIs:\n")
-    
+
     # Thermo Fisher API
-    print(f"ThermoFisher API {'Available' if THERMO_API_AVAILABLE else 'Not Available'}")
+    print(
+        f"ThermoFisher API {'Available' if THERMO_API_AVAILABLE else 'Not Available'}"
+    )
     if THERMO_API_AVAILABLE:
         from fibsem.microscope import version as autoscript_version
+
         print(f"AutoScript v{autoscript_version}")
     print("-" * 80)
 
@@ -58,6 +64,7 @@ def main():
     print(f"Tescan API {'Available' if TESCAN_API_AVAILABLE else 'Not Available'}")
     if TESCAN_API_AVAILABLE:
         print(f"TescanAutomation v{TESCAN_API_VERSION}")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test_installation.py
+++ b/scripts/test_installation.py
@@ -1,5 +1,5 @@
 from fibsem.microscope import THERMO_API_AVAILABLE
-from fibsem.microscopes.tescan import TESCAN_API_AVAILABLE
+from fibsem.microscopes.tescan import TESCAN_API_AVAILABLE, TESCAN_API_VERSION
 
 
 def main():
@@ -57,8 +57,7 @@ def main():
     # Tescan API
     print(f"Tescan API {'Available' if TESCAN_API_AVAILABLE else 'Not Available'}")
     if TESCAN_API_AVAILABLE:
-        from fibsem.microscopes.tescan import tescanautomation
-        print(f"TescanAutomation v{tescanautomation.__version__}")
+        print(f"TescanAutomation v{TESCAN_API_VERSION}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Two files. **Read `d51c983f` — it is +10/−3.** The second commit is the reformat format-on-touch demands (685 lines in `tescan.py`), which is exactly why it is separate.

## The trap

`scripts/test_installation.py` read the SDK version by importing the SDK *through* fibsem:

```python
if TESCAN_API_AVAILABLE:
    from fibsem.microscopes.tescan import tescanautomation
    print(f"TescanAutomation v{tescanautomation.__version__}")
```

That only worked because `tescan.py`'s guarded import block contains a bare `import tescanautomation` it never uses itself — everything else goes through `from tescanautomation import ...`. Ruff flags that as `F401` and rates the removal **`safe`**, so `ruff check --fix` would delete it and break the checker.

**Nothing in this repo could have caught it.** CI has no Tescan SDK, so `TESCAN_API_AVAILABLE` is `False` and the failing line never executes — same for the test suite and any dev machine. It would surface only on a microscope PC, inside the script whose entire job is to report whether your install works. It would have read as *"the SDK is broken"* to someone already diagnosing a Tescan problem.

## The fix

Export what the script actually wants, mirroring the flag that already does this:

```python
TESCAN_API_VERSION: Optional[str] = None        # beside TESCAN_API_AVAILABLE = False
...
    TESCAN_API_VERSION = getattr(tescanautomation, "__version__", None)
```

`getattr`, not attribute access, and deliberately: that line runs **inside the `try`**, so an SDK build without `__version__` would otherwise be swallowed by the `except Exception` below and silently disable the whole Tescan backend over a missing version string. Same class of failure, one layer down.

The bare import is now genuinely used, so the `F401` disappears for the right reason instead of being suppressed with a `noqa`.

## Verification

- `import tescanautomation` is no longer in `ruff --fix`'s removal set for that file — checked against the actual diff, not inferred
- The three `F401`s that remain (`os`, `Queue`, `HVBeamStatus`) were each checked for external importers: **none**. They belong to the `fibsem/microscopes` slice of the burn-down, not here.
- `ruff check .` clean; tescan tests 141 passed; full suite **5,756 passed, 24 skipped**
- `scripts/test_installation.py` runs and correctly reports *Tescan API Not Available* here

**Limitation, stated plainly:** only the no-SDK path is exercisable on this machine. That the version string prints correctly can only be confirmed on a Tescan PC.
