### PR TITLE
[feature] Offer the connection dialog as the session starts

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -955,6 +955,30 @@ class AutoLamellaSingleWindowUI(QMainWindow):
                 message, notification_type
             )
 
+    def offer_connection_at_launch(self) -> None:
+        """Open the connection dialog as the session starts.
+
+        Connecting is the first thing every session does, and until the dialog
+        existed the only way to do it was a tab -- which is why `--quickstart` was
+        written, to skip the two clicks nobody could avoid. Offering it outright is
+        what that flag was working around.
+
+        Not chained into create-or-load afterwards. The header already carries both
+        as primary buttons the moment a connection succeeds, and a second modal
+        before the application is usable would be a worse version of the same step.
+
+        Nothing happens if a microscope is already attached (`--quickstart` got
+        there first) or if the feature is off, which is also what keeps this out of
+        the way of the Connection tab while that is still how people connect.
+        """
+        if not self._connection_chip_enabled:
+            return
+        if self.autolamella_ui is None:
+            return
+        if self.autolamella_ui.system_widget.microscope is not None:
+            return
+        self._on_connect_microscope()
+
     def _on_connect_microscope(self):
         """Connect from the dialog, then hand the session to the system widget.
 
@@ -3248,6 +3272,12 @@ def run_ui(argv: Optional[List[str]] = None):
         QTimer.singleShot(
             0, lambda: window.autolamella_ui.quickstart(load_experiment=args.quickload)
         )
+    else:
+        # Same reasoning, and the same zero timer: the dialog is modal, and opening
+        # it before the window behind it has painted shows a dialog floating over an
+        # empty frame. `--quickstart` and `--quickload` skip it because they are
+        # already doing what it asks for.
+        QTimer.singleShot(0, window.offer_connection_at_launch)
     sys.exit(app.exec_())
 
 

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -25,6 +25,7 @@ from PyQt5.QtWidgets import (
     QSizePolicy,
     QSpacerItem,
     QTabWidget,
+    QVBoxLayout,
     QWidget,
 )
 
@@ -59,6 +60,7 @@ from fibsem.ui import (
 from fibsem.ui import utils as fui
 from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
 from fibsem.ui.fm.widgets import FMImageViewerWidget
+from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.qt.threading import FunctionWorker
 
 if (
@@ -289,6 +291,7 @@ class AutoLamellaUI(QMainWindow):
         self.pushButton_no = QPushButton("No")
 
         self.gridLayout.addWidget(self.tabWidget, 1, 0, 1, 2)
+        self.gridLayout.addWidget(self._build_empty_state(), 1, 0, 1, 2)
         self.gridLayout.addWidget(self.label_workflow_information, 2, 0, 1, 2)
         self.gridLayout.addWidget(self.label_instructions, 3, 0, 1, 2)
         self.gridLayout.addWidget(self.pushButton_yes, 4, 0)
@@ -296,6 +299,50 @@ class AutoLamellaUI(QMainWindow):
 
         self.setCentralWidget(self.centralwidget)
         self.tabWidget.setCurrentIndex(0)
+
+    def _build_empty_state(self) -> QWidget:
+        """What the panel shows when it has no tabs to show.
+
+        Every tab here needs a microscope: the Experiment tab is hidden until one
+        is connected, and the rest are only built at connection time. Before the
+        Connection tab was removed it filled this space itself, so a panel with
+        nothing in it is new -- and an empty panel reads as something having gone
+        wrong rather than as something not having happened yet.
+
+        Deliberately no Connect button. The header carries one, and the status bar
+        already says what to do; a third would be the same action in three places.
+        """
+        self.empty_state = QWidget()
+        layout = QVBoxLayout(self.empty_state)
+        layout.setAlignment(Qt.AlignCenter)
+        layout.setSpacing(8)
+
+        icon = QLabel()
+        icon.setPixmap(
+            fibsem_icon("mdi:connection", color=stylesheets.TEXT_MUTED_COLOR).pixmap(
+                32, 32
+            )
+        )
+        icon.setAlignment(Qt.AlignCenter)
+        layout.addWidget(icon)
+
+        message = QLabel("No microscope connected")
+        message.setAlignment(Qt.AlignCenter)
+        message.setStyleSheet(
+            f"color: {stylesheets.TEXT_MUTED_COLOR}; font-size: 12px;"
+        )
+        layout.addWidget(message)
+
+        self.empty_state.setVisible(False)
+        return self.empty_state
+
+    def _update_empty_state(self) -> None:
+        """Swap the placeholder in when the tab widget has nothing left to show."""
+        has_a_tab = any(
+            self.tabWidget.isTabVisible(i) for i in range(self.tabWidget.count())
+        )
+        self.tabWidget.setVisible(has_a_tab)
+        self.empty_state.setVisible(not has_a_tab)
 
     @property
     def protocol(self) -> Optional[AutoLamellaTaskProtocol]:
@@ -1109,6 +1156,10 @@ class AutoLamellaUI(QMainWindow):
         if self.det_widget is not None:
             idx = self.tabWidget.indexOf(self.det_widget)
             self.tabWidget.setTabVisible(idx, False)  # hide detection tab for now
+
+        # After the visibility rules above, and after the connection-time tabs are
+        # built, so it sees the same tab set the user does.
+        self._update_empty_state()
 
         if is_experiment_loaded and self.experiment is not None:
             self.lamella_list.setEnabled(has_lamella)

--- a/tests/ui/test_connection_tab_removal.py
+++ b/tests/ui/test_connection_tab_removal.py
@@ -1,19 +1,20 @@
-"""The Connection tab goes, and the first-run offer goes with it — somewhere.
+"""The Connection tab goes, the first-run offer goes with it, and nothing is blank.
 
 The tab is a gate in a bar that otherwise means "the instrument needs you here
 now": the only tab that can never be a workflow step, sitting at position 0 for
 something done once a session (FIB-775). With `features.connection_chip` on, the
 dialog and the header chip reach the connection instead, and the tab is not built.
 
-The part that would have been lost silently is the **guided-setup offer** (#472).
-It is a banner inside `FibsemSystemSetupWidget`, and the Connection tab was the
-only place it rendered — removing the tab would have left a fresh install with
-Tools > Guided Setup, which is not somewhere a first-time user looks. It now lives
-in the connection dialog, which is what they reach first.
+Two things had to come with it. The **guided-setup offer** (#472) is a banner inside
+`FibsemSystemSetupWidget`, and that tab was the only place it rendered — removing
+it would have left a fresh install with Tools > Guided Setup, which is not
+somewhere a first-time user looks. And the **panel would have been empty**: every
+other tab here needs a microscope, so before a connection there was nothing left
+to show.
 
-Preferences are redirected to a temp file throughout: `is_first_run` reads the
-real configuration registry, and these tests must neither depend on the
-developer's own state nor write to it.
+Preferences are redirected throughout: `is_first_run` reads the real configuration
+registry, and these tests must neither depend on the developer's own state nor
+write to it.
 """
 
 from __future__ import annotations
