### PR TITLE
[fix] Report a failed connection instead of aborting (FIB-778)

### DIFF
--- a/fibsem/ui/FibsemSystemSetupWidget.py
+++ b/fibsem/ui/FibsemSystemSetupWidget.py
@@ -384,7 +384,29 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
         is_microscope_connected = bool(self.microscope)
 
         if is_microscope_connected:
-            self.microscope.disconnect()
+            try:
+                self.microscope.disconnect()
+            except Exception as e:
+                # Same reasoning as the connect path below: an exception escaping this
+                # slot is a process abort rather than an error message (FIB-329). A
+                # disconnect can fail for ordinary reasons -- the instrument went away,
+                # the client is already dead -- and none of them are worth losing the
+                # application over.
+                #
+                # Logged rather than only toasted, because a client that would not
+                # close is a leak, and the log is where anyone would look for it.
+                logging.error(f"Could not cleanly disconnect the microscope: {e}")
+                # Phrased as one outcome, not two. The tab *does* drop to disconnected
+                # a line below, so "Disconnect failed" beside a disconnected tab reads
+                # as a contradiction; what actually happened is that we let go of a
+                # client that would not close.
+                notification_service.show_toast(
+                    f"Disconnected, but the client did not close cleanly: {e}", "error"
+                )
+            # Cleared either way, and outside the try for that reason. The request was
+            # to disconnect; holding a client that could not be closed would leave the
+            # tab offering to disconnect something it can no longer reach, with no way
+            # back to a working connection.
             self.microscope, self.settings = None, None
         else:
             notification_service.show_toast("Connecting to microscope...", "info")
@@ -396,14 +418,30 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
                 return
 
             # connect
-            self.microscope, self.settings = utils.setup_session(
-                config_path=configuration_path,
-            )
-
-            # user notification
-            msg = f"Connected to microscope at {self.microscope.system.info.ip_address}"
-            logging.info(msg)
-            notification_service.show_toast(msg, "info")
+            try:
+                self.microscope, self.settings = utils.setup_session(
+                    config_path=configuration_path,
+                )
+            except Exception as e:
+                # Reported, not raised. This runs as a Qt slot, and PyQt5 turns an
+                # unhandled exception in a slot into qFatal -- the entire application
+                # aborts, leaving the traceback and nothing else (FIB-329). Failing to
+                # connect is an ordinary outcome here rather than a defect: the vendor
+                # API may not be installed, the instrument may be off, the address may
+                # belong to a different bay.
+                #
+                # Broad on purpose. The backends raise whatever their own SDK raises,
+                # and the point is that *nothing* from this call reaches Qt -- a
+                # narrower except would leave the abort in place for the exception
+                # nobody predicted, which is the one that will happen.
+                self.microscope, self.settings = None, None
+                logging.error(f"Could not connect to the microscope: {e}")
+                notification_service.show_toast(f"Could not connect: {e}", "error")
+            else:
+                # user notification
+                msg = f"Connected to microscope at {self.microscope.system.info.ip_address}"
+                logging.info(msg)
+                notification_service.show_toast(msg, "info")
 
         self.update_ui()
 

--- a/fibsem/ui/FibsemSystemSetupWidget.py
+++ b/fibsem/ui/FibsemSystemSetupWidget.py
@@ -33,6 +33,11 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
 
         self.microscope: Optional[FibsemMicroscope] = None
         self.settings: Optional[MicroscopeSettings] = None
+        # Why the last attempt failed, or None if the last thing that happened was not
+        # a failure. Held rather than only toasted: toasts are off by default
+        # (`display.toasts_enabled`), so a toast alone turns the crash this guards
+        # against into silence, which is not much of an improvement.
+        self._last_connection_error: Optional[str] = None
 
         # grid layout
         self.gridLayout = QtWidgets.QGridLayout(self)
@@ -241,6 +246,9 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
         )
 
         self._label_status_subtitle = QtWidgets.QLabel("")
+        # Wrapped, because this now carries the reason a connection failed -- a full
+        # sentence from the backend rather than a two-word status.
+        self._label_status_subtitle.setWordWrap(True)
         self._label_status_subtitle.setStyleSheet(
             f"background-color: transparent; color: {NEUTRAL_500}; font-size: 10px; border: none;"
         )
@@ -409,6 +417,9 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
             # back to a working connection.
             self.microscope, self.settings = None, None
         else:
+            # Cleared before the attempt, so a retry never shows the previous reason
+            # beside a connection that is still being made.
+            self._last_connection_error = None
             notification_service.show_toast("Connecting to microscope...", "info")
 
             configuration_path = self.load_configuration(None)
