### PR TITLE
[refactor] Give each progress signal its own handler and its own bar

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -375,11 +375,12 @@ class FMOverviewWidget(QWidget):
         self.overlay_controls = CanvasOverlayControls(
             list(stage_context.CONTEXT_OVERLAY_ENTRIES)
         )
-        self.overlay_controls.toggled.connect(
-            lambda *_: self._refresh_stage_metadata()
-        )
+        self.overlay_controls.toggled.connect(lambda *_: self._refresh_stage_metadata())
         self.btn_overlays = self.canvas.canvas.add_toolbar_button(
-            "mdi:eye-outline", "Overlays", self._toggle_overlays, checkable=True,
+            "mdi:eye-outline",
+            "Overlays",
+            self._toggle_overlays,
+            checkable=True,
         )
         self.overlay_popover = CanvasPopover(
             self.overlay_controls, parent=self.canvas.canvas
@@ -450,9 +451,7 @@ class FMOverviewWidget(QWidget):
         self.channel_widget = FluorescenceMultiChannelWidget(self.fm, channels)
         # Every overview setting lives in one widget, z-stack included, so their order
         # is decided in one place rather than split across two.
-        self.settings_widget = FMOverviewSettingsWidget(
-            channel_settings=channels
-        )
+        self.settings_widget = FMOverviewSettingsWidget(channel_settings=channels)
 
         controls = QWidget()
         self._controls_layout = QVBoxLayout(controls)
@@ -652,7 +651,9 @@ class FMOverviewWidget(QWidget):
         try:
             pixel_size_x, pixel_size_y = self.fm.camera.pixel_size
             width, height = self.fm.camera.resolution
-            self.settings_widget.set_tile_fov(width * pixel_size_x, height * pixel_size_y)
+            self.settings_widget.set_tile_fov(
+                width * pixel_size_x, height * pixel_size_y
+            )
         except Exception as e:
             logging.debug(f"Could not read the camera field of view: {e}")
 
@@ -1007,7 +1008,9 @@ class FMOverviewWidget(QWidget):
             image = FluorescenceImage.load(path)
         except Exception as e:
             logging.error(f"Could not load an overview from {path}: {e}")
-            notification_service.show_toast(f"Could not load that overview.\n{e}", "error")
+            notification_service.show_toast(
+                f"Could not load that overview.\n{e}", "error"
+            )
             return None
 
         # Placed even without a geometry, but said out loud. `_offset_of` falls back to
@@ -1015,7 +1018,9 @@ class FMOverviewWidget(QWidget):
         # taken -- and an overview silently in the wrong place is worse than one you
         # have been told to distrust. Anything acquired before FIB-416 is this case.
         if FMStageProjection.from_image(image) is None:
-            logging.warning(f"Overview {path} has no recorded geometry; placing at the origin.")
+            logging.warning(
+                f"Overview {path} has no recorded geometry; placing at the origin."
+            )
             notification_service.show_toast(
                 "That overview has no recorded geometry, so it cannot be placed where "
                 "it was taken. Showing it at the canvas origin.",
@@ -1100,9 +1105,7 @@ class FMOverviewWidget(QWidget):
             logging.debug(f"Could not place the image in stage space: {e}")
             return (0.0, 0.0)
 
-    def _offset_from_origin(
-        self, position: FibsemStagePosition
-    ) -> Tuple[float, float]:
+    def _offset_from_origin(self, position: FibsemStagePosition) -> Tuple[float, float]:
         """Where a stage position sits relative to the canvas origin, in metres.
 
         The live-position counterpart of :meth:`_offset_of`, which answers the same
@@ -1118,7 +1121,9 @@ class FMOverviewWidget(QWidget):
             logging.debug(f"Could not place {position} in the canvas frame: {e}")
             return (0.0, 0.0)
 
-    def add_settings_section(self, title: str, widget: QWidget, first: bool = True) -> None:
+    def add_settings_section(
+        self, title: str, widget: QWidget, first: bool = True
+    ) -> None:
         """Put a host's own controls in the settings column, under *title*.
 
         Part of the host contract, alongside `set_positions` and `set_save_directory`,
@@ -1142,7 +1147,9 @@ class FMOverviewWidget(QWidget):
             self._controls_layout.insertWidget(0, section)
         else:
             # -1 is the stretch added in `_init_ui`; stay above it.
-            self._controls_layout.insertWidget(self._controls_layout.count() - 1, section)
+            self._controls_layout.insertWidget(
+                self._controls_layout.count() - 1, section
+            )
 
     def set_positions(self, positions: List[FibsemStagePosition]) -> None:
         """Stage positions to mark on the overview, e.g. saved lamella positions.
@@ -1407,8 +1414,11 @@ class FMOverviewWidget(QWidget):
         if current is None:
             return origin
         return FibsemStagePosition(
-            x=origin.x, y=origin.y, z=origin.z,
-            r=current.r, t=current.t,
+            x=origin.x,
+            y=origin.y,
+            z=origin.z,
+            r=current.r,
+            t=current.t,
             coordinate_system=origin.coordinate_system,
         )
 
@@ -1430,13 +1440,17 @@ class FMOverviewWidget(QWidget):
         if frame is None:
             self.stage_overlay.set_shapes([])
             return
-        self.stage_overlay.set_shapes(stage_context.context_shapes(
-            self.microscope, frame,
-            limits=self.overlay_controls.is_visible(stage_context.OVERLAY_LIMITS),
-            boundaries=self.overlay_controls.is_visible(
-                stage_context.OVERLAY_BOUNDARIES),
-            slots=self.overlay_controls.is_visible(stage_context.OVERLAY_SLOTS),
-        ))
+        self.stage_overlay.set_shapes(
+            stage_context.context_shapes(
+                self.microscope,
+                frame,
+                limits=self.overlay_controls.is_visible(stage_context.OVERLAY_LIMITS),
+                boundaries=self.overlay_controls.is_visible(
+                    stage_context.OVERLAY_BOUNDARIES
+                ),
+                slots=self.overlay_controls.is_visible(stage_context.OVERLAY_SLOTS),
+            )
+        )
 
     def _refresh_current_position(self) -> None:
         """Mark where the stage is now."""
@@ -1931,9 +1945,7 @@ class FMOverviewWidget(QWidget):
                 point = transform.transform(centre)
             except Exception:
                 continue
-            distance = (
-                (click[0] - point[0]) ** 2 + (click[1] - point[1]) ** 2
-            ) ** 0.5
+            distance = ((click[0] - point[0]) ** 2 + (click[1] - point[1]) ** 2) ** 0.5
             # `centre` is in canvas units and `point` in screen pixels: the box is a
             # fixed piece of sample, the radius a fixed piece of screen.
             if distance >= self.PICK_RADIUS_PX and not self.position_overlay.covers(
@@ -2313,7 +2325,10 @@ class FMOverviewWidget(QWidget):
         # pose -- the button is not the guard, and a host calling this directly, or a
         # stage that moved between the click and here, is exactly what this is for.
         if not self.at_acquisition_orientation():
-            where, needed = self._where_the_stage_is(), self._where_the_stage_needs_to_be()
+            where, needed = (
+                self._where_the_stage_is(),
+                self._where_the_stage_needs_to_be(),
+            )
             logging.warning(
                 f"Cannot acquire an overview: the stage is at {where}, and an overview "
                 f"needs to be at {needed}."
@@ -2346,8 +2361,10 @@ class FMOverviewWidget(QWidget):
             self.status.setText(f"Objective is {state.lower()}.")
             return
 
-        if (parameters.objective_start is ObjectiveStartPosition.FOCUS
-                and self.fm.objective.focus_position is None):
+        if (
+            parameters.objective_start is ObjectiveStartPosition.FOCUS
+            and self.fm.objective.focus_position is None
+        ):
             message = (
                 "This overview is set to start from the saved focus position, but none "
                 "has been saved. Set one with 'Set Focus Position', or start from the "
@@ -2412,7 +2429,9 @@ class FMOverviewWidget(QWidget):
             centre_position=self._target,
             # None when no save directory has been set -- the standalone default. The
             # runner writes each tile as it lands, so a cancelled run keeps what it got.
-            save_directory=self._destination.tiles_directory if self._destination else None,
+            save_directory=self._destination.tiles_directory
+            if self._destination
+            else None,
         )
         self._worker = FunctionWorker(self._acquire_worker)
         self._worker.start()
@@ -2710,12 +2729,15 @@ class FMOverviewWidget(QWidget):
         # counted and nothing more -- otherwise it reads "Tile 4/9 — 4/9".
         message = "Tiles"
         if remaining:
-            self.progress_tiles.update_progress(ProgressUpdate.combined(
-                current=current, total=total,
-                remaining_seconds=remaining,
-                total_seconds=payload.get("estimated_total_time", 0.0),
-                message=message,
-            ))
+            self.progress_tiles.update_progress(
+                ProgressUpdate.combined(
+                    current=current,
+                    total=total,
+                    remaining_seconds=remaining,
+                    total_seconds=payload.get("estimated_total_time", 0.0),
+                    message=message,
+                )
+            )
         else:
             self.progress_tiles.update_progress(
                 ProgressUpdate.numeric(current=current, total=total, message=message)
@@ -2735,8 +2757,11 @@ class FMOverviewWidget(QWidget):
                 # Say which pass, so a coarse sweep followed by a fine one does not
                 # look like the same bar inexplicably starting over.
                 total_passes = payload.get("total_passes", 1)
-                which = (f" {payload.get('pass_index', 1)}/{total_passes}"
-                         if total_passes > 1 else "")
+                which = (
+                    f" {payload.get('pass_index', 1)}/{total_passes}"
+                    if total_passes > 1
+                    else ""
+                )
                 return ProgressUpdate.numeric(
                     current=zlevel, total=total_z, message=f"{channel} focus{which}"
                 )
@@ -2846,7 +2871,9 @@ class FMOverviewWidget(QWidget):
             self.canvas.canvas.remove_image(PREVIEW_KEY)
             shape = self._mosaic.data.shape
             suffix, tooltip = self._describe_save()
-            self.status.setText(f"Overview acquired — {shape[-1]} × {shape[-2]} px{suffix}")
+            self.status.setText(
+                f"Overview acquired — {shape[-1]} × {shape[-2]} px{suffix}"
+            )
             self.status.setToolTip(tooltip)
             self.progress_tiles.update_progress(ProgressUpdate.done())
             self.progress_tiles.show()

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -213,12 +213,16 @@ class FMOverviewWidget(QWidget):
     position_selected = pyqtSignal(str)
 
     # Internal hop from the acquisition thread to the GUI thread. The microscope's
-    # progress signal is a psygnal, which calls its callbacks synchronously on
+    # progress signals are psygnals, which call their callbacks synchronously on
     # whichever thread emitted -- here, the worker. Touching widgets from there is a
     # cross-thread GUI access (Qt says so: "Cannot set parent, new parent is in a
     # different thread"). Re-emitting as a Qt signal gets it queued onto the GUI
     # thread, because this widget lives there.
-    _progress_received = pyqtSignal(dict)
+    #
+    # One per source, because the two describe different things at different scales and
+    # each drives its own bar: the run as a whole, and the tile currently being taken.
+    _tile_progress_received = pyqtSignal(dict)
+    _fm_progress_received = pyqtSignal(dict)
     # Same hop for stage moves: `stage_position_changed` is a psygnal, so it fires
     # on whichever thread moved the stage -- a worker, during an acquisition.
     _stage_moved = pyqtSignal(object)
@@ -302,16 +306,21 @@ class FMOverviewWidget(QWidget):
         self._sync_tile_fov()
         self._on_settings_changed()
 
-        self._progress_received.connect(self._apply_progress)
-        # Two scales, two signals now. The tileset -- tile n of N, the mosaic so far,
-        # and how the run ended -- reports on `tiled_acquisition_signal` beside the beam
-        # tiler's, because it is the same event (FIB-725). The work *inside* a tile
-        # stays on the detector's own progress signal, which is where a z-stack, a
+        self._tile_progress_received.connect(self._apply_tile_progress)
+        self._fm_progress_received.connect(self._apply_fm_progress)
+        # Two scales, two signals, two handlers. The tileset -- tile n of N, the mosaic
+        # so far, and how the run ended -- reports on `tiled_acquisition_signal` beside
+        # the beam tiler's, because it is the same event (FIB-725). The work *inside* a
+        # tile stays on the detector's own progress signal, which is where a z-stack, a
         # channel acquisition and an autofocus sweep report from whether or not a
-        # tileset is running. `_apply_progress` still sorts them; it just no longer has
-        # to sort them out of one stream.
-        self.microscope.tiled_acquisition_signal.connect(self._on_progress)
-        self.fm.acquisition_progress_signal.connect(self._on_progress)
+        # tileset is running.
+        #
+        # They were briefly merged into one slot that sorted them back apart by `task`.
+        # Sorting a stream that arrived already sorted is work with a failure mode and
+        # no benefit: a payload reaching the wrong bar is a mislabelled run, and the
+        # only thing keeping them apart was a vocabulary neither producer declares.
+        self.microscope.tiled_acquisition_signal.connect(self._on_tile_progress)
+        self.fm.acquisition_progress_signal.connect(self._on_fm_progress)
         self._stage_moved.connect(self._on_stage_moved)
         # A plain bound method, not `self._stage_moved.emit`, matching how the progress
         # signal is subscribed just above. psygnal holds bound methods weakly and drops
@@ -1812,7 +1821,7 @@ class FMOverviewWidget(QWidget):
     def _on_stage_signal(self, position: FibsemStagePosition) -> None:
         """Called by psygnal, on whichever thread polled. Touches no widgets.
 
-        The counterpart of :meth:`_on_progress`, and a real method rather than the Qt
+        The counterpart of :meth:`_on_tile_progress`, and a real method rather than the
         signal's `emit` for a reason beyond symmetry -- see the note where it is
         connected.
         """
@@ -2520,7 +2529,7 @@ class FMOverviewWidget(QWidget):
     def _emit_terminal(self, state: str, outcome: str, error: str = "") -> None:
         """Say how the run ended, in both vocabularies.
 
-        `state` is this widget's own -- `_apply_progress` and `_finish` branch on it,
+        `state` is this widget's own -- `_apply_tile_progress` and `_finish` branch on it,
         and it distinguishes "the mosaic is saved" from the runner's "the tiles are in".
 
         `finished` and `outcome` are the shared signal's, which the beam tiler has used
@@ -2622,37 +2631,45 @@ class FMOverviewWidget(QWidget):
 
     # ── progress ─────────────────────────────────────────────────────────
 
-    def _on_progress(self, payload: dict) -> None:
+    def _on_tile_progress(self, payload: dict) -> None:
         """Called by psygnal, on whichever thread emitted. Touches no widgets."""
-        self._progress_received.emit(payload)
+        self._tile_progress_received.emit(payload)
 
-    def _apply_progress(self, payload: dict) -> None:
-        """Runs on the GUI thread, queued via `_progress_received`.
+    def _on_fm_progress(self, payload: dict) -> None:
+        """Called by psygnal, on whichever thread emitted. Touches no widgets."""
+        self._fm_progress_received.emit(payload)
 
-        One signal carries both scales -- the tileset runner's and, from inside each
-        tile, `acquire_z_stack`/`acquire_channels` -- so `task` decides which bar a
-        payload belongs to. Anything else is ignored rather than shown twice.
+    def _apply_fm_progress(self, payload: dict) -> None:
+        """The tile currently being taken, on the detail bar.
+
+        Runs on the GUI thread, queued via `_fm_progress_received`. The detector's
+        progress signal reports whatever it is doing, tileset or not, so the tasks this
+        bar can render are named rather than assumed: everything else on it -- a
+        workflow task announcing a stage move, a `finished` with no task -- describes
+        something this widget is not showing, and is dropped rather than rendered as a
+        bar with nothing in it.
         """
+        if payload.get("task") in ("z-stack", "channels", "autofocus"):
+            self.progress_tile_detail.update_progress(self._tile_detail_update(payload))
+
+    def _apply_tile_progress(self, payload: dict) -> None:
+        """The run as a whole, on the tile bar.
+
+        Runs on the GUI thread, queued via `_tile_progress_received`.
+        """
+        if not is_modality(payload, MODALITY_FLUORESCENCE):
+            # A beam run, on the signal this shares with the beam tiler. Checked before
+            # anything else, terminal states included: the two tilers write into
+            # different canvases and different bars, and the only payload this widget
+            # has any business acting on is its own (FIB-725).
+            return
+
         state = payload.get("state")
 
         if state in ("overview-finished", "overview-cancelled", "overview-failed"):
             self._finish(state, payload.get("error"))
             return
 
-        task = payload.get("task")
-        if task == "tileset":
-            if not is_modality(payload, MODALITY_FLUORESCENCE):
-                # A beam run, on the signal this now shares with the beam tiler. It is
-                # ignored today even without this -- beam payloads carry no `task` -- but
-                # that is an accident of vocabulary, not a decision, and the beam tiler
-                # gaining a `task` key would be an entirely reasonable thing for it to
-                # do (FIB-725).
-                return
-            self._apply_tile_progress(payload, state)
-        elif task in ("z-stack", "channels", "autofocus"):
-            self.progress_tile_detail.update_progress(self._tile_detail_update(payload))
-
-    def _apply_tile_progress(self, payload: dict, state: Optional[str]) -> None:
         label = PHASE_LABELS.get(state or "")
         if label is not None:
             # Deliberately not `indeterminate`: that paints a *full* bar with a
@@ -2860,7 +2877,9 @@ class FMOverviewWidget(QWidget):
         # writes into freed memory. Closing the tab and then moving the stage from
         # anywhere else in the application was a hard segfault, not an exception.
         for signal, slot in (
-            (self.fm.acquisition_progress_signal, self._on_progress),
+            (self.fm.acquisition_progress_signal, self._on_fm_progress),
+            # Subscribed since FIB-725 and never in this list either.
+            (self.microscope.tiled_acquisition_signal, self._on_tile_progress),
             (self.microscope.stage_position_changed, self._on_stage_signal),
             (self.fm.objective.position_changed, self._on_objective_moved),
             # Subscribed since FIB-441 and never in this list, though the comment above

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -6,6 +6,7 @@ combo box shows the label it was given.
 
 Uses PyQt5 directly with the offscreen platform (no pytest-qt dependency).
 """
+
 import os
 from copy import deepcopy
 
@@ -83,8 +84,8 @@ def test_resizing_the_grid_keeps_the_tiles_that_still_exist(qapp):
     widget.set_grid_size(4, 4)
 
     mask = widget.mask
-    assert mask[0][1] is True and mask[0][0] is False    # carried over
-    assert all(mask[3])                                   # new row starts enabled
+    assert mask[0][1] is True and mask[0][0] is False  # carried over
+    assert all(mask[3])  # new row starts enabled
 
 
 def test_all_none_and_invert(qapp):
@@ -114,9 +115,14 @@ def test_the_mask_property_hands_back_a_copy(qapp):
 
 def test_settings_round_trip_every_field(qapp):
     """The widget's output is what the acquisition consumes, verbatim."""
-    widget = FMOverviewSettingsWidget(channel_settings=[ChannelSettings(name="GFP"), ChannelSettings(name="RFP")])
+    widget = FMOverviewSettingsWidget(
+        channel_settings=[ChannelSettings(name="GFP"), ChannelSettings(name="RFP")]
+    )
     parameters = OverviewParameters(
-        rows=5, cols=5, overlap=0.15, use_zstack=True,
+        rows=5,
+        cols=5,
+        overlap=0.15,
+        use_zstack=True,
         autofocus_mode=AutoFocusMode.EACH_TILE,
         tile_order=TileOrderStrategy.SERPENTINE,
         tile_mask=plus_mask(5),
@@ -177,9 +183,9 @@ def test_the_selection_is_counted_once(qapp):
     ("rows", "cols", "overlap", "expected"),
     [
         (3, 3, 0.0, "300 × 300 µm"),
-        (3, 3, 0.1, "280 × 280 µm"),   # (n-1) steps of 90 µm, plus one whole tile
-        (2, 5, 0.0, "500 × 200 µm"),   # width from columns, height from rows
-        (1, 1, 0.5, "100 × 100 µm"),   # a single tile is its own field of view
+        (3, 3, 0.1, "280 × 280 µm"),  # (n-1) steps of 90 µm, plus one whole tile
+        (2, 5, 0.0, "500 × 200 µm"),  # width from columns, height from rows
+        (1, 1, 0.5, "100 × 100 µm"),  # a single tile is its own field of view
     ],
 )
 def test_the_grid_reports_the_total_field_of_view(qapp, rows, cols, overlap, expected):
@@ -330,27 +336,42 @@ def _bar(widget):
 def test_a_tileset_payload_moves_only_the_tile_bar(qapp):
     router = _Router()
 
-    router._apply_tile_progress({
-        "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 4, "total": 9,
-    })
+    router._apply_tile_progress(
+        {
+            "modality": "fluorescence",
+            "state": "acquiring",
+            "task": "tileset",
+            "counter": 4,
+            "total": 9,
+        }
+    )
 
     # value/maximum directly, not a percentage -- the widget counts items.
-    assert (_bar(router.progress_tiles).value(),
-            _bar(router.progress_tiles).maximum()) == (4, 9)
+    assert (
+        _bar(router.progress_tiles).value(),
+        _bar(router.progress_tiles).maximum(),
+    ) == (4, 9)
     assert not router.progress_tile_detail.isVisible()
 
 
 def test_a_zstack_payload_moves_only_the_detail_bar(qapp):
     router = _Router()
 
-    router._apply_fm_progress({
-        "state": "acquiring", "task": "z-stack", "channel": "GFP",
-        "zlevel": 7, "total_zlevels": 21,
-    })
+    router._apply_fm_progress(
+        {
+            "state": "acquiring",
+            "task": "z-stack",
+            "channel": "GFP",
+            "zlevel": 7,
+            "total_zlevels": 21,
+        }
+    )
 
     assert "z-stack" in _bar(router.progress_tile_detail).format()
-    assert (_bar(router.progress_tile_detail).value(),
-            _bar(router.progress_tile_detail).maximum()) == (7, 21)
+    assert (
+        _bar(router.progress_tile_detail).value(),
+        _bar(router.progress_tile_detail).maximum(),
+    ) == (7, 21)
     assert not router.progress_tiles.isVisible()
 
 
@@ -358,14 +379,21 @@ def test_a_channels_payload_drives_the_detail_bar_too(qapp):
     """Without this the second bar is dead on every run that is not z-stacked."""
     router = _Router()
 
-    router._apply_fm_progress({
-        "state": "acquiring", "task": "channels", "channel": "RFP",
-        "channel_index": 2, "total_channels": 3,
-    })
+    router._apply_fm_progress(
+        {
+            "state": "acquiring",
+            "task": "channels",
+            "channel": "RFP",
+            "channel_index": 2,
+            "total_channels": 3,
+        }
+    )
 
     assert "RFP" in _bar(router.progress_tile_detail).format()
-    assert (_bar(router.progress_tile_detail).value(),
-            _bar(router.progress_tile_detail).maximum()) == (2, 3)
+    assert (
+        _bar(router.progress_tile_detail).value(),
+        _bar(router.progress_tile_detail).maximum(),
+    ) == (2, 3)
 
 
 def test_a_completed_tile_leaves_the_detail_bar_alone(qapp):
@@ -373,14 +401,25 @@ def test_a_completed_tile_leaves_the_detail_bar_alone(qapp):
     -- a flicker for the length of the run. The next tile overwrites it a moment later
     anyway, so the stale count is never seen."""
     router = _Router()
-    router._apply_fm_progress({
-        "state": "acquiring", "task": "z-stack", "channel": "GFP",
-        "zlevel": 21, "total_zlevels": 21,
-    })
+    router._apply_fm_progress(
+        {
+            "state": "acquiring",
+            "task": "z-stack",
+            "channel": "GFP",
+            "zlevel": 21,
+            "total_zlevels": 21,
+        }
+    )
 
-    router._apply_tile_progress({
-        "modality": "fluorescence", "state": "tile", "task": "tileset", "current": 1, "total": 9,
-    })
+    router._apply_tile_progress(
+        {
+            "modality": "fluorescence",
+            "state": "tile",
+            "task": "tileset",
+            "current": 1,
+            "total": 9,
+        }
+    )
 
     assert router.progress_tile_detail.isVisible()
 
@@ -409,9 +448,14 @@ def test_a_beam_payload_moves_neither_bar(qapp):
     """
     router = _Router()
 
-    router._apply_tile_progress({
-        "modality": "beam", "counter": 8, "total": 9, "msg": "Tile Collected",
-    })
+    router._apply_tile_progress(
+        {
+            "modality": "beam",
+            "counter": 8,
+            "total": 9,
+            "msg": "Tile Collected",
+        }
+    )
 
     assert not router.progress_tiles.isVisible()
     assert not router.progress_tile_detail.isVisible()
@@ -420,10 +464,17 @@ def test_a_beam_payload_moves_neither_bar(qapp):
 def test_the_estimate_is_shown_when_the_payload_carries_one(qapp):
     router = _Router()
 
-    router._apply_tile_progress({
-        "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 2, "total": 9,
-        "estimated_remaining_time": 134.0, "estimated_total_time": 180.0,
-    })
+    router._apply_tile_progress(
+        {
+            "modality": "fluorescence",
+            "state": "acquiring",
+            "task": "tileset",
+            "counter": 2,
+            "total": 9,
+            "estimated_remaining_time": 134.0,
+            "estimated_total_time": 180.0,
+        }
+    )
 
     assert "remaining" in _bar(router.progress_tiles).format()
 
@@ -435,14 +486,24 @@ def test_a_stage_move_does_not_fill_the_bar(qapp):
     goes to the status label.
     """
     router = _Router()
-    router._apply_tile_progress({
-        "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 3, "total": 9,
-    })
+    router._apply_tile_progress(
+        {
+            "modality": "fluorescence",
+            "state": "acquiring",
+            "task": "tileset",
+            "counter": 3,
+            "total": 9,
+        }
+    )
 
-    router._apply_tile_progress({"modality": "fluorescence", "state": "moving", "task": "tileset"})
+    router._apply_tile_progress(
+        {"modality": "fluorescence", "state": "moving", "task": "tileset"}
+    )
 
-    assert (_bar(router.progress_tiles).value(),
-            _bar(router.progress_tiles).maximum()) == (3, 9)
+    assert (
+        _bar(router.progress_tiles).value(),
+        _bar(router.progress_tiles).maximum(),
+    ) == (3, 9)
     assert router.status.text() == "Moving stage…"
 
 
@@ -464,28 +525,44 @@ def test_the_end_of_a_run_is_not_silent(qapp, state, label):
     impression these phases exist to correct.
     """
     router = _Router()
-    router._apply_tile_progress({
-        "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 9, "total": 9,
-    })
+    router._apply_tile_progress(
+        {
+            "modality": "fluorescence",
+            "state": "acquiring",
+            "task": "tileset",
+            "counter": 9,
+            "total": 9,
+        }
+    )
 
     router._apply_tile_progress(
         {"modality": "fluorescence", "state": state, "task": "tileset"}
     )
 
     assert router.status.text() == label
-    assert (_bar(router.progress_tiles).value(),
-            _bar(router.progress_tiles).maximum()) == (9, 9)
+    assert (
+        _bar(router.progress_tiles).value(),
+        _bar(router.progress_tiles).maximum(),
+    ) == (9, 9)
 
 
 def test_a_phase_label_is_cleared_by_the_next_tile(qapp):
     """Otherwise "Stitching tiles…" would still be on screen through the next run."""
     router = _Router()
-    router._apply_tile_progress({"modality": "fluorescence", "state": "saving", "task": "tileset"})
+    router._apply_tile_progress(
+        {"modality": "fluorescence", "state": "saving", "task": "tileset"}
+    )
     assert router.status.text() == "Saving overview…"
 
-    router._apply_tile_progress({
-        "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 1, "total": 9,
-    })
+    router._apply_tile_progress(
+        {
+            "modality": "fluorescence",
+            "state": "acquiring",
+            "task": "tileset",
+            "counter": 1,
+            "total": 9,
+        }
+    )
     assert router.status.text() == ""
 
 
@@ -501,8 +578,9 @@ def test_the_bar_text_is_smaller_than_the_default(qapp):
     shrink_progress_text(shrunk)
 
     sample = "Tiles — 4/9 · 74s remaining"
-    assert (QFontMetrics(shrunk._bar.font()).width(sample)
-            < QFontMetrics(plain._bar.font()).width(sample))
+    assert QFontMetrics(shrunk._bar.font()).width(sample) < QFontMetrics(
+        plain._bar.font()
+    ).width(sample)
 
 
 def test_shrinking_the_text_keeps_the_failed_colouring(qapp):
@@ -536,8 +614,13 @@ def test_channel_detail_fields_fill_the_panel(qapp):
     widget.show()
     qapp.processEvents()
 
-    fields = (widget.excitation_combo, widget.emission_combo,
-              widget.exposure_spin, widget.power_spin, widget.gain_spin)
+    fields = (
+        widget.excitation_combo,
+        widget.emission_combo,
+        widget.exposure_spin,
+        widget.power_spin,
+        widget.gain_spin,
+    )
     widths = {f.width() for f in fields}
 
     assert len(widths) == 1, f"ragged field widths: {[f.width() for f in fields]}"
@@ -668,7 +751,9 @@ def overview_widget(qapp):
     return widget
 
 
-def test_clicking_a_tile_updates_the_mask_the_settings_widget_owns(qapp, overview_widget):
+def test_clicking_a_tile_updates_the_mask_the_settings_widget_owns(
+    qapp, overview_widget
+):
     """One mask, two views. The overlay must not keep its own copy -- a click routes
     through the settings widget, and the redraw follows from that."""
     widget = overview_widget
@@ -684,9 +769,7 @@ def test_clicking_a_tile_updates_the_mask_the_settings_widget_owns(qapp, overvie
     assert widget.settings_widget.tile_mask[0][0] is False
     assert widget.settings_widget.grid.tile_mask.n_enabled == 8
     # and the overlay redrew from the widget's mask, rather than mutating its own
-    assert next(
-        t for t in overlay._tiles if (t.row, t.col) == (0, 0)
-    ).enabled is False
+    assert next(t for t in overlay._tiles if (t.row, t.col) == (0, 0)).enabled is False
 
 
 def test_clicking_the_same_tile_twice_returns_it(qapp, overview_widget):
@@ -745,8 +828,9 @@ def test_positions_are_marked_where_they_are(qapp, overview_widget):
     base = image.metadata.stage_position
     pixel_size = image.metadata.pixel_size_x
 
-    widget.set_positions([_offset(base, name="here"),
-                          _offset(base, dx=20e-6, name="right")])
+    widget.set_positions(
+        [_offset(base, name="here"), _offset(base, dx=20e-6, name="right")]
+    )
     qapp.processEvents()
 
     points = widget.position_overlay._points
@@ -783,16 +867,22 @@ def test_an_image_without_geometry_can_still_be_marked(qapp, overview_widget):
     widget.set_positions([_offset(base, dx=20e-6, name="markable")])
     qapp.processEvents()
 
-    assert widget.position_overlay._points, "the image's missing geometry blocked marking"
+    assert widget.position_overlay._points, (
+        "the image's missing geometry blocked marking"
+    )
 
 
-def test_positions_are_dropped_when_no_geometry_is_available_at_all(qapp, overview_widget):
+def test_positions_are_dropped_when_no_geometry_is_available_at_all(
+    qapp, overview_widget
+):
     """Better an empty overlay than markers in plausible-looking wrong places."""
     widget = overview_widget
     original = widget._frame
     widget._frame = lambda: None
     try:
-        widget.set_positions([_offset(widget._current_stage_position(), name="nowhere")])
+        widget.set_positions(
+            [_offset(widget._current_stage_position(), name="nowhere")]
+        )
         qapp.processEvents()
         assert widget.position_overlay._points == []
     finally:
@@ -820,14 +910,15 @@ def test_setting_both_grid_dimensions_notifies_once(qapp):
     event, refreshing the overlay repeatedly against a size that was never requested."""
     widget = FMOverviewSettingsWidget()
     seen = []
-    widget.changed.connect(
-        lambda: seen.append((widget.grid.rows, widget.grid.cols))
-    )
+    widget.changed.connect(lambda: seen.append((widget.grid.rows, widget.grid.cols)))
 
     widget.set_grid_size(2, 7)
 
     assert seen == [(2, 7)]
-    assert (widget.grid.tile_mask.grid._rows, widget.grid.tile_mask.grid._cols) == (2, 7)
+    assert (widget.grid.tile_mask.grid._rows, widget.grid.tile_mask.grid._cols) == (
+        2,
+        7,
+    )
 
 
 def test_setting_the_same_grid_size_is_a_no_op(qapp):
@@ -982,7 +1073,9 @@ def test_dragging_the_grid_leaves_the_view_alone(qapp, overview_widget):
     # Far enough to leave the declared working area, which is what zooming out makes
     # easy: a drag that stays inside it never tripped the old refit either, so a short
     # one would pass against the bug it is meant to catch.
-    declared_width = widget.canvas.canvas.world_extent[0] / widget.canvas.canvas.reference_pixel_size
+    declared_width = (
+        widget.canvas.canvas.world_extent[0] / widget.canvas.canvas.reference_pixel_size
+    )
     reach = declared_width  # twice the half-width that bounds the area
 
     overlay._on_press(_mouse(overlay, anchor[0], anchor[1], px=0.0, py=0.0))
@@ -995,7 +1088,9 @@ def test_dragging_the_grid_leaves_the_view_alone(qapp, overview_widget):
         qapp.processEvents()
         assert overlay.is_dragging
         assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == zoomed
-    _end_gesture(overlay, _mouse(overlay, anchor[0] + 3 * reach, anchor[1], px=60.0, py=0.0))
+    _end_gesture(
+        overlay, _mouse(overlay, anchor[0] + 3 * reach, anchor[1], px=60.0, py=0.0)
+    )
     qapp.processEvents()
 
     assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == zoomed
@@ -1025,7 +1120,9 @@ def test_the_working_area_still_follows_a_dragged_grid(qapp, overview_widget):
     assert (after[0], after[1]) == (before[0], before[1])  # same size, it only moved
 
 
-def test_declaring_a_working_area_without_a_refit_does_not_move_the_view(qapp, overview_widget):
+def test_declaring_a_working_area_without_a_refit_does_not_move_the_view(
+    qapp, overview_widget
+):
     """The canvas-level half of the fix, stated on its own: `refit=False` has to hold
     even on an empty canvas, where `_fit_extent` falls back to the working area and so
     *does* change when it is re-declared."""
@@ -1071,8 +1168,12 @@ def test_a_run_hands_the_camera_over(qapp):
     assert canvas.auto_fit is False
 
     # Somewhere well outside the framing, which is what an end-of-run swap can be.
-    canvas.add_image(np.zeros((64, 64), dtype=np.uint8), centre=(2e-3, 2e-3),
-                     pixel_size=1e-6, key="stitch")
+    canvas.add_image(
+        np.zeros((64, 64), dtype=np.uint8),
+        centre=(2e-3, 2e-3),
+        pixel_size=1e-6,
+        key="stitch",
+    )
     qapp.processEvents()
 
     assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == framing
@@ -1092,7 +1193,9 @@ def test_the_grid_keeps_its_scale_under_a_decimated_preview(qapp, overview_widge
     qapp.processEvents()
     before = widget.tile_grid_overlay._rect_for(widget.tile_grid_overlay._tiles[0])
 
-    widget._show_preview({"image": np.zeros((1, 256, 256), np.uint8), "preview_stride": 4})
+    widget._show_preview(
+        {"image": np.zeros((1, 256, 256), np.uint8), "preview_stride": 4}
+    )
     qapp.processEvents()
 
     after = widget.tile_grid_overlay._rect_for(widget.tile_grid_overlay._tiles[0])
@@ -1115,11 +1218,14 @@ def test_the_stage_and_grid_limits_are_drawn_in_the_canvas_frame(qapp, overview_
 
     stage = by_label["Stage Limits"]
     assert stage.width == pytest.approx((limits["x"].max - limits["x"].min) / reference)
-    assert stage.height == pytest.approx((limits["y"].max - limits["y"].min) / reference)
+    assert stage.height == pytest.approx(
+        (limits["y"].max - limits["y"].min) / reference
+    )
 
     from fibsem.ui.widgets.canvas.overlays.minimap_overlays import (
         GRID_BOUNDARY_RADIUS_M,
     )
+
     # An ellipse of the full diameter per axis, not a circle of one radius (FIB-698).
     # A circle on the sample is a circle on screen only where the view looks down the
     # surface normal, which the fluorescence pose does and the milling pose does not --
@@ -1191,7 +1297,9 @@ def test_the_current_position_marker_follows_the_stage(qapp, overview_widget):
     assert moved != at_origin, "the marker did not follow the stage"
 
 
-def test_the_marker_lands_where_an_image_acquired_there_is_placed(qapp, overview_widget):
+def test_the_marker_lands_where_an_image_acquired_there_is_placed(
+    qapp, overview_widget
+):
     """The marker and the image reach the canvas by different routes — one through
     set_points, the other through add_image — so agreeing is worth checking. If they
     ever diverge, the canvas is telling two stories about the same stage position."""
@@ -1199,7 +1307,9 @@ def test_the_marker_lands_where_an_image_acquired_there_is_placed(qapp, overview
 
     widget = overview_widget
     widget.canvas.clear_overviews()
-    widget.set_image(widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01")))
+    widget.set_image(
+        widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    )
     qapp.processEvents()
 
     tilt = widget.microscope.get_stage_position().t
@@ -1209,7 +1319,9 @@ def test_the_marker_lands_where_an_image_acquired_there_is_placed(qapp, overview
     qapp.processEvents()
     marker = widget.current_position_overlay._points[0]
 
-    widget.set_image(widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01")))
+    widget.set_image(
+        widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
+    )
     qapp.processEvents()
 
     placed = widget.canvas.canvas._placed[max(widget.canvas.canvas.placed_keys)]
@@ -1267,7 +1379,11 @@ def test_a_canvas_point_resolves_to_the_position_it_was_drawn_from(interactive_w
 
     for dx, dy in [(0.0, 0.0), (120e-6, 0.0), (0.0, -85e-6), (-250e-6, 375e-6)]:
         marked = FibsemStagePosition(
-            x=base.x + dx, y=base.y + dy, z=base.z, r=base.r, t=base.t,
+            x=base.x + dx,
+            y=base.y + dy,
+            z=base.z,
+            r=base.r,
+            t=base.t,
             coordinate_system=base.coordinate_system,
         )
         resolved = frame.to_stage(*frame.to_canvas(marked))
@@ -1276,7 +1392,9 @@ def test_a_canvas_point_resolves_to_the_position_it_was_drawn_from(interactive_w
         assert resolved.y == pytest.approx(marked.y, abs=1e-12)
 
 
-def test_double_clicking_moves_the_stage_to_that_point(qapp, interactive_widget, monkeypatch):
+def test_double_clicking_moves_the_stage_to_that_point(
+    qapp, interactive_widget, monkeypatch
+):
     from fibsem.ui.fm.widgets import fm_overview_widget as module
 
     widget = interactive_widget
@@ -1296,7 +1414,9 @@ def test_double_clicking_moves_the_stage_to_that_point(qapp, interactive_widget,
     )
 
 
-def test_the_marker_follows_the_stage_after_a_double_click(qapp, interactive_widget, monkeypatch):
+def test_the_marker_follows_the_stage_after_a_double_click(
+    qapp, interactive_widget, monkeypatch
+):
     """The move is confirmed by re-reading the stage rather than assumed, so the marker
     shows where the instrument went rather than where it was asked to go."""
     from fibsem.ui.fm.widgets import fm_overview_widget as module
@@ -1311,7 +1431,9 @@ def test_the_marker_follows_the_stage_after_a_double_click(qapp, interactive_wid
     assert widget.current_position_overlay._points != before
 
 
-def test_the_stage_cannot_be_driven_during_an_acquisition(qapp, interactive_widget, monkeypatch):
+def test_the_stage_cannot_be_driven_during_an_acquisition(
+    qapp, interactive_widget, monkeypatch
+):
     from fibsem.ui.fm.widgets import fm_overview_widget as module
 
     widget = interactive_widget
@@ -1333,7 +1455,9 @@ def test_the_stage_cannot_be_driven_during_an_acquisition(qapp, interactive_widg
     assert (after.x, after.y) == (before.x, before.y)
 
 
-def test_a_point_outside_the_stage_limits_is_refused(qapp, interactive_widget, monkeypatch):
+def test_a_point_outside_the_stage_limits_is_refused(
+    qapp, interactive_widget, monkeypatch
+):
     """A click can land anywhere on a real-space canvas, including well past where the
     stage can physically go. Asking for it is how a stage ends up against its stop."""
     from fibsem.ui.fm.widgets import fm_overview_widget as module
@@ -1353,7 +1477,9 @@ def test_a_point_outside_the_stage_limits_is_refused(qapp, interactive_widget, m
     assert (after.x, after.y) == (before.x, before.y)
 
 
-def test_dragging_the_grid_sets_a_target_without_moving_the_stage(qapp, interactive_widget):
+def test_dragging_the_grid_sets_a_target_without_moving_the_stage(
+    qapp, interactive_widget
+):
     """Planning a run and driving the instrument are separate acts. A drag is
     exploratory -- you push the grid around to see what it would cover."""
     widget = interactive_widget
@@ -1401,10 +1527,14 @@ def test_an_untargeted_grid_follows_the_stage(qapp, interactive_widget, monkeypa
     widget._on_canvas_double_clicked(before[0] + 1500.0, before[1], None)
     qapp.processEvents()
 
-    assert widget.tile_grid_overlay._anchor()[0] == pytest.approx(before[0] + 1500.0, abs=1.0)
+    assert widget.tile_grid_overlay._anchor()[0] == pytest.approx(
+        before[0] + 1500.0, abs=1.0
+    )
 
 
-def test_a_targeted_grid_stays_put_when_the_stage_moves(qapp, interactive_widget, monkeypatch):
+def test_a_targeted_grid_stays_put_when_the_stage_moves(
+    qapp, interactive_widget, monkeypatch
+):
     from fibsem.ui.fm.widgets import fm_overview_widget as module
 
     widget = interactive_widget
@@ -1420,7 +1550,9 @@ def test_a_targeted_grid_stays_put_when_the_stage_moves(qapp, interactive_widget
     assert widget.tile_grid_overlay._anchor() == pytest.approx(targeted)
 
 
-def test_centring_the_grid_is_only_offered_once_it_is_off_centre(qapp, interactive_widget):
+def test_centring_the_grid_is_only_offered_once_it_is_off_centre(
+    qapp, interactive_widget
+):
     """The way back from a drag. A control that is always live invites a click that
     does nothing, and one that is never live strands the state it set."""
     widget = interactive_widget
@@ -1449,9 +1581,13 @@ def test_the_target_reaches_the_acquisition(qapp, interactive_widget, monkeypatc
             recorded.update(kwargs)
 
     monkeypatch.setattr(module, "FMTiledAcquisitionRunner", _RecordingRunner)
-    monkeypatch.setattr(module, "FunctionWorker", lambda *a, **k: _SynchronousWorker(lambda: None))
     monkeypatch.setattr(
-        module.FMOverviewConfirmationDialog, "exec_", lambda self: module.QDialog.Accepted
+        module, "FunctionWorker", lambda *a, **k: _SynchronousWorker(lambda: None)
+    )
+    monkeypatch.setattr(
+        module.FMOverviewConfirmationDialog,
+        "exec_",
+        lambda self: module.QDialog.Accepted,
     )
     anchor = widget.tile_grid_overlay._anchor()
     widget._on_grid_move(anchor[0] + 800.0, anchor[1])
@@ -1482,7 +1618,9 @@ def test_the_cursor_readout_names_the_position_under_it(qapp, interactive_widget
     )
 
 
-def test_the_reported_offset_is_measured_in_the_frame_it_is_drawn_in(qapp, interactive_widget):
+def test_the_reported_offset_is_measured_in_the_frame_it_is_drawn_in(
+    qapp, interactive_widget
+):
     """Subtracting stage axes describes the same gap in a frame the user cannot see: on
     a compustage at t = -180 it reports y with the sign reversed, so the panel said the
     grid was above the stage while it was drawn below."""
@@ -1502,7 +1640,9 @@ def test_the_reported_offset_is_measured_in_the_frame_it_is_drawn_in(qapp, inter
     assert widget._target_offset()[1] > 0
 
 
-def test_the_working_area_follows_the_grid_not_the_canvas_origin(qapp, interactive_widget):
+def test_the_working_area_follows_the_grid_not_the_canvas_origin(
+    qapp, interactive_widget
+):
     """Pinned to the origin, it framed empty space once the stage travelled far from
     wherever the frame was anchored -- moving to an offset FM mount steps 48 mm -- and
     stretched the content extent across the gap, which capped how far the view could
@@ -1510,15 +1650,21 @@ def test_the_working_area_follows_the_grid_not_the_canvas_origin(qapp, interacti
     widget = interactive_widget
     span = widget.canvas.canvas.world_extent[0]
 
-    widget._on_grid_move(*[v + 4 * span / widget.canvas.canvas.reference_pixel_size
-                           for v in widget.tile_grid_overlay._anchor()])
+    widget._on_grid_move(
+        *[
+            v + 4 * span / widget.canvas.canvas.reference_pixel_size
+            for v in widget.tile_grid_overlay._anchor()
+        ]
+    )
     qapp.processEvents()
 
     _, _, cx, cy = widget.canvas.canvas.world_extent
     assert (cx, cy) == pytest.approx(widget._grid_offset())
 
 
-def test_a_move_inside_the_working_area_leaves_the_framing_alone(qapp, interactive_widget):
+def test_a_move_inside_the_working_area_leaves_the_framing_alone(
+    qapp, interactive_widget
+):
     """A move must not throw away the user's zoom -- a double-click to somewhere 100 µm
     away did, the same failure a tile toggle used to cause.
 
@@ -1540,7 +1686,9 @@ def test_a_move_inside_the_working_area_leaves_the_framing_alone(qapp, interacti
 
     assert (tuple(ax.get_xlim()), tuple(ax.get_ylim())) == framing
     # ...and the grid still moved, which is the point of not re-framing for it
-    assert widget.tile_grid_overlay._anchor()[0] == pytest.approx(anchor[0] + span_px / 4)
+    assert widget.tile_grid_overlay._anchor()[0] == pytest.approx(
+        anchor[0] + span_px / 4
+    )
 
 
 def test_the_working_area_follows_the_grid_on_every_move(qapp, interactive_widget):
@@ -1600,7 +1748,11 @@ def test_the_frame_can_be_anchored_at_a_chosen_position(qapp, interactive_widget
     widget.canvas.clear_overviews()
     stage = widget._current_stage_position()
     elsewhere = FibsemStagePosition(
-        x=stage.x + 48e-3, y=stage.y, z=stage.z, r=stage.r, t=stage.t,
+        x=stage.x + 48e-3,
+        y=stage.y,
+        z=stage.z,
+        r=stage.r,
+        t=stage.t,
         coordinate_system=stage.coordinate_system,
     )
     try:
@@ -1624,10 +1776,16 @@ def test_anchoring_again_returns_to_following_the_stage(qapp, interactive_widget
     widget = interactive_widget
     widget.canvas.clear_overviews()
     stage = widget._current_stage_position()
-    widget.set_origin(FibsemStagePosition(
-        x=stage.x + 1e-3, y=stage.y, z=stage.z, r=stage.r, t=stage.t,
-        coordinate_system=stage.coordinate_system,
-    ))
+    widget.set_origin(
+        FibsemStagePosition(
+            x=stage.x + 1e-3,
+            y=stage.y,
+            z=stage.z,
+            r=stage.r,
+            t=stage.t,
+            coordinate_system=stage.coordinate_system,
+        )
+    )
     qapp.processEvents()
 
     widget.set_origin(None)
@@ -1982,7 +2140,10 @@ def test_no_microscope_yet_says_something_different(qapp):
     index = host.tab_widget.indexOf(host.fm_overview_tab)
     assert host.tab_widget.isTabVisible(index)
     assert not host.tab_widget.isTabEnabled(index)
-    assert host.tab_widget.tabToolTip(index) == "Connect a microscope to use the FM Overview"
+    assert (
+        host.tab_widget.tabToolTip(index)
+        == "Connect a microscope to use the FM Overview"
+    )
     assert host.fm_overview_widget is None
 
 
@@ -2179,10 +2340,10 @@ def test_everything_tolerates_the_tab_being_dead(qapp):
     the same state."""
     host = _StubHost(microscope=_plain_microscope())
 
-    host._build_fm_overview_widget()           # must not raise
-    host._update_fm_overview_experiment()      # must not raise
+    host._build_fm_overview_widget()  # must not raise
+    host._update_fm_overview_experiment()  # must not raise
     host._set_minimap_workflow_enabled(False)  # must not raise
-    host._refresh_fm_overview_microscope()       # must not raise
+    host._refresh_fm_overview_microscope()  # must not raise
 
     assert getattr(host, "fm_overview_widget", None) is None
 
@@ -2304,13 +2465,17 @@ def test_showing_the_bars_survives_their_own_reset(qapp):
 # ── the canvas says where things are ─────────────────────────────────────
 
 
-def test_the_cursor_readout_takes_the_status_zone_from_the_grid_hint(qapp, interactive_widget):
+def test_the_cursor_readout_takes_the_status_zone_from_the_grid_hint(
+    qapp, interactive_widget
+):
     """Both want the top left, and this widget used to give each its own label there --
     which drew the coordinates straight over the hint. One zone showing one thing at a
     time is what makes that impossible rather than merely fixed."""
     widget = interactive_widget
     canvas = widget.canvas.canvas
-    assert "Shift+drag" in canvas._status_label.text(), "the hint holds the zone at rest"
+    assert "Shift+drag" in canvas._status_label.text(), (
+        "the hint holds the zone at rest"
+    )
 
     widget._on_cursor_moved(1500.0, -900.0)
     qapp.processEvents()
@@ -2320,7 +2485,9 @@ def test_the_cursor_readout_takes_the_status_zone_from_the_grid_hint(qapp, inter
     assert shown == canvas._readout_text
 
 
-def test_the_zone_goes_back_to_the_hint_when_the_pointer_leaves(qapp, interactive_widget):
+def test_the_zone_goes_back_to_the_hint_when_the_pointer_leaves(
+    qapp, interactive_widget
+):
     """The readout is only true while the pointer is where it is; the hint is still true
     afterwards, so leaving the canvas hands the zone back rather than blanking it."""
     widget = interactive_widget
@@ -2376,7 +2543,9 @@ def test_the_info_bar_leaves_out_the_milling_angle(qapp, interactive_widget):
     assert "milling" not in (widget.canvas.canvas._info_text or "")
 
 
-def test_an_unreadable_objective_does_not_cost_the_stage_position(qapp, interactive_widget):
+def test_an_unreadable_objective_does_not_cost_the_stage_position(
+    qapp, interactive_widget
+):
     """A microscope with no objective, or one that will not answer, should lose that
     field and not the whole line."""
     widget = interactive_widget
@@ -2401,7 +2570,9 @@ def test_an_unreadable_objective_does_not_cost_the_stage_position(qapp, interact
     assert "objective" not in info
 
 
-def test_a_move_updates_the_info_bar_without_reading_the_device(qapp, interactive_widget):
+def test_a_move_updates_the_info_bar_without_reading_the_device(
+    qapp, interactive_widget
+):
     """The point of FIB-534: the bar is rebuilt from what the move announced.
 
     Reading it back would take the shared imaging channel again for numbers the signal
@@ -2630,9 +2801,7 @@ def _named(name: str, x: float, y: float, tilt_deg: float = -180.0):
 
     from fibsem.structures import FibsemStagePosition
 
-    position = FibsemStagePosition(
-        x=x, y=y, z=0.0, r=0.0, t=np.deg2rad(tilt_deg)
-    )
+    position = FibsemStagePosition(x=x, y=y, z=0.0, r=0.0, t=np.deg2rad(tilt_deg))
     position.name = name
     return position
 
@@ -2807,9 +2976,13 @@ def test_no_experiment_clears_the_marked_positions(qapp, tmp_path):
     host._build_fm_overview_widget()
     microscope = host.autolamella_ui.microscope
     host.autolamella_ui.experiment = type(
-        "_Exp", (), {
+        "_Exp",
+        (),
+        {
             "path": "/tmp",
-            "positions": [_lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6)],
+            "positions": [
+                _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6)
+            ],
         },
     )()
     host._update_fm_overview_positions()
@@ -2847,7 +3020,7 @@ def test_the_host_tolerates_no_fm_overview_tab(qapp):
     host = _StubHost(microscope=_plain_microscope())
     host._refresh_fm_overview_microscope()
 
-    host._update_fm_overview_positions()   # must not raise
+    host._update_fm_overview_positions()  # must not raise
     host._update_fm_overview_selection(None)  # must not raise
 
 
@@ -2965,7 +3138,9 @@ def test_moving_is_offered_only_once_something_is_selected(qapp, interactive_wid
     widget.set_positions([])
 
 
-def test_moving_requests_the_selected_name_and_the_clicked_point(qapp, interactive_widget):
+def test_moving_requests_the_selected_name_and_the_clicked_point(
+    qapp, interactive_widget
+):
     widget = interactive_widget
     widget.set_positions([_named("Lamella-04", 0.0, 0.0)])
     widget.set_selected_position("Lamella-04")
@@ -3049,6 +3224,7 @@ def test_nothing_is_offered_from_a_beam_orientation(qapp):
 
 def _experiment_with(positions, tmp_path):
     """An experiment stub that records saves, for the host handlers."""
+
     class _Exp:
         def __init__(self):
             self.path = str(tmp_path)
@@ -3071,13 +3247,19 @@ def _wired_host(qapp, tmp_path, positions=()):
     host.autolamella_ui.added = []
     host.autolamella_ui.updated = 0
 
-    def add_new_lamella(stage_position=None, name=None, objective_position=None,
-                        marked_at=None):
+    def add_new_lamella(
+        stage_position=None, name=None, objective_position=None, marked_at=None
+    ):
         host.autolamella_ui.added.append(
-            {"position": stage_position, "objective_position": objective_position,
-             "marked_at": marked_at}
+            {
+                "position": stage_position,
+                "objective_position": objective_position,
+                "marked_at": marked_at,
+            }
         )
-        lamella = type("_Lamella", (), {"name": f"Lamella-{len(host.autolamella_ui.added):02d}"})()
+        lamella = type(
+            "_Lamella", (), {"name": f"Lamella-{len(host.autolamella_ui.added):02d}"}
+        )()
         return lamella
 
     def update_ui():
@@ -3167,7 +3349,9 @@ def test_adding_without_an_experiment_is_refused_not_crashed(qapp, tmp_path):
     host = _wired_host(qapp, tmp_path)
     host.autolamella_ui.experiment = None
 
-    host.fm_overview_tab._on_add_requested(_named("wherever", 0.0, 0.0))  # must not raise
+    host.fm_overview_tab._on_add_requested(
+        _named("wherever", 0.0, 0.0)
+    )  # must not raise
 
     assert host.autolamella_ui.added == []
 
@@ -3184,7 +3368,9 @@ def test_a_refused_add_is_reported_rather_than_raised(qapp, tmp_path):
 
     host.autolamella_ui.add_new_lamella = refuse
 
-    host.fm_overview_tab._on_add_requested(_named("wherever", 0.0, 0.0))  # must not raise
+    host.fm_overview_tab._on_add_requested(
+        _named("wherever", 0.0, 0.0)
+    )  # must not raise
 
     host._teardown_fm_overview_widget()
 
@@ -3208,10 +3394,14 @@ def test_moving_asks_before_it_moves_anything(qapp, tmp_path, monkeypatch):
         module, "message_box_ui", lambda **kwargs: asked.append(kwargs) or False
     )
 
-    host.fm_overview_tab._on_move_requested("Lamella-01", _named("target", 400e-6, -200e-6))
+    host.fm_overview_tab._on_move_requested(
+        "Lamella-01", _named("target", 400e-6, -200e-6)
+    )
 
     assert len(asked) == 1, "moved without asking"
-    assert lamella.poses["MILLING"].stage_position.x == before["MILLING"].stage_position.x
+    assert (
+        lamella.poses["MILLING"].stage_position.x == before["MILLING"].stage_position.x
+    )
     assert (
         lamella.poses["FLUORESCENCE"].stage_position.x
         == before["FLUORESCENCE"].stage_position.x
@@ -3250,7 +3440,9 @@ def test_confirming_a_move_moves_both_poses(qapp, tmp_path, monkeypatch):
     host._teardown_fm_overview_widget()
 
 
-def test_a_move_rewrites_the_stage_positions_and_nothing_else(qapp, tmp_path, monkeypatch):
+def test_a_move_rewrites_the_stage_positions_and_nothing_else(
+    qapp, tmp_path, monkeypatch
+):
     """A move is a move. The poses are edited in place rather than replaced, so the beam
     settings the lamella was marked with survive -- and so does the objective position,
     because the user moved sideways, they did not refocus."""
@@ -3266,7 +3458,9 @@ def test_a_move_rewrites_the_stage_positions_and_nothing_else(qapp, tmp_path, mo
     host.autolamella_ui.experiment.positions = [lamella]
     monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
 
-    host.fm_overview_tab._on_move_requested("Lamella-01", _named("target", 400e-6, -200e-6))
+    host.fm_overview_tab._on_move_requested(
+        "Lamella-01", _named("target", 400e-6, -200e-6)
+    )
 
     assert lamella.milling_pose.electron_detector.brightness == pytest.approx(0.123)
     assert lamella.fluorescence_pose.objective_position == pytest.approx(7.7e-3)
@@ -3290,12 +3484,16 @@ def test_moving_a_lamella_that_has_no_fluorescence_pose_gives_it_one(
     host.autolamella_ui.experiment.positions = [lamella]
     monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
 
-    host.fm_overview_tab._on_move_requested("Lamella-01", _named("target", 400e-6, -200e-6))
+    host.fm_overview_tab._on_move_requested(
+        "Lamella-01", _named("target", 400e-6, -200e-6)
+    )
 
     assert lamella.fluorescence_pose is not None
     assert lamella.fluorescence_pose.stage_position.x == pytest.approx(400e-6)
     # built on the lamella's own state, not the live microscope's
-    assert lamella.fluorescence_pose.electron_detector.brightness == pytest.approx(0.123)
+    assert lamella.fluorescence_pose.electron_detector.brightness == pytest.approx(
+        0.123
+    )
 
     host._teardown_fm_overview_widget()
 
@@ -3314,7 +3512,9 @@ def test_a_move_re_derives_the_milling_angle(qapp, tmp_path, monkeypatch):
     host.autolamella_ui.experiment.positions = [lamella]
     monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
 
-    host.fm_overview_tab._on_move_requested("Lamella-01", _named("target", 400e-6, -200e-6))
+    host.fm_overview_tab._on_move_requested(
+        "Lamella-01", _named("target", 400e-6, -200e-6)
+    )
 
     assert lamella.milling_angle != pytest.approx(999.0)
     assert lamella.milling_angle == pytest.approx(
@@ -3503,7 +3703,9 @@ def test_a_confirmed_move_re_marks_the_canvas(qapp, tmp_path, monkeypatch):
     before = host.fm_overview_widget._positions[0].x
     monkeypatch.setattr(module, "message_box_ui", lambda **kwargs: True)
 
-    host.fm_overview_tab._on_move_requested("Lamella-01", _named("target", 400e-6, -200e-6))
+    host.fm_overview_tab._on_move_requested(
+        "Lamella-01", _named("target", 400e-6, -200e-6)
+    )
 
     assert host.fm_overview_widget._positions[0].x == pytest.approx(400e-6)
     assert host.fm_overview_widget._positions[0].x != pytest.approx(before)
@@ -3523,9 +3725,7 @@ def _tab_with(qapp, tmp_path, positions=()):
 
     microscope = build_microscope()
     experiment = _experiment_with(positions, tmp_path)
-    ui = type(
-        "_UI", (), {"microscope": microscope, "experiment": experiment}
-    )()
+    ui = type("_UI", (), {"microscope": microscope, "experiment": experiment})()
     ui.update_ui = lambda: None
     tab = AutoLamellaFluorescenceOverviewTab(ui)
     tab.refresh_microscope()
@@ -3579,10 +3779,12 @@ def test_the_list_shows_every_lamella_including_the_unplaceable(qapp, tmp_path):
 def test_picking_a_row_highlights_it_on_the_canvas(qapp, tmp_path):
     tab = _tab_with(qapp, tmp_path)
     microscope = tab.microscope
-    tab.experiment.positions.extend([
-        _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6),
-        _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6),
-    ])
+    tab.experiment.positions.extend(
+        [
+            _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6),
+            _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6),
+        ]
+    )
     tab.refresh_positions()
     qapp.processEvents()
 
@@ -3599,10 +3801,12 @@ def test_picking_a_row_tells_the_window(qapp, tmp_path):
     beats four talking to each other."""
     tab = _tab_with(qapp, tmp_path)
     microscope = tab.microscope
-    tab.experiment.positions.extend([
-        _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6),
-        _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6),
-    ])
+    tab.experiment.positions.extend(
+        [
+            _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6),
+            _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6),
+        ]
+    )
     tab.refresh_positions()
     qapp.processEvents()
     seen = []
@@ -3621,10 +3825,12 @@ def test_picking_a_row_tells_the_window(qapp, tmp_path):
 def test_a_selection_arriving_from_elsewhere_reaches_the_list(qapp, tmp_path):
     tab = _tab_with(qapp, tmp_path)
     microscope = tab.microscope
-    tab.experiment.positions.extend([
-        _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6),
-        _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6),
-    ])
+    tab.experiment.positions.extend(
+        [
+            _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6),
+            _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6),
+        ]
+    )
     tab.refresh_positions()
     qapp.processEvents()
 
