### PR TITLE
[refactor] Give the connection dialog the status card's shape, not its claim

### DIFF
--- a/fibsem/ui/widgets/connection_dialog.py
+++ b/fibsem/ui/widgets/connection_dialog.py
@@ -25,7 +25,6 @@ from PyQt5.QtWidgets import (
     QComboBox,
     QDialog,
     QFrame,
-    QGridLayout,
     QHBoxLayout,
     QLabel,
     QPushButton,
@@ -154,34 +153,62 @@ class ConnectionDialog(QDialog):
 
         The tab never said: it offered a name and a Connect button, so which
         instrument a name meant was something you learned by connecting to it.
+
+        Laid out as the Connection tab's status card is -- framed panel, icon,
+        bold line, muted line -- so this reads as part of the application rather
+        than a second way of saying the same thing. What it *says* is deliberately
+        not what that card says; see `_set_details`.
         """
         frame = QFrame()
-        frame.setStyleSheet(
-            f"background: {PANEL_COLOR}; border: 1px solid {BORDER_COLOR}; "
-            "border-radius: 4px;"
-        )
-        frame_layout = QGridLayout(frame)
-        frame_layout.setContentsMargins(10, 8, 10, 8)
-        frame_layout.setHorizontalSpacing(12)
-        frame_layout.setVerticalSpacing(2)
+        frame.setObjectName("frame_connection_details")
+        frame.setStyleSheet(f"""
+            QFrame#frame_connection_details {{
+                background-color: {PANEL_COLOR};
+                border-radius: 6px;
+                border: 1px solid {BORDER_COLOR};
+            }}
+        """)
 
-        self.manufacturer_label = QLabel()
-        self.address_label = QLabel()
-        # A grid rather than tab stops in one label: the columns have to line up
-        # whatever the manufacturer is called.
-        for row, (name, value) in enumerate(
-            (("Manufacturer", self.manufacturer_label), ("Address", self.address_label))
-        ):
-            key = QLabel(name)
-            for label in (key, value):
-                label.setStyleSheet(
-                    f"color: {TEXT_MUTED_COLOR}; font-size: 11px; border: none;"
-                )
-            frame_layout.addWidget(key, row, 0)
-            frame_layout.addWidget(value, row, 1)
-        frame_layout.setColumnStretch(1, 1)
+        frame_layout = QHBoxLayout(frame)
+        frame_layout.setContentsMargins(12, 12, 12, 12)
+        frame_layout.setSpacing(10)
+
+        self.details_icon = QLabel()
+        self.details_icon.setStyleSheet("border: none;")
+        self.details_icon.setFixedSize(20, 20)
+        frame_layout.addWidget(self.details_icon)
+
+        text_layout = QVBoxLayout()
+        text_layout.setSpacing(2)
+        self.details_title = QLabel()
+        self.details_title.setStyleSheet(
+            f"background-color: transparent; color: {TEXT_STRONG_COLOR}; "
+            "font-weight: bold; font-size: 11px; border: none;"
+        )
+        self.details_subtitle = QLabel()
+        self.details_subtitle.setStyleSheet(
+            f"background-color: transparent; color: {TEXT_MUTED_COLOR}; "
+            "font-size: 10px; border: none;"
+        )
+        text_layout.addWidget(self.details_title)
+        text_layout.addWidget(self.details_subtitle)
+        frame_layout.addLayout(text_layout)
+        frame_layout.addStretch()
 
         return frame
+
+    def _set_details(self, title: str, subtitle: str, icon: str, colour: str) -> None:
+        """Fill the panel. Absence is knowable; presence is not.
+
+        The Connection tab's card reads "Microscope Connected" over a green tick,
+        and this deliberately does not copy that. Nothing watches the link
+        (FIB-777), so with a session that was opened hours ago a tick asserts
+        something no one has checked. "No microscope connected" is safe in the
+        other direction -- there is nothing to be wrong about.
+        """
+        self.details_icon.setPixmap(fibsem_icon(icon, color=colour).pixmap(20, 20))
+        self.details_title.setText(title)
+        self.details_subtitle.setText(subtitle)
 
     def _build_buttons(self) -> QHBoxLayout:
         buttons = QHBoxLayout()
@@ -239,10 +266,9 @@ class ConnectionDialog(QDialog):
         Reads the file, not the microscope -- there is nothing connected yet, and
         the whole point is to say where Connect is about to go.
         """
