### PR TITLE
[fix] Stop a workflow payload without a message from aborting the app

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1949,9 +1949,22 @@ class AutoLamellaUI(QMainWindow):
                 fluorescence_channel_settings
             )
 
-        # instruction message
+        # Instruction message. Read with `.get`, not indexed: this signal has no
+        # declared contract, and 12 of its 13 emit sites pass an opaque variable, so
+        # what a payload carries is not knowable without running it. Every emitter in
+        # this repository sends `msg` today -- but a raise here does not degrade a
+        # label, it aborts the process. PyQt5 calls `qFatal()` on any exception that
+        # escapes a slot invoked from C++, which a queued signal from the workflow
+        # thread is, and the abort takes the run with it and reaches no logfile
+        # (FIB-329, FIB-402). It has happened: a queue edit put a payload without
+        # `msg` on this signal and killed the app on every queue action.
+        #
+        # The default is `""` rather than a placeholder because an empty message
+        # already means something here: `set_instructions_msg` hides the label, which
+        # is what one emit site sends `{"msg": ""}` deliberately to do. A payload
+        # carrying no message is an update about something other than the prompt.
         self.set_instructions_msg(
-            info["msg"], info.get("pos", None), info.get("neg", None)
+            info.get("msg", ""), info.get("pos", None), info.get("neg", None)
         )
         self.set_current_workflow_message(info.get("workflow_info", None))
 

--- a/tests/ui/test_workflow_timeline_sync.py
+++ b/tests/ui/test_workflow_timeline_sync.py
@@ -13,6 +13,7 @@ or with the previous snapshot; the id is the only stable handle.
 
 Uses the shared offscreen ``qapp`` fixture from tests/conftest.py.
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -60,8 +61,10 @@ def status_for(queue: TaskQueue, item, status, **extra) -> dict:
 
 def labels(widget: WorkflowProgressWidget):
     """(lamella, task) per visible row, read back off the rendered widgets."""
-    return [(r._label.text(), r._subtitle.text().split(" (")[0])
-            for r in widget._outer._rows]
+    return [
+        (r._label.text(), r._subtitle.text().split(" (")[0])
+        for r in widget._outer._rows
+    ]
 
 
 def layout_order(widget: WorkflowProgressWidget):
@@ -82,13 +85,19 @@ def start_next(widget: WorkflowProgressWidget, queue: TaskQueue):
     return item
 
 
-def finish(widget: WorkflowProgressWidget, queue: TaskQueue, item,
-           status=Status.Completed, **extra):
+def finish(
+    widget: WorkflowProgressWidget,
+    queue: TaskQueue,
+    item,
+    status=Status.Completed,
+    **extra,
+):
     queue.mark_done(item, status)
     widget.update_from_status(status_for(queue, item, status, **extra))
 
 
 # ── First paint ───────────────────────────────────────────────────────────────
+
 
 def test_first_status_builds_the_timeline(widget, queue):
     """Regression: this used to need a separate set_workflow() call first."""
@@ -114,6 +123,7 @@ def test_a_second_run_rebuilds_from_scratch(widget, queue):
 
 # ── Add ───────────────────────────────────────────────────────────────────────
 
+
 def test_item_added_mid_run_appears(widget, queue):
     start_next(widget, queue)
     queue.add("L9", "Polish")
@@ -135,6 +145,7 @@ def test_item_added_at_the_front_appears_directly_after_the_active_row(widget, q
 
 
 # ── Remove ────────────────────────────────────────────────────────────────────
+
 
 def test_removed_item_disappears_from_the_timeline(widget, queue):
     start_next(widget, queue)
@@ -206,6 +217,7 @@ def test_removed_item_leaves_both_sides_of_the_header_fraction(widget, queue):
 
 # ── Reorder ───────────────────────────────────────────────────────────────────
 
+
 def test_reorder_moves_the_rows(widget, queue):
     start_next(widget, queue)
     last = queue.pending[-1]
@@ -253,12 +265,16 @@ def test_reorder_carries_the_selection_with_its_row(widget, queue):
 
 # ── The active row survives all of it ─────────────────────────────────────────
 
-@pytest.mark.parametrize("mutate", [
-    pytest.param(lambda q: q.add("L9", "Polish"), id="add"),
-    pytest.param(lambda q: q.add("L9", "Polish", front=True), id="add-front"),
-    pytest.param(lambda q: q.remove(q.pending[-1].id), id="remove"),
-    pytest.param(lambda q: q.move_to_front(q.pending[-1].id), id="reorder"),
-])
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda q: q.add("L9", "Polish"), id="add"),
+        pytest.param(lambda q: q.add("L9", "Polish", front=True), id="add-front"),
+        pytest.param(lambda q: q.remove(q.pending[-1].id), id="remove"),
+        pytest.param(lambda q: q.move_to_front(q.pending[-1].id), id="reorder"),
+    ],
+)
 def test_active_row_keeps_its_inner_steps_and_timer(widget, queue, mutate):
     """_show_inner_at() clears the inner list, so a rebuild on every edit would
     wipe the running task's step history in front of the user."""
