### PR TITLE
[refactor] Remove FMControlWidget's second progress bar, which cannot be shown

### DIFF
--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -303,8 +303,13 @@ class FMControlWidget(QWidget):
         # Debounced auto-save of the FM working state on any settings change, so
         # edits persist even if the app is force-killed before closeEvent runs.
         from superqt.utils import qdebounced
-        self._autosave_fm_configuration = qdebounced(self.save_fm_configuration, timeout=1000)
-        self.channelSettingsWidget.settings_changed.connect(self._on_fm_settings_changed)
+
+        self._autosave_fm_configuration = qdebounced(
+            self.save_fm_configuration, timeout=1000
+        )
+        self.channelSettingsWidget.settings_changed.connect(
+            self._on_fm_settings_changed
+        )
         self.cameraWidget.settings_changed.connect(self._on_fm_settings_changed)
         self.autofocusWidget.settings_changed.connect(self._on_fm_settings_changed)
         self.zParametersWidget.settings_changed.connect(self._on_fm_settings_changed)
@@ -326,7 +331,9 @@ class FMControlWidget(QWidget):
             # canvas outlives this widget, so a leaked connection would drive a stale
             # stage move through a destroyed widget
             self._fm_canvas = controller.fm_canvas
-            self._fm_canvas.canvas_double_clicked.connect(self._on_canvas_fm_double_click)
+            self._fm_canvas.canvas_double_clicked.connect(
+                self._on_canvas_fm_double_click
+            )
             self._fm_canvas.canvas_scrolled.connect(
                 self.objectiveControlWidget._on_canvas_scroll
             )
@@ -370,8 +377,14 @@ class FMControlWidget(QWidget):
 
         if self._fm_canvas is not None:
             for signal, slot in (
-                (self._fm_canvas.canvas_double_clicked, self._on_canvas_fm_double_click),
-                (self._fm_canvas.canvas_scrolled, self.objectiveControlWidget._on_canvas_scroll),
+                (
+                    self._fm_canvas.canvas_double_clicked,
+                    self._on_canvas_fm_double_click,
+                ),
+                (
+                    self._fm_canvas.canvas_scrolled,
+                    self.objectiveControlWidget._on_canvas_scroll,
+                ),
             ):
                 try:
                     signal.disconnect(slot)
@@ -562,8 +575,11 @@ class FMControlWidget(QWidget):
                 # and says which pass, so a coarse sweep followed by a fine one does
                 # not look like the same bar inexplicably starting over.
                 total_passes = progress.get("total_passes", 1)
-                which = (f" · pass {progress.get('pass_index', 1)}/{total_passes}"
-                         if total_passes > 1 else "")
+                which = (
+                    f" · pass {progress.get('pass_index', 1)}/{total_passes}"
+                    if total_passes > 1
+                    else ""
+                )
                 label = f"Focus {progress_zlevels}/{progress_total_zlevels}{which}"
             else:
                 label = f"Z-level {progress_zlevels}/{progress_total_zlevels}"