@@ -3663,7 +3869,9 @@ def test_move_to_drives_the_stage_to_the_fluorescence_pose(qapp, tmp_path, monke
     tab._drop_overview()
 
 
-def test_move_to_a_lamella_with_no_fluorescence_pose_is_refused(qapp, tmp_path, monkeypatch):
+def test_move_to_a_lamella_with_no_fluorescence_pose_is_refused(
+    qapp, tmp_path, monkeypatch
+):
     from fibsem.ui.fm.widgets import fm_overview_widget as module
 
     tab = _tab_with(qapp, tmp_path)
@@ -3897,8 +4105,9 @@ def test_translating_the_stage_leaves_the_markers_alone(qapp):
 
     here = microscope.get_stage_position()
     microscope.move_stage_absolute(
-        FibsemStagePosition(x=here.x + 200e-6, y=here.y - 90e-6, z=here.z,
-                            r=here.r, t=here.t)
+        FibsemStagePosition(
+            x=here.x + 200e-6, y=here.y - 90e-6, z=here.z, r=here.r, t=here.t
+        )
     )
     widget._on_stage_moved(microscope.get_stage_position())
     qapp.processEvents()
@@ -3955,10 +4164,12 @@ def test_clicking_a_marker_selects_it(qapp, interactive_widget):
     """As the minimap does. The markers are drawn by a non-interactive overlay, so the
     canvas's own click signal does the picking."""
     widget = interactive_widget
-    widget.set_positions([
-        _named("Lamella-01", 120e-6, 90e-6),
-        _named("Lamella-02", -160e-6, 40e-6),
-    ])
+    widget.set_positions(
+        [
+            _named("Lamella-01", 120e-6, 90e-6),
+            _named("Lamella-02", -160e-6, 40e-6),
+        ]
+    )
     picked = []
     widget.position_selected.connect(lambda name: picked.append(name))
     frame = widget._frame()
@@ -4037,15 +4248,18 @@ def test_the_nearest_marker_wins(qapp, interactive_widget):
     answer if the nearest happened to come last.
     """
     widget = interactive_widget
-    widget.set_positions([
-        _named("Lamella-02", 121e-6, 90e-6),   # nearest to the probe, and first
-        _named("Lamella-01", 120e-6, 90e-6),
-    ])
+    widget.set_positions(
+        [
+            _named("Lamella-02", 121e-6, 90e-6),  # nearest to the probe, and first
+            _named("Lamella-01", 120e-6, 90e-6),
+        ]
+    )
     frame = widget._frame()
 
-    assert widget._position_at(
-        *frame.to_canvas(_named("probe", 120.9e-6, 90e-6))
-    ) == "Lamella-02"
+    assert (
+        widget._position_at(*frame.to_canvas(_named("probe", 120.9e-6, 90e-6)))
+        == "Lamella-02"
+    )
 
     widget.set_positions([])
 
@@ -4055,10 +4269,12 @@ def test_clicking_a_marker_selects_the_lamella_everywhere(qapp, tmp_path):
     and it goes out on the same path a row click takes."""
     tab = _tab_with(qapp, tmp_path)
     microscope = tab.microscope
-    tab.experiment.positions.extend([
-        _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6),
-        _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6),
-    ])
+    tab.experiment.positions.extend(
+        [
+            _lamella_with_poses("Lamella-01", microscope, tmp_path, 100e-6, 50e-6),
+            _lamella_with_poses("Lamella-02", microscope, tmp_path, -80e-6, 20e-6),
+        ]
+    )
     tab.refresh_positions()
     qapp.processEvents()
     seen = []
