### PR TITLE
[autolamella] Say what a task is for, not only what it is called

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -139,6 +139,143 @@ class AutoLamellaTaskState:
         return cls(**{k: v for k, v in data.items() if k in known})
 
 
+TASK_LEVEL_RECOMMENDED = "recommended"
+TASK_LEVEL_STANDARD = "standard"
+TASK_LEVEL_ADVANCED = "advanced"
+TASK_LEVELS = (TASK_LEVEL_RECOMMENDED, TASK_LEVEL_STANDARD, TASK_LEVEL_ADVANCED)
+
+
+@dataclass(frozen=True)
+class TaskInfo:
+    """What a picker needs to present a task type, and to gate choosing it.
+
+    One frozen structure rather than a ClassVar apiece, for the same reason
+    `field_meta` exists (FIB-384): a misspelled ClassVar on a subclass is not an
+    error. It shadows nothing, nobody is told, and the picker quietly renders
+    without whatever it was meant to carry. `TaskInfo(descripton=...)` is a
+    TypeError the moment the module imports.
+
+    None of this is serialised. It describes the *type*, not a configured task,
+    so it never reaches protocol.yaml and adding a field here needs no migration.
+
+    Kept out of it deliberately: `task_type` (which is serialised), and
+    `display_name` and `related_tasks`, which drive behaviour outside any picker.
+    This is the metadata a person needs in order to choose, not the metadata the
+    program needs in order to run.
+
+    A subclass that wants to vary one field of its parent's should say so:
+
+        info: ClassVar[TaskInfo] = replace(ParentConfig.info, tags=("Correlation",))
+    """
+
+    description: str = ""
+    """One or two sentences, present tense, about what running it does."""
+
+    tags: Tuple[str, ...] = ()
+    """What the task is *for*, not what it mechanically does.
+
+    A tuple because the purposes genuinely overlap: a spot burn is a correlation
+    fiducial and an alignment aid, and making it pick one hides it from whoever
+    went looking under the other. The first is the heading it files under; the
+    rest are still matched by search.
+    """
+
+    icon: str = "mdi:cog-outline"
+    """An `mdi:` key, resolved offline through `fibsem_icon`."""
+
+    thumbnail: Optional[str] = None
+    """Packaged schematic for the detail pane. Falls back to `icon` drawn large."""
+
+    requires_hardware: Tuple[str, ...] = ()
+    """Hardware the task cannot run without, e.g. ``("fm",)``.
+
+    Not `requires`: `AutoLamellaTaskDescription.requires` already owns that word
+    for the *tasks* that must run first. Two kinds of prerequisite under one
+    name, in one domain, is exactly the confusion this class exists to stop --
+    a reader would reasonably assume the two mean the same thing.
+
+    Declared but not yet read by anything. Whatever consumes it should also run
+    as a pre-flight when a workflow starts, not only where a task is chosen:
+    protocols move between machines, so one authored where an FM exists will
+    eventually be run where one does not.
+    """
+
+    order: int = 100
+    """Rank within the task's own heading. Lower comes first; ties sort by name.
+
+    Alphabetical is actively misleading here: it lists the on-grid sequence as
+    Polishing, Rough, Trench, Undercut, which is close to backwards. The default
+    puts anything that does not say sensibly at the end.
+    """
+
+    experimental: bool = False
+    """Present, but not settled: the behaviour or the parameters may still change.
+
+    Its own flag rather than a level, because it is a different question. Level
+    asks how often a task is the right answer; this asks whether it can be
+    relied on. A brand new task can be both recommended and experimental.
+    """
+
+    deprecated: str = ""
+    """Why this task is on its way out, and what to use instead. Empty if it is not.
+
+    A sentence rather than a flag, because "deprecated" on its own strands
+    anyone who has it in a protocol already. Non-empty keeps it out of the
+    picker -- there is no reason to add a new one -- while leaving existing
+    protocols loading exactly as before.
+    """
+
+    level: str = TASK_LEVEL_STANDARD
+    """How often this task is the right answer. One of TASK_LEVELS.
+
+    One ordinal field rather than a `beginner` flag beside an `advanced` one:
+    they are the same axis, and two booleans admit `beginner and advanced`,
+    which means nothing. Ordering and filtering both read this, so a task moves
+    between tiers by changing one word.
+
+    `recommended` the standard path -- what a first protocol is made of.
+    `standard`    ordinary, but situational; you reach for it when you need it.
+    `advanced`    a primitive or escape hatch. Hidden behind "Show advanced":
+                  `BASIC_MILLING` runs whatever stages it is handed, which is
+                what you want when nothing more specific fits and not what you
+                want to scroll past every other time.
+    """
+
+    def __post_init__(self) -> None:
+        # A typo here would otherwise sort silently to the end of every heading
+        # and never be hidden, which looks like a bug in the picker.
+        if self.level not in TASK_LEVELS:
+            raise ValueError(
+                f"TaskInfo.level must be one of {TASK_LEVELS}, got {self.level!r}"
+            )
+
+    @property
+    def summary(self) -> str:
+        """The lead sentence -- what a list or table cell shows.
+
+        Descriptions are written so the first sentence stands alone, which makes
+        this a deliberate summary rather than a truncation. The rest is detail
+        for a tooltip or a detail pane.
+        """
+        if not self.description:
+            return ""
+        return self.description.split(". ")[0].rstrip(".") + "."
+
+    @property
+    def is_deprecated(self) -> bool:
+        return bool(self.deprecated)
+
+    @property
+    def advanced(self) -> bool:
+        """Whether the picker hides this behind its "Show advanced" toggle."""
+        return self.level == TASK_LEVEL_ADVANCED
+
+    @property
+    def recommended(self) -> bool:
+        """Whether this is part of the standard path, not a situational choice."""
+        return self.level == TASK_LEVEL_RECOMMENDED
+
+
 @evented
 @dataclass
 class AutoLamellaTaskConfig(ABC):