@@ -27,7 +28,7 @@ import pytest
 pytest.importorskip("PyQt5")
 
 from fibsem import config as cfg  # noqa: E402
-from fibsem import guided_setup  # noqa: E402
+from fibsem import guided_setup, utils  # noqa: E402
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI  # noqa: E402
 from fibsem.ui.widgets.connection_dialog import ConnectionDialog  # noqa: E402
 
@@ -43,50 +44,127 @@ def prefs(monkeypatch, tmp_path):
     return preferences
 
 
+@pytest.fixture
+def build(qapp, prefs):
+    """Build windows through here, so every one of them is really torn down.
+
+    `deleteLater` is not teardown on its own: without a turn of the event loop the
+    widget is still alive, and a shown one stays `QApplication.activeWindow()`.
+    That leaks into any later test that asks who is active — the coincidence
+    viewer declines to raise itself while another window holds focus, which is
+    exactly right of it and exactly wrong of a leftover from here.
+    """
+    built = []
+
+    def _build(widget):
+        built.append(widget)
+        widget.show()
+        return widget
+
+    yield _build
+
+    for widget in built:
+        widget.close()
+        widget.deleteLater()
+    # `deleteLater` needs a turn of the loop before the object is really gone, and
+    # the active window has to be cleared *after* that turn -- clearing it first
+    # and then spinning the loop lets the not-yet-deleted window take it back.
+    qapp.processEvents()
+    qapp.setActiveWindow(None)
+
+
 def _tabs(ui: AutoLamellaUI) -> list[str]:
     return [ui.tabWidget.tabText(i) for i in range(ui.tabWidget.count())]
 
 
-def test_the_tab_is_there_with_the_flag_off(qapp, prefs):
+# ── the tab ─────────────────────────────────────────────────────────────────
+
+
+def test_the_tab_is_there_with_the_flag_off(build, prefs):
     """The shipping default. Nothing about connecting has moved."""
     prefs.features.connection_chip = False
 
