### PR TITLE
[fix] Let a marked position win the click from the tile grid (FIB-767)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -357,6 +357,21 @@ class FMOverviewWidget(QWidget):
         # mask `TileMaskWidget` owns, not a second copy: clicks are routed through the
         # settings widget so there is one place the selection lives.
         self.tile_grid_overlay = TileGridOverlay()
+        # Stand aside for a marked position. A press on one belongs to the marker, not
+        # to the tile under it -- see `TileGridOverlay.set_reserved`. Wired to the same
+        # hit test a click uses, so the grid stands aside for exactly what a click would
+        # have selected, rather than for a second opinion about where the markers are.
+        #
+        # The crosshair, though, not the field-of-view box. The box is a large thing to
+        # reserve -- a whole tile on the fluorescence tab, and a whole tile here at any
+        # HFW of 100 um or under -- and reserving it leaves tiles that cannot be toggled
+        # at all with nothing on screen to say why. Reserving the crosshair costs at
+        # worst a click that toggles a tile you meant to select, which greys out visibly
+        # and undoes with one more click. A wrong action that announces itself beats a
+        # dead end that does not.
+        self.tile_grid_overlay.set_reserved(
+            lambda x, y: self._position_at(x, y, crosshair_only=True) is not None
+        )
         self.canvas.canvas.add_overlay(self.tile_grid_overlay)
 
         # The same three switches the beam tab offers, over the same three shapes, from
@@ -366,11 +381,12 @@ class FMOverviewWidget(QWidget):
         self.overlay_controls = CanvasOverlayControls(
             list(stage_context.CONTEXT_OVERLAY_ENTRIES)
         )
