### PR TITLE
[format] Apply ruff format to the files the Add Task stack touches

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -52,8 +52,6 @@ if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
 
 
-
-
 class AutoLamellaTaskStatus(Enum):
     NotStarted = auto()
     InProgress = auto()
@@ -61,7 +59,7 @@ class AutoLamellaTaskStatus(Enum):
     Failed = auto()
     Skipped = auto()
     Cancelled = auto()  # aborted by the user (Stop), distinct from a genuine Failure
-    Removed = auto()    # pulled from the queue by the user before it ran
+    Removed = auto()  # pulled from the queue by the user before it ran
 
 
 # AutoLamellaUser lived here: a richer user identity (role, preferences, is_default)
@@ -80,7 +78,9 @@ class AutoLamellaTaskState:
     task_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     task_type: str = ""
     lamella_id: str = ""
-    start_timestamp: float = field(default_factory=lambda: datetime.timestamp(datetime.now()))
+    start_timestamp: float = field(
+        default_factory=lambda: datetime.timestamp(datetime.now())
+    )
     end_timestamp: Optional[float] = None
     status: AutoLamellaTaskStatus = AutoLamellaTaskStatus.NotStarted
     status_message: str = ""
@@ -100,11 +100,15 @@ class AutoLamellaTaskState:
     def completed_at(self) -> str:
         if self.end_timestamp is None:
             return "in progress"
-        return datetime.fromtimestamp(self.end_timestamp).strftime(TIME_DISPLAY_AMPM_SHORT)
+        return datetime.fromtimestamp(self.end_timestamp).strftime(
+            TIME_DISPLAY_AMPM_SHORT
+        )
 
     @property
     def started_at(self) -> str:
-        return datetime.fromtimestamp(self.start_timestamp).strftime(TIME_DISPLAY_AMPM_SHORT)
+        return datetime.fromtimestamp(self.start_timestamp).strftime(
+            TIME_DISPLAY_AMPM_SHORT
+        )
 
     @property
     def duration(self) -> float:
@@ -123,7 +127,7 @@ class AutoLamellaTaskState:
         return ddict
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'AutoLamellaTaskState':
+    def from_dict(cls, data: dict) -> "AutoLamellaTaskState":
         """Create a task state from a dictionary."""
         if data is None:
             return cls()
@@ -139,21 +143,20 @@ class AutoLamellaTaskState:
 @dataclass
 class AutoLamellaTaskConfig(ABC):
     """Configuration for AutoLamella tasks."""
+
     task_type: ClassVar[str]
     display_name: ClassVar[str]
-    related_tasks: ClassVar[list[type['AutoLamellaTaskConfig']]] = []
-    task_name: str = "" # unique name for identifying in multi-task workflows
+    related_tasks: ClassVar[list[type["AutoLamellaTaskConfig"]]] = []
+    task_name: str = ""  # unique name for identifying in multi-task workflows
     milling: Dict[str, FibsemMillingTaskConfig] = field(default_factory=dict)
-    reference_imaging: ReferenceImageParameters = field(default_factory=ReferenceImageParameters)
+    reference_imaging: ReferenceImageParameters = field(
+        default_factory=ReferenceImageParameters
+    )
 
     @property
     def parameters(self) -> Tuple[str, ...]:
         core_params = [f.name for f in fields(AutoLamellaTaskConfig)]
-        return tuple(
-            f.name
-            for f in fields(self)
-            if f.name not in core_params
-        )
+        return tuple(f.name for f in fields(self) if f.name not in core_params)
 
     @property
     def field_metadata(self) -> Dict[str, Dict[str, Any]]:
@@ -181,7 +184,7 @@ class AutoLamellaTaskConfig(ABC):
         return ddict
 
     @classmethod
-    def from_dict(cls, ddict: Dict[str, Any]) -> 'AutoLamellaTaskConfig':
+    def from_dict(cls, ddict: Dict[str, Any]) -> "AutoLamellaTaskConfig":
         kwargs = {}
 
         for f in fields(cls):
@@ -189,7 +192,7 @@ class AutoLamellaTaskConfig(ABC):
                 kwargs[f.name] = ddict[f.name]
 
         # unroll the parameters dictionary
-        if "parameters" in ddict and ddict["parameters"] is not None:                
+        if "parameters" in ddict and ddict["parameters"] is not None:
             for key, value in ddict["parameters"].items():
                 if key in cls.__annotations__:
                     kwargs[key] = value
@@ -198,10 +201,13 @@ class AutoLamellaTaskConfig(ABC):
 
         if "milling" in ddict:
             kwargs["milling"] = {
-                k: FibsemMillingTaskConfig.from_dict(v) for k, v in ddict["milling"].items()
+                k: FibsemMillingTaskConfig.from_dict(v)
+                for k, v in ddict["milling"].items()
             }
         if "reference_imaging" in ddict:
-            kwargs["reference_imaging"] = ReferenceImageParameters.from_dict(ddict["reference_imaging"])
+            kwargs["reference_imaging"] = ReferenceImageParameters.from_dict(
+                ddict["reference_imaging"]
+            )
 
         return cls(**kwargs)
 
@@ -260,12 +266,12 @@ class AutoLamellaTaskConfig(ABC):
         for milling_task in self.milling.values():
             total += timing.milling_task_cost(milling_task)
         return total
-    
+
     @property
     def imaging(self) -> ImageSettings:
         """Get the imaging settings from the reference imaging parameters."""
         return self.reference_imaging.imaging
-    
+
     @imaging.setter
     def imaging(self, value: ImageSettings):
         """Set the imaging settings in the reference imaging parameters."""
@@ -275,7 +281,7 @@ class AutoLamellaTaskConfig(ABC):
 @evented
 @dataclass
 class AutoLamellaTaskDescription:
-    name: str # unique_name
+    name: str  # unique_name
     supervise: bool
     required: bool
     requires: List[str] = field(default_factory=list)
@@ -288,9 +294,11 @@ class AutoLamellaTaskDescription:
         return d
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaTaskDescription':
+    def from_dict(cls, data: Dict[str, Any]) -> "AutoLamellaTaskDescription":
         if data is None:
-            return cls(name="", task_type="", supervise=False, required=False, requires=[])
+            return cls(
+                name="", task_type="", supervise=False, required=False, requires=[]
+            )
         data = dict(data)
         sa = data.get("scheduled_at")
         if isinstance(sa, str):
@@ -311,8 +319,10 @@ class AutoLamellaWorkflowConfig:
         return ddict
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaWorkflowConfig':
-        data["tasks"] = [AutoLamellaTaskDescription.from_dict(task) for task in data.get("tasks", [])]
+    def from_dict(cls, data: Dict[str, Any]) -> "AutoLamellaWorkflowConfig":
+        data["tasks"] = [
+            AutoLamellaTaskDescription.from_dict(task) for task in data.get("tasks", [])
+        ]
         return cls(**data)
 
     @property
@@ -330,7 +340,9 @@ class AutoLamellaWorkflowConfig:
                 return task.requires
         return []
 