-    ui = AutoLamellaUI(parent_ui=None)
-    try:
-        assert "Connection" in _tabs(ui)
-        # And it is the one the panel opens on, as it always was.
-        assert ui.tabWidget.tabText(0) == "Connection"
-    finally:
-        ui.deleteLater()
+    ui = build(AutoLamellaUI(parent_ui=None))
+
+    assert "Connection" in _tabs(ui)
+    # And it is the one the panel opens on, as it always was.
+    assert ui.tabWidget.tabText(0) == "Connection"
 
 
-def test_the_tab_is_gone_with_the_flag_on(qapp, prefs):
+def test_the_tab_is_gone_with_the_flag_on(build, prefs):
     prefs.features.connection_chip = True
 
-    ui = AutoLamellaUI(parent_ui=None)
+    ui = build(AutoLamellaUI(parent_ui=None))
+
+    assert "Connection" not in _tabs(ui)
+    # The widget stays: it owns the connection, and everything in the application
+    # follows its signals. Only the tab was ever conditional.
+    assert ui.system_widget is not None
+
+
+# ── the space the tab used to fill ──────────────────────────────────────────
+
+
+def test_the_panel_is_not_left_blank(build, prefs):
+    """Every tab in this panel needs a microscope.
+
+    The Experiment tab is hidden until one is connected and the rest are only
+    built at connection time, so with the Connection tab gone there is nothing
+    left to show — and an empty panel reads as something having gone wrong rather
+    than as something not having happened yet.
+    """
+    prefs.features.connection_chip = True
+
+    ui = build(AutoLamellaUI(parent_ui=None))
+    ui.update_ui()
+
+    assert not any(ui.tabWidget.isTabVisible(i) for i in range(ui.tabWidget.count())), (
+        "sanity: a tab is visible, so there would be nothing to place-hold"
+    )
+    assert ui.empty_state.isVisible()
+    assert not ui.tabWidget.isVisible()
+
+
+def test_the_placeholder_gives_way_to_the_tabs(build, prefs):
+    prefs.features.connection_chip = True
+    ui = build(AutoLamellaUI(parent_ui=None))
+    ui.update_ui()
+    assert ui.empty_state.isVisible()
+
+    microscope, settings = utils.setup_session(manufacturer="Demo")
     try:
-        assert "Connection" not in _tabs(ui)
-        # The widget stays: it owns the connection, and everything in the
-        # application follows its signals. Only the tab was conditional.
-        assert ui.system_widget is not None
+        ui.system_widget.microscope = microscope
+        ui.system_widget.settings = settings
+        ui.connect_to_microscope()
+
+        assert not ui.empty_state.isVisible()
+        assert ui.tabWidget.isVisible()
     finally:
-        ui.deleteLater()
+        microscope.disconnect()
+
+
+def test_the_placeholder_stays_away_with_the_flag_off(build, prefs):
+    """The Connection tab is filling that space, as it always did."""
+    prefs.features.connection_chip = False
+
+    ui = build(AutoLamellaUI(parent_ui=None))
+    ui.update_ui()
+
+    assert ui.tabWidget.isVisible()
+    assert not ui.empty_state.isVisible()
 
 
 # ── the offer that came with the tab ────────────────────────────────────────
 
 
-def test_the_offer_shows_on_a_fresh_install(qapp, prefs, monkeypatch):
+def test_the_offer_shows_on_a_fresh_install(build, prefs, monkeypatch):
     monkeypatch.setattr(guided_setup, "is_first_run", lambda: True)
     prefs.features.guided_setup_enabled = True
     prefs.display.guided_setup_dismissed = False
 