@@ -4242,7 +4458,9 @@ def test_the_live_preview_never_becomes_a_record(qapp, blank_canvas):
     widget = blank_canvas
     import numpy as np
 
-    widget._show_preview({"image": np.zeros((4, 4), dtype=np.uint16), "preview_stride": 1})
+    widget._show_preview(
+        {"image": np.zeros((4, 4), dtype=np.uint16), "preview_stride": 1}
+    )
     qapp.processEvents()
 
     assert PREVIEW_KEY in widget.canvas.canvas.placed_keys, "the preview was not drawn"
@@ -4324,7 +4542,9 @@ def test_a_record_describes_its_grid_and_scale(qapp, blank_canvas):
     assert widget.overviews()[0].detail == "3×3 · 1.20 µm/px"
 
 
-def test_a_saved_overview_is_labelled_by_the_folder_its_tiles_are_in(qapp, blank_canvas):
+def test_a_saved_overview_is_labelled_by_the_folder_its_tiles_are_in(
+    qapp, blank_canvas
+):
     """`OverviewDestination` stamps the run's directory name onto the mosaic, which is
     what someone looking for it on disk would search for."""
     widget = blank_canvas
@@ -4381,7 +4601,9 @@ def test_the_list_does_not_grow_a_row_for_the_live_preview(qapp, blank_canvas):
     widget = blank_canvas
     import numpy as np
 