@@ -295,6 +311,7 @@ def test_a_reorder_does_not_restart_the_running_task(widget, queue):
 
 
 # ── Statuses still render ─────────────────────────────────────────────────────
+
 
 def test_statuses_track_the_queue_through_a_full_run(widget, queue):
     for _ in range(4):
@@ -348,6 +365,7 @@ def test_what_a_finished_row_says_is_not_wiped_by_a_later_sync(widget, queue):
 
 # ── Through the real TaskManager ──────────────────────────────────────────────
 
+
 class _ParentUI(QObject):
     """The signals TaskManager emits on, declared as real pyqtSignals.
 
@@ -375,6 +393,7 @@ class _NoMicroscope:
     it has to be something attributes can be set on. Same stand-in as
     tests/autolamella/test_task_manager_hooks.py.
     """
+
     fm = None
 
 
@@ -404,8 +423,9 @@ def manager(widget, tmp_path) -> TaskManager:
         lambda info: widget.refresh_queue(info["queue_items"])
     )
 
-    m = TaskManager(microscope=_NoMicroscope(), experiment=experiment,
-                    parent_ui=parent_ui)
+    m = TaskManager(
+        microscope=_NoMicroscope(), experiment=experiment, parent_ui=parent_ui
+    )
     m.queue.build_from_matrix(
         ["Trench", "Undercut"], [p.name for p in experiment.positions]
     )
@@ -421,8 +441,12 @@ def test_the_managers_own_payload_builds_the_timeline(widget, manager):
     item = manager.queue.next()
     emit(manager, item, Status.InProgress)
 
-    assert labels(widget) == [("L1", "Trench"), ("L2", "Trench"),
-                              ("L1", "Undercut"), ("L2", "Undercut")]
+    assert labels(widget) == [
+        ("L1", "Trench"),
+        ("L2", "Trench"),
+        ("L1", "Undercut"),
+        ("L2", "Undercut"),
+    ]
     assert widget._outer_index == 0
     assert widget._outer._steps[0].status is StepStatus.ACTIVE
 
@@ -441,8 +465,11 @@ def test_notify_queue_changed_reaches_the_timeline(widget, manager):
 
 
 def test_notify_queue_changed_is_a_noop_headless(tmp_path):
-    m = TaskManager(microscope=_NoMicroscope(),
-                    experiment=_experiment(tmp_path, names=["L1"]), parent_ui=None)
+    m = TaskManager(
+        microscope=_NoMicroscope(),
+        experiment=_experiment(tmp_path, names=["L1"]),
+        parent_ui=None,
+    )
     m.queue.build_from_matrix(["Trench"], ["L1"])
     m.notify_queue_changed()  # must not raise
 

--- a/tests/ui/test_workflow_timeline_sync.py
+++ b/tests/ui/test_workflow_timeline_sync.py
@@ -472,10 +472,18 @@ def test_task_status_still_goes_out_on_the_workflow_signal(manager):
     assert manager.parent_ui.queue_changes == []
 
 
-def test_every_workflow_update_carries_the_key_its_other_slot_requires(manager):
-    """AutoLamellaUI.handle_workflow_update reads info["msg"] with no default, and
-    PyQt5 aborts the process on an exception escaping a slot. Every payload put on
-    this signal has to satisfy that, whoever emits it."""
+def test_every_workflow_update_carries_a_message(manager):
+    """The prompt is this signal's main job, so a payload should say what to show.
+
+    This used to be load-bearing against a crash: `handle_workflow_update` indexed
+    `info["msg"]`, and PyQt5 aborts the process on an exception escaping a slot, so
+    an emitter that forgot the key killed the app. That handler now reads it with a
+    default and a payload without one clears the prompt, which is a real outcome
+    rather than a fallback -- see `tests/ui/test_workflow_update_payload.py`.
+
+    Kept because the invariant is still worth holding at this end: every payload
+    *these* emitters put on the signal is about the prompt, and one that silently
+    blanked it would be a bug here rather than a crash there."""
     item = manager.queue.next()
     emit(manager, item, Status.InProgress)
     manager.queue.mark_done(item, Status.Completed)