-    def get_completed_tasks(self, lamella: 'Lamella', with_timestamps: bool = False) -> List[str]:
+    def get_completed_tasks(
+        self, lamella: "Lamella", with_timestamps: bool = False
+    ) -> List[str]:
         """Get the list of completed tasks for a given lamella.
 
         Filtered on status for the same reason as Lamella.completed_tasks:
@@ -350,7 +362,7 @@ class AutoLamellaWorkflowConfig:
                 completed_tasks.append(txt)
         return completed_tasks
 
-    def get_remaining_tasks(self, lamella: 'Lamella') -> List[str]:
+    def get_remaining_tasks(self, lamella: "Lamella") -> List[str]:
         """Get the list of remaining tasks for a given lamella."""
         remaining_tasks = []
         completed_tasks = self.get_completed_tasks(lamella)
@@ -359,7 +371,7 @@ class AutoLamellaWorkflowConfig:
                 remaining_tasks.append(task)
         return remaining_tasks
 
-    def is_completed(self, lamella: 'Lamella') -> bool:
+    def is_completed(self, lamella: "Lamella") -> bool:
         """Check if all required tasks for the workflow are completed."""
         completed_tasks = self.get_completed_tasks(lamella)
         for task in self.required_tasks:
@@ -383,10 +395,11 @@ class AutoLamellaWorkflowConfig:
 
     def add_task(self, task: AutoLamellaTaskConfig) -> None:
         """Add a task to the workflow configuration."""
-        self.tasks.append(AutoLamellaTaskDescription(name=task.task_name, 
-                                                     supervise=True, 
-                                                     required=True, 
-                                                     requires=[]))
+        self.tasks.append(
+            AutoLamellaTaskDescription(
+                name=task.task_name, supervise=True, required=True, requires=[]
+            )
+        )
 
     @property
     def is_valid(self) -> bool:
@@ -403,7 +416,9 @@ class AutoLamellaWorkflowConfig:
                 if req not in task_names:
                     issues.append(f"Task '{task.name}' requires unknown task '{req}'.")
                 elif req not in task_names[:i]:
-                    issues.append(f"Task '{task.name}' requires '{req}' which comes after it in the workflow.")
+                    issues.append(
+                        f"Task '{task.name}' requires '{req}' which comes after it in the workflow."
+                    )
         return issues
 
 
@@ -416,7 +431,7 @@ class AutoLamellaWorkflowOptions:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaWorkflowOptions':
+    def from_dict(cls, data: Dict[str, Any]) -> "AutoLamellaWorkflowOptions":
         return cls(**data)
 
 
@@ -424,6 +439,7 @@ class AutoLamellaWorkflowOptions:
 @dataclass
 class LamellaDefaultConfig:
     """Initial state applied to every new Lamella created from this protocol."""
+
     use_petname: bool = True
     name_prefix: str = ""
     alignment_area: Optional[FibsemRectangle] = None
@@ -441,13 +457,15 @@ class LamellaDefaultConfig:
         return d
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'LamellaDefaultConfig':
+    def from_dict(cls, data: Dict[str, Any]) -> "LamellaDefaultConfig":
         aa = data.get("alignment_area")
         poi = data.get("poi")
         return cls(
             use_petname=data.get("use_petname", True),
             name_prefix=data.get("name_prefix", ""),
-            alignment_area=FibsemRectangle.from_dict(aa) if isinstance(aa, dict) else None,
+            alignment_area=FibsemRectangle.from_dict(aa)
+            if isinstance(aa, dict)
+            else None,
             poi=Point.from_dict(poi) if isinstance(poi, dict) else None,
         )
 
@@ -459,9 +477,15 @@ class AutoLamellaTaskProtocol:
     description: str = "Protocol for AutoLamella"
     version: str = "1.0"
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    task_config: EventedDict[str, AutoLamellaTaskConfig] = field(default_factory=lambda: EventedDict())   # unique_name: AutoLamellaTaskConfig
-    workflow_config: AutoLamellaWorkflowConfig = field(default_factory=AutoLamellaWorkflowConfig)
-    options: AutoLamellaWorkflowOptions = field(default_factory=AutoLamellaWorkflowOptions)
+    task_config: EventedDict[str, AutoLamellaTaskConfig] = field(
+        default_factory=lambda: EventedDict()
+    )  # unique_name: AutoLamellaTaskConfig
+    workflow_config: AutoLamellaWorkflowConfig = field(
+        default_factory=AutoLamellaWorkflowConfig
+    )
+    options: AutoLamellaWorkflowOptions = field(
+        default_factory=AutoLamellaWorkflowOptions
+    )
     lamella_defaults: LamellaDefaultConfig = field(default_factory=LamellaDefaultConfig)
     # Experiment-global correlation config (FIB-298): a user-step config, not an
     # automated task, so a peer field rather than an entry in task_config.
@@ -481,8 +505,9 @@ class AutoLamellaTaskProtocol:
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaTaskProtocol':
+    def from_dict(cls, data: Dict[str, Any]) -> "AutoLamellaTaskProtocol":
         from fibsem.applications.autolamella.workflows.tasks import load_task_config
+
         task_config = load_task_config(data.get("tasks", {}))
         workflow_config = AutoLamellaWorkflowConfig.from_dict(data.get("workflow", {}))
 
@@ -493,7 +518,9 @@ class AutoLamellaTaskProtocol:
             task_config=task_config,
             workflow_config=workflow_config,
             options=AutoLamellaWorkflowOptions.from_dict(data.get("options", {})),
-            lamella_defaults=LamellaDefaultConfig.from_dict(data.get("lamella_defaults", {})),
+            lamella_defaults=LamellaDefaultConfig.from_dict(
+                data.get("lamella_defaults", {})
+            ),
             # Missing on protocols saved before this field -> a default config.
             correlation=CorrelationConfig.from_dict(data.get("correlation")),
         )
@@ -502,26 +529,28 @@ class AutoLamellaTaskProtocol:
         return protocol
 
     @classmethod
-    def load(cls, filename: str) -> 'AutoLamellaTaskProtocol':
-        with open(filename, 'r') as file:
+    def load(cls, filename: str) -> "AutoLamellaTaskProtocol":
+        with open(filename, "r") as file:
             data = yaml.safe_load(file)
         return cls.from_dict(data)
 
     def save(self, filename: str) -> None:
         """Save the task protocol to a YAML file."""
-        with open(filename, 'w') as file:
-            yaml.safe_dump(self.to_dict(), 
-                           file,
-                           indent=4, 
-                           default_flow_style=False, 
-                           sort_keys=False)
+        with open(filename, "w") as file:
+            yaml.safe_dump(
+                self.to_dict(),
+                file,
+                indent=4,
+                default_flow_style=False,
+                sort_keys=False,
+            )
 
     def get_supervision(self, task_name: str) -> bool:
         """Check if a task requires supervision."""
         return self.workflow_config.get_supervision(task_name)
 
     @classmethod
-    def load_from_old_protocol(cls, path: Path) -> 'AutoLamellaTaskProtocol':
+    def load_from_old_protocol(cls, path: Path) -> "AutoLamellaTaskProtocol":
         """Convert an AutoLamellaProtocol to an AutoLamellaTaskProtocol.
         This involves mapping the milling configurations to the new task names.
         Used to converte old protocols to the new task-based protocol format."""
@@ -539,6 +568,7 @@ class AutoLamellaTaskProtocol:
             MillUndercutTaskConfig,
             SelectMillingPositionTaskConfig,
         )
+
         protocol = AutoLamellaProtocol.load(path)
 
         # we need to map the milling configurations to the new task names
@@ -549,9 +579,15 @@ class AutoLamellaTaskProtocol:
         # undercut -> Trench Milling / undercut
         # fiducial -> Setup Lamella / fiducial
         # mill_polishing -> Polishing
-        
-        if protocol.method not in [AutoLamellaMethod.ON_GRID, AutoLamellaMethod.TRENCH, AutoLamellaMethod.WAFFLE]:
-            raise ValueError(f"Protocol method {protocol.method} not supported for conversion to task protocol")
+
+        if protocol.method not in [
+            AutoLamellaMethod.ON_GRID,
+            AutoLamellaMethod.TRENCH,
+            AutoLamellaMethod.WAFFLE,
+        ]:
+            raise ValueError(
+                f"Protocol method {protocol.method} not supported for conversion to task protocol"
+            )
 
         ROUGH_MILLING_TASK_NAME = "Rough Milling"
         POLISHING_TASK_NAME = "Polishing"
@@ -566,22 +602,40 @@ class AutoLamellaTaskProtocol:
         if protocol.method in [AutoLamellaMethod.ON_GRID, AutoLamellaMethod.WAFFLE]:
             rough_milling_task = MillRoughTaskConfig(
                 task_name=ROUGH_MILLING_TASK_NAME,
-                milling={MILL_ROUGH_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[MILL_ROUGH_KEY], name="Rough Milling")},
+                milling={
+                    MILL_ROUGH_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[MILL_ROUGH_KEY], name="Rough Milling"
+                    )
+                },
             )
 
             if protocol.options.use_microexpansion:
-                rough_milling_task.milling[MILL_ROUGH_KEY].stages.extend(protocol.milling[MICROEXPANSION_KEY])
+                rough_milling_task.milling[MILL_ROUGH_KEY].stages.extend(
+                    protocol.milling[MICROEXPANSION_KEY]
+                )
             if protocol.options.use_notch:
-                rough_milling_task.milling[STRESS_RELIEF_KEY] = FibsemMillingTaskConfig.from_stages(protocol.milling[NOTCH_KEY], name="Notch")
+                rough_milling_task.milling[STRESS_RELIEF_KEY] = (
+                    FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[NOTCH_KEY], name="Notch"
+                    )
+                )
 
             polishing_milling_task = MillPolishingTaskConfig(
                 task_name=POLISHING_TASK_NAME,
-                milling={MILL_POLISHING_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[MILL_POLISHING_KEY], name="Polishing")},
+                milling={
+                    MILL_POLISHING_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[MILL_POLISHING_KEY], name="Polishing"
+                    )
+                },
             )
 
             mill_fiducial_task = MillFiducialTaskConfig(
                 task_name=MILL_FIDUCIAL_TASK_NAME,
-                milling={FIDUCIAL_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[FIDUCIAL_KEY], name="Fiducial")},
+                milling={
+                    FIDUCIAL_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[FIDUCIAL_KEY], name="Fiducial"
+                    )
+                },
             )
             setup_lamella_task = SelectMillingPositionTaskConfig(
                 task_name=SETUP_LAMELLA_POSITION_TASK_NAME,
@@ -595,57 +649,93 @@ class AutoLamellaTaskProtocol:
             task_config[SETUP_LAMELLA_POSITION_TASK_NAME] = setup_lamella_task
 
             workflow_config.tasks = [
-                AutoLamellaTaskDescription(name=SETUP_LAMELLA_POSITION_TASK_NAME, supervise=protocol.supervision[AutoLamellaStage.SetupLamella], required=True),
-                AutoLamellaTaskDescription(name=MILL_FIDUCIAL_TASK_NAME, supervise=protocol.supervision[AutoLamellaStage.SetupLamella], required=True),
-                AutoLamellaTaskDescription(name=ROUGH_MILLING_TASK_NAME, supervise=protocol.supervision[AutoLamellaStage.MillRough], required=True, requires=[MILL_FIDUCIAL_TASK_NAME]),
-                AutoLamellaTaskDescription(name=POLISHING_TASK_NAME, supervise=protocol.supervision[AutoLamellaStage.MillPolishing], required=True, requires=[ROUGH_MILLING_TASK_NAME]),
+                AutoLamellaTaskDescription(
+                    name=SETUP_LAMELLA_POSITION_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.SetupLamella],
+                    required=True,
+                ),
+                AutoLamellaTaskDescription(
+                    name=MILL_FIDUCIAL_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.SetupLamella],
+                    required=True,
+                ),
+                AutoLamellaTaskDescription(
+                    name=ROUGH_MILLING_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.MillRough],
+                    required=True,
+                    requires=[MILL_FIDUCIAL_TASK_NAME],
+                ),
+                AutoLamellaTaskDescription(
+                    name=POLISHING_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.MillPolishing],
+                    required=True,
+                    requires=[ROUGH_MILLING_TASK_NAME],
+                ),
             ]
-
 
         if protocol.method in [AutoLamellaMethod.TRENCH, AutoLamellaMethod.WAFFLE]:
             trench_milling_task = MillTrenchTaskConfig(
                 task_name=TRENCH_MILLING_TASK_NAME,
-                milling={TRENCH_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[TRENCH_KEY], name="Trench"),
+                milling={
+                    TRENCH_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[TRENCH_KEY], name="Trench"
+                    ),
                 },
                 orientation="FIB",
             )
             task_config[TRENCH_MILLING_TASK_NAME] = trench_milling_task
-            workflow_config.tasks.insert(0, AutoLamellaTaskDescription(name=TRENCH_MILLING_TASK_NAME,
-                                                                    supervise=protocol.supervision[AutoLamellaStage.MillTrench], 
-                                                                    required=True))
+            workflow_config.tasks.insert(
+                0,
+                AutoLamellaTaskDescription(
+                    name=TRENCH_MILLING_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.MillTrench],
+                    required=True,
+                ),
+            )
 
         if protocol.method is AutoLamellaMethod.WAFFLE:
-
             undercut_task = MillUndercutTaskConfig(
                 task_name=UNDERCUT_TASK_NAME,
-                milling={UNDERCUT_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[UNDERCUT_KEY], name="Undercut")},
+                milling={
+                    UNDERCUT_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[UNDERCUT_KEY], name="Undercut"
+                    )
+                },
                 orientation="SEM",
-
             )
             task_config[UNDERCUT_TASK_NAME] = undercut_task
-            workflow_config.tasks.insert(1, AutoLamellaTaskDescription(name=UNDERCUT_TASK_NAME,
-                                                                    supervise=protocol.supervision[AutoLamellaStage.MillUndercut], 
-                                                                    required=True, requires=[TRENCH_MILLING_TASK_NAME]))
-
+            workflow_config.tasks.insert(
+                1,
+                AutoLamellaTaskDescription(
+                    name=UNDERCUT_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.MillUndercut],
+                    required=True,
+                    requires=[TRENCH_MILLING_TASK_NAME],
+                ),
+            )
 
         options = AutoLamellaWorkflowOptions(
             turn_beams_off=protocol.options.turn_beams_off,
         )
 
         workflow_config.name = protocol.name
-        workflow_config.description = f"auto-converted protocol from {protocol.name} - {protocol.method.name}"
+        workflow_config.description = (
+            f"auto-converted protocol from {protocol.name} - {protocol.method.name}"
+        )
 
         task_protocol = AutoLamellaTaskProtocol(
             name=protocol.name,
             description=f"auto-converted protocol from {protocol.name} - {protocol.method.name}",
             task_config=task_config,
             workflow_config=workflow_config,
-            options=options
+            options=options,
         )
 
         return task_protocol
 
-    def get_task_config_by_type(self, task_type: Type['AutoLamellaTaskConfig']) -> EventedDict[str, AutoLamellaTaskConfig]:
+    def get_task_config_by_type(
+        self, task_type: Type["AutoLamellaTaskConfig"]
+    ) -> EventedDict[str, AutoLamellaTaskConfig]:
         """Get the task configuration by type."""
         task_configs = EventedDict()
         for k, v in self.task_config.items():
@@ -677,13 +767,17 @@ class DefectState:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'DefectState':
+    def from_dict(cls, data: dict) -> "DefectState":
         if not data:
             return cls()
         # Backwards compatibility: old format used has_defect / requires_rework bools
         if "has_defect" in data:
             if data.get("has_defect"):
-                state = DefectType.REWORK if data.get("requires_rework") else DefectType.FAILURE
+                state = (
+                    DefectType.REWORK
+                    if data.get("requires_rework")
+                    else DefectType.FAILURE
+                )
             else:
                 state = DefectType.NONE
             return cls(
@@ -726,6 +820,7 @@ _THUMBNAIL_MAX_EDGE = 512
 def _make_thumbnail_placeholder():
     import numpy as np
     from PIL import Image, ImageDraw, ImageFont
+
     img = Image.new("RGB", (256, 170), color=(30, 30, 30))
     draw = ImageDraw.Draw(img)
     text = "No Data"
@@ -746,17 +841,23 @@ _THUMBNAIL_PLACEHOLDER = None
 @dataclass
 class Lamella:
     path: Path
-    number: int                                                             # TODO: deprecate, use petname instead
+    number: int  # TODO: deprecate, use petname instead
     petname: str
-    alignment_area: FibsemRectangle = field(default_factory=lambda: FibsemRectangle.from_dict(DEFAULT_ALIGNMENT_AREA))
+    alignment_area: FibsemRectangle = field(
+        default_factory=lambda: FibsemRectangle.from_dict(DEFAULT_ALIGNMENT_AREA)
+    )
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    task_config: EventedDict[str, 'AutoLamellaTaskConfig'] = field(default_factory=lambda: EventedDict())
+    task_config: EventedDict[str, "AutoLamellaTaskConfig"] = field(
+        default_factory=lambda: EventedDict()
+    )
     poses: Dict[str, MicroscopeState] = field(default_factory=dict)
     task_state: AutoLamellaTaskState = field(default_factory=AutoLamellaTaskState)
-    task_history: List['AutoLamellaTaskState'] = field(default_factory=list)
+    task_history: List["AutoLamellaTaskState"] = field(default_factory=list)
     defect: DefectState = field(default_factory=DefectState)
     milling_angle: Optional[float] = None
-    poi: Point = field(default_factory=lambda: Point(0,0))  # point of interest within lamella area (milling coordinate system)
+    poi: Point = field(
+        default_factory=lambda: Point(0, 0)
+    )  # point of interest within lamella area (milling coordinate system)
     description: str = ""  # free-text note about the lamella
 
     def __post_init__(self):
@@ -823,7 +924,7 @@ class Lamella:
 
     @property
     def stage_position(self) -> FibsemStagePosition:
-        return self.milling_pose.stage_position # type: ignore
+        return self.milling_pose.stage_position  # type: ignore
 
     @stage_position.setter
     def stage_position(self, value: FibsemStagePosition):
@@ -849,7 +950,7 @@ class Lamella:
         ]
 
     @property
-    def last_completed_task(self) -> Optional['AutoLamellaTaskState']:
+    def last_completed_task(self) -> Optional["AutoLamellaTaskState"]:
         """Return the last completed task state.
 
         The last *completed* one, not the last recorded: a failure landing last
@@ -900,7 +1001,10 @@ class Lamella:
 
     @property
     def fluorescence_selected(self) -> bool:
-        return self.fluorescence_pose is not None and self.fluorescence_pose.objective_position is not None
+        return (
+            self.fluorescence_pose is not None
+            and self.fluorescence_pose.objective_position is not None
+        )
 
     def update_milling_angle(self, microscope: "FibsemMicroscope") -> None:
         """Recompute milling_angle from the milling-pose stage tilt.
@@ -909,14 +1013,20 @@ class Lamella:
         column-tilt configuration), so it is kept consistent with the stored milling pose.
         Leaves the existing value unchanged if the stage tilt/rotation is unavailable.
         """
-        if microscope is None or self.milling_pose is None or self.milling_pose.stage_position is None:
+        if (
+            microscope is None
+            or self.milling_pose is None
+            or self.milling_pose.stage_position is None
+        ):
             return
         try:
             self.milling_angle = microscope.get_current_milling_angle(
                 stage_position=self.milling_pose.stage_position
             )
         except ValueError:
-            logging.debug(f"Could not compute milling angle for {self.name}: stage tilt/rotation unavailable")
+            logging.debug(
+                f"Could not compute milling angle for {self.name}: stage tilt/rotation unavailable"
+            )
 
     def to_dict(self):
         return {
@@ -946,19 +1056,25 @@ class Lamella:
     @property
     def pretty_fm_name(self) -> str:
         """Generate a pretty name for the stage position."""
-        obj_pos = self.fluorescence_pose.objective_position if self.fluorescence_pose is not None else None
+        obj_pos = (
+            self.fluorescence_pose.objective_position
+            if self.fluorescence_pose is not None
+            else None
+        )
         objective_str = f"{obj_pos * 1e3:.3f}mm" if obj_pos is not None else "N/A"
         return f"{self.name} ({self.stage_position.x * 1e6:.1f}μm, {self.stage_position.y * 1e6:.1f}μm, {objective_str})"
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'Lamella':
+    def from_dict(cls, data: dict) -> "Lamella":
         # backwards compatibility
         alignment_area_ddict = data.get("alignment_area", DEFAULT_ALIGNMENT_AREA)
         alignment_area = FibsemRectangle.from_dict(alignment_area_ddict)
 
         from fibsem.applications.autolamella.workflows.tasks import load_task_config
 
-        poses = {k: MicroscopeState.from_dict(v) for k, v in data.get("poses", {}).items()}
+        poses = {
+            k: MicroscopeState.from_dict(v) for k, v in data.get("poses", {}).items()
+        }
         # backwards compat: migrate legacy top-level objective_position into fluorescence_pose
         legacy_obj_pos = data.get("objective_position", None)
         if legacy_obj_pos is not None and "FLUORESCENCE" in poses:
@@ -974,10 +1090,13 @@ class Lamella:
             poses=poses,
             task_config=load_task_config(data.get("task_config", {})),
             task_state=AutoLamellaTaskState.from_dict(data.get("task_state", {})),
-            task_history=[AutoLamellaTaskState.from_dict(task) for task in data.get("task_history", [])],
+            task_history=[
+                AutoLamellaTaskState.from_dict(task)
+                for task in data.get("task_history", [])
+            ],
             defect=DefectState.from_dict(data.get("defect", {})),
             milling_angle=data.get("milling_angle", None),
-            poi=Point.from_dict(data.get("poi", {"x":0,"y":0})),
+            poi=Point.from_dict(data.get("poi", {"x": 0, "y": 0})),
             description=data.get("description", ""),
         )
 
@@ -1005,6 +1124,7 @@ class Lamella:
         thumb_path = os.path.join(self.path, "thumbnail.png")
         import numpy as np
         from PIL import Image
+
         if not os.path.exists(thumb_path):
             if _THUMBNAIL_PLACEHOLDER is None:
                 _THUMBNAIL_PLACEHOLDER = _make_thumbnail_placeholder()
@@ -1044,6 +1164,7 @@ class Lamella:
 
         import numpy as np
         from PIL import Image
+
         data = image.filtered_data
         if data.ndim == 2:
             data = np.stack([data, data, data], axis=2)
@@ -1082,7 +1203,7 @@ class Lamella:
     #     return task_configs
 
     def sync_tasks_to_poi(self, point: Optional[Point] = None) -> list[str]:
-        """Sync the milling patterns to point of interest  """
+        """Sync the milling patterns to point of interest"""
 
         if point is None:
             point = self.poi
@@ -1107,6 +1228,7 @@ class Lamella:
             synced_tasks.append(task_name)
         return synced_tasks
 
+
 @evented
 @dataclass
 class Experiment:
@@ -1115,14 +1237,21 @@ class Experiment:
     path: Path
     positions: EventedList[Lamella] = field(default_factory=EventedList)
     landing_positions: List[FibsemStagePosition] = field(default_factory=list)