@@ -1003,8 +1019,9 @@ class FMControlWidget(QWidget):
         """Worker thread for auto-focus."""
         try:
             ranges = ", ".join(
-                f"{p.search_range*1e6:.1f}µm/{p.step_size*1e6:.1f}µm"
-                for p in autofocus_settings.passes if p.enabled
+                f"{p.search_range * 1e6:.1f}µm/{p.step_size * 1e6:.1f}µm"
+                for p in autofocus_settings.passes
+                if p.enabled
             )
             logging.info(
                 f"Running auto-focus: {len(autofocus_settings.passes)} pass(es) [{ranges}], "
@@ -1102,6 +1119,7 @@ class FMControlWidget(QWidget):
         if self.microscope.fm is None:
             return
         from fibsem.fm.config import save_fm_configuration
+
         try:
             save_fm_configuration(self._build_fluorescence_configuration())
         except Exception as e:

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -92,11 +92,6 @@ class FMControlWidget(QWidget):
         self._acquisition_thread: Optional[FunctionWorker] = None
         self._acquisition_stop_event = threading.Event()
         self._current_acquisition_type: Optional[str] = None
-        # Initialised here, not only in the acquire methods: the widget is connected to
-        # the microscope's progress signal from construction, so a workflow task driving
-        # the FM reaches _on_acquisition_progress without this widget having started
-        # anything.
-        self._last_remaining_time: Optional[float] = None
 
         # FM canvas click context (quad-view): retained from the latest image so a
         # double-click can convert pixel -> stage without napari layer metadata
@@ -199,10 +194,8 @@ class FMControlWidget(QWidget):
 
         # Create progress bar (hidden by default)
         self.progressBar_current_acquisition = QProgressBar(self)
-        self.progressBar_acquisition_task = QProgressBar(self)
         self.progressText = QLabel("Acquisition Progress", self)
         self.progressBar_current_acquisition.hide()
-        self.progressBar_acquisition_task.hide()
         self.progressText.hide()
 
         # Create scroll area for main content
@@ -233,7 +226,6 @@ class FMControlWidget(QWidget):
         button_layout.addWidget(self.pushButton_cancel_acquisition, 5, 0, 1, 2)
         button_layout.addWidget(self.progressText, 6, 0, 1, 2)
         button_layout.addWidget(self.progressBar_current_acquisition, 7, 0, 1, 2)
-        button_layout.addWidget(self.progressBar_acquisition_task, 8, 0, 1, 2)
 
         # Main layout with scroll area and buttons
         layout = QVBoxLayout()
@@ -500,10 +492,8 @@ class FMControlWidget(QWidget):
 
         # clear acquisition state
         self._current_acquisition_type = None
-        self._last_remaining_time = None
 
         # hide progress bar when acquisition finishes
-        self.progressBar_acquisition_task.hide()
         self.progressBar_current_acquisition.hide()
         self.progressText.setText("")
 
@@ -517,10 +507,6 @@ class FMControlWidget(QWidget):
         """Update progress bars on acquisition signal"""
 
         # Show progress bar when acquisition progress is updated
-        if self._current_acquisition_type in ["positions", "overview"]:
-            # only show acquisition_task progress bar when acquiring overview/positions
-            if not self.progressBar_acquisition_task.isVisible():
-                self.progressBar_acquisition_task.show()
         if not self.progressBar_current_acquisition.isVisible():
             self.progressBar_current_acquisition.show()
         if not self.progressText.isVisible():
@@ -528,8 +514,6 @@ class FMControlWidget(QWidget):
 
         progress_zlevels = progress.get("zlevel", None)
         progress_total_zlevels = progress.get("total_zlevels", None)
-        progress_current = progress.get("current", None)
-        progress_total = progress.get("total", None)
         channel_name = progress.get("channel", None)
         progress_state = progress.get("state", None)
         progress_task = progress.get("task", None)
@@ -545,7 +529,6 @@ class FMControlWidget(QWidget):
             self.progressBar_current_acquisition.setFormat("")
 
         if progress_state == "finished":
-            self.progressBar_acquisition_task.hide()
             self.progressBar_current_acquisition.hide()
             self.progressText.setText("Acquisition complete.")
             self.progressText.hide()
@@ -585,26 +568,6 @@ class FMControlWidget(QWidget):
             else:
                 label = f"Z-level {progress_zlevels}/{progress_total_zlevels}"
             self.progressBar_current_acquisition.setFormat(label)
-
-        # set total acquisition task progress
-        if progress_current is not None and progress_total is not None:
-            # Format time remaining string if available
-            time_remaining_str = ""
-            remaining_time = progress.get("estimated_remaining_time", 0)
-            if remaining_time > 0:
-                self._last_remaining_time = remaining_time
-            if self._last_remaining_time is not None and self._last_remaining_time > 0:
-                time_remaining_str = f"Remaining Time: {utils.format_duration(self._last_remaining_time)}"
-
-            # Set progress bar/text
-            percentage = (
-                int((progress_current / progress_total) * 100)
-                if progress_total > 0
-                else 0
-            )
-            msg = f"Position {progress_current}/{progress_total} - {time_remaining_str}"
-            self.progressBar_acquisition_task.setValue(percentage)
-            self.progressBar_acquisition_task.setFormat(msg)
 
     @ensure_main_thread
     def update_image(self, image: FluorescenceImage):
@@ -867,7 +830,6 @@ class FMControlWidget(QWidget):
 
         logging.info("Starting image acquisition")
         self._current_acquisition_type = "image"
-        self._last_remaining_time = None
         self._update_acquisition_button_states()
         self._acquisition_stop_event.clear()
 
@@ -1019,7 +981,6 @@ class FMControlWidget(QWidget):
 
         logging.info("Starting auto-focus")
         self._current_acquisition_type = "autofocus"
-        self._last_remaining_time = None
         self._update_acquisition_button_states()
         self._acquisition_stop_event.clear()
 

--- a/tests/ui/test_fm_control_widget_teardown.py
+++ b/tests/ui/test_fm_control_widget_teardown.py
@@ -23,8 +23,18 @@ from PyQt5.QtWidgets import QApplication
 
 from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget, _DemoHost
 
-# Enough of a progress payload to reach the task bar and the remaining-time branch.
-PROGRESS = {"zlevel": 1, "total_zlevels": 3, "current": 1, "total": 4}
+# A payload an emitter actually produces: the within-tile z-stack progress from
+# `acquire_z_stack`. It reaches the bar and the label, which is what these tests need
+# a live slot to touch.
+PROGRESS = {
+    "state": "acquiring",
+    "task": "z-stack",
+    "channel": "DAPI",
+    "channel_index": 1,
+    "total_channels": 1,
+    "zlevel": 1,
+    "total_zlevels": 3,
+}
 
 
 @pytest.fixture(scope="module")
@@ -74,7 +84,7 @@ def test_emitting_after_teardown_and_delete_does_not_raise(widget):
     event loop. Before the fix each of these raised RuntimeError out of the emit.
     """
     fm = widget.fm
-    widget._current_acquisition_type = "overview"
+    widget._current_acquisition_type = "image"
 
     widget._teardown_connections()
     sip.delete(widget)
@@ -96,8 +106,8 @@ def test_progress_before_any_local_acquisition_does_not_raise(widget):
     """A workflow task drives the FM while the tab sits open.
 
     The widget is connected from construction, so it receives progress for an
-    acquisition it never started -- reaching the remaining-time branch with
-    `_last_remaining_time` never assigned by one of its own acquire methods.
+    acquisition it never started -- `_current_acquisition_type` is still None, and the
+    handler runs anyway. Left deliberately unset here: that *is* the condition.
     """
-    widget._current_acquisition_type = "overview"
+    assert widget._current_acquisition_type is None
     widget.fm.acquisition_progress_signal.emit(PROGRESS)

--- a/tests/ui/test_fm_control_widget_teardown.py
+++ b/tests/ui/test_fm_control_widget_teardown.py
@@ -10,6 +10,7 @@ The failure this pins is not a wrong value -- it is a `RuntimeError: wrapped C/C
 object ... has been deleted` raised inside somebody else's worker thread, which reads
 as a broken acquisition rather than as a teardown bug.
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")


### PR DESCRIPTION
`progressBar_acquisition_task` has no route to the screen and nothing to put on it.

## Dead at both ends

**It cannot be shown.** The only `show()` is behind `if self._current_acquisition_type in ["positions", "overview"]`. That attribute is assigned in exactly three places — `"image"`, `"autofocus"`, and `None`. Neither gate value is ever set by anything.

**It has nothing to display.** Its only data source is the `current`/`total` branch of `_on_acquisition_progress`, and the only emitter of those keys on `acquisition_progress_signal` is `acquire_at_positions` — which has no caller either (#506, independent of this).

## What goes with it

`_last_remaining_time`, a sticky fallback that exists because `.get("estimated_remaining_time", 0)` cannot distinguish "not computed yet" from "zero seconds remaining". It is read only by the block removed here.

## The tests

Both teardown tests reached into the dead branch to exercise it: setting `_current_acquisition_type = "overview"` by hand, and sending a payload carrying `current`/`total`. Neither condition can arise at runtime, so they were pinning behaviour against a harness rather than against the widget.

They now use a z-stack payload an emitter actually produces. `test_progress_before_any_local_acquisition_does_not_raise` — whose premise is a workflow task driving the FM while the tab sits open — asserts the `None` state that genuinely occurs instead of faking `"overview"`.

## Verification

- `tests/ui/test_fm_control_widget_teardown.py`, `tests/ui/test_viewer_less_widgets.py`: 28 passed.
- No visible change. Drove a real `FMControlWidget` through every payload shape its emitters produce — channels, z-stack, single- and multi-pass autofocus, a workflow task's `moving`, the task-less `state: "autofocus"`, and `finished`. Every label and bar value is identical before and after.