### PR TITLE
[fix] Say where a stage move got to, once rather than four times (FIB-781)

### DIFF
--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -29,6 +29,12 @@ INSTRUCTIONS_TEXT = (
     """Instructions: Double Click to Move. Alt + Double Click to Move Vertically"""
 )
 
+# What every path says once the stage has arrived and the images are being retaken.
+# A constant rather than three string literals: the three movement paths had drifted
+# to "updating images", "taking new images" and, on the orientation path, nothing at
+# all -- so the same phase looked different depending on how the move was started.
+ACQUIRING_IMAGES = "Acquiring images…"
+
 
 class FibsemMovementWidget(QtWidgets.QWidget):
     movement_progress_signal = QtCore.pyqtSignal(dict)
@@ -481,10 +487,10 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     def absolute_movement_worker(self, stage_position: FibsemStagePosition) -> None:
         """Worker function to move the stage to the specified position"""
         self.movement_progress_signal.emit(
-            {"msg": f"Moving to {stage_position.pretty}"}
+            {"msg": f"Moving to {stage_position.pretty}…"}
         )
         self.microscope.safe_absolute_stage_movement(stage_position)
-        self.movement_progress_signal.emit({"msg": "Move finished, taking new images"})
+        self.movement_progress_signal.emit({"msg": ACQUIRING_IMAGES})
         self.update_ui_after_movement()
 
     def move_stage_finished(self):
@@ -546,7 +552,18 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             }
         )
 
-        self.movement_progress_signal.emit({"msg": "Moving stage..."})
+        # Which kind of move, because they are different operations and the user chose
+        # between them: a plain double-click moves laterally, Alt + double-click moves
+        # along the beam axis to hold eucentricity. "Vertically" rather than
+        # "eucentric" so the message matches the words already on screen in
+        # INSTRUCTIONS_TEXT.
+        self.movement_progress_signal.emit(
+            {
+                "msg": "Moving the stage vertically…"
+                if vertical_move
+                else "Moving the stage…"
+            }
+        )
         # eucentric is only supported for ION beam
         if beam_type is BeamType.ION and vertical_move:
             self.microscope.vertical_move(dx=point.x, dy=point.y)
@@ -566,7 +583,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
                 dy=point.y,
                 beam_type=beam_type,
             )