-    created_at: float = field(default_factory=lambda: datetime.timestamp(datetime.now()))
-    task_protocol: 'AutoLamellaTaskProtocol' = field(default_factory=lambda: AutoLamellaTaskProtocol())
+    created_at: float = field(
+        default_factory=lambda: datetime.timestamp(datetime.now())
+    )
+    task_protocol: "AutoLamellaTaskProtocol" = field(
+        default_factory=lambda: AutoLamellaTaskProtocol()
+    )
     metadata: Dict[str, Any] = field(default_factory=dict)
     session: Optional[SessionInfo] = None
 
-    def __init__(self, path: Path,
-                 name: str = cfg.EXPERIMENT_NAME,
-                 metadata: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(
+        self,
+        path: Path,
+        name: str = cfg.EXPERIMENT_NAME,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Create a new experiment.
 
         Args:
@@ -1138,7 +1267,7 @@ class Experiment:
         self.positions: EventedList[Lamella] = EventedList()
         self.landing_positions: List[FibsemStagePosition] = []
 
-        self.task_protocol: AutoLamellaTaskProtocol = None # must be set externally
+        self.task_protocol: AutoLamellaTaskProtocol = None  # must be set externally
         self.metadata: Dict[str, Any] = metadata if metadata is not None else {}
         # The instrument, operator and software that last worked on this. Filled in
         # by register_metadata, when a session adopts the experiment and there is a
@@ -1160,12 +1289,14 @@ class Experiment:
         }
 
         if include_protocol:
-            state_dict["protocol"] = self.task_protocol.to_dict() if self.task_protocol is not None else None
+            state_dict["protocol"] = (
+                self.task_protocol.to_dict() if self.task_protocol is not None else None
+            )
 
         return state_dict
 
     @classmethod
-    def from_dict(cls, ddict: dict) -> 'Experiment':
+    def from_dict(cls, ddict: dict) -> "Experiment":
 
         path = os.path.dirname(ddict["path"])
         name = ddict["name"]
@@ -1233,7 +1364,7 @@ class Experiment:
         """Set the organisation name in metadata."""
         self.metadata["organisation"] = value
 
-    def get_lamella_by_name(self, name: str) -> Optional['Lamella']:
+    def get_lamella_by_name(self, name: str) -> Optional["Lamella"]:
         """Return the Lamella with the given name, or None if not found."""
         return next((p for p in self.positions if p.name == name), None)
 
@@ -1253,7 +1384,7 @@ class Experiment:
         """
 
     @staticmethod
-    def load(fname: Path) -> 'Experiment':
+    def load(fname: Path) -> "Experiment":
         """Load an experiment from disk.
 
         Automatically attempts to load the task_protocol from protocol.yaml
@@ -1291,7 +1422,9 @@ class Experiment:
                 experiment.task_protocol = AutoLamellaTaskProtocol.load(protocol_path)
                 logging.info(f"Loaded task protocol from {protocol_path}")
             except Exception as e:
-                logging.warning(f"Failed to load task protocol from {protocol_path}: {e}")
+                logging.warning(
+                    f"Failed to load task protocol from {protocol_path}: {e}"
+                )
 
         return experiment
 
@@ -1350,7 +1483,9 @@ class Experiment:
                 # Preserve existing milling pattern positions
                 if existing_config is not None and new_config.milling:
                     for milling_name, new_milling_config in new_config.milling.items():
-                        existing_milling_config = existing_config.milling.get(milling_name)
+                        existing_milling_config = existing_config.milling.get(
+                            milling_name
+                        )
                         if existing_milling_config is None:
                             continue
 
@@ -1366,10 +1501,9 @@ class Experiment:
                             if existing_stage is None:
                                 continue
 
-                            if (
-                                type(existing_stage.pattern) is type(new_stage.pattern)
-                                and hasattr(existing_stage.pattern, "point")
-                            ):
+                            if type(existing_stage.pattern) is type(
+                                new_stage.pattern
+                            ) and hasattr(existing_stage.pattern, "point"):
                                 new_stage.pattern.point = deepcopy(
                                     existing_stage.pattern.point
                                 )
@@ -1383,7 +1517,11 @@ class Experiment:
             )
 
         # Update base protocol if requested (skip if source is already the base protocol)
-        if update_base_protocol and self.task_protocol is not None and source_lamella_name is not None:
+        if (
+            update_base_protocol
+            and self.task_protocol is not None
+            and source_lamella_name is not None
+        ):
             for task_name in task_names:
                 if task_name in source_task_config:
                     self.task_protocol.task_config[task_name] = deepcopy(
@@ -1416,13 +1554,20 @@ class Experiment:
 
         # check if lamella already exists
         if lamella in self.positions:
-            raise ValueError(f"Lamella {lamella.name} already exists in the experiment.")
+            raise ValueError(
+                f"Lamella {lamella.name} already exists in the experiment."
+            )
 
         self.positions.append(deepcopy(lamella))
         logging.info(f"Added lamella {lamella.name} to experiment {self.name}")
 
     @classmethod
-    def create(cls, path: Path, name: str = cfg.EXPERIMENT_NAME, metadata: Optional[Dict[str, Any]] = None) -> 'Experiment':
+    def create(
+        cls,
+        path: Path,
+        name: str = cfg.EXPERIMENT_NAME,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> "Experiment":
         """Create a new experiment with the given path and name. Also configures logging.
 
         Args:
@@ -1501,9 +1646,7 @@ class Experiment:
 
         # After _register_metadata, which sets `application` on the very SystemInfo
         # being snapshotted here.
-        self.session = SessionInfo.collect(
-            microscope, user=self._declared_user()
-        )
+        self.session = SessionInfo.collect(microscope, user=self._declared_user())
 
         # Written now rather than left to whatever saves next -- relying on someone
         # else's save is how FIB-490 lost every failed task. Only for an experiment
@@ -1543,13 +1686,15 @@ class Experiment:
         """Save the task protocol to disk in the experiment directory."""
         self.task_protocol.save(os.path.join(self.path, "protocol.yaml"))
 
-###### TASK REFACTORING ##########
+    ###### TASK REFACTORING ##########
 
-    def add_new_lamella(self,
-                        microscope_state: MicroscopeState,
-                        task_config: EventedDict[str, AutoLamellaTaskConfig],
-                        name: Optional[str] = None,
-                        fluorescence_pose: Optional[MicroscopeState] = None) -> None:
+    def add_new_lamella(
+        self,
+        microscope_state: MicroscopeState,
+        task_config: EventedDict[str, AutoLamellaTaskConfig],
+        name: Optional[str] = None,
+        fluorescence_pose: Optional[MicroscopeState] = None,
+    ) -> None:
         """Create a new lamella and add it to the experiment.
 
         Args:
@@ -1573,10 +1718,9 @@ class Experiment:
         path = Path(os.path.join(self.path, name))
 
         # create the lamella
-        lamella = Lamella(petname=name,
-                          path=path,
-                          number=number,
-                          task_config=deepcopy(task_config))
+        lamella = Lamella(
+            petname=name, path=path, number=number, task_config=deepcopy(task_config)
+        )
         if template.alignment_area is not None:
             lamella.alignment_area = deepcopy(template.alignment_area)
         if template.poi is not None:
@@ -1616,7 +1760,7 @@ class Experiment:
 
         df_task_history = pd.DataFrame(history)
         return df_task_history
-    
+
     def experiment_summary_dataframe(self) -> pd.DataFrame:
         """Create a summary dataframe of the experiment."""
         edict = []
@@ -1628,9 +1772,15 @@ class Experiment:
                 "experiment_id": self.id,
                 "lamella_name": p.name,
                 "lamella_id": p.id,
-                "last_completed": p.last_completed_task.completed if p.last_completed_task else None,
-                "last_completed_task": p.last_completed_task.name if p.last_completed_task else None,
-                "last_completed_at": p.last_completed_task.completed_at if p.last_completed_task else None,
+                "last_completed": p.last_completed_task.completed
+                if p.last_completed_task
+                else None,
+                "last_completed_task": p.last_completed_task.name
+                if p.last_completed_task
+                else None,
+                "last_completed_at": p.last_completed_task.completed_at
+                if p.last_completed_task
+                else None,
                 "is_completed": self.task_protocol.workflow_config.is_completed(p),
                 "is_failure": p.is_failure,
                 "milling_angle": p.milling_angle,
@@ -1640,9 +1790,9 @@ class Experiment:
         df = pd.DataFrame(edict)
 
         return df
-    
+
     def workflow_dataframe(self) -> pd.DataFrame:
-        """Create a dataframe with the workflow """
+        """Create a dataframe with the workflow"""
         wlist: List[Dict] = []
         for i, t in enumerate(self.task_protocol.workflow_config.tasks, 1):
             ddict = {

--- a/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
@@ -1,4 +1,3 @@
-
 import copy
 import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
@@ -80,10 +79,13 @@ if TYPE_CHECKING:
     from fibsem.milling.tasks import FibsemMillingTaskConfig
     from fibsem.structures import ReferenceImageParameters
 
+
 class AddTaskDialog(QDialog):
     """Dialog for adding a new task to the protocol."""
 
-    def __init__(self, existing_task_config: Dict[str, Any], parent: Optional[QWidget] = None):
+    def __init__(
+        self, existing_task_config: Dict[str, Any], parent: Optional[QWidget] = None
+    ):
         super().__init__(parent)
         self.existing_task_config = existing_task_config
         self.setWindowTitle("Add New Task")
@@ -105,7 +107,9 @@ class AddTaskDialog(QDialog):
         self.label_warning.setStyleSheet("color: orange; font-weight: bold;")
 
         # Dialog buttons
-        self.button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.button_box = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
         self.button_box.accepted.connect(self.validate_and_accept)
         self.button_box.rejected.connect(self.reject)
 
@@ -123,7 +127,9 @@ class AddTaskDialog(QDialog):
 
         # Connect signals
         self.lineEdit_task_name.textChanged.connect(self.validate_task_name)
-        self.comboBox_task_type.currentIndexChanged.connect(self.update_default_task_name)
+        self.comboBox_task_type.currentIndexChanged.connect(
+            self.update_default_task_name
+        )
 
         # Set default task name
         self.update_default_task_name()
@@ -148,7 +154,9 @@ class AddTaskDialog(QDialog):
             return False
 
         if task_name in self.existing_task_config:
-            self.label_warning.setText(f"⚠ Warning: Task name '{task_name}' already exists!")
+            self.label_warning.setText(
+                f"⚠ Warning: Task name '{task_name}' already exists!"
+            )
             return False
 
         self.label_warning.setText("")
@@ -179,14 +187,14 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
     workflow_config_changed = pyqtSignal(object)  # AutoLamellaWorkflowConfig
 
-    def __init__(self, parent: 'AutoLamellaUI'):
+    def __init__(self, parent: "AutoLamellaUI"):
         super().__init__(parent)
         self.parent_widget = parent
         self.setStyleSheet(stylesheets.NAPARI_STYLE)
 
         self.milling_task_editor: Optional[MillingTaskViewerWidget] = None
-        self.microscope = getattr(self.parent_widget, 'microscope', None)  # type: ignore[assignment]
-        self.experiment: 'Experiment' = getattr(self.parent_widget, 'experiment', None)  # type: ignore[assignment]
+        self.microscope = getattr(self.parent_widget, "microscope", None)  # type: ignore[assignment]
+        self.experiment: "Experiment" = getattr(self.parent_widget, "experiment", None)  # type: ignore[assignment]
         self._current_milling_key: Optional[str] = None
 
         self._main_layout = QVBoxLayout(self)
@@ -234,7 +242,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         else:
             self._try_initialize()
 
-    def set_experiment(self, experiment: 'Experiment'):
+    def set_experiment(self, experiment: "Experiment"):
         """Set the experiment for the protocol editor."""
         self.experiment = experiment
         if self.milling_task_editor is None:
@@ -250,7 +258,9 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         self.protocol_info_widget = ProtocolInformationWidget(parent=self)
 
         # Task parameters (Column 2)
-        self.task_parameters_config_widget = AutoLamellaTaskParametersConfigWidget(parent=self)
+        self.task_parameters_config_widget = AutoLamellaTaskParametersConfigWidget(
+            parent=self
+        )
         self.ref_image_params_widget = ReferenceImageParametersWidget(parent=self)
 
         # Milling task editor (Column 3 — no controller, config panels only)
@@ -261,31 +271,47 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         )
         self.milling_task_editor.setMinimumHeight(550)
 
-        self.fluorescence_acquisition_task_config_widget = AutoLamellaFluorescenceAcquisitionTaskConfigWidget(
-            microscope=self.microscope,
-            config=None,
-            parent=self
+        self.fluorescence_acquisition_task_config_widget = (
+            AutoLamellaFluorescenceAcquisitionTaskConfigWidget(
+                microscope=self.microscope, config=None, parent=self
+            )
         )
 
         # lamella, milling controls (Column 1)
         self.task_list_widget = TaskNameListWidget()
 
-        self.pushButton_sync_to_lamella = QPushButton("Apply Config to Existing Lamella")
-        self.pushButton_sync_to_lamella.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
-        self.pushButton_sync_to_lamella.setToolTip("Update all existing lamella with the current task configuration")
+        self.pushButton_sync_to_lamella = QPushButton(
+            "Apply Config to Existing Lamella"
+        )
+        self.pushButton_sync_to_lamella.setStyleSheet(
+            stylesheets.SECONDARY_BUTTON_STYLESHEET
+        )
+        self.pushButton_sync_to_lamella.setToolTip(
+            "Update all existing lamella with the current task configuration"
+        )
         self._protocol_dirty = False
 
         self.pushButton_open_global_editor = QPushButton("Global Edit")
-        self.pushButton_open_global_editor.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
-        self.pushButton_open_global_editor.setToolTip("Globally edit reference imaging settings and milling FoV across multiple tasks.")
+        self.pushButton_open_global_editor.setStyleSheet(
+            stylesheets.SECONDARY_BUTTON_STYLESHEET
+        )
+        self.pushButton_open_global_editor.setToolTip(
+            "Globally edit reference imaging settings and milling FoV across multiple tasks."
+        )
 
         self.pushButton_open_lamella_defaults = QPushButton("Lamella Template")
-        self.pushButton_open_lamella_defaults.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
-        self.pushButton_open_lamella_defaults.setToolTip("Edit the initial state applied to every new lamella created from this protocol.")
+        self.pushButton_open_lamella_defaults.setStyleSheet(
+            stylesheets.SECONDARY_BUTTON_STYLESHEET
+        )
+        self.pushButton_open_lamella_defaults.setToolTip(
+            "Edit the initial state applied to every new lamella created from this protocol."
+        )
 
         # only meaningful for a spot-burn task; shown/hidden in _on_selected_task_changed
         self.pushButton_edit_spot_burn = QPushButton("Spot Burn Coordinates")
-        self.pushButton_edit_spot_burn.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.pushButton_edit_spot_burn.setStyleSheet(
+            stylesheets.SECONDARY_BUTTON_STYLESHEET
+        )
         self.pushButton_edit_spot_burn.setToolTip(
             "Place this task's default spot-burn coordinates on a reference frame, "
             "instead of hand-editing them in the protocol file."
@@ -351,36 +377,58 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
     def _set_protocol_dirty(self, dirty: bool):
         self._protocol_dirty = dirty
         if dirty and self.pushButton_sync_to_lamella.isEnabled():
-            self.pushButton_sync_to_lamella.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+            self.pushButton_sync_to_lamella.setStyleSheet(
+                stylesheets.PRIMARY_BUTTON_STYLESHEET
+            )
             self.pushButton_sync_to_lamella.setToolTip(
                 "Protocol edited — click to apply current task configuration to existing lamella."
             )
         else:
-            self.pushButton_sync_to_lamella.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+            self.pushButton_sync_to_lamella.setStyleSheet(
+                stylesheets.SECONDARY_BUTTON_STYLESHEET
+            )
             self.pushButton_sync_to_lamella.setToolTip(
                 "Update all existing lamella with the current task configuration"
             )
 
     def _setup_connections(self):
         """Setup signal connections - called once during initialization."""
-        self.task_list_widget.task_selected.connect(lambda _: self._on_selected_task_changed())
+        self.task_list_widget.task_selected.connect(
+            lambda _: self._on_selected_task_changed()
+        )
         self.task_list_widget.add_clicked.connect(self._on_add_task_clicked)
         self.task_list_widget.remove_clicked.connect(self._on_remove_task_clicked)
-        self.milling_task_editor.settings_changed.connect(self._on_milling_settings_changed)
-        self.task_parameters_config_widget.parameter_changed.connect(self._on_task_parameters_config_changed)
-        self.ref_image_params_widget.settings_changed.connect(self._on_ref_image_settings_changed)
-        self.fluorescence_acquisition_task_config_widget.settings_changed.connect(self._on_fluorescence_acquisition_settings_changed)
-        self.pushButton_edit_spot_burn.clicked.connect(self._on_spot_burn_coordinates_clicked)
-        self.pushButton_sync_to_lamella.clicked.connect(self._on_sync_to_lamella_clicked)
+        self.milling_task_editor.settings_changed.connect(
+            self._on_milling_settings_changed
+        )
+        self.task_parameters_config_widget.parameter_changed.connect(
+            self._on_task_parameters_config_changed
+        )
+        self.ref_image_params_widget.settings_changed.connect(
+            self._on_ref_image_settings_changed
+        )
+        self.fluorescence_acquisition_task_config_widget.settings_changed.connect(
+            self._on_fluorescence_acquisition_settings_changed
+        )
+        self.pushButton_edit_spot_burn.clicked.connect(
+            self._on_spot_burn_coordinates_clicked
+        )
+        self.pushButton_sync_to_lamella.clicked.connect(
+            self._on_sync_to_lamella_clicked
+        )
         self.pushButton_open_global_editor.clicked.connect(self._on_global_edit_clicked)
-        self.pushButton_open_lamella_defaults.clicked.connect(self._on_lamella_defaults_clicked)
+        self.pushButton_open_lamella_defaults.clicked.connect(
+            self._on_lamella_defaults_clicked
+        )
         self.protocol_info_widget.field_changed.connect(self._on_protocol_field_changed)
 
     def _initialise_widgets(self):
         """Initialise the widgets based on the current experiment protocol."""
 
         if self.experiment is None or self.experiment.task_protocol is None:
-            raise ValueError("Experiment or task protocol is None, cannot initialise protocol editor.")
+            raise ValueError(
+                "Experiment or task protocol is None, cannot initialise protocol editor."
+            )
 
         self.protocol_info_widget.update_from_protocol(self.experiment.task_protocol)
 
@@ -398,7 +446,9 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         # set milling task config
         if task_config.milling:
             self._current_milling_key = next(iter(task_config.milling))
-            self.milling_task_editor.set_config(task_config.milling[self._current_milling_key])
+            self.milling_task_editor.set_config(
+                task_config.milling[self._current_milling_key]
+            )
             self.milling_task_editor.setVisible(True)
         else:
             self._current_milling_key = None
@@ -407,11 +457,15 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
         # special handling for fluorescence acquisition task
         is_fluorescence_task = isinstance(task_config, AcquireFluorescenceImageConfig)
-        self.fluorescence_acquisition_task_config_widget.setVisible(is_fluorescence_task)
+        self.fluorescence_acquisition_task_config_widget.setVisible(
+            is_fluorescence_task
+        )
         self.task_parameters_config_widget.setVisible(not is_fluorescence_task)
         self.ref_image_params_widget.setVisible(not is_fluorescence_task)
         if is_fluorescence_task:
-            self.fluorescence_acquisition_task_config_widget.set_task_config(task_config)
+            self.fluorescence_acquisition_task_config_widget.set_task_config(
+                task_config
+            )
 
         self._set_protocol_dirty(False)
 
@@ -421,13 +475,15 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
             isinstance(task_config, SpotBurnFiducialTaskConfig)
         )
 
-    def _on_milling_settings_changed(self, config: 'FibsemMillingTaskConfig'):
+    def _on_milling_settings_changed(self, config: "FibsemMillingTaskConfig"):
         """Callback when the milling task config is changed."""
         self._set_protocol_dirty(True)
         selected_task_name = self.task_list_widget.selected_task
         key = self._current_milling_key
         if key and selected_task_name in self.experiment.task_protocol.task_config:
-            self.experiment.task_protocol.task_config[selected_task_name].milling[key] = config
+            self.experiment.task_protocol.task_config[selected_task_name].milling[
+                key
+            ] = config
             logging.info(f"Updated {selected_task_name} Task, milling key '{key}'")
 
         # save the experiment
@@ -437,25 +493,35 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         """Callback when the task parameters config is updated."""
         self._set_protocol_dirty(True)
         selected_task_name = self.task_list_widget.selected_task
-        logging.info(f"Updated {selected_task_name} Task Parameters: {field_name} = {new_value}")
+        logging.info(
+            f"Updated {selected_task_name} Task Parameters: {field_name} = {new_value}"
+        )
 
         # update parameters in the task config
-        setattr(self.experiment.task_protocol.task_config[selected_task_name], field_name, new_value)
+        setattr(
+            self.experiment.task_protocol.task_config[selected_task_name],
+            field_name,
+            new_value,
+        )
 
         # save the experiment
         self._save_experiment()
 
-    def _on_ref_image_settings_changed(self, settings: 'ReferenceImageParameters'):
+    def _on_ref_image_settings_changed(self, settings: "ReferenceImageParameters"):
         """Callback when the image settings are changed."""
         self._set_protocol_dirty(True)
         # Update the image settings in the task config
         selected_task_name = self.task_list_widget.selected_task
-        self.experiment.task_protocol.task_config[selected_task_name].reference_imaging = settings
+        self.experiment.task_protocol.task_config[
+            selected_task_name
+        ].reference_imaging = settings
 
         # Save the experiment
         self._save_experiment()
 
-    def _on_fluorescence_acquisition_settings_changed(self, config: 'AcquireFluorescenceImageConfig'):
+    def _on_fluorescence_acquisition_settings_changed(
+        self, config: "AcquireFluorescenceImageConfig"
+    ):
         """Callback when the fluorescence acquisition settings are changed."""
         self._set_protocol_dirty(True)
         # Update the task config
@@ -573,7 +639,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
     def _on_add_task_clicked(self):
         """Show dialog to add a new task."""
-        dialog = AddTaskDialog(self.experiment.task_protocol.task_config, parent=self) # type: ignore
+        dialog = AddTaskDialog(self.experiment.task_protocol.task_config, parent=self)  # type: ignore
         if dialog.exec_() == QDialog.Accepted:
             task_type, task_name = dialog.get_task_info()
             if task_type and task_name:
@@ -596,7 +662,9 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
                 # Refresh widgets
                 self._initialise_widgets()
                 self.task_list_widget.select(task_name)
-                self.workflow_config_changed.emit(self.experiment.task_protocol.workflow_config)
+                self.workflow_config_changed.emit(
+                    self.experiment.task_protocol.workflow_config
+                )
                 logging.info(f"Added new task: {task_name} ({task_type})")
 
     def _on_remove_task_clicked(self):
@@ -612,7 +680,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
             "Confirm Removal",
             f"Are you sure you want to remove the task '{selected_task_name}'?\n\nThis action cannot be undone.",
             QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No
+            QMessageBox.No,
         )
 
         if reply == QMessageBox.Yes:
@@ -625,7 +693,9 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
                 # Refresh widgets
                 self._initialise_widgets()
-                self.workflow_config_changed.emit(self.experiment.task_protocol.workflow_config)
+                self.workflow_config_changed.emit(
+                    self.experiment.task_protocol.workflow_config
+                )
 
                 logging.info(f"Removed task: {selected_task_name}")
 
@@ -696,7 +766,9 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
         try:
             if dialog.exec_() == QDialog.Accepted:
-                self.experiment.task_protocol.lamella_defaults = template_widget.get_template()
+                self.experiment.task_protocol.lamella_defaults = (
+                    template_widget.get_template()
+                )
                 self._save_experiment()
         finally:
             dialog.deleteLater()  # parented to this editor, so Qt keeps it otherwise
@@ -723,7 +795,6 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
             )
             return
 
-
         # Show confirmation dialog
         num_lamella = len(self.experiment.positions)
         reply = QMessageBox.question(
@@ -739,7 +810,6 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         )
 
         if reply == QMessageBox.Yes:
-
             # Perform the sync (from base protocol to all lamella)
             all_lamella_names = [p.name for p in self.experiment.positions]
             updated_count = self.experiment.apply_lamella_config(
@@ -758,7 +828,6 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
                 f"Successfully synced task configuration '{selected_task_name}' to {updated_count} lamella.",
             )
 
-            logging.info(f"Synced task configuration '{selected_task_name}' to {updated_count} lamella")
-
-
-
+            logging.info(
+                f"Synced task configuration '{selected_task_name}' to {updated_count} lamella"
+            )

--- a/fibsem/applications/autolamella/ui/lamella_workflow_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_workflow_widget.py
@@ -46,6 +46,7 @@ _SECTION_LABEL_STYLE = (
     f" padding: 4px 6px 2px 6px; background: {CANVAS_BG};"
 )
 
+
 class AddTaskDialog(QDialog):
     """Dialog for selecting a task to add to the workflow."""
 
@@ -92,7 +93,7 @@ class AddTaskDialog(QDialog):
 
         # Dialog buttons
         button_box = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel # type: ignore
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel  # type: ignore
         )
         button_box.accepted.connect(self._on_accept)
         button_box.rejected.connect(self.reject)