-    dialog = ConnectionDialog()
-    try:
-        dialog.show()
-        assert dialog.first_run_frame.isVisible()
-    finally:
-        dialog.deleteLater()
+    dialog = build(ConnectionDialog())
+
+    assert dialog.first_run_frame.isVisible()
 
 
 @pytest.mark.parametrize(
@@ -98,7 +176,7 @@ def test_the_offer_shows_on_a_fresh_install(qapp, prefs, monkeypatch):
     ],
 )
 def test_the_offer_stays_away_otherwise(
-    qapp, prefs, monkeypatch, flag, dismissed, first_run
+    build, prefs, monkeypatch, flag, dismissed, first_run
 ):
     """Three separate conditions, as the tab applied them.
 
@@ -110,15 +188,12 @@ def test_the_offer_stays_away_otherwise(
     prefs.features.guided_setup_enabled = flag
     prefs.display.guided_setup_dismissed = dismissed
 
-    dialog = ConnectionDialog()
-    try:
-        dialog.show()
-        assert not dialog.first_run_frame.isVisible()
-    finally:
-        dialog.deleteLater()
+    dialog = build(ConnectionDialog())
+
+    assert not dialog.first_run_frame.isVisible()
 
 
-def test_declining_the_offer_records_it(qapp, prefs, monkeypatch):
+def test_declining_the_offer_records_it(build, prefs, monkeypatch):
     monkeypatch.setattr(guided_setup, "is_first_run", lambda: True)
     prefs.features.guided_setup_enabled = True
     recorded = []
@@ -126,35 +201,25 @@ def test_declining_the_offer_records_it(qapp, prefs, monkeypatch):
         guided_setup, "dismiss_first_run", lambda: recorded.append(True)
     )
 
-    dialog = ConnectionDialog()
-    try:
-        dialog.show()
-        dialog.dismiss_first_run_button.click()
+    dialog = build(ConnectionDialog())
+    dialog.dismiss_first_run_button.click()
 
-        assert not dialog.first_run_frame.isVisible()
-        assert recorded == [True], "declining has to persist, or it returns next start"
-    finally:
-        dialog.deleteLater()
+    assert not dialog.first_run_frame.isVisible()
+    assert recorded == [True], "declining has to persist, or it returns next start"
 
 
-def test_finishing_the_wizard_selects_what_it_wrote(qapp, prefs, monkeypatch):
+def test_finishing_the_wizard_selects_what_it_wrote(build, prefs, monkeypatch):
     """Otherwise the dialog still points at whatever was selected before it ran."""
     monkeypatch.setattr(guided_setup, "is_first_run", lambda: True)
     prefs.features.guided_setup_enabled = True
 
-    dialog = ConnectionDialog()
-    try:
-        dialog.show()
-        written = "a-brand-new-configuration"
-        monkeypatch.setitem(
-            cfg.USER_CONFIGURATIONS, written, {"path": "/tmp/nope.yaml"}
-        )
-        monkeypatch.setattr(
-            "fibsem.ui.widgets.guided_setup_dialog.open_guided_setup",
-            lambda parent=None, microscope=None: written,
-        )
+    dialog = build(ConnectionDialog())
+    written = "a-brand-new-configuration"
+    monkeypatch.setitem(cfg.USER_CONFIGURATIONS, written, {"path": "/tmp/nope.yaml"})
+    monkeypatch.setattr(
+        "fibsem.ui.widgets.guided_setup_dialog.open_guided_setup",
+        lambda parent=None, microscope=None: written,
+    )
 
-        assert dialog.run_guided_setup() == written
-        assert dialog.configuration_combo.currentText() == written
-    finally:
-        dialog.deleteLater()
+    assert dialog.run_guided_setup() == written
+    assert dialog.configuration_combo.currentText() == written

--- a/tests/ui/test_launch_connection.py
+++ b/tests/ui/test_launch_connection.py
@@ -1,0 +1,128 @@
+"""The connection dialog is offered as the session starts.
+
+Connecting is the first thing every session does, and until the dialog existed the
+only way to do it was a tab — which is why `--quickstart` was written, to skip two
+clicks nobody could avoid. Offering it outright is what that flag was working
+around (FIB-775).
+
+The window cannot be constructed offscreen (napari, vispy), so the launch handler
+is borrowed onto a host. What it decides is the whole of it: whether to open the
+dialog at all.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import os
+import textwrap
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (  # noqa: E402
+    AutoLamellaSingleWindowUI,
+    run_ui,
+)
+
+
+class _SystemWidgetStub:
+    def __init__(self, microscope=None):
+        self.microscope = microscope
+
+
+class _UIStub:
+    def __init__(self, microscope=None):
+        self.system_widget = _SystemWidgetStub(microscope)
+
+
+class _LaunchHost:
+    offer_connection_at_launch = AutoLamellaSingleWindowUI.offer_connection_at_launch
+
+    def __init__(self, chip_enabled=True, microscope=None, autolamella_ui=True):
+        self._connection_chip_enabled = chip_enabled
+        self.autolamella_ui = _UIStub(microscope) if autolamella_ui else None
+        self.opened = 0
+
+    def _on_connect_microscope(self):
+        self.opened += 1
+
+
+def test_it_opens_on_a_fresh_start():
+    host = _LaunchHost()
+
+    host.offer_connection_at_launch()
+
+    assert host.opened == 1
+
+
+def test_it_stays_shut_with_the_feature_off():
+    """The shipping default, where the Connection tab is still how people connect."""
+    host = _LaunchHost(chip_enabled=False)
+
+    host.offer_connection_at_launch()
+
+    assert host.opened == 0
+
+
+def test_it_stays_shut_when_something_is_already_connected():
+    """`--quickstart` got there first, and asking again would be asking twice."""
+    host = _LaunchHost(microscope=object())
+
+    host.offer_connection_at_launch()
+
+    assert host.opened == 0
+
+
+def test_it_stays_shut_before_the_panel_exists():
+    host = _LaunchHost(autolamella_ui=False)
+
+    host.offer_connection_at_launch()
+
+    assert host.opened == 0
+
+
+def test_the_quick_flags_skip_it():
+    """They already do what the dialog would be asking for.
+
+    Read off `run_ui`, which cannot be executed in a test: it builds the window and
+    enters the event loop. The offer has to sit in the branch the quick flags do
+    not take.
+    """
+    tree = ast.parse(textwrap.dedent(inspect.getsource(run_ui)))
+
+    branches = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If)
+        and any(
+            isinstance(n, ast.Attribute) and n.attr in ("quickstart", "quickload")
+            for n in ast.walk(node.test)
+        )
+    ]
+    assert branches, "sanity: no branch on the quick flags found in run_ui"
+
+    def _calls_offer(nodes) -> bool:
+        return any(
+            isinstance(n, ast.Attribute) and n.attr == "offer_connection_at_launch"
+            for node in nodes
+            for n in ast.walk(node)
+        )
+
+    branch = branches[0]
+    assert _calls_offer(branch.orelse), "the offer is not in the else branch"
+    assert not _calls_offer(branch.body), (
+        "the offer is in the quick-flag branch, so it would ask on top of a "
+        "connection those flags are already making"
+    )
+
+
+def test_it_is_deferred_past_the_first_paint():
+    """A modal opened before the window behind it has painted floats over an empty
+    frame. The quick flags are deferred for the same reason, and say so."""
+    source = inspect.getsource(run_ui)
+
+    assert "QTimer.singleShot(0, window.offer_connection_at_launch)" in source