-        self.movement_progress_signal.emit({"msg": "Move finished, updating images..."})
+        self.movement_progress_signal.emit({"msg": ACQUIRING_IMAGES})
         self.update_ui_after_movement()
 
     def _on_canvas_double_click(
@@ -610,7 +627,6 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         h, w = image.data.shape[:2]
         if not (0 <= x < w and 0 <= y < h):
             return  # click landed outside the image area
-        self.movement_progress_signal.emit({"msg": "Click to move in progress..."})
         point = conversions.image_to_microscope_image_coordinates(
             coord=Point(x=x, y=y),
             image=image.data,
@@ -633,7 +649,10 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     def move_to_orientation_worker(self, orientation: str) -> None:
         """Threaded worker function to move the stage to the specified orientation"""
         self.movement_progress_signal.emit(
-            {"msg": f"Moving to {orientation} orientation..."}
+            {"msg": f"Moving to the {orientation} orientation…"}
         )
         self.microscope.move_to_orientation(orientation)
+        # The orientation path never said this, so the label sat on "Moving to the SEM
+        # orientation…" while the move had finished and the images were being retaken.
+        self.movement_progress_signal.emit({"msg": ACQUIRING_IMAGES})
         self.update_ui_after_movement()

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -375,11 +375,11 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     def handle_movement_progress_update(self, ddict: dict) -> None:
         """Handle movement progress updates from the microscope.
 
-        Shown in the instructions label rather than as toasts. These messages bracket
-        a blocking move -- one click-to-move emits four of them inside ~45 ms -- so as
-        popups they stack into a wall that says nothing the moving stage and the
-        refreshing images do not already show. A label carries the same words for the
-        duration of the move, which is when they are worth reading.
+        Written to the canvas info bar rather than shown as toasts. These messages
+        bracket a blocking move -- one click-to-move emits four of them inside ~45 ms
+        -- so as popups they stack into a wall that says nothing the moving stage and
+        the refreshing images do not already show. On the info bar the same words stay
+        put for the duration of the move, which is when they are worth reading.
 
         They are invisible today because `display.toasts_enabled` defaults to False.
         That default should change, and this is what has to be true first.
@@ -387,15 +387,42 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         msg = ddict.get("msg", None)
         if msg is not None:
             logging.debug(msg)
-            self.label_movement_instructions.setText(msg)
+            self._set_move_status(msg)
 
         is_finished = ddict.get("finished", False)
         if is_finished:
-            # Restored, or the last progress line sits there afterwards as though the
-            # stage were still moving. Every path reaches here: each worker connects
-            # `finished` to `move_stage_finished`, which emits this.
-            self.label_movement_instructions.setText(INSTRUCTIONS_TEXT)
+            # Cleared, or the last line sits there afterwards as though the stage were
+            # still moving. Every path reaches here: each worker connects `finished` to
+            # `move_stage_finished`, which emits this.
+            #
+            # Except while the images are still being retaken -- which is the usual
+            # case, because `update_ui_after_movement` only *queues* the acquisition
+            # before the worker returns. `move_stage_finished` already declines to
+            # re-enable the buttons in that window; the status has to keep the same
+            # counsel or it says "done" over a second of acquisition, and offers a
+            # double-click that is still disabled. `handle_acquisition_update` clears
+            # it when the images actually land.
+            if not self.image_widget.is_acquiring:
+                self._set_move_status(None)
             self._update_position_readout()
+
+    def _set_move_status(self, msg: Optional[str]) -> None:
+        """Put *msg* on the info bar of every canvas, or clear it when None.
+
+        Not the instructions label on this tab. Five of the six paths that start a
+        stage move start it from somewhere else -- the canvas beside the tabs (which
+        takes a double-click whatever tab is showing), either minimap, or the lamella
+        list -- so a message on the Movement tab is one the operator is usually not
+        looking at, where a toast could be read from anywhere. The info bar is beside
+        the canvas that was clicked, is visible from every tab, and is already where
+        the stage position this move is changing gets written.
+        """
+        controller = self._view_controller()
+        if controller is None:
+            return
+        controller.set_info(BeamType.ELECTRON, "move", msg)
+        controller.set_info(BeamType.ION, "move", msg)
+        controller.set_fm_info("move", msg)
 
     def _update_position_readout(
         self, stage_position: Optional[FibsemStagePosition] = None
@@ -409,6 +436,10 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         """Handle acquisition updates from the image widget"""
         is_finished = ddict.get("finished", False)
         if is_finished:
+            # The other half of the hand-off above: a move's status outlives its
+            # `finished` so it covers the acquisition that follows, and this is what
+            # takes it down. A no-op when no move put anything there.
+            self._set_move_status(None)
             self.update_ui()
 
     @ensure_main_thread

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -1,4 +1,3 @@
-
 import logging
 from functools import partial
 from typing import Optional
@@ -26,7 +25,9 @@ from fibsem.ui.stylesheets import (
 from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel
 
-INSTRUCTIONS_TEXT = """Instructions: Double Click to Move. Alt + Double Click to Move Vertically"""
+INSTRUCTIONS_TEXT = (
+    """Instructions: Double Click to Move. Alt + Double Click to Move Vertically"""
+)
 
 
 class FibsemMovementWidget(QtWidgets.QWidget):
@@ -41,8 +42,12 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self._setup_ui()
         self.parent = parent
 
-        if not hasattr(parent, 'image_widget') or not isinstance(parent.image_widget, FibsemImageSettingsWidget):
-            raise ValueError("Parent must have an 'image_widget' attribute of type FibsemImageSettingsWidget")
+        if not hasattr(parent, "image_widget") or not isinstance(
+            parent.image_widget, FibsemImageSettingsWidget
+        ):
+            raise ValueError(
+                "Parent must have an 'image_widget' attribute of type FibsemImageSettingsWidget"
+            )
 
         self.microscope = microscope
         self.image_widget: FibsemImageSettingsWidget = parent.image_widget
@@ -111,7 +116,9 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.doubleSpinBox_movement_stage_rotation = QtWidgets.QDoubleSpinBox()
         self.doubleSpinBox_movement_stage_rotation.setMinimum(-360.0)
         self.doubleSpinBox_movement_stage_rotation.setMaximum(360.0)
-        self.doubleSpinBox_movement_stage_rotation.setSuffix(f" {constants.DEGREE_SYMBOL}")
+        self.doubleSpinBox_movement_stage_rotation.setSuffix(
+            f" {constants.DEGREE_SYMBOL}"
+        )
         self.gridLayout_3.addWidget(self.label_movement_stage_rotation, 3, 0)
         self.gridLayout_3.addWidget(self.doubleSpinBox_movement_stage_rotation, 3, 1)
 
@@ -124,13 +131,19 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.pushButton_move = QtWidgets.QPushButton("Move to Position")
         self.gridLayout_3.addWidget(self.pushButton_move, 5, 0, 1, 2)
 
-        self.pushButton_move_to_sem_orientation = QtWidgets.QPushButton("Move Flat to ELECTRON Beam")
-        self.pushButton_move_to_fib_orientation = QtWidgets.QPushButton("Move Flat to ION Beam")
+        self.pushButton_move_to_sem_orientation = QtWidgets.QPushButton(
+            "Move Flat to ELECTRON Beam"
+        )
+        self.pushButton_move_to_fib_orientation = QtWidgets.QPushButton(
+            "Move Flat to ION Beam"
+        )
         self.gridLayout_3.addWidget(self.pushButton_move_to_sem_orientation, 6, 0)
         self.gridLayout_3.addWidget(self.pushButton_move_to_fib_orientation, 6, 1)
 
         self.doubleSpinBox_milling_angle = QtWidgets.QDoubleSpinBox()
-        self.pushButton_move_to_milling_angle = QtWidgets.QPushButton("Move to Milling Angle")
+        self.pushButton_move_to_milling_angle = QtWidgets.QPushButton(
+            "Move to Milling Angle"
+        )
         self.gridLayout_3.addWidget(self.doubleSpinBox_milling_angle, 7, 0)
         self.gridLayout_3.addWidget(self.pushButton_move_to_milling_angle, 7, 1)
 
@@ -138,8 +151,12 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.label_movement_instructions.setWordWrap(True)
         self.gridLayout_3.addWidget(self.label_movement_instructions, 8, 0, 1, 2)
 
-        self.btn_refresh_stage = IconToolButton(icon="mdi:refresh", tooltip="Refresh stage position")
-        self.stage_panel = TitledPanel("Stage Movement", content=stage_content, collapsible=False)
+        self.btn_refresh_stage = IconToolButton(
+            icon="mdi:refresh", tooltip="Refresh stage position"
+        )
+        self.stage_panel = TitledPanel(
+            "Stage Movement", content=stage_content, collapsible=False
+        )
         self.stage_panel.add_header_widget(self.btn_refresh_stage)
         self.gridLayout_2.addWidget(self.stage_panel, 0, 0)
 
@@ -147,8 +164,11 @@ class FibsemMovementWidget(QtWidgets.QWidget):
 
         # --- Panel: Saved Positions ---
         from fibsem.ui.widgets.saved_position_widget import SavedPositionListWidget
+
         self.saved_positions_widget = SavedPositionListWidget(microscope=None)
-        self.saved_positions_panel = TitledPanel("Saved Positions", content=self.saved_positions_widget, collapsible=True)
+        self.saved_positions_panel = TitledPanel(
+            "Saved Positions", content=self.saved_positions_widget, collapsible=True
+        )
         self.gridLayout_2.addWidget(self.saved_positions_panel, 2, 0)
 
         self._move_buttons = [
@@ -160,17 +180,23 @@ class FibsemMovementWidget(QtWidgets.QWidget):
 
         # Bottom spacer (row 4 — row 3 reserved for optional sample holder widget)
         self.gridLayout_2.addItem(
-            QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding),
-            4, 0,
+            QtWidgets.QSpacerItem(
+                20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding
+            ),
+            4,
+            0,
         )
 
     def setup_connections(self):
 
-
         # buttons
         self.pushButton_move.clicked.connect(lambda: self.move_to_position(None))
-        self.pushButton_move_to_fib_orientation.clicked.connect(lambda: self.move_to_orientation("FIB"))
-        self.pushButton_move_to_sem_orientation.clicked.connect(lambda: self.move_to_orientation("SEM"))
+        self.pushButton_move_to_fib_orientation.clicked.connect(
+            lambda: self.move_to_orientation("FIB")
+        )
+        self.pushButton_move_to_sem_orientation.clicked.connect(
+            lambda: self.move_to_orientation("SEM")
+        )
         self.btn_refresh_stage.clicked.connect(lambda: self.update_ui(None))
 
         # register mouse callbacks — one canvas per beam. The canvases are app-lifetime
@@ -202,31 +228,50 @@ class FibsemMovementWidget(QtWidgets.QWidget):
 
         # signals
         self.movement_progress_signal.connect(self.handle_movement_progress_update)
-        self.image_widget.acquisition_progress_signal.connect(self.handle_acquisition_update)
+        self.image_widget.acquisition_progress_signal.connect(
+            self.handle_acquisition_update
+        )
 
         stage_limits = self.microscope._stage.limits
-        xlimits = stage_limits['x']
-        ylimits = stage_limits['y']
-        zlimits = stage_limits['z']
-        tlimits = stage_limits['t']
+        xlimits = stage_limits["x"]
+        ylimits = stage_limits["y"]
+        zlimits = stage_limits["z"]
+        tlimits = stage_limits["t"]
 
         self.doubleSpinBox_movement_stage_tilt.setMinimum(tlimits.min)
         self.doubleSpinBox_movement_stage_tilt.setMaximum(tlimits.max)
-        self.doubleSpinBox_movement_stage_x.setMinimum(xlimits.min * constants.SI_TO_MILLI)
-        self.doubleSpinBox_movement_stage_x.setMaximum(xlimits.max * constants.SI_TO_MILLI)
-        self.doubleSpinBox_movement_stage_y.setMinimum(ylimits.min * constants.SI_TO_MILLI)
-        self.doubleSpinBox_movement_stage_y.setMaximum(ylimits.max * constants.SI_TO_MILLI)
-        self.doubleSpinBox_movement_stage_z.setMinimum(zlimits.min * constants.SI_TO_MILLI)
-        self.doubleSpinBox_movement_stage_z.setMaximum(zlimits.max * constants.SI_TO_MILLI)
+        self.doubleSpinBox_movement_stage_x.setMinimum(
+            xlimits.min * constants.SI_TO_MILLI
+        )
+        self.doubleSpinBox_movement_stage_x.setMaximum(
+            xlimits.max * constants.SI_TO_MILLI
+        )
+        self.doubleSpinBox_movement_stage_y.setMinimum(
+            ylimits.min * constants.SI_TO_MILLI
+        )
+        self.doubleSpinBox_movement_stage_y.setMaximum(
+            ylimits.max * constants.SI_TO_MILLI
+        )
+        self.doubleSpinBox_movement_stage_z.setMinimum(
+            zlimits.min * constants.SI_TO_MILLI
+        )
+        self.doubleSpinBox_movement_stage_z.setMaximum(
+            zlimits.max * constants.SI_TO_MILLI
+        )
 
         # set custom tilt limits for the compustage
         if self.microscope.stage_is_compustage:
-
             # NOTE: these values are expressed in mm in the UI, hence the conversion
             # set x, y, z step sizes to be 1 um
-            self.doubleSpinBox_movement_stage_x.setSingleStep(1e-6 * constants.SI_TO_MILLI)
-            self.doubleSpinBox_movement_stage_y.setSingleStep(1e-6 * constants.SI_TO_MILLI)
-            self.doubleSpinBox_movement_stage_z.setSingleStep(1e-6 * constants.SI_TO_MILLI)
+            self.doubleSpinBox_movement_stage_x.setSingleStep(
+                1e-6 * constants.SI_TO_MILLI
+            )
+            self.doubleSpinBox_movement_stage_y.setSingleStep(
+                1e-6 * constants.SI_TO_MILLI
+            )
+            self.doubleSpinBox_movement_stage_z.setSingleStep(
+                1e-6 * constants.SI_TO_MILLI
+            )
 
             # hide rotation control for compustage
             self.label_movement_stage_rotation.setVisible(False)
@@ -234,8 +279,12 @@ class FibsemMovementWidget(QtWidgets.QWidget):
 
         # stylesheets
         self.pushButton_move.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
-        self.pushButton_move_to_fib_orientation.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
-        self.pushButton_move_to_sem_orientation.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
+        self.pushButton_move_to_fib_orientation.setStyleSheet(
+            SECONDARY_BUTTON_STYLESHEET
+        )
+        self.pushButton_move_to_sem_orientation.setStyleSheet(
+            SECONDARY_BUTTON_STYLESHEET
+        )
         self.pushButton_move_to_milling_angle.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
 
         # display orientation values on tooltips
@@ -249,15 +298,23 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.pushButton_move_to_milling_angle.setToolTip(milling.pretty_orientation)
 
         # milling angle controls
-        self.doubleSpinBox_milling_angle.setValue(self.microscope.system.stage.milling_angle) # deg
+        self.doubleSpinBox_milling_angle.setValue(
+            self.microscope.system.stage.milling_angle
+        )  # deg
         self.doubleSpinBox_milling_angle.setSuffix(constants.DEGREE_SYMBOL)
         self.doubleSpinBox_milling_angle.setSingleStep(1.0)
         self.doubleSpinBox_milling_angle.setDecimals(1)
         self.doubleSpinBox_milling_angle.setRange(0, 45)
-        self.doubleSpinBox_milling_angle.setToolTip("The milling angle is the difference between the stage and the fib viewing angle.")
+        self.doubleSpinBox_milling_angle.setToolTip(
+            "The milling angle is the difference between the stage and the fib viewing angle."
+        )
         self.doubleSpinBox_milling_angle.setKeyboardTracking(False)
-        self.doubleSpinBox_milling_angle.valueChanged.connect(self._update_milling_angle)
-        self.pushButton_move_to_milling_angle.clicked.connect(lambda: self.move_to_orientation("MILLING"))
+        self.doubleSpinBox_milling_angle.valueChanged.connect(
+            self._update_milling_angle
+        )
+        self.pushButton_move_to_milling_angle.clicked.connect(
+            lambda: self.move_to_orientation("MILLING")
+        )
 
         # set degree symbols for rotation and tilt
         self.doubleSpinBox_movement_stage_rotation.setSuffix(constants.DEGREE_SYMBOL)
@@ -273,6 +330,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
 
         if cfg.FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED:
             from fibsem.ui.widgets.sample_holder_widget import SampleHolderWidget
+
             self.sample_holder_widget = SampleHolderWidget(microscope=self.microscope)
             self.sample_holder_widget.set_holder(self.microscope._stage.holder)
             self.gridLayout_2.addWidget(self.sample_holder_widget, 3, 0)
@@ -302,19 +360,35 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         # No disabled branch: both sheets carry a :disabled rule, so setEnabled
         # above is what greys these out.
         for btn in self._move_buttons:
-            btn.setStyleSheet(PRIMARY_BUTTON_STYLESHEET if btn is self.pushButton_move
-                              else SECONDARY_BUTTON_STYLESHEET)
+            btn.setStyleSheet(
+                PRIMARY_BUTTON_STYLESHEET
+                if btn is self.pushButton_move
+                else SECONDARY_BUTTON_STYLESHEET
+            )
 
     def handle_movement_progress_update(self, ddict: dict) -> None:
-        """Handle movement progress updates from the microscope"""
+        """Handle movement progress updates from the microscope.
 
+        Shown in the instructions label rather than as toasts. These messages bracket
+        a blocking move -- one click-to-move emits four of them inside ~45 ms -- so as
+        popups they stack into a wall that says nothing the moving stage and the
+        refreshing images do not already show. A label carries the same words for the
+        duration of the move, which is when they are worth reading.
+
+        They are invisible today because `display.toasts_enabled` defaults to False.
+        That default should change, and this is what has to be true first.
+        """
         msg = ddict.get("msg", None)
         if msg is not None:
             logging.debug(msg)
-            notification_service.show_toast(msg)
+            self.label_movement_instructions.setText(msg)
 
         is_finished = ddict.get("finished", False)
         if is_finished:
+            # Restored, or the last progress line sits there afterwards as though the
+            # stage were still moving. Every path reaches here: each worker connects
+            # `finished` to `move_stage_finished`, which emits this.
+            self.label_movement_instructions.setText(INSTRUCTIONS_TEXT)
             self._update_position_readout()
 
     def _update_position_readout(
@@ -337,10 +411,18 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         if stage_position is None:
             stage_position = self.microscope.get_stage_position()
 
-        self.doubleSpinBox_movement_stage_x.setValue(stage_position.x * constants.SI_TO_MILLI)
-        self.doubleSpinBox_movement_stage_y.setValue(stage_position.y * constants.SI_TO_MILLI)
-        self.doubleSpinBox_movement_stage_z.setValue(stage_position.z * constants.SI_TO_MILLI)
-        self.doubleSpinBox_movement_stage_rotation.setValue(np.degrees(stage_position.r))
+        self.doubleSpinBox_movement_stage_x.setValue(
+            stage_position.x * constants.SI_TO_MILLI
+        )
+        self.doubleSpinBox_movement_stage_y.setValue(
+            stage_position.y * constants.SI_TO_MILLI
+        )
+        self.doubleSpinBox_movement_stage_z.setValue(
+            stage_position.z * constants.SI_TO_MILLI
+        )
+        self.doubleSpinBox_movement_stage_rotation.setValue(
+            np.degrees(stage_position.r)
+        )
         self.doubleSpinBox_movement_stage_tilt.setValue(np.degrees(stage_position.t))
 
         # update the current position label
@@ -349,9 +431,12 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     @ensure_main_thread
     def update_ui_after_movement(self, retake: bool = True):
         # disable taking images after movement here
-        if (retake is False or self.microscope.is_acquiring or
-            self.microscope.fm is not None and
-            self.microscope.fm.objective.state == "Inserted"):
+        if (
+            retake is False
+            or self.microscope.is_acquiring
+            or self.microscope.fm is not None
+            and self.microscope.fm.objective.state == "Inserted"
+        ):
             self.update_ui()
             return
         prefs = cfg.load_user_preferences()
@@ -369,7 +454,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
 
     def _update_milling_angle(self):
         """Update the milling angle in the microscope and the UI"""
-        milling_angle = self.doubleSpinBox_milling_angle.value() # deg
+        milling_angle = self.doubleSpinBox_milling_angle.value()  # deg
         self.microscope.set_milling_angle(milling_angle)
 
         # refresh tooltip and overlay
@@ -377,7 +462,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.pushButton_move_to_milling_angle.setToolTip(milling.pretty_orientation)
         self._update_position_readout()
 
-#### MOVEMENT
+    #### MOVEMENT
 
     def move_to_position(self, stage_position: Optional[FibsemStagePosition] = None):
         """Move the stage to the position specified in the UI"""
@@ -391,11 +476,13 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         worker = self.absolute_movement_worker(stage_position=stage_position)
         worker.finished.connect(self.move_stage_finished)
         worker.start()
-    
+
     @thread_worker
     def absolute_movement_worker(self, stage_position: FibsemStagePosition) -> None:
         """Worker function to move the stage to the specified position"""
-        self.movement_progress_signal.emit({"msg": f"Moving to {stage_position.pretty}"})
+        self.movement_progress_signal.emit(
+            {"msg": f"Moving to {stage_position.pretty}"}
+        )
         self.microscope.safe_absolute_stage_movement(stage_position)
         self.movement_progress_signal.emit({"msg": "Move finished, taking new images"})
         self.update_ui_after_movement()
@@ -449,21 +536,29 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         """
         movement_mode = "Vertical" if vertical_move else "Stable"
 
-        logging.debug({
-            "msg": "stage_movement",                    # message type
-            "movement_mode": movement_mode,             # movement mode
-            "beam_type": beam_type.name,                # beam type
-            "dm": point.to_dict(),                      # shift in microscope coordinates
-            "coords": coords,                           # coords in image coordinates
-        })
+        logging.debug(
+            {
+                "msg": "stage_movement",  # message type
+                "movement_mode": movement_mode,  # movement mode
+                "beam_type": beam_type.name,  # beam type
+                "dm": point.to_dict(),  # shift in microscope coordinates
+                "coords": coords,  # coords in image coordinates
+            }
+        )
 
         self.movement_progress_signal.emit({"msg": "Moving stage..."})
         # eucentric is only supported for ION beam
         if beam_type is BeamType.ION and vertical_move:
             self.microscope.vertical_move(dx=point.x, dy=point.y)
-        elif beam_type is BeamType.ELECTRON and vertical_move and hasattr(self.microscope, "move_coincident_from_sem"):
+        elif (
+            beam_type is BeamType.ELECTRON
+            and vertical_move
+            and hasattr(self.microscope, "move_coincident_from_sem")
+        ):
             # move coincident from SEM
-            self.microscope.move_coincident_from_sem(dx=0, dy=point.y) # TMP: disable dx for now
+            self.microscope.move_coincident_from_sem(
+                dx=0, dy=point.y
+            )  # TMP: disable dx for now
         else:
             # corrected stage movement
             self.microscope.stable_move(
@@ -471,10 +566,12 @@ class FibsemMovementWidget(QtWidgets.QWidget):
                 dy=point.y,
                 beam_type=beam_type,
             )
-        self.movement_progress_signal.emit({"msg": "Move finished, updating UI"})
+        self.movement_progress_signal.emit({"msg": "Move finished, updating images..."})
         self.update_ui_after_movement()
 
-    def _on_canvas_double_click(self, beam_type: BeamType, x: float, y: float, modifiers) -> None:
+    def _on_canvas_double_click(
+        self, beam_type: BeamType, x: float, y: float, modifiers
+    ) -> None:
         """Canvas double-click -> move stage."""
         if not self._click_to_move_available():
             return
@@ -484,7 +581,9 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         worker.start()
 
     @thread_worker
-    def _canvas_double_click_worker(self, beam_type: BeamType, x: float, y: float, modifiers):
+    def _canvas_double_click_worker(
+        self, beam_type: BeamType, x: float, y: float, modifiers
+    ):
         """Thread worker for quad-view double-clicks (one image per canvas).
 
         ``x, y`` are already beam-local, full-resolution image pixels — the canvas emits
@@ -492,8 +591,13 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         """
         if "Shift" in modifiers:
             return
-        if hasattr(self.parent, "milling_widget") and self.parent.milling_widget.is_milling:
-            notification_service.show_toast("Cannot move stage while milling is in progress.")
+        if (
+            hasattr(self.parent, "milling_widget")
+            and self.parent.milling_widget.is_milling
+        ):
+            notification_service.show_toast(
+                "Cannot move stage while milling is in progress."
+            )
             return
         image = (
             self.image_widget.eb_image
@@ -516,7 +620,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             beam_type, point, "Alt" in modifiers, coords={"x": x, "y": y}
         )
 
-    def move_to_orientation(self, orientation: str)-> None:
+    def move_to_orientation(self, orientation: str) -> None:
         """Move to the specifed orientation"""
         if orientation not in ["SEM", "FIB", "MILLING"]:
             raise ValueError(f"Invalid orientation: {orientation}")
@@ -528,7 +632,8 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     @thread_worker
     def move_to_orientation_worker(self, orientation: str) -> None:
         """Threaded worker function to move the stage to the specified orientation"""
-        self.movement_progress_signal.emit({"msg": f"Moving to {orientation} orientation..."})
+        self.movement_progress_signal.emit(
+            {"msg": f"Moving to {orientation} orientation..."}
+        )
         self.microscope.move_to_orientation(orientation)
         self.update_ui_after_movement()
-

--- a/tests/ui/test_movement_progress.py
+++ b/tests/ui/test_movement_progress.py
@@ -1,118 +1,286 @@
 """Where movement progress goes, now that it is no longer a stream of toasts.
 
 One click-to-move emits four progress messages inside ~45 ms. As toasts they stack
-into a wall of popups saying nothing the moving stage does not already show; in the
-instructions label they read as one status for the duration of the move.
+into a wall of popups saying nothing the moving stage does not already show. They go
+to the quad-view info bar instead -- *not* to the instructions label on the Movement
+tab, because five of the six paths that start a stage move start it from somewhere
+else, and a message on a hidden tab is one nobody reads. The info bar sits beside the
+canvas that was clicked and is visible from every tab.
 
-They are invisible today because ``display.toasts_enabled`` defaults to False. This
-is what has to be true before that default can change.
+They are invisible today because ``display.toasts_enabled`` defaults to False. This is
+what has to be true before that default can change.
 """
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
 
 import pytest
 
 pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
 
-from fibsem.ui.FibsemMovementWidget import (
-    ACQUIRING_IMAGES,
-    INSTRUCTIONS_TEXT,
-    FibsemMovementWidget,
+from PyQt5 import QtWidgets
+from PyQt5.QtCore import QEventLoop, QTimer
+
+# The real construction seam: a host with a view controller, a real image widget and a
+# Demo microscope. Building the widget through `__new__` and hand-injecting a label
+# would let every test here pass with `movement_progress_signal` disconnected.
+sys.path.insert(0, os.path.dirname(__file__))  # not str.rsplit: Windows paths
+from test_viewer_less_widgets import (  # noqa: E402
+    _CanvasHost,
+    _image_widget,
+    _movement_widget,
 )
 
-# The real sequence one click-to-move produces, in order, taken from the emit sites.
-CLICK_TO_MOVE = [
-    {"msg": "Moving the stage…"},
-    {"msg": ACQUIRING_IMAGES},
-    {"finished": True},
-]
+from fibsem.structures import BeamType, FibsemStagePosition, Point  # noqa: E402
+from fibsem.ui.FibsemMovementWidget import (  # noqa: E402
+    ACQUIRING_IMAGES,
+    INSTRUCTIONS_TEXT,
+)
+
+TARGET = FibsemStagePosition(x=1e-6, y=1e-6, z=1e-6, r=0.0, t=0.0)
+
+
+def _pump(ms: int = 200) -> None:
+    """Let queued signals and the debounced info-bar render run."""
+    loop = QEventLoop()
+    QTimer.singleShot(ms, loop.quit)
+    loop.exec_()
+
+
+def _run(condition, tries: int = 15) -> None:
+    """Pump until *condition* holds, or give up and let the assertion report it."""
+    for _ in range(tries):
+        _pump()
+        if condition():
+            return
 
 
 @pytest.fixture
-def widget(qapp, monkeypatch):
-    # The widget connects to canvases and a microscope it has no business reaching in
-    # a test; only the progress handler and its label are under test here.
-    monkeypatch.setattr(FibsemMovementWidget, "setup_connections", lambda self: None)
-    w = FibsemMovementWidget.__new__(FibsemMovementWidget)
-    from PyQt5 import QtWidgets
-
-    QtWidgets.QWidget.__init__(w)
-    w.label_movement_instructions = QtWidgets.QLabel(INSTRUCTIONS_TEXT)
-    w._update_position_readout = lambda: None
-    yield w
-    w.deleteLater()
+def movement(qapp):
+    host = _CanvasHost()
+    _image_widget(host)
+    widget = _movement_widget(host)
+    yield widget
+    host.deleteLater()
 
 
-def test_progress_reaches_the_label(widget):
-    widget.handle_movement_progress_update({"msg": "Moving stage..."})
-    assert widget.label_movement_instructions.text() == "Moving stage..."
+def _info(widget, beam: BeamType = BeamType.ELECTRON) -> dict:
+    """The info-bar fields on one canvas, as {key: text}."""
+    controller = widget._view_controller()
+    canvas = (
+        controller.sem_canvas if beam is BeamType.ELECTRON else controller.fib_canvas
+    )
+    return dict(controller._states[canvas].info)
 
 
-def test_progress_does_not_toast(widget, monkeypatch):
-    """The whole point: four popups per click is worse than none."""
+def _status(widget, beam: BeamType = BeamType.ELECTRON):
+    return _info(widget, beam).get("move")
+
+
+def _record(widget) -> list:
+    """Every status the info bar held, in order, as the move ran."""
+    seen = []
+    widget.movement_progress_signal.connect(lambda _d: seen.append(_status(widget)))
+    return seen
+
+
+# --- it reaches the info bar, on every canvas ---------------------------------
+
+
+def test_progress_reaches_the_info_bar(movement):
+    seen = _record(movement)
+    movement._move_to_absolute_position(TARGET)
+    _run(lambda: seen and seen[-1] is None)
+    assert any(s and s.startswith("Moving to") for s in seen), seen
+
+
+def test_every_canvas_carries_it(movement):
+    """A stage move moves what all three canvases are looking at, so the status is not
+    the electron canvas's business alone -- the operator may be watching any of them."""
+    movement._set_move_status("Moving the stage…")
+    controller = movement._view_controller()
+    for canvas in (controller.sem_canvas, controller.fib_canvas, controller.fm_canvas):
+        assert dict(controller._states[canvas].info).get("move") == "Moving the stage…"
+
+
+def test_it_does_not_disturb_the_stage_readout(movement):
+    """The info bar is shared. `STAGE:` is what this widget already writes there, and a
+    status that replaced it would trade one reading for another."""
+    before = _info(movement).get("stage")
+    assert before, "no stage readout to begin with"
+    movement._set_move_status("Moving the stage…")
+    assert _info(movement).get("stage") == before
+
+
+# --- the reason it is not on the Movement tab ---------------------------------
+
+
+def test_the_status_shows_from_another_tab(movement):
+    """The regression this replaced: click-to-move works whatever tab is showing --
+    `_click_to_move_available` gates on the button being enabled and nothing else, and
+    the canvas sits beside the tabs, not inside them. A status on the Movement tab is
+    therefore usually written where nobody can see it."""
+    tabs = QtWidgets.QTabWidget()
+    tabs.addTab(QtWidgets.QLabel("Image"), "Image")
+    tabs.addTab(movement, "Movement")
+    tabs.addTab(QtWidgets.QLabel("Milling"), "Milling")
+    tabs.show()
+    tabs.setCurrentIndex(2)  # Milling: the Movement tab is now hidden
+    _pump(150)
+
+    assert not movement.label_movement_instructions.isVisible(), (
+        "the Movement tab is showing; this test proves nothing"
+    )
+    seen = _record(movement)
+    movement._move_to_absolute_position(TARGET)
+    _run(lambda: seen and seen[-1] is None)
+    assert any(s and s.startswith("Moving to") for s in seen), seen
+    tabs.close()
+
+
+def test_the_instructions_label_is_left_alone(movement):
+    """It says what a double-click does, which does not change while the stage moves."""
+    seen = []
+    movement.movement_progress_signal.connect(
+        lambda _d: seen.append(movement.label_movement_instructions.text())
+    )
+    movement._move_to_absolute_position(TARGET)
+    _run(lambda: seen and _status(movement) is None)
+    assert set(seen) == {INSTRUCTIONS_TEXT}, seen
+
+
+# --- no toasts ----------------------------------------------------------------
+
+
+def test_progress_does_not_toast(movement, monkeypatch):
+    """The whole point: four popups per click is worse than none.
+
+    Scoped to the movement messages. The image widget still raises one of its own for
+    the acquisition that follows -- that is its message on its own path, and one popup
+    per move was never the complaint.
+    """
     from fibsem.ui import notification_service
 
     shown = []
     monkeypatch.setattr(
         notification_service,
         "show_toast",
-        lambda *a, **k: shown.append(a),
+        lambda *a, **k: shown.append(a[0] if a else ""),
     )
-    for update in CLICK_TO_MOVE:
-        widget.handle_movement_progress_update(update)
-    assert shown == []
+    progress = []
+    movement.movement_progress_signal.connect(lambda d: progress.append(d.get("msg")))
+    movement._move_to_absolute_position(TARGET)
+    _run(lambda: _status(movement) is None)
+
+    assert any(progress), "the move emitted no progress at all"
+    assert [t for t in shown if t in progress] == [], shown
 
 
-def test_the_instructions_come_back_when_the_move_finishes(widget):
-    """Otherwise the last progress line sits there as though the stage were still
-    moving, and the instructions are gone for the rest of the session."""
-    for update in CLICK_TO_MOVE:
-        widget.handle_movement_progress_update(update)
-    assert widget.label_movement_instructions.text() == INSTRUCTIONS_TEXT
+# --- when it clears -----------------------------------------------------------
 
 
-def test_no_progress_message_says_updating_ui(widget):
-    """Developer phrasing was fine while nobody could see it.
+def test_it_clears_when_the_images_land_not_before(movement):
+    """`update_ui_after_movement` only *queues* the acquisition before the worker
+    returns, so `finished` arrives with ~a second of acquiring still to come.
+    `move_stage_finished` already declines to re-enable the buttons in that window; if
+    the status cleared there it would read "nothing is happening" over the acquisition
+    it just announced, and offer a double-click that is still disabled."""
+    at_finished = []
+    movement.movement_progress_signal.connect(
+        lambda d: (
+            d.get("finished")
+            and at_finished.append(
+                (_status(movement), movement.image_widget.is_acquiring)
+            )
+        )
+    )
+    movement._move_to_absolute_position(TARGET)
+    _run(lambda: at_finished and not movement.image_widget.is_acquiring)
 
-    These were toasts on a preference that defaults to off, so the wording never
-    reached a user. In the label it is on screen.
-    """
-    for update in CLICK_TO_MOVE:
-        widget.handle_movement_progress_update(update)
-        assert "updating UI" not in widget.label_movement_instructions.text()
+    assert at_finished, "the move never finished"
+    status, acquiring = at_finished[-1]
+    assert acquiring, "the images had already landed; this test proves nothing"
+    assert status == ACQUIRING_IMAGES, status
+    assert _status(movement) is None, "the status outlived the acquisition"
 
 
-def test_one_start_message_not_two(widget):
-    """The dropped message was replaced within 38 ms by the next one.
+def test_it_clears_when_the_move_fails(movement, monkeypatch):
+    """A raising move still ends: `FunctionWorker` emits `finished` from a `finally`.
+    Without that the info bar would keep 'Moving to…' for the rest of the session."""
+    monkeypatch.setattr(
+        movement.microscope,
+        "safe_absolute_stage_movement",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("stage refused")),
+    )
+    movement._move_to_absolute_position(TARGET)
+    _run(lambda: _status(movement) is None)
+    assert _status(movement) is None
 
-    Nobody ever read it, and it was the one that duplicated in the log.
-    """
-    starts = [u["msg"] for u in CLICK_TO_MOVE if "msg" in u and "Moving" in u["msg"]]
-    assert len(starts) == 1, starts
+
+# --- what it says -------------------------------------------------------------
 
 
-def test_a_vertical_move_says_so(widget):
+@pytest.mark.parametrize(
+    "vertical, expected",
+    [(False, "Moving the stage…"), (True, "Moving the stage vertically…")],
+)
+def test_a_vertical_move_says_so(movement, vertical, expected):
     """A plain double-click moves laterally, Alt + double-click along the beam axis.
-
-    The user chose between them, so the status should not call both the same thing.
-    """
-    import inspect
-
-    from fibsem.ui import FibsemMovementWidget as module
-
-    source = inspect.getsource(module)
-    assert "Moving the stage vertically…" in source
+    The user chose between them, so the status should not call both the same thing."""
+    seen = _record(movement)
+    movement._execute_stage_move(
+        BeamType.ION, Point(x=1e-6, y=1e-6), vertical_move=vertical
+    )
+    _pump()
+    assert seen[0] == expected, seen
 
 
-def test_every_path_says_the_same_thing_while_acquiring(widget):
-    """Three paths had drifted to "updating images", "taking new images", and nothing.
+def test_every_path_says_the_same_thing_while_acquiring(movement):
+    """Three paths had drifted to "updating images", "taking new images", and nothing
+    at all -- the same phase looked different depending on how the move was started.
 
-    Checked against the source rather than the constant alone, which would still pass
-    if every path quietly stopped using it.
-    """
-    import inspect
+    Driven through each path rather than counted in the source, which would still pass
+    if a path stopped reaching the emit at all."""
+    paths = {
+        "absolute": lambda: movement._move_to_absolute_position(TARGET),
+        "click": lambda: movement._execute_stage_move(
+            BeamType.ION, Point(x=1e-6, y=1e-6), vertical_move=False
+        ),
+        "orientation": lambda: movement.move_to_orientation("SEM"),
+    }
+    for name, start in paths.items():
+        seen = _record(movement)
+        start()
+        _run(lambda: _status(movement) is None)
+        assert ACQUIRING_IMAGES in seen, f"{name} path: {seen}"
 
-    from fibsem.ui import FibsemMovementWidget as module
 
-    source = inspect.getsource(module)
-    assert source.count('{"msg": ACQUIRING_IMAGES}') == 3
-    for stale in ("updating images", "taking new images", "updating UI"):
-        assert stale not in source, stale
+def test_no_progress_message_says_updating_ui(movement):
+    """Developer phrasing was fine while nobody could see it. These were toasts on a
+    preference that defaults to off, so the wording never reached a user."""
+    seen = _record(movement)
+    movement._move_to_absolute_position(TARGET)
+    _run(lambda: seen and seen[-1] is None)
+    assert not any(s and "updating UI" in s for s in seen), seen
+
+
+# --- the threading question ---------------------------------------------------
+
+
+def test_the_status_is_written_on_the_gui_thread(movement):
+    """`movement_progress_signal` is a `pyqtSignal` on a widget with main-thread
+    affinity, so emitting it from a worker queues delivery onto the GUI thread -- which
+    is why the handler needs no `@ensure_main_thread` (`update_ui_after_movement` does,
+    because a worker calls *that* directly rather than through a signal). Asserted
+    rather than assumed: writing the info bar off-thread would be a Qt violation."""
+    threads = []
+    movement.movement_progress_signal.connect(
+        lambda _d: threads.append(threading.current_thread().name)
+    )
+    movement._move_to_absolute_position(TARGET)
+    _run(lambda: _status(movement) is None)
+    assert threads, "the handler never ran"
+    assert set(threads) == {"MainThread"}, threads

--- a/tests/ui/test_movement_progress.py
+++ b/tests/ui/test_movement_progress.py
@@ -1,0 +1,77 @@
+"""Where movement progress goes, now that it is no longer a stream of toasts.
+
+One click-to-move emits four progress messages inside ~45 ms. As toasts they stack
+into a wall of popups saying nothing the moving stage does not already show; in the
+instructions label they read as one status for the duration of the move.
+
+They are invisible today because ``display.toasts_enabled`` defaults to False. This
+is what has to be true before that default can change.
+"""
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from fibsem.ui.FibsemMovementWidget import INSTRUCTIONS_TEXT, FibsemMovementWidget
+
+# The real sequence one click-to-move produces, in order, taken from the emit sites.
+CLICK_TO_MOVE = [
+    {"msg": "Click to move in progress..."},
+    {"msg": "Moving stage..."},
+    {"msg": "Move finished, updating images..."},
+    {"finished": True},
+]
+
+
+@pytest.fixture
+def widget(qapp, monkeypatch):
+    # The widget connects to canvases and a microscope it has no business reaching in
+    # a test; only the progress handler and its label are under test here.
+    monkeypatch.setattr(FibsemMovementWidget, "setup_connections", lambda self: None)
+    w = FibsemMovementWidget.__new__(FibsemMovementWidget)
+    from PyQt5 import QtWidgets
+
+    QtWidgets.QWidget.__init__(w)
+    w.label_movement_instructions = QtWidgets.QLabel(INSTRUCTIONS_TEXT)
+    w._update_position_readout = lambda: None
+    yield w
+    w.deleteLater()
+
+
+def test_progress_reaches_the_label(widget):
+    widget.handle_movement_progress_update({"msg": "Moving stage..."})
+    assert widget.label_movement_instructions.text() == "Moving stage..."
+
+
+def test_progress_does_not_toast(widget, monkeypatch):
+    """The whole point: four popups per click is worse than none."""
+    from fibsem.ui import notification_service
+
+    shown = []
+    monkeypatch.setattr(
+        notification_service,
+        "show_toast",
+        lambda *a, **k: shown.append(a),
+    )
+    for update in CLICK_TO_MOVE:
+        widget.handle_movement_progress_update(update)
+    assert shown == []
+
+
+def test_the_instructions_come_back_when_the_move_finishes(widget):
+    """Otherwise the last progress line sits there as though the stage were still
+    moving, and the instructions are gone for the rest of the session."""
+    for update in CLICK_TO_MOVE:
+        widget.handle_movement_progress_update(update)
+    assert widget.label_movement_instructions.text() == INSTRUCTIONS_TEXT
+
+
+def test_no_progress_message_says_updating_ui(widget):
+    """Developer phrasing was fine while nobody could see it.
+
+    These were toasts on a preference that defaults to off, so the wording never
+    reached a user. In the label it is on screen.
+    """
+    for update in CLICK_TO_MOVE:
+        widget.handle_movement_progress_update(update)
+        assert "updating UI" not in widget.label_movement_instructions.text()

--- a/tests/ui/test_movement_progress.py
+++ b/tests/ui/test_movement_progress.py
@@ -12,13 +12,16 @@ import pytest
 
 pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
 
-from fibsem.ui.FibsemMovementWidget import INSTRUCTIONS_TEXT, FibsemMovementWidget
+from fibsem.ui.FibsemMovementWidget import (
+    ACQUIRING_IMAGES,
+    INSTRUCTIONS_TEXT,
+    FibsemMovementWidget,
+)
 
 # The real sequence one click-to-move produces, in order, taken from the emit sites.
 CLICK_TO_MOVE = [
-    {"msg": "Click to move in progress..."},
-    {"msg": "Moving stage..."},
-    {"msg": "Move finished, updating images..."},
+    {"msg": "Moving the stage…"},
+    {"msg": ACQUIRING_IMAGES},
     {"finished": True},
 ]
 
@@ -75,3 +78,41 @@ def test_no_progress_message_says_updating_ui(widget):
     for update in CLICK_TO_MOVE:
         widget.handle_movement_progress_update(update)
         assert "updating UI" not in widget.label_movement_instructions.text()
+
+
+def test_one_start_message_not_two(widget):
+    """The dropped message was replaced within 38 ms by the next one.
+
+    Nobody ever read it, and it was the one that duplicated in the log.
+    """
+    starts = [u["msg"] for u in CLICK_TO_MOVE if "msg" in u and "Moving" in u["msg"]]
+    assert len(starts) == 1, starts
+
+
+def test_a_vertical_move_says_so(widget):
+    """A plain double-click moves laterally, Alt + double-click along the beam axis.
+
+    The user chose between them, so the status should not call both the same thing.
+    """
+    import inspect
+
+    from fibsem.ui import FibsemMovementWidget as module
+
+    source = inspect.getsource(module)
+    assert "Moving the stage vertically…" in source
+
+
+def test_every_path_says_the_same_thing_while_acquiring(widget):
+    """Three paths had drifted to "updating images", "taking new images", and nothing.
+
+    Checked against the source rather than the constant alone, which would still pass
+    if every path quietly stopped using it.
+    """
+    import inspect
+
+    from fibsem.ui import FibsemMovementWidget as module
+
+    source = inspect.getsource(module)
+    assert source.count('{"msg": ACQUIRING_IMAGES}') == 3
+    for stale in ("updating images", "taking new images", "updating UI"):
+        assert stale not in source, stale


### PR DESCRIPTION
One click-to-move emits four progress messages inside 45 ms, and every one of them was a toast. Measured across three sessions in a real log, identical each time:

```
16:06:51,575  Click to move in progress...
16:06:51,613  Click to move in progress...     <- twice, 38 ms apart
16:06:51,613  Moving stage...
16:06:51,613  Move finished, updating UI
```

Invisible today only because `display.toasts_enabled` defaults to False, so nobody has yet seen the wall of popups this makes. **This is the prerequisite for flipping that default** — see FIB-781, which has the full audit of all 165 `show_toast` call sites. This handler was the single genuinely noisy one; the other five flagged were cleared on inspection.

## What changes

Progress goes to the **quad-view info bar**, under the `STAGE:` readout this widget already writes there, and is cleared when the move and the acquisition after it are done.

### Why the info bar and not a label on this tab

The obvious move was the pattern **FIB-765 established in `overview_widget`**: progress to a persistent label, refusals to a label *and* a toast. It does not transfer. There the label sits on the same widget as the canvas being clicked, so it is always in view when it has something to say. Here the canvas is *beside* the tabs and the widget is *in* one of them.

Five of the six paths that start a stage move start it from somewhere other than the Movement tab:

| trigger | where the operator is |
|---|---|
| canvas double-click | any tab — `_click_to_move_available` gates on the button being enabled and nothing else, so a double-click moves the stage whatever tab is showing |
| `FibsemMinimapWidget.move_to_stage_position` | a separate napari window in FibsemUI; a different tab widget in AutoLamella |
| `minimap_plot_widget` | the FM minimap |
| Move to Lamella Position | the lamella list |
| pose move-to | the lamella list |
| saved positions | ✅ the Movement tab |

Measured with the widget in a real `QTabWidget`, Milling tab selected: every update landed on a label with `isVisible()` False. Replacing a toast that can be read from anywhere with a message on a hidden page is a worse deal than the popups.

The info bar has none of that problem — it is beside the canvas that was clicked, visible from every tab, and already the place this widget reports stage state. `set_info(beam, key, text)` upserts and drops on empty, so it needed no new plumbing.

### Why the clear moved too

`update_ui_after_movement` only *queues* the acquisition before the worker returns, so `finished` arrives with about a second of acquiring still to come:

```
   5 ms  status -> 'Acquiring images…'
   7 ms  status cleared, is_acquiring=True     <- 921 ms early
 928 ms  ACQUISITION {'finished': True}
```

`move_stage_finished` already declines to re-enable the buttons in that window. The status now keeps the same counsel — otherwise it reads as idle over the acquisition it just announced, while offering a double-click that is still disabled — and `handle_acquisition_update` takes it down when the images actually land.

Read back off the canvas through the debounced render, with the simulated move delay on:

```
   53 ms   STAGE: X:0.00, Y:0.00, … | Moving to X:0.00mm, …, T:0.0°…
 2364 ms   STAGE: X:0.00, Y:0.00, … | Acquiring images…
           (clears when the acquisition finishes)
```

Each phase now lasts as long as the thing it describes.

### Wording

**"Move finished, updating UI" becomes "Acquiring images…"**, as a constant rather than three string literals: the three movement paths had drifted to "updating images", "taking new images" and, on the orientation path, nothing at all, so the same phase looked different depending on how the move was started. Telling someone their UI is updating is developer phrasing that was fine only while nobody could see it.

The click path now also says **which** kind of move — a plain double-click moves laterally, Alt + double-click along the beam axis — because the operator chose between them.

## Threading

No `@ensure_main_thread` is needed on the handler, and this is asserted rather than assumed. `movement_progress_signal` is a `QtCore.pyqtSignal` on a widget with main-thread affinity, and the handler is only ever reached through it, so emitting from a worker queues delivery onto the GUI thread. `update_ui_after_movement` and `update_ui` do carry the decorator, because a worker calls *those* directly rather than through a signal.

## Tests

Rebuilt on the real construction seam from `tests/ui/test_viewer_less_widgets.py` — a host with a view controller, a real image widget and a Demo microscope — rather than `__new__` plus a hand-injected label, which would have let every test pass with `movement_progress_signal` disconnected. Thirteen tests, all behavioural: no assertions on `inspect.getsource`, none on the test file's own constants. They drive all three movement paths end to end and cover the tab-visibility regression (asserting the label really is hidden first, so the test cannot quietly stop proving anything), the clear-timing hand-off, the failed-move path, and the GUI-thread claim.

## Not fixed here

**The duplicate emission.** 38 ms is too wide for one signal delivered twice — that would arrive in the same event-loop turn — so it is two separate triggers rather than a double connection. Removing that emit removes both copies, but the underlying double-fire is undiagnosed, and on `main` it sat after every early-return guard and immediately before `_execute_stage_move`, which is worth a look. Recorded on FIB-781.

**A failed move still clears the status silently** — nothing connects `worker.errored` in this widget. `overview_widget` says "Could not move the stage" in the same situation.

**The acquisition that follows still raises its own toast** (`"Acquiring Both Images..."`, from `FibsemImageSettingsWidget`). That is a different widget on its own path, and one popup per move was never the complaint — noted rather than changed.

Follow-up filed: **FIB-783**, splitting this 660-line widget into `StagePositionWidget` and `StageControlWidget`.