@@ -112,6 +113,7 @@ class AddTaskDialog(QDialog):
     def get_selected_task(self) -> str | None:
         """Get the selected task name."""
         return self.selected_task
+
 
 class _TaskEditorDialog(QDialog):
     """Modal dialog wrapping WorkflowTaskEditorWidget."""
@@ -155,24 +157,24 @@ class LamellaWorkflowWidget(QWidget):
     """
 
     # ── lamella signals ──────────────────────────────────────────────────
-    lamella_move_to_requested = pyqtSignal(object)   # Lamella
-    lamella_edit_requested = pyqtSignal(object)      # Lamella
-    lamella_remove_requested = pyqtSignal(object)    # Lamella
-    lamella_defect_changed = pyqtSignal(object)      # Lamella
-    lamella_selection_changed = pyqtSignal(list)     # List[Lamella]
+    lamella_move_to_requested = pyqtSignal(object)  # Lamella
+    lamella_edit_requested = pyqtSignal(object)  # Lamella
+    lamella_remove_requested = pyqtSignal(object)  # Lamella
+    lamella_defect_changed = pyqtSignal(object)  # Lamella
+    lamella_selection_changed = pyqtSignal(list)  # List[Lamella]
 
     # ── workflow signals ─────────────────────────────────────────────────
-    task_supervised_changed = pyqtSignal(object)     # AutoLamellaTaskDescription
-    task_edited = pyqtSignal(object)                 # AutoLamellaTaskDescription (after apply)
-    task_remove_requested = pyqtSignal(object)       # AutoLamellaTaskDescription
-    task_added = pyqtSignal(object)                  # AutoLamellaTaskDescription
-    task_selection_changed = pyqtSignal(list)        # List[AutoLamellaTaskDescription]
-    task_order_changed = pyqtSignal(list)            # List[AutoLamellaTaskDescription]
+    task_supervised_changed = pyqtSignal(object)  # AutoLamellaTaskDescription
+    task_edited = pyqtSignal(object)  # AutoLamellaTaskDescription (after apply)
+    task_remove_requested = pyqtSignal(object)  # AutoLamellaTaskDescription
+    task_added = pyqtSignal(object)  # AutoLamellaTaskDescription
+    task_selection_changed = pyqtSignal(list)  # List[AutoLamellaTaskDescription]
+    task_order_changed = pyqtSignal(list)  # List[AutoLamellaTaskDescription]
 
     # ── workflow info signals ────────────────────────────────────────────
     workflow_name_changed = pyqtSignal(str)
     workflow_description_changed = pyqtSignal(str)
-    workflow_options_changed = pyqtSignal(object)    # AutoLamellaWorkflowOptions
+    workflow_options_changed = pyqtSignal(object)  # AutoLamellaWorkflowOptions
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)

--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -27,23 +27,42 @@ from fibsem.structures import field_meta
 @dataclass
 class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
     """Configuration for the AcquireFluorescenceImageTask."""
+
     task_type: ClassVar[str] = "ACQUIRE_FLUORESCENCE_IMAGE"
     display_name: ClassVar[str] = "Acquire Fluorescence Image"
-    channel_settings: list[ChannelSettings] = field(default_factory=list,
-                                                    metadata=field_meta(tooltip="Settings for each fluorescence channel",
-                                                                        label="Channel Settings"))
-    zparams: ZParameters = field(default_factory=ZParameters,
-                                  metadata=field_meta(tooltip="Z-stack acquisition parameters",
-                                                      label="Z-Stack Parameters"))
-    autofocus_settings: AutoFocusSettings = field(default_factory=AutoFocusSettings,
-                                                  metadata=field_meta(tooltip="Settings for autofocus before acquiring fluorescence images",
-                                                                      label="Autofocus Settings"))
-    orientation: Optional[str] = field(default=None,
-                                       metadata=field_meta(tooltip="Orientation for acquisition. 'FM' or 'SEM'. None = use fluorescence_pose as-is.",
-                                                           label="Orientation"))
-    retract_objective: bool = field(default=True,
-                                    metadata=field_meta(tooltip="Retract the objective when the task finishes, so it is clear of the stage for subsequent moves. Disable for back-to-back fluorescence tasks.",
-                                                        label="Retract Objective"))
+    channel_settings: list[ChannelSettings] = field(
+        default_factory=list,
+        metadata=field_meta(
+            tooltip="Settings for each fluorescence channel", label="Channel Settings"
+        ),
+    )
+    zparams: ZParameters = field(
+        default_factory=ZParameters,
+        metadata=field_meta(
+            tooltip="Z-stack acquisition parameters", label="Z-Stack Parameters"
+        ),
+    )
+    autofocus_settings: AutoFocusSettings = field(
+        default_factory=AutoFocusSettings,
+        metadata=field_meta(
+            tooltip="Settings for autofocus before acquiring fluorescence images",
+            label="Autofocus Settings",
+        ),
+    )
+    orientation: Optional[str] = field(
+        default=None,
+        metadata=field_meta(
+            tooltip="Orientation for acquisition. 'FM' or 'SEM'. None = use fluorescence_pose as-is.",
+            label="Orientation",
+        ),
+    )
+    retract_objective: bool = field(
+        default=True,
+        metadata=field_meta(
+            tooltip="Retract the objective when the task finishes, so it is clear of the stage for subsequent moves. Disable for back-to-back fluorescence tasks.",
+            label="Retract Objective",
+        ),
+    )
 
     def to_dict(self) -> dict:
         ddict = {}
@@ -56,9 +75,13 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
         return ddict
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'AcquireFluorescenceImageConfig':
-        channel_settings = [ChannelSettings.from_dict(cs) for cs in data.get("channel_settings", [])]
-        autofocus_settings = AutoFocusSettings.from_dict(data.get("autofocus_settings", {}))
+    def from_dict(cls, data: dict) -> "AcquireFluorescenceImageConfig":
+        channel_settings = [
+            ChannelSettings.from_dict(cs) for cs in data.get("channel_settings", [])
+        ]
+        autofocus_settings = AutoFocusSettings.from_dict(
+            data.get("autofocus_settings", {})
+        )
         zparams = ZParameters.from_dict(data.get("zparams", {}))
         return cls(
             task_name=data.get("task_name", ""),
@@ -94,31 +117,43 @@ class AcquireFluorescenceImageConfig(AutoLamellaTaskConfig):
 
 class AcquireFluorescenceImageTask(AutoLamellaTask):
     """Task to acquire fluorescence image with specified settings."""
+
     config: AcquireFluorescenceImageConfig
-    config_cls: ClassVar[Type[AcquireFluorescenceImageConfig]] = AcquireFluorescenceImageConfig
+    config_cls: ClassVar[Type[AcquireFluorescenceImageConfig]] = (
+        AcquireFluorescenceImageConfig
+    )
 
     def _run(self) -> None:
         """Run the task to acquire fluorescence image with the specified settings."""
 
         if self.microscope.fm is None:
-            raise ValueError("Fluorescence microscope not initialized in the FibsemMicroscope instance")
-        if self.lamella.fluorescence_pose is None or self.lamella.fluorescence_pose.objective_position is None:
-            raise ValueError(f"Objective position for {self.lamella.name} is not set. Please set the objective position before acquiring fluorescence images.")
+            raise ValueError(
+                "Fluorescence microscope not initialized in the FibsemMicroscope instance"
+            )
+        if (
+            self.lamella.fluorescence_pose is None
+            or self.lamella.fluorescence_pose.objective_position is None
+        ):
+            raise ValueError(
+                f"Objective position for {self.lamella.name} is not set. Please set the objective position before acquiring fluorescence images."
+            )
         if self.lamella.stage_position is None:
-            raise ValueError(f"Stage position for {self.lamella.name} is not set. Please set the stage position before acquiring fluorescence images.")
-
+            raise ValueError(
+                f"Stage position for {self.lamella.name} is not set. Please set the stage position before acquiring fluorescence images."
+            )
 
         self._move_to_stage_position()
 
         self._move_to_objective_position()
-
 
         # Run autofocus if requested
         if self.config.autofocus_settings.enabled:
             result = self._run_autofocus()
             # autofocus found a better focus — make it the lamella's saved objective position
             if result is not None and self.lamella.fluorescence_pose is not None:
-                self.lamella.fluorescence_pose.objective_position = result.working_distance
+                self.lamella.fluorescence_pose.objective_position = (
+                    result.working_distance
+                )
 
         # Generate timestamp-based filename
         timestamp = utils.current_timestamp_v3(timeonly=True)
@@ -126,13 +161,19 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
         filename = os.path.join(self.lamella.path, basename)
 
         # Acquire image
-        self.log_status_message("ACQUIRE_FLUORESCENCE_IMAGE", "Acquiring Fluorescence Image...")
-        self.microscope.fm.acquisition_progress_signal.emit({"state": "acquiring", "task": f"{self.task_name}"})
-        image = acquire_image(microscope=self.microscope.fm,
-                                channel_settings=self.config.channel_settings,
-                                zparams=self.config.zparams,
-                                stop_event=self._stop_event,
-                                filename=filename)
+        self.log_status_message(
+            "ACQUIRE_FLUORESCENCE_IMAGE", "Acquiring Fluorescence Image..."
+        )
+        self.microscope.fm.acquisition_progress_signal.emit(
+            {"state": "acquiring", "task": f"{self.task_name}"}
+        )
+        image = acquire_image(
+            microscope=self.microscope.fm,
+            channel_settings=self.config.channel_settings,
+            zparams=self.config.zparams,
+            stop_event=self._stop_event,
+            filename=filename,
+        )
 
         # acquire_image swallows save failures (it logs and carries on), so the
         # requested filename is not proof the file was written. FluorescenceImage.save
@@ -147,7 +188,6 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
         if self.config.retract_objective:
             self._retract_objective()
 
-
     def _run_autofocus(self) -> Optional[AutoFocusResult]:
         """Run autofocus with the specified settings, returning the result."""
         # Find autofocus channel by name if specified in autofocus_settings
@@ -160,9 +200,10 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
 
         # Fall back to first channel if no specific channel found
         if autofocus_channel is None:
-            logging.warning(f"Autofocus channel '{self.config.autofocus_settings.channel_name}' not found, using first channel")
+            logging.warning(
+                f"Autofocus channel '{self.config.autofocus_settings.channel_name}' not found, using first channel"
+            )
             autofocus_channel = self.config.channel_settings[0]
-
 
         af_settings = self.config.autofocus_settings
         logging.info(
@@ -170,28 +211,38 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
             f"with method '{af_settings.method.value}' and {len(af_settings.passes)} pass(es)"
         )
         if self.validate:
-            ask_user(self.parent_ui,
+            ask_user(
+                self.parent_ui,
                 msg=f"Run autofocus for {self.lamella.name} using channel '{autofocus_channel.name}'. Press continue when ready.",
-                pos="Continue"
-                )
+                pos="Continue",
+            )
 
-        af_display = (f"Autofocus: {autofocus_channel.name} "
-                      f"[{af_settings.method.value}], {len(af_settings.passes)} pass(es)")
+        af_display = (
+            f"Autofocus: {autofocus_channel.name} "
+            f"[{af_settings.method.value}], {len(af_settings.passes)} pass(es)"
+        )
         self.log_status_message("AUTOFOCUS", af_display)
-        self.microscope.fm.acquisition_progress_signal.emit({"state": "autofocusing", "task": f"{self.task_name}"}) # type: ignore
+        self.microscope.fm.acquisition_progress_signal.emit(
+            {"state": "autofocusing", "task": f"{self.task_name}"}
+        )  # type: ignore
         # Query: pass in channel settings so we are certain the channel is correct
         result = run_coarse_fine_autofocus(
-                self.microscope.fm,
-                autofocus_settings=self.config.autofocus_settings,
-                channel_settings=autofocus_channel,
-                stop_event=self._stop_event
-            )
+            self.microscope.fm,
+            autofocus_settings=self.config.autofocus_settings,
+            channel_settings=autofocus_channel,
+            stop_event=self._stop_event,
+        )
         if result is None:
             logging.info("Autofocus cancelled")
-            raise InterruptedError(f"Task {self.task_name} for {self.lamella.name} cancelled during autofocus.")
+            raise InterruptedError(
+                f"Task {self.task_name} for {self.lamella.name} cancelled during autofocus."
+            )
         try:
             ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-            result.save(path=os.path.join(self.lamella.path, "autofunctions"), name=f"{self.task_name}_autofocus_{ts}")
+            result.save(
+                path=os.path.join(self.lamella.path, "autofunctions"),
+                name=f"{self.task_name}_autofocus_{ts}",
+            )
         except Exception as e:
             logging.warning(f"Failed to save autofocus result: {e}")
 
@@ -199,7 +250,10 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
 
     def _move_to_stage_position(self):
         """Move the stage to the fluorescence pose stage position, or the lamella stage position if fluorescence pose is not set."""
-        if self.lamella.fluorescence_pose is not None and self.lamella.fluorescence_pose.stage_position is not None:
+        if (
+            self.lamella.fluorescence_pose is not None
+            and self.lamella.fluorescence_pose.stage_position is not None
+        ):
             stage_position = self.lamella.fluorescence_pose.stage_position
         else:
             stage_position = self.lamella.stage_position
@@ -207,26 +261,38 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
         if self.config.orientation is not None:
             stage_position = self.microscope.get_target_position(
                 stage_position=stage_position,
-                target_orientation=self.config.orientation
+                target_orientation=self.config.orientation,
             )
         elif not self.microscope.fm.has_valid_orientation(stage_position):
-            logging.warning(f"Stage Position {self.lamella.name} is not in a valid orientation: {stage_position}, moving to SEM orientation...")
-            stage_position = self.microscope.get_target_position(stage_position=stage_position, target_orientation="SEM")
+            logging.warning(
+                f"Stage Position {self.lamella.name} is not in a valid orientation: {stage_position}, moving to SEM orientation..."
+            )
+            stage_position = self.microscope.get_target_position(
+                stage_position=stage_position, target_orientation="SEM"
+            )
 
         # Check for cancellation before each position
         if self._stop_event and self._stop_event.is_set():
-            logging.info(f"{self.task_name}: {self.lamella.name} - Acquisition cancelled")
+            logging.info(
+                f"{self.task_name}: {self.lamella.name} - Acquisition cancelled"
+            )
             return
 
         # Move stage to the saved stage position and objective position
         self.log_status_message("MOVE_TO_POSITION", "Moving to Position...")
-        self.microscope.fm.acquisition_progress_signal.emit({"state": "moving", "task": f"{self.task_name}"})
+        self.microscope.fm.acquisition_progress_signal.emit(
+            {"state": "moving", "task": f"{self.task_name}"}
+        )
         self.microscope.safe_absolute_stage_movement(stage_position)
 
     def _move_to_objective_position(self):
         # move objective to saved position
         self.log_status_message("MOVE_OBJECTIVE", "Moving Objective to position...")
         if not self.microscope.fm.objective.state == "Inserted":
-            logging.warning("Objective is not inserted. Inserting the objective before acquiring fluorescence images.")
+            logging.warning(
+                "Objective is not inserted. Inserting the objective before acquiring fluorescence images."
+            )
             self.microscope.fm.objective.insert()
-        self.microscope.fm.objective.move_absolute(self.lamella.fluorescence_pose.objective_position)
+        self.microscope.fm.objective.move_absolute(
+            self.lamella.fluorescence_pose.objective_position
+        )

--- a/fibsem/applications/autolamella/workflows/tasks/basic_milling.py
+++ b/fibsem/applications/autolamella/workflows/tasks/basic_milling.py
@@ -1,4 +1,3 @@
-
 ######## BASIC MILLING TASK DEFINITIONS ########
 
 from copy import deepcopy
@@ -16,6 +15,7 @@ from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
 @dataclass
 class BasicMillingTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the BasicMillingTask."""