-        manufacturer, address = self._describe_configuration()
-        self.manufacturer_label.setText(manufacturer)
-        self.address_label.setText(address)
-        self.connect_button.setEnabled(self.configuration_path() is not None)
+        resolves = self.configuration_path() is not None
+        self.connect_button.setEnabled(resolves)
+        self._refresh_details()
 
     def _describe_configuration(self) -> Tuple[str, str]:
         path = self.configuration_path()
@@ -271,6 +297,35 @@ class ConnectionDialog(QDialog):
 
     # ── connecting ──────────────────────────────────────────────────────────
 
+    def _refresh_details(self) -> None:
+        """Say what is attached, or where Connect is about to go."""
+        if self.microscope is not None:
+            info = self.microscope.system.info
+            self._set_details(
+                f"{info.manufacturer} {info.model}".strip(),
+                f"{info.ip_address}  ·  serial {info.serial_number}",
+                "mdi:microscope",
+                TEXT_STRONG_COLOR,
+            )
+            return
+
+        if self.configuration_path() is None:
+            self._set_details(
+                "No configuration",
+                f"{self.configuration_combo.currentText()} could not be found",
+                "mdi:alert-circle",
+                ERROR_COLOR,
+            )
+            return
+
+        manufacturer, address = self._describe_configuration()
+        self._set_details(
+            "No microscope connected",
+            f"{manufacturer} at {address}",
+            "mdi:close-circle",
+            TEXT_MUTED_COLOR,
+        )
+
     def _apply_connection_state(self) -> None:
         """Two states, one dialog: nothing connected, or something already is.
 
@@ -282,6 +337,7 @@ class ConnectionDialog(QDialog):
 
         self.disconnect_button.setVisible(connected)
         self.offline_button.setText("Close" if connected else "Not now")
+        self._refresh_details()
 
         if not connected:
             self.title_label.setText("Connect to microscope")
@@ -292,10 +348,10 @@ class ConnectionDialog(QDialog):
             )
             return
 
-        info = self.microscope.system.info
-        self.title_label.setText(
-            f"Connected to {info.manufacturer} at {info.ip_address}"
-        )
+        # The panel below names the instrument; the title saying it too is the
+        # duplication this whole batch has been removing. It states what the dialog
+        # is for instead, which is the part that differs between the two states.
+        self.title_label.setText("Microscope connection")
         # Reconnect, not Connect: with a session in progress this drops it and takes
         # the selected configuration instead, and the button should say so.
         self.connect_button.setText("Reconnect")

--- a/fibsem/ui/widgets/connection_dialog.py
+++ b/fibsem/ui/widgets/connection_dialog.py
@@ -33,7 +33,6 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-import fibsem
 from fibsem import config as cfg
 from fibsem import utils
 from fibsem.microscope import FibsemMicroscope
@@ -101,12 +100,7 @@ class ConnectionDialog(QDialog):
 
         self.title_label = QLabel()
         self.title_label.setStyleSheet(f"color: {TEXT_STRONG_COLOR}; font-size: 14px;")
-        # The plain version, not `get_version_string()` -- its git-describe suffix
-        # belongs in Help > About, not on the first thing a session sees.
-        version = QLabel(f"AutoLamella {fibsem.__version__}")
-        version.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 12px;")
         layout.addWidget(self.title_label)
-        layout.addWidget(version)
 
         layout.addWidget(self._build_configuration_row())
         layout.addWidget(self._build_details_panel())

--- a/fibsem/ui/widgets/connection_dialog.py
+++ b/fibsem/ui/widgets/connection_dialog.py
@@ -83,6 +83,9 @@ class ConnectionDialog(QDialog):
                 it is using it -- but it is not allowed quietly.
         """
         super().__init__(parent)
+        # The window bar already says what the dialog is; the heading inside says
+        # what to do in it, and neither repeats the other.
+        self.setWindowTitle("Connect to Microscope")
         self.setModal(True)
         self.setMinimumWidth(DIALOG_WIDTH)
 