@@ -435,6 +446,7 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
                 # narrower except would leave the abort in place for the exception
                 # nobody predicted, which is the one that will happen.
                 self.microscope, self.settings = None, None
+                self._last_connection_error = str(e)
                 logging.error(f"Could not connect to the microscope: {e}")
                 notification_service.show_toast(f"Could not connect: {e}", "error")
             else:
@@ -495,11 +507,22 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
             )
             self.disconnected_signal.emit()
 
+            # "Not connected" and "tried and failed" are different states, and the
+            # difference is exactly what someone needs. The card says which, and it is
+            # on screen regardless of whether toasts are enabled.
+            failed = self._last_connection_error is not None
             self._label_status_icon.setPixmap(
-                fibsem_icon("mdi:close-circle", color="#f44336").pixmap(20, 20)
+                fibsem_icon(
+                    "mdi:alert-circle" if failed else "mdi:close-circle",
+                    color="#f44336",
+                ).pixmap(20, 20)
             )
-            self._label_status_title.setText("Not Connected")
-            self._label_status_subtitle.setText("No microscope connected")
+            self._label_status_title.setText(
+                "Connection Failed" if failed else "Not Connected"
+            )
+            self._label_status_subtitle.setText(
+                self._last_connection_error or "No microscope connected"
+            )
             self._button_disconnect.setVisible(False)
 
 

