### PR TITLE
[ui] Rebuild Add Task as a table of every task type

### DIFF
--- a/fibsem/applications/autolamella/ui/add_task_dialog.py
+++ b/fibsem/applications/autolamella/ui/add_task_dialog.py
@@ -1,0 +1,721 @@
+"""The Add Task dialog: a table of every task type, and one name to type.
+
+Replaces a two-field form whose central problem was that both fields said
+almost the same words -- the type combo read ``Trench Milling (MILL_TRENCH)``
+and the name box beneath it was prefilled ``Trench Milling``, with nothing to
+say that the first is a fixed class from the registry and the second is an
+arbitrary label that becomes the protocol's dictionary key.
+
+Choosing the type is now selecting a row, so nothing on screen can be mistaken
+for the name. Exactly one thing is typed, it sits alone in the footer, and it
+arrives already free -- the collision the old dialog was guaranteed to hit on
+the second copy of any task type never happens.
+
+A table rather than a list with a detail pane: with a description, a purpose and
+a source for every task there is enough to compare, and comparing is the whole
+job. A detail pane shows one row at a time and leaves most of the dialog empty.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QColor, QFont
+from PyQt5.QtWidgets import (
+    QAbstractItemView,
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.applications.autolamella.workflows.tasks.catalogue import (
+    has_advanced_tasks,
+    task_info,
+    task_source,
+    tasks_by_tag,
+    unique_task_name,
+)
+from fibsem.plugins.report import Extension, ExtensionSource
+from fibsem.ui.stylesheets import (
+    ACCENT_COLOR,
+    BORDER_COLOR,
+    ERROR_COLOR,
+    PANEL_COLOR,
+    PRIMARY_BUTTON_STYLESHEET,
+    ROW_ALT_COLOR,
+    SECONDARY_BUTTON_STYLESHEET,
+    SURFACE_COLOR,
+    TEXT_COLOR,
+    TEXT_MUTED_COLOR,
+    TEXT_STRONG_COLOR,
+    WARN_COLOR,
+)
+from fibsem.ui.widgets.custom_widgets import chip, style_with_tooltip
+
+# "Also used for", not "Tags": the heading a row sits under already states its
+# primary purpose, so this column carries only the others. Naming it for what
+# it holds means an empty cell reads as "no second use" rather than as missing
+# data -- which is what most rows are, and is worth knowing.
+_COLUMNS = ("Task", "What it does", "Also used for")
+_COL_TASK, _COL_WHAT, _COL_TAGS = range(3)
+
+# Small. At the sizes a chip is drawn elsewhere it is the loudest thing in the
+# row, and there are two or three of them per row here.
+_CHIP_SIZE = 9
+
+_ALL_PURPOSES = "All purposes"
+
+# Same vocabulary and colours the Plugins dialog uses. Only the sources that can
+# reach a picker are listed: a failed or shadowed extension registered nothing,
+# so it never appears in the registry this dialog reads.
+_SOURCE_LABEL = {
+    ExtensionSource.PLUGIN: "Plugin",
+    ExtensionSource.SCRIPT: "Script",
+    ExtensionSource.REGISTERED: "Registered",
+    ExtensionSource.BUILTIN: "Built-in",
+}
+
+# Description cell: margins here, and the font set programmatically below. A
+# stylesheet font-size never reaches QWidget.font(), so metrics taken from a
+# stylesheet-styled label measure the wrong face.
+_DESC_MARGINS = (12, 9, 14, 9)
+
+_TABLE_STYLE = f"""
+QTableWidget {{
+    background-color: {SURFACE_COLOR};
+    alternate-background-color: {ROW_ALT_COLOR};
+    border: 1px solid {BORDER_COLOR};
+    border-radius: 6px;
+    color: {TEXT_COLOR};
+    gridline-color: transparent;
+    outline: none;
+}}
+QHeaderView::section {{
+    background-color: {PANEL_COLOR};
+    color: {TEXT_MUTED_COLOR};
+    border: none;
+    padding: 6px 10px;
+    font-size: 11px;
+}}
+QTableWidget::item {{ padding: 8px 10px; border-bottom: 1px solid #31353f; }}
+QTableWidget::item:selected {{
+    background-color: #2d3947;
+    color: {TEXT_STRONG_COLOR};
+}}
+"""
+
+_FIELD_STYLE = f"""
+QLineEdit, QComboBox {{
+    background-color: #16181d;
+    border: 1px solid {BORDER_COLOR};
+    border-radius: 3px;
+    padding: 5px 8px;
+    color: {TEXT_STRONG_COLOR};
+}}
+QLineEdit:focus {{ border: 1px solid {ACCENT_COLOR}; }}
+QComboBox::drop-down {{ border: none; width: 18px; }}
+"""
+
+
+def _description_font() -> QFont:
+    font = QFont()
+    font.setPixelSize(12)
+    return font
+
+
+def _transparent(widget: QWidget) -> QWidget:
+    style_with_tooltip(widget, "background: transparent;")
+    return widget
+
+
+class AddTaskDialog(QDialog):
+    """Pick a task type from the registry and name the copy being added."""
+
+    def __init__(
+        self,
+        existing_task_config: Dict[str, Any],
+        lamella_count: int = 0,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.existing_task_config = existing_task_config
+        self.lamella_count = lamella_count
+        self.task_types: Dict[str, Any] = {}
+        self._rows: Dict[int, str] = {}  # table row -> task_type
+        self._sizing = False  # re-entrancy guard for _size_rows
+        self._named_for: Optional[str] = None  # the selection the name belongs to
+
+        self.setWindowTitle("Add task")
+        self.setModal(True)
+        self.setStyleSheet(f"QDialog {{ background-color: {SURFACE_COLOR}; }}")
+        self.setMinimumSize(820, 460)
+        self.resize(980, 580)
+
+        self._build()
+        self._populate()
+
+    # --- construction ---
+
+    def _build(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(16, 14, 16, 14)
+        outer.setSpacing(10)
+
+        title = QLabel("Add a task to this protocol")
+        style_with_tooltip(
+            title, f"font-size: 15px; font-weight: 600; color: {TEXT_STRONG_COLOR};"
+        )
+        outer.addWidget(title)
+        outer.addLayout(self._build_toolbar())
+        outer.addWidget(self._build_table(), 1)
+        outer.addWidget(self._build_footer())
+
+    def _build_toolbar(self) -> QHBoxLayout:
+        bar = QHBoxLayout()
+        bar.setSpacing(9)
+
+        self.search_field = QLineEdit()
+        self.search_field.setPlaceholderText("Search tasks")
+        self.search_field.setStyleSheet(_FIELD_STYLE)
+        self.search_field.setClearButtonEnabled(True)
+        self.search_field.setFixedWidth(240)
+        self.search_field.textChanged.connect(self._refresh_visibility)
+        bar.addWidget(self.search_field)
+
+        self.tag_filter = QComboBox()
+        self.tag_filter.setStyleSheet(_FIELD_STYLE)
+        self.tag_filter.setFixedWidth(180)
+        self.tag_filter.setToolTip(
+            "Show only tasks used for one purpose. Matches every tag a task "
+            "declares, not only the heading it sits under."
+        )
+        self.tag_filter.currentIndexChanged.connect(self._refresh_visibility)
+        bar.addWidget(self.tag_filter)
+
+        bar.addStretch(1)
+
+        self.advanced_checkbox = QCheckBox("Show advanced")
+        style_with_tooltip(
+            self.advanced_checkbox, f"font-size: 12px; color: {TEXT_MUTED_COLOR};"
+        )
+        self.advanced_checkbox.setToolTip(
+            "Primitives and escape hatches: tasks that run whatever they are "
+            "handed, rather than performing one step of a protocol."
+        )
+        self.advanced_checkbox.setVisible(has_advanced_tasks())
+        self.advanced_checkbox.toggled.connect(self._on_advanced_toggled)
+        bar.addWidget(self.advanced_checkbox)
+        return bar
+
+    def _build_table(self) -> QTableWidget:
+        table = QTableWidget()
+        table.setStyleSheet(_TABLE_STYLE)
+        table.setColumnCount(len(_COLUMNS))
+        table.setHorizontalHeaderLabels(list(_COLUMNS))
+        table.verticalHeader().setVisible(False)
+        table.setShowGrid(False)
+        table.setAlternatingRowColors(False)  # group headings do the banding
+        table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        table.setSelectionMode(QAbstractItemView.SingleSelection)
+        table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        table.setWordWrap(True)
+        table.itemSelectionChanged.connect(self._validate)
+
+        header = table.horizontalHeader()
+        header.setDefaultAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        header.setSectionResizeMode(_COL_TASK, QHeaderView.Fixed)
+        header.setSectionResizeMode(_COL_WHAT, QHeaderView.Stretch)
+        header.setSectionResizeMode(_COL_TAGS, QHeaderView.Fixed)
+        table.setColumnWidth(_COL_TASK, 218)
+        table.setColumnWidth(_COL_TAGS, 152)
+        self.table = table
+        return table
+
+    def _build_footer(self) -> QWidget:
+        """Form content, a rule, then an action bar.
+
+        The convention this restores: the bottom strip holds actions and nothing
+        else. Sharing that row with a text input makes the input read as part of
+        the button group, and it puts the primary action next to something you
+        are still typing in. Validation belongs with the field it is about, not
+        underneath the buttons where it is both easy to miss and easy to mistake
+        for a caption on them.
+        """
+        footer = QWidget()
+        layout = QVBoxLayout(footer)
+        layout.setContentsMargins(0, 4, 0, 0)
+        layout.setSpacing(6)
+
+        label = QLabel("Name this task")
+        style_with_tooltip(
+            label, f"font-size: 12px; font-weight: 600; color: {TEXT_STRONG_COLOR};"
+        )
+        layout.addWidget(label)
+
+        self.name_field = QLineEdit()
+        self.name_field.setStyleSheet(_FIELD_STYLE)
+        # The sentence the old dialog was missing: "Task Name:" never said the
+        # name is the protocol's key, which is why it read as a duplicate of the
+        # type rather than as a decision.
+        self.name_field.setToolTip(
+            "The label this task is known by in the workflow, and its key in "
+            "protocol.yaml. Must be unique within the protocol."
+        )
+        self.name_field.textChanged.connect(self._validate)
+        self.name_field.returnPressed.connect(self._on_return_pressed)
+        layout.addWidget(self.name_field)
+
+        self.error_label = QLabel()
+        style_with_tooltip(self.error_label, f"font-size: 11px; color: {ERROR_COLOR};")
+        self.error_label.setWordWrap(True)
+        self.error_label.setVisible(False)
+        layout.addWidget(self.error_label)
+
+        rule = QFrame()
+        rule.setFrameShape(QFrame.HLine)
+        rule.setStyleSheet(f"color: {BORDER_COLOR};")
+        layout.addWidget(rule)
+
+        actions = QHBoxLayout()
+        actions.setSpacing(9)
+        # What Add will do, beside the button that will do it.
+        self.status_label = QLabel()
+        style_with_tooltip(
+            self.status_label, f"font-size: 11px; color: {TEXT_MUTED_COLOR};"
+        )
+        self.status_label.setWordWrap(True)
+        actions.addWidget(self.status_label, 1)
+
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
+        self.cancel_button.clicked.connect(self.reject)
+        self.add_button = QPushButton("Add task")
+        self.add_button.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
+        self.add_button.setDefault(True)
+        self.add_button.clicked.connect(self.accept)
+        actions.addWidget(self.cancel_button)
+        actions.addWidget(self.add_button)
+        layout.addLayout(actions)
+        return footer
+
+    # --- cells ---
+
+    def _existing_count(self, task_type: str) -> int:
+        """How many tasks of this type the protocol already holds.
+
+        Duplicates are legitimate -- a protocol can want three reference-image
+        tasks -- so this is context, not a warning. It is also what explains the
+        name field: without it, a default of "Trench Milling 2" appears out of
+        nowhere.
+        """
+        return sum(
+            1
+            for config in self.existing_task_config.values()
+            if getattr(config, "task_type", None) == task_type
+        )
+
+    def _task_cell(self, task_type: str, display_name: str, info) -> QWidget:
+        widget = _transparent(QWidget())
+        layout = QVBoxLayout(widget)
+        layout.setContentsMargins(12, 9, 10, 9)
+        layout.setSpacing(3)
+
+        name = QLabel(display_name)
+        style_with_tooltip(
+            name,
+            f"font-size: 13px; font-weight: 600; color: {TEXT_STRONG_COLOR};"
+            " background: transparent;",
+        )
+        name.setWordWrap(True)
+        layout.addWidget(name)
+
+        count = self._existing_count(task_type)
+        if count:
+            already = QLabel(f"{count} in this protocol")
+            style_with_tooltip(
+                already,
+                f"font-size: 11px; color: {TEXT_MUTED_COLOR}; background: transparent;",
+            )
+            layout.addWidget(already)
+
+        # No identifier line. In capitals it was the loudest thing in the row
+        # and it is not what anyone is reading for -- it lives in the tooltip,
+        # where someone holding a traceback can still find it.
+        if info.experimental:
+            marks = QHBoxLayout()
+            marks.setSpacing(4)
+            marks.addWidget(chip("Experimental", WARN_COLOR, font_size=_CHIP_SIZE))
+            marks.addStretch(1)
+            layout.addLayout(marks)
+        return widget
+
+    def _description_cell(self, text: str) -> QWidget:
+        widget = _transparent(QWidget())
+        layout = QVBoxLayout(widget)
+        layout.setContentsMargins(*_DESC_MARGINS)
+        label = QLabel(text)
+        label.setWordWrap(True)
+        label.setFont(_description_font())
+        label.setAlignment(Qt.AlignLeft | Qt.AlignTop)
+        style_with_tooltip(label, f"color: {TEXT_COLOR}; background: transparent;")
+        layout.addWidget(label)
+        widget.setProperty("_label", label)
+        return widget
+
+    def _chips_cell(self, tags: Tuple[str, ...]) -> QWidget:
+        widget = _transparent(QWidget())
+        layout = QHBoxLayout(widget)
+        layout.setContentsMargins(10, 9, 10, 9)
+        layout.setSpacing(4)
+        layout.setAlignment(Qt.AlignTop)
+        for tag in tags:
+            layout.addWidget(chip(tag, TEXT_MUTED_COLOR, font_size=_CHIP_SIZE))
+        layout.addStretch(1)
+        return widget
+
+    def _tooltip(self, task_type: str, task_cls, info) -> str:
+        """Everything the table does not have room for, on hover."""
+        source = task_source(task_type)
+        lines = [
+            f"<b>{task_cls.config_cls.display_name}</b>",
+            f"<code style='color:{TEXT_MUTED_COLOR}'>{task_type}</code>",
+        ]
+        if info.description:
+            lines.append(f"<p>{info.description}</p>")
+        rows = []
+        if info.tags:
+            rows.append(("Used for", ", ".join(info.tags)))
+        related = [
+            c.display_name for c in getattr(task_cls.config_cls, "related_tasks", [])
+        ]
+        if related:
+            rows.append(("Used with", ", ".join(related)))
+        if source is not None:
+            label = _SOURCE_LABEL.get(source.source, "Built-in")
+            rows.append(
+                ("Source", f"{label} · {source.origin}" if source.origin else label)
+            )
+        rows.append(("Level", info.level))
+        if info.experimental:
+            rows.append(
+                ("Note", "Experimental — behaviour and parameters may still change.")
+            )
+        lines.append(
+            "<table cellspacing='0' cellpadding='0'>"
+            + "".join(
+                f"<tr><td style='color:{TEXT_MUTED_COLOR}'>{k}&nbsp;&nbsp;</td>"
+                f"<td>{v}</td></tr>"
+                for k, v in rows
+            )
+            + "</table>"
+        )
+        return "".join(lines)
+
+    # --- population ---
+
+    def _populate(self, keep: Optional[str] = None) -> None:
+        include_advanced = self.advanced_checkbox.isChecked()
+        grouped = tasks_by_tag(include_advanced)
+        self.task_types = {
+            task_type: cls
+            for tasks in grouped.values()
+            for task_type, cls in tasks.items()
+        }
+        self._rows = {}
+
+        self.table.blockSignals(True)
+        self.table.clearContents()
+        self.table.setRowCount(0)
+        row = 0
+        for tag, tasks in grouped.items():
+            self.table.insertRow(row)
+            heading = QTableWidgetItem(tag.upper())
+            font = heading.font()
+            font.setBold(True)
+            font.setPointSize(max(8, font.pointSize() - 2))
+            heading.setFont(font)
+            heading.setForeground(QColor(TEXT_MUTED_COLOR))
+            heading.setFlags(Qt.NoItemFlags)
+            self.table.setItem(row, 0, heading)
+            self.table.setSpan(row, 0, 1, len(_COLUMNS))
+            self.table.setRowHeight(row, 30)
+            row += 1
+
+            for task_type, task_cls in tasks.items():
+                info = task_info(task_cls)
+                self.table.insertRow(row)
+                self.table.setCellWidget(
+                    row,
+                    _COL_TASK,
+                    self._task_cell(task_type, task_cls.config_cls.display_name, info),
+                )
+                self.table.setCellWidget(
+                    row, _COL_WHAT, self._description_cell(info.summary)
+                )
+                self.table.setCellWidget(
+                    row, _COL_TAGS, self._chips_cell(info.tags[1:])
+                )
+                tooltip = self._tooltip(task_type, task_cls, info)
+                for column in range(len(_COLUMNS)):
+                    item = QTableWidgetItem()  # empty items keep row selection working
+                    item.setToolTip(tooltip)
+                    self.table.setItem(row, column, item)
+                    widget = self.table.cellWidget(row, column)
+                    if widget is not None:
+                        widget.setToolTip(tooltip)
+                self._rows[row] = task_type
+                row += 1
+
+        self._rebuild_tag_filter(grouped)
+        self.table.blockSignals(False)
+        self._refresh_visibility()
+        if keep is not None and keep in self.task_types:
+            self.select(keep)
+        elif self.selected_task_type is None:
+            self._select_first_visible()
+
+    def _rebuild_tag_filter(self, grouped) -> None:
+        """Every tag any offered task declares, not only the headings."""
+        tags: List[str] = []
+        for tasks in grouped.values():
+            for task_cls in tasks.values():
+                for tag in task_info(task_cls).tags:
+                    if tag not in tags:
+                        tags.append(tag)
+        previous = self.tag_filter.currentText()
+        self.tag_filter.blockSignals(True)
+        self.tag_filter.clear()
+        self.tag_filter.addItem(_ALL_PURPOSES)
+        self.tag_filter.addItems(sorted(tags))
+        index = self.tag_filter.findText(previous)
+        self.tag_filter.setCurrentIndex(max(0, index))
+        self.tag_filter.blockSignals(False)
+
+    # --- filtering ---
+
+    def _refresh_visibility(self) -> None:
+        query = self.search_field.text().strip().lower()
+        wanted_tag = self.tag_filter.currentText()
+        if wanted_tag == _ALL_PURPOSES:
+            wanted_tag = ""
+
+        visible_rows = set()
+        for row, task_type in self._rows.items():
+            info = task_info(self.task_types[task_type])
+            display_name = self.task_types[task_type].config_cls.display_name
+            # Match the identifier and every tag as well as the visible text:
+            # someone reading a protocol.yaml or a traceback has the TASK_TYPE.
+            haystack = " ".join(
+                [display_name, task_type, info.summary, *info.tags]
+            ).lower()
+            hidden = bool(query) and query not in haystack
+            if wanted_tag and wanted_tag not in info.tags:
+                hidden = True
+            self.table.setRowHidden(row, hidden)
+            if not hidden:
+                visible_rows.add(row)
+
+        # A heading with nothing under it is noise, and a run of them reads as
+        # if the filter is broken.
+        for row in range(self.table.rowCount()):
+            if row in self._rows:
+                continue
+            following = [r for r in self._rows if r > row]
+            next_heading = min(
+                (
+                    r
+                    for r in range(row + 1, self.table.rowCount())
+                    if r not in self._rows
+                ),
+                default=self.table.rowCount(),
+            )
+            members = [r for r in following if r < next_heading]
+            self.table.setRowHidden(row, not any(r in visible_rows for r in members))
+
+        current = self.table.currentRow()
+        if current < 0 or current not in visible_rows:
+            self._select_first_visible()
+        self._size_rows()
+        self._validate()
+
+    def _select_first_visible(self) -> None:
+        for row in sorted(self._rows):
+            if not self.table.isRowHidden(row):
+                self.table.selectRow(row)
+                return
+        self.table.clearSelection()
+        self.table.setCurrentCell(-1, -1)
+
+    # --- row sizing ---
+
+    def _size_rows(self) -> None:
+        """Row heights from the labels themselves, at the width they actually got.
+
+        Every arithmetic approach here is wrong by a line. `resizeRowsToContents`
+        measures the item rather than the cell widget, so a row of widgets over
+        empty items collapses; and deriving the wrap width from the column means
+        guessing at the layout margins and the QSS item padding together.
+
+        Two things make this correct. The label is asked for its own height at
+        its own width -- trustworthy only because the description font is set
+        programmatically, not through a stylesheet. And the difference between
+        the row and the widget it holds is *measured*, because
+        `QTableWidget::item` carries `padding: 8px 10px`, which is 16px of every
+        row that never reaches the cell. Assuming that number instead of
+        measuring it silently clips the last line off every description.
+        """
+        if self._sizing:
+            return
+        self._sizing = True
+        try:
+            for row, _ in self._rows.items():
+                if self.table.isRowHidden(row):
+                    continue
+                cell = self.table.cellWidget(row, _COL_WHAT)
+                label = cell.property("_label")
+                _, top, _, bottom = _DESC_MARGINS
+                chrome = max(0, self.table.rowHeight(row) - cell.height())
+                needed = label.heightForWidth(label.width()) + top + bottom + chrome
+                others = [
+                    self.table.cellWidget(row, c).sizeHint().height() + chrome
+                    for c in range(len(_COLUMNS))
+                    if c != _COL_WHAT and self.table.cellWidget(row, c) is not None
+                ]
+                self.table.setRowHeight(row, max([needed] + others))
+        finally:
+            self._sizing = False
+
+    def showEvent(self, event) -> None:
+        super().showEvent(event)
+        # Widths only settle once the table has been laid out, and the wrapped
+        # height depends on them, so the first pass measures and the second uses
+        # what it measured.
+        for _ in range(2):
+            self._size_rows()
+
+    def resizeEvent(self, event) -> None:
+        super().resizeEvent(event)
+        # The description column stretches, so a resize re-wraps every row.
+        self._size_rows()
+
+    # --- selection ---
+
+    @property
+    def selected_task_type(self) -> Optional[str]:
+        row = self.table.currentRow()
+        if row < 0 or row not in self._rows or self.table.isRowHidden(row):
+            return None
+        return self._rows[row]
+
+    @property
+    def task_name(self) -> str:
+        return self.name_field.text().strip()
+
+    def select(self, task_type: str) -> None:
+        """Select the row for ``task_type``, if it is on offer and visible."""
+        for row, candidate in self._rows.items():
+            if candidate == task_type and not self.table.isRowHidden(row):
+                self.table.selectRow(row)
+                return
+
+    def _on_advanced_toggled(self, _checked: bool) -> None:
+        self._populate(keep=self.selected_task_type)
+
+    # --- validation ---
+
+    def _on_return_pressed(self) -> None:
+        if self.add_button.isEnabled():
+            self.accept()
+
+    def _suggested_name(self) -> str:
+        task_type = self.selected_task_type
+        if task_type is None:
+            return ""
+        display_name = self.task_types[task_type].config_cls.display_name
+        return unique_task_name(display_name, self.existing_task_config)
+
+    def _validate(self) -> bool:
+        """Enable Add only when there is something valid to add, and say why not.
+
+        The old dialog left OK enabled and returned silently from its accept
+        handler, so a duplicate name produced a button that looked live, did
+        nothing when clicked, and never said what to do instead.
+        """
+        task_type = self.selected_task_type
+        if task_type != self._named_for:
+            # The selection moved, so whatever is in the box belonged to the
+            # previous one. Replace it with a name that is already free.
+            self._named_for = task_type
+            self.name_field.blockSignals(True)
+            self.name_field.setText(self._suggested_name())
+            self.name_field.blockSignals(False)
+
+        name = self.task_name
+        # The destination stays put whether or not the name is valid: it
+        # describes the button, not the input, and watching it vanish while you
+        # fix a typo is how a static line becomes wallpaper.
+        self.status_label.setText(
+            self._destination_summary() if task_type is not None else ""
+        )
+
+        if task_type is None:
+            return self._reject("")
+        if not name:
+            return self._reject("")
+        if name in self.existing_task_config:
+            suggestion = unique_task_name(name, self.existing_task_config)
+            return self._reject(
+                f"“{name}” is already in this protocol. Try “{suggestion}”."
+            )
+
+        self._set_error("")
+        self.add_button.setEnabled(True)
+        return True
+
+    def _reject(self, message: str) -> bool:
+        self._set_error(message)
+        self.add_button.setEnabled(False)
+        return False
+
+    def _destination_summary(self) -> str:
+        """Where adding this actually writes.
+
+        Three places, only one of which a user would guess: the protocol's task
+        config, the workflow order, and a copy on every lamella that already
+        exists. Saying so is the difference between an edit and a surprise.
+        """
+        base = "Adds to the protocol and the end of the workflow"
+        if self.lamella_count == 1:
+            return f"{base}, and to the 1 existing lamella."
+        if self.lamella_count > 1:
+            return f"{base}, and to all {self.lamella_count} existing lamellae."
+        return f"{base}."
+
+    def _set_error(self, text: str) -> None:
+        """Show a problem on the field itself, or clear it."""
+        self.error_label.setText(text)
+        self.error_label.setVisible(bool(text))
+        border = ERROR_COLOR if text else BORDER_COLOR
+        self.name_field.setStyleSheet(
+            _FIELD_STYLE + f"QLineEdit {{ border: 1px solid {border}; }}"
+        )
+
+    # --- result ---
+
+    def accept(self) -> None:
+        if not self._validate():
+            return
+        super().accept()
+
+    def get_task_info(self) -> Tuple[Optional[str], str]:
+        """The selected task type and the name to give it."""
+        return self.selected_task_type, self.task_name

--- a/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
@@ -19,6 +19,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from fibsem.applications.autolamella.ui.add_task_dialog import AddTaskDialog
 from fibsem.applications.autolamella.ui.autolamella_fluorescence_acquisition_task_config_widget import (
     AutoLamellaFluorescenceAcquisitionTaskConfigWidget,
 )
@@ -80,8 +81,8 @@ if TYPE_CHECKING:
     from fibsem.structures import ReferenceImageParameters
 
 
-class AddTaskDialog(QDialog):
-    """Dialog for adding a new task to the protocol."""
+class _LegacyAddTaskDialog(QDialog):
+    """Superseded by add_task_dialog.AddTaskDialog; removed in the next commit."""
 
     def __init__(
         self, existing_task_config: Dict[str, Any], parent: Optional[QWidget] = None
@@ -639,7 +640,11 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
     def _on_add_task_clicked(self):
         """Show dialog to add a new task."""
-        dialog = AddTaskDialog(self.experiment.task_protocol.task_config, parent=self)  # type: ignore
+        dialog = AddTaskDialog(
+            self.experiment.task_protocol.task_config,  # type: ignore[arg-type]
+            lamella_count=len(self.experiment.positions),
+            parent=self,
+        )
         if dialog.exec_() == QDialog.Accepted:
             task_type, task_name = dialog.get_task_info()
             if task_type and task_name:

--- a/tests/ui/test_add_task_dialog.py
+++ b/tests/ui/test_add_task_dialog.py
@@ -1,0 +1,386 @@
+"""Headless tests for the Add Task table.
+
+CI installs fibsem without the [ui] extra, so this file does not run there --
+the Qt-free half is covered by tests/autolamella/test_task_catalogue.py. What is
+left here is the wiring only reachable through the widget.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_add_task_dialog.py
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.applications.autolamella.ui.add_task_dialog import AddTaskDialog
+from fibsem.applications.autolamella.workflows.tasks.catalogue import (
+    available_task_types,
+    task_info,
+    task_source,
+)
+
+
+@pytest.fixture(scope="module")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def dialog(app):
+    """A dialog over a protocol that already holds three tasks.
+
+    `show()` matters twice over: isVisible() is False for every child of a top
+    level that was never shown, and the row heights are only measured once the
+    table has real column widths.
+    """
+    existing = {"Trench Milling": 1, "Rough Milling": 1, "Rough Milling 2": 1}
+    d = AddTaskDialog(existing, lamella_count=4)
+    d.show()
+    app.processEvents()
+    yield d
+    d.close()
+    d.deleteLater()
+
+
+def _visible_tasks(dialog):
+    return [
+        t
+        for row, t in sorted(dialog._rows.items())
+        if not dialog.table.isRowHidden(row)
+    ]
+
+
+def _visible_headings(dialog):
+    return [
+        dialog.table.item(row, 0).text()
+        for row in range(dialog.table.rowCount())
+        if row not in dialog._rows and not dialog.table.isRowHidden(row)
+    ]
+
+
+class TestTable:
+    def test_lists_every_offered_task_once(self, dialog):
+        dialog.advanced_checkbox.setChecked(True)
+        tasks = _visible_tasks(dialog)
+        assert sorted(tasks) == sorted(available_task_types())
+        assert len(tasks) == len(set(tasks))
+
+    def test_mill_fiducial_appears_exactly_once(self, dialog):
+        """The SETUP_LAMELLA alias used to put this row in the table twice."""
+        assert _visible_tasks(dialog).count("MILL_FIDUCIAL") == 1
+
+    def test_groups_under_purpose_headings(self, dialog):
+        assert "ON-GRID MILLING" in _visible_headings(dialog)
+
+    def test_each_sequence_is_listed_in_working_order(self, dialog):
+        tasks = _visible_tasks(dialog)
+        for sequence in (
+            [
+                "SELECT_MILLING_POSITION",
+                "MILL_FIDUCIAL",
+                "MILL_ROUGH",
+                "MILL_POLISHING",
+            ],
+            ["MILL_TRENCH", "MILL_UNDERCUT"],
+        ):
+            assert [t for t in tasks if t in sequence] == sequence
+
+    def test_opens_on_a_task_not_a_heading(self, dialog):
+        assert dialog.selected_task_type is not None
+
+    def test_no_description_is_clipped(self, dialog):
+        """Row heights are measured, not computed; this is what that protects.
+
+        Every arithmetic version of the sizing was short by a line, and a
+        clipped description gives no sign that anything is missing.
+        """
+        for row in dialog._rows:
+            if dialog.table.isRowHidden(row):
+                continue
+            label = dialog.table.cellWidget(row, 1).property("_label")
+            assert label.height() >= label.heightForWidth(label.width())
+
+    def test_rows_resize_when_the_dialog_narrows(self, dialog, app):
+        """The description column stretches, so a resize re-wraps every row."""
+        dialog.resize(1200, 620)
+        app.processEvents()
+        wide = [dialog.table.rowHeight(r) for r in sorted(dialog._rows)]
+        dialog.resize(840, 620)
+        app.processEvents()
+        narrow = [dialog.table.rowHeight(r) for r in sorted(dialog._rows)]
+        assert sum(narrow) > sum(wide), "narrowing must make some row taller"
+
+
+class TestFiltering:
+    def test_search_matches_display_name(self, dialog):
+        dialog.search_field.setText("undercut")
+        assert _visible_tasks(dialog) == ["MILL_UNDERCUT"]
+
+    def test_search_matches_what_a_task_does(self, dialog):
+        """Spot Burn does not say "fluorescence" in its name, only in its summary.
+
+        Matching the description is the point: someone searching for the job
+        rather than the label should still find it.
+        """
+        dialog.search_field.setText("fluor")
+        found = _visible_tasks(dialog)
+        assert "SPOT_BURN_FIDUCIAL" in found
+        assert "ACQUIRE_FLUORESCENCE_IMAGE" in found
+        assert "MILL_TRENCH" not in found
+
+    def test_search_matches_the_identifier(self, dialog):
+        """Someone holding a traceback has MILL_TRENCH, not 'Trench Milling'."""
+        dialog.search_field.setText("MILL_TRENCH")
+        assert _visible_tasks(dialog) == ["MILL_TRENCH"]
+
+    def test_tag_filter_lists_every_declared_tag(self, dialog):
+        items = [
+            dialog.tag_filter.itemText(i) for i in range(dialog.tag_filter.count())
+        ]
+        assert items[0] == "All purposes"
+        assert {
+            "On-grid milling",
+            "Waffle milling",
+            "Correlation",
+            "Imaging",
+            "Alignment",
+            "Fluorescence",
+        } <= set(items)
+
+    def test_tag_filter_matches_secondary_tags_too(self, dialog):
+        """Spot Burn files under Correlation but is also an Alignment aid."""
+        dialog.tag_filter.setCurrentText("Alignment")
+        assert "SPOT_BURN_FIDUCIAL" in _visible_tasks(dialog)
+        assert "MILL_TRENCH" not in _visible_tasks(dialog)
+
+    def test_a_filtered_task_keeps_its_own_heading(self, dialog):
+        """It files under its primary even when matched on a secondary."""
+        dialog.tag_filter.setCurrentText("Alignment")
+        assert "CORRELATION" in _visible_headings(dialog)
+
+    def test_headings_with_nothing_under_them_are_hidden(self, dialog):
+        dialog.tag_filter.setCurrentText("Fluorescence")
+        assert "ON-GRID MILLING" not in _visible_headings(dialog)
+
+    def test_clearing_the_filter_restores_everything(self, dialog):
+        before = _visible_tasks(dialog)
+        dialog.tag_filter.setCurrentText("Alignment")
+        dialog.tag_filter.setCurrentText("All purposes")
+        assert _visible_tasks(dialog) == before
+
+    def test_search_and_tag_filter_compose(self, dialog):
+        dialog.tag_filter.setCurrentText("Correlation")
+        dialog.search_field.setText("spot")
+        assert _visible_tasks(dialog) == ["SPOT_BURN_FIDUCIAL"]
+
+
+class TestAdvanced:
+    def test_hidden_until_asked_for(self, dialog):
+        assert "BASIC_MILLING" not in _visible_tasks(dialog)
+        dialog.advanced_checkbox.setChecked(True)
+        assert "BASIC_MILLING" in _visible_tasks(dialog)
+
+    def test_sorts_last_under_its_heading(self, dialog):
+        dialog.advanced_checkbox.setChecked(True)
+        tasks = _visible_tasks(dialog)
+        assert tasks.index("BASIC_MILLING") > tasks.index("MILL_POLISHING")
+
+    def test_toggling_keeps_the_selection(self, dialog):
+        dialog.select("MILL_ROUGH")
+        dialog.advanced_checkbox.setChecked(True)
+        assert dialog.selected_task_type == "MILL_ROUGH"
+
+    def test_toggling_off_recovers_a_lost_selection(self, dialog):
+        dialog.advanced_checkbox.setChecked(True)
+        dialog.select("BASIC_MILLING")
+        dialog.advanced_checkbox.setChecked(False)
+        assert dialog.selected_task_type not in (None, "BASIC_MILLING")
+
+    def test_toggle_hides_itself_when_it_would_do_nothing(self, dialog):
+        from fibsem.applications.autolamella.workflows.tasks.catalogue import (
+            has_advanced_tasks,
+        )
+
+        assert dialog.advanced_checkbox.isHidden() != has_advanced_tasks()
+
+
+class TestSecondaryTagColumn:
+    def test_shows_only_the_tags_the_heading_does_not(self, dialog):
+        """The heading states the primary; repeating it in a column says nothing."""
+        from PyQt5.QtWidgets import QLabel
+
+        row = next(r for r, t in dialog._rows.items() if t == "SPOT_BURN_FIDUCIAL")
+        chips = [
+            lb.text() for lb in dialog.table.cellWidget(row, 2).findChildren(QLabel)
+        ]
+        assert chips == ["Alignment"], "Correlation is the heading, not a chip"
+
+    def test_is_empty_for_a_task_with_one_purpose(self, dialog):
+        from PyQt5.QtWidgets import QLabel
+
+        row = next(r for r, t in dialog._rows.items() if t == "MILL_TRENCH")
+        assert not dialog.table.cellWidget(row, 2).findChildren(QLabel)
+
+
+class TestTooltip:
+    def test_carries_what_the_table_has_no_room_for(self, dialog):
+        row = next(r for r, t in dialog._rows.items() if t == "MILL_TRENCH")
+        tip = dialog.table.item(row, 0).toolTip()
+        assert "MILL_TRENCH" in tip, "the identifier lives here now, not in the row"
+        assert "Built-in" in tip
+        assert "Waffle milling" in tip
+        assert "pedestal" in tip, "the full description, not just the summary"
+
+    def test_every_cell_in_a_row_carries_it(self, dialog):
+        """Hovering anywhere on the row should explain the row."""
+        row = next(iter(dialog._rows))
+        tips = {
+            dialog.table.item(row, c).toolTip()
+            for c in range(dialog.table.columnCount())
+        }
+        assert len(tips) == 1 and tips != {""}
+
+
+class TestNaming:
+    def test_default_name_avoids_a_collision(self, dialog):
+        dialog.select("MILL_TRENCH")
+        assert dialog.task_name == "Trench Milling 2"
+
+    def test_default_name_skips_taken_suffixes(self, dialog):
+        dialog.select("MILL_ROUGH")
+        assert dialog.task_name == "Rough Milling 3"
+
+    def test_free_name_is_left_alone(self, dialog):
+        dialog.select("MILL_POLISHING")
+        assert dialog.task_name == "Polishing"
+
+    def test_changing_selection_replaces_the_name(self, dialog):
+        dialog.select("MILL_POLISHING")
+        dialog.name_field.setText("something custom")
+        dialog.select("MILL_TRENCH")
+        assert dialog.task_name == "Trench Milling 2"
+
+    def test_typed_name_survives_within_one_selection(self, dialog):
+        """Re-validating must not overwrite what the user is typing."""
+        dialog.select("MILL_POLISHING")
+        dialog.name_field.setText("Final Polish")
+        assert dialog.task_name == "Final Polish"
+
+
+class TestValidation:
+    def test_add_enabled_for_a_fresh_name(self, dialog):
+        dialog.select("MILL_POLISHING")
+        assert dialog.add_button.isEnabled()
+
+    def test_duplicate_disables_add_and_suggests_one(self, dialog):
+        dialog.select("MILL_POLISHING")
+        dialog.name_field.setText("Trench Milling")
+        assert not dialog.add_button.isEnabled()
+        assert "Trench Milling 2" in dialog.error_label.text()
+        assert not dialog.error_label.isHidden()
+
+    def test_the_destination_survives_an_error(self, dialog):
+        """It describes the button, not the input.
+
+        Watching it vanish while you fix a typo is how a static line becomes
+        wallpaper -- and how nobody reads it when it matters.
+        """
+        dialog.select("MILL_POLISHING")
+        before = dialog.status_label.text()
+        dialog.name_field.setText("Trench Milling")
+        assert dialog.status_label.text() == before
+
+    def test_a_valid_name_clears_the_error(self, dialog):
+        dialog.select("MILL_POLISHING")
+        dialog.name_field.setText("Trench Milling")
+        dialog.name_field.setText("Something Free")
+        assert dialog.error_label.isHidden()
+        assert dialog.add_button.isEnabled()
+
+    @pytest.mark.parametrize("blank", ["", "   "])
+    def test_blank_disables_add(self, dialog, blank):
+        dialog.select("MILL_POLISHING")
+        dialog.name_field.setText(blank)
+        assert not dialog.add_button.isEnabled()
+
+    def test_accept_refused_while_invalid(self, dialog):
+        dialog.select("MILL_POLISHING")
+        dialog.name_field.setText("Trench Milling")
+        dialog.accept()
+        assert dialog.result() != AddTaskDialog.Accepted
+
+    def test_states_where_the_task_lands(self, dialog):
+        dialog.select("MILL_POLISHING")
+        assert "all 4 existing lamellae" in dialog.status_label.text()
+
+    def test_get_task_info_returns_type_and_name(self, dialog):
+        dialog.select("MILL_POLISHING")
+        dialog.name_field.setText("Final Polish")
+        assert dialog.get_task_info() == ("MILL_POLISHING", "Final Polish")
+
+
+class TestExistingCount:
+    def test_counts_what_the_protocol_already_holds(self, app):
+        """Also what explains a default name of "Trench Milling 3"."""
+        from PyQt5.QtWidgets import QLabel
+
+        from fibsem.applications.autolamella.workflows.tasks import get_tasks
+
+        existing = {}
+        for name, task_type in [
+            ("Trench Milling", "MILL_TRENCH"),
+            ("Trench Milling 2", "MILL_TRENCH"),
+            ("Rough Milling", "MILL_ROUGH"),
+        ]:
+            config = get_tasks()[task_type].config_cls()
+            config.task_name = name
+            existing[name] = config
+
+        d = AddTaskDialog(existing, lamella_count=1)
+        d.show()
+        app.processEvents()
+        try:
+
+            def cell_text(task_type):
+                row = next(r for r, t in d._rows.items() if t == task_type)
+                return " ".join(
+                    lb.text() for lb in d.table.cellWidget(row, 0).findChildren(QLabel)
+                )
+
+            assert "2 in this protocol" in cell_text("MILL_TRENCH")
+            assert "1 in this protocol" in cell_text("MILL_ROUGH")
+            assert "in this protocol" not in cell_text("MILL_POLISHING")
+            d.select("MILL_TRENCH")
+            assert d.task_name == "Trench Milling 3"
+        finally:
+            d.close()
+            d.deleteLater()
+
+
+class TestPlugins:
+    def test_a_plugin_task_is_labelled_in_its_tooltip(self, dialog):
+        """Only reachable with a plugin installed; CI has none."""
+        plugins = [
+            t
+            for t in available_task_types()
+            if (src := task_source(t)) is not None and src.source.name == "PLUGIN"
+        ]
+        if not plugins:
+            pytest.skip("no plugin tasks installed")
+        dialog.advanced_checkbox.setChecked(True)
+        row = next(r for r, t in dialog._rows.items() if t == plugins[0])
+        assert "Plugin" in dialog.table.item(row, 0).toolTip()
+
+    def test_a_task_declaring_no_tags_still_appears(self, dialog):
+        untagged = [
+            t for t, c in available_task_types().items() if not task_info(c).tags
+        ]
+        if not untagged:
+            pytest.skip("every installed task declares a tag")
+        dialog.advanced_checkbox.setChecked(True)
+        assert untagged[0] in _visible_tasks(dialog)


### PR DESCRIPTION
**3 of 4 — stacked on #511. This is the one with the visible change.**

The dialog was two fields that said almost the same words. The combo read `Trench Milling (MILL_TRENCH)`; the name box beneath it was prefilled `Trench Milling`; nothing on screen said the first is a fixed class from the registry and the second is an arbitrary label that becomes the protocol's dictionary key.

Choosing the type is now selecting a row, so nothing can be mistaken for the name. Exactly one thing is typed, and it arrives already free.

### Why a table, not a list with a detail pane

With a description, a purpose and a source for every task there is enough to compare, and comparing is the whole job. A detail pane shows one row at a time and leaves most of the dialog empty.

Rows group under what a task is *for*, ordered as the work happens — the on-grid sequence reads Select Lamella Position → Mill Fiducial → Rough → Polishing rather than alphabetically. Search matches name, identifier, description and every tag. The filter narrows to one purpose, matching secondary tags too. Primitives sit behind **Show advanced**.

### Six defects this closes

| | |
|---|---|
| Name and type said the same words twice | choosing is selecting; the identifier moved to the tooltip |
| Default name always collided on the second copy | prefilled with the first free name |
| OK stayed enabled while invalid, then returned silently | Add disabled; the error sits on the field with the fix |
| Mill Fiducial listed twice | alias filtered upstream |
| A plugin task looked identical to a built-in | source and version in the tooltip |
| Adding wrote to three places, silently | the footer names all three, with the real lamella count |

A row also says how many of that type the protocol already holds — which is what explains a default name of "Trench Milling 3".

### One thing to be careful with on review

**Row heights here are measured, not computed, and that is load-bearing.** `resizeRowsToContents()` measures the item rather than the cell widget, so a row of widgets over empty items collapses; and deriving the wrap width from the column means guessing at the layout margins and the QSS item padding together. Every arithmetic version was short by exactly one line, which clipped the last line off every description with no sign anything was missing.

Two tests guard it, one of which narrows the dialog and asserts rows grow. Please don't simplify it back to `resizeRowsToContents()`.

3 files.