-    widget._show_preview({"image": np.zeros((4, 4), dtype=np.uint16), "preview_stride": 1})
+    widget._show_preview(
+        {"image": np.zeros((4, 4), dtype=np.uint16), "preview_stride": 1}
+    )
     qapp.processEvents()
 
     assert widget.overview_list._list.count() == 0
@@ -4399,7 +4621,9 @@ def _saved(widget, tmp_path, date="2026-08-07T09:00:00", name="overview-14-02-33
     return image, path
 
 
-def test_a_loaded_overview_lands_where_the_acquired_one_did(qapp, blank_canvas, tmp_path):
+def test_a_loaded_overview_lands_where_the_acquired_one_did(
+    qapp, blank_canvas, tmp_path
+):
     """The claim the whole feature rests on. `set_image` places by projecting through
     the image's *own* recorded geometry, and everything that projection needs -- the
     stage position's r and t, the hardware geometry, the pixel size -- survives the
@@ -4432,7 +4656,9 @@ def test_loading_gives_the_overview_a_record_and_a_row(qapp, blank_canvas, tmp_p
     assert widget.overview_list._list.count() == 1
 
 
-def test_a_loaded_overview_is_named_for_the_run_that_made_it(qapp, blank_canvas, tmp_path):
+def test_a_loaded_overview_is_named_for_the_run_that_made_it(
+    qapp, blank_canvas, tmp_path
+):
     """`description` survives the round trip, so the row still names the folder the
     tiles are in rather than falling back to a number."""
     widget = blank_canvas
@@ -4443,7 +4669,9 @@ def test_a_loaded_overview_is_named_for_the_run_that_made_it(qapp, blank_canvas,
     assert record.label == "overview-11-20-05"
 
 
-def test_a_loaded_overview_keeps_its_scale_but_loses_its_grid(qapp, blank_canvas, tmp_path):
+def test_a_loaded_overview_keeps_its_scale_but_loses_its_grid(
+    qapp, blank_canvas, tmp_path
+):
     """Documented, not a bug. `stitch_tileset` carries the grid in
     `stage_position.name`, which the OME-TIFF drops -- so a loaded row shows what it
     still knows rather than guessing (FIB-438)."""
@@ -4493,7 +4721,9 @@ def test_an_overview_with_no_geometry_is_shown_but_not_trusted(
     assert any(level == "warning" for _, level in toasts), "placed with no warning"
 
 
-def test_loading_the_same_file_twice_does_not_stack_two_copies(qapp, blank_canvas, tmp_path):
+def test_loading_the_same_file_twice_does_not_stack_two_copies(
+    qapp, blank_canvas, tmp_path
+):
     """The acquisition date survives the round trip, so the record match still holds
     across a reload."""
     widget = blank_canvas
@@ -4557,7 +4787,9 @@ def test_picking_no_file_places_nothing(qapp, blank_canvas, monkeypatch):
 # ── the start options say what they currently mean (FIB-417) ─────────────
 
 
-def test_the_start_options_show_where_they_would_put_the_objective(qapp, overview_widget):
+def test_the_start_options_show_where_they_would_put_the_objective(
+    qapp, overview_widget
+):
     """An option that names a position has to say which one. "Saved focus position" is
     only actionable next to the number, and next to where the objective is now."""
     widget = overview_widget
@@ -4568,7 +4800,9 @@ def test_the_start_options_show_where_they_would_put_the_objective(qapp, overvie
     combo = widget.settings_widget.combo_objective_start
     labels = [combo.itemText(i) for i in range(combo.count())]
     assert any("mm" in label for label in labels), f"no positions shown: {labels}"
-    assert any("8.000 mm" in label for label in labels), f"saved focus missing: {labels}"
+    assert any("8.000 mm" in label for label in labels), (
+        f"saved focus missing: {labels}"
+    )
 
 
 def test_an_unsaved_focus_position_says_so_rather_than_showing_nothing(
@@ -4646,7 +4880,9 @@ def test_acquiring_with_the_objective_retracted_is_refused_before_the_dialog(
     widget.fm.set_acquiring(False)
     widget.status.setText("")
     assert widget.at_acquisition_orientation()
-    monkeypatch.setattr(type(widget.fm.objective), "state", property(lambda self: "Retracted"))
+    monkeypatch.setattr(
+        type(widget.fm.objective), "state", property(lambda self: "Retracted")
+    )
     shown = []
     monkeypatch.setattr(
         "fibsem.ui.fm.widgets.fm_overview_widget.FMOverviewConfirmationDialog",
@@ -4753,7 +4989,9 @@ class TestTheCameraTransformReachesTheProjection:
             fm.set_image_transform(CameraImageTransform.FLIP_X)
             qapp.processEvents()
 
-            assert widget._projection().geometry.transform is CameraImageTransform.FLIP_X, (
+            assert (
+                widget._projection().geometry.transform is CameraImageTransform.FLIP_X
+            ), (
                 "the projection still carries the old transform, so every overlay "
                 "placed through it is drawn for a flip that no longer applies"
             )
@@ -4810,7 +5048,9 @@ def test_the_canvas_says_how_to_edit_the_grid_while_it_is_shown(qapp):
     assert widget.canvas.canvas._hint_text is None
 
 
-def test_zz_the_shared_fixture_is_still_wired_at_the_end_of_the_file(qapp, overview_widget):
+def test_zz_the_shared_fixture_is_still_wired_at_the_end_of_the_file(
+    qapp, overview_widget
+):
     """A canary, deliberately last: it only catches what happens *before* it.
 
     The module-scoped widget is shared by ~100 tests, and psygnal holds bound methods
@@ -4901,7 +5141,9 @@ class TestSayingWhenARunStarts:
         widget._set_running(False)
         assert seen == [True, False]
 
-    def test_is_acquiring_already_agrees_when_the_signal_arrives(self, interactive_widget):
+    def test_is_acquiring_already_agrees_when_the_signal_arrives(
+        self, interactive_widget
+    ):
         widget = interactive_widget
         answers = []
         widget.acquiring_changed.connect(lambda _: answers.append(widget.is_acquiring))
@@ -4913,7 +5155,9 @@ class TestSayingWhenARunStarts:
         assert answers == [True, False]
 
 
-def test_the_worker_announces_the_save_before_it_writes(qapp, overview_widget, tmp_path):
+def test_the_worker_announces_the_save_before_it_writes(
+    qapp, overview_widget, tmp_path
+):
     """The larger half of the end-of-run gap, and the half the *widget* owns.
 
     Measured: the stitch is ~0.3 s for a 1.3 GB mosaic and the write is ~2.3 s of the
@@ -4942,7 +5186,11 @@ def test_the_worker_announces_the_save_before_it_writes(qapp, overview_widget, t
         widget._acquire_worker()
     finally:
         widget.microscope.tiled_acquisition_signal.disconnect(seen.append)
-        widget._runner, widget._destination, widget._saved_path = runner, destination, saved
+        widget._runner, widget._destination, widget._saved_path = (
+            runner,
+            destination,
+            saved,
+        )
 
     states = [p.get("state") for p in seen if p.get("task") == "tileset"]
     assert "saving" in states, "the write is still silent"
@@ -4961,10 +5209,15 @@ def test_a_tileset_payload_reaches_the_real_widget(qapp, overview_widget):
     test noticing.
     """
     widget = overview_widget
-    widget.microscope.tiled_acquisition_signal.emit({
-        "modality": "fluorescence", "state": "acquiring", "task": "tileset",
-        "counter": 4, "total": 9,
-    })
+    widget.microscope.tiled_acquisition_signal.emit(
+        {
+            "modality": "fluorescence",
+            "state": "acquiring",
+            "task": "tileset",
+            "counter": 4,
+            "total": 9,
+        }
+    )
     qapp.processEvents()
 
     assert "4 / 9" in _bar(widget.progress_tiles).format()
@@ -4979,10 +5232,15 @@ def test_an_fm_payload_reaches_the_real_widget(qapp, overview_widget):
     slow acquisition rather than as a bug.
     """
     widget = overview_widget
-    widget.fm.acquisition_progress_signal.emit({
-        "state": "acquiring", "task": "z-stack", "channel": "GFP",
-        "zlevel": 7, "total_zlevels": 21,
-    })
+    widget.fm.acquisition_progress_signal.emit(
+        {
+            "state": "acquiring",
+            "task": "z-stack",
+            "channel": "GFP",
+            "zlevel": 7,
+            "total_zlevels": 21,
+        }
+    )
     qapp.processEvents()
 
     assert "7 / 21" in _bar(widget.progress_tile_detail).format()
@@ -5017,17 +5275,27 @@ def test_a_beam_run_does_not_drive_the_fluorescence_bar(qapp, overview_widget):
     a `task` key would be a reasonable thing for it to do.
     """
     widget = overview_widget
-    widget.microscope.tiled_acquisition_signal.emit({
-        "modality": "fluorescence", "state": "acquiring", "task": "tileset",
-        "counter": 4, "total": 9,
-    })
+    widget.microscope.tiled_acquisition_signal.emit(
+        {
+            "modality": "fluorescence",
+            "state": "acquiring",
+            "task": "tileset",
+            "counter": 4,
+            "total": 9,
+        }
+    )
     qapp.processEvents()
     before = _bar(widget.progress_tiles).format()
 
-    widget.microscope.tiled_acquisition_signal.emit({
-        "modality": "beam", "task": "tileset", "counter": 8, "total": 9,
-        "msg": "Tile Collected",
-    })
+    widget.microscope.tiled_acquisition_signal.emit(
+        {
+            "modality": "beam",
+            "task": "tileset",
+            "counter": 8,
+            "total": 9,
+            "msg": "Tile Collected",
+        }
+    )
     qapp.processEvents()
 
     assert _bar(widget.progress_tiles).format() == before
@@ -5048,23 +5316,40 @@ def test_the_announcement_payload_does_not_redraw_the_tile_bar(qapp):
     counts at all, which settles both.
     """
     router = _Router()
-    router._apply_tile_progress({
-        "modality": "fluorescence", "state": "tile", "task": "tileset",
-        "counter": 2, "total": 4,
-        "estimated_remaining_time": 18.0, "estimated_total_time": 24.0,
-    })
-    before = (_bar(router.progress_tiles).value(),
-              _bar(router.progress_tiles).maximum(),
-              _bar(router.progress_tiles).format())
+    router._apply_tile_progress(
+        {
+            "modality": "fluorescence",
+            "state": "tile",
+            "task": "tileset",
+            "counter": 2,
+            "total": 4,
+            "estimated_remaining_time": 18.0,
+            "estimated_total_time": 24.0,
+        }
+    )
+    before = (
+        _bar(router.progress_tiles).value(),
+        _bar(router.progress_tiles).maximum(),
+        _bar(router.progress_tiles).format(),
+    )
 
-    router._apply_tile_progress({
-        "modality": "fluorescence", "state": "acquiring", "task": "tileset",
-        "row": 2, "col": 3, "total_rows": 2, "total_cols": 2,
-    })
+    router._apply_tile_progress(
+        {
+            "modality": "fluorescence",
+            "state": "acquiring",
+            "task": "tileset",
+            "row": 2,
+            "col": 3,
+            "total_rows": 2,
+            "total_cols": 2,
+        }
+    )
 
-    after = (_bar(router.progress_tiles).value(),
-             _bar(router.progress_tiles).maximum(),
-             _bar(router.progress_tiles).format())
+    after = (
+        _bar(router.progress_tiles).value(),
+        _bar(router.progress_tiles).maximum(),
+        _bar(router.progress_tiles).format(),
+    )
     assert after == before, "the announcement redrew the bar"
     assert "remaining" in after[2], "the estimate was dropped"
 
@@ -5076,8 +5361,11 @@ def test_the_preview_is_still_shown(qapp):
     router._show_preview = shown.append
 
     payload = {
-        "modality": "fluorescence", "state": "tile", "task": "tileset",
-        "counter": 2, "total": 4,
+        "modality": "fluorescence",
+        "state": "tile",
+        "task": "tileset",
+        "counter": 2,
+        "total": 4,
     }
     router._apply_tile_progress(payload)
 
@@ -5353,7 +5641,7 @@ def test_a_real_reason_to_re_frame_still_re_frames(qapp, grid_of):
     original = overlay.fit_view
     overlay.fit_view = lambda *a, **k: fits.append(1)
     try:
-        grid_of(5, 5)                        # a different footprint, outside any drag
+        grid_of(5, 5)  # a different footprint, outside any drag
         qapp.processEvents()
     finally:
         overlay.fit_view = original

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -297,9 +297,11 @@ def test_without_a_format_fn_the_built_in_rendering_still_applies(qapp):
 
 # ── progress bars ────────────────────────────────────────────────────────
 #
-# One signal carries both scales: the tileset runner's tile counter, and -- from
-# inside each tile -- `acquire_z_stack` / `acquire_channels`. `task` decides which
-# bar a payload drives, so a payload must never move both.
+# Two signals, two scales, one bar each: the tileset runner's tile counter on
+# `tiled_acquisition_signal`, and -- from inside each tile -- `acquire_z_stack` /
+# `acquire_channels` on the detector's own. A payload must never move both bars,
+# which is now a property of *which handler it reaches* rather than of a `task`
+# key both producers happen to agree on.
 
 
 class _Router:
@@ -310,8 +312,8 @@ class _Router:
         self.progress_tile_detail = FibsemProgressWidget()
         self.status = QLabel()
 
-    _apply_progress = FMOverviewWidget._apply_progress
     _apply_tile_progress = FMOverviewWidget._apply_tile_progress
+    _apply_fm_progress = FMOverviewWidget._apply_fm_progress
     _tile_detail_update = FMOverviewWidget._tile_detail_update
 
     def _show_preview(self, payload):
@@ -328,7 +330,7 @@ def _bar(widget):
 def test_a_tileset_payload_moves_only_the_tile_bar(qapp):
     router = _Router()
 
-    router._apply_progress({
+    router._apply_tile_progress({
         "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 4, "total": 9,
     })
 
@@ -341,7 +343,7 @@ def test_a_tileset_payload_moves_only_the_tile_bar(qapp):
 def test_a_zstack_payload_moves_only_the_detail_bar(qapp):
     router = _Router()
 
-    router._apply_progress({
+    router._apply_fm_progress({
         "state": "acquiring", "task": "z-stack", "channel": "GFP",
         "zlevel": 7, "total_zlevels": 21,
     })
@@ -356,7 +358,7 @@ def test_a_channels_payload_drives_the_detail_bar_too(qapp):
     """Without this the second bar is dead on every run that is not z-stacked."""
     router = _Router()
 
-    router._apply_progress({
+    router._apply_fm_progress({
         "state": "acquiring", "task": "channels", "channel": "RFP",
         "channel_index": 2, "total_channels": 3,
     })
@@ -371,12 +373,12 @@ def test_a_completed_tile_leaves_the_detail_bar_alone(qapp):
     -- a flicker for the length of the run. The next tile overwrites it a moment later
     anyway, so the stale count is never seen."""
     router = _Router()
-    router._apply_progress({
+    router._apply_fm_progress({
         "state": "acquiring", "task": "z-stack", "channel": "GFP",
         "zlevel": 21, "total_zlevels": 21,
     })
 
-    router._apply_progress({
+    router._apply_tile_progress({
         "modality": "fluorescence", "state": "tile", "task": "tileset", "current": 1, "total": 9,
     })
 
@@ -384,9 +386,32 @@ def test_a_completed_tile_leaves_the_detail_bar_alone(qapp):
 
 
 def test_an_unknown_task_moves_nothing(qapp):
+    """The detector reports whatever it is doing, tileset or not.
+
+    A workflow task driving the FM while this tab is open emits its own task name, and
+    `finished` arrives with no task at all. Neither describes the tile being taken.
+    """
     router = _Router()
 
-    router._apply_progress({"state": "acquiring", "task": "something-else"})
+    router._apply_fm_progress({"state": "acquiring", "task": "something-else"})
+    router._apply_fm_progress({"state": "finished"})
+
+    assert not router.progress_tiles.isVisible()
+    assert not router.progress_tile_detail.isVisible()
+
+
+def test_a_beam_payload_moves_neither_bar(qapp):
+    """The other half of the same invariant, on the other handler.
+
+    `tiled_acquisition_signal` has two producers. Ignored today even without the
+    modality check -- beam payloads carry no `task` -- but that is an accident of
+    vocabulary, not a decision.
+    """
+    router = _Router()
+
+    router._apply_tile_progress({
+        "modality": "beam", "counter": 8, "total": 9, "msg": "Tile Collected",
+    })
 
     assert not router.progress_tiles.isVisible()
     assert not router.progress_tile_detail.isVisible()
@@ -395,7 +420,7 @@ def test_an_unknown_task_moves_nothing(qapp):
 def test_the_estimate_is_shown_when_the_payload_carries_one(qapp):
     router = _Router()
 
-    router._apply_progress({
+    router._apply_tile_progress({
         "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 2, "total": 9,
         "estimated_remaining_time": 134.0, "estimated_total_time": 180.0,
     })
@@ -410,11 +435,11 @@ def test_a_stage_move_does_not_fill_the_bar(qapp):
     goes to the status label.
     """
     router = _Router()
-    router._apply_progress({
+    router._apply_tile_progress({
         "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 3, "total": 9,
     })
 
-    router._apply_progress({"modality": "fluorescence", "state": "moving", "task": "tileset"})
+    router._apply_tile_progress({"modality": "fluorescence", "state": "moving", "task": "tileset"})
 
     assert (_bar(router.progress_tiles).value(),
             _bar(router.progress_tiles).maximum()) == (3, 9)
@@ -439,11 +464,11 @@ def test_the_end_of_a_run_is_not_silent(qapp, state, label):
     impression these phases exist to correct.
     """
     router = _Router()
-    router._apply_progress({
+    router._apply_tile_progress({
         "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 9, "total": 9,
     })
 
-    router._apply_progress(
+    router._apply_tile_progress(
         {"modality": "fluorescence", "state": state, "task": "tileset"}
     )
 
@@ -455,10 +480,10 @@ def test_the_end_of_a_run_is_not_silent(qapp, state, label):
 def test_a_phase_label_is_cleared_by_the_next_tile(qapp):
     """Otherwise "Stitching tiles…" would still be on screen through the next run."""
     router = _Router()
-    router._apply_progress({"modality": "fluorescence", "state": "saving", "task": "tileset"})
+    router._apply_tile_progress({"modality": "fluorescence", "state": "saving", "task": "tileset"})
     assert router.status.text() == "Saving overview…"
 
-    router._apply_progress({
+    router._apply_tile_progress({
         "modality": "fluorescence", "state": "acquiring", "task": "tileset", "counter": 1, "total": 9,
     })
     assert router.status.text() == ""
@@ -4929,7 +4954,7 @@ def test_the_worker_announces_the_save_before_it_writes(qapp, overview_widget, t
 def test_a_tileset_payload_reaches_the_real_widget(qapp, overview_widget):
     """The wiring, not the rendering.
 
-    Every other test here drives `_apply_progress` directly, which covers what the
+    Every other test here drives `_apply_tile_progress` directly, which covers what the
     widget *does* with a payload and nothing about whether one arrives. The tileset
     moved to `tiled_acquisition_signal` (FIB-725), so the subscription is precisely what
     changed — and a broken one leaves this tab's own bar dead for a whole run with no
@@ -4943,6 +4968,45 @@ def test_a_tileset_payload_reaches_the_real_widget(qapp, overview_widget):
     qapp.processEvents()
 
     assert "4 / 9" in _bar(widget.progress_tiles).format()
+
+
+def test_an_fm_payload_reaches_the_real_widget(qapp, overview_widget):
+    """The other subscription, for the same reason as the one above.
+
+    The two scales arrive on two signals and are handled by two slots, so each
+    subscription can break on its own. This one going quiet leaves the within-tile bar
+    dead for a whole run -- visible only as a bar that never moves, which reads as a
+    slow acquisition rather than as a bug.
+    """
+    widget = overview_widget
+    widget.fm.acquisition_progress_signal.emit({
+        "state": "acquiring", "task": "z-stack", "channel": "GFP",
+        "zlevel": 7, "total_zlevels": 21,
+    })
+    qapp.processEvents()
+
+    assert "7 / 21" in _bar(widget.progress_tile_detail).format()
+
+
+def test_closing_disconnects_both_progress_signals(qapp, overview_widget):
+    """Both psygnals outlive the widget, so both must be dropped on the way out.
+
+    `tiled_acquisition_signal` was subscribed when the tileset moved onto it (FIB-725)
+    and never added to the teardown list, which the list's own comment claims is
+    exhaustive. Emitting into a closed tab from a beam run elsewhere in the application
+    is the segfault that list exists to prevent.
+    """
+    widget = overview_widget
+    widget.close()
+    qapp.processEvents()
+
+    for signal, slot_name in (
+        (widget.microscope.tiled_acquisition_signal, "_on_tile_progress"),
+        (widget.fm.acquisition_progress_signal, "_on_fm_progress"),
+    ):
+        assert not any(slot_name in repr(s) for s in signal._slots), (
+            f"{slot_name} still connected after close"
+        )
 
 
 def test_a_beam_run_does_not_drive_the_fluorescence_bar(qapp, overview_widget):
@@ -4984,7 +5048,7 @@ def test_the_announcement_payload_does_not_redraw_the_tile_bar(qapp):
     counts at all, which settles both.
     """
     router = _Router()
-    router._apply_progress({
+    router._apply_tile_progress({
         "modality": "fluorescence", "state": "tile", "task": "tileset",
         "counter": 2, "total": 4,
         "estimated_remaining_time": 18.0, "estimated_total_time": 24.0,
@@ -4993,7 +5057,7 @@ def test_the_announcement_payload_does_not_redraw_the_tile_bar(qapp):
               _bar(router.progress_tiles).maximum(),
               _bar(router.progress_tiles).format())
 
-    router._apply_progress({
+    router._apply_tile_progress({
         "modality": "fluorescence", "state": "acquiring", "task": "tileset",
         "row": 2, "col": 3, "total_rows": 2, "total_cols": 2,
     })
@@ -5015,7 +5079,7 @@ def test_the_preview_is_still_shown(qapp):
         "modality": "fluorescence", "state": "tile", "task": "tileset",
         "counter": 2, "total": 4,
     }
-    router._apply_progress(payload)
+    router._apply_tile_progress(payload)
 
     assert shown == [payload]
 


### PR DESCRIPTION
`FMOverviewWidget` subscribed both `tiled_acquisition_signal` and `acquisition_progress_signal` to one slot, which then sorted them back apart by a `task` key to decide which of its two bars a payload belonged to.

The two arrive already sorted — different signals, different producers, different scales. Re-deriving that from a vocabulary neither producer declares is work with a failure mode and no upside: the beam tiler gaining a `task` key, or a payload spelling one differently, puts a run's progress on the wrong bar.

## After

| signal | slot | GUI-thread relay | bar |
| -- | -- | -- | -- |
| `tiled_acquisition_signal` | `_on_tile_progress` → `_apply_tile_progress` | `_tile_progress_received` | `progress_tiles` — the run as a whole |
| `acquisition_progress_signal` | `_on_fm_progress` → `_apply_fm_progress` | `_fm_progress_received` | `progress_tile_detail` — inside the current tile |

Each keeps its own relay signal: both psygnals fire on the acquisition worker, so both need the hop onto the GUI thread.

`_apply_tile_progress` now checks the modality **first**, terminal states included, rather than after a `task == "tileset"` test. Only this widget emits the `overview-*` states and it always stamps them fluorescence, so nothing changes today — but a beam payload can no longer reach `_finish`.

## Incidental fix

`tiled_acquisition_signal` has been subscribed since the tileset moved onto it, and was never added to the `closeEvent` disconnect list — the list whose own comment claims it holds every psygnal this widget subscribed to "without exception", and whose absence that comment describes as a segfault rather than an exception. Added, with `test_closing_disconnects_both_progress_signals`; verified it fails when the disconnect is removed.

## Verification

- `tests/ui/test_fm_overview_widget.py` + `tests/ui/test_overview_widget.py`: 462 passed. The existing routing tests now drive whichever handler owns each payload; `test_an_unknown_task_moves_nothing` gained the `finished`-with-no-task case, and a new `test_a_beam_payload_moves_neither_bar` states the same invariant on the other handler.
- Two new real-widget tests for the wiring itself, one per subscription — the split's actual risk is a slot that silently stops arriving, which every test that calls the handler directly is blind to.
- End to end on the Demo, a real 2×2 z-stacked run through the real runner and the real signals:

```
--- tile bar ---            --- detail bar ---          --- status ---
Tiles — 0/4 · 43s remaining  Channel-01 z-stack — 1/3    Moving stage…
Tiles — 1/4 · 22s remaining  Channel-01 z-stack — 2/3    Stitching tiles…
Tiles — 2/4 · 14s remaining  Channel-01 z-stack — 3/3
Tiles — 3/4 · 7s remaining   (×4, once per tile)
Tiles — 4 / 4
```

Each scale on its own bar for a whole run, the estimate riding the tile count, and the countless phases on the status label rather than filling a bar.