### PR TITLE
[refactor] Stop the workflow tasks reaching into FM acquisition for nothing

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -127,7 +127,6 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
 
         # Acquire image
         self.log_status_message("ACQUIRE_FLUORESCENCE_IMAGE", "Acquiring Fluorescence Image...")
-        self.microscope.fm.acquisition_progress_signal.emit({"state": "acquiring", "task": f"{self.task_name}"})
         image = acquire_image(microscope=self.microscope.fm,
                                 channel_settings=self.config.channel_settings,
                                 zparams=self.config.zparams,
@@ -178,7 +177,6 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
         af_display = (f"Autofocus: {autofocus_channel.name} "
                       f"[{af_settings.method.value}], {len(af_settings.passes)} pass(es)")
         self.log_status_message("AUTOFOCUS", af_display)
-        self.microscope.fm.acquisition_progress_signal.emit({"state": "autofocusing", "task": f"{self.task_name}"}) # type: ignore
         # Query: pass in channel settings so we are certain the channel is correct
         result = run_coarse_fine_autofocus(
                 self.microscope.fm,

--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -274,9 +274,6 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
 
         # Move stage to the saved stage position and objective position
         self.log_status_message("MOVE_TO_POSITION", "Moving to Position...")
-        self.microscope.fm.acquisition_progress_signal.emit(
-            {"state": "moving", "task": f"{self.task_name}"}
-        )
         self.microscope.safe_absolute_stage_movement(stage_position)
 
     def _move_to_objective_position(self):

--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -27,23 +27,42 @@ from fibsem.structures import field_meta
 @dataclass
 class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
     """Configuration for the AcquireFluorescenceImageTask."""
+
     task_type: ClassVar[str] = "ACQUIRE_FLUORESCENCE_IMAGE"
     display_name: ClassVar[str] = "Acquire Fluorescence Image"
-    channel_settings: list[ChannelSettings] = field(default_factory=list,
-                                                    metadata=field_meta(tooltip="Settings for each fluorescence channel",
-                                                                        label="Channel Settings"))
-    zparams: ZParameters = field(default_factory=ZParameters,
-                                  metadata=field_meta(tooltip="Z-stack acquisition parameters",
-                                                      label="Z-Stack Parameters"))
-    autofocus_settings: AutoFocusSettings = field(default_factory=AutoFocusSettings,
-                                                  metadata=field_meta(tooltip="Settings for autofocus before acquiring fluorescence images",
-                                                                      label="Autofocus Settings"))
-    orientation: Optional[str] = field(default=None,
-                                       metadata=field_meta(tooltip="Orientation for acquisition. 'FM' or 'SEM'. None = use fluorescence_pose as-is.",
-                                                           label="Orientation"))
-    retract_objective: bool = field(default=True,
-                                    metadata=field_meta(tooltip="Retract the objective when the task finishes, so it is clear of the stage for subsequent moves. Disable for back-to-back fluorescence tasks.",
-                                                        label="Retract Objective"))
+    channel_settings: list[ChannelSettings] = field(
+        default_factory=list,
+        metadata=field_meta(
+            tooltip="Settings for each fluorescence channel", label="Channel Settings"
+        ),
+    )
+    zparams: ZParameters = field(
+        default_factory=ZParameters,
+        metadata=field_meta(
+            tooltip="Z-stack acquisition parameters", label="Z-Stack Parameters"
+        ),
+    )
+    autofocus_settings: AutoFocusSettings = field(
+        default_factory=AutoFocusSettings,
+        metadata=field_meta(
+            tooltip="Settings for autofocus before acquiring fluorescence images",
+            label="Autofocus Settings",
+        ),
+    )
+    orientation: Optional[str] = field(
+        default=None,
+        metadata=field_meta(
+            tooltip="Orientation for acquisition. 'FM' or 'SEM'. None = use fluorescence_pose as-is.",
+            label="Orientation",
+        ),
+    )
+    retract_objective: bool = field(
+        default=True,
+        metadata=field_meta(
+            tooltip="Retract the objective when the task finishes, so it is clear of the stage for subsequent moves. Disable for back-to-back fluorescence tasks.",
+            label="Retract Objective",
+        ),
+    )
 
     def to_dict(self) -> dict:
         ddict = {}
@@ -56,9 +75,13 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
         return ddict
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'AcquireFluorescenceImageConfig':
-        channel_settings = [ChannelSettings.from_dict(cs) for cs in data.get("channel_settings", [])]
-        autofocus_settings = AutoFocusSettings.from_dict(data.get("autofocus_settings", {}))
+    def from_dict(cls, data: dict) -> "AcquireFluorescenceImageConfig":
+        channel_settings = [
+            ChannelSettings.from_dict(cs) for cs in data.get("channel_settings", [])
+        ]
+        autofocus_settings = AutoFocusSettings.from_dict(
+            data.get("autofocus_settings", {})
+        )
         zparams = ZParameters.from_dict(data.get("zparams", {}))
         return cls(
             task_name=data.get("task_name", ""),
@@ -94,31 +117,43 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
 
 class AcquireFluorescenceImageTask(AutoLamellaTask):
     """Task to acquire fluorescence image with specified settings."""
+
     config: AcquireFluorescenceImageConfig
-    config_cls: ClassVar[Type[AcquireFluorescenceImageConfig]] = AcquireFluorescenceImageConfig
+    config_cls: ClassVar[Type[AcquireFluorescenceImageConfig]] = (
+        AcquireFluorescenceImageConfig
+    )
 
     def _run(self) -> None:
         """Run the task to acquire fluorescence image with the specified settings."""
 
         if self.microscope.fm is None:
-            raise ValueError("Fluorescence microscope not initialized in the FibsemMicroscope instance")
-        if self.lamella.fluorescence_pose is None or self.lamella.fluorescence_pose.objective_position is None:
-            raise ValueError(f"Objective position for {self.lamella.name} is not set. Please set the objective position before acquiring fluorescence images.")
+            raise ValueError(
+                "Fluorescence microscope not initialized in the FibsemMicroscope instance"
+            )
+        if (
+            self.lamella.fluorescence_pose is None
+            or self.lamella.fluorescence_pose.objective_position is None
+        ):
+            raise ValueError(
+                f"Objective position for {self.lamella.name} is not set. Please set the objective position before acquiring fluorescence images."
+            )
         if self.lamella.stage_position is None:
-            raise ValueError(f"Stage position for {self.lamella.name} is not set. Please set the stage position before acquiring fluorescence images.")
-
+            raise ValueError(
+                f"Stage position for {self.lamella.name} is not set. Please set the stage position before acquiring fluorescence images."
+            )
 
         self._move_to_stage_position()
 
         self._move_to_objective_position()
-
 
         # Run autofocus if requested
         if self.config.autofocus_settings.enabled:
             result = self._run_autofocus()
             # autofocus found a better focus — make it the lamella's saved objective position
             if result is not None and self.lamella.fluorescence_pose is not None:
-                self.lamella.fluorescence_pose.objective_position = result.working_distance
+                self.lamella.fluorescence_pose.objective_position = (
+                    result.working_distance
+                )
 
         # Generate timestamp-based filename
         timestamp = utils.current_timestamp_v3(timeonly=True)
@@ -126,12 +161,16 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
         filename = os.path.join(self.lamella.path, basename)
 
         # Acquire image
-        self.log_status_message("ACQUIRE_FLUORESCENCE_IMAGE", "Acquiring Fluorescence Image...")
-        image = acquire_image(microscope=self.microscope.fm,
-                                channel_settings=self.config.channel_settings,
-                                zparams=self.config.zparams,
-                                stop_event=self._stop_event,
-                                filename=filename)
+        self.log_status_message(
+            "ACQUIRE_FLUORESCENCE_IMAGE", "Acquiring Fluorescence Image..."
+        )
+        image = acquire_image(
+            microscope=self.microscope.fm,
+            channel_settings=self.config.channel_settings,
+            zparams=self.config.zparams,
+            stop_event=self._stop_event,
+            filename=filename,
+        )
 
         # acquire_image swallows save failures (it logs and carries on), so the
         # requested filename is not proof the file was written. FluorescenceImage.save
@@ -146,7 +185,6 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
         if self.config.retract_objective:
             self._retract_objective()
 
-
     def _run_autofocus(self) -> Optional[AutoFocusResult]:
         """Run autofocus with the specified settings, returning the result."""
         # Find autofocus channel by name if specified in autofocus_settings
@@ -159,9 +197,10 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
 
         # Fall back to first channel if no specific channel found
         if autofocus_channel is None:
-            logging.warning(f"Autofocus channel '{self.config.autofocus_settings.channel_name}' not found, using first channel")
+            logging.warning(
+                f"Autofocus channel '{self.config.autofocus_settings.channel_name}' not found, using first channel"
+            )
             autofocus_channel = self.config.channel_settings[0]
-
 
         af_settings = self.config.autofocus_settings
         logging.info(
@@ -169,27 +208,35 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
             f"with method '{af_settings.method.value}' and {len(af_settings.passes)} pass(es)"
         )
         if self.validate:
-            ask_user(self.parent_ui,
+            ask_user(
+                self.parent_ui,
                 msg=f"Run autofocus for {self.lamella.name} using channel '{autofocus_channel.name}'. Press continue when ready.",
-                pos="Continue"
-                )
+                pos="Continue",
+            )
 
-        af_display = (f"Autofocus: {autofocus_channel.name} "
-                      f"[{af_settings.method.value}], {len(af_settings.passes)} pass(es)")
+        af_display = (
+            f"Autofocus: {autofocus_channel.name} "
+            f"[{af_settings.method.value}], {len(af_settings.passes)} pass(es)"
+        )
         self.log_status_message("AUTOFOCUS", af_display)
         # Query: pass in channel settings so we are certain the channel is correct
         result = run_coarse_fine_autofocus(
-                self.microscope.fm,
-                autofocus_settings=self.config.autofocus_settings,
-                channel_settings=autofocus_channel,
-                stop_event=self._stop_event
-            )
+            self.microscope.fm,
+            autofocus_settings=self.config.autofocus_settings,
+            channel_settings=autofocus_channel,
+            stop_event=self._stop_event,
+        )
         if result is None:
             logging.info("Autofocus cancelled")
-            raise InterruptedError(f"Task {self.task_name} for {self.lamella.name} cancelled during autofocus.")
+            raise InterruptedError(
+                f"Task {self.task_name} for {self.lamella.name} cancelled during autofocus."
+            )
         try:
             ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-            result.save(path=os.path.join(self.lamella.path, "autofunctions"), name=f"{self.task_name}_autofocus_{ts}")
+            result.save(
+                path=os.path.join(self.lamella.path, "autofunctions"),
+                name=f"{self.task_name}_autofocus_{ts}",
+            )
         except Exception as e:
             logging.warning(f"Failed to save autofocus result: {e}")
 
@@ -197,7 +244,10 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
 
     def _move_to_stage_position(self):
         """Move the stage to the fluorescence pose stage position, or the lamella stage position if fluorescence pose is not set."""
-        if self.lamella.fluorescence_pose is not None and self.lamella.fluorescence_pose.stage_position is not None:
+        if (
+            self.lamella.fluorescence_pose is not None
+            and self.lamella.fluorescence_pose.stage_position is not None
+        ):
             stage_position = self.lamella.fluorescence_pose.stage_position
         else:
             stage_position = self.lamella.stage_position
@@ -205,26 +255,38 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
         if self.config.orientation is not None:
             stage_position = self.microscope.get_target_position(
                 stage_position=stage_position,
-                target_orientation=self.config.orientation
+                target_orientation=self.config.orientation,
             )
         elif not self.microscope.fm.has_valid_orientation(stage_position):
-            logging.warning(f"Stage Position {self.lamella.name} is not in a valid orientation: {stage_position}, moving to SEM orientation...")
-            stage_position = self.microscope.get_target_position(stage_position=stage_position, target_orientation="SEM")
+            logging.warning(
+                f"Stage Position {self.lamella.name} is not in a valid orientation: {stage_position}, moving to SEM orientation..."
+            )
+            stage_position = self.microscope.get_target_position(
+                stage_position=stage_position, target_orientation="SEM"
+            )
 
         # Check for cancellation before each position
         if self._stop_event and self._stop_event.is_set():
-            logging.info(f"{self.task_name}: {self.lamella.name} - Acquisition cancelled")
+            logging.info(
+                f"{self.task_name}: {self.lamella.name} - Acquisition cancelled"
+            )
             return
 
         # Move stage to the saved stage position and objective position
         self.log_status_message("MOVE_TO_POSITION", "Moving to Position...")
-        self.microscope.fm.acquisition_progress_signal.emit({"state": "moving", "task": f"{self.task_name}"})
+        self.microscope.fm.acquisition_progress_signal.emit(
+            {"state": "moving", "task": f"{self.task_name}"}
+        )
         self.microscope.safe_absolute_stage_movement(stage_position)
 
     def _move_to_objective_position(self):
         # move objective to saved position
         self.log_status_message("MOVE_OBJECTIVE", "Moving Objective to position...")
         if not self.microscope.fm.objective.state == "Inserted":
-            logging.warning("Objective is not inserted. Inserting the objective before acquiring fluorescence images.")
+            logging.warning(
+                "Objective is not inserted. Inserting the objective before acquiring fluorescence images."
+            )
             self.microscope.fm.objective.insert()
-        self.microscope.fm.objective.move_absolute(self.lamella.fluorescence_pose.objective_position)
+        self.microscope.fm.objective.move_absolute(
+            self.lamella.fluorescence_pose.objective_position
+        )

--- a/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
+++ b/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
@@ -45,10 +45,16 @@ DEFAULT_MILLING_CONFIG[MILL_COINCIDENT_KEY] = FibsemMillingTaskConfig(
     stages=[
         FibsemMillingStage(
             name="Coincident Milling 01",
-            milling=FibsemMillingSettings(milling_current=60e-12, application_file="Si-ccs"),
-            pattern=RectanglePattern(width=9.0e-6, depth=4.0e-7, height=20e-6, 
-                                  cross_section=CrossSectionPattern.CleaningCrossSection),
-            strategy=CoincidenceMillingStrategy()
+            milling=FibsemMillingSettings(
+                milling_current=60e-12, application_file="Si-ccs"
+            ),
+            pattern=RectanglePattern(
+                width=9.0e-6,
+                depth=4.0e-7,
+                height=20e-6,
+                cross_section=CrossSectionPattern.CleaningCrossSection,
+            ),
+            strategy=CoincidenceMillingStrategy(),
         )
     ],
 )
@@ -85,7 +91,9 @@ class MillCoincidentTaskConfig(AutoLamellaTaskConfig):
     )
     channel_name: str = field(
         default="Red Channel",
-        metadata=field_meta(tooltip="The fluorescence channel to use for coincident milling"),
+        metadata=field_meta(
+            tooltip="The fluorescence channel to use for coincident milling"
+        ),
     )
     task_type: ClassVar[str] = "MILL_COINCIDENT"
 
@@ -178,7 +186,9 @@ class MillCoincidentTask(AutoLamellaTask):
             return
 
         # Move stage to the saved stage position and objective position
-        self.microscope.fm.objective.move_absolute(self.lamella.fluorescence_pose.objective_position)
+        self.microscope.fm.objective.move_absolute(
+            self.lamella.fluorescence_pose.objective_position
+        )
 
         # mill coincident
         self.log_status_message("MILL_COINCIDENT", "Milling Coincident Lamella...")

--- a/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
+++ b/fibsem/applications/autolamella/workflows/tasks/mill_coincident.py
@@ -264,9 +264,6 @@ class MillCoincidentTask(AutoLamellaTask):
             basename = f"{self.lamella.name}-coincidence-final-{timestamp}.ome.tiff"
             filename = os.path.join(self.lamella.path, basename)
 
-            self.microscope.fm.acquisition_progress_signal.emit(
-                {"state": "acquiring", "task": f"{self.task_name}"}
-            )
             image = acquire_image(
                 microscope=self.microscope.fm,
                 channel_settings=fm_config.channel_settings,

--- a/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
@@ -17,61 +17,89 @@ from fibsem.applications.autolamella.workflows.ui import (
 @dataclass
 class SelectFluorescencePositionConfig(AutoLamellaTaskConfig):
     """Configuration for the SelectFluorescencePositionTask."""
+
     task_type: ClassVar[str] = "SELECT_FLUORESCENCE_POSITION"
     display_name: ClassVar[str] = "Select Fluorescence Position"
 
 
 class SelectFluorescencePositionTask(AutoLamellaTask):
     """Task to select fluorescence stage position and objective position."""
+
     config: SelectFluorescencePositionConfig
-    config_cls: ClassVar[Type[SelectFluorescencePositionConfig]] = SelectFluorescencePositionConfig
+    config_cls: ClassVar[Type[SelectFluorescencePositionConfig]] = (
+        SelectFluorescencePositionConfig
+    )
 
     def _run(self) -> None:
         """Run the task to select fluorescence stage position and objective position."""
 
         if self.microscope.fm is None:
-            raise ValueError("Fluorescence microscope not initialized in the FibsemMicroscope instance")
-        if self.lamella.fluorescence_pose is None or self.lamella.fluorescence_pose.objective_position is None:
-            raise ValueError(f"Objective position for {self.lamella.name} is not set. Please set the objective position before acquiring fluorescence images.")
+            raise ValueError(
+                "Fluorescence microscope not initialized in the FibsemMicroscope instance"
+            )
+        if (
+            self.lamella.fluorescence_pose is None
+            or self.lamella.fluorescence_pose.objective_position is None
+        ):
+            raise ValueError(
+                f"Objective position for {self.lamella.name} is not set. Please set the objective position before acquiring fluorescence images."
+            )
         if self.lamella.stage_position is None:
-            raise ValueError(f"Stage position for {self.lamella.name} is not set. Please set the stage position before acquiring fluorescence images.")
+            raise ValueError(
+                f"Stage position for {self.lamella.name} is not set. Please set the stage position before acquiring fluorescence images."
+            )
 
-        if self.lamella.fluorescence_pose is not None and self.lamella.fluorescence_pose.stage_position is not None:
+        if (
+            self.lamella.fluorescence_pose is not None
+            and self.lamella.fluorescence_pose.stage_position is not None
+        ):
             stage_position = self.lamella.fluorescence_pose.stage_position
         else:
             stage_position = self.lamella.stage_position
 
         if not self.microscope.fm.has_valid_orientation(stage_position):
-            raise ValueError(f"Stage Position {self.lamella.name} is not in a valid orientation: {stage_position.pretty}, {self.microscope.fm.valid_orientations}")
+            raise ValueError(
+                f"Stage Position {self.lamella.name} is not in a valid orientation: {stage_position.pretty}, {self.microscope.fm.valid_orientations}"
+            )
 
         # Check for cancellation before each position
         if self._stop_event and self._stop_event.is_set():
-            logging.info(f"{self.task_name}: {self.lamella.name} - Acquisition cancelled")
+            logging.info(
+                f"{self.task_name}: {self.lamella.name} - Acquisition cancelled"
+            )
             return
 
         # Move stage to the saved stage position and objective position
         self.log_status_message("MOVE_TO_POSITION", "Moving to Position...")
-        self.microscope.fm.acquisition_progress_signal.emit({"state": "moving", "task": f"{self.task_name}"})
+        self.microscope.fm.acquisition_progress_signal.emit(
+            {"state": "moving", "task": f"{self.task_name}"}
+        )
         self.microscope.safe_absolute_stage_movement(stage_position)
 
         # move objective to saved position
         self.log_status_message("MOVE_OBJECTIVE", "Moving Objective to position...")
         if not self.microscope.fm.objective.state == "Inserted":
-            logging.info("Objective is not inserted. Inserting the objective before acquiring fluorescence images.")
+            logging.info(
+                "Objective is not inserted. Inserting the objective before acquiring fluorescence images."
+            )
             self.microscope.fm.objective.insert()
-        self.microscope.fm.objective.move_absolute(self.lamella.fluorescence_pose.objective_position)
+        self.microscope.fm.objective.move_absolute(
+            self.lamella.fluorescence_pose.objective_position
+        )
 
         # Acquire image
-        self.log_status_message("ACQUIRE_FLUORESCENCE_IMAGE", "Acquiring Fluorescence Image...")
+        self.log_status_message(
+            "ACQUIRE_FLUORESCENCE_IMAGE", "Acquiring Fluorescence Image..."
+        )
         self.microscope.fm.acquire_image()
 
         if self.validate:
-            ask_user(self.parent_ui,
+            ask_user(
+                self.parent_ui,
                 msg=f"Move to fluorescence position (stage and objective)for {self.lamella.name}. Press Continue to proceed.",
-                pos="Continue"
-                )
+                pos="Continue",
+            )
             self.microscope.fm.stop_acquisition()
 
         # refresh the recorded fluorescence pose (preserving the configured objective position)
         self._update_fluorescence_pose()
-

--- a/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
@@ -84,12 +84,15 @@ class SelectFluorescencePositionTask(AutoLamellaTask):
             self.lamella.fluorescence_pose.objective_position
         )
 
-        # Acquire image
-        self.log_status_message(
-            "ACQUIRE_FLUORESCENCE_IMAGE", "Acquiring Fluorescence Image..."
-        )
-        self.microscope.fm.acquire_image()
-
+        # No acquisition here. This task's job is to put the stage and objective where
+        # the fluorescence pose says, and record where that turned out to be. The
+        # operator drives the FM controls themselves while confirming below -- which is
+        # what the `stop_acquisition` is for: whatever live view they started, the task
+        # takes down on the way out.
+        #
+        # There used to be a bare `acquire_image()` here whose result was discarded. It
+        # emits no signal, so nothing reached the canvas; it exposed the camera once and
+        # threw the frame away.
         if self.validate:
             ask_user(
                 self.parent_ui,

--- a/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
@@ -63,7 +63,6 @@ class SelectFluorescencePositionTask(AutoLamellaTask):
 
         # Acquire image
         self.log_status_message("ACQUIRE_FLUORESCENCE_IMAGE", "Acquiring Fluorescence Image...")
-        self.microscope.fm.acquisition_progress_signal.emit({"state": "acquiring", "task": f"{self.task_name}"})
         self.microscope.fm.acquire_image()
 
         if self.validate:

--- a/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
@@ -71,9 +71,6 @@ class SelectFluorescencePositionTask(AutoLamellaTask):
 
         # Move stage to the saved stage position and objective position
         self.log_status_message("MOVE_TO_POSITION", "Moving to Position...")
-        self.microscope.fm.acquisition_progress_signal.emit(
-            {"state": "moving", "task": f"{self.task_name}"}
-        )
         self.microscope.safe_absolute_stage_movement(stage_position)
 
         # move objective to saved position


### PR DESCRIPTION
`acquisition_progress_signal` reports what an FM **acquisition routine** is doing — channels, z-stack, autofocus. Six emits from the workflow tasks were using it to report what a *task* was doing, which is a different thing: a task does many things, of which acquiring is one. All six go, and the signal now has no emitters outside `fibsem/fm`.

A seventh call in the same category goes with them: an acquisition whose frame nobody could see.

## The four emits that rendered nothing

Verified by reading every branch of both consumers against each payload: with no channel name and no z-levels, every branch falls through. Worse than inert — `FMControlWidget._on_acquisition_progress` shows the progress widgets *before* deciding what to draw, so each made an empty progress bar visible and then wrote nothing into it.

| site | precedes | which emits |
| -- | -- | -- |
| `acquire_fluorescence.py:130` | `fm.acquisition.acquire_image` | per-channel + per-z-level progress, and a `finished` |
| `mill_coincident.py:267` | `fm.acquisition.acquire_image` | same |
| `acquire_fluorescence.py:181` | `run_coarse_fine_autofocus` | the real sweep progress |
| `select_fluorescence_position.py:66` | `FluorescenceMicroscope.acquire_image` | nothing — see below |

Three were duplicating their callee one layer up and less informatively. The autofocus one also spelled the state `"autofocusing"` — a third spelling that no consumer decodes; grepping the package and the tests finds exactly one hit, that emit.

## The two `moving` emits

They reported a real thing — a blocking `safe_absolute_stage_movement` — on the wrong signal, and redundantly. The line directly above each already does:

```python
self.log_status_message("MOVE_TO_POSITION", "Moving to Position...")
```

which emits `step_update_signal` → `workflow_timeline.update_step`, **and** calls `update_status_ui` → `workflow_update_signal` with `"<lamella> [<task>] Moving to Position…"`. Both are visible while a workflow runs. The FM emit was a third copy in a widget that has nothing to do with the task.

## The acquisition nobody could see

`SelectFluorescencePositionTask` called `FluorescenceMicroscope.acquire_image()` and discarded the result. That method emits no signal — only the live stream from `start_acquisition` emits `acquisition_signal`, which is what the FM canvas displays — so the call exposed the camera once and threw the frame away.

Its `stop_acquisition()` is not orphaned by removing it, it is **explained** by it: the operator drives the FM controls while confirming the position, and the task takes down whatever live view they started on the way out. `stop_acquisition` is documented as safe when nothing is streaming, so the unsupervised path is unaffected.

The `ACQUIRE_FLUORESCENCE_IMAGE` status line goes too — it described the removed call. The step string is only ever emitted, never read, and the two tasks that genuinely acquire keep theirs. The operator still sees the right thing while confirming: `ask_user` puts its own message up.

## Context

Step 1 of 4 in typing this signal. It stands alone — no typing involved — and removes two defects on its own: the third autofocus spelling, and the empty-bar flash. It also takes the signal from 12 emit sites to 6, all in `fibsem/fm`, before anyone has to write down what it carries.

## Verification

`tests/autolamella/`: 558 passed, unchanged throughout.

The reformat of the three files is a **separate commit** — the actual change is seven deletions.