@@ -98,7 +101,7 @@ class ConnectionDialog(QDialog):
         layout.setContentsMargins(16, 14, 16, 14)
         layout.setSpacing(10)
 
-        self.title_label = QLabel()
+        self.title_label = QLabel("Select Configuration")
         self.title_label.setStyleSheet(f"color: {TEXT_STRONG_COLOR}; font-size: 14px;")
         layout.addWidget(self.title_label)
 
@@ -125,10 +128,8 @@ class ConnectionDialog(QDialog):
         row_layout.setContentsMargins(0, 0, 0, 0)
         row_layout.setSpacing(6)
 
-        label = QLabel("Configuration")
-        label.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 11px;")
-        row_layout.addWidget(label)
-
+        # No "Configuration" label in front of it: the heading above already says
+        # Select Configuration, and the combo box holds configuration names.
         self.configuration_combo = QComboBox()
         self.configuration_combo.currentTextChanged.connect(
             self._on_configuration_changed
@@ -333,7 +334,6 @@ class ConnectionDialog(QDialog):
         self._refresh_details()
 
         if not connected:
-            self.title_label.setText("Connect to microscope")
             self.connect_button.setText("Connect")
             self.offline_button.setToolTip(
                 "Start without a microscope. Most of the application stays "
@@ -341,10 +341,6 @@ class ConnectionDialog(QDialog):
             )
             return
 
-        # The panel below names the instrument; the title saying it too is the
-        # duplication this whole batch has been removing. It states what the dialog
-        # is for instead, which is the part that differs between the two states.
-        self.title_label.setText("Microscope connection")
         # Reconnect, not Connect: with a session in progress this drops it and takes
         # the selected configuration instead, and the button should say so.
         self.connect_button.setText("Reconnect")

--- a/fibsem/ui/widgets/connection_dialog.py
+++ b/fibsem/ui/widgets/connection_dialog.py
@@ -46,6 +46,7 @@ from fibsem.ui.stylesheets import (
 from fibsem.ui.tokens import (
     BORDER_COLOR,
     ERROR_COLOR,
+    OK_COLOR,
     PANEL_COLOR,
     SURFACE_COLOR,
     TEXT_MUTED_COLOR,
@@ -155,9 +156,9 @@ class ConnectionDialog(QDialog):
         instrument a name meant was something you learned by connecting to it.
 
         Laid out as the Connection tab's status card is -- framed panel, icon,
-        bold line, muted line -- so this reads as part of the application rather
-        than a second way of saying the same thing. What it *says* is deliberately
-        not what that card says; see `_set_details`.
+        bold line, muted line, and its green tick on a connection that succeeded --
+        so this reads as part of the application rather than a second way of saying
+        the same thing.
         """
         frame = QFrame()
         frame.setObjectName("frame_connection_details")
@@ -198,14 +199,7 @@ class ConnectionDialog(QDialog):
         return frame
 
     def _set_details(self, title: str, subtitle: str, icon: str, colour: str) -> None:
-        """Fill the panel. Absence is knowable; presence is not.
-
-        The Connection tab's card reads "Microscope Connected" over a green tick,
-        and this deliberately does not copy that. Nothing watches the link
-        (FIB-777), so with a session that was opened hours ago a tick asserts
-        something no one has checked. "No microscope connected" is safe in the
-        other direction -- there is nothing to be wrong about.
-        """
+        """Fill the panel, in the Connection tab's own status-card language."""
         self.details_icon.setPixmap(fibsem_icon(icon, color=colour).pixmap(20, 20))
         self.details_title.setText(title)
         self.details_subtitle.setText(subtitle)
@@ -300,13 +294,18 @@ class ConnectionDialog(QDialog):
     def _refresh_details(self) -> None:
         """Say what is attached, or where Connect is about to go."""
         if self.microscope is not None:
+            # A green tick, as the Connection tab's card has: the session was
+            # established, and reporting that outcome is what this panel is for.
+            # (The header chip in #515 stays wordless about it for a different
+            # reason -- it is on screen for hours, and nothing watches the link.)
             info = self.microscope.system.info
             self._set_details(
-                f"{info.manufacturer} {info.model}".strip(),
-                f"{info.ip_address}  ·  serial {info.serial_number}",
-                "mdi:microscope",
-                TEXT_STRONG_COLOR,
+                "Microscope connected",
+                f"{info.manufacturer} {info.model} at {info.ip_address}".strip(),
+                "mdi:check-circle",
+                OK_COLOR,
             )
+            self.details_subtitle.setToolTip(f"Serial number: {info.serial_number}")
             return
 
         if self.configuration_path() is None:

--- a/tests/ui/test_connection_dialog.py
+++ b/tests/ui/test_connection_dialog.py
@@ -58,10 +58,12 @@ def test_it_says_what_the_configuration_points_at_before_connecting(dialog):
     was something you found out by connecting to it.
     """
     settings = utils.load_microscope_configuration(dialog.configuration_path())
+    info = settings.system.info
 
     assert dialog.microscope is None
-    assert dialog.manufacturer_label.text() == settings.system.info.manufacturer
-    assert dialog.address_label.text() == settings.system.info.ip_address
+    assert dialog.details_title.text() == "No microscope connected"
+    assert info.manufacturer in dialog.details_subtitle.text()
+    assert info.ip_address in dialog.details_subtitle.text()
 
 
 def test_dismissing_leaves_the_session_empty(dialog):
@@ -157,8 +159,11 @@ def test_it_shows_what_is_connected(connected_dialog):
     """Not the same dialog worded as though nothing had happened yet."""
     info = connected_dialog.microscope.system.info
 
-    assert info.manufacturer in connected_dialog.title_label.text()
-    assert info.ip_address in connected_dialog.title_label.text()
+    assert info.manufacturer in connected_dialog.details_title.text()
+    assert info.ip_address in connected_dialog.details_subtitle.text()
+    # The panel names it; the title says what the dialog is for, once.
+    assert connected_dialog.title_label.text() == "Microscope connection"
+    assert info.manufacturer not in connected_dialog.title_label.text()
     assert connected_dialog.disconnect_button.isVisible()
     # Reconnect, because connecting now means dropping the session in progress.
     assert connected_dialog.connect_button.text() == "Reconnect"
@@ -261,3 +266,27 @@ def test_losing_the_session_mid_workflow_says_what_it_will_break(qapp, monkeypat
     finally:
         microscope.disconnect()
         d.deleteLater()
+
+
+def test_the_details_panel_never_claims_the_link_is_up(connected_dialog):
+    """The Connection tab's card says "Microscope Connected" over a green tick.
+
+    This deliberately does not. Nothing watches the link (FIB-777), so with a
+    session opened hours ago that tick asserts something nobody has checked. The
+    other direction is safe: with no microscope there is nothing to be wrong about,
+    which is why the disconnected panel does say so outright.
+    """
+    text = (
+        connected_dialog.details_title.text() + connected_dialog.details_subtitle.text()
+    ).lower()
+
+    assert "connected" not in text
+    assert "online" not in text
+
+
+def test_a_configuration_that_resolves_nowhere_shows_in_the_panel(dialog):
+    dialog.configuration_combo.addItem("a-configuration-that-was-deleted")
+    dialog.configuration_combo.setCurrentText("a-configuration-that-was-deleted")
+
+    assert dialog.details_title.text() == "No configuration"
+    assert "could not be found" in dialog.details_subtitle.text()

--- a/tests/ui/test_connection_dialog.py
+++ b/tests/ui/test_connection_dialog.py
@@ -161,8 +161,10 @@ def test_it_shows_what_is_connected(connected_dialog):
 
     assert info.manufacturer in connected_dialog.details_subtitle.text()
     assert info.ip_address in connected_dialog.details_subtitle.text()
-    # The panel names it; the title says what the dialog is for, once.
-    assert connected_dialog.title_label.text() == "Microscope connection"
+    # The panel names the instrument, the window bar says what the dialog is, and
+    # the heading says what to do in it. Nothing says any of it twice.
+    assert connected_dialog.windowTitle() == "Connect to Microscope"
+    assert connected_dialog.title_label.text() == "Select Configuration"
     assert info.manufacturer not in connected_dialog.title_label.text()
     assert connected_dialog.disconnect_button.isVisible()
     # Reconnect, because connecting now means dropping the session in progress.

--- a/tests/ui/test_connection_dialog.py
+++ b/tests/ui/test_connection_dialog.py
@@ -159,7 +159,7 @@ def test_it_shows_what_is_connected(connected_dialog):
     """Not the same dialog worded as though nothing had happened yet."""
     info = connected_dialog.microscope.system.info
 
-    assert info.manufacturer in connected_dialog.details_title.text()
+    assert info.manufacturer in connected_dialog.details_subtitle.text()
     assert info.ip_address in connected_dialog.details_subtitle.text()
     # The panel names it; the title says what the dialog is for, once.
     assert connected_dialog.title_label.text() == "Microscope connection"
@@ -268,20 +268,20 @@ def test_losing_the_session_mid_workflow_says_what_it_will_break(qapp, monkeypat
         d.deleteLater()
 
 
-def test_the_details_panel_never_claims_the_link_is_up(connected_dialog):
-    """The Connection tab's card says "Microscope Connected" over a green tick.
+def test_the_details_panel_reports_the_connection(connected_dialog):
+    """Reported as the Connection tab's card reports it, tick included.
 
-    This deliberately does not. Nothing watches the link (FIB-777), so with a
-    session opened hours ago that tick asserts something nobody has checked. The
-    other direction is safe: with no microscope there is nothing to be wrong about,
-    which is why the disconnected panel does say so outright.
+    Deliberate: this panel describes the outcome of a connection that was
+    established, in a dialog someone opened to look at it. The header chip in #515
+    stays wordless about the link for a different reason -- it is on screen for
+    hours, and nothing watches the connection (FIB-777).
     """
-    text = (
-        connected_dialog.details_title.text() + connected_dialog.details_subtitle.text()
-    ).lower()
+    info = connected_dialog.microscope.system.info
 
-    assert "connected" not in text
-    assert "online" not in text
+    assert connected_dialog.details_title.text() == "Microscope connected"
+    assert info.manufacturer in connected_dialog.details_subtitle.text()
+    assert info.ip_address in connected_dialog.details_subtitle.text()
+    assert info.serial_number in connected_dialog.details_subtitle.toolTip()
 
 
 def test_a_configuration_that_resolves_nowhere_shows_in_the_panel(dialog):


### PR DESCRIPTION
Following #515. The dialog's detail panel was two plain rows — `Manufacturer` and `Address` — which said what was needed and looked like nothing else in the application.

It now uses the Connection tab's status-card language: framed panel, 20px icon, bold line, muted line, and its green tick on a connection that succeeded. Same shapes, same sizes, same tokens.

## Three states, not two

| state | reads |
|---|---|
| connected | ✅ **Microscope connected** — `Demo DemoMicroscope at 192.168.0.1`, serial number on hover |
| nothing connected | ⊗ **No microscope connected** — `Demo at 192.168.0.1`, read off the configuration file so it says where Connect is about to go |
| configuration resolves nowhere | ⚠ **No configuration** — names the entry that could not be found |

The third is new. It is the state that used to take the application down when selected, so it is worth showing rather than leaving the panel describing an instrument that cannot be reached.

## On the tick

Worth recording, since #515 argued the other way for the header chip. The chip stays wordless about the link because it is on screen for hours and **nothing watches the connection** (`connected_signal` fires off `bool(self.microscope)`, a Python reference — FIB-777). This panel is a different surface with a different lifetime: it describes the outcome of a connection that was established, in a dialog someone opened deliberately to look at it. Two surfaces, two answers.

## The title stops repeating the panel

Connected, the dialog title said `Connected to Demo at 192.168.0.1` while the panel immediately below said the same thing. It now reads "Microscope connection" — what the dialog is for, which is the part that actually differs between the states. Disconnected it still reads "Connect to microscope", because there the framing is the instruction.

## Tests

`tests/ui/test_connection_dialog.py` — 17, three new: the connected panel reports the connection with the instrument and the serial number, a configuration that resolves nowhere shows in the panel, and the title does not repeat what the panel says.

Full `tests/ui`: 2183 passed, 1 skipped. Formatted per #489, AST-identical.

Still behind `features.connection_chip`, off, so this changes nothing in a release. Part of FIB-775; the tab removal is next.