--- a/tests/ui/test_system_setup_widget.py
+++ b/tests/ui/test_system_setup_widget.py
@@ -1,0 +1,177 @@
+"""The connection tab, and what it does when connecting does not work.
+
+Failing to connect is an ordinary outcome on this tab -- the vendor API may not be
+installed, the instrument may be off, the address may belong to another bay. What it
+must never be is fatal: this runs as a Qt slot, and PyQt5 turns an unhandled exception
+in a slot into ``qFatal``, which aborts the whole application (FIB-329).
+"""
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from fibsem import utils
+from fibsem.ui import notification_service
+from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
+
+# The real message a ThermoFisher backend raises with no AutoScript on the machine.
+# Verbatim from microscope.py, because the toast shows it and a user reading "not
+# installed" is being told what to do next.
+AUTOSCRIPT_MISSING = (
+    "Autoscript (ThermoFisher) not installed. "
+    "Please see the user guide for installation instructions."
+)
+
+
+@pytest.fixture
+def widget(qapp):
+    w = FibsemSystemSetupWidget()
+    yield w
+    w.deleteLater()
+
+
+@pytest.fixture
+def demo_microscope():
+    """A real Demo session, so the success path is exercised against the object the
+    tab actually goes on to use."""
+    microscope, _ = utils.setup_session(manufacturer="Demo", setup_logging=False)
+    yield microscope
+    microscope.disconnect()
+
+
+@pytest.fixture
+def toasts(monkeypatch):
+    """Collect the toasts rather than showing them."""
+    captured = []
+    monkeypatch.setattr(
+        notification_service,
+        "show_toast",
+        lambda message, level="info", *a, **k: captured.append((level, message)),
+    )
+    return captured
+
+
+def _fail_to_connect(monkeypatch, error: Exception) -> None:
+    """Make the connection attempt raise, the way a real backend would.
+
+    Patched rather than driven by pointing at a real ThermoFisher configuration: that
+    would pass or fail depending on whether the developer's machine has AutoScript,
+    which is the environment dependence FIB-779 is about. The failure being simulated
+    is precisely `setup_session` raising, so patching it is the whole of the fixture.
+    """
+
+    def raise_it(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(utils, "setup_session", raise_it)
+
+
+def test_a_failed_connection_does_not_escape_the_slot(widget, monkeypatch, toasts):
+    """The crash this file exists for: an exception here aborts the process."""
+    _fail_to_connect(monkeypatch, Exception(AUTOSCRIPT_MISSING))
+    monkeypatch.setattr(widget, "load_configuration", lambda *a, **k: "/some/path.yaml")
+
+    widget.connect_to_microscope()  # must not raise
+
+    assert widget.microscope is None
+    assert widget.settings is None
+
+
+def test_a_failed_connection_says_why(widget, monkeypatch, toasts):
+    """Silence would leave someone pressing Connect again with nothing to act on."""
+    _fail_to_connect(monkeypatch, Exception(AUTOSCRIPT_MISSING))
+    monkeypatch.setattr(widget, "load_configuration", lambda *a, **k: "/some/path.yaml")
+
+    widget.connect_to_microscope()
+
+    errors = [message for level, message in toasts if level == "error"]
+    assert errors, "a failed connection reported nothing"
+    assert "not installed" in errors[-1]
+
+
+def test_a_failed_connection_leaves_the_tab_usable(widget, monkeypatch, toasts):
+    """``update_ui`` still has to run, or the tab keeps claiming it is connecting."""
+    _fail_to_connect(monkeypatch, Exception(AUTOSCRIPT_MISSING))
+    monkeypatch.setattr(widget, "load_configuration", lambda *a, **k: "/some/path.yaml")
+
+    widget.connect_to_microscope()
+
+    # Offered again rather than left disabled: the address or the missing API can be
+    # fixed and the button is how you retry.
+    assert widget.pushButton_connect_to_microscope.isEnabled()
+    assert "Connect" in widget.pushButton_connect_to_microscope.text()
+
+
+def test_an_unexpected_failure_is_caught_too(widget, monkeypatch, toasts):
+    """The except is broad on purpose.
+
+    Backends raise whatever their own SDK raises. A narrower catch would leave the
+    abort in place for the exception nobody predicted, which is the one that happens.
+    """
+    _fail_to_connect(monkeypatch, RuntimeError("the SDK returned something odd"))
+    monkeypatch.setattr(widget, "load_configuration", lambda *a, **k: "/some/path.yaml")
+
+    widget.connect_to_microscope()
+
+    assert widget.microscope is None
+
+
+def test_a_failed_disconnect_does_not_escape_the_slot(widget, toasts):
+    """Disconnecting can fail for ordinary reasons -- the instrument went away, the
+    client is already dead -- and none are worth losing the application over."""
+
+    class WillNotClose:
+        def disconnect(self):
+            raise RuntimeError("the client is already gone")
+
+    widget.microscope = WillNotClose()
+
+    widget.connect_to_microscope()  # must not raise
+
+    # One outcome, not two: the tab does drop to disconnected, so the message says
+    # what happened rather than announcing a failure beside a disconnected tab.
+    errors = [message for level, message in toasts if level == "error"]
+    assert any("did not close cleanly" in message for message in errors)
+
+
+def test_a_failed_disconnect_still_lets_go_of_the_microscope(widget, toasts):
+    """Holding a client that would not close leaves the tab offering to disconnect
+    something it can no longer reach, with no way back to a working connection."""
+
+    class WillNotClose:
+        def disconnect(self):
+            raise RuntimeError("the client is already gone")
+
+    widget.microscope = WillNotClose()
+
+    widget.connect_to_microscope()
+
+    assert widget.microscope is None
+    assert widget.settings is None
+
+
+def test_a_successful_disconnect_lets_go_too(widget, toasts, demo_microscope):
+    """The ordinary path, against a real session rather than a stand-in."""
+    widget.microscope = demo_microscope
+
+    widget.connect_to_microscope()
+
+    assert widget.microscope is None
+    assert not [message for level, message in toasts if level == "error"]
+
+
+def test_a_successful_connection_still_reports_and_holds_the_microscope(
+    widget, monkeypatch, toasts, demo_microscope
+):
+    """The else branch. A real Demo session, so the success path is exercised against
+    the object the tab actually goes on to use rather than a stand-in."""
+    monkeypatch.setattr(
+        utils, "setup_session", lambda *a, **k: (demo_microscope, object())
+    )
+    monkeypatch.setattr(widget, "load_configuration", lambda *a, **k: "/some/path.yaml")
+
+    widget.connect_to_microscope()
+
+    assert widget.microscope is demo_microscope
+    infos = [message for level, message in toasts if level == "info"]
+    assert any("Connected to microscope at" in message for message in infos)

--- a/tests/ui/test_system_setup_widget.py
+++ b/tests/ui/test_system_setup_widget.py
@@ -116,6 +116,42 @@ def test_an_unexpected_failure_is_caught_too(widget, monkeypatch, toasts):
     assert widget.microscope is None
 
 
+def test_a_failed_connection_is_visible_without_toasts(widget, monkeypatch, toasts):
+    """Toasts are off by default (`display.toasts_enabled`), and `show_toast`
+    deliberately does not reach notification history -- so a toast alone would turn
+    the crash this guards against into silence. The status card is always on screen.
+    """
+    _fail_to_connect(monkeypatch, Exception(AUTOSCRIPT_MISSING))
+    monkeypatch.setattr(widget, "load_configuration", lambda *a, **k: "/some/path.yaml")
+
+    widget.connect_to_microscope()
+
+    # "Not connected" and "tried and failed" are different states, and the difference
+    # is the whole of what someone needs here.
+    assert widget._label_status_title.text() == "Connection Failed"
+    assert "not installed" in widget._label_status_subtitle.text()
+
+
+def test_a_retry_does_not_show_the_previous_reason(widget, monkeypatch, toasts):
+    """Stale text beside a connection being made reads as a fresh failure."""
+    _fail_to_connect(monkeypatch, Exception(AUTOSCRIPT_MISSING))
+    monkeypatch.setattr(widget, "load_configuration", lambda *a, **k: "/some/path.yaml")
+    widget.connect_to_microscope()
+    assert widget._label_status_title.text() == "Connection Failed"
+
+    # A configuration that is never selected returns before connecting at all.
+    monkeypatch.setattr(widget, "load_configuration", lambda *a, **k: None)
+    widget.connect_to_microscope()
+
+    assert widget._last_connection_error is None
+
+
+def test_a_never_attempted_connection_says_so_plainly(widget):
+    """Nothing has failed yet, so the card must not imply something has."""
+    assert widget._label_status_title.text() == "Not Connected"
+    assert widget._label_status_subtitle.text() == "No microscope connected"
+
+
 def test_a_failed_disconnect_does_not_escape_the_slot(widget, toasts):
     """Disconnecting can fail for ordinary reasons -- the instrument went away, the
     client is already dead -- and none are worth losing the application over."""


### PR DESCRIPTION
Pressing **Connect** with a ThermoFisher configuration on a machine without AutoScript killed the application outright — `Fatal Python error: Aborted`, no dialog, no chance to pick a different configuration.

```
exit code before:  134   (SIGABRT)
exit code after:     0
```

`connect_to_microscope` is a Qt slot and called `utils.setup_session` bare. PyQt5 turns an unhandled exception in a slot into `qFatal`, so **every way a backend can fail to connect was a way to lose the whole application** (FIB-329). Failing to connect is an ordinary outcome on this tab rather than a defect: the vendor API may not be installed, the instrument may be off, the address may belong to a different bay.

## Both directions, because both abort

Disconnecting fails the same way — a dead client, an instrument that went away — and takes the process down identically. They differ in one deliberate detail:

| | where the microscope is cleared | why |
| -- | -- | -- |
| **Connect** fails | inside the `except` | no connection was made |
| **Disconnect** fails | *outside* the `try` | the request was to disconnect |

Holding a client that would not close leaves the tab offering to disconnect something it can no longer reach, with no route back to a working connection. So it is let go either way, and reported as **one outcome rather than two** — *"Disconnected, but the client did not close cleanly"*, because "Disconnect failed" beside a tab that has just gone to disconnected reads as a contradiction. It is logged as well as toasted, since a client that refused to close is a leak and the log is where anyone would look for it.

## Both `except Exception` on purpose

Backends raise whatever their own SDK raises, and the point is that *nothing* from these calls reaches Qt. A narrower catch would leave the abort in place for the exception nobody predicted, which is the one that will happen. Noted in the code, since a bare `except Exception` normally deserves suspicion.

## What verified it, and what could not

**The unit tests cannot reproduce this crash**, and it is worth being explicit about that. `qFatal` fires when an exception escapes a slot *Qt* invoked; calling `connect_to_microscope()` directly — as a test does — never aborts, so those tests would have passed before the fix on that specific point.

What proves it is clicking the button inside a real `QApplication`, against a real ThermoFisher configuration with nothing patched, and reading the process exit code: **134 before, 0 after**.

The eight new tests in `tests/ui/test_system_setup_widget.py` cover the surrounding behaviour instead — the microscope is released, the failure is reported, the tab returns to offering a connection, an unexpected exception type is caught too, and both success paths still work. Each was confirmed to fail with its own guard removed: dropping the connect guard fails five, dropping the disconnect guard fails exactly the two disconnect ones.

`setup_session` is patched rather than pointed at a real ThermoFisher file, deliberately — the latter would pass or fail depending on whether the developer's machine has AutoScript, which is the environment dependence FIB-779 is about.

## Not in scope

**The connection stays on the main thread.** Moving it changes when the microscope object exists relative to everything that touches it, which is a much larger question than this crash — and a real AutoScript connection blocking the UI for seconds is a separate problem from aborting the process. The guided setup wizard already does connect off-thread through a `FunctionWorker`, so the pattern exists if that is wanted later.