+
     task_type: ClassVar[str] = "BASIC_MILLING"
     display_name: ClassVar[str] = "Basic Milling"
 
@@ -26,6 +26,7 @@ class BasicMillingTaskConfig(AutoLamellaTaskConfig):
 
 class BasicMillingTask(AutoLamellaTask):
     """A simple milling task that moves to the lamella position, runs milling, and takes reference images."""
+
     config: BasicMillingTaskConfig
     config_cls: ClassVar[Type[BasicMillingTaskConfig]] = BasicMillingTaskConfig
 
@@ -42,8 +43,10 @@ class BasicMillingTask(AutoLamellaTask):
 
         for key, milling_task_config in self.config.milling.items():
             milling_task_config.acquisition.imaging.path = self.lamella.path
-            milling_task_config = self.update_milling_config_ui( milling_task_config)
+            milling_task_config = self.update_milling_config_ui(milling_task_config)
             self.config.milling[key] = deepcopy(milling_task_config)
 
-        self.log_status_message("ACQUIRE_REFERENCE_IMAGES", "Acquiring Reference Images...")
+        self.log_status_message(
+            "ACQUIRE_REFERENCE_IMAGES", "Acquiring Reference Images..."
+        )
         self._acquire_set_of_reference_images(image_settings)

--- a/fibsem/applications/autolamella/workflows/tasks/fiducial.py
+++ b/fibsem/applications/autolamella/workflows/tasks/fiducial.py
@@ -1,4 +1,3 @@
-
 ######## FIDUCIAL TASK DEFINITIONS ########
 
 import logging
@@ -39,15 +38,16 @@ class MillFiducialTaskConfig(AutoLamellaTaskConfig):
         default=True,
         metadata=field_meta(
             tooltip="Align to the reference image before milling fiducial (if available)"
-        )
-
+        ),
     )
     task_type: ClassVar[str] = "MILL_FIDUCIAL"
     display_name: ClassVar[str] = "Mill Fiducial"
 
     def __post_init__(self):
         if self.milling == {}:
-            self.milling = deepcopy({FIDUCIAL_KEY: DEFAULT_MILLING_CONFIG[FIDUCIAL_KEY]})
+            self.milling = deepcopy(
+                {FIDUCIAL_KEY: DEFAULT_MILLING_CONFIG[FIDUCIAL_KEY]}
+            )
 
     @property
     def opens_with_reference_alignment(self) -> bool:
@@ -57,6 +57,7 @@ class MillFiducialTaskConfig(AutoLamellaTaskConfig):
 
 class MillFiducialTask(AutoLamellaTask):
     """Task to setup the lamella for milling."""
+
     config: MillFiducialTaskConfig
     config_cls: ClassVar[Type[MillFiducialTaskConfig]] = MillFiducialTaskConfig
 
@@ -65,6 +66,7 @@ class MillFiducialTask(AutoLamellaTask):
 
         # bookkeeping
         from fibsem.structures import ImageSettings
+
         image_settings: ImageSettings = self.config.imaging
         image_settings.path = self.lamella.path
 
@@ -77,32 +79,42 @@ class MillFiducialTask(AutoLamellaTask):
 
         fiducial_task_config = self.config.milling[FIDUCIAL_KEY]
 
-        self._acquire_reference_image(image_settings, field_of_view=fiducial_task_config.field_of_view)
+        self._acquire_reference_image(
+            image_settings, field_of_view=fiducial_task_config.field_of_view
+        )
 
         # fiducial
         self.log_status_message("MILL_FIDUCIAL", "Milling Fiducial...")
         msg = f"Press Run Milling to mill the Fiducial for {self.lamella.name}. Press Continue when done."
         fiducial_task_config.alignment.rect = self.lamella.alignment_area
         fiducial_task_config.acquisition.imaging.path = self.lamella.path
-        milling_task_config = self.update_milling_config_ui(fiducial_task_config, msg=msg)
+        milling_task_config = self.update_milling_config_ui(
+            fiducial_task_config, msg=msg
+        )
         self.config.milling[FIDUCIAL_KEY] = deepcopy(milling_task_config)
 
         alignment_hfw = milling_task_config.field_of_view
         # get alignment area based on fiducial bounding box
