### PR TITLE
[feature] Remove the Connection tab, and take its first-run offer with it

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -195,6 +195,11 @@ class AutoLamellaUI(QMainWindow):
         self.microscope: Optional[FibsemMicroscope] = None
         self.settings: Optional[MicroscopeSettings] = None
 
+        # Read here rather than taken from parent_ui: this widget is constructed
+        # with parent_ui=None in tests, and the tab it gates is built in __init__.
+        self._connection_chip_enabled = (
+            fibsem_cfg.load_user_preferences().features.connection_chip
+        )
         self.system_widget = FibsemSystemSetupWidget(parent=self)
         self.image_widget: Optional[FibsemImageSettingsWidget] = None
         self.movement_widget: Optional[FibsemMovementWidget] = None
@@ -210,8 +215,18 @@ class AutoLamellaUI(QMainWindow):
         self.minimap_plot_widget.setWindowTitle("Minimap Plot")
         self.minimap_plot_widget.hide()
 
-        # add widgets to tabs
-        self.tabWidget.insertTab(0, self.system_widget, "Connection")
+        # add widgets to tabs.
+        #
+        # The Connection tab is a gate in a bar that otherwise means "the instrument
+        # needs you here now" -- it is the only tab that can never be a workflow
+        # step, and it sits at position 0, the default landing spot, for something
+        # done once a session. With the connection dialog on it has somewhere else
+        # to be reached from, so it goes (FIB-775).
+        #
+        # The widget itself stays either way: it owns the connection, and everything
+        # in the application follows its signals. Only the tab is conditional.
+        if not self._connection_chip_enabled:
+            self.tabWidget.insertTab(0, self.system_widget, "Connection")
 
         self.WAITING_FOR_USER_INTERACTION: bool = False
         # A run is active but nothing is executing -- today only during a