@@ -147,6 +284,10 @@ class AutoLamellaTaskConfig(ABC):
     task_type: ClassVar[str]
     display_name: ClassVar[str]
     related_tasks: ClassVar[list[type["AutoLamellaTaskConfig"]]] = []
+    # Everything a picker needs to present this task type and gate the choice.
+    # See TaskInfo. Never serialised; defaulted, so a task that declares nothing
+    # still appears rather than vanishing from the list.
+    info: ClassVar[TaskInfo] = TaskInfo()
     task_name: str = ""  # unique name for identifying in multi-task workflows
     milling: Dict[str, FibsemMillingTaskConfig] = field(default_factory=dict)
     reference_imaging: ReferenceImageParameters = field(

--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -7,12 +7,17 @@ from datetime import datetime
 from typing import (
     ClassVar,
     Optional,
+    Tuple,
     Type,
 )
 
 import fibsem.utils as utils
 from fibsem import timing
-from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.structures import (
+    TASK_LEVEL_STANDARD,
+    AutoLamellaTaskConfig,
+    TaskInfo,
+)
 from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
 from fibsem.applications.autolamella.workflows.ui import (
     ask_user,
@@ -30,6 +35,17 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
 
     task_type: ClassVar[str] = "ACQUIRE_FLUORESCENCE_IMAGE"
     display_name: ClassVar[str] = "Acquire Fluorescence Image"
+    info: ClassVar[TaskInfo] = TaskInfo(
+        description=(
+            "Acquires a z-stack for every configured channel. Moves to the "
+            "fluorescence pose, optionally autofocuses, and retracts the "
+            "objective when it finishes unless you turn that off for "
+            "back-to-back acquisitions."
+        ),
+        tags=("Correlation", "Imaging", "Fluorescence"),
+        level=TASK_LEVEL_STANDARD,
+        order=20,
+    )
     channel_settings: list[ChannelSettings] = field(
         default_factory=list,
         metadata=field_meta(

--- a/fibsem/applications/autolamella/workflows/tasks/basic_milling.py
+++ b/fibsem/applications/autolamella/workflows/tasks/basic_milling.py
@@ -2,10 +2,14 @@
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import ClassVar, Type
+from typing import ClassVar, Tuple, Type
 
 from fibsem.applications.autolamella.protocol.constants import TRENCH_KEY
-from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.structures import (
+    TASK_LEVEL_ADVANCED,
+    AutoLamellaTaskConfig,
+    TaskInfo,
+)
 from fibsem.applications.autolamella.workflows._default_milling_config import (
     DEFAULT_MILLING_CONFIG,
 )
@@ -18,6 +22,16 @@ class BasicMillingTaskConfig(AutoLamellaTaskConfig):
 
     task_type: ClassVar[str] = "BASIC_MILLING"
     display_name: ClassVar[str] = "Basic Milling"
+    info: ClassVar[TaskInfo] = TaskInfo(
+        description=(
+            "Runs whatever milling stages it is given, with no alignment. The "
+            "escape hatch for a pattern none of the named milling tasks cover; "
+            "moves to the lamella and mills, with no feature detection."
+        ),
+        tags=("Custom",),
+        order=100,
+        level=TASK_LEVEL_ADVANCED,
+    )
 
     def __post_init__(self):
         if self.milling == {}:

--- a/fibsem/applications/autolamella/workflows/tasks/fiducial.py
+++ b/fibsem/applications/autolamella/workflows/tasks/fiducial.py
@@ -3,14 +3,18 @@
 import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import ClassVar, Optional, Type
+from typing import ClassVar, Optional, Tuple, Type
 
 from fibsem.applications.autolamella.protocol.constants import (
     FIDUCIAL_KEY,
     MILL_POLISHING_KEY,
     MILL_ROUGH_KEY,
 )
-from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.structures import (
+    TASK_LEVEL_RECOMMENDED,
+    AutoLamellaTaskConfig,
+    TaskInfo,
+)
 from fibsem.applications.autolamella.workflows._default_milling_config import (
     DEFAULT_MILLING_CONFIG,
 )
@@ -42,6 +46,16 @@ class MillFiducialTaskConfig(AutoLamellaTaskConfig):
     )
     task_type: ClassVar[str] = "MILL_FIDUCIAL"
     display_name: ClassVar[str] = "Mill Fiducial"
+    info: ClassVar[TaskInfo] = TaskInfo(
+        description=(
+            "Mills the marker that every later alignment tracks. Records the "
+            "area around it as the lamella's alignment region, so run it before "
+            "rough milling or those tasks have nothing to align to."
+        ),
+        tags=("On-grid milling", "Alignment"),
+        level=TASK_LEVEL_RECOMMENDED,
+        order=10,
+    )
 
     def __post_init__(self):
         if self.milling == {}:

--- a/fibsem/applications/autolamella/workflows/tasks/polishing.py
+++ b/fibsem/applications/autolamella/workflows/tasks/polishing.py
@@ -2,10 +2,14 @@
 
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import ClassVar, Type
+from typing import ClassVar, Tuple, Type
 
 from fibsem.applications.autolamella.protocol.constants import MILL_POLISHING_KEY
-from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.structures import (
+    TASK_LEVEL_RECOMMENDED,
+    AutoLamellaTaskConfig,
+    TaskInfo,
+)
 from fibsem.applications.autolamella.workflows._default_milling_config import (
     DEFAULT_MILLING_CONFIG,
 )
@@ -35,6 +39,17 @@ class MillPolishingTaskConfig(AutoLamellaTaskConfig):
         return True
 
     display_name: ClassVar[str] = "Polishing"
+
+    info: ClassVar[TaskInfo] = TaskInfo(
+        description=(
+            "Thins the lamella to electron transparency. The final pass, "
+            "aligned to the fiducial by beam shift before the polishing "
+            "patterns are milled."
+        ),
+        tags=("On-grid milling",),
+        level=TASK_LEVEL_RECOMMENDED,
+        order=40,
+    )
 
     def __post_init__(self):
         if self.milling == {}:

--- a/fibsem/applications/autolamella/workflows/tasks/reference_image.py
+++ b/fibsem/applications/autolamella/workflows/tasks/reference_image.py
@@ -1,10 +1,14 @@
 ######## REFERENCE IMAGE TASK DEFINITIONS ########
 
 from dataclasses import dataclass, field
-from typing import ClassVar, Literal, Optional, Type
+from typing import ClassVar, Literal, Optional, Tuple, Type
 
 from fibsem import utils
-from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.structures import (
+    TASK_LEVEL_RECOMMENDED,
+    AutoLamellaTaskConfig,
+    TaskInfo,
+)
 from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
 from fibsem.applications.autolamella.workflows.ui import ask_user
 from fibsem.structures import field_meta
@@ -16,6 +20,16 @@ class AcquireReferenceImageConfig(AutoLamellaTaskConfig):
 
     task_type: ClassVar[str] = "ACQUIRE_REFERENCE_IMAGE"
     display_name: ClassVar[str] = "Acquire Reference Image"
+    info: ClassVar[TaskInfo] = TaskInfo(
+        description=(
+            "Acquires reference images at the current position. Saved against "
+            "the lamella, to record state between milling steps and to give a "
+            "later alignment something to align to."
+        ),
+        tags=("Imaging", "Alignment"),
+        level=TASK_LEVEL_RECOMMENDED,
+        order=10,
+    )
     orientation: Literal["SEM", "FIB", "MILLING"] = field(
         default="MILLING",
         metadata=field_meta(

--- a/fibsem/applications/autolamella/workflows/tasks/rough.py
+++ b/fibsem/applications/autolamella/workflows/tasks/rough.py
@@ -3,14 +3,18 @@
 import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import ClassVar, Optional, Type
+from typing import ClassVar, Optional, Tuple, Type
 
 from fibsem.applications.autolamella.protocol.constants import (
     MILL_POLISHING_KEY,
     MILL_ROUGH_KEY,
     STRESS_RELIEF_KEY,
 )
-from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.structures import (
+    TASK_LEVEL_RECOMMENDED,
+    AutoLamellaTaskConfig,
+    TaskInfo,
+)
 from fibsem.applications.autolamella.workflows._default_milling_config import (
     DEFAULT_MILLING_CONFIG,
 )
@@ -55,6 +59,18 @@ class MillRoughTaskConfig(AutoLamellaTaskConfig):
         return True
 
     display_name: ClassVar[str] = "Rough Milling"
+
+    info: ClassVar[TaskInfo] = TaskInfo(
+        description=(
+            "Thins the lamella towards its target thickness. The coarse milling "
+            "steps: aligns to the fiducial by beam shift first, and can "
+            "re-acquire the alignment reference afterwards so later tasks start "
+            "from a fresh one."
+        ),
+        tags=("On-grid milling",),
+        level=TASK_LEVEL_RECOMMENDED,
+        order=30,
+    )
 
     def __post_init__(self):
         if self.milling == {}:

--- a/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
@@ -4,10 +4,15 @@ import logging
 from dataclasses import dataclass
 from typing import (
     ClassVar,
+    Tuple,
     Type,
 )
 
-from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.structures import (
+    TASK_LEVEL_STANDARD,
+    AutoLamellaTaskConfig,
+    TaskInfo,
+)
 from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
 from fibsem.applications.autolamella.workflows.ui import (
     ask_user,
@@ -20,6 +25,16 @@ class SelectFluorescencePositionConfig(AutoLamellaTaskConfig):
 
     task_type: ClassVar[str] = "SELECT_FLUORESCENCE_POSITION"
     display_name: ClassVar[str] = "Select Fluorescence Position"
+    info: ClassVar[TaskInfo] = TaskInfo(
+        description=(
+            "Moves to the fluorescence pose so you can confirm it. Inserts the "
+            "objective; needs a fluorescence microscope and a pose already "
+            "recorded against the lamella."
+        ),
+        tags=("Correlation", "Fluorescence", "Positioning"),
+        level=TASK_LEVEL_STANDARD,
+        order=10,
+    )
 
 
 class SelectFluorescencePositionTask(AutoLamellaTask):

--- a/fibsem/applications/autolamella/workflows/tasks/select_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_position.py
@@ -2,12 +2,16 @@
 
 import logging
 from dataclasses import dataclass, field
-from typing import ClassVar, Type
+from typing import ClassVar, Tuple, Type
 
 import numpy as np
 
 from fibsem import constants
-from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.structures import (
+    TASK_LEVEL_RECOMMENDED,
+    AutoLamellaTaskConfig,
+    TaskInfo,
+)
 from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
 from fibsem.applications.autolamella.workflows.ui import ask_user, select_poi_ui
 from fibsem.structures import BeamType, ImageSettings, field_meta
@@ -47,7 +51,17 @@ class SelectMillingPositionTaskConfig(AutoLamellaTaskConfig):
         ),
     )
     task_type: ClassVar[str] = "SELECT_MILLING_POSITION"
-    display_name: ClassVar[str] = "Select Milling Position"
+    display_name: ClassVar[str] = "Select Lamella Position"
+    info: ClassVar[TaskInfo] = TaskInfo(
+        description=(
+            "Asks you to confirm where the lamella will be milled. Moves to the "
+            "milling angle, optionally autofocusing both beams, and saves the "
+            "position you settle on."
+        ),
+        tags=("On-grid milling", "Alignment", "Positioning"),
+        level=TASK_LEVEL_RECOMMENDED,
+        order=5,
+    )
 
 
 class SelectMillingPositionTask(AutoLamellaTask):

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import ClassVar, Optional, Type
+from typing import ClassVar, Optional, Tuple, Type
 
 from fibsem import config as fcfg
 from fibsem import timing
-from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.structures import (
+    TASK_LEVEL_STANDARD,
+    AutoLamellaTaskConfig,
+    TaskInfo,
+)
 from fibsem.applications.autolamella.workflows.tasks.base import (
     ALIGNMENT_REFERENCE_IMAGE_FILENAME,
     AutoLamellaTask,
@@ -28,6 +32,16 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
 
     task_type: ClassVar[str] = "SPOT_BURN_FIDUCIAL"
     display_name: ClassVar[str] = "Spot Burn Fiducial"
+    info: ClassVar[TaskInfo] = TaskInfo(
+        description=(
+            "Burns small marks with the ion beam for correlating fluorescence "
+            "with the FIB view. Uses coordinates you choose, can autofocus "
+            "first, and runs unattended or hands off to the spot-burn editor."
+        ),
+        tags=("Correlation", "Alignment"),
+        level=TASK_LEVEL_STANDARD,
+        order=30,
+    )
     milling_current: float = field(
         default=60.0e-12,  # in Amperes
         metadata=field_meta(tooltip="Milling current in Amperes", unit="A", scale=1e12),

--- a/fibsem/applications/autolamella/workflows/tasks/trench.py
+++ b/fibsem/applications/autolamella/workflows/tasks/trench.py
@@ -3,12 +3,16 @@
 import os
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import ClassVar, Literal, Optional, Type
+from typing import ClassVar, Literal, Optional, Tuple, Type
 
 from fibsem import alignment, calibration
 from fibsem.alignment import AlignmentSubsystem
 from fibsem.applications.autolamella.protocol.constants import TRENCH_KEY
-from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.structures import (
+    TASK_LEVEL_RECOMMENDED,
+    AutoLamellaTaskConfig,
+    TaskInfo,
+)
 from fibsem.applications.autolamella.workflows._default_milling_config import (
     DEFAULT_MILLING_CONFIG,
 )
@@ -42,6 +46,16 @@ class MillTrenchTaskConfig(AutoLamellaTaskConfig):
     )
     task_type: ClassVar[str] = "MILL_TRENCH"
     display_name: ClassVar[str] = "Trench Milling"
+    info: ClassVar[TaskInfo] = TaskInfo(
+        description=(
+            "Mills the bulk away above and below the lamella, leaving it on a "
+            "pedestal. Moves to the trench angle first, optionally aligning to "
+            "a saved reference, and neutralises sample charge afterwards."
+        ),
+        tags=("Waffle milling",),
+        level=TASK_LEVEL_RECOMMENDED,
+        order=10,
+    )
 
     def __post_init__(self):
         if self.milling == {}:

--- a/fibsem/applications/autolamella/workflows/tasks/undercut.py
+++ b/fibsem/applications/autolamella/workflows/tasks/undercut.py
@@ -2,14 +2,18 @@
 
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import ClassVar, List, Literal, Optional, Type
+from typing import ClassVar, List, Literal, Optional, Tuple, Type
 
 import numpy as np
 
 from fibsem import config as fcfg
 from fibsem import constants
 from fibsem.applications.autolamella.protocol.constants import UNDERCUT_KEY
-from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.structures import (
+    TASK_LEVEL_RECOMMENDED,
+    AutoLamellaTaskConfig,
+    TaskInfo,
+)
 from fibsem.applications.autolamella.workflows._default_milling_config import (
     DEFAULT_MILLING_CONFIG,
 )
@@ -41,6 +45,16 @@ class MillUndercutTaskConfig(AutoLamellaTaskConfig):
     )
     task_type: ClassVar[str] = "MILL_UNDERCUT"
     display_name: ClassVar[str] = "Undercut Milling"
+    info: ClassVar[TaskInfo] = TaskInfo(
+        description=(
+            "Cuts beneath the lamella to free it from the bulk below. Tilts to "
+            "the undercut angle and aligns to the trench at each step, using "
+            "feature detection to keep the cut on target."
+        ),
+        tags=("Waffle milling",),
+        level=TASK_LEVEL_RECOMMENDED,
+        order=20,
+    )
 
     def __post_init__(self):
         if self.milling == {}:


### PR DESCRIPTION
**1 of 4 — stacked. Merge bottom-up; each PR targets the one below.**

A task type carried `task_type` and `display_name` and nothing else, so anything choosing between task types had a name and a registry key to go on. This adds `TaskInfo`, a frozen ClassVar holding what a *person* needs in order to choose.

```python
info: ClassVar[TaskInfo] = TaskInfo(
    description="Cuts beneath the lamella to free it from the bulk below. …",
    tags=("Waffle milling",),
    order=20,
    level=TASK_LEVEL_RECOMMENDED,
)
```

### Why one structure and not a ClassVar apiece

The reason `field_meta` exists (FIB-384): a misspelled ClassVar on a subclass is not an error. It shadows nothing, nobody is told, and whatever was meant to consume it quietly renders without it. `TaskInfo(descripton=...)` is a `TypeError` when the module imports.

### Nothing is serialised

`info` describes the *type*, not a configured task, so `protocol.yaml` is untouched and adding a field later needs no migration. Verified rather than assumed — serialising all 13 registered task types before and after gives byte-identical `to_dict()` output, dataclass fields and `parameters` tuples, and five protocols (including two real experiments) round-trip unchanged.

### What deliberately stayed put

`task_type` is serialised and has 46 call sites; `display_name` and `related_tasks` drive behaviour outside any picker. TaskInfo is the metadata a person needs to choose, not the metadata the program needs to run.

### Three naming decisions worth a look

- **`level`** is one ordinal field (`recommended` / `standard` / `advanced`) rather than a `beginner` flag beside an `advanced` one — two booleans admit a state that means nothing. A bad value raises rather than sorting silently to the end.
- **`deprecated`** is a sentence, not a flag. A bare marker strands whoever already has the task in a protocol.
- **`requires_hardware`**, not `requires` — `AutoLamellaTaskDescription.requires` already owns that word for the tasks that must run first. Two kinds of prerequisite under one name is the confusion this class exists to stop. Declared but unread; whatever consumes it should also run as a workflow pre-flight, since protocols move between machines.

### Also

Renames the `SELECT_MILLING_POSITION` label to "Select Lamella Position". The identifier is unchanged, so existing protocols keep loading — confirmed with a protocol whose task is *named* "Select Milling Position".

### Reviewing

12 files, but 11 are a single declaration each; `structures.py` is the one with logic in it. The tag vocabulary is the part most worth arguing with — headings are On-grid milling, Waffle milling, Correlation, Imaging, Custom, with Alignment / Positioning / Fluorescence cross-cutting.