-        self.lamella.alignment_area = get_pattern_reduced_area(pattern=milling_task_config.stages[0].pattern,
-                                                        image=FibsemImage.generate_blank_image(hfw=alignment_hfw),
-                                                        expand_percent=int(self.config.alignment_expansion))
+        self.lamella.alignment_area = get_pattern_reduced_area(
+            pattern=milling_task_config.stages[0].pattern,
+            image=FibsemImage.generate_blank_image(hfw=alignment_hfw),
+            expand_percent=int(self.config.alignment_expansion),
+        )
 
         if not self.lamella.alignment_area.is_valid_reduced_area:
-            raise ValueError(f"Invalid alignment area: {self.lamella.alignment_area}, check the field of view for the fiducial milling pattern.")
+            raise ValueError(
+                f"Invalid alignment area: {self.lamella.alignment_area}, check the field of view for the fiducial milling pattern."
+            )
 
         # validate alignment area
         self._validate_alignment_area()
 
         # # acquire alignment reference image
-        self._acquire_alignment_reference_image(image_settings=image_settings,
-                                      reduced_area=self.lamella.alignment_area,
-                                      field_of_view=alignment_hfw)
+        self._acquire_alignment_reference_image(
+            image_settings=image_settings,
+            reduced_area=self.lamella.alignment_area,
+            field_of_view=alignment_hfw,
+        )
 
         # sync alignment area to rough and polishing milling tasks (QUERY: should we sync all tasks?)
         rough_milling_task_config: Optional[FibsemMillingTaskConfig] = None
@@ -117,15 +129,26 @@ class MillFiducialTask(AutoLamellaTask):
                     rough_milling_task_config = task_config.milling[MILL_ROUGH_KEY]
                     rough_milling_name = task_name
                 elif task_config.task_type == "MILL_POLISHING":
-                    polishing_milling_task_config = task_config.milling[MILL_POLISHING_KEY]
+                    polishing_milling_task_config = task_config.milling[
+                        MILL_POLISHING_KEY
+                    ]
                     polishing_milling_name = task_name
         except Exception as e:
-            logging.warning(f"Unable to find MillRoughTaskConfig or MillPolishingTaskConfig in lamella task config: {e}")
+            logging.warning(
+                f"Unable to find MillRoughTaskConfig or MillPolishingTaskConfig in lamella task config: {e}"
+            )
 
         if rough_milling_task_config is not None and rough_milling_name is not None:
-            self.lamella.task_config[rough_milling_name].milling[MILL_ROUGH_KEY].alignment.rect = deepcopy(self.lamella.alignment_area)
-        if polishing_milling_task_config is not None and polishing_milling_name is not None:
-            self.lamella.task_config[polishing_milling_name].milling[MILL_POLISHING_KEY].alignment.rect = deepcopy(self.lamella.alignment_area)
+            self.lamella.task_config[rough_milling_name].milling[
+                MILL_ROUGH_KEY
+            ].alignment.rect = deepcopy(self.lamella.alignment_area)
+        if (
+            polishing_milling_task_config is not None
+            and polishing_milling_name is not None
+        ):
+            self.lamella.task_config[polishing_milling_name].milling[
+                MILL_POLISHING_KEY
+            ].alignment.rect = deepcopy(self.lamella.alignment_area)
 
         # reference images
         self._acquire_set_of_reference_images(image_settings)

--- a/fibsem/applications/autolamella/workflows/tasks/polishing.py
+++ b/fibsem/applications/autolamella/workflows/tasks/polishing.py
@@ -1,4 +1,3 @@
-
 ######## POLISHING TASK DEFINITIONS ########
 
 from copy import deepcopy
@@ -20,11 +19,13 @@ from fibsem.structures import field_meta
 @dataclass
 class MillPolishingTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the MillPolishingTask."""
+
     sync_to_poi: bool = field(
         default=True,
         metadata=field_meta(
             label="Link to Point of Interest",
-            tooltip="Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated."),
+            tooltip="Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated.",
+        ),
     )
     task_type: ClassVar[str] = "MILL_POLISHING"
 
@@ -37,16 +38,18 @@ class MillPolishingTaskConfig(AutoLamellaTaskConfig):
 
     def __post_init__(self):
         if self.milling == {}:
-            self.milling = deepcopy({MILL_POLISHING_KEY: DEFAULT_MILLING_CONFIG[MILL_POLISHING_KEY]})
+            self.milling = deepcopy(
+                {MILL_POLISHING_KEY: DEFAULT_MILLING_CONFIG[MILL_POLISHING_KEY]}
+            )
 
 
 class MillPolishingTask(AutoLamellaTask):
     """Task to mill the polishing trench for a lamella."""
+
     config: MillPolishingTaskConfig
     config_cls: ClassVar[Type[MillPolishingTaskConfig]] = MillPolishingTaskConfig
 
     def _run(self) -> None:
-
         """Run the task to mill the polishing trenches for a lamella."""
         # bookkeeping
         image_settings = self.config.imaging
@@ -59,7 +62,10 @@ class MillPolishingTask(AutoLamellaTask):
         self._align_reference_image(ALIGNMENT_REFERENCE_IMAGE_FILENAME)
 
         # reference images
-        self._acquire_reference_image(image_settings, field_of_view=self.config.milling[MILL_POLISHING_KEY].field_of_view)
+        self._acquire_reference_image(
+            image_settings,
+            field_of_view=self.config.milling[MILL_POLISHING_KEY].field_of_view,
+        )
 
         # mill polishing
         self.log_status_message("MILL_LAMELLA", "Milling Polishing Lamella...")
@@ -68,7 +74,9 @@ class MillPolishingTask(AutoLamellaTask):
         milling_task_config.acquisition.imaging.path = self.lamella.path
 
         msg = f"Press Run Milling to mill the polishing for {self.lamella.name}. Press Continue when done."
-        milling_task_config = self.update_milling_config_ui(milling_task_config, msg=msg)
+        milling_task_config = self.update_milling_config_ui(
+            milling_task_config, msg=msg
+        )
         self.config.milling[MILL_POLISHING_KEY] = deepcopy(milling_task_config)
 
         # reference images

--- a/fibsem/applications/autolamella/workflows/tasks/reference_image.py
+++ b/fibsem/applications/autolamella/workflows/tasks/reference_image.py
@@ -1,4 +1,3 @@
-
 ######## REFERENCE IMAGE TASK DEFINITIONS ########
 
 from dataclasses import dataclass, field
@@ -14,22 +13,31 @@ from fibsem.structures import field_meta
 @dataclass
 class AcquireReferenceImageConfig(AutoLamellaTaskConfig):
     """Configuration for the AcquireReferenceImageTask."""
+
     task_type: ClassVar[str] = "ACQUIRE_REFERENCE_IMAGE"
     display_name: ClassVar[str] = "Acquire Reference Image"
     orientation: Literal["SEM", "FIB", "MILLING"] = field(
         default="MILLING",
-        metadata=field_meta(tooltip="The orientation to acquire reference images in (SEM, FIB, MILLING)", items=("SEM", "FIB", "MILLING")),
-    ) # change to pose?
+        metadata=field_meta(
+            tooltip="The orientation to acquire reference images in (SEM, FIB, MILLING)",
+            items=("SEM", "FIB", "MILLING"),
+        ),
+    )  # change to pose?
     filename: Optional[str] = field(
         default=None,
-        metadata=field_meta(tooltip="Custom filename for reference images. If None, auto-generates from last completed task name and timestamp."),
+        metadata=field_meta(
+            tooltip="Custom filename for reference images. If None, auto-generates from last completed task name and timestamp."
+        ),
     )
 
 
 class AcquireReferenceImageTask(AutoLamellaTask):
     """Task to acquire reference image with specified settings."""
+
     config: AcquireReferenceImageConfig
-    config_cls: ClassVar[Type[AcquireReferenceImageConfig]] = AcquireReferenceImageConfig
+    config_cls: ClassVar[Type[AcquireReferenceImageConfig]] = (
+        AcquireReferenceImageConfig
+    )
 
     def _run(self) -> None:
         """Run the task to acquire reference image with the specified settings."""
@@ -38,16 +46,19 @@ class AcquireReferenceImageTask(AutoLamellaTask):
         self._move_to_milling_pose()
 
         if self.validate:
-            ask_user(self.parent_ui,
-                    msg=f"Acquire reference image for {self.lamella.name}. Press continue when ready.",
-                    pos="Continue"
-                    )
+            ask_user(
+                self.parent_ui,
+                msg=f"Acquire reference image for {self.lamella.name}. Press continue when ready.",
+                pos="Continue",
+            )
 
         # bookkeeping
         image_settings = self.config.imaging
         image_settings.path = self.lamella.path
 
-        self.log_status_message("ACQUIRE_REFERENCE_IMAGE", "Acquiring Reference Image...")
+        self.log_status_message(
+            "ACQUIRE_REFERENCE_IMAGE", "Acquiring Reference Image..."
+        )
 
         # acquire reference images — use config filename if provided, else use last completed task name
         if self.config.filename is not None:
@@ -63,6 +74,6 @@ class AcquireReferenceImageTask(AutoLamellaTask):
         # default rule reads the role off the filename and would file a named set
         # under "other", which is right for a task grabbing an extra set mid-run and
         # wrong here -- it hid these images from the review panel entirely (FIB-579).
-        self._acquire_set_of_reference_images(image_settings=image_settings,
-                                              filename=filename,
-                                              phase="final")
+        self._acquire_set_of_reference_images(
+            image_settings=image_settings, filename=filename, phase="final"
+        )

--- a/fibsem/applications/autolamella/workflows/tasks/rough.py
+++ b/fibsem/applications/autolamella/workflows/tasks/rough.py
@@ -1,4 +1,3 @@
-
 ######## ROUGH MILLING TASK DEFINITIONS ########
 
 import logging
@@ -26,23 +25,27 @@ from fibsem.structures import Point, field_meta
 @dataclass
 class MillRoughTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the MillRoughTask."""
+
     sync_polishing_position: bool = field(
         default=True,
         metadata=field_meta(
             label="Synchronize Polishing Position",
-            tooltip="Whether to synchronize the polishing position with the rough milling position (recommended.)"),
+            tooltip="Whether to synchronize the polishing position with the rough milling position (recommended.)",
+        ),
     )
     sync_to_poi: bool = field(
         default=True,
         metadata=field_meta(
             label="Link to Point of Interest",
-            tooltip="Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated."),
+            tooltip="Link the milling pattern positions to the point of interest. Pattern positions will update when the POI is updated.",
+        ),
     )
     reacquire_alignment_reference: bool = field(
         default=False,
         metadata=field_meta(
             label="Reacquire Alignment Reference",
-            tooltip="Whether to reacquire the alignment reference after milling"),
+            tooltip="Whether to reacquire the alignment reference after milling",
+        ),
     )
     task_type: ClassVar[str] = "MILL_ROUGH"
 
@@ -55,11 +58,14 @@ class MillRoughTaskConfig(AutoLamellaTaskConfig):
 
     def __post_init__(self):
         if self.milling == {}:
-            self.milling = deepcopy({MILL_ROUGH_KEY: DEFAULT_MILLING_CONFIG[MILL_ROUGH_KEY]})
+            self.milling = deepcopy(
+                {MILL_ROUGH_KEY: DEFAULT_MILLING_CONFIG[MILL_ROUGH_KEY]}
+            )
 
 
 class MillRoughTask(AutoLamellaTask):
     """Task to mill the rough trench for a lamella."""
+
     config: MillRoughTaskConfig
     config_cls: ClassVar[Type[MillRoughTaskConfig]] = MillRoughTaskConfig
 
@@ -77,28 +83,37 @@ class MillRoughTask(AutoLamellaTask):
         self._align_reference_image(ALIGNMENT_REFERENCE_IMAGE_FILENAME)
 
         # take reference images
-        self._acquire_reference_image(self.image_settings,
-                                      field_of_view=self.config.milling[MILL_ROUGH_KEY].field_of_view)
-
+        self._acquire_reference_image(
+            self.image_settings,
+            field_of_view=self.config.milling[MILL_ROUGH_KEY].field_of_view,
+        )
 
         # mill rough trench
         self.log_status_message("MILL_LAMELLA", "Milling Rough Lamella...")
         milling_task_config = self.config.milling[MILL_ROUGH_KEY]
         milling_task_config.alignment.rect = self.lamella.alignment_area
-        milling_task_config.acquisition.imaging.path = self.lamella.path # TODO: move into update_milling_config_ui
+        milling_task_config.acquisition.imaging.path = (
+            self.lamella.path
+        )  # TODO: move into update_milling_config_ui
 
-        msg=f"Press Run Milling to mill the lamella for {self.lamella.name}. Press Continue when done."
-        milling_task_config = self.update_milling_config_ui(milling_task_config, msg=msg)
+        msg = f"Press Run Milling to mill the lamella for {self.lamella.name}. Press Continue when done."
+        milling_task_config = self.update_milling_config_ui(
+            milling_task_config, msg=msg
+        )
         self.config.milling[MILL_ROUGH_KEY] = deepcopy(milling_task_config)
 
         # sync polishing milling task position
-        self.sync_polishing_milling_task_position(milling_task_config.stages[0].pattern.point)
+        self.sync_polishing_milling_task_position(
+            milling_task_config.stages[0].pattern.point
+        )
 
         # acquire alignment reference image
         if self.config.reacquire_alignment_reference:
-            self._acquire_alignment_reference_image(image_settings=self.image_settings,
-                                        reduced_area=self.lamella.alignment_area,
-                                        field_of_view=milling_task_config.field_of_view)
+            self._acquire_alignment_reference_image(
+                image_settings=self.image_settings,
+                reduced_area=self.lamella.alignment_area,
+                field_of_view=milling_task_config.field_of_view,
+            )
 
         # reference images
         self._acquire_set_of_reference_images(self.image_settings)
@@ -114,15 +129,26 @@ class MillRoughTask(AutoLamellaTask):
         try:
             for task_name, task_config in self.lamella.task_config.items():
                 if task_config.task_type == "MILL_POLISHING":
-                    polishing_milling_task_config = task_config.milling[MILL_POLISHING_KEY]
+                    polishing_milling_task_config = task_config.milling[
+                        MILL_POLISHING_KEY
+                    ]
                     polishing_task_name = task_name
                     break
         except Exception as e:
-            logging.warning(f"Unable to find MillPolishingTaskConfig in lamella task config: {e}")
+            logging.warning(
+                f"Unable to find MillPolishingTaskConfig in lamella task config: {e}"
+            )
 
-        if polishing_milling_task_config is not None and polishing_task_name is not None:
-            logging.info("Syncing polishing milling pattern positions with rough milling pattern positions...")
+        if (
+            polishing_milling_task_config is not None
+            and polishing_task_name is not None
+        ):
+            logging.info(
+                "Syncing polishing milling pattern positions with rough milling pattern positions..."
+            )
             for polishing_stage in polishing_milling_task_config.stages:
                 polishing_stage.pattern.point = deepcopy(rough_milling_point)
             # update lamella task config