--- a/fibsem/ui/widgets/connection_dialog.py
+++ b/fibsem/ui/widgets/connection_dialog.py
@@ -34,12 +34,13 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem import config as cfg
-from fibsem import utils
+from fibsem import guided_setup, utils
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import MicroscopeSettings
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.stylesheets import (
     PRIMARY_BUTTON_STYLESHEET,
+    PRIMARY_COLOR,
     SECONDARY_BUTTON_STYLESHEET,
 )
 from fibsem.ui.tokens import (
@@ -105,6 +106,9 @@ class ConnectionDialog(QDialog):
         self.title_label.setStyleSheet(f"color: {TEXT_STRONG_COLOR}; font-size: 14px;")
         layout.addWidget(self.title_label)
 
+        # Above the configuration row on purpose: on a fresh install there is no
+        # configuration worth choosing yet, and the walkthrough is what makes one.
+        layout.addWidget(self._build_first_run_offer())
         layout.addWidget(self._build_configuration_row())
         layout.addWidget(self._build_details_panel())
 
@@ -119,8 +123,129 @@ class ConnectionDialog(QDialog):
 
         self._populate_configurations()
         self._apply_connection_state()
+        self.refresh_first_run_offer()
 
     # ── construction ────────────────────────────────────────────────────────
+
+    def _build_first_run_offer(self) -> QFrame:
+        """The guided-setup offer, which used to live on the Connection tab.
+
+        It came with the tab (FIB-740, #472) and would have gone with it: a fresh
+        install would have been left with Tools > Guided Setup, which is not
+        somewhere a first-time user thinks to look. This dialog is what they reach
+        first instead, so the offer follows it here.
+        """
+        frame = QFrame()
+        frame.setObjectName("frame_first_run")
+        frame.setStyleSheet(f"""
+            QFrame#frame_first_run {{
+                background-color: {PANEL_COLOR};
+                border-radius: 6px;
+                border: 1px solid {PRIMARY_COLOR};
+            }}
+        """)
+        frame_layout = QHBoxLayout(frame)
+        frame_layout.setContentsMargins(12, 10, 8, 10)
+        frame_layout.setSpacing(10)
+
+        icon = QLabel()
+        icon.setStyleSheet("background: transparent; border: none;")
+        icon.setFixedSize(20, 20)
+        icon.setPixmap(fibsem_icon("mdi:auto-fix", color=PRIMARY_COLOR).pixmap(20, 20))
+        frame_layout.addWidget(icon, 0, Qt.AlignTop)
+
+        text = QVBoxLayout()
+        text.setSpacing(2)
+        title = QLabel("First time here?")
+        title.setStyleSheet(
+            f"background: transparent; border: none; color: {PRIMARY_COLOR}; "
+            "font-weight: bold; font-size: 11px;"
+        )
+        subtitle = QLabel(
+            "A guided walkthrough that configures fibsemOS to work with your "
+            "microscope."
+        )
+        subtitle.setWordWrap(True)
+        subtitle.setStyleSheet(
+            f"background: transparent; border: none; color: {TEXT_MUTED_COLOR}; "
+            "font-size: 10px;"
+        )
+        text.addWidget(title)
+        text.addWidget(subtitle)
+        frame_layout.addLayout(text, 1)
+
+        self.guided_setup_button = QPushButton("Start Guided Setup")
+        self.guided_setup_button.setStyleSheet(f"""
+            QPushButton {{
+                background-color: transparent;
+                color: {PRIMARY_COLOR};
+                border: 1px solid {PRIMARY_COLOR};
+                border-radius: 4px;
+                padding: 5px 12px;
+                font-size: 11px;
+                font-weight: bold;
+            }}
+            QPushButton:hover {{ background-color: rgba(0, 122, 204, 0.20); }}
+        """)
+        self.guided_setup_button.clicked.connect(self.run_guided_setup)
+        frame_layout.addWidget(self.guided_setup_button, 0, Qt.AlignVCenter)
+
+        self.dismiss_first_run_button = QToolButton()
+        self.dismiss_first_run_button.setIcon(
+            fibsem_icon("mdi:close", color=TEXT_MUTED_COLOR)
+        )
+        self.dismiss_first_run_button.setToolTip("Do not offer this again")
+        self.dismiss_first_run_button.setAutoRaise(True)
+        self.dismiss_first_run_button.setStyleSheet(
+            "border: none; background: transparent;"
+        )
+        self.dismiss_first_run_button.clicked.connect(self._dismiss_first_run)
+        frame_layout.addWidget(self.dismiss_first_run_button, 0, Qt.AlignTop)
+
+        self.first_run_frame = frame
+        frame.setVisible(False)
+        return frame
+
+    def refresh_first_run_offer(self, preferences=None) -> None:
+        """Show the offer when the flag is on, nothing is configured, and it stands.
+
+        The same three conditions the Connection tab applied, and separate for the
+        same reason: the flag lives in the file whose absence means "fresh install",
+        so folding the first two together suppresses the offer it enables.
+        """
+        if preferences is None:
+            preferences = cfg.load_user_preferences()
+        self.first_run_frame.setVisible(
+            preferences.features.guided_setup_enabled
+            and not preferences.display.guided_setup_dismissed
+            and guided_setup.is_first_run()
+        )
+
+    def _dismiss_first_run(self) -> None:
+        """Hide the offer, and record that it was declined."""
+        self.first_run_frame.setVisible(False)
+        guided_setup.dismiss_first_run()
+
+    def run_guided_setup(self) -> Optional[str]:
+        """Open the wizard, then select whatever it saved.
+
+        The live microscope is handed over so the wizard can read the stage without
+        opening a second client against the same instrument.
+        """
+        from fibsem.ui.widgets.guided_setup_dialog import open_guided_setup
+
+        name = open_guided_setup(parent=self, microscope=self.microscope)
+        if name is None:
+            # Backing out is not declining, so the offer stays where it was.
+            return None
+
+        # Finishing writes the file `is_first_run` reads, so the offer goes now
+        # rather than at the next start -- and the new configuration is the one
+        # this dialog should be pointing at.
+        self._populate_configurations()
+        self.configuration_combo.setCurrentText(name)
+        self.refresh_first_run_offer()
+        return name
 
     def _build_configuration_row(self) -> QWidget:
         row = QWidget()

--- a/tests/ui/test_connection_tab_removal.py
+++ b/tests/ui/test_connection_tab_removal.py
@@ -1,0 +1,160 @@
+"""The Connection tab goes, and the first-run offer goes with it — somewhere.
+
+The tab is a gate in a bar that otherwise means "the instrument needs you here
+now": the only tab that can never be a workflow step, sitting at position 0 for
+something done once a session (FIB-775). With `features.connection_chip` on, the
+dialog and the header chip reach the connection instead, and the tab is not built.
+
+The part that would have been lost silently is the **guided-setup offer** (#472).
+It is a banner inside `FibsemSystemSetupWidget`, and the Connection tab was the
+only place it rendered — removing the tab would have left a fresh install with
+Tools > Guided Setup, which is not somewhere a first-time user looks. It now lives
+in the connection dialog, which is what they reach first.
+
+Preferences are redirected to a temp file throughout: `is_first_run` reads the
+real configuration registry, and these tests must neither depend on the
+developer's own state nor write to it.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem import config as cfg  # noqa: E402
+from fibsem import guided_setup  # noqa: E402
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI  # noqa: E402
+from fibsem.ui.widgets.connection_dialog import ConnectionDialog  # noqa: E402
+
+
+@pytest.fixture
+def prefs(monkeypatch, tmp_path):
+    """Isolated preferences, and a `load_user_preferences` that returns them."""
+    preferences = cfg.UserPreferences()
+    monkeypatch.setattr(cfg, "load_user_preferences", lambda: preferences)
+    monkeypatch.setattr(
+        cfg, "USER_PREFERENCES_PATH", str(tmp_path / "user-preferences.yaml")
+    )
+    return preferences
+
+
+def _tabs(ui: AutoLamellaUI) -> list[str]:
+    return [ui.tabWidget.tabText(i) for i in range(ui.tabWidget.count())]
+
+
+def test_the_tab_is_there_with_the_flag_off(qapp, prefs):
+    """The shipping default. Nothing about connecting has moved."""
+    prefs.features.connection_chip = False
+
+    ui = AutoLamellaUI(parent_ui=None)
+    try:
+        assert "Connection" in _tabs(ui)
+        # And it is the one the panel opens on, as it always was.
+        assert ui.tabWidget.tabText(0) == "Connection"
+    finally:
+        ui.deleteLater()
+
+
+def test_the_tab_is_gone_with_the_flag_on(qapp, prefs):
+    prefs.features.connection_chip = True
+
+    ui = AutoLamellaUI(parent_ui=None)
+    try:
+        assert "Connection" not in _tabs(ui)
+        # The widget stays: it owns the connection, and everything in the
+        # application follows its signals. Only the tab was conditional.
+        assert ui.system_widget is not None
+    finally:
+        ui.deleteLater()
+
+
+# ── the offer that came with the tab ────────────────────────────────────────
+
+
+def test_the_offer_shows_on_a_fresh_install(qapp, prefs, monkeypatch):
+    monkeypatch.setattr(guided_setup, "is_first_run", lambda: True)
+    prefs.features.guided_setup_enabled = True
+    prefs.display.guided_setup_dismissed = False
+
+    dialog = ConnectionDialog()
+    try:
+        dialog.show()
+        assert dialog.first_run_frame.isVisible()
+    finally:
+        dialog.deleteLater()
+
+
+@pytest.mark.parametrize(
+    "flag, dismissed, first_run",
+    [
+        (False, False, True),  # the feature is off
+        (True, True, True),  # already declined
+        (True, False, False),  # something is configured already
+    ],
+)
+def test_the_offer_stays_away_otherwise(
+    qapp, prefs, monkeypatch, flag, dismissed, first_run
+):
+    """Three separate conditions, as the tab applied them.
+
+    Folding the first two together is what broke this the first time: the flag
+    lives in the file whose absence means "fresh install", so turning the flag on
+    suppressed the offer it enables.
+    """
+    monkeypatch.setattr(guided_setup, "is_first_run", lambda: first_run)
+    prefs.features.guided_setup_enabled = flag
+    prefs.display.guided_setup_dismissed = dismissed
+
+    dialog = ConnectionDialog()
+    try:
+        dialog.show()
+        assert not dialog.first_run_frame.isVisible()
+    finally:
+        dialog.deleteLater()
+
+
+def test_declining_the_offer_records_it(qapp, prefs, monkeypatch):
+    monkeypatch.setattr(guided_setup, "is_first_run", lambda: True)
+    prefs.features.guided_setup_enabled = True
+    recorded = []
+    monkeypatch.setattr(
+        guided_setup, "dismiss_first_run", lambda: recorded.append(True)
+    )
+
+    dialog = ConnectionDialog()
+    try:
+        dialog.show()
+        dialog.dismiss_first_run_button.click()
+
+        assert not dialog.first_run_frame.isVisible()
+        assert recorded == [True], "declining has to persist, or it returns next start"
+    finally:
+        dialog.deleteLater()
+
+
+def test_finishing_the_wizard_selects_what_it_wrote(qapp, prefs, monkeypatch):
+    """Otherwise the dialog still points at whatever was selected before it ran."""
+    monkeypatch.setattr(guided_setup, "is_first_run", lambda: True)
+    prefs.features.guided_setup_enabled = True
+
+    dialog = ConnectionDialog()
+    try:
+        dialog.show()
+        written = "a-brand-new-configuration"
+        monkeypatch.setitem(
+            cfg.USER_CONFIGURATIONS, written, {"path": "/tmp/nope.yaml"}
+        )
+        monkeypatch.setattr(
+            "fibsem.ui.widgets.guided_setup_dialog.open_guided_setup",
+            lambda parent=None, microscope=None: written,
+        )
+
+        assert dialog.run_guided_setup() == written
+        assert dialog.configuration_combo.currentText() == written
+    finally:
+        dialog.deleteLater()


### PR DESCRIPTION
The point of FIB-775, now that #515 and #519 have given connecting somewhere else to live.

The Connection tab is a **gate in a bar that otherwise means "the instrument needs you here now"** — the panel's tab bar is driven by the workflow from five places in `AutoLamellaUI.py`, and Connection is the only tab that can never be a workflow step. It sits at position 0, the default landing spot, for something done once a session.

With `features.connection_chip` on, it is not built. The header chip and `File → Connect to Microscope` reach the connection instead.

**The widget stays either way.** `FibsemSystemSetupWidget` owns the connection and everything in the application follows its `connected_signal` / `disconnected_signal`; only the tab was ever conditional. `--quickstart` still drives it directly and is untouched.

## The part that would have gone silently

The **guided-setup offer** from #472 is a banner *inside* that widget, driven from `AutoLamellaMainUI:914`, and the Connection tab was the only place it rendered. Removing the tab would have left a fresh install with Tools → Guided Setup — not somewhere a first-time user looks, and a first-time user is the entire audience for it.

It now sits at the top of the connection dialog, **above** the configuration row: on a fresh install there is no configuration worth choosing yet, and the walkthrough is what makes one.

Carried across intact:

- the three separate conditions (flag on, not dismissed, nothing configured) — separate for the reason the original comment gives, that the flag lives in the file whose absence means "fresh install";
- dismissing persists, or the offer returns next start;
- backing out of the wizard is not declining;
- finishing it now **selects what it wrote**, rather than leaving the dialog pointing at whatever was selected before it ran.

## What a release sees

Nothing. The flag is off, the tab is built exactly as it always was, and the offer renders where it always did.

## Tests

`tests/ui/test_connection_tab_removal.py` — 8. The tab is present with the flag off and absent with it on, with the widget surviving both; the offer shows on a fresh install and stays away in each of the three ways it should, parameterised; declining persists; finishing the wizard selects the new configuration.

Preferences are redirected to a temp file throughout — `is_first_run` reads the real configuration registry, and these tests must neither depend on the developer's own state nor write to it.

Full `tests/ui`: 2191 passed, 1 skipped. Formatted per #489, AST-identical.

Left for FIB-775: opening the dialog at launch and chaining into create/load, then turning the flag on and deleting it.