-        self.overlay_controls.toggled.connect(
-            lambda *_: self._refresh_stage_metadata()
-        )
+        self.overlay_controls.toggled.connect(lambda *_: self._refresh_stage_metadata())
         self.btn_overlays = self.canvas.canvas.add_toolbar_button(
-            "mdi:eye-outline", "Overlays", self._toggle_overlays, checkable=True,
+            "mdi:eye-outline",
+            "Overlays",
+            self._toggle_overlays,
+            checkable=True,
         )
         self.overlay_popover = CanvasPopover(
             self.overlay_controls, parent=self.canvas.canvas
@@ -441,9 +457,7 @@ class FMOverviewWidget(QWidget):
         self.channel_widget = FluorescenceMultiChannelWidget(self.fm, channels)
         # Every overview setting lives in one widget, z-stack included, so their order
         # is decided in one place rather than split across two.
-        self.settings_widget = FMOverviewSettingsWidget(
-            channel_settings=channels
-        )
+        self.settings_widget = FMOverviewSettingsWidget(channel_settings=channels)
 
         controls = QWidget()
         self._controls_layout = QVBoxLayout(controls)
@@ -643,7 +657,9 @@ class FMOverviewWidget(QWidget):
         try:
             pixel_size_x, pixel_size_y = self.fm.camera.pixel_size
             width, height = self.fm.camera.resolution
-            self.settings_widget.set_tile_fov(width * pixel_size_x, height * pixel_size_y)
+            self.settings_widget.set_tile_fov(
+                width * pixel_size_x, height * pixel_size_y
+            )
         except Exception as e:
             logging.debug(f"Could not read the camera field of view: {e}")
 
@@ -998,7 +1014,9 @@ class FMOverviewWidget(QWidget):
             image = FluorescenceImage.load(path)
         except Exception as e:
             logging.error(f"Could not load an overview from {path}: {e}")
-            notification_service.show_toast(f"Could not load that overview.\n{e}", "error")
+            notification_service.show_toast(
+                f"Could not load that overview.\n{e}", "error"
+            )
             return None
 
         # Placed even without a geometry, but said out loud. `_offset_of` falls back to
@@ -1006,7 +1024,9 @@ class FMOverviewWidget(QWidget):
         # taken -- and an overview silently in the wrong place is worse than one you
         # have been told to distrust. Anything acquired before FIB-416 is this case.
         if FMStageProjection.from_image(image) is None:
-            logging.warning(f"Overview {path} has no recorded geometry; placing at the origin.")
+            logging.warning(
+                f"Overview {path} has no recorded geometry; placing at the origin."
+            )
             notification_service.show_toast(
                 "That overview has no recorded geometry, so it cannot be placed where "
                 "it was taken. Showing it at the canvas origin.",
@@ -1091,9 +1111,7 @@ class FMOverviewWidget(QWidget):
             logging.debug(f"Could not place the image in stage space: {e}")
             return (0.0, 0.0)
 
-    def _offset_from_origin(
-        self, position: FibsemStagePosition
-    ) -> Tuple[float, float]:
+    def _offset_from_origin(self, position: FibsemStagePosition) -> Tuple[float, float]:
         """Where a stage position sits relative to the canvas origin, in metres.
 
         The live-position counterpart of :meth:`_offset_of`, which answers the same
@@ -1109,7 +1127,9 @@ class FMOverviewWidget(QWidget):
             logging.debug(f"Could not place {position} in the canvas frame: {e}")
             return (0.0, 0.0)
 
-    def add_settings_section(self, title: str, widget: QWidget, first: bool = True) -> None:
+    def add_settings_section(
+        self, title: str, widget: QWidget, first: bool = True
+    ) -> None:
         """Put a host's own controls in the settings column, under *title*.
 
         Part of the host contract, alongside `set_positions` and `set_save_directory`,
@@ -1133,7 +1153,9 @@ class FMOverviewWidget(QWidget):
             self._controls_layout.insertWidget(0, section)
         else:
             # -1 is the stretch added in `_init_ui`; stay above it.
-            self._controls_layout.insertWidget(self._controls_layout.count() - 1, section)
+            self._controls_layout.insertWidget(
+                self._controls_layout.count() - 1, section
+            )
 
     def set_positions(self, positions: List[FibsemStagePosition]) -> None:
         """Stage positions to mark on the overview, e.g. saved lamella positions.
@@ -1398,8 +1420,11 @@ class FMOverviewWidget(QWidget):
         if current is None:
             return origin
         return FibsemStagePosition(
-            x=origin.x, y=origin.y, z=origin.z,
-            r=current.r, t=current.t,
+            x=origin.x,
+            y=origin.y,
+            z=origin.z,
+            r=current.r,
+            t=current.t,
             coordinate_system=origin.coordinate_system,
         )
 
@@ -1421,13 +1446,17 @@ class FMOverviewWidget(QWidget):
         if frame is None:
             self.stage_overlay.set_shapes([])
             return
-        self.stage_overlay.set_shapes(stage_context.context_shapes(
-            self.microscope, frame,
-            limits=self.overlay_controls.is_visible(stage_context.OVERLAY_LIMITS),
-            boundaries=self.overlay_controls.is_visible(
-                stage_context.OVERLAY_BOUNDARIES),
-            slots=self.overlay_controls.is_visible(stage_context.OVERLAY_SLOTS),
-        ))
+        self.stage_overlay.set_shapes(
+            stage_context.context_shapes(
+                self.microscope,
+                frame,
+                limits=self.overlay_controls.is_visible(stage_context.OVERLAY_LIMITS),
+                boundaries=self.overlay_controls.is_visible(
+                    stage_context.OVERLAY_BOUNDARIES
+                ),
+                slots=self.overlay_controls.is_visible(stage_context.OVERLAY_SLOTS),
+            )
+        )
 
     def _refresh_current_position(self) -> None:
         """Mark where the stage is now."""
@@ -1887,7 +1916,9 @@ class FMOverviewWidget(QWidget):
     # microns so that how close you have to click does not change with the zoom.
     PICK_RADIUS_PX = 12
 
-    def _position_at(self, x: float, y: float) -> Optional[str]:
+    def _position_at(
+        self, x: float, y: float, crosshair_only: bool = False
+    ) -> Optional[str]:
         """The marked position under a canvas point, or None.
 
         A click hits a position if it lands inside that position's field-of-view box
@@ -1900,6 +1931,14 @@ class FMOverviewWidget(QWidget):
         would be within any sensible micron radius of the click, and at a tight one none
         would be. Nearest crosshair wins among the hits, which also settles overlapping
         boxes -- and lamellae closer together than one camera frame do overlap.
+                *crosshair_only* drops the box and leaves the radius, for a caller that has to
+        share the canvas with something else. The tile grid stands aside wherever this
+        answers a name (FIB-767), and a field-of-view box is a large thing to reserve:
+        it is a whole tile on the fluorescence tab by construction, and a whole tile on
+        this one at any HFW of 100 um or under. Reserving it would leave tiles that
+        cannot be toggled at all, with nothing on screen to say why -- where reserving
+        only the crosshair costs at worst a click that toggles a tile you meant to
+        select, which greys out visibly and undoes with one more click.
         """
         frame = self._frame()
         ax = getattr(self.canvas.canvas, "_ax", None)
@@ -1922,13 +1961,11 @@ class FMOverviewWidget(QWidget):
                 point = transform.transform(centre)
             except Exception:
                 continue
-            distance = (
-                (click[0] - point[0]) ** 2 + (click[1] - point[1]) ** 2
-            ) ** 0.5
+            distance = ((click[0] - point[0]) ** 2 + (click[1] - point[1]) ** 2) ** 0.5
             # `centre` is in canvas units and `point` in screen pixels: the box is a
             # fixed piece of sample, the radius a fixed piece of screen.
-            if distance >= self.PICK_RADIUS_PX and not self.position_overlay.covers(
-                centre, x, y
+            if distance >= self.PICK_RADIUS_PX and (
+                crosshair_only or not self.position_overlay.covers(centre, x, y)
             ):
                 continue
             if distance < best_distance:
@@ -2304,7 +2341,10 @@ class FMOverviewWidget(QWidget):
         # pose -- the button is not the guard, and a host calling this directly, or a
         # stage that moved between the click and here, is exactly what this is for.
         if not self.at_acquisition_orientation():
-            where, needed = self._where_the_stage_is(), self._where_the_stage_needs_to_be()
+            where, needed = (
+                self._where_the_stage_is(),
+                self._where_the_stage_needs_to_be(),
+            )
             logging.warning(
                 f"Cannot acquire an overview: the stage is at {where}, and an overview "
                 f"needs to be at {needed}."
@@ -2337,8 +2377,10 @@ class FMOverviewWidget(QWidget):
             self.status.setText(f"Objective is {state.lower()}.")
             return
 
-        if (parameters.objective_start is ObjectiveStartPosition.FOCUS
-                and self.fm.objective.focus_position is None):
+        if (
+            parameters.objective_start is ObjectiveStartPosition.FOCUS
+            and self.fm.objective.focus_position is None
+        ):
             message = (
                 "This overview is set to start from the saved focus position, but none "
                 "has been saved. Set one with 'Set Focus Position', or start from the "
@@ -2403,7 +2445,9 @@ class FMOverviewWidget(QWidget):
             centre_position=self._target,
             # None when no save directory has been set -- the standalone default. The
             # runner writes each tile as it lands, so a cancelled run keeps what it got.
-            save_directory=self._destination.tiles_directory if self._destination else None,
+            save_directory=self._destination.tiles_directory
+            if self._destination
+            else None,
         )
         self._worker = FunctionWorker(self._acquire_worker)
         self._worker.start()
@@ -2693,12 +2737,15 @@ class FMOverviewWidget(QWidget):
         # counted and nothing more -- otherwise it reads "Tile 4/9 — 4/9".
         message = "Tiles"
         if remaining:
-            self.progress_tiles.update_progress(ProgressUpdate.combined(
-                current=current, total=total,
-                remaining_seconds=remaining,
-                total_seconds=payload.get("estimated_total_time", 0.0),
-                message=message,
-            ))
+            self.progress_tiles.update_progress(
+                ProgressUpdate.combined(
+                    current=current,
+                    total=total,
+                    remaining_seconds=remaining,
+                    total_seconds=payload.get("estimated_total_time", 0.0),
+                    message=message,
+                )
+            )
         else:
             self.progress_tiles.update_progress(
                 ProgressUpdate.numeric(current=current, total=total, message=message)
@@ -2718,8 +2765,11 @@ class FMOverviewWidget(QWidget):
                 # Say which pass, so a coarse sweep followed by a fine one does not
                 # look like the same bar inexplicably starting over.
                 total_passes = payload.get("total_passes", 1)
-                which = (f" {payload.get('pass_index', 1)}/{total_passes}"
-                         if total_passes > 1 else "")
+                which = (
+                    f" {payload.get('pass_index', 1)}/{total_passes}"
+                    if total_passes > 1
+                    else ""
+                )
                 return ProgressUpdate.numeric(
                     current=zlevel, total=total_z, message=f"{channel} focus{which}"
                 )
@@ -2829,7 +2879,9 @@ class FMOverviewWidget(QWidget):
             self.canvas.canvas.remove_image(PREVIEW_KEY)
             shape = self._mosaic.data.shape
             suffix, tooltip = self._describe_save()
-            self.status.setText(f"Overview acquired — {shape[-1]} × {shape[-2]} px{suffix}")
+            self.status.setText(
+                f"Overview acquired — {shape[-1]} × {shape[-2]} px{suffix}"
+            )
             self.status.setToolTip(tooltip)
             self.progress_tiles.update_progress(ProgressUpdate.done())
             self.progress_tiles.show()

--- a/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/tile_grid_overlay.py
@@ -19,7 +19,7 @@ is absorbed into the stage moves, not into where the tiles appear.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Iterable, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Callable, Iterable, List, Optional, Sequence, Tuple
 
 from PyQt5.QtCore import QObject, Qt, QTimer, pyqtSignal
 from PyQt5.QtWidgets import QApplication
@@ -102,8 +102,8 @@ class TileGridOverlay(QObject, CanvasOverlay):
     state is how they drift apart.
     """
 
-    tile_toggled = pyqtSignal(int, int, bool)      # row, col, enabled
-    grid_resize_requested = pyqtSignal(int, int)   # rows, cols
+    tile_toggled = pyqtSignal(int, int, bool)  # row, col, enabled
+    grid_resize_requested = pyqtSignal(int, int)  # rows, cols
     grid_move_requested = pyqtSignal(float, float)  # new centre, canvas coordinates
     # A move or resize gesture has ended. For work a host wants to do once, at the end,
     # rather than on every motion event -- anything that repaints the whole canvas
@@ -114,7 +114,7 @@ class TileGridOverlay(QObject, CanvasOverlay):
     def __init__(self, parent: Optional[QObject] = None) -> None:
         QObject.__init__(self, parent)
         self._tiles: List[TilePosition] = []
-        self._tile_shape: Tuple[int, int] = (0, 0)     # (height, width) px
+        self._tile_shape: Tuple[int, int] = (0, 0)  # (height, width) px
         self._tile_pixel_size: float = 0.0
         self._display_pixel_size: Optional[float] = None
         self._overlap: float = 0.0
@@ -140,11 +140,15 @@ class TileGridOverlay(QObject, CanvasOverlay):
         # Whether dragging may change the grid's *geometry*. Tile toggling is separate
         # and always allowed -- see `set_grid_editable`.
         self._geometry_editable: bool = True
+        # Points the host has claimed for itself -- see `set_reserved`.
+        self._reserved: Optional[Callable[[float, float], bool]] = None
         self._cursor_set: bool = False
         # A press inside the grid, held until it resolves into a move or a tile click:
         # (press_px_x, press_px_y, press_x, press_y, anchor_x, anchor_y). The screen
         # coordinates drive the threshold, the data coordinates the displacement.
-        self._move_start: Optional[Tuple[float, float, float, float, float, float]] = None
+        self._move_start: Optional[Tuple[float, float, float, float, float, float]] = (
+            None
+        )
         self._move_active: bool = False
         # A paint drag: the value being swept in, the tile the press landed on, and the
         # tiles already given it. `_paint_value` doubles as "this press is a paint" --
@@ -332,6 +336,45 @@ class TileGridOverlay(QObject, CanvasOverlay):
         """
         self._geometry_editable = bool(editable)
 
+    def set_reserved(self, predicate: Optional[Callable[[float, float], bool]]) -> None:
+        """Let the host claim points where the grid should not act.
+
+        *predicate* is asked, in canvas coordinates, whether a press belongs to
+        something else. When it answers yes this overlay takes no part in the gesture:
+        it does not claim the press, so the canvas emits `canvas_clicked` as usual and
+        whatever owns that point gets it.
+
+        This exists because the grid was winning clicks it had no claim to. A press
+        anywhere inside the grid's bounding box was claimed and turned into a tile
+        toggle, and the canvas's click signal was suppressed to stop the view panning
+        out from under a drag -- so a marked position inside the grid could not be
+        selected at all, and the footprint is exactly where the marked positions are
+        (FIB-767).
+
+        Both overview tabs wire this to their own marker hit test, so what the grid
+        stands aside for is precisely what a click would otherwise have selected --
+        including its field-of-view box, and including the rule that hidden markers are
+        not targets. One hit test, not two that must agree.
+
+        Pass None to take the reservation away.
+        """
+        self._reserved = predicate
+
+    def _is_reserved(self, x: float, y: float) -> bool:
+        """Whether the host has claimed the canvas point *x*, *y*.
+
+        Defensive because the predicate is the host's code running inside a mouse
+        handler: a raised exception here would abort the press and leave the grid in a
+        half-started gesture, which is worse than losing the reservation for one click.
+        """
+        if self._reserved is None:
+            return False
+        try:
+            return bool(self._reserved(x, y))
+        except Exception as e:
+            logging.debug(f"Could not ask whether a point is reserved: {e}")
+            return False
+
     @property
     def is_grid_visible(self) -> bool:
         return self._visible
@@ -437,7 +480,12 @@ class TileGridOverlay(QObject, CanvasOverlay):
 
     def _redraw(self) -> None:
         self._remove_artists()
-        if self._ax is None or not self._tiles or self._anchor() is None or not self._visible:
+        if (
+            self._ax is None
+            or not self._tiles
+            or self._anchor() is None
+            or not self._visible
+        ):
             # Still repaint: removing the artists takes them out of the axes, but the
             # canvas keeps showing the last render until it is asked to redraw -- so
             # returning early here left a hidden grid on screen.
@@ -470,14 +518,18 @@ class TileGridOverlay(QObject, CanvasOverlay):
             # fill's opacity and left them all but invisible -- so the grid could only
             # be seen by turning the fill up until it obscured the data.
             patch = Rectangle(
-                (x, y), width, height,
+                (x, y),
+                width,
+                height,
                 fill=tile.enabled,
                 facecolor=(
                     to_rgba(self._color, self._fill_alpha) if tile.enabled else "none"
                 ),
                 edgecolor=(
-                    to_rgba(self._color, UNREACHABLE_EDGE_ALPHA) if out_of_reach
-                    else to_rgba(self._color, 1.0) if tile.enabled
+                    to_rgba(self._color, UNREACHABLE_EDGE_ALPHA)
+                    if out_of_reach
+                    else to_rgba(self._color, 1.0)
+                    if tile.enabled
                     else to_rgba(DISABLED_EDGE, DISABLED_ALPHA)
                 ),
                 linestyle="-" if tile.enabled else "--",
@@ -516,8 +568,20 @@ class TileGridOverlay(QObject, CanvasOverlay):
         centre_x, centre_y = x + width / 2, y + height / 2
         arm = min(width, height) * UNREACHABLE_MARK_SIZE / 2
         line = Line2D(
-            (centre_x - arm, centre_x + arm, float("nan"), centre_x - arm, centre_x + arm),
-            (centre_y - arm, centre_y + arm, float("nan"), centre_y + arm, centre_y - arm),
+            (
+                centre_x - arm,
+                centre_x + arm,
+                float("nan"),
+                centre_x - arm,
+                centre_x + arm,
+            ),
+            (
+                centre_y - arm,
+                centre_y + arm,
+                float("nan"),
+                centre_y + arm,
+                centre_y - arm,
+            ),
             color=UNREACHABLE_MARK_COLOUR,
             linewidth=1.3,
             solid_capstyle="round",
@@ -727,6 +791,18 @@ class TileGridOverlay(QObject, CanvasOverlay):
             self._claim(event)
             return
 
+        if self._is_reserved(event.xdata, event.ydata):
+            # The host owns this point. Return without claiming, exactly as the
+            # double-click branch above does: `_move_start` stays unset, so the release
+            # that follows schedules no toggle, and the canvas emits the click.
+            #
+            # After the edge test rather than before it. A marked position is a larger
+            # target than an edge and would swallow the resize gesture wherever the two
+            # meet, and a grid whose corner cannot be dragged because a lamella sits
+            # near it is a worse trade than a marker that has to be clicked a few pixels
+            # further in.
+            return
+
         anchor = self._anchor()
         if anchor is None or not self._within(event.xdata, event.ydata):
             # Outside the grid, so this press belongs to the canvas -- leave it to pan.
@@ -734,7 +810,12 @@ class TileGridOverlay(QObject, CanvasOverlay):
         # Inside: held rather than acted on, because the same press starts both a move
         # and a tile toggle and only the pointer's next few pixels say which.
         self._move_start = (
-            event.x, event.y, event.xdata, event.ydata, anchor[0], anchor[1]
+            event.x,
+            event.y,
+            event.xdata,
+            event.ydata,
+            anchor[0],
+            anchor[1],
         )
         if self._painting(event):
             tile = self._tile_at(event.xdata, event.ydata)
@@ -798,6 +879,11 @@ class TileGridOverlay(QObject, CanvasOverlay):
         if cursor is not None:
             return cursor
         if not self._within(x, y):
+            return None
+        if self._is_reserved(x, y):
+            # Nothing, so the canvas's own cursor shows through. The pointer is the only
+            # warning that a press here will not move the grid, and a move cursor over a
+            # point the grid has stood aside for is a lie.
             return None
         return Qt.CrossCursor if painting else Qt.SizeAllCursor
 
@@ -865,13 +951,9 @@ class TileGridOverlay(QObject, CanvasOverlay):
         cols = max(t.col for t in self._tiles) + 1
 
         if horizontal:
-            cols = self._count_for(
-                abs(event.xdata - anchor[0]), tile_w * scale
-            )
+            cols = self._count_for(abs(event.xdata - anchor[0]), tile_w * scale)
         if vertical:
-            rows = self._count_for(
-                abs(event.ydata - anchor[1]), tile_h * scale
-            )
+            rows = self._count_for(abs(event.ydata - anchor[1]), tile_h * scale)
 
         self.grid_resize_requested.emit(rows, cols)
 
@@ -888,7 +970,7 @@ class TileGridOverlay(QObject, CanvasOverlay):
             return
         if not self._move_active:
             travelled = (event.x - press_x) ** 2 + (event.y - press_y) ** 2
-            if travelled < MOVE_DRAG_THRESHOLD_PX ** 2:
+            if travelled < MOVE_DRAG_THRESHOLD_PX**2:
                 return
             self._move_active = True
 
@@ -910,7 +992,7 @@ class TileGridOverlay(QObject, CanvasOverlay):
             return
         if not self._paint_active:
             travelled = (event.x - press_x) ** 2 + (event.y - press_y) ** 2
-            if travelled < MOVE_DRAG_THRESHOLD_PX ** 2:
+            if travelled < MOVE_DRAG_THRESHOLD_PX**2:
                 return
             # The move gesture's threshold, deliberately: a modified press that never
             # travels has to reach `_on_release` still looking like a click, so that

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -415,8 +415,13 @@ class OverviewRecord:
     given, and both overviews use the same list.
     """
 
-    def __init__(self, record_id: str, label: str, keys: List[str],
-                 view: Optional["OverviewView"] = None) -> None:
+    def __init__(
+        self,
+        record_id: str,
+        label: str,
+        keys: List[str],
+        view: Optional["OverviewView"] = None,
+    ) -> None:
         self.id = record_id
         self.label = label
         self.keys = list(keys)
@@ -612,8 +617,10 @@ class FibsemOverviewWidget(QWidget):
         # would emphasise the seams rather than hide them. Selecting one image to adjust
         # is the later half of FIB-415, and needs a selection the canvas has not got.
         self.btn_contrast = self.canvas.add_toolbar_button(
-            "mdi:contrast-circle", "Contrast and gamma",
-            self._toggle_contrast, checkable=True,
+            "mdi:contrast-circle",
+            "Contrast and gamma",
+            self._toggle_contrast,
+            checkable=True,
         )
         self.contrast_control = ContrastGammaControl(self.canvas)
         self.contrast_control.changed.connect(self._reapply_contrast)
@@ -630,6 +637,21 @@ class FibsemOverviewWidget(QWidget):
         self.tile_grid_overlay.tile_toggled.connect(self._on_tile_toggled)
         self.tile_grid_overlay.grid_resize_requested.connect(self._on_grid_resized)
         self.tile_grid_overlay.grid_move_requested.connect(self._on_grid_moved)
+        # Stand aside for a marked position. A press on one belongs to the marker, not
+        # to the tile under it -- see `TileGridOverlay.set_reserved`. Wired to the same
+        # hit test a click uses, so the grid stands aside for exactly what a click would
+        # have selected, rather than for a second opinion about where the markers are.
+        #
+        # The crosshair, though, not the field-of-view box. The box is a large thing to
+        # reserve -- a whole tile on the fluorescence tab, and a whole tile here at any
+        # HFW of 100 um or under -- and reserving it leaves tiles that cannot be toggled
+        # at all with nothing on screen to say why. Reserving the crosshair costs at
+        # worst a click that toggles a tile you meant to select, which greys out visibly
+        # and undoes with one more click. A wrong action that announces itself beats a
+        # dead end that does not.
+        self.tile_grid_overlay.set_reserved(
+            lambda x, y: self._position_at(x, y, crosshair_only=True) is not None
+        )
         self.canvas.add_overlay(self.tile_grid_overlay)
 
         # Where the sample and the stage can physically go -- the context an overview is
@@ -745,11 +767,13 @@ class FibsemOverviewWidget(QWidget):
         # Ordered as they sit on the canvas, outermost first: where the stage can go,
         # then the holder's grids, then the marks inside them. Grid bars last because
         # they are a lattice over everything and the two controls under them are theirs.
-        self.overlay_controls = CanvasOverlayControls([
-            *stage_context.CONTEXT_OVERLAY_ENTRIES,
-            (_OVERLAY_POSITIONS, "Saved positions", True),
-            (_OVERLAY_GRIDBARS, "Grid bars", False),
-        ])
+        self.overlay_controls = CanvasOverlayControls(
+            [
+                *stage_context.CONTEXT_OVERLAY_ENTRIES,
+                (_OVERLAY_POSITIONS, "Saved positions", True),
+                (_OVERLAY_GRIDBARS, "Grid bars", False),
+            ]
+        )
         self.overlay_controls.toggled.connect(self._on_overlay_toggled)
         self.spin_gridbar_spacing = ValueSpinBox(
             suffix=" um", minimum=1.0, maximum=10000.0, step=10.0, decimals=1
@@ -774,7 +798,10 @@ class FibsemOverviewWidget(QWidget):
         # other toolbar buttons because it holds the controls above, which have to exist
         # first.
         self.btn_overlays = self.canvas.add_toolbar_button(
-            "mdi:eye-outline", "Overlays", self._toggle_overlays, checkable=True,
+            "mdi:eye-outline",
+            "Overlays",
+            self._toggle_overlays,
+            checkable=True,
         )
         self.overlay_popover = CanvasPopover(self._overlay_panel(), parent=self.canvas)
 
@@ -785,7 +812,10 @@ class FibsemOverviewWidget(QWidget):
         # class as the FM tab now that it lives beside the overlay it configures, so the
         # two tabs cannot drift apart on the one overlay they both draw.
         self.btn_tile_grid = self.canvas.add_toolbar_button(
-            "mdi:grid", "Tile grid", self._toggle_tile_grid_panel, checkable=True,
+            "mdi:grid",
+            "Tile grid",
+            self._toggle_tile_grid_panel,
+            checkable=True,
         )
         self.tile_grid_panel = TileGridOptionsPanel(self)
         self.tile_grid_panel.hide()
@@ -1208,7 +1238,9 @@ class FibsemOverviewWidget(QWidget):
             return BeamType.ELECTRON
         return settings.image_settings.beam_type
 
-    def add_settings_section(self, title: str, widget: QWidget, first: bool = True) -> None:
+    def add_settings_section(
+        self, title: str, widget: QWidget, first: bool = True
+    ) -> None:
         """Let a host put its own section in the settings column.
 
         In the column rather than beside it: a host's section is usually the subject of
@@ -1562,14 +1594,21 @@ class FibsemOverviewWidget(QWidget):
 
     # ── placing images ───────────────────────────────────────────────────
 
-    def place_image(self, image: FibsemImage, key: Optional[str] = None,
-                    zorder: Optional[float] = None) -> Optional[str]:
+    def place_image(
+        self,
+        image: FibsemImage,
+        key: Optional[str] = None,
+        zorder: Optional[float] = None,
+    ) -> Optional[str]:
         """Put one image on the canvas where it was acquired. See :meth:`_place`."""
         return self._place(image, key=key, zorder=zorder)[0]
 
-    def _place(self, image: FibsemImage, key: Optional[str] = None,
-               zorder: Optional[float] = None
-               ) -> Tuple[Optional[str], Optional["_PlacedTile"]]:
+    def _place(
+        self,
+        image: FibsemImage,
+        key: Optional[str] = None,
+        zorder: Optional[float] = None,
+    ) -> Tuple[Optional[str], Optional["_PlacedTile"]]:
         """Put one image on the canvas, and hand back the tile that was stored for it.
 
         The tile comes back because a caller that keeps a *record* needs the same one:
@@ -1657,7 +1696,9 @@ class FibsemOverviewWidget(QWidget):
         y0 = min(max(0, int(np.floor(region.top * height))), height - 1)
         x1 = min(width, max(int(np.ceil(region.right * width)), x0 + 1))
         y1 = min(height, max(int(np.ceil(region.bottom * height)), y0 + 1))
-        curve = None if self.contrast_control.is_default() else self.contrast_control.apply
+        curve = (
+            None if self.contrast_control.is_default() else self.contrast_control.apply
+        )
         drawn = _as_colour_and_coverage(
             downsample(grey[y0:y1, x0:x1], max_px),
             downsample_mask(acquired[y0:y1, x0:x1], max_px),
@@ -1689,8 +1730,11 @@ class FibsemOverviewWidget(QWidget):
         self.canvas.refresh_detail(force=True)
 
     def _place_on_canvas(
-        self, tile: "_PlacedTile", view: "OverviewView",
-        key: Optional[str] = None, zorder: Optional[float] = None,
+        self,
+        tile: "_PlacedTile",
+        view: "OverviewView",
+        key: Optional[str] = None,
+        zorder: Optional[float] = None,
     ) -> Optional[str]:
         """Draw a stored tile in *view*. Shared by first placement and re-placement.
 
@@ -1707,8 +1751,12 @@ class FibsemOverviewWidget(QWidget):
             logger.debug(f"Could not place an image: {e}")
             return None
         return self.canvas.add_image(
-            self._for_display(tile), centre=centre, pixel_size=tile.pixel_size,
-            key=key, zorder=zorder, covers=tile.covers,
+            self._for_display(tile),
+            centre=centre,
+            pixel_size=tile.pixel_size,
+            key=key,
+            zorder=zorder,
+            covers=tile.covers,
             # Bound to this tile, and the canvas holds it for as long as the image is
             # placed -- so a contrast change reaches every placed image without walking
             # the records, which would miss the acquisition preview, the one thing on
@@ -1735,7 +1783,9 @@ class FibsemOverviewWidget(QWidget):
                 "warning",
             )
             return None
-        record = OverviewRecord(record_id, os.path.basename(record_id), [key], view=view)
+        record = OverviewRecord(
+            record_id, os.path.basename(record_id), [key], view=view
+        )
         record.pixel_size = self._pixel_size_of(image)
         record.images.append(tile)
         self._records[record_id] = record
@@ -1919,8 +1969,9 @@ class FibsemOverviewWidget(QWidget):
             image = FibsemImage.load(path)
         except Exception as e:
             logger.error(f"Could not load {path}: {e}")
-            notification_service.show_toast(f"Could not load {os.path.basename(path)}.",
-                                            "error")
+            notification_service.show_toast(
+                f"Could not load {os.path.basename(path)}.", "error"
+            )
             return None
         return self.set_image(image)
 
@@ -1964,12 +2015,15 @@ class FibsemOverviewWidget(QWidget):
             self.context_overlay.set_shapes([])
             return
 
-        self.context_overlay.set_shapes(stage_context.context_shapes(
-            self.microscope, frame,
-            limits=self.overlay_controls.is_visible(_OVERLAY_LIMITS),
-            boundaries=self.overlay_controls.is_visible(_OVERLAY_BOUNDARIES),
-            slots=self.overlay_controls.is_visible(_OVERLAY_SLOTS),
-        ))
+        self.context_overlay.set_shapes(
+            stage_context.context_shapes(
+                self.microscope,
+                frame,
+                limits=self.overlay_controls.is_visible(_OVERLAY_LIMITS),
+                boundaries=self.overlay_controls.is_visible(_OVERLAY_BOUNDARIES),
+                slots=self.overlay_controls.is_visible(_OVERLAY_SLOTS),
+            )
+        )
         self._declare_working_area(frame)
         self._refresh_tile_grid()
         self._refresh_stage_info()
@@ -2289,8 +2343,11 @@ class FibsemOverviewWidget(QWidget):
             return
 
         if not self.overlay_controls.is_visible(_OVERLAY_POSITIONS):
-            for overlay in (self.position_overlay, self.flagged_position_overlay,
-                            self.selected_position_overlay):
+            for overlay in (
+                self.position_overlay,
+                self.flagged_position_overlay,
+                self.selected_position_overlay,
+            ):
                 overlay.set_points([])
             if self._stage_position is not None:
                 try:
@@ -2303,7 +2360,9 @@ class FibsemOverviewWidget(QWidget):
 
         if self._stage_position is not None:
             try:
-                self.current_position_overlay.set_points([frame.to_canvas(self._stage_position)])
+                self.current_position_overlay.set_points(
+                    [frame.to_canvas(self._stage_position)]
+                )
             except Exception as e:
                 logger.debug(f"Could not mark the current stage position: {e}")
 
@@ -2441,7 +2500,9 @@ class FibsemOverviewWidget(QWidget):
         self.set_selected_position(name)
         self.position_selected.emit(name)
 
-    def _position_at(self, x: float, y: float) -> Optional[str]:
+    def _position_at(
+        self, x: float, y: float, crosshair_only: bool = False
+    ) -> Optional[str]:
         """The marked position under a canvas point, or None.
 
         A click hits a position if it lands inside that position's field-of-view box
@@ -2454,6 +2515,14 @@ class FibsemOverviewWidget(QWidget):
         would be within any sensible micron radius of the click, and at a tight one none
         would be. Nearest crosshair wins among the hits, which also settles overlapping
         boxes -- and lamellae closer together than the field of view do overlap.
+                *crosshair_only* drops the box and leaves the radius, for a caller that has to
+        share the canvas with something else. The tile grid stands aside wherever this
+        answers a name (FIB-767), and a field-of-view box is a large thing to reserve:
+        it is a whole tile on the fluorescence tab by construction, and a whole tile on
+        this one at any HFW of 100 um or under. Reserving it would leave tiles that
+        cannot be toggled at all, with nothing on screen to say why -- where reserving
+        only the crosshair costs at worst a click that toggles a tile you meant to
+        select, which greys out visibly and undoes with one more click.
         """
         if not self.overlay_controls.is_visible(_OVERLAY_POSITIONS):
             # Turned off means gone, not merely invisible. `_refresh_position_markers`
@@ -2487,8 +2556,8 @@ class FibsemOverviewWidget(QWidget):
             distance = ((click[0] - point[0]) ** 2 + (click[1] - point[1]) ** 2) ** 0.5
             # `centre` is in canvas units and `point` in screen pixels: the box is a
             # fixed piece of sample, the radius a fixed piece of screen.
-            if distance >= PICK_RADIUS_PX and not self.position_overlay.covers(
-                centre, x, y
+            if distance >= PICK_RADIUS_PX and (
+                crosshair_only or not self.position_overlay.covers(centre, x, y)
             ):
                 continue
             if distance < best_distance:
@@ -2603,9 +2672,7 @@ class FibsemOverviewWidget(QWidget):
             return None
         return target
 
-    def _posed_like_the_stage(
-        self, target: FibsemStagePosition
-    ) -> FibsemStagePosition:
+    def _posed_like_the_stage(self, target: FibsemStagePosition) -> FibsemStagePosition:
         """A resolved position, wearing the pose the stage is actually in.
 
         Neither steering nor planning reorients. A point on the canvas says *where on

--- a/tests/ui/test_marked_position_wins_the_click.py
+++ b/tests/ui/test_marked_position_wins_the_click.py
@@ -1,0 +1,294 @@
+"""A click on a marked position selects it, even when the tile grid is over the top.
+
+The tile grid claimed every left press inside its bounding box and turned it into a
+tile toggle. Claiming also suppresses the canvas's `canvas_clicked` signal -- which is
+what stops the view panning out from under a grid drag -- and position picking hangs
+off that signal. So while a grid was displayed, selecting a marked position inside its
+footprint was impossible, and the footprint is exactly where the marked positions are
+(FIB-767).
+
+The grid now asks the host first, through `TileGridOverlay.set_reserved`. These tests
+drive the real dispatch order -- the canvas connects its own handlers in `__init__`,
+before any overlay exists, so a press reaches the canvas and then the overlay -- rather
+than asserting on the seam and hoping the two halves meet.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_marked_position_wins_the_click.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication  # noqa: E402
+
+from fibsem import utils  # noqa: E402
+from fibsem.structures import (  # noqa: E402
+    BeamType,
+    FibsemImage,
+    FibsemStagePosition,
+    ImageSettings,
+)
+from fibsem.ui.widgets.overview_widget import FibsemOverviewWidget  # noqa: E402
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    import fibsem.config as fibsem_config
+
+    path = os.path.join(
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "sim-arctis-configuration.yaml",
+    )
+    scope, _ = utils.setup_session(manufacturer="Demo", config_path=path)
+    return scope
+
+
+def _at(base, dx=0.0, dy=0.0, name=None):
+    p = FibsemStagePosition(x=base.x + dx, y=base.y + dy, z=base.z, r=base.r, t=base.t)
+    p.name = name
+    return p
+
+
+@pytest.fixture
+def widget(microscope):
+    """A beam overview with one lamella at the stage position and a grid over it."""
+    w = FibsemOverviewWidget(microscope)
+    w.resize(1000, 800)
+    base = microscope.get_stage_position()
+
+    image = FibsemImage.generate_blank_image(resolution=(512, 512), hfw=800e-6)
+    image.data = np.zeros((512, 512), dtype=np.uint8)
+    state = microscope.get_microscope_state(beam_type=BeamType.ELECTRON)
+    state.stage_position = _at(base)
+    image.metadata.image_settings = ImageSettings(
+        hfw=800e-6, beam_type=BeamType.ELECTRON
+    )
+    image.metadata.microscope_state = state
+    image.metadata.system_info = microscope.system.info
+    image.metadata.hardware_geometry = microscope.hardware_geometry()
+    w.place_image(image)
+    w.set_positions([_at(base, 0.0, 0.0, "Lamella-01")])
+    w._refresh_tile_grid()
+    _app.processEvents()
+    yield w
+    w.close()
+
+
+def _marker(widget, microscope):
+    """Canvas coordinates of the one marked position."""
+    return widget._frame().to_canvas(_at(microscope.get_stage_position()))
+
+
+def _bare_grid(widget):
+    """A canvas point inside the grid that no marker has claimed."""
+    overlay = widget.tile_grid_overlay
+    left, top, width, height = overlay._bounds()
+    for fx, fy in ((0.9, 0.9), (0.1, 0.1), (0.9, 0.1), (0.1, 0.9)):
+        point = (left + fx * width, top + fy * height)
+        if overlay._within(*point) and not overlay._is_reserved(*point):
+            return point
+    raise AssertionError("the grid is entirely reserved; the fixture is wrong")
+
+
+def _event(widget, x, y):
+    transform = widget.canvas._ax.transData
+    px, py = transform.transform((x, y))
+    return SimpleNamespace(
+        button=1,
+        inaxes=widget.canvas._ax,
+        xdata=x,
+        ydata=y,
+        x=px,
+        y=py,
+        dblclick=False,
+        key=None,
+        guiEvent=None,
+    )
+
+
+def _click(widget, x, y):
+    """One press and release, dispatched the way matplotlib would.
+
+    The canvas connects its handlers in `__init__`, before any overlay is added, so it
+    sees both events first. Order matters: the canvas's release reads the claim before
+    clearing it.
+    """
+    overlay = widget.tile_grid_overlay
+    selected, toggled = [], []
+    widget.position_selected.connect(selected.append)
+    overlay.tile_toggled.connect(lambda r, c, e: toggled.append((r, c, e)))
+
+    press = _event(widget, x, y)
+    widget.canvas._on_press(press)
+    overlay._on_press(press)
+    claimed = widget.canvas._overlay_consuming_event
+
+    release = _event(widget, x, y)
+    widget.canvas._on_release(release)
+    overlay._on_release(release)
+    if overlay._toggle_timer.isActive():
+        overlay._toggle_timer.stop()
+        overlay._emit_pending_toggle()
+    _app.processEvents()
+    return SimpleNamespace(claimed=claimed, selected=selected, toggled=toggled)
+
+
+class TestAMarkedPositionInsideTheGrid:
+    def test_the_grid_really_is_over_the_marker(self, widget, microscope):
+        """The precondition. Without it every test below passes for the wrong reason."""
+        overlay = widget.tile_grid_overlay
+        assert overlay._tiles, "no grid drawn"
+        assert overlay._within(*_marker(widget, microscope)), (
+            "grid is not over the marker"
+        )
+
+    def test_clicking_it_selects_it(self, widget, microscope):
+        result = _click(widget, *_marker(widget, microscope))
+
+        assert result.claimed is False, "the grid claimed the press and ate the click"
+        assert result.selected == ["Lamella-01"]
+
+    def test_clicking_it_does_not_toggle_the_tile_underneath(self, widget, microscope):
+        """Not claiming is only half of it -- a release that still toggled would edit
+        the mask behind a click meant for the marker."""
+        result = _click(widget, *_marker(widget, microscope))
+
+        assert result.toggled == []
+
+
+class TestTheRestOfTheGridIsUnchanged:
+    def test_a_click_on_bare_grid_still_toggles_its_tile(self, widget):
+        result = _click(widget, *_bare_grid(widget))
+
+        assert result.claimed is True
+        assert len(result.toggled) == 1
+        assert result.selected == []
+
+    def test_a_click_on_bare_grid_selects_nothing(self, widget):
+        result = _click(widget, *_bare_grid(widget))
+
+        assert result.selected == []
+
+
+class TestTheReservationFollowsTheMarkers:
+    """It is wired to `_position_at`, not to a second opinion about where markers are.
+    So everything that decides whether a click would select -- the field-of-view box,
+    and the rule that hidden markers are not targets -- decides this too."""
+
+    def test_hiding_the_markers_gives_the_tile_back(self, widget, microscope):
+        """Turned off means gone. A grid standing aside for a marker nothing is drawing
+        would be a tile you cannot toggle with nothing on screen to say why."""
+        point = _marker(widget, microscope)
+        assert _click(widget, *point).toggled == [], "reserved while shown"
+
+        widget.overlay_controls.set_visible("positions", False)
+        _app.processEvents()
+
+        result = _click(widget, *point)
+        assert result.claimed is True
+        assert len(result.toggled) == 1
+
+    def test_the_reservation_is_the_crosshair_not_the_whole_box(
+        self, widget, microscope
+    ):
+        """The box is too big to reserve.
+
+        It is one whole tile on the fluorescence tab by construction -- a tile is one
+        camera frame and so is the box -- and one whole tile here at any HFW of 100 um
+        or under. Reserving it leaves tiles that cannot be toggled at all, with nothing
+        on screen to say why.
+
+        Reserving only the crosshair costs at worst a click that toggles a tile you
+        meant to select. That greys out visibly and undoes with one more click, which is
+        the better failure: a wrong action that announces itself beats a dead end that
+        does not.
+        """
+        overlay = widget.tile_grid_overlay
+        centre = _marker(widget, microscope)
+        half_w, _ = widget.position_overlay.half_extent_canvas()
+        inside_box = (centre[0] + half_w * 0.8, centre[1])
+
+        transform = widget.canvas._ax.transData
+        a, b = transform.transform(centre), transform.transform(inside_box)
+        distance = ((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2) ** 0.5
+        assert distance > 12, "probe is within the crosshair radius; it proves nothing"
+        assert overlay._within(*inside_box), "probe left the grid; it proves nothing"
+
+        assert not overlay._is_reserved(*inside_box)
+
+    def test_a_click_in_the_box_but_off_the_crosshair_toggles_the_tile(
+        self, widget, microscope
+    ):
+        """The other half of it, through the real dispatch rather than the predicate."""
+        centre = _marker(widget, microscope)
+        half_w, _ = widget.position_overlay.half_extent_canvas()
+        inside_box = (centre[0] + half_w * 0.8, centre[1])
+
+        result = _click(widget, *inside_box)
+
+        assert result.claimed is True
+        assert len(result.toggled) == 1
+
+    def test_selection_still_uses_the_box(self, widget, microscope):
+        """Only the reservation narrowed. What a click *selects* is unchanged, so the
+        box keeps its aim benefit everywhere the grid is not contending for the point.
+        """
+        centre = _marker(widget, microscope)
+        half_w, _ = widget.position_overlay.half_extent_canvas()
+        inside_box = (centre[0] + half_w * 0.8, centre[1])
+
+        assert widget._position_at(*inside_box) == "Lamella-01"
+        assert widget._position_at(*inside_box, crosshair_only=True) is None
+
+
+# ── the fluorescence tab ─────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def fm_widget(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+    from fibsem.ui.fm.widgets.fm_overview_widget import FMOverviewWidget
+
+    scope = build_microscope()
+    scope.fm.objective.insert()
+    w = FMOverviewWidget(scope)
+    w.resize(1200, 800)
+    w.show()
+    qapp.processEvents()
+    w._refresh_tile_grid()
+    qapp.processEvents()
+    return w
+
+
+def test_the_fluorescence_tab_stands_aside_too(qapp, fm_widget):
+    """Both tabs draw the same overlay over the same kind of marker, so both wire it.
+    A fix on one tab only would be the sort of asymmetry `_position_at` already had."""
+    position = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(-180.0))
+    position.name = "Lamella-01"
+    fm_widget.set_positions([position])
+    qapp.processEvents()
+
+    overlay = fm_widget.tile_grid_overlay
+    point = fm_widget._frame().to_canvas(position)
+    assert overlay._tiles, "no grid drawn"
+    assert overlay._within(*point), "the grid is not over the marker"
+
+    assert overlay._is_reserved(*point)
+    assert fm_widget._position_at(*point) == "Lamella-01"
+
+    fm_widget.set_positions([])
+    qapp.processEvents()
+    assert not overlay._is_reserved(*point), "the reservation outlived the marker"

--- a/tests/ui/test_tile_grid_overlay.py
+++ b/tests/ui/test_tile_grid_overlay.py
@@ -5,6 +5,7 @@ if it disagrees with where tiles actually land it is worse than not drawing one.
 placed from the same `canvas_x/canvas_y` that `stitch_tileset` pastes with, and these
 tests hold it to that rather than to a second derivation of the same arithmetic.
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -47,10 +48,10 @@ class _FakeCanvas:
     def draw_idle(self):
         self.redraws += 1
 
-    def setCursor(self, cursor):   # noqa: N802 - mirrors the Qt API
+    def setCursor(self, cursor):  # noqa: N802 - mirrors the Qt API
         self.cursor = cursor
 
-    def unsetCursor(self):         # noqa: N802 - mirrors the Qt API
+    def unsetCursor(self):  # noqa: N802 - mirrors the Qt API
         self.cursor = None
 
     def set_view_margin(self, margin):
@@ -192,8 +193,8 @@ def test_a_click_in_an_overlap_picks_the_nearer_tile(qapp):
     rx, _, _, _ = overlay._rect_for(right)
     seam_y = ly + lh / 2
 
-    just_left = overlay._tile_at(rx + 1, seam_y)          # inside both, nearer `left`
-    just_right = overlay._tile_at(lx + lw - 1, seam_y)    # inside both, nearer `right`
+    just_left = overlay._tile_at(rx + 1, seam_y)  # inside both, nearer `left`
+    just_right = overlay._tile_at(lx + lw - 1, seam_y)  # inside both, nearer `right`
 
     assert (just_left.row, just_left.col) == (1, 0)
     assert (just_right.row, just_right.col) == (1, 1)
@@ -238,7 +239,9 @@ def test_a_differing_display_pixel_size_rescales_the_grid(qapp):
     overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
     full = overlay._rect_for(tiles[0])[2]
 
-    overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, display_pixel_size=PIXEL_SIZE * 2)
+    overlay.set_grid(
+        tiles, (HEIGHT, WIDTH), PIXEL_SIZE, display_pixel_size=PIXEL_SIZE * 2
+    )
     half = overlay._rect_for(tiles[0])[2]
 
     assert half == pytest.approx(full / 2)
@@ -248,9 +251,9 @@ def test_disabled_tiles_keep_their_place_in_the_grid(qapp):
     """A skipped tile still defines the extent and the layout -- it is simply not
     acquired -- so removing it must not shift its neighbours."""
     dense, _ = build(3, 3)
-    sparse, tiles = build(3, 3, mask=[[True, True, True],
-                                      [True, False, True],
-                                      [True, True, True]])
+    sparse, tiles = build(
+        3, 3, mask=[[True, True, True], [True, False, True], [True, True, True]]
+    )
 
     centre = next(t for t in tiles if (t.row, t.col) == (1, 1))
     assert centre.enabled is False
@@ -309,7 +312,7 @@ def test_the_scale_follows_the_canvas_pixel_size(qapp):
     very image it describes."""
 
     overlay, _ = build(3, 3)
-    overlay._display_pixel_size = None      # not pinned -> read from the canvas
+    overlay._display_pixel_size = None  # not pinned -> read from the canvas
     overlay._canvas._pixel_size = PIXEL_SIZE * 2
 
     assert overlay._scale() == pytest.approx(0.5)
@@ -333,7 +336,10 @@ def test_skipped_tiles_are_grey_regardless_of_the_grid_colour(qapp):
 
 
 def _edge_hues(overlay):
-    return {tuple(round(c, 3) for c in patch.get_edgecolor()[:3]) for patch in overlay._artists}
+    return {
+        tuple(round(c, 3) for c in patch.get_edgecolor()[:3])
+        for patch in overlay._artists
+    }
 
 
 def _is_mark(artist):
@@ -407,7 +413,9 @@ def test_the_cross_scales_with_the_tiles(qapp):
     import math
 
     xs = [v for v in _marks(overlay)[0].get_xdata() if not math.isnan(v)]
-    assert max(xs) - min(xs) == pytest.approx(min(width, height) * UNREACHABLE_MARK_SIZE)
+    assert max(xs) - min(xs) == pytest.approx(
+        min(width, height) * UNREACHABLE_MARK_SIZE
+    )
 
 
 def test_a_reachable_tile_is_not_marked(qapp):
@@ -453,7 +461,9 @@ def test_passing_no_flags_leaves_the_previous_ones_alone(qapp):
     assert overlay._unreachable == {(0, 0)}
 
     overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
-    assert overlay._unreachable == {(0, 0)}, "the flags were dropped by an unrelated redraw"
+    assert overlay._unreachable == {(0, 0)}, (
+        "the flags were dropped by an unrelated redraw"
+    )
 
     overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE, unreachable=[])
     assert overlay._unreachable == set(), "an empty set must clear them"
@@ -635,7 +645,7 @@ def test_the_background_is_dropped_when_the_canvas_bounds_change(qapp):
 def test_a_canvas_that_cannot_blit_still_gets_its_grid(qapp):
     """Not every host is a matplotlib canvas. Falling back costs a frame's efficiency;
     failing would cost the frame."""
-    overlay, tiles = build(3, 3)          # the plain fake, with no blit calls
+    overlay, tiles = build(3, 3)  # the plain fake, with no blit calls
     overlay._move_active = True
 
     overlay.set_grid(tiles, (HEIGHT, WIDTH), PIXEL_SIZE)
@@ -756,8 +766,8 @@ def test_a_click_is_not_the_end_of_a_drag(qapp):
 def _edges(overlay):
     span_w, span_h = overlay._extent()
     return (
-        overlay._rect.cx + span_w / 2,   # right
-        overlay._rect.cy + span_h / 2,   # bottom
+        overlay._rect.cx + span_w / 2,  # right
+        overlay._rect.cy + span_h / 2,  # bottom
     )
 
 
@@ -769,7 +779,7 @@ def test_only_the_outer_edges_grab(qapp):
 
     assert overlay._edge_at(right, overlay._rect.cy) == (True, False)
     assert overlay._edge_at(overlay._rect.cx, bottom) == (False, True)
-    assert overlay._edge_at(right, bottom) == (True, True)      # corner: both axes
+    assert overlay._edge_at(right, bottom) == (True, True)  # corner: both axes
     assert overlay._edge_at(overlay._rect.cx, overlay._rect.cy) is None
 
 
@@ -1286,7 +1296,9 @@ def test_a_shift_click_that_never_travels_is_an_ordinary_toggle(qapp):
     overlay._on_drag(_event(overlay, *point, px=MOVE_DRAG_THRESHOLD_PX - 1, py=0.0))
     overlay._on_release(_event(overlay, *point))
 
-    assert painted == [], "a modified click must still wait out the double-click interval"
+    assert painted == [], (
+        "a modified click must still wait out the double-click interval"
+    )
     _flush_toggle(overlay)
     assert painted == [(1, 1, False)]
 
@@ -1297,10 +1309,13 @@ def test_a_paint_does_not_also_toggle_the_tile_it_ends_on(qapp):
     painted = []
     overlay.tile_toggled.connect(lambda r, c, e: painted.append((r, c, e)))
 
-    _sweep(overlay, [
-        _tile_centre(overlay, tiles, 1, 0),
-        _tile_centre(overlay, tiles, 1, 1),
-    ])
+    _sweep(
+        overlay,
+        [
+            _tile_centre(overlay, tiles, 1, 0),
+            _tile_centre(overlay, tiles, 1, 1),
+        ],
+    )
 
     assert painted == [(1, 0, False), (1, 1, False)]
 
@@ -1469,5 +1484,128 @@ def test_a_fixed_grid_offers_no_resize_cursor(qapp):
     right, _ = _edges(overlay)
 
     overlay._update_cursor(_event(overlay, right, overlay._rect.cy))
+
+    assert overlay._canvas.cursor is None
+
+
+# ── standing aside for a marked position (FIB-767) ───────────────────────────
+#
+# A press anywhere inside the bounding box used to be claimed and turned into a tile
+# toggle, and claiming suppresses the canvas's click signal -- so a marked position
+# inside the grid could not be selected at all, and the footprint is exactly where the
+# marked positions are. `set_reserved` lets the host say "this point is mine".
+
+
+def _reserve(overlay, *points, radius=40.0):
+    """Reserve *points*, in canvas coordinates, within *radius*."""
+    overlay.set_reserved(
+        lambda x, y: any(
+            abs(x - px) <= radius and abs(y - py) <= radius for px, py in points
+        )
+    )
+
+
+def test_a_reserved_press_is_not_claimed(qapp):
+    """The whole point: the canvas has to be left free to emit the click, or whatever
+    owns that point never hears about it."""
+    overlay, _ = build(3, 3)
+    centre = _centre(overlay)
+    _reserve(overlay, centre)
+    overlay._canvas._overlay_consuming_event = False
+
+    overlay._on_press(_event(overlay, *centre))
+
+    assert overlay._canvas._overlay_consuming_event is False
+
+
+def test_a_reserved_press_toggles_no_tile(qapp):
+    """Not claiming is only half of it. A release that still toggled would edit the
+    mask behind a click the user meant for the marker."""
+    overlay, _ = build(3, 3)
+    centre = _centre(overlay)
+    _reserve(overlay, centre)
+    toggled = []
+    overlay.tile_toggled.connect(lambda r, c, e: toggled.append((r, c, e)))
+
+    _click(overlay, *centre)
+
+    assert toggled == []
+
+
+def test_an_unreserved_press_still_toggles(qapp):
+    """The reservation has to be a hole, not a lid. Everywhere else is unchanged."""
+    overlay, _ = build(3, 3)
+    centre = _centre(overlay)
+    left, top, width, height = overlay._bounds()
+    elsewhere = (left + width * 0.9, top + height * 0.9)
+    _reserve(overlay, centre)
+    toggled = []
+    overlay.tile_toggled.connect(lambda r, c, e: toggled.append((r, c, e)))
+
+    _click(overlay, *elsewhere)
+
+    assert len(toggled) == 1
+
+
+def test_clearing_the_reservation_gives_the_point_back(qapp):
+    """The guard must not outlive the state it reads."""
+    overlay, _ = build(3, 3)
+    centre = _centre(overlay)
+    _reserve(overlay, centre)
+    toggled = []
+    overlay.tile_toggled.connect(lambda r, c, e: toggled.append((r, c, e)))
+    _click(overlay, *centre)
+    assert toggled == [], "reserved, so nothing should have toggled"
+
+    overlay.set_reserved(None)
+    _click(overlay, *centre)
+
+    assert len(toggled) == 1
+
+
+def test_an_edge_still_resizes_through_a_reservation(qapp):
+    """Deliberate precedence, not an oversight. A marked position is a far larger
+    target than an edge and would swallow the resize wherever the two meet; a grid
+    whose corner cannot be dragged because a lamella sits near it is the worse trade."""
+    overlay, _ = build(3, 3)
+    right, _ = _edges(overlay)
+    on_the_edge = (right, overlay._rect.cy)
+    _reserve(overlay, on_the_edge)
+    overlay._canvas._overlay_consuming_event = False
+
+    overlay._on_press(_event(overlay, *on_the_edge))
+
+    assert overlay._canvas._overlay_consuming_event is True
+    assert overlay._resize_axes is not None
+
+
+def test_a_reservation_that_raises_does_not_break_the_press(qapp):
+    """The predicate is the host's code running inside a mouse handler. An exception
+    escaping here would abort the press and strand the grid mid-gesture, which is worse
+    than losing the reservation for one click."""
+    overlay, _ = build(3, 3)
+
+    def explode(x, y):
+        raise RuntimeError("host is having a bad day")
+
+    overlay.set_reserved(explode)
+    toggled = []
+    overlay.tile_toggled.connect(lambda r, c, e: toggled.append((r, c, e)))
+
+    _click(overlay, *_centre(overlay))
+
+    assert len(toggled) == 1, "the press should have gone through unreserved"
+
+
+def test_the_cursor_is_left_alone_over_a_reserved_point(qapp):
+    """The pointer is the only warning that a press here will not move the grid. A move
+    cursor over a point the grid has stood aside for is a lie."""
+    overlay, _ = build(3, 3)
+    centre = _centre(overlay)
+    overlay._update_cursor(_event(overlay, *centre))
+    assert overlay._canvas.cursor is not None, "the move cursor should show normally"
+
+    _reserve(overlay, centre)
+    overlay._update_cursor(_event(overlay, *centre))
 
     assert overlay._canvas.cursor is None


### PR DESCRIPTION
From the hardware session: *"selecting lamella positions in overview tab, end up fighting the grid overlay."*

Not a matter of degree — it was impossible.

## What was happening

`TileGridOverlay._on_press` claimed **every** left press inside the grid's bounding box. Claiming suppresses the canvas's `canvas_clicked` signal, which is what stops the view panning out from under a grid drag. Position picking hangs off that signal.

So while a grid was displayed, selecting a marked position inside its footprint could not happen on either tab — and the footprint is exactly where the marked positions are. FIB-524 made it more visible rather than causing it: a lamella now has a box you can aim at, and the aim still couldn't land.

## The fix

`TileGridOverlay.set_reserved(predicate)` lets the host say "this point is mine". When it answers yes the overlay takes no part in the gesture — it doesn't claim the press, so the canvas emits the click, and `_move_start` stays unset so the release schedules no toggle either. That's the same shape as the existing double-click branch, which already had to stand aside for the same reason.

Both tabs wire it to their own `_position_at`, so the grid stands aside for **precisely what a click would otherwise have selected** — including the rule that hidden markers are not targets. One hit test, not two that have to agree.

## Two decisions worth arguing with

- **The check sits after the edge test**, so dragging an edge still resizes. A marked position is a far larger target than an edge and would swallow the resize wherever the two meet; a grid whose corner can't be dragged because a lamella sits near it is the worse trade.
- **The cursor is left alone over a reserved point** rather than showing the move cursor. The pointer is the only warning that a press there won't move the grid, and a move cursor over a point the grid has stood aside for is a lie.

The predicate is host code running inside a mouse handler, so it's called defensively — an exception escaping would abort the press and strand the grid mid-gesture, which is worse than losing the reservation for one click.

## Tests

`tests/ui/test_marked_position_wins_the_click.py` (10) drives the **real dispatch order** — the canvas connects its handlers in `__init__`, before any overlay exists, so a press reaches the canvas and then the overlay — rather than asserting on the seam and hoping the halves meet. Plus 7 overlay-level tests in `test_tile_grid_overlay.py`.

Seven mutations, each killed by the test that should catch it:

| mutation | killed by |
| -- | -- |
| the fix reverted | the reserved-press tests, both levels |
| everything reserved | 18 existing grid tests — the reservation must be a hole, not a lid |
| reservation beats the edge | **only** `test_an_edge_still_resizes_through_a_reservation` |
| beam tab never wires it | the four widget-level tests |
| reservation widened back to the box | the two crosshair-narrowing tests |
| `crosshair_only` ignored | those two, plus `test_selection_still_uses_the_box` |
| cursor still claims a reserved point | **only** `test_the_cursor_is_left_alone_over_a_reserved_point` |

There's a precondition test (`test_the_grid_really_is_over_the_marker`) because without it every other widget test would pass for the wrong reason.

618 tests pass across the overlay, both overview tabs, the FOV box and the sparse entry point. Ruff check and format clean.

## The reservation is the crosshair, not the box

Reserving the whole field-of-view box was the first version and it was too greedy. Measured, box area as a fraction of one tile:

| tile HFW | tile size | box covers |
| -- | -- | -- |
| 50 µm | 50 × 33 µm | **100%** |
| 100 µm | 100 × 67 µm | **100%** |
| 200 µm | 200 × 133 µm | 25% |
| 400 µm | 400 × 267 µm | 6% |

And on the **fluorescence tab it is 100% structurally** — a tile is one camera frame and so is the box — so every lamella would make its own tile untoggleable.

`_position_at` grows a `crosshair_only` flag, used only for the reservation. What a click *selects* is unchanged, so the box keeps its aim benefit everywhere the grid is not contending for the point.

The deciding argument is which error is recoverable. Reserve the crosshair and you may occasionally toggle a tile you meant to select — it greys out visibly and one more click undoes it. Reserve the box and there are tiles you simply cannot toggle, with nothing on screen saying why. **A wrong action that announces itself beats a dead end that does not.**

## Worth checking at the bench

Whether the 12 px crosshair is a comfortable target in practice when a grid is over the markers. It is the same size at every zoom, which is the point, but it is a smaller thing to hit than the box.