-            self.lamella.task_config[polishing_task_name].milling[MILL_POLISHING_KEY] = deepcopy(polishing_milling_task_config)
+            self.lamella.task_config[polishing_task_name].milling[
+                MILL_POLISHING_KEY
+            ] = deepcopy(polishing_milling_task_config)

--- a/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
@@ -17,62 +17,92 @@ from fibsem.applications.autolamella.workflows.ui import (
 @dataclass
 class SelectFluorescencePositionConfig(AutoLamellaTaskConfig):
     """Configuration for the SelectFluorescencePositionTask."""
+
     task_type: ClassVar[str] = "SELECT_FLUORESCENCE_POSITION"
     display_name: ClassVar[str] = "Select Fluorescence Position"
 
 
 class SelectFluorescencePositionTask(AutoLamellaTask):
     """Task to select fluorescence stage position and objective position."""
+
     config: SelectFluorescencePositionConfig
-    config_cls: ClassVar[Type[SelectFluorescencePositionConfig]] = SelectFluorescencePositionConfig
+    config_cls: ClassVar[Type[SelectFluorescencePositionConfig]] = (
+        SelectFluorescencePositionConfig
+    )
 
     def _run(self) -> None:
         """Run the task to select fluorescence stage position and objective position."""
 
         if self.microscope.fm is None:
-            raise ValueError("Fluorescence microscope not initialized in the FibsemMicroscope instance")
-        if self.lamella.fluorescence_pose is None or self.lamella.fluorescence_pose.objective_position is None:
-            raise ValueError(f"Objective position for {self.lamella.name} is not set. Please set the objective position before acquiring fluorescence images.")
+            raise ValueError(
+                "Fluorescence microscope not initialized in the FibsemMicroscope instance"
+            )
+        if (
+            self.lamella.fluorescence_pose is None
+            or self.lamella.fluorescence_pose.objective_position is None
+        ):
+            raise ValueError(
+                f"Objective position for {self.lamella.name} is not set. Please set the objective position before acquiring fluorescence images."
+            )
         if self.lamella.stage_position is None:
-            raise ValueError(f"Stage position for {self.lamella.name} is not set. Please set the stage position before acquiring fluorescence images.")
+            raise ValueError(
+                f"Stage position for {self.lamella.name} is not set. Please set the stage position before acquiring fluorescence images."
+            )
 
-        if self.lamella.fluorescence_pose is not None and self.lamella.fluorescence_pose.stage_position is not None:
+        if (
+            self.lamella.fluorescence_pose is not None
+            and self.lamella.fluorescence_pose.stage_position is not None
+        ):
             stage_position = self.lamella.fluorescence_pose.stage_position
         else:
             stage_position = self.lamella.stage_position
 
         if not self.microscope.fm.has_valid_orientation(stage_position):
-            raise ValueError(f"Stage Position {self.lamella.name} is not in a valid orientation: {stage_position.pretty}, {self.microscope.fm.valid_orientations}")
+            raise ValueError(
+                f"Stage Position {self.lamella.name} is not in a valid orientation: {stage_position.pretty}, {self.microscope.fm.valid_orientations}"
+            )
 
         # Check for cancellation before each position
         if self._stop_event and self._stop_event.is_set():
-            logging.info(f"{self.task_name}: {self.lamella.name} - Acquisition cancelled")
+            logging.info(
+                f"{self.task_name}: {self.lamella.name} - Acquisition cancelled"
+            )
             return
 
         # Move stage to the saved stage position and objective position
         self.log_status_message("MOVE_TO_POSITION", "Moving to Position...")
-        self.microscope.fm.acquisition_progress_signal.emit({"state": "moving", "task": f"{self.task_name}"})
+        self.microscope.fm.acquisition_progress_signal.emit(
+            {"state": "moving", "task": f"{self.task_name}"}
+        )
         self.microscope.safe_absolute_stage_movement(stage_position)
 
         # move objective to saved position
         self.log_status_message("MOVE_OBJECTIVE", "Moving Objective to position...")
         if not self.microscope.fm.objective.state == "Inserted":
-            logging.info("Objective is not inserted. Inserting the objective before acquiring fluorescence images.")
+            logging.info(
+                "Objective is not inserted. Inserting the objective before acquiring fluorescence images."
+            )
             self.microscope.fm.objective.insert()
-        self.microscope.fm.objective.move_absolute(self.lamella.fluorescence_pose.objective_position)
+        self.microscope.fm.objective.move_absolute(
+            self.lamella.fluorescence_pose.objective_position
+        )
 
         # Acquire image
-        self.log_status_message("ACQUIRE_FLUORESCENCE_IMAGE", "Acquiring Fluorescence Image...")
-        self.microscope.fm.acquisition_progress_signal.emit({"state": "acquiring", "task": f"{self.task_name}"})
+        self.log_status_message(
+            "ACQUIRE_FLUORESCENCE_IMAGE", "Acquiring Fluorescence Image..."
+        )
+        self.microscope.fm.acquisition_progress_signal.emit(
+            {"state": "acquiring", "task": f"{self.task_name}"}
+        )
         self.microscope.fm.acquire_image()
 
         if self.validate:
-            ask_user(self.parent_ui,
+            ask_user(
+                self.parent_ui,
                 msg=f"Move to fluorescence position (stage and objective)for {self.lamella.name}. Press Continue to proceed.",
-                pos="Continue"
-                )
+                pos="Continue",
+            )
             self.microscope.fm.stop_acquisition()
 
         # refresh the recorded fluorescence pose (preserving the configured objective position)
         self._update_fluorescence_pose()
-

--- a/fibsem/applications/autolamella/workflows/tasks/select_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_position.py
@@ -1,4 +1,3 @@
-
 ######## SELECT MILLING POSITION TASK DEFINITIONS ########
 
 import logging
@@ -23,35 +22,41 @@ class SelectMillingPositionTaskConfig(AutoLamellaTaskConfig):
         metadata=field_meta(
             tooltip="The angle between the FIB and sample used for milling",
             unit=constants.DEGREE_SYMBOL,
-        ),)
+        ),
+    )
     auto_milling_alignment: bool = field(
         default=False,
         metadata=field_meta(
             label="Auto Milling Angle Alignment",
-            tooltip="Whether to automatically align for a milling position"),
+            tooltip="Whether to automatically align for a milling position",
+        ),
     )
     use_autofocus: bool = field(
         default=True,
         metadata=field_meta(
             label="Use Autofocus",
-            tooltip="Whether to autofocus before moving to the milling position"),
+            tooltip="Whether to autofocus before moving to the milling position",
+        ),
     )
 
     select_poi: bool = field(
         default=True,
         metadata=field_meta(
             label="Select Point of Interest",
-            tooltip="Whether to ask the user to select a point of interest in the FIB image"),
+            tooltip="Whether to ask the user to select a point of interest in the FIB image",
+        ),
     )
     task_type: ClassVar[str] = "SELECT_MILLING_POSITION"
     display_name: ClassVar[str] = "Select Milling Position"
 
 
-
 class SelectMillingPositionTask(AutoLamellaTask):
     """Task to setup the lamella for milling."""
+
     config: SelectMillingPositionTaskConfig
-    config_cls: ClassVar[Type[SelectMillingPositionTaskConfig]] = SelectMillingPositionTaskConfig
+    config_cls: ClassVar[Type[SelectMillingPositionTaskConfig]] = (
+        SelectMillingPositionTaskConfig
+    )
 
     def _run(self) -> None:
         """Run the task to select the milling position for the lamella for milling."""
@@ -65,54 +70,74 @@ class SelectMillingPositionTask(AutoLamellaTask):
 
         self.log_status_message("SELECT_POSITION", "Selecting Position...")
         milling_angle = self.config.milling_angle
-        is_close = self.microscope.is_close_to_milling_angle(milling_angle=milling_angle)
+        is_close = self.microscope.is_close_to_milling_angle(
+            milling_angle=milling_angle
+        )
 
         # acquire an image at the milling position
         if self.config.use_autofocus:
             self._run_autofocus(beam_type=BeamType.ELECTRON)
             self._run_autofocus(beam_type=BeamType.ION)
-        self._acquire_reference_image(image_settings=self.image_settings,
-                                      filename=f"ref_{self.task_name}_start",
-                                      field_of_view=self.config.reference_imaging.field_of_view1)
+        self._acquire_reference_image(
+            image_settings=self.image_settings,
+            filename=f"ref_{self.task_name}_start",
+            field_of_view=self.config.reference_imaging.field_of_view1,
+        )
 
         if not is_close:
             if self.config.auto_milling_alignment:
                 from fibsem import alignment
                 from fibsem.transformations import get_stage_tilt_from_milling_angle
-                target_stage_tilt_degrees = np.degrees(get_stage_tilt_from_milling_angle(self.microscope,
-                                                                                 np.radians(milling_angle)))
-                alignment._eucentric_tilt_alignment(microscope=self.microscope,
-                                                    image_settings=self.image_settings,
-                                                    target_angle=float(target_stage_tilt_degrees),
-                                                    step_size=3,
-                                                    )
+
+                target_stage_tilt_degrees = np.degrees(
+                    get_stage_tilt_from_milling_angle(
+                        self.microscope, np.radians(milling_angle)
+                    )
+                )
+                alignment._eucentric_tilt_alignment(
+                    microscope=self.microscope,
+                    image_settings=self.image_settings,
+                    target_angle=float(target_stage_tilt_degrees),
+                    step_size=3,
+                )
 
             elif self.validate:
                 current_milling_angle = self.microscope.get_current_milling_angle()
-                ret = ask_user(parent_ui=self.parent_ui,
-                            msg=f"Tilt to specified milling angle ({milling_angle:.1f}{constants.DEGREE_SYMBOL})? "
-                            f"Current milling angle is {current_milling_angle:.1f}{constants.DEGREE_SYMBOL}.",
-                            pos="Tilt", neg="Skip")
+                ret = ask_user(
+                    parent_ui=self.parent_ui,
+                    msg=f"Tilt to specified milling angle ({milling_angle:.1f}{constants.DEGREE_SYMBOL})? "
+                    f"Current milling angle is {current_milling_angle:.1f}{constants.DEGREE_SYMBOL}.",
+                    pos="Tilt",
+                    neg="Skip",
+                )
                 if ret:
-                    self.microscope.move_to_milling_angle(milling_angle=np.radians(milling_angle))
+                    self.microscope.move_to_milling_angle(
+                        milling_angle=np.radians(milling_angle)
+                    )
             else:
-                self.microscope.move_to_milling_angle(milling_angle=np.radians(milling_angle))
+                self.microscope.move_to_milling_angle(
+                    milling_angle=np.radians(milling_angle)
+                )
 
             if self.config.use_autofocus:
                 self._run_autofocus(beam_type=BeamType.ION)
 
             # reacquire image at milling angle
-            self._acquire_reference_image(image_settings=self.image_settings,
-                                        filename=f"ref_{self.task_name}_post_tilt",
-                                        field_of_view=self.config.reference_imaging.field_of_view1)
+            self._acquire_reference_image(
+                image_settings=self.image_settings,
+                filename=f"ref_{self.task_name}_post_tilt",
+                field_of_view=self.config.reference_imaging.field_of_view1,
+            )
 
         # confirm with user to move to milling position
         if self.validate:
-            ask_user(parent_ui=self.parent_ui,
-                    msg=f"Double click the image to move to the milling position for {self.lamella.name}. "
-                        f"Press Continue when done.",
-                    pos="Continue")
-        
+            ask_user(
+                parent_ui=self.parent_ui,
+                msg=f"Double click the image to move to the milling position for {self.lamella.name}. "
+                f"Press Continue when done.",
+                pos="Continue",
+            )
+
         # select point of interest
         if self.config.select_poi:
             poi = select_poi_ui(
@@ -131,9 +156,11 @@ class SelectMillingPositionTask(AutoLamellaTask):
         self._validate_alignment_area()
 
         # acquire alignment reference image
-        self._acquire_alignment_reference_image(image_settings=self.image_settings,
-                                      reduced_area=self.lamella.alignment_area,
-                                      field_of_view=self.config.reference_imaging.field_of_view1)
+        self._acquire_alignment_reference_image(
+            image_settings=self.image_settings,
+            reduced_area=self.lamella.alignment_area,
+            field_of_view=self.config.reference_imaging.field_of_view1,
+        )
 
         # reference images
         self._acquire_set_of_reference_images(self.image_settings)

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -1,4 +1,3 @@
-
 ######## SPOT BURN FIDUCIAL TASK DEFINITIONS ########
 from __future__ import annotations
 
@@ -26,35 +25,30 @@ from fibsem.structures import BeamType, Point, field_meta
 @dataclass
 class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the SpotBurnFiducialTask."""
+
     task_type: ClassVar[str] = "SPOT_BURN_FIDUCIAL"
     display_name: ClassVar[str] = "Spot Burn Fiducial"
     milling_current: float = field(
         default=60.0e-12,  # in Amperes
-        metadata=field_meta(
-            tooltip='Milling current in Amperes',
-            unit='A',
-            scale=1e12
-        )
+        metadata=field_meta(tooltip="Milling current in Amperes", unit="A", scale=1e12),
     )
     exposure_time: int = field(
         default=10,
-        metadata=field_meta(
-            tooltip='Exposure time in seconds',
-            unit='s',
-            scale=1
-        )
+        metadata=field_meta(tooltip="Exposure time in seconds", unit="s", scale=1),
     )
     autofocus: bool = field(
         default=False,
         metadata=field_meta(
             tooltip="Run a FIB autofocus before acquiring the reference image, so the "
-                    "points are placed on (and burned into) a focused image",
+            "points are placed on (and burned into) a focused image",
             label="Autofocus",
         ),
     )
     coordinates: list[Point] = field(
         default_factory=list,
-        metadata=field_meta(tooltip="Spot burn positions in normalised image coordinates (0-1)"),
+        metadata=field_meta(
+            tooltip="Spot burn positions in normalised image coordinates (0-1)"
+        ),
     )
 
     @property
@@ -78,7 +72,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
         Each point costs its exposure plus a blank/park/unblank cycle.
         """
         total = super().estimated_duration
-        total += 2 * timing.BEAM_CURRENT_CHANGE_S     # into the burn current and back
+        total += 2 * timing.BEAM_CURRENT_CHANGE_S  # into the burn current and back
         total += len(self.coordinates) * (
             self.exposure_time + timing.SPOT_BURN_POINT_OVERHEAD_S
         )
@@ -99,7 +93,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
         return ddict
 
     @classmethod
-    def from_dict(cls, ddict: dict) -> 'SpotBurnFiducialTaskConfig':
+    def from_dict(cls, ddict: dict) -> "SpotBurnFiducialTaskConfig":
         cfg = AutoLamellaTaskConfig.from_dict(ddict)
         params = ddict.get("parameters", {})
         coordinates = [Point.from_dict(pt) for pt in ddict.get("coordinates", [])]
@@ -131,6 +125,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
 
 class SpotBurnFiducialTask(AutoLamellaTask):
     """Task to mill spot fiducial markers for correlation."""
+
     config: SpotBurnFiducialTaskConfig
     config_cls: ClassVar[Type[SpotBurnFiducialTaskConfig]] = SpotBurnFiducialTaskConfig
 
@@ -180,10 +175,12 @@ class SpotBurnFiducialTask(AutoLamellaTask):
                 )
                 return
             # burn the stored coordinates directly (progress via the microscope signal)