--- a/tests/ui/test_workflow_update_payload.py
+++ b/tests/ui/test_workflow_update_payload.py
@@ -1,0 +1,91 @@
+"""What `AutoLamellaUI.handle_workflow_update` must survive being handed.
+
+`workflow_update_signal` has no declared contract. It has 13 emit sites and 12 of
+them pass an opaque variable, so what a payload carries cannot be established by
+reading the code -- only by running it.
+
+That would be a cosmetic problem in most slots. Here it is not: PyQt5 calls Qt's
+`qFatal()` whenever a Python exception escapes a slot invoked from C++, which a
+queued signal from the workflow thread is. So a missing key is not a blank label,
+it is `SIGABRT` -- the run dies mid-workflow and nothing reaches the logfile
+(FIB-329). Measured on this handler while writing these tests: emitting a payload
+without `msg` through the signal exits **134**, with no traceback in the log.
+
+It has happened. A queue edit put a payload without `msg` on this signal and killed
+the app on every queue action; see `test_a_queue_edit_never_reaches_the_workflow_update_slot`.
+That was fixed at the emitting end, one emitter at a time, and pinned by a test
+that every payload carries `msg`. This is the other end, which is the end that
+holds for emitters nobody has written yet.
+
+These tests call the handler directly rather than emitting. A test that went
+through the signal could not *fail* -- it would abort the pytest process, taking
+the summary with it and naming no test.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+
+
+@pytest.fixture
+def ui(qapp):
+    """A real AutoLamellaUI, connected, without the main window that hosts it.
+
+    Connected because the handler needs `image_widget` and
+    `milling_task_config_widget`, which `update_microscope_ui()` builds. The
+    shipped default configuration is Demo, so this touches no hardware.
+    """
+    widget = AutoLamellaUI(parent_ui=None)
+    widget.system_widget.connect_to_microscope()
+    yield widget
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+
+
+def test_a_payload_without_a_message_does_not_raise(ui):
+    """The regression. Indexing `msg` here aborts the process, not the label."""
+    ui.handle_workflow_update({"status": {}})
+
+
+def test_a_payload_without_a_message_clears_the_prompt(ui):
+    """Not merely "does not raise": an update that says nothing about the prompt
+    must not leave the previous question standing.
+
+    `set_instructions_msg("")` hides the label rather than showing a blank line,
+    which is what one emit site sends `{"msg": ""}` deliberately to do -- so the
+    default and the explicit clear take the same path.
+    """
+    ui.set_instructions_msg("Continue?", "Yes", "No")
+
+    ui.handle_workflow_update({"status": {}})
+
+    assert ui.label_instructions.text() == ""
+    assert not ui.label_instructions.isVisible()
+
+
+def test_a_message_is_still_shown_when_one_is_sent(ui):
+    """The default must not have swallowed the normal path."""
+    ui.handle_workflow_update({"msg": "Select a lamella position", "pos": "Continue"})
+
+    assert ui.label_instructions.text() == "Select a lamella position"
+    assert ui.pushButton_yes.text() == "Continue"
+
+
+def test_the_handler_releases_the_workflow_thread(ui):
+    """Every emitter sets `WAITING_FOR_UI_UPDATE` and then blocks on it in a
+    `while ... time.sleep(0.5)` loop, so the flag is the workflow thread's only way
+    out of that wait. It is cleared on the last line of the handler -- after the
+    message -- so anything that raises on the way there strands the caller as well
+    as killing the process."""
+    ui.WAITING_FOR_UI_UPDATE = True
+
+    ui.handle_workflow_update({"status": {}})
+
+    assert ui.WAITING_FOR_UI_UPDATE is False


### PR DESCRIPTION
`AutoLamellaUI.handle_workflow_update` read `info["msg"]` with no default. PyQt5 calls Qt's `qFatal()` on any exception escaping a slot invoked from C++ — which a queued signal from the workflow thread is — so a payload missing that one key does not blank a label. It takes the process down mid-run, and the abort reaches no logfile.

**Measured while fixing:** emitting `{"status": {}}` through the signal exits **134** (SIGABRT), with no traceback in the log. With the fix, exit 0 and the prompt clears.

## This has already happened

A queue edit put a payload without `msg` on this signal and killed the app on every queue action — see `test_a_queue_edit_never_reaches_the_workflow_update_slot`. It was fixed at the **emitting** end, one emitter at a time, and pinned by a test asserting every payload carries `msg`.

That invariant holds for the emitters that exist. It cannot hold for ones nobody has written yet: `workflow_update_signal` has 13 emit sites and 12 pass an opaque variable, so what a payload carries is not knowable by reading the code. This PR fixes the **consuming** end, which is the end that holds regardless.

## The default

`""`, not a placeholder. An empty message already means something here — `set_instructions_msg` hides the label rather than showing a blank line, and one emit site sends `{"msg": ""}` deliberately to do exactly that. So an update carrying no message clears the prompt, which is the right reading of "this update is about something other than the prompt", and it takes the same path as the explicit clear.

## Context

This is the **last** consumer of any of the six progress signals that indexed its payload — I AST-scanned all 17 handlers; every other one already reads through `.get()`. That completes FIB-402 Part 1, which is what makes the typed-payload migration possible without a flag day: a typed event implementing `.get()` can be emitted with zero consumer changes, per signal.

## Tests

New `tests/ui/test_workflow_update_payload.py` — 4 tests against a real `AutoLamellaUI` connected to the Demo microscope. 3 of the 4 fail (cleanly) with the fix reverted; verified.

They call the handler directly rather than emitting through the signal, deliberately: a test that went through the signal could not *fail*: it would abort the pytest process, taking the summary with it and naming no test.

`test_every_workflow_update_carries_the_key_its_other_slot_requires` is renamed and its rationale corrected — it was justified by the crash this PR removes, and a future reader trusting that reasoning might undo the fix. The invariant is kept, for the reason that still applies.

The reformat of `test_workflow_timeline_sync.py` is a **separate commit** — the content change there is one docstring.

- `tests/ui/`: 2139 passed, 1 skipped.