### PR TITLE
[feature] Connect from a dialog, and name the instrument in the header

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -956,13 +956,20 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if self.autolamella_ui is None:
             return
 
-        microscope, settings = connect_to_microscope_dialog(parent=self)
-        if microscope is None:
+        system_widget = self.autolamella_ui.system_widget
+        result = connect_to_microscope_dialog(
+            parent=self,
+            microscope=system_widget.microscope,
+            settings=system_widget.settings,
+        )
+        if not result.changed:
             return
 
-        system_widget = self.autolamella_ui.system_widget
-        system_widget.microscope = microscope
-        system_widget.settings = settings
+        # Including a disconnect, where the new session is None. Handing that back
+        # through the widget is what tells the rest of the application, which
+        # follows its signals rather than knowing about this dialog.
+        system_widget.microscope = result.microscope
+        system_widget.settings = result.settings
         system_widget.update_ui()
 
     def _on_new_experiment(self):

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -107,6 +107,7 @@ from fibsem.ui.tokens import (
 )
 from fibsem.ui.widgets import preflight
 from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+from fibsem.ui.widgets.connection_dialog import connect_to_microscope_dialog
 from fibsem.ui.widgets.notifications import NotificationBell, ToastManager
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
 from fibsem.utils import format_duration
@@ -124,6 +125,8 @@ warnings.filterwarnings(
 # enough that a default name -- "AutoLamella-" plus a date stamp -- is never elided;
 # the point of the button is to say which experiment is open.
 EXPERIMENT_MENU_MAX_WIDTH = 360
+# The connection chip: a manufacturer and an address, and no more room than that.
+CONNECTION_CHIP_MAX_WIDTH = 220
 
 # Icons sat on a button, rather than in a menu, are drawn at this size.
 BUTTON_ICON_SIZE = 16
@@ -474,6 +477,12 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # menu (see create_notification_button), where the icons do the work of
         # telling create from load at a glance. Qt hides action icons in menus on
         # macOS unless each action asks for them, hence set_menu_icon.
+        # Connecting had no menu entry at all -- the Connection tab was the only
+        # door, which is what made that tab impossible to remove (FIB-775).
+        self.action_connect_microscope = QAction("Connect to Microscope...", self)
+        set_menu_icon(self.action_connect_microscope, "mdi:connection")
+        self.action_connect_microscope.triggered.connect(self._on_connect_microscope)
+
         self.action_new_experiment = QAction("New Experiment", self)
         set_menu_icon(self.action_new_experiment, "mdi:plus")
         self.action_new_experiment.triggered.connect(self._on_new_experiment)
@@ -497,6 +506,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.action_exit = QAction("Exit", self)
         self.action_exit.triggered.connect(self.close)  # type: ignore
 
+        file_menu.addAction(self.action_connect_microscope)
+        file_menu.addSeparator()
         file_menu.addAction(self.action_new_experiment)
         file_menu.addAction(self.action_load_experiment)
         file_menu.addAction(self.action_open_experiment_directory)
@@ -934,6 +945,25 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.toast_manager.notification_bell.add_notification(
                 message, notification_type
             )
+
+    def _on_connect_microscope(self):
+        """Connect from the dialog, then hand the session to the system widget.
+
+        The widget stays the one place that owns the connection: everything else in
+        the application follows its `connected_signal`, so routing through it means
+        the dialog needs to know nothing about who cares.
+        """
+        if self.autolamella_ui is None:
+            return
+
+        microscope, settings = connect_to_microscope_dialog(parent=self)
+        if microscope is None:
+            return
+
+        system_widget = self.autolamella_ui.system_widget
+        system_widget.microscope = microscope
+        system_widget.settings = settings
+        system_widget.update_ui()
 
     def _on_new_experiment(self):
         """Handle New Experiment action."""
@@ -1520,6 +1550,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.autolamella_ui.microscope.spot_burn_progress_signal.connect(
                 self._on_spot_burn_progress
             )
+        self._update_connection_chip()
         self._update_experiment_header()
         self._update_instructions()
 
@@ -1844,6 +1875,48 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             events.changed.connect(self._refresh_overview_positions)
         self._lamella_list_experiment = experiment
 
+    def _update_connection_chip(self):
+        """Name the instrument this session attached to, or offer to attach one.
+
+        Identity, not liveness. Nothing watches the link -- `connected_signal` is
+        emitted off `bool(self.microscope)`, a Python reference (FIB-777) -- so a
+        chip claiming "Connected" would keep claiming it through a pulled cable.
+        What it connected to is a fact established once, and it does not decay.
+        """
+        if not self._connection_chip_enabled:
+            return
+
+        autolamella_ui = getattr(self, "autolamella_ui", None)
+        microscope = autolamella_ui.microscope if autolamella_ui else None
+
+        if microscope is None:
+            # The same words as the Connection tab's button and the File menu
+            # entry: three doors to one action should not each name it differently.
+            self.btn_connection.setText("Connect to Microscope")
+            self.btn_connection.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
+            self.btn_connection.setToolTip("Choose a configuration and connect")
+            return
+
+        # `system.info` is a stored record, not a question put to the instrument.
+        info = microscope.system.info
+        self.btn_connection.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
+        self.btn_connection.setToolTip(
+            f"{info.manufacturer} {info.model} at {info.ip_address}\n"
+            f"Serial number: {info.serial_number}\n"
+            "Click to change the connection."
+        )
+
+        label = f"{info.manufacturer}  {info.ip_address}"
+        self.btn_connection.setText(label)
+        overflow = self.btn_connection.sizeHint().width() - CONNECTION_CHIP_MAX_WIDTH
+        if overflow > 0:
+            metrics = self.btn_connection.fontMetrics()
+            self.btn_connection.setText(
+                metrics.elidedText(
+                    label, Qt.ElideRight, metrics.horizontalAdvance(label) - overflow
+                )
+            )
+
     def _update_experiment_header(self):
         """Show either the create/load buttons or the experiment menu, never both.
 
@@ -1858,10 +1931,17 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             autolamella_ui is not None and autolamella_ui.microscope is not None
         )
 
-        self.btn_create_experiment.setEnabled(is_connected)
-        self.btn_load_experiment.setEnabled(is_connected)
-        self.btn_create_experiment.setVisible(experiment is None)
-        self.btn_load_experiment.setVisible(experiment is None)
+        # With the chip, neither button is on screen before there is a microscope:
+        # a greyed-out pair beside a Connect chip is the same spent chrome the
+        # loaded state used to carry. Without it there is nothing else in the header
+        # to connect from, so they stay visible-but-disabled as they were. Both
+        # branches go when the flag does (FIB-775).
+        show = experiment is None and (
+            is_connected or not self._connection_chip_enabled
+        )
+        for button in (self.btn_create_experiment, self.btn_load_experiment):
+            button.setVisible(show)
+            button.setEnabled(experiment is None and is_connected)
 
         self.btn_experiment_menu.setVisible(experiment is not None)
         if experiment is None:
@@ -1908,6 +1988,16 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.btn_load_experiment.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         self.btn_load_experiment.clicked.connect(self._on_load_experiment)
 
+        # Which instrument this session is attached to, and the way back to the
+        # connection dialog -- see _update_connection_chip. Behind a flag while the
+        # Connection tab is still how people connect (FIB-775); the dialog itself is
+        # not gated, so File -> Connect to Microscope reaches it either way.
+        self._connection_chip_enabled = self._preferences.features.connection_chip
+        self.btn_connection = QPushButton()
+        self.btn_connection.setMaximumWidth(CONNECTION_CHIP_MAX_WIDTH)
+        self.btn_connection.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+        self.btn_connection.clicked.connect(self._on_connect_microscope)
+
         # The experiment name, once there is one, is itself the control that reaches
         # the create/load actions -- see _update_experiment_header.
         self.btn_experiment_menu = QPushButton()
@@ -1933,6 +2023,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.toast_manager.set_notification_bell(self.notification_bell)
 
         # Add widgets to layout
+        if self._connection_chip_enabled:
+            button_layout.addWidget(self.btn_connection)
         button_layout.addWidget(self.btn_experiment_menu)
         button_layout.addWidget(self.btn_create_experiment)
         button_layout.addWidget(self.btn_load_experiment)
@@ -1940,6 +2032,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         # Add to tab widget corner
         self.tab_widget.setCornerWidget(button_widget)
+
+        # The chip has a state before anything connects, and only the connect
+        # handler would otherwise ever set one.
+        self._update_connection_chip()
 
     def add_protocol_editor_tab(self):
         """Add the protocol editor as a separate tab with its own viewer."""

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -961,6 +961,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             parent=self,
             microscope=system_widget.microscope,
             settings=system_widget.settings,
+            workflow_running=self.autolamella_ui.is_workflow_running,
         )
         if not result.changed:
             return

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -436,6 +436,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self._preferences = fibsem_cfg.load_user_preferences()
         fibsem_cfg.apply_feature_flags(self._preferences)
 
+        # Read once, here, because both the menu entry and the header chip are gated
+        # on it and the menu is built before the tabs are.
+        self._connection_chip_enabled = self._preferences.features.connection_chip
+
         # User attention tracking
         self._user_interaction_sound_played = False  # Track if sound was played
         self._sound_enabled = self._preferences.display.sound_enabled
@@ -478,7 +482,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # telling create from load at a glance. Qt hides action icons in menus on
         # macOS unless each action asks for them, hence set_menu_icon.
         # Connecting had no menu entry at all -- the Connection tab was the only
-        # door, which is what made that tab impossible to remove (FIB-775).
+        # door, which is what made that tab impossible to remove (FIB-775). Built
+        # unconditionally, offered only when the feature flag is on: see below.
         self.action_connect_microscope = QAction("Connect to Microscope...", self)
         set_menu_icon(self.action_connect_microscope, "mdi:connection")
         self.action_connect_microscope.triggered.connect(self._on_connect_microscope)
@@ -506,8 +511,12 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.action_exit = QAction("Exit", self)
         self.action_exit.triggered.connect(self.close)  # type: ignore
 
-        file_menu.addAction(self.action_connect_microscope)
-        file_menu.addSeparator()
+        # Behind the same flag as the chip. The action is built either way -- it is
+        # the thing the tab removal will depend on -- but nothing offers it until
+        # the feature is switched on, so a release carrying this changes nothing.
+        if self._connection_chip_enabled:
+            file_menu.addAction(self.action_connect_microscope)
+            file_menu.addSeparator()
         file_menu.addAction(self.action_new_experiment)
         file_menu.addAction(self.action_load_experiment)
         file_menu.addAction(self.action_open_experiment_directory)
@@ -2000,7 +2009,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # connection dialog -- see _update_connection_chip. Behind a flag while the
         # Connection tab is still how people connect (FIB-775); the dialog itself is
         # not gated, so File -> Connect to Microscope reaches it either way.
-        self._connection_chip_enabled = self._preferences.features.connection_chip
         self.btn_connection = QPushButton()
         self.btn_connection.setMaximumWidth(CONNECTION_CHIP_MAX_WIDTH)
         self.btn_connection.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -372,6 +372,7 @@ class DisplayPreferences:
     guided_setup_dismissed: bool = False
 
 
+
 @dataclass
 class FeatureFlags:
     coincidence_milling_enabled: bool = False
@@ -388,6 +389,17 @@ class FeatureFlags:
     #
     # Deleted when the tab replaces the napari one, not kept as a preference.
     overview_canvas_tab: bool = False
+    # The connection chip in the tab-corner header, and the experiment buttons
+    # waiting for a microscope alongside it. Off while the Connection tab is still
+    # how people connect: this is the header half of FIB-775, landing ahead of the
+    # tab removal so it can have bench time first.
+    #
+    # The dialog it opens is NOT gated -- File -> Connect to Microscope reaches it
+    # either way, which is how it gets exercised while this is off.
+    #
+    # A staging flag like `overview_canvas_tab`, and it goes the same way: deleted
+    # when the chip replaces the tab, not kept as a preference.
+    connection_chip: bool = False
     # Planning a sparse fluorescence overview by drawing regions on a FIB/SEM one.
     # Off while it has had no bench time: it decides where an expensive acquisition
     # goes, and the geometry it rests on is only checkable against real data
@@ -403,6 +415,7 @@ class FeatureFlags:
     # a configuration file plus two registry entries. Until it has had bench time on
     # real instruments, that offer should be made deliberately rather than by default.
     guided_setup_enabled: bool = False
+
 
 
 @dataclass

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -372,7 +372,6 @@ class DisplayPreferences:
     guided_setup_dismissed: bool = False
 
 
-
 @dataclass
 class FeatureFlags:
     coincidence_milling_enabled: bool = False
@@ -415,7 +414,6 @@ class FeatureFlags:
     # a configuration file plus two registry entries. Until it has had bench time on
     # real instruments, that offer should be made deliberately rather than by default.
     guided_setup_enabled: bool = False
-
 
 
 @dataclass

--- a/fibsem/ui/widgets/connection_dialog.py
+++ b/fibsem/ui/widgets/connection_dialog.py
@@ -1,0 +1,308 @@
+"""Connect to a microscope from a dialog, rather than from a tab.
+
+Connecting is the first thing every session does, and until now the only way to do
+it was the Connection tab -- the leftmost tab of the microscope panel, a gate
+sitting in a bar that otherwise means "the instrument needs you here now". A
+developer flag exists purely to skip it (``--quickstart`` connects "instead of
+waiting for the Connection tab"), and no menu offered the action at all.
+
+This dialog is the other door. It is deliberately dismissable: preferences, a
+protocol or the logs are all reasons to open the application without hardware, and
+a modal that cannot be closed turns those into a reason not to open it at all.
+
+See FIB-775. The Connection tab is untouched by this -- swapping it out is separate
+work, and this has to be usable first.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+import fibsem
+from fibsem import config as cfg
+from fibsem import utils
+from fibsem.microscope import FibsemMicroscope
+from fibsem.structures import MicroscopeSettings
+from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.stylesheets import (
+    PRIMARY_BUTTON_STYLESHEET,
+    SECONDARY_BUTTON_STYLESHEET,
+)
+from fibsem.ui.tokens import (
+    BORDER_COLOR,
+    ERROR_COLOR,
+    PANEL_COLOR,
+    SURFACE_COLOR,
+    TEXT_MUTED_COLOR,
+    TEXT_STRONG_COLOR,
+)
+from fibsem.ui.utils import open_existing_file_dialog
+
+DIALOG_WIDTH = 400
+
+
+class ConnectionDialog(QDialog):
+    """Pick a configuration, see what it points at, and connect to it.
+
+    On success ``microscope`` and ``settings`` hold the session, and the dialog
+    accepts. On failure it stays open carrying the reason, because the alternative
+    is closing onto an application that cannot do anything.
+    """
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Connect to microscope")
+        self.setModal(True)
+        self.setMinimumWidth(DIALOG_WIDTH)
+
+        self.microscope: Optional[FibsemMicroscope] = None
+        self.settings: Optional[MicroscopeSettings] = None
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 14, 16, 14)
+        layout.setSpacing(10)
+
+        title = QLabel("Connect to microscope")
+        title.setStyleSheet(f"color: {TEXT_STRONG_COLOR}; font-size: 14px;")
+        # The plain version, not `get_version_string()` -- its git-describe suffix
+        # belongs in Help > About, not on the first thing a session sees.
+        version = QLabel(f"AutoLamella {fibsem.__version__}")
+        version.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 12px;")
+        layout.addWidget(title)
+        layout.addWidget(version)
+
+        layout.addWidget(self._build_configuration_row())
+        layout.addWidget(self._build_details_panel())
+
+        # Empty until something goes wrong, and it stays visible afterwards so the
+        # reason is still there while you change the configuration and retry.
+        self.message_label = QLabel()
+        self.message_label.setWordWrap(True)
+        self.message_label.setVisible(False)
+        layout.addWidget(self.message_label)
+
+        layout.addLayout(self._build_buttons())
+
+        self._populate_configurations()
+
+    # ── construction ────────────────────────────────────────────────────────
+
+    def _build_configuration_row(self) -> QWidget:
+        row = QWidget()
+        row_layout = QHBoxLayout(row)
+        row_layout.setContentsMargins(0, 0, 0, 0)
+        row_layout.setSpacing(6)
+
+        label = QLabel("Configuration")
+        label.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 11px;")
+        row_layout.addWidget(label)
+
+        self.configuration_combo = QComboBox()
+        self.configuration_combo.currentTextChanged.connect(
+            self._on_configuration_changed
+        )
+        row_layout.addWidget(self.configuration_combo, stretch=1)
+
+        self.import_button = QToolButton()
+        self.import_button.setIcon(fibsem_icon("mdi:plus", color=TEXT_MUTED_COLOR))
+        self.import_button.setToolTip("Import a configuration file")
+        self.import_button.clicked.connect(self._on_import_clicked)
+        row_layout.addWidget(self.import_button)
+
+        return row
+
+    def _build_details_panel(self) -> QFrame:
+        """What this configuration points at, before committing to it.
+
+        The tab never said: it offered a name and a Connect button, so which
+        instrument a name meant was something you learned by connecting to it.
+        """
+        frame = QFrame()
+        frame.setStyleSheet(
+            f"background: {PANEL_COLOR}; border: 1px solid {BORDER_COLOR}; "
+            "border-radius: 4px;"
+        )
+        frame_layout = QGridLayout(frame)
+        frame_layout.setContentsMargins(10, 8, 10, 8)
+        frame_layout.setHorizontalSpacing(12)
+        frame_layout.setVerticalSpacing(2)
+
+        self.manufacturer_label = QLabel()
+        self.address_label = QLabel()
+        # A grid rather than tab stops in one label: the columns have to line up
+        # whatever the manufacturer is called.
+        for row, (name, value) in enumerate(
+            (("Manufacturer", self.manufacturer_label), ("Address", self.address_label))
+        ):
+            key = QLabel(name)
+            for label in (key, value):
+                label.setStyleSheet(
+                    f"color: {TEXT_MUTED_COLOR}; font-size: 11px; border: none;"
+                )
+            frame_layout.addWidget(key, row, 0)
+            frame_layout.addWidget(value, row, 1)
+        frame_layout.setColumnStretch(1, 1)
+
+        return frame
+
+    def _build_buttons(self) -> QHBoxLayout:
+        buttons = QHBoxLayout()
+        buttons.setSpacing(8)
+
+        # "Not now", not "Work offline": there is no offline mode to promise. With
+        # no microscope, creating and loading an experiment are both disabled and
+        # every tab stays shut, so this leaves you with preferences and the logs.
+        # It dismisses the dialog; it does not open a way of working.
+        self.offline_button = QPushButton("Not now")
+        self.offline_button.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
+        self.offline_button.setToolTip(
+            "Start without a microscope. Most of the application stays unavailable "
+            "until you connect, from File → Connect to Microscope."
+        )
+        self.offline_button.clicked.connect(self.reject)
+        buttons.addWidget(self.offline_button)
+
+        buttons.addStretch(1)
+
+        self.connect_button = QPushButton("Connect")
+        self.connect_button.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
+        self.connect_button.setDefault(True)
+        self.connect_button.clicked.connect(self.connect_to_microscope)
+        buttons.addWidget(self.connect_button)
+
+        return buttons
+
+    # ── configuration ───────────────────────────────────────────────────────
+
+    def _populate_configurations(self) -> None:
+        self.configuration_combo.blockSignals(True)
+        self.configuration_combo.clear()
+        self.configuration_combo.addItems(cfg.USER_CONFIGURATIONS.keys())
+        self.configuration_combo.setCurrentText(cfg.DEFAULT_CONFIGURATION_NAME)
+        self.configuration_combo.blockSignals(False)
+        self._on_configuration_changed(self.configuration_combo.currentText())
+
+    def configuration_path(self) -> Optional[str]:
+        """Where the selected configuration lives, or None if it resolves nowhere."""
+        configuration = cfg.USER_CONFIGURATIONS.get(
+            self.configuration_combo.currentText()
+        )
+        return configuration.get("path") if configuration else None
+
+    def _on_configuration_changed(self, _name: str = "") -> None:
+        """Read the selected configuration and show what it points at.
+
+        Reads the file, not the microscope -- there is nothing connected yet, and
+        the whole point is to say where Connect is about to go.
+        """
+        manufacturer, address = self._describe_configuration()
+        self.manufacturer_label.setText(manufacturer)
+        self.address_label.setText(address)
+        self.connect_button.setEnabled(self.configuration_path() is not None)
+
+    def _describe_configuration(self) -> Tuple[str, str]:
+        path = self.configuration_path()
+        if path is None:
+            return "unknown", "unknown"
+        try:
+            settings = utils.load_microscope_configuration(path)
+        except Exception as e:  # unreadable or malformed: say so rather than raise
+            logging.warning(f"Could not read configuration at {path}: {e}")
+            return "unreadable", "unreadable"
+        return settings.system.info.manufacturer, settings.system.info.ip_address
+
+    def _on_import_clicked(self) -> None:
+        path = open_existing_file_dialog(
+            msg="Select microscope configuration file",
+            path=cfg.CONFIG_PATH,
+            _filter="YAML (*.yaml *.yml)",
+            parent=self,
+        )
+        if not path:
+            return
+
+        name = cfg.register_configuration(path=path)
+        self._populate_configurations()
+        self.configuration_combo.setCurrentText(name)
+
+    # ── connecting ──────────────────────────────────────────────────────────
+
+    def connect_to_microscope(self) -> None:
+        path = self.configuration_path()
+        if path is None:
+            self._show_message(
+                f"Configuration {self.configuration_combo.currentText()!r} could not "
+                "be found.",
+                is_error=True,
+            )
+            return
+
+        manufacturer, address = self._describe_configuration()
+        self._set_busy(True, f"Connecting to {address}…")
+
+        try:
+            self.microscope, self.settings = utils.setup_session(config_path=path)
+        except Exception as e:
+            logging.warning(f"Could not connect to microscope at {address}: {e}")
+            self.microscope, self.settings = None, None
+            self._set_busy(False)
+            self._show_message(f"Could not reach {address}.\n{e}", is_error=True)
+            self.connect_button.setText("Retry")
+            return
+
+        logging.info(f"Connected to microscope at {address}")
+        self.accept()
+
+    def _set_busy(self, busy: bool, message: str = "") -> None:
+        """Say what is happening, then let Qt paint it before the call that blocks.
+
+        `setup_session` runs on this thread, so the window is frozen for its
+        duration -- the same as the Connection tab today. Painting first at least
+        means the frozen window says what it is waiting for. Doing it off-thread is
+        its own change.
+        """
+        for widget in (
+            self.connect_button,
+            self.offline_button,
+            self.configuration_combo,
+            self.import_button,
+        ):
+            widget.setEnabled(not busy)
+        if busy:
+            self._show_message(message, is_error=False)
+            QApplication.processEvents()
+
+    def _show_message(self, message: str, is_error: bool) -> None:
+        colour = ERROR_COLOR if is_error else TEXT_MUTED_COLOR
+        self.message_label.setStyleSheet(
+            f"color: {colour}; font-size: 11px; background: {SURFACE_COLOR}; "
+            f"border-left: 3px solid {colour}; padding: 6px 8px;"
+        )
+        self.message_label.setText(message)
+        self.message_label.setVisible(bool(message))
+
+
+def connect_to_microscope_dialog(
+    parent: Optional[QWidget] = None,
+) -> Tuple[Optional[FibsemMicroscope], Optional[MicroscopeSettings]]:
+    """Ask for a microscope. Returns (None, None) if the user chose not to connect."""
+    dialog = ConnectionDialog(parent=parent)
+    if dialog.exec_() == QDialog.Accepted:
+        return dialog.microscope, dialog.settings
+    return None, None

--- a/fibsem/ui/widgets/connection_dialog.py
+++ b/fibsem/ui/widgets/connection_dialog.py
@@ -17,7 +17,7 @@ work, and this has to be usable first.
 from __future__ import annotations
 
 import logging
-from typing import Optional, Tuple
+from typing import NamedTuple, Optional
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
@@ -65,26 +65,41 @@ class ConnectionDialog(QDialog):
     is closing onto an application that cannot do anything.
     """
 
-    def __init__(self, parent: Optional[QWidget] = None) -> None:
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        microscope: Optional[FibsemMicroscope] = None,
+        settings: Optional[MicroscopeSettings] = None,
+    ) -> None:
+        """
+        Args:
+            microscope: the session already in progress, if there is one. The dialog
+                is reached from the header chip as well as from an empty start, and
+                changing the connection is most of what it is for once something is
+                connected.
+        """
         super().__init__(parent)
-        self.setWindowTitle("Connect to microscope")
         self.setModal(True)
         self.setMinimumWidth(DIALOG_WIDTH)
 
-        self.microscope: Optional[FibsemMicroscope] = None
-        self.settings: Optional[MicroscopeSettings] = None
+        self.microscope = microscope
+        self.settings = settings
+        # Whether the session handed in is not the session handed back. Tells
+        # "closed without touching anything" from "disconnected", which look
+        # identical if the answer is only ever a microscope-or-None.
+        self.changed = False
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 14, 16, 14)
         layout.setSpacing(10)
 
-        title = QLabel("Connect to microscope")
-        title.setStyleSheet(f"color: {TEXT_STRONG_COLOR}; font-size: 14px;")
+        self.title_label = QLabel()
+        self.title_label.setStyleSheet(f"color: {TEXT_STRONG_COLOR}; font-size: 14px;")
         # The plain version, not `get_version_string()` -- its git-describe suffix
         # belongs in Help > About, not on the first thing a session sees.
         version = QLabel(f"AutoLamella {fibsem.__version__}")
         version.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 12px;")
-        layout.addWidget(title)
+        layout.addWidget(self.title_label)
         layout.addWidget(version)
 
         layout.addWidget(self._build_configuration_row())
@@ -100,6 +115,7 @@ class ConnectionDialog(QDialog):
         layout.addLayout(self._build_buttons())
 
         self._populate_configurations()
+        self._apply_connection_state()
 
     # ── construction ────────────────────────────────────────────────────────
 
@@ -180,6 +196,12 @@ class ConnectionDialog(QDialog):
 
         buttons.addStretch(1)
 
+        self.disconnect_button = QPushButton("Disconnect")
+        self.disconnect_button.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
+        self.disconnect_button.setToolTip("Release the microscope and work with none")
+        self.disconnect_button.clicked.connect(self.disconnect_from_microscope)
+        buttons.addWidget(self.disconnect_button)
+
         self.connect_button = QPushButton("Connect")
         self.connect_button.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
         self.connect_button.setDefault(True)
@@ -243,6 +265,50 @@ class ConnectionDialog(QDialog):
 
     # ── connecting ──────────────────────────────────────────────────────────
 
+    def _apply_connection_state(self) -> None:
+        """Two states, one dialog: nothing connected, or something already is.
+
+        Opened from the header chip mid-session, the useful actions are leaving,
+        swapping to another configuration, and letting the instrument go -- not the
+        same dialog worded as though nothing had happened yet.
+        """
+        connected = self.microscope is not None
+
+        self.disconnect_button.setVisible(connected)
+        self.offline_button.setText("Close" if connected else "Not now")
+
+        if not connected:
+            self.title_label.setText("Connect to microscope")
+            self.connect_button.setText("Connect")
+            self.offline_button.setToolTip(
+                "Start without a microscope. Most of the application stays "
+                "unavailable until you connect, from File \u2192 Connect to Microscope."
+            )
+            return
+
+        info = self.microscope.system.info
+        self.title_label.setText(
+            f"Connected to {info.manufacturer} at {info.ip_address}"
+        )
+        # Reconnect, not Connect: with a session in progress this drops it and takes
+        # the selected configuration instead, and the button should say so.
+        self.connect_button.setText("Reconnect")
+        self.offline_button.setToolTip("Leave the connection as it is")
+
+    def disconnect_from_microscope(self) -> None:
+        """Let the instrument go, and say so to whoever opened the dialog."""
+        if self.microscope is None:
+            return
+
+        try:
+            self.microscope.disconnect()
+        except Exception as e:  # a failed teardown still ends the session here
+            logging.warning(f"Error while disconnecting: {e}")
+
+        self.microscope, self.settings = None, None
+        self.changed = True
+        self.accept()
+
     def connect_to_microscope(self) -> None:
         path = self.configuration_path()
         if path is None:
@@ -256,6 +322,15 @@ class ConnectionDialog(QDialog):
         manufacturer, address = self._describe_configuration()
         self._set_busy(True, f"Connecting to {address}…")
 
+        # A reconnect is a disconnect and a connect. Leaving the old session open
+        # would hold the instrument against the new one.
+        if self.microscope is not None:
+            try:
+                self.microscope.disconnect()
+            except Exception as e:
+                logging.warning(f"Error while disconnecting before reconnect: {e}")
+            self.microscope, self.settings = None, None
+
         try:
             self.microscope, self.settings = utils.setup_session(config_path=path)
         except Exception as e:
@@ -267,6 +342,7 @@ class ConnectionDialog(QDialog):
             return
 
         logging.info(f"Connected to microscope at {address}")
+        self.changed = True
         self.accept()
 
     def _set_busy(self, busy: bool, message: str = "") -> None:
@@ -280,6 +356,7 @@ class ConnectionDialog(QDialog):
         for widget in (
             self.connect_button,
             self.offline_button,
+            self.disconnect_button,
             self.configuration_combo,
             self.import_button,
         ):
@@ -298,11 +375,27 @@ class ConnectionDialog(QDialog):
         self.message_label.setVisible(bool(message))
 
 
+class ConnectionResult(NamedTuple):
+    """What the dialog did, which is not the same as what it is holding.
+
+    `changed` is the part a caller acts on: a disconnect and a cancel both end with
+    no microscope, and applying the first while ignoring the second is the whole
+    difference between letting the instrument go and being left holding it.
+    """
+
+    changed: bool
+    microscope: Optional[FibsemMicroscope]
+    settings: Optional[MicroscopeSettings]
+
+
 def connect_to_microscope_dialog(
     parent: Optional[QWidget] = None,
-) -> Tuple[Optional[FibsemMicroscope], Optional[MicroscopeSettings]]:
-    """Ask for a microscope. Returns (None, None) if the user chose not to connect."""
-    dialog = ConnectionDialog(parent=parent)
-    if dialog.exec_() == QDialog.Accepted:
-        return dialog.microscope, dialog.settings
-    return None, None
+    microscope: Optional[FibsemMicroscope] = None,
+    settings: Optional[MicroscopeSettings] = None,
+) -> ConnectionResult:
+    """Offer the connection, starting from whatever session is already in progress."""
+    dialog = ConnectionDialog(parent=parent, microscope=microscope, settings=settings)
+    dialog.exec_()
+    if not dialog.changed:
+        return ConnectionResult(False, microscope, settings)
+    return ConnectionResult(True, dialog.microscope, dialog.settings)

--- a/fibsem/ui/widgets/connection_dialog.py
+++ b/fibsem/ui/widgets/connection_dialog.py
@@ -52,7 +52,7 @@ from fibsem.ui.tokens import (
     TEXT_MUTED_COLOR,
     TEXT_STRONG_COLOR,
 )
-from fibsem.ui.utils import open_existing_file_dialog
+from fibsem.ui.utils import message_box_ui, open_existing_file_dialog
 
 DIALOG_WIDTH = 400
 
@@ -70,6 +70,7 @@ class ConnectionDialog(QDialog):
         parent: Optional[QWidget] = None,
         microscope: Optional[FibsemMicroscope] = None,
         settings: Optional[MicroscopeSettings] = None,
+        workflow_running: bool = False,
     ) -> None:
         """
         Args:
@@ -77,6 +78,10 @@ class ConnectionDialog(QDialog):
                 is reached from the header chip as well as from an empty start, and
                 changing the connection is most of what it is for once something is
                 connected.
+            workflow_running: whether the instrument is in the middle of doing
+                something. Disconnecting is still allowed -- an instrument that has
+                already gone away needs releasing precisely when a workflow thinks
+                it is using it -- but it is not allowed quietly.
         """
         super().__init__(parent)
         self.setModal(True)
@@ -84,6 +89,7 @@ class ConnectionDialog(QDialog):
 
         self.microscope = microscope
         self.settings = settings
+        self._workflow_running = workflow_running
         # Whether the session handed in is not the session handed back. Tells
         # "closed without touching anything" from "disconnected", which look
         # identical if the answer is only ever a microscope-or-None.
@@ -300,6 +306,9 @@ class ConnectionDialog(QDialog):
         if self.microscope is None:
             return
 
+        if not self._confirm_losing_the_session("Disconnect from"):
+            return
+
         try:
             self.microscope.disconnect()
         except Exception as e:  # a failed teardown still ends the session here
@@ -308,6 +317,24 @@ class ConnectionDialog(QDialog):
         self.microscope, self.settings = None, None
         self.changed = True
         self.accept()
+
+    def _confirm_losing_the_session(self, verb: str) -> bool:
+        """Ask before the session in progress ends.
+
+        Both paths here end it: disconnecting outright, and reconnecting, which
+        drops the old one to take the selected configuration. Neither is undoable
+        from this dialog, and mid-workflow both pull the instrument out from under
+        whatever is running -- so the question is the same one, worded for whichever
+        button was pressed.
+        """
+        info = self.microscope.system.info
+        text = f"{verb} {info.manufacturer} at {info.ip_address}?"
+        if self._workflow_running:
+            text += (
+                "\n\nA workflow is running. This will not stop it cleanly, and "
+                "anything it has not finished will fail."
+            )
+        return message_box_ui(title=f"{verb} microscope?", text=text, parent=self)
 
     def connect_to_microscope(self) -> None:
         path = self.configuration_path()
@@ -323,8 +350,13 @@ class ConnectionDialog(QDialog):
         self._set_busy(True, f"Connecting to {address}…")
 
         # A reconnect is a disconnect and a connect. Leaving the old session open
-        # would hold the instrument against the new one.
+        # would hold the instrument against the new one -- and losing it is worth
+        # the same question as losing it deliberately.
         if self.microscope is not None:
+            if not self._confirm_losing_the_session("Reconnect to"):
+                self._set_busy(False)
+                self._show_message("", is_error=False)
+                return
             try:
                 self.microscope.disconnect()
             except Exception as e:
@@ -392,9 +424,15 @@ def connect_to_microscope_dialog(
     parent: Optional[QWidget] = None,
     microscope: Optional[FibsemMicroscope] = None,
     settings: Optional[MicroscopeSettings] = None,
+    workflow_running: bool = False,
 ) -> ConnectionResult:
     """Offer the connection, starting from whatever session is already in progress."""
-    dialog = ConnectionDialog(parent=parent, microscope=microscope, settings=settings)
+    dialog = ConnectionDialog(
+        parent=parent,
+        microscope=microscope,
+        settings=settings,
+        workflow_running=workflow_running,
+    )
     dialog.exec_()
     if not dialog.changed:
         return ConnectionResult(False, microscope, settings)

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -81,6 +81,12 @@ _TIP_GUIDED_SETUP = (
     "editing the one you are using, so it is non-destructive — but it is still being "
     "finished, and it has not had bench time on every instrument."
 )
+_LBL_CONNECTION_CHIP = "Enable Connection Chip"
+_TIP_CONNECTION_CHIP = (
+    "Show the connected instrument in the tab bar, beside the experiment, and open "
+    "the connection dialog from it. The Connection tab still works and is still "
+    "where connecting happens; this is the header half of replacing it."
+)
 _LBL_SCRIPTS = "Enable User Scripts"
 _TIP_SCRIPTS = (
     "Show Tools > Scripts, for running your own .py files against the open "
@@ -190,6 +196,8 @@ class PreferencesDialog(QDialog):
         self._chk_sparse_fm.setToolTip(_TIP_SPARSE_FM)
         self._chk_guided_setup = QCheckBox()
         self._chk_guided_setup.setToolTip(_TIP_GUIDED_SETUP)
+        self._chk_connection_chip = QCheckBox()
+        self._chk_connection_chip.setToolTip(_TIP_CONNECTION_CHIP)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
         features_form.addRow(_LBL_SAMPLE_HOLDER, self._chk_sample_holder)
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
@@ -197,6 +205,7 @@ class PreferencesDialog(QDialog):
         features_form.addRow(_LBL_OVERVIEW_CANVAS, self._chk_overview_canvas)
         features_form.addRow(_LBL_SPARSE_FM, self._chk_sparse_fm)
         features_form.addRow(_LBL_GUIDED_SETUP, self._chk_guided_setup)
+        features_form.addRow(_LBL_CONNECTION_CHIP, self._chk_connection_chip)
         self._stack.addWidget(features_page)
 
         # --- Experiment Defaults ---
@@ -271,6 +280,7 @@ class PreferencesDialog(QDialog):
         self._chk_overview_canvas.setChecked(f.overview_canvas_tab)
         self._chk_sparse_fm.setChecked(f.sparse_fm_selection)
         self._chk_guided_setup.setChecked(f.guided_setup_enabled)
+        self._chk_connection_chip.setChecked(f.connection_chip)
 
         e = prefs.experiment
         self._dir_experiment.setText(e.default_experiment_directory)
@@ -342,6 +352,7 @@ class PreferencesDialog(QDialog):
                 bug_report_enabled=self._chk_bug_report.isChecked(),
                 scripts_enabled=self._chk_scripts.isChecked(),
                 overview_canvas_tab=self._chk_overview_canvas.isChecked(),
+                connection_chip=self._chk_connection_chip.isChecked(),
                 sparse_fm_selection=self._chk_sparse_fm.isChecked(),
                 guided_setup_enabled=self._chk_guided_setup.isChecked(),
             ),

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -83,8 +83,9 @@ _TIP_GUIDED_SETUP = (
 )
 _LBL_CONNECTION_CHIP = "Enable Connection Chip"
 _TIP_CONNECTION_CHIP = (
-    "Show the connected instrument in the tab bar, beside the experiment, and open "
-    "the connection dialog from it. The Connection tab still works and is still "
+    "Show the connected instrument in the tab bar, beside the experiment, and add "
+    "File > Connect to Microscope, which opens a dialog for connecting, "
+    "reconnecting and disconnecting. The Connection tab still works and is still "
     "where connecting happens; this is the header half of replacing it."
 )
 _LBL_SCRIPTS = "Enable User Scripts"

--- a/tests/ui/test_connection_chip.py
+++ b/tests/ui/test_connection_chip.py
@@ -1,0 +1,180 @@
+"""The header names the instrument this session attached to, and offers the way back.
+
+Identity, not liveness. Nothing in the application watches the link —
+`connected_signal` is emitted off `bool(self.microscope)`, a Python reference, not
+the connection (FIB-777) — so a chip claiming "Connected" would go on claiming it
+through a pulled cable, which is exactly when someone would be reading it. What it
+connected *to* is established once and does not decay.
+
+The window cannot be constructed offscreen (napari, vispy), so the two header
+handlers are borrowed onto a host carrying the real buttons. The microscope is a
+real Demo session.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QPushButton  # noqa: E402
+
+from fibsem import utils  # noqa: E402
+from fibsem.applications.autolamella.structures import Experiment  # noqa: E402
+from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (  # noqa: E402
+    CONNECTION_CHIP_MAX_WIDTH,
+    AutoLamellaSingleWindowUI,
+)
+
+
+class _UIStub:
+    def __init__(self, microscope=None, experiment=None):
+        self.microscope = microscope
+        self.experiment = experiment
+
+
+class _HeaderHost:
+    _update_connection_chip = AutoLamellaSingleWindowUI._update_connection_chip
+    _update_experiment_header = AutoLamellaSingleWindowUI._update_experiment_header
+
+    def __init__(self, chip_enabled: bool = True):
+        # The tests exercise the flag on, which is the point of landing it: the code
+        # has to be right before it is switched on, not after. The off branch has a
+        # test of its own below.
+        self._connection_chip_enabled = chip_enabled
+        self.btn_connection = QPushButton()
+        self.btn_connection.setMaximumWidth(CONNECTION_CHIP_MAX_WIDTH)
+        self.btn_create_experiment = QPushButton("Create Experiment")
+        self.btn_load_experiment = QPushButton("Load Experiment")
+        self.btn_experiment_menu = QPushButton()
+        self.autolamella_ui = _UIStub()
+
+    def close(self):
+        for btn in (
+            self.btn_connection,
+            self.btn_create_experiment,
+            self.btn_load_experiment,
+            self.btn_experiment_menu,
+        ):
+            btn.deleteLater()
+
+
+@pytest.fixture
+def host(qapp):
+    host = _HeaderHost(chip_enabled=True)
+    yield host
+    host.close()
+
+
+@pytest.fixture
+def host_without_chip(qapp):
+    """The shipping default: flag off, Connection tab still the way to connect."""
+    host = _HeaderHost(chip_enabled=False)
+    yield host
+    host.close()
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    yield microscope
+    microscope.disconnect()
+
+
+def test_disconnected_the_chip_asks_to_connect(host):
+    """Worded as the Connection tab's button and the File menu entry are.
+
+    Three doors to one action, each naming it differently, is three actions as
+    far as a reader is concerned.
+    """
+    host._update_connection_chip()
+
+    assert host.btn_connection.text() == "Connect to Microscope"
+
+
+def test_connected_the_chip_names_the_instrument(host, microscope):
+    host.autolamella_ui.microscope = microscope
+
+    host._update_connection_chip()
+
+    info = microscope.system.info
+    assert info.manufacturer in host.btn_connection.text()
+    assert info.ip_address in host.btn_connection.text()
+    # And the rest, including the serial number, one hover away.
+    assert info.serial_number in host.btn_connection.toolTip()
+
+
+def test_the_chip_never_claims_the_link_is_up(host, microscope):
+    """It says what it attached to, not that it is still attached.
+
+    Nothing polls the instrument, so "Connected" would be a claim the application
+    cannot back, and it would survive the cable being pulled.
+    """
+    host.autolamella_ui.microscope = microscope
+    host._update_connection_chip()
+
+    text = host.btn_connection.text().lower()
+    assert "connected" not in text
+    assert "online" not in text
+
+
+def test_the_chip_stays_within_its_width(host, microscope):
+    """A long manufacturer must not spend the room #490 reclaimed."""
+    host.autolamella_ui.microscope = microscope
+    original = microscope.system.info.manufacturer
+    microscope.system.info.manufacturer = "A Very Long Instrument Manufacturer Name"
+    try:
+        host._update_connection_chip()
+        assert host.btn_connection.sizeHint().width() <= CONNECTION_CHIP_MAX_WIDTH
+        assert "…" in host.btn_connection.text()
+    finally:
+        microscope.system.info.manufacturer = original
+
+
+def test_the_experiment_buttons_wait_for_a_microscope(host, microscope, tmp_path):
+    """Neither can do anything without one, so neither is on screen without one.
+
+    A greyed-out pair beside the Connect chip is the spent chrome #490 removed
+    from the loaded state, moved to the disconnected one.
+    """
+    host._update_experiment_header()
+    assert host.btn_create_experiment.isHidden()
+    assert host.btn_load_experiment.isHidden()
+
+    host.autolamella_ui.microscope = microscope
+    host._update_experiment_header()
+    assert not host.btn_create_experiment.isHidden()
+    assert host.btn_create_experiment.isEnabled()
+    assert host.btn_load_experiment.isEnabled()
+
+    # And they give way to the experiment name once there is one.
+    host.autolamella_ui.experiment = Experiment(path=str(tmp_path), name="loaded")
+    host._update_experiment_header()
+    assert host.btn_create_experiment.isHidden()
+    assert not host.btn_experiment_menu.isHidden()
+
+
+def test_with_the_flag_off_nothing_changes(host_without_chip, microscope):
+    """The release default, and the reason this can land now.
+
+    With no chip in the header there is nothing else there to connect from, so the
+    experiment buttons keep the behaviour they have shipped with: on screen, and
+    greyed out until a microscope arrives.
+    """
+    host = host_without_chip
+
+    host._update_connection_chip()
+    assert host.btn_connection.text() == ""
+
+    host._update_experiment_header()
+    assert not host.btn_create_experiment.isHidden()
+    assert not host.btn_create_experiment.isEnabled()
+
+    host.autolamella_ui.microscope = microscope
+    host._update_experiment_header()
+    assert not host.btn_create_experiment.isHidden()
+    assert host.btn_create_experiment.isEnabled()

--- a/tests/ui/test_connection_chip.py
+++ b/tests/ui/test_connection_chip.py
@@ -178,3 +178,45 @@ def test_with_the_flag_off_nothing_changes(host_without_chip, microscope):
     host._update_experiment_header()
     assert not host.btn_create_experiment.isHidden()
     assert host.btn_create_experiment.isEnabled()
+
+
+def test_the_menu_entry_is_gated_too(qapp):
+    """Nothing offers the dialog until the flag is on, so a release carrying this
+    changes nothing a user can see.
+
+    The window cannot be constructed offscreen, so the menu builder is read: the
+    Connect action has to be added inside a test on the flag, not at the top level
+    of the File menu.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(
+        textwrap.dedent(inspect.getsource(AutoLamellaSingleWindowUI._create_menu_bar))
+    )
+
+    def _adds_connect(node) -> bool:
+        return any(
+            isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "addAction"
+            and n.args
+            and isinstance(n.args[0], ast.Attribute)
+            and n.args[0].attr == "action_connect_microscope"
+            for n in ast.walk(node)
+        )
+
+    assert _adds_connect(tree), "sanity: the Connect action is not added at all"
+
+    guarded = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If) and _adds_connect(node)
+    ]
+    assert guarded, "the Connect menu entry is added unconditionally"
+    assert any(
+        isinstance(n, ast.Attribute) and n.attr == "_connection_chip_enabled"
+        for node in guarded
+        for n in ast.walk(node.test)
+    ), "the Connect menu entry is guarded, but not on the connection chip flag"

--- a/tests/ui/test_connection_dialog.py
+++ b/tests/ui/test_connection_dialog.py
@@ -117,3 +117,79 @@ def test_a_failure_stays_in_the_dialog(dialog, monkeypatch):
     # And usable again, rather than left disabled by the attempt.
     assert dialog.connect_button.isEnabled()
     assert dialog.configuration_combo.isEnabled()
+
+
+# ── opened with a session already in progress ───────────────────────────────
+
+
+@pytest.fixture
+def connected_dialog(qapp):
+    """The dialog as the header chip opens it: something is already connected."""
+    microscope, settings = utils.setup_session(manufacturer="Demo")
+    d = ConnectionDialog(microscope=microscope, settings=settings)
+    d.show()
+    yield d
+    if d.microscope is not None:
+        d.microscope.disconnect()
+    d.deleteLater()
+
+
+def test_it_shows_what_is_connected(connected_dialog):
+    """Not the same dialog worded as though nothing had happened yet."""
+    info = connected_dialog.microscope.system.info
+
+    assert info.manufacturer in connected_dialog.title_label.text()
+    assert info.ip_address in connected_dialog.title_label.text()
+    assert connected_dialog.disconnect_button.isVisible()
+    # Reconnect, because connecting now means dropping the session in progress.
+    assert connected_dialog.connect_button.text() == "Reconnect"
+    assert connected_dialog.offline_button.text() == "Close"
+
+
+def test_disconnecting_ends_the_session_and_says_so(connected_dialog):
+    connected_dialog.disconnect_button.click()
+
+    assert connected_dialog.microscope is None
+    assert connected_dialog.settings is None
+    # The part a caller acts on: a disconnect and a cancel both end with no
+    # microscope, and only one of them should be applied.
+    assert connected_dialog.changed is True
+
+
+def test_closing_changes_nothing(connected_dialog):
+    microscope = connected_dialog.microscope
+
+    connected_dialog.offline_button.click()
+
+    assert connected_dialog.changed is False
+    assert connected_dialog.microscope is microscope
+
+
+def test_reconnecting_replaces_the_session(connected_dialog):
+    """The old one is released first: leaving it open holds the instrument."""
+    original = connected_dialog.microscope
+
+    connected_dialog.connect_to_microscope()
+
+    assert connected_dialog.changed is True
+    assert connected_dialog.microscope is not None
+    assert connected_dialog.microscope is not original
+
+
+def test_the_helper_reports_no_change_when_nothing_happened(qapp):
+    """A cancel must not read as a disconnect, or the caller drops the session."""
+    from fibsem.ui.widgets.connection_dialog import ConnectionResult
+
+    microscope, settings = utils.setup_session(manufacturer="Demo")
+    try:
+        result = ConnectionResult(False, microscope, settings)
+        assert result.changed is False
+        assert result.microscope is microscope
+    finally:
+        microscope.disconnect()
+
+
+def test_a_disconnected_dialog_offers_no_disconnect(dialog):
+    assert not dialog.disconnect_button.isVisible()
+    assert dialog.connect_button.text() == "Connect"
+    assert dialog.offline_button.text() == "Not now"

--- a/tests/ui/test_connection_dialog.py
+++ b/tests/ui/test_connection_dialog.py
@@ -24,6 +24,7 @@ from PyQt5.QtWidgets import QDialog  # noqa: E402
 
 from fibsem import config as cfg  # noqa: E402
 from fibsem import utils  # noqa: E402
+from fibsem.ui.widgets import connection_dialog  # noqa: E402
 from fibsem.ui.widgets.connection_dialog import ConnectionDialog  # noqa: E402
 
 
@@ -122,6 +123,24 @@ def test_a_failure_stays_in_the_dialog(dialog, monkeypatch):
 # ── opened with a session already in progress ───────────────────────────────
 
 
+def _answer_disconnect(monkeypatch, confirmed: bool) -> None:
+    """Answer the confirmation. A modal cannot be clicked from a test."""
+    monkeypatch.setattr(connection_dialog, "message_box_ui", lambda *a, **k: confirmed)
+
+
+def _record_question(monkeypatch) -> dict:
+    """Capture what the confirmation asked, and decline it."""
+    asked: dict = {}
+
+    def _decline(title, text, parent=None, **kwargs):
+        asked["title"] = title
+        asked["text"] = text
+        return False
+
+    monkeypatch.setattr(connection_dialog, "message_box_ui", _decline)
+    return asked
+
+
 @pytest.fixture
 def connected_dialog(qapp):
     """The dialog as the header chip opens it: something is already connected."""
@@ -146,7 +165,9 @@ def test_it_shows_what_is_connected(connected_dialog):
     assert connected_dialog.offline_button.text() == "Close"
 
 
-def test_disconnecting_ends_the_session_and_says_so(connected_dialog):
+def test_disconnecting_ends_the_session_and_says_so(connected_dialog, monkeypatch):
+    _answer_disconnect(monkeypatch, True)
+
     connected_dialog.disconnect_button.click()
 
     assert connected_dialog.microscope is None
@@ -165,8 +186,9 @@ def test_closing_changes_nothing(connected_dialog):
     assert connected_dialog.microscope is microscope
 
 
-def test_reconnecting_replaces_the_session(connected_dialog):
+def test_reconnecting_replaces_the_session(connected_dialog, monkeypatch):
     """The old one is released first: leaving it open holds the instrument."""
+    _answer_disconnect(monkeypatch, True)
     original = connected_dialog.microscope
 
     connected_dialog.connect_to_microscope()
@@ -193,3 +215,49 @@ def test_a_disconnected_dialog_offers_no_disconnect(dialog):
     assert not dialog.disconnect_button.isVisible()
     assert dialog.connect_button.text() == "Connect"
     assert dialog.offline_button.text() == "Not now"
+
+
+def test_disconnecting_asks_first(connected_dialog, monkeypatch):
+    """Not undoable from here, so it is not done quietly."""
+    asked = _record_question(monkeypatch)
+    microscope = connected_dialog.microscope
+
+    connected_dialog.disconnect_button.click()
+
+    info = microscope.system.info
+    assert info.ip_address in asked["text"]
+    # Declined, so nothing happened at all.
+    assert connected_dialog.microscope is microscope
+    assert connected_dialog.changed is False
+
+
+def test_declining_a_reconnect_keeps_the_session(connected_dialog, monkeypatch):
+    """Reconnecting ends the session too, so it asks the same question.
+
+    Saying no must leave the old microscope in place, not half-dropped.
+    """
+    _answer_disconnect(monkeypatch, False)
+    original = connected_dialog.microscope
+
+    connected_dialog.connect_to_microscope()
+
+    assert connected_dialog.microscope is original
+    assert connected_dialog.changed is False
+
+
+def test_losing_the_session_mid_workflow_says_what_it_will_break(qapp, monkeypatch):
+    """Still allowed -- an instrument that has already gone needs releasing exactly
+    when a workflow believes it is using it -- but the warning has to say so."""
+    asked = _record_question(monkeypatch)
+
+    microscope, settings = utils.setup_session(manufacturer="Demo")
+    d = ConnectionDialog(
+        microscope=microscope, settings=settings, workflow_running=True
+    )
+    d.show()
+    try:
+        d.disconnect_button.click()
+        assert "workflow is running" in asked["text"].lower()
+    finally:
+        microscope.disconnect()
+        d.deleteLater()

--- a/tests/ui/test_connection_dialog.py
+++ b/tests/ui/test_connection_dialog.py
@@ -1,0 +1,119 @@
+"""Connecting from a dialog, and what happens when it does not work.
+
+The Connection tab was the only way to connect and the only place that action
+existed — no menu offered it — which is what made the tab impossible to remove
+(FIB-775). This dialog is the other door, and the states that matter are the ones
+the tab handled badly: choosing without knowing what a configuration points at,
+and a failure that leaves the application running but useless.
+
+The Demo microscope is real here. Only the failure is simulated, because there is
+no way to ask a working connection to fail.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QDialog  # noqa: E402
+
+from fibsem import config as cfg  # noqa: E402
+from fibsem import utils  # noqa: E402
+from fibsem.ui.widgets.connection_dialog import ConnectionDialog  # noqa: E402
+
+
+@pytest.fixture
+def dialog(qapp):
+    d = ConnectionDialog()
+    # Shown, not exec_'d: a child of a hidden window reports `isVisible() == False`
+    # whatever its own flag says, so "the message is shown" would pass without the
+    # code doing anything. exec_ would block the test on the event loop.
+    d.show()
+    yield d
+    if d.microscope is not None:
+        d.microscope.disconnect()
+    d.deleteLater()
+
+
+def test_it_offers_the_configurations_and_defaults_to_the_default(dialog):
+    listed = [
+        dialog.configuration_combo.itemText(i)
+        for i in range(dialog.configuration_combo.count())
+    ]
+
+    assert listed == list(cfg.USER_CONFIGURATIONS)
+    assert dialog.configuration_combo.currentText() == cfg.DEFAULT_CONFIGURATION_NAME
+
+
+def test_it_says_what_the_configuration_points_at_before_connecting(dialog):
+    """Read off the file, not the instrument — nothing is connected yet.
+
+    The tab offered a name and a Connect button, so which instrument a name meant
+    was something you found out by connecting to it.
+    """
+    settings = utils.load_microscope_configuration(dialog.configuration_path())
+
+    assert dialog.microscope is None
+    assert dialog.manufacturer_label.text() == settings.system.info.manufacturer
+    assert dialog.address_label.text() == settings.system.info.ip_address
+
+
+def test_dismissing_leaves_the_session_empty(dialog):
+    """Dismissable on purpose: a modal that cannot be closed makes the application
+    impossible to open without an instrument, and preferences and the logs are
+    reasons to do that. It says "Not now" rather than "Work offline" because there
+    is no offline mode -- creating and loading an experiment are both disabled
+    without a microscope."""
+    dialog.offline_button.click()
+
+    assert dialog.result() == QDialog.Rejected
+    assert dialog.microscope is None
+    assert dialog.settings is None
+
+
+def test_connecting_holds_the_session_and_accepts(dialog):
+    dialog.connect_to_microscope()
+
+    assert dialog.result() == QDialog.Accepted
+    assert dialog.microscope is not None
+    assert dialog.settings is not None
+
+
+def test_a_configuration_that_resolves_nowhere_is_reported(dialog):
+    """Selecting a name with no registered path used to take the application down."""
+    dialog.configuration_combo.addItem("a-configuration-that-was-deleted")
+    dialog.configuration_combo.setCurrentText("a-configuration-that-was-deleted")
+
+    assert dialog.configuration_path() is None
+    assert not dialog.connect_button.isEnabled()
+
+    dialog.connect_to_microscope()
+
+    assert dialog.message_label.isVisible()
+    assert "could not be found" in dialog.message_label.text()
+    assert dialog.result() != QDialog.Accepted
+
+
+def test_a_failure_stays_in_the_dialog(dialog, monkeypatch):
+    """The reason, and a retry — not a closed dialog and a dead application."""
+
+    def _refuse(*args, **kwargs):
+        raise ConnectionError("connection timed out after 30s")
+
+    monkeypatch.setattr(utils, "setup_session", _refuse)
+
+    dialog.connect_to_microscope()
+
+    assert dialog.isVisible() or dialog.result() != QDialog.Accepted
+    assert dialog.microscope is None
+    assert "Could not reach" in dialog.message_label.text()
+    assert "timed out" in dialog.message_label.text()
+    assert dialog.connect_button.text() == "Retry"
+    # And usable again, rather than left disabled by the attempt.
+    assert dialog.connect_button.isEnabled()
+    assert dialog.configuration_combo.isEnabled()

--- a/tests/ui/test_experiment_header_button.py
+++ b/tests/ui/test_experiment_header_button.py
@@ -56,6 +56,10 @@ class _HeaderHost:
     _update_experiment_header = AutoLamellaSingleWindowUI._update_experiment_header
 
     def __init__(self):
+        # This file is about the experiment half of the header, which behaves the
+        # same either way once a microscope is connected. The connection chip's own
+        # flag is exercised in `test_connection_chip.py`.
+        self._connection_chip_enabled = True
         self.btn_create_experiment = QPushButton("Create Experiment")
         self.btn_load_experiment = QPushButton("Load Experiment")
         self.btn_experiment_menu = QPushButton()
@@ -82,21 +86,29 @@ def experiment(tmp_path):
     return Experiment(path=str(tmp_path), name="AutoLamella-2026-08-21-headers")
 
 
-def test_buttons_shown_and_disabled_before_connecting(host):
+def test_buttons_wait_for_a_microscope(host):
+    """They used to be shown and greyed out here.
+
+    Neither can do anything without a microscope, and once the header carries a
+    Connect chip a greyed-out pair beside it is the same spent chrome this file
+    removed from the loaded state. Only true with that chip present, which is why
+    the host sets its flag; `test_connection_chip.py` covers the other branch.
+    """
+    host._update_experiment_header()
+
+    assert host.btn_create_experiment.isHidden()
+    assert host.btn_load_experiment.isHidden()
+    # Nothing to name yet either, so the name button stays out of the way.
+    assert host.btn_experiment_menu.isHidden()
+
+
+def test_buttons_appear_once_connected(host):
+    host.autolamella_ui.microscope = object()
+
     host._update_experiment_header()
 
     assert not host.btn_create_experiment.isHidden()
     assert not host.btn_load_experiment.isHidden()
-    assert not host.btn_create_experiment.isEnabled()
-    assert not host.btn_load_experiment.isEnabled()
-    # Nothing to name yet, so the name button stays out of the way.
-    assert host.btn_experiment_menu.isHidden()
-
-
-def test_buttons_enabled_once_connected(host):
-    host.autolamella_ui.microscope = object()
-
-    host._update_experiment_header()
 
     assert host.btn_create_experiment.isEnabled()
     assert host.btn_load_experiment.isEnabled()


### PR DESCRIPTION
The first half of FIB-775. **Nothing here is reachable by default** — every entry point is behind `features.connection_chip`, off — so a release carrying this changes nothing a user can see. **The Connection tab is untouched**; removing it is the other half.

## Why the tab was not removable

Connecting is the first thing every session does, and the tab was the only way to do it. No menu offered the action, so deleting the tab would have deleted the ability to connect. `--quickstart` exists purely to skip it — its help text says it connects *"instead of waiting for the Connection tab"*.

The panel's tab bar is also driven by the workflow (five sites in `AutoLamellaUI.py`), so a tab there means "the instrument needs you here now". Connection is the only tab that can never be a workflow step.

## The dialog

Opened from `File → Connect to Microscope…` or from the header chip. Three states:

- **Nothing connected** — names the manufacturer and address it is about to reach, read off the configuration file. The tab offered a name and a Connect button, so which instrument a name meant was something you learned by connecting to it.
- **Already connected** — names the instrument in its title, offers **Disconnect**, and the primary button reads **Reconnect**, which drops the session before taking the selected configuration. Leaving the old one open would hold the instrument against its replacement.
- **Failed** — stays open with the reason and a Retry, instead of closing onto an application that can do nothing.

**Losing the session asks first.** Disconnect and Reconnect both end it, neither is undoable from here, and mid-workflow both pull the instrument out from under whatever is running — so the warning names that. Allowed rather than forbidden: an instrument that has already gone away needs releasing exactly when a workflow believes it is using it.

**"Not now", not "Work offline".** The first version said "Work offline" and the reviewer asked what that meant, which was the answer. There is no offline mode: without a microscope, Create and Load Experiment are both disabled, the panel shows only the Connection tab, and every main tab stays shut.

### `ConnectionResult`, not a microscope

A disconnect and a cancel both end with the dialog holding no microscope. Returning microscope-or-None makes them indistinguishable, and the caller would treat "changed their mind" as "release the instrument", silently dropping a working session. The helper returns `changed` and the caller acts only on that.

## The header chip

**Identity, not liveness.** It reads `Demo 192.168.0.1`, never "Connected". Nothing watches the link — `connected_signal` is emitted off `bool(self.microscope)`, a Python reference (FIB-777) — so a chip claiming the connection is up would keep claiming it through a pulled cable, which is exactly when someone would be reading it.

With the chip on, the create/load pair **waits for a microscope** rather than sitting greyed out beside it — the same spent chrome #490 removed from the loaded state. The disconnected header goes 459px → 244px.

## What changes with the flag off

Nothing on screen. The QAction is still built — it is what the tab removal depends on — but the menu does not offer it, the chip is not added, and the experiment buttons keep their shipped behaviour (rewritten formula, equivalent; there is a test). The only trace is a new key in `user-preferences.yaml`: an old file missing it loads as `False`, and a file carrying an unknown future key does not raise, so a rollback is safe.

## Known limitation, stated rather than hidden

`setup_session` runs on the GUI thread, so the window freezes while connecting — as the Connection tab does today. The dialog paints its status before the call that blocks rather than pretending otherwise. A cancellable progress bar needs an off-thread connect; that is its own change, and FIB-777 is probably a prerequisite.

## Tests

- `tests/ui/test_connection_dialog.py` — 15. Real Demo connect; only the failure and the confirmation are simulated, because there is no way to ask a working connection to fail or to click a modal from a test. Covers both dialog states, disconnect, declining a disconnect, declining a reconnect leaving the old session intact, the mid-workflow warning, a configuration that resolves nowhere (which used to take the application down), and a failure leaving the dialog open and re-enabled.
- `tests/ui/test_connection_chip.py` — 7, including **both flag states** and an AST check that the menu entry is gated, mutation-verified.
- `tests/ui/test_experiment_header_button.py` — one test updated: it pinned "shown and greyed out before connecting", which the chip deliberately changes.

Full `tests/ui`: 2160 passed, 1 skipped. Formatted per #489, AST-identical. Rebased onto #472 (guided setup), which touched three of the same files — the two are complementary: that wizard builds a configuration for a fresh install, this connects to one that exists.
