### PR TITLE
[refactor] Call the FM progress discriminator `operation`, not `task`

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -58,7 +58,7 @@ def acquire_channels(
         microscope.acquisition_progress_signal.emit(
             {
                 "state": "acquiring",
-                "task": "channels",
+                "operation": "channels",
                 "channel": channel.name,
                 "channel_index": i + 1,
                 "total_channels": len(channel_settings),
@@ -113,7 +113,7 @@ def acquire_z_stack(
                     microscope.acquisition_progress_signal.emit(
                         {
                             "state": "acquiring",
-                            "task": "z-stack",
+                            "operation": "z-stack",
                             "channel": ch.name,
                             "channel_index": i + 1,
                             "total_channels": len(channel_settings),
@@ -149,7 +149,7 @@ def acquire_z_stack(
                     microscope.acquisition_progress_signal.emit(
                         {
                             "state": "acquiring",
-                            "task": "z-stack",
+                            "operation": "z-stack",
                             "channel": ch.name,
                             "channel_index": i + 1,
                             "total_channels": len(channel_settings),

--- a/fibsem/fm/calibration/__init__.py
+++ b/fibsem/fm/calibration/__init__.py
@@ -4,6 +4,7 @@ This module provides focus measure algorithms used in focus stacking and autofoc
 applications. Different algorithms are suitable for different types of samples
 and imaging conditions.
 """
+
 from __future__ import annotations
 
 import logging
@@ -140,7 +141,9 @@ def run_autofocus(
             microscope.set_channel(channel_settings=channel_settings)
 
         microscope.acquisition_progress_signal.emit({"state": "autofocus"})
-        logging.info(f"Starting autofocus: {len(z_positions)} positions, method='{method}'")
+        logging.info(
+            f"Starting autofocus: {len(z_positions)} positions, method='{method}'"
+        )
 
         initial_z = microscope.objective.position
         iterations: list[AutoFocusIteration] = []
@@ -154,26 +157,32 @@ def run_autofocus(
             # Same payload shape the z-stack and channel loops emit, so a viewer that
             # renders within-tile progress renders this too. Without it the bars froze for
             # the whole sweep -- which on per-tile autofocus is most of the run.
-            microscope.acquisition_progress_signal.emit({
-                "state": "acquiring",
-                "operation": "autofocus",
-                "channel": channel_settings.name if channel_settings is not None else "",
-                "zlevel": i + 1,
-                "total_zlevels": len(z_positions),
-                "pass_index": pass_index,
-                "total_passes": total_passes,
-            })
+            microscope.acquisition_progress_signal.emit(
+                {
+                    "state": "acquiring",
+                    "operation": "autofocus",
+                    "channel": channel_settings.name
+                    if channel_settings is not None
+                    else "",
+                    "zlevel": i + 1,
+                    "total_zlevels": len(z_positions),
+                    "pass_index": pass_index,
+                    "total_passes": total_passes,
+                }
+            )
 
             microscope.objective.move_absolute(z_pos)
             image = microscope.acquire_image()
             image_data = image.crop(roi) if roi is not None else image.data
             focus_score = calculate_focus_quality(image_data, method=method)
-            iterations.append(AutoFocusIteration(
-                working_distance=float(z_pos),
-                focus_score=float(focus_score),
-                pass_index=0,
-                image=image_data,
-            ))
+            iterations.append(
+                AutoFocusIteration(
+                    working_distance=float(z_pos),
+                    focus_score=float(focus_score),
+                    pass_index=0,
+                    image=image_data,
+                )
+            )
             logging.debug(
                 f"Z[{i + 1}/{len(z_positions)}]: {z_pos * 1e6:.1f} μm, Score: {focus_score:.4f}"
             )
@@ -182,7 +191,9 @@ def run_autofocus(
         best = iterations[best_idx]
 
         microscope.objective.move_absolute(best.working_distance)
-        logging.info(f"Autofocus complete: Best position {best.working_distance * 1e6:.1f} μm (score: {best.focus_score:.4f})")
+        logging.info(
+            f"Autofocus complete: Best position {best.working_distance * 1e6:.1f} μm (score: {best.focus_score:.4f})"
+        )
 
         result = AutoFocusResult(
             image=best.image,
@@ -252,7 +263,9 @@ def run_coarse_fine_autofocus(
             if last_result is None:
                 logging.warning("Autofocus cancelled during first pass")
                 return None
-            logging.warning("Autofocus cancelled at pass %d — keeping previous result", pass_index)
+            logging.warning(
+                "Autofocus cancelled at pass %d — keeping previous result", pass_index
+            )
             break
 
         for it in result.iterations:
@@ -361,7 +374,9 @@ def run_multi_position_autofocus(
         for pos_name, data in focus_map.items():
             focus_z = data["focus_z"]
             stage_pos = data["stage_position"]
-            focus_z_str = f"{focus_z * 1e6:.1f} μm" if focus_z is not None else "cancelled"
+            focus_z_str = (
+                f"{focus_z * 1e6:.1f} μm" if focus_z is not None else "cancelled"
+            )
             logging.info(
                 f"  {pos_name}: {focus_z_str} at ({stage_pos.x * 1e6:.1f}, {stage_pos.y * 1e6:.1f}) μm"
             )

--- a/fibsem/fm/calibration/__init__.py
+++ b/fibsem/fm/calibration/__init__.py
@@ -156,7 +156,7 @@ def run_autofocus(
             # the whole sweep -- which on per-tile autofocus is most of the run.
             microscope.acquisition_progress_signal.emit({
                 "state": "acquiring",
-                "task": "autofocus",
+                "operation": "autofocus",
                 "channel": channel_settings.name if channel_settings is not None else "",
                 "zlevel": i + 1,
                 "total_zlevels": len(z_positions),

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -675,6 +675,28 @@ class FluorescenceMicroscope(ABC):
 
     # live acquisition signals (psygnal binds these per-instance on access)
     acquisition_signal = Signal(FluorescenceImage)
+    # How far along an acquisition *routine* is. Still a bare dict, pending the typed
+    # payload it should carry (FIB-401); until then the contract is here rather than
+    # only in the emit sites.
+    #
+    #   operation: which routine -- "channels" | "z-stack" | "autofocus". A closed set,
+    #             one member per function in `fm.acquisition` / `fm.calibration` that
+    #             reports progress. Absent on events that are not about a routine.
+    #   state:    "acquiring" | "moving" | "finished" | "autofocus"
+    #
+    # Plus, per operation: `channel`, `channel_index`, `total_channels`; `zlevel` and
+    # `total_zlevels` for a z-stack or a focus sweep; `pass_index` and `total_passes`
+    # for a sweep.
+    #
+    # `operation`, not `task`: an AutoLamella *task* is a different and larger thing,
+    # and while this field was called `task` the workflow tasks filled it in with their
+    # own names -- six emit sites whose value no consumer could ever match, since every
+    # read compares against the closed set above. Removed in #521, renamed here so the
+    # mistake is not available to make again.
+    #
+    # What a *task* is doing belongs on the task's own signals (`step_update_signal`,
+    # `workflow_update_signal`), and tile progress belongs on `tiled_acquisition_signal`
+    # (FIB-725). This signal is the acquisition functions', and nothing else's.
     acquisition_progress_signal = Signal(dict)
     # Raised when something starts or stops driving the FM, so a widget that did not
     # start it can grey its controls out. Emitted from whichever thread set the flag --

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -744,7 +744,9 @@ class FluorescenceMicroscope(ABC):
             "MILLING",
         ]  # valid orientations for fluorescence acquisition
         self._allow_unknown_orientations: bool = ALLOW_UNKNOWN_ORIENTATIONS
-        self.default_orientation: str = "FM"  # orientation used when computing fluorescence pose for new lamellas
+        self.default_orientation: str = (
+            "FM"  # orientation used when computing fluorescence pose for new lamellas
+        )
         # Orientations the objective can actually image the sample from -- a stricter
         # question than `valid_orientations`, which asks only whether FM control is
         # allowed. Turning the light on and watching the camera from a beam pose is

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -2730,7 +2730,7 @@ class FMOverviewWidget(QWidget):
         something this widget is not showing, and is dropped rather than rendered as a
         bar with nothing in it.
         """
-        if payload.get("task") in ("z-stack", "channels", "autofocus"):
+        if payload.get("operation") in ("z-stack", "channels", "autofocus"):
             self.progress_tile_detail.update_progress(self._tile_detail_update(payload))
 
     def _apply_tile_progress(self, payload: dict) -> None:
@@ -2815,7 +2815,7 @@ class FMOverviewWidget(QWidget):
         channel = payload.get("channel", "")
         zlevel, total_z = payload.get("zlevel"), payload.get("total_zlevels")
         if zlevel and total_z:
-            if payload.get("task") == "autofocus":
+            if payload.get("operation") == "autofocus":
                 # Say which pass, so a coarse sweep followed by a fine one does not
                 # look like the same bar inexplicably starting over.
                 total_passes = payload.get("total_passes", 1)

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -529,7 +529,7 @@ class FMControlWidget(QWidget):
         progress_total_zlevels = progress.get("total_zlevels", None)
         channel_name = progress.get("channel", None)
         progress_state = progress.get("state", None)
-        progress_task = progress.get("task", None)
+        progress_operation = progress.get("operation", None)
 
         if progress_state == "moving":
             self.progressText.setText("Moving stage...")
@@ -548,7 +548,7 @@ class FMControlWidget(QWidget):
             return
 
         # set progress message
-        if progress_task == "autofocus":
+        if progress_operation == "autofocus":
             # Handled before the channel branch, not inside it: a sweep with no channel
             # reports an empty name, which used to render "Acquiring  (1/1)..." and now
             # would leave the previous message sitting there instead.
@@ -569,7 +569,7 @@ class FMControlWidget(QWidget):
                 else 0
             )
             self.progressBar_current_acquisition.setValue(percentage_zlevel)
-            if progress_task == "autofocus":
+            if progress_operation == "autofocus":
                 # A focus sweep steps the objective through a search range. Calling
                 # those positions "Z-level" names the z-stack, which is not running --
                 # and says which pass, so a coarse sweep followed by a fine one does

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -1556,7 +1556,7 @@ def _autofocus_payloads(microscope, monkeypatch, mode):
     _record_tile_positions(microscope, monkeypatch)
     seen = []
     microscope.fm.acquisition_progress_signal.connect(
-        lambda d: seen.append(d) if d.get("task") == "autofocus" else None
+        lambda d: seen.append(d) if d.get("operation") == "autofocus" else None
     )
     acquisition.FMTiledAcquisitionRunner(
         microscope=microscope,
@@ -1608,7 +1608,7 @@ def test_a_cancelled_sweep_does_not_start_the_next_pass(fm_microscope, monkeypat
     # Still the detector's signal: an autofocus sweep is work *inside* a tile, which is
     # the scale that stayed there when the tileset moved to `tiled_acquisition_signal`.
     fm_microscope.fm.acquisition_progress_signal.connect(
-        lambda d: seen.append(d) if d.get("task") == "autofocus" else None
+        lambda d: seen.append(d) if d.get("operation") == "autofocus" else None
     )
 
     def cancel_during_the_first_pass(*args, **kwargs):

--- a/tests/ui/test_fm_control_widget_teardown.py
+++ b/tests/ui/test_fm_control_widget_teardown.py
@@ -29,7 +29,7 @@ from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget, _Demo
 # a live slot to touch.
 PROGRESS = {
     "state": "acquiring",
-    "task": "z-stack",
+    "operation": "z-stack",
     "channel": "DAPI",
     "channel_index": 1,
     "total_channels": 1,

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -361,7 +361,7 @@ def test_a_zstack_payload_moves_only_the_detail_bar(qapp):
     router._apply_fm_progress(
         {
             "state": "acquiring",
-            "task": "z-stack",
+            "operation": "z-stack",
             "channel": "GFP",
             "zlevel": 7,
             "total_zlevels": 21,
@@ -383,7 +383,7 @@ def test_a_channels_payload_drives_the_detail_bar_too(qapp):
     router._apply_fm_progress(
         {
             "state": "acquiring",
-            "task": "channels",
+            "operation": "channels",
             "channel": "RFP",
             "channel_index": 2,
             "total_channels": 3,
@@ -405,7 +405,7 @@ def test_a_completed_tile_leaves_the_detail_bar_alone(qapp):
     router._apply_fm_progress(
         {
             "state": "acquiring",
-            "task": "z-stack",
+            "operation": "z-stack",
             "channel": "GFP",
             "zlevel": 21,
             "total_zlevels": 21,
@@ -433,7 +433,7 @@ def test_an_unknown_task_moves_nothing(qapp):
     """
     router = _Router()
 
-    router._apply_fm_progress({"state": "acquiring", "task": "something-else"})
+    router._apply_fm_progress({"state": "acquiring", "operation": "something-else"})
     router._apply_fm_progress({"state": "finished"})
 
     assert not router.progress_tiles.isVisible()
@@ -5258,7 +5258,7 @@ def test_an_fm_payload_reaches_the_real_widget(qapp, overview_widget):
     widget.fm.acquisition_progress_signal.emit(
         {
             "state": "acquiring",
-            "task": "z-stack",
+            "operation": "z-stack",
             "channel": "GFP",
             "zlevel": 7,
             "total_zlevels": 21,


### PR DESCRIPTION
The field on `acquisition_progress_signal` identifies which acquisition **routine** is running. Every read of it, in both consumers, compares against a closed set — one member per function in `fm.acquisition`/`fm.calibration` that reports progress:

```python
{"channels", "z-stack", "autofocus"}
```

Calling it `task` invited a collision, and the collision happened: six emit sites in the workflow tasks filled it with their own `task_name` — a protocol-defined string no consumer could ever match. Those are gone (#521). This renames the field so the mistake is not available to make again. An AutoLamella *task* is a different and larger thing, and what one is doing belongs on the task's own signals.

## Scope

Four emit sites, four comparison sites, three test files — all in one commit, because a rename is atomic: emitters and consumers have to move together or the labels break.

**8 files, but 8 changed lines.** The rest is the contract comment added at the signal declaration (~26 lines) and `ruff format` on two files, which is a separate commit.

Deliberately **not** in scope: the two events that carry no operation — `state: "finished"` and the sweep-start `state: "autofocus"`. Giving every event a discriminator is the typed-payload work (FIB-401), not this.

Also not in scope: `task: "tileset"` on `tiled_acquisition_signal`. Different signal, different field — and worth noting for FIB-402 that **no consumer reads it at all**; it is vestigial from when the FM tileset shared this signal.

## The contract

Written at the signal declaration rather than living only in the emit sites, which is the smallest useful step toward the typed payload:

```
#   operation: which routine -- "channels" | "z-stack" | "autofocus"
#   state:    "acquiring" | "moving" | "finished" | "autofocus"
```

## Verification

- `tests/fm/test_acquisition.py`, `test_calibration.py`, `test_fm_autofocus.py`, `tests/ui/test_fm_overview_widget.py`, `test_fm_control_widget_teardown.py`: 393 passed.
- Drove a real `FMControlWidget` through every payload its emitters produce — labels identical to before: `Acquiring DAPI (1/2)...`, `Z-level 2/5`, `Focus 3/7 · pass 2/2`, `Moving stage...`, `Acquisition complete.`
- End to end on the Demo, a real 2×2 z-stacked run through the real runner and both bars: `Tiles — 1/4 · 25s remaining` … `4 / 4`, detail bar `Channel-01 z-stack — 1/3 → 3/3` per tile, status `Moving stage…` / `Stitching tiles…`. Unchanged.

One note on migration: this is a hard rename, no compatibility shim reading both names. Every emitter and reader in the repo moves in this commit, and an out-of-tree emitter of this signal would have to be calling `acquire_z_stack`'s internals to exist. The failure mode if one were missed is visible rather than silent — I checked by leaving a stale `task` payload in a scratch harness, and it renders the old "Z-level 3/7" mislabelling that FIB-400 fixed, not a blank.