### PR DESCRIPTION
The launch half of FIB-775, after #515 (dialog), #519 (status panel) and #523 (tab removal).

## The offer

Connecting is the first thing every session does, and until the dialog existed the only way was a tab — which is why `--quickstart` was written, to skip two clicks nobody could avoid. **Offering it outright is what that flag was working around.**

It is deferred behind the same zero timer the quick flags use, for the reason their comment already gives: a modal opened before the window behind it has painted floats over an empty frame. `--quickstart` and `--quickload` skip it, because they are already doing what it would be asking for. It also stays shut if something is connected, or if the feature is off.

## Not chained into create-or-load

FIB-775 sketched `Connect → Create or load experiment → the app`. The middle step is already there and is better as chrome than as a modal: the header carries **Create Experiment** and **Load Experiment** as primary buttons the moment a connection succeeds. A second modal before the application is usable would be a worse version of the same step, and the load dialog has no "create" affordance, so chaining into it would force a choice.

Say the word if you would rather have the modal.

## A regression from #523, caught by running it

With the tab gone, **the panel was blank on startup**. Every tab in it needs a microscope — the Experiment tab is hidden until one is connected, and the rest are only built at connection time — so before connecting there was nothing left to show. An empty panel reads as something having gone wrong rather than as something not having happened yet.

There is a placeholder now: a muted icon and "No microscope connected". Deliberately **no Connect button on it** — the header has one and the status bar already says what to do, and a third would be the same action in three places.

## Tests

- `tests/ui/test_launch_connection.py` — 6. The four conditions the launch handler decides on, plus two read off `run_ui` by AST since it cannot be executed in a test (it builds the window and enters the event loop): the offer sits in the branch the quick flags do not take, and it is deferred past the first paint. Mutation-checked — moving it into the quick-flag branch, or dropping the already-connected guard, each fails exactly one test.
- `tests/ui/test_connection_tab_removal.py` — 11, three new for the placeholder.

## Two things worth flagging

**A test leak I introduced and fixed.** Showing an `AutoLamellaUI` and only calling `deleteLater` leaves it as `QApplication.activeWindow()`, which the coincidence viewer reads before deciding whether to raise itself. The teardown now closes, spins the loop, *then* clears the active window — in that order, because clearing it first lets the not-yet-deleted window take it back.

**A pre-existing failure on main, not from this branch.** `tests/ui/test_coincidence_viewer_layering.py` fails two tests in a *serial* full run — on `origin/main` as well, identically (2218 passed, 2 failed there; 2223 passed, 2 failed here). CI does not see it because it runs `-n auto --dist worksteal`, so the ordering that triggers it does not arise. Those two tests depend on no other window being active, while a third in the same file monkeypatches `activeWindow` explicitly. Worth its own fix; happy to do it.

Full `tests/ui` on this branch: 2223 passed, 1 skipped, and the same 2 pre-existing failures as main. Formatted per #489, AST-identical. Still behind `features.connection_chip`, off.