-            run_spot_burn(microscope=self.microscope,
-                          settings=self.config.to_settings(),
-                          beam_type=BeamType.ION,
-                          stop_event=self._stop_event)
+            run_spot_burn(
+                microscope=self.microscope,
+                settings=self.config.to_settings(),
+                beam_type=BeamType.ION,
+                stop_event=self._stop_event,
+            )
             return
 
         # supervised path: task-orchestrated run/wait/re-prompt loop (mirrors milling).
@@ -202,7 +199,9 @@ class SpotBurnFiducialTask(AutoLamellaTask):
         # before continuing so the workflow can't advance mid-burn.
         spot_burn_widget = self.parent_ui.spot_burn_widget
         msg = f"Place points and run the spot burn for {self.lamella.name}. Press Continue when finished."
-        response = ask_user(self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True)
+        response = ask_user(
+            self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True
+        )
         while response:
             self.update_status_ui("Running Spot Burn...")
             spot_burn_widget.start_spot_burn_signal.emit()
@@ -220,7 +219,13 @@ class SpotBurnFiducialTask(AutoLamellaTask):
                 # a threading.Event, so it is safe to call from the task thread.
                 spot_burn_widget.cancel_spot_burn()
                 raise
-            response = ask_user(self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True)
+            response = ask_user(
+                self.parent_ui,
+                msg=msg,
+                pos="Run Spot Burn",
+                neg="Continue",
+                spot_burn=True,
+            )
 
         # store the user's settings (coordinates + current/exposure) back to the config
         self.config.apply_settings(spot_burn_widget.get_settings())

--- a/fibsem/applications/autolamella/workflows/tasks/trench.py
+++ b/fibsem/applications/autolamella/workflows/tasks/trench.py
@@ -1,4 +1,3 @@
-
 ######## TRENCH TASK DEFINITIONS ########
 
 import os
@@ -25,6 +24,7 @@ from fibsem.structures import BeamType, FibsemImage, field_meta
 @dataclass
 class MillTrenchTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the MillTrenchTask."""
+
     align_reference: bool = field(
         default=False,  # whether to align to a trench reference image
         metadata=field_meta(tooltip="Whether to align to a trench reference image"),
@@ -35,7 +35,10 @@ class MillTrenchTaskConfig(AutoLamellaTaskConfig):
     )
     orientation: Optional[Literal["SEM", "FIB", "MILLING"]] = field(
         default=None,
-        metadata=field_meta(tooltip="The orientation to perform trench milling in", items=("SEM", "FIB", "MILLING", None)),
+        metadata=field_meta(
+            tooltip="The orientation to perform trench milling in",
+            items=("SEM", "FIB", "MILLING", None),
+        ),
     )
     task_type: ClassVar[str] = "MILL_TRENCH"
     display_name: ClassVar[str] = "Trench Milling"
@@ -47,6 +50,7 @@ class MillTrenchTaskConfig(AutoLamellaTaskConfig):
 
 class MillTrenchTask(AutoLamellaTask):
     """Task to mill the trench for a lamella."""
+
     config_cls: ClassVar[Type[MillTrenchTaskConfig]] = MillTrenchTaskConfig
     config: MillTrenchTaskConfig
 
@@ -58,38 +62,49 @@ class MillTrenchTask(AutoLamellaTask):
         image_settings.path = self.lamella.path
 
         self.log_status_message("MOVE_TO_TRENCH", "Moving to Trench Position...")
-        trench_position = self._get_stage_position_for_orientation(self.lamella.stage_position,
-                                                                   self.config.orientation)
+        trench_position = self._get_stage_position_for_orientation(
+            self.lamella.stage_position, self.config.orientation
+        )
         self.microscope.safe_absolute_stage_movement(trench_position)
 
         # align to reference image
         # TODO: support saving a reference image when selecting the trench from minimap
         reference_image_path = os.path.join(self.lamella.path, "ref_PositionReady.tif")
         if os.path.exists(reference_image_path) and self.config.align_reference:
-            self.log_status_message("ALIGN_TRENCH_REFERENCE", "Aligning Trench Reference...")
+            self.log_status_message(
+                "ALIGN_TRENCH_REFERENCE", "Aligning Trench Reference..."
+            )
             ref_image = FibsemImage.load(reference_image_path)
-            alignment.multi_step_alignment_v2(microscope=self.microscope,
-                                            ref_image=ref_image,
-                                            steps=1, subsystem=AlignmentSubsystem.STAGE)
+            alignment.multi_step_alignment_v2(
+                microscope=self.microscope,
+                ref_image=ref_image,
+                steps=1,
+                subsystem=AlignmentSubsystem.STAGE,
+            )
 
         # get trench milling stages
         milling_task_config = self.config.milling[TRENCH_KEY]
 
         # acquire reference images
-        self._acquire_reference_image(image_settings, field_of_view=milling_task_config.field_of_view)
+        self._acquire_reference_image(
+            image_settings, field_of_view=milling_task_config.field_of_view
+        )
 
         # log the task configuration
         self.log_status_message("MILL_TRENCH", "Milling Trench...")
         msg = f"Press Run Milling to mill the Trench for {self.lamella.name}. Press Continue when done."
         milling_task_config.acquisition.imaging.path = self.lamella.path
-        milling_task_config = self.update_milling_config_ui(milling_task_config,
-                                                          msg=msg,
-                                                          )
+        milling_task_config = self.update_milling_config_ui(
+            milling_task_config,
+            msg=msg,
+        )
         self.config.milling[TRENCH_KEY] = deepcopy(milling_task_config)
 
         # charge neutralisation
         if self.config.charge_neutralisation:
-            self.log_status_message("CHARGE_NEUTRALISATION", "Neutralising Sample Charge...")
+            self.log_status_message(
+                "CHARGE_NEUTRALISATION", "Neutralising Sample Charge..."
+            )
             image_settings.beam_type = BeamType.ELECTRON
             auto_charge_neutralisation(self.microscope, image_settings)
 

--- a/fibsem/applications/autolamella/workflows/tasks/undercut.py
+++ b/fibsem/applications/autolamella/workflows/tasks/undercut.py
@@ -1,4 +1,3 @@
-
 ######## UNDERCUT TASK DEFINITIONS ########
 
 from copy import deepcopy
@@ -26,25 +25,33 @@ from fibsem.structures import BeamType, field_meta
 @dataclass
 class MillUndercutTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the MillUndercutTask."""
+
     orientation: Optional[Literal["SEM", "FIB", "MILLING"]] = field(
         default="SEM",
-        metadata=field_meta(tooltip="The orientation to perform undercut milling in", items=("SEM", "FIB", "MILLING", None)),
+        metadata=field_meta(
+            tooltip="The orientation to perform undercut milling in",
+            items=("SEM", "FIB", "MILLING", None),
+        ),
     )
     milling_angles: List[float] = field(
         default_factory=lambda: [25, 20],  # in degrees
-        metadata=field_meta(tooltip="The angles to mill the undercuts at",
-                            unit=constants.DEGREE_SYMBOL),
+        metadata=field_meta(
+            tooltip="The angles to mill the undercuts at", unit=constants.DEGREE_SYMBOL
+        ),
     )
     task_type: ClassVar[str] = "MILL_UNDERCUT"
     display_name: ClassVar[str] = "Undercut Milling"
 
     def __post_init__(self):
         if self.milling == {}:
-            self.milling = deepcopy({UNDERCUT_KEY: DEFAULT_MILLING_CONFIG[UNDERCUT_KEY]})
+            self.milling = deepcopy(
+                {UNDERCUT_KEY: DEFAULT_MILLING_CONFIG[UNDERCUT_KEY]}
+            )
 
 
 class MillUndercutTask(AutoLamellaTask):
     """Task to mill the undercut for a lamella."""
+
     config: MillUndercutTaskConfig
     config_cls: ClassVar[Type[MillUndercutTaskConfig]] = MillUndercutTaskConfig
 
@@ -54,12 +61,13 @@ class MillUndercutTask(AutoLamellaTask):
         image_settings = self.config.imaging
         image_settings.path = self.lamella.path
 
-        checkpoint = "autolamella-waffle-20240107.pt" # if self.lamella.protocol.options.checkpoint is None else self.lamella.protocol.options.checkpoint
+        checkpoint = "autolamella-waffle-20240107.pt"  # if self.lamella.protocol.options.checkpoint is None else self.lamella.protocol.options.checkpoint
 
         # move to sem orientation
         self.log_status_message("MOVE_TO_UNDERCUT", "Moving to Undercut Position...")
-        undercut_position = self._get_stage_position_for_orientation(self.lamella.stage_position,
-                                                                     self.config.orientation)
+        undercut_position = self._get_stage_position_for_orientation(
+            self.lamella.stage_position, self.config.orientation
+        )
         self.microscope.safe_absolute_stage_movement(undercut_position)
         # TODO: support compucentric offset
 
@@ -78,7 +86,7 @@ class MillUndercutTask(AutoLamellaTask):
         # mill under cut
         milling_task_config = self.config.milling[UNDERCUT_KEY]
         post_milled_undercut_stages = []
-        undercut_milling_angles = self.config.milling_angles # deg
+        undercut_milling_angles = self.config.milling_angles  # deg
 
         # TODO: support multiple undercuts?
 
@@ -89,30 +97,43 @@ class MillUndercutTask(AutoLamellaTask):
             )
 
         for i, undercut_milling_angle in enumerate(undercut_milling_angles):
-
-            nid = f"{i+1:02d}" # helper
+            nid = f"{i + 1:02d}"  # helper
 
             # tilt down, align to trench
-            self.log_status_message(f"TILT_UNDERCUT_{nid}", f"Tilting to Undercut Position {nid}...")
-            self.microscope.move_to_milling_angle(milling_angle=np.radians(undercut_milling_angle))
+            self.log_status_message(
+                f"TILT_UNDERCUT_{nid}", f"Tilting to Undercut Position {nid}..."
+            )
+            self.microscope.move_to_milling_angle(
+                milling_angle=np.radians(undercut_milling_angle)
+            )
 
             # detect
-            self.log_status_message(f"ALIGN_UNDERCUT_{nid}", f"Aligning Undercut Position {nid}...")
-            self._acquire_reference_image(image_settings,
-                                          filename=f"ref_{self.task_name}_align_ml_{nid}",
-                                          field_of_view=milling_task_config.field_of_view)
+            self.log_status_message(
+                f"ALIGN_UNDERCUT_{nid}", f"Aligning Undercut Position {nid}..."
+            )
+            self._acquire_reference_image(
+                image_settings,
+                filename=f"ref_{self.task_name}_align_ml_{nid}",
+                field_of_view=milling_task_config.field_of_view,
+            )
 
             # get pattern
             scan_rotation = self.microscope.get_scan_rotation(beam_type=BeamType.ION)
-            features = [LamellaTopEdge() if np.isclose(scan_rotation, 0) else LamellaBottomEdge()]
+            features = [
+                LamellaTopEdge()
+                if np.isclose(scan_rotation, 0)
+                else LamellaBottomEdge()
+            ]
 
-            det = update_detection_ui(microscope=self.microscope,
-                                    image_settings=image_settings,
-                                    checkpoint=checkpoint,
-                                    features=features,
-                                    parent_ui=self.parent_ui,
-                                    validate=self.validate,
-                                    msg=lamella.status_info)
+            det = update_detection_ui(
+                microscope=self.microscope,
+                image_settings=image_settings,
+                checkpoint=checkpoint,
+                features=features,
+                parent_ui=self.parent_ui,
+                validate=self.validate,
+                msg=lamella.status_info,
+            )
 
             # set pattern position
             offset = milling_task_config.stages[0].pattern.height / 2
@@ -122,8 +143,10 @@ class MillUndercutTask(AutoLamellaTask):
 
             # mill undercut
             self.log_status_message(f"MILL_UNDERCUT_{nid}")
-            msg=f"Press Run Milling to mill the Undercut for {self.lamella.name}. Press Continue when done."
-            milling_task_config = self.update_milling_config_ui(milling_task_config, msg=msg)
+            msg = f"Press Run Milling to mill the Undercut for {self.lamella.name}. Press Continue when done."
+            milling_task_config = self.update_milling_config_ui(
+                milling_task_config, msg=msg
+            )
 
             # log the task configuration
             # post_milled_undercut_stages.extend(stages)
@@ -132,7 +155,9 @@ class MillUndercutTask(AutoLamellaTask):
         self.config.milling[UNDERCUT_KEY] = deepcopy(milling_task_config)
 
         # take reference images
-        self._acquire_set_of_reference_images(image_settings, filename=f"ref_{self.task_name}_undercut")
+        self._acquire_set_of_reference_images(
+            image_settings, filename=f"ref_{self.task_name}_undercut"
+        )
 
         # re-align to lamella centre
         self.log_status_message("ALIGN_FINAL", "Aligning Final Position...")
@@ -140,13 +165,15 @@ class MillUndercutTask(AutoLamellaTask):
         image_settings.hfw = fcfg.REFERENCE_HFW_HIGH
 
         features = [LamellaCentre()]
-        det = update_detection_ui(microscope=self.microscope,
-                                    image_settings=image_settings,
-                                    checkpoint=checkpoint,
-                                    features=features,
-                                    parent_ui=self.parent_ui,
-                                    validate=self.validate,
-                                    msg=self.lamella.status_info)
+        det = update_detection_ui(
+            microscope=self.microscope,
+            image_settings=image_settings,
+            checkpoint=checkpoint,
+            features=features,
+            parent_ui=self.parent_ui,
+            validate=self.validate,
+            msg=self.lamella.status_info,
+        )
 
         # align vertical
         self.microscope.vertical_move(


### PR DESCRIPTION
**Base of the Add Task stack ([#510](https://github.com/fibsem-os/fibsem-os/pull/510)–[#513](https://github.com/fibsem-os/fibsem-os/pull/513) now sit on this).**

Formatting only. No behaviour change, no imports moved, nothing renamed.

CI gates `ruff format` on the files a PR touches, and these 14 have never been formatted — `structures.py` fails the check on `main` today. That makes the failure yours the moment you edit the file for any reason, which is what happened to the Add Task work: complying would have injected ~1,300 lines of unrelated reformatting into commits meant to be read.

So it is split out here instead, in four commits of at most five files:

| commit | files | reformatted |
|---|---|---|
| structures module | 1 | 418 |
| five task configs | 5 | 305 |
| four more task configs | 4 | 280 |
| the remaining Add Task files | 4 | 345 |

### Reviewing this

Don't read the diff — check the claim. Each commit was verified by parsing every file before and after and comparing ASTs. They are identical, with one exception worth stating: `ruff format` strips trailing whitespace inside docstrings, which changed two string constants in `structures.py` (`'…point of interest  '` → `'…point of interest'`). The comparison normalises string whitespace so it still catches anything that alters code.

568 tests pass on this branch alone.