### PR TITLE
Wire spot burn through a polymorphic run_spot_burn seam (FIB-297)

### DIFF
--- a/fibsem/imaging/spot.py
+++ b/fibsem/imaging/spot.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import logging
 import threading
-import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Optional
 
@@ -15,8 +13,6 @@ if TYPE_CHECKING:
     # into `fibsem.imaging`. `from __future__ import annotations` is already on, so the
     # annotation below needs no runtime object.
     from fibsem.microscope import FibsemMicroscope
-
-SLEEP_TIME = 1
 
 
 @dataclass
@@ -52,8 +48,13 @@ def run_spot_burn(microscope: FibsemMicroscope,
                   settings: SpotBurnSettings,
                   beam_type: BeamType = BeamType.ION,
                   stop_event: Optional[threading.Event] = None) -> None:
-    """Run a spot burner job on the microscope. Exposes the coordinates in *settings* for
+    """Run a spot burn job on the microscope. Exposes the coordinates in *settings* for
     the exposure time at the milling current it specifies.
+
+    Delegates to ``microscope.run_spot_burn`` so each backend supplies its own
+    mechanism: the default implementation blanks and parks the beam per point
+    (ThermoFisher, simulator), while TESCAN overrides it with a DrawBeam layer of
+    timed dots — its FIB scan API has no blanker or beam parking.
 
     Progress is reported via ``microscope.spot_burn_progress_signal`` (a dict), which the
     status bar and the spot burn widget subscribe to.
@@ -66,80 +67,6 @@ def run_spot_burn(microscope: FibsemMicroscope,
     Returns:
         None
     """
-    # - QUERY: do we need to set the full frame scanning mode each time, or only at the end?
-
-    # coerce numeric parameters: protocol-editor fields can arrive as strings
-    # (e.g. "3e-11"), which would break beam-current/timing arithmetic on hardware.
-    # Read into locals rather than writing back — settings belongs to the caller.
-    exposure_time = float(settings.exposure_time)
-    milling_current = float(settings.milling_current)
-
-    # drop points outside the image bounds (0-1 normalised); set_spot rejects out-of-range
-    # coordinates on hardware. The supervised widget filters these, so filter here too for
-    # the unsupervised/automatic path (coordinates come straight from the stored config).
-    in_bounds, dropped = [], []
-    for pt in settings.coordinates:
-        (in_bounds if 0 <= pt.x <= 1 and 0 <= pt.y <= 1 else dropped).append(pt)
-    if dropped:
-        logging.warning(
-            f"Skipping {len(dropped)} spot burn coordinate(s) outside image bounds (0-1): {dropped}"
-        )
-    coordinates = in_bounds
-
-    total_estimated_time = len(coordinates) * exposure_time
-    total_remaining_time = total_estimated_time
-
-    # emit initial progress signal
-    microscope.spot_burn_progress_signal.emit(
-        {
-            "current_point": 0,
-            "total_points": len(coordinates),
-            "remaining_time": exposure_time,
-            "total_remaining_time": total_remaining_time,
-            "total_estimated_time": total_estimated_time,
-        }
+    return microscope.run_spot_burn(
+        settings=settings, beam_type=beam_type, stop_event=stop_event
     )
-
-    # set the beam current to the milling current
-    imaging_current = microscope.get_beam_current(beam_type=beam_type)
-    microscope.set_beam_current(current=milling_current, beam_type=beam_type)
-
-    for i, pt in enumerate(coordinates, 1):
-
-        if stop_event is not None and stop_event.is_set():
-            logging.info(f"Spot burn cancelled before point {i}/{len(coordinates)}.")
-            break
-
-        logging.info(f'burning spot {i}: {pt}, exposure time: {exposure_time}, milling current: {milling_current}')
-
-        microscope.blank(beam_type=beam_type)
-        microscope.set_spot_scanning_mode(point=pt, beam_type=beam_type)
-        microscope.unblank(beam_type=beam_type)
-
-        # countdown for the exposure time, emit progress signal
-        remaining_time = exposure_time
-        while remaining_time > 0:
-            if stop_event is not None and stop_event.is_set():
-                microscope.blank(beam_type=beam_type)
-                logging.info(f"Spot burn cancelled during point {i}/{len(coordinates)}.")
-                break
-            time.sleep(SLEEP_TIME)
-            remaining_time -= SLEEP_TIME
-            total_remaining_time -= SLEEP_TIME
-            microscope.spot_burn_progress_signal.emit(
-                {
-                    "current_point": i,
-                    "total_points": len(coordinates),
-                    "remaining_time": remaining_time,
-                    "total_remaining_time": total_remaining_time,
-                    "total_estimated_time": total_estimated_time,
-                }
-            )
-
-    # always restore full frame scanning mode and imaging current
-    microscope.set_full_frame_scanning_mode(beam_type=beam_type)
-
-    # emit finished signal
-    microscope.spot_burn_progress_signal.emit({"finished": True})
-
-    microscope.set_beam_current(current=imaging_current, beam_type=beam_type)

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -149,6 +149,7 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
+    from fibsem.imaging.spot import SpotBurnSettings
     from fibsem.structures import TFibsemPatternSettings
 
 
@@ -1113,6 +1114,108 @@ class FibsemMicroscope(ABC):
         """Set the full frame scanning mode for the specified beam type."""
         self.set("full_frame", None, beam_type)
         return
+
+    def run_spot_burn(
+        self,
+        settings: SpotBurnSettings,
+        beam_type: BeamType = BeamType.ION,
+        stop_event: Optional[threading.Event] = None,
+    ) -> None:
+        """Burn each coordinate in *settings* with the beam for the configured exposure time.
+
+        Default implementation: blank -> park the beam on the point (spot scanning mode)
+        -> unblank, at ``settings.milling_current``, restoring full-frame scanning and
+        the imaging current afterwards. Backends whose scan API cannot park the beam
+        (e.g. TESCAN, whose FIB has no blanker) override this with a native
+        implementation.
+
+        Progress is reported via ``spot_burn_progress_signal`` (a dict), which the
+        status bar and the spot burn widget subscribe to.
+
+        Args:
+            settings: What to burn — coordinates (0-1 image coordinates), exposure time
+                per point in seconds, and the milling current to burn at.
+            beam_type: The type of beam to use. (Default: BeamType.ION)
+            stop_event: Threading event to signal cancellation. (Default: None)
+        """
+        # - QUERY: do we need to set the full frame scanning mode each time, or only at the end?
+        SLEEP_TIME = 1
+
+        # coerce numeric parameters: protocol-editor fields can arrive as strings
+        # (e.g. "3e-11"), which would break beam-current/timing arithmetic on hardware.
+        # Read into locals rather than writing back — settings belongs to the caller.
+        exposure_time = float(settings.exposure_time)
+        milling_current = float(settings.milling_current)
+
+        # drop points outside the image bounds (0-1 normalised); set_spot rejects out-of-range
+        # coordinates on hardware. The supervised widget filters these, so filter here too for
+        # the unsupervised/automatic path (coordinates come straight from the stored config).
+        in_bounds, dropped = [], []
+        for pt in settings.coordinates:
+            (in_bounds if 0 <= pt.x <= 1 and 0 <= pt.y <= 1 else dropped).append(pt)
+        if dropped:
+            logging.warning(
+                f"Skipping {len(dropped)} spot burn coordinate(s) outside image bounds (0-1): {dropped}"
+            )
+        coordinates = in_bounds
+
+        total_estimated_time = len(coordinates) * exposure_time
+        total_remaining_time = total_estimated_time
+
+        # emit initial progress signal
+        self.spot_burn_progress_signal.emit(
+            {
+                "current_point": 0,
+                "total_points": len(coordinates),
+                "remaining_time": exposure_time,
+                "total_remaining_time": total_remaining_time,
+                "total_estimated_time": total_estimated_time,
+            }
+        )
+
+        # set the beam current to the milling current
+        imaging_current = self.get_beam_current(beam_type=beam_type)
+        self.set_beam_current(current=milling_current, beam_type=beam_type)
+
+        for i, pt in enumerate(coordinates, 1):
+
+            if stop_event is not None and stop_event.is_set():
+                logging.info(f"Spot burn cancelled before point {i}/{len(coordinates)}.")
+                break
+
+            logging.info(f'burning spot {i}: {pt}, exposure time: {exposure_time}, milling current: {milling_current}')
+
+            self.blank(beam_type=beam_type)
+            self.set_spot_scanning_mode(point=pt, beam_type=beam_type)
+            self.unblank(beam_type=beam_type)
+
+            # countdown for the exposure time, emit progress signal
+            remaining_time = exposure_time
+            while remaining_time > 0:
+                if stop_event is not None and stop_event.is_set():
+                    self.blank(beam_type=beam_type)
+                    logging.info(f"Spot burn cancelled during point {i}/{len(coordinates)}.")
+                    break
+                time.sleep(SLEEP_TIME)
+                remaining_time -= SLEEP_TIME
+                total_remaining_time -= SLEEP_TIME
+                self.spot_burn_progress_signal.emit(
+                    {
+                        "current_point": i,
+                        "total_points": len(coordinates),
+                        "remaining_time": remaining_time,
+                        "total_remaining_time": total_remaining_time,
+                        "total_estimated_time": total_estimated_time,
+                    }
+                )
+
+        # always restore full frame scanning mode and imaging current
+        self.set_full_frame_scanning_mode(beam_type=beam_type)
+
+        # emit finished signal
+        self.spot_burn_progress_signal.emit({"finished": True})
+
+        self.set_beam_current(current=imaging_current, beam_type=beam_type)
 
     def get_beam_current(self, beam_type: BeamType) -> float:
         """Get the beam current for the specified beam type."""

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -52,7 +52,9 @@ try:
 except Exception as e:
     logging.debug(f"Automation (TESCAN) not installed. {e}")
 
+from fibsem.imaging.spot import SpotBurnSettings
 from fibsem.structures import (  # noqa
+    ACTIVE_MILLING_STATES,
     BeamSettings,
     BeamSystemSettings,
     BeamType,
@@ -74,10 +76,9 @@ from fibsem.structures import (  # noqa
     FibsemUser,
     ImageSettings,
     MicroscopeState,
+    MillingState,
     Point,
     SystemSettings,
-    MillingState,
-    ACTIVE_MILLING_STATES,
 )
 
 
@@ -1525,28 +1526,28 @@ class TescanMicroscope(FibsemMicroscope):
 
     def run_spot_burn(
         self,
-        coordinates: List[Point],
-        exposure_time: float,
-        milling_current: Optional[float] = None,
+        settings: SpotBurnSettings,
         beam_type: BeamType = BeamType.ION,
         stop_event: Optional[threading.Event] = None,
     ) -> None:
-        """Expose each coordinate with the ion beam for exposure_time seconds.
+        """Expose each coordinate with the ion beam for the configured exposure time.
 
-        TESCAN cannot implement the blank -> park -> unblank sequence the other backends use
-        for spot burning: FIB.Scan is a strict subset of SEM.Scan, missing exactly SetBlanker,
-        GetBlanker and SetBeamPosition, and no FIB blanker exists anywhere in the SDK. This
-        instead uses DrawBeam, which does the same job natively -- a Dot object with
-        DepthUnit.Second is a timed exposure at a point.
+        TESCAN cannot implement the blank -> park -> unblank sequence the default
+        implementation uses for spot burning: FIB.Scan is a strict subset of SEM.Scan,
+        missing exactly SetBlanker, GetBlanker and SetBeamPosition, and no FIB blanker
+        exists anywhere in the SDK. This instead uses DrawBeam, which does the same job
+        natively -- a Dot object with DepthUnit.Second is a timed exposure at a point.
 
-        All points go into a single layer, so this runs as one DrawBeam exposition and reports
-        progress the same way run_milling does, via milling_progress_signal.
+        All points go into a single layer, so this runs as one DrawBeam exposition.
+        Progress is reported via ``spot_burn_progress_signal`` in the shape the spot
+        burn widget parses; the point index is derived from elapsed time, since DrawBeam
+        runs the dots sequentially at exposure_time each and the SDK has no per-dot
+        callback.
 
         Args:
-            coordinates: points to burn, normalised image coordinates (0-1).
-            exposure_time: seconds to expose each point.
-            milling_current: ignored on TESCAN, accepted for cross-backend signature parity;
-                the beam conditions come from SPOT_BURN_PRESET.
+            settings: coordinates to burn (normalised image coordinates, 0-1) and the
+                exposure time per point. ``settings.milling_current`` is ignored on
+                TESCAN; the beam conditions come from SPOT_BURN_PRESET.
             beam_type: must be BeamType.ION.
             stop_event: set to cancel the exposition.
         """
@@ -1555,19 +1556,19 @@ class TescanMicroscope(FibsemMicroscope):
                 f"Spot burn is only supported on the ion beam, got {beam_type.name}."
             )
 
-        exposure_time = float(exposure_time)
+        exposure_time = float(settings.exposure_time)
         if exposure_time <= 0:
             raise ValueError(f"exposure_time must be positive, got {exposure_time}.")
 
-        if milling_current is not None:
+        if settings.milling_current is not None:
             logging.info(
                 f"Spot burn milling_current is ignored on TESCAN; using preset "
-                f"{SPOT_BURN_PRESET!r}. (requested: {milling_current})"
+                f"{SPOT_BURN_PRESET!r}. (requested: {settings.milling_current})"
             )
 
         # drop points outside the image bounds, matching the shared implementation
         in_bounds, dropped = [], []
-        for pt in coordinates:
+        for pt in settings.coordinates:
             (in_bounds if 0 <= pt.x <= 1 and 0 <= pt.y <= 1 else dropped).append(pt)
         if dropped:
             logging.warning(
@@ -1592,15 +1593,26 @@ class TescanMicroscope(FibsemMicroscope):
             resolution=resolution,
         )
 
+        total_points = len(coordinates)
+        estimated_time = total_points * exposure_time
         start_time = time.time()
-        estimated_time = len(coordinates) * exposure_time
-        remaining_time = estimated_time
 
         self.connection.DrawBeam.LoadLayer(layer)
         logging.info(
-            f"running spot burn now: {len(coordinates)} point(s), "
+            f"running spot burn now: {total_points} point(s), "
             f"{exposure_time}s each, {estimated_time}s total..."
         )
+
+        self.spot_burn_progress_signal.emit(
+            {
+                "current_point": 0,
+                "total_points": total_points,
+                "remaining_time": exposure_time,
+                "total_remaining_time": estimated_time,
+                "total_estimated_time": estimated_time,
+            }
+        )
+
         self.connection.DrawBeam.Start()
 
         try:
@@ -1611,19 +1623,24 @@ class TescanMicroscope(FibsemMicroscope):
                     break
 
                 time.sleep(SPOT_BURN_POLL_INTERVAL)
-                remaining_time = max(0.0, estimated_time - (time.time() - start_time))
 
-                self.milling_progress_signal.emit(
+                # DrawBeam exposes no per-dot progress, but it burns the dots in order
+                # at exposure_time each, so elapsed time maps onto the point index.
+                elapsed = time.time() - start_time
+                current_point = min(total_points, int(elapsed // exposure_time) + 1)
+                self.spot_burn_progress_signal.emit(
                     {
-                        "progress": {
-                            "state": "update",
-                            "milling_state": self.get_milling_state(),
-                            "start_time": start_time,
-                            "estimated_time": estimated_time,
-                            "remaining_time": remaining_time,
-                        }
+                        "current_point": current_point,
+                        "total_points": total_points,
+                        "remaining_time": max(
+                            0.0, current_point * exposure_time - elapsed
+                        ),
+                        "total_remaining_time": max(0.0, estimated_time - elapsed),
+                        "total_estimated_time": estimated_time,
                     }
                 )
+
+            self.spot_burn_progress_signal.emit({"finished": True})
         except Exception as e:
             logging.error(f"Error in run_spot_burn: {e}")
             raise

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -15,6 +15,7 @@ from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
     SpotBurnFiducialTaskConfig,
 )
 from fibsem.imaging.spot import SpotBurnSettings, run_spot_burn
+from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, Point
 
 # The widget-dispatch tests need the UI stack (napari/PyQt5), which isn't installed
@@ -55,8 +56,7 @@ def mock_microscope():
 @pytest.fixture(autouse=True)
 def _no_sleep(monkeypatch):
     """Skip the real exposure countdown so tests run instantly."""
-    import fibsem.imaging.spot as spot
-    monkeypatch.setattr(spot.time, "sleep", lambda *_: None)
+    monkeypatch.setattr("time.sleep", lambda *_: None)
 
 
 def _burned_points(mic: MagicMock) -> list:
@@ -76,8 +76,8 @@ def test_run_spot_burn_filters_out_of_bounds_coordinates(mock_microscope):
         Point(-0.1, 0.3),  # x < 0
         Point(0.5, 1.5),   # y > 1
     ]
-    run_spot_burn(
-        microscope=mock_microscope,
+    FibsemMicroscope.run_spot_burn(
+        mock_microscope,
         settings=SpotBurnSettings(coordinates=coords, exposure_time=1.0,
                                   milling_current=30e-12),
         beam_type=BeamType.ION,
@@ -88,8 +88,8 @@ def test_run_spot_burn_filters_out_of_bounds_coordinates(mock_microscope):
 def test_run_spot_burn_keeps_boundary_coordinates(mock_microscope):
     """Exact 0 and 1 boundaries are inclusive."""
     coords = [Point(0.0, 0.0), Point(1.0, 1.0)]
-    run_spot_burn(
-        microscope=mock_microscope,
+    FibsemMicroscope.run_spot_burn(
+        mock_microscope,
         settings=SpotBurnSettings(coordinates=coords, exposure_time=1.0,
                                   milling_current=30e-12),
     )
@@ -98,8 +98,8 @@ def test_run_spot_burn_keeps_boundary_coordinates(mock_microscope):
 
 def test_run_spot_burn_empty_coordinates_does_not_burn(mock_microscope):
     """No coordinates -> no spot exposures, but the beam state is still restored."""
-    run_spot_burn(
-        microscope=mock_microscope,
+    FibsemMicroscope.run_spot_burn(
+        mock_microscope,
         settings=SpotBurnSettings(coordinates=[], exposure_time=1.0,
                                   milling_current=30e-12),
     )
@@ -112,8 +112,8 @@ def test_run_spot_burn_empty_coordinates_does_not_burn(mock_microscope):
 
 def test_run_spot_burn_coerces_string_parameters(mock_microscope):
     """String milling_current/exposure_time (from the editor QLineEdit bug) don't crash."""
-    run_spot_burn(
-        microscope=mock_microscope,
+    FibsemMicroscope.run_spot_burn(
+        mock_microscope,
         settings=SpotBurnSettings(coordinates=[Point(0.5, 0.5)], exposure_time="2",
                                   milling_current="3e-11"),
         beam_type=BeamType.ION,
@@ -129,8 +129,8 @@ def test_run_spot_burn_coerces_string_parameters(mock_microscope):
 
 def test_run_spot_burn_restores_full_frame_and_imaging_current(mock_microscope):
     """After burning, scanning returns to full frame and the imaging current is restored."""
-    run_spot_burn(
-        microscope=mock_microscope,
+    FibsemMicroscope.run_spot_burn(
+        mock_microscope,
         settings=SpotBurnSettings(coordinates=[Point(0.5, 0.5)], exposure_time=1.0,
                                   milling_current=30e-12),
     )
@@ -144,8 +144,8 @@ def test_run_spot_burn_restores_full_frame_and_imaging_current(mock_microscope):
 
 def test_run_spot_burn_emits_progress_via_microscope(mock_microscope):
     """Progress is reported through microscope.spot_burn_progress_signal (both run paths)."""
-    run_spot_burn(
-        microscope=mock_microscope,
+    FibsemMicroscope.run_spot_burn(
+        mock_microscope,
         settings=SpotBurnSettings(coordinates=[Point(0.5, 0.5), Point(0.6, 0.6)],
                                   exposure_time=1.0, milling_current=30e-12),
     )
@@ -157,6 +157,18 @@ def test_run_spot_burn_emits_progress_via_microscope(mock_microscope):
     assert emitted[0]["total_points"] == 2
     # final emission signals completion
     assert emitted[-1] == {"finished": True}
+
+
+def test_run_spot_burn_module_function_delegates_to_the_microscope(mock_microscope):
+    """The module entry point dispatches polymorphically (FIB-297): the default
+    implementation parks the beam per point, TESCAN overrides with DrawBeam dots."""
+    settings = SpotBurnSettings(coordinates=[Point(0.5, 0.5)], exposure_time=1.0,
+                                milling_current=30e-12)
+    run_spot_burn(microscope=mock_microscope, settings=settings,
+                  beam_type=BeamType.ION, stop_event=None)
+    mock_microscope.run_spot_burn.assert_called_once_with(
+        settings=settings, beam_type=BeamType.ION, stop_event=None
+    )
 
 
 @requires_ui

--- a/tests/test_tescan_spot_burn.py
+++ b/tests/test_tescan_spot_burn.py
@@ -16,6 +16,7 @@ from typing import List, Optional, Tuple
 
 import pytest
 
+from fibsem.imaging.spot import SpotBurnSettings
 from fibsem.microscopes import tescan as tescan_module
 from fibsem.microscopes.tescan import TescanMicroscope
 from fibsem.structures import BeamType, MillingState, Point
@@ -124,8 +125,15 @@ def make_microscope(monkeypatch, busy_polls: int = 1, resolution: Tuple[int, int
 
 def collect_progress(microscope) -> List[dict]:
     events: List[dict] = []
-    microscope.milling_progress_signal.connect(lambda d: events.append(d))
+    microscope.spot_burn_progress_signal.connect(lambda d: events.append(d))
     return events
+
+
+def run_burn(m, coordinates, exposure_time, **kwargs):
+    """Drive run_spot_burn with the settings payload the real callers pass."""
+    return m.run_spot_burn(
+        SpotBurnSettings(coordinates=coordinates, exposure_time=exposure_time), **kwargs
+    )
 
 
 # --------------------------------------------------------------------------
@@ -172,7 +180,7 @@ def test_all_points_go_into_one_layer_as_timed_dots(monkeypatch):
     m = make_microscope(monkeypatch)
     coords = [Point(0.25, 0.25), Point(0.5, 0.5), Point(0.75, 0.75)]
 
-    m.run_spot_burn(coordinates=coords, exposure_time=3.0)
+    run_burn(m, coordinates=coords, exposure_time=3.0)
 
     db = m.connection.DrawBeam
     assert len(db.layers) == 1
@@ -191,7 +199,7 @@ def test_all_points_go_into_one_layer_as_timed_dots(monkeypatch):
 def test_layer_is_loaded_started_and_unloaded_once(monkeypatch):
     m = make_microscope(monkeypatch)
 
-    m.run_spot_burn(coordinates=[Point(0.5, 0.5), Point(0.4, 0.4)], exposure_time=1.0)
+    run_burn(m, coordinates=[Point(0.5, 0.5), Point(0.4, 0.4)], exposure_time=1.0)
 
     # leading UnloadLayer clears any layer left loaded by a previous job
     assert m.connection.DrawBeam.calls == ["UnloadLayer", "LoadLayer", "Start", "UnloadLayer"]
@@ -199,7 +207,7 @@ def test_layer_is_loaded_started_and_unloaded_once(monkeypatch):
 
 def test_beam_is_prepared_once(monkeypatch):
     m = make_microscope(monkeypatch)
-    m.run_spot_burn(coordinates=[Point(0.5, 0.5)], exposure_time=1.0)
+    run_burn(m, coordinates=[Point(0.5, 0.5)], exposure_time=1.0)
     assert m._test_state["prepared"] == [BeamType.ION]
 
 
@@ -207,7 +215,7 @@ def test_out_of_bounds_coordinates_are_dropped(monkeypatch):
     m = make_microscope(monkeypatch)
     coords = [Point(0.5, 0.5), Point(1.5, 0.5), Point(-0.1, 0.2), Point(0.2, 0.2)]
 
-    m.run_spot_burn(coordinates=coords, exposure_time=1.0)
+    run_burn(m, coordinates=coords, exposure_time=1.0)
 
     assert len(m.connection.DrawBeam.layers[0].dots) == 2
 
@@ -215,7 +223,7 @@ def test_out_of_bounds_coordinates_are_dropped(monkeypatch):
 def test_nothing_runs_when_every_coordinate_is_out_of_bounds(monkeypatch):
     m = make_microscope(monkeypatch)
 
-    m.run_spot_burn(coordinates=[Point(1.5, 0.5), Point(-0.1, 0.2)], exposure_time=1.0)
+    run_burn(m, coordinates=[Point(1.5, 0.5), Point(-0.1, 0.2)], exposure_time=1.0)
 
     assert m.connection.DrawBeam.calls == []
 
@@ -226,7 +234,7 @@ def test_layer_settings_use_the_spot_burn_preset_and_configured_defaults(monkeyp
     m = make_microscope(monkeypatch)
     defaults = FibsemMillingSettings()
 
-    m.run_spot_burn(coordinates=[Point(0.5, 0.5)], exposure_time=1.0)
+    run_burn(m, coordinates=[Point(0.5, 0.5)], exposure_time=1.0)
 
     layer_settings = m.connection.DrawBeam.layers[0].settings
     assert layer_settings["preset"] == "30 keV; 100 pA"
@@ -258,7 +266,8 @@ def test_stop_event_during_exposure_stops_the_exposition(monkeypatch):
 
     m.get_milling_state = counting_state
 
-    m.run_spot_burn(
+    run_burn(
+        m,
         coordinates=[Point(0.5, 0.5), Point(0.25, 0.25)],
         exposure_time=30.0,
         stop_event=stop_event,
@@ -272,21 +281,30 @@ def test_stop_event_during_exposure_stops_the_exposition(monkeypatch):
 # progress + validation
 # --------------------------------------------------------------------------
 
-def test_progress_uses_the_milling_progress_shape(monkeypatch):
-    """Progress is reported exactly as run_milling reports it."""
+def test_progress_uses_the_spot_burn_widget_shape(monkeypatch):
+    """Progress goes out on spot_burn_progress_signal in the dict shape the widget parses."""
     m = make_microscope(monkeypatch, busy_polls=2)
     events = collect_progress(m)
 
-    m.run_spot_burn(coordinates=[Point(0.5, 0.5), Point(0.2, 0.2)], exposure_time=2.0)
+    run_burn(m, coordinates=[Point(0.5, 0.5), Point(0.2, 0.2)], exposure_time=2.0)
 
-    assert events, "expected at least one progress update"
-    progress = events[0]["progress"]
-    assert set(progress) == {
-        "state", "milling_state", "start_time", "estimated_time", "remaining_time"
-    }
-    assert progress["state"] == "update"
-    assert progress["estimated_time"] == 4.0  # 2 points x 2s
-    assert 0.0 <= progress["remaining_time"] <= 4.0
+    assert len(events) >= 3, "expected initial + at least one update + finished"
+    initial, updates, finished = events[0], events[1:-1], events[-1]
+
+    assert initial["current_point"] == 0
+    assert initial["total_points"] == 2
+    assert initial["total_estimated_time"] == 4.0  # 2 points x 2s
+
+    for update in updates:
+        assert set(update) == {
+            "current_point", "total_points", "remaining_time",
+            "total_remaining_time", "total_estimated_time",
+        }
+        assert 1 <= update["current_point"] <= 2
+        assert 0.0 <= update["remaining_time"] <= 2.0
+        assert 0.0 <= update["total_remaining_time"] <= 4.0
+
+    assert finished == {"finished": True}
 
 
 def test_layer_is_unloaded_even_when_drawbeam_raises(monkeypatch):
@@ -298,7 +316,7 @@ def test_layer_is_unloaded_even_when_drawbeam_raises(monkeypatch):
     m.get_milling_state = boom
 
     with pytest.raises(RuntimeError):
-        m.run_spot_burn(coordinates=[Point(0.5, 0.5)], exposure_time=1.0)
+        run_burn(m, coordinates=[Point(0.5, 0.5)], exposure_time=1.0)
 
     assert m.connection.DrawBeam.calls[-1] == "UnloadLayer"
 
@@ -306,8 +324,8 @@ def test_layer_is_unloaded_even_when_drawbeam_raises(monkeypatch):
 def test_electron_beam_is_rejected(monkeypatch):
     m = make_microscope(monkeypatch)
     with pytest.raises(ValueError, match="ion beam"):
-        m.run_spot_burn(
-            coordinates=[Point(0.5, 0.5)], exposure_time=1.0, beam_type=BeamType.ELECTRON
+        run_burn(
+            m, coordinates=[Point(0.5, 0.5)], exposure_time=1.0, beam_type=BeamType.ELECTRON
         )
 
 
@@ -315,4 +333,4 @@ def test_electron_beam_is_rejected(monkeypatch):
 def test_non_positive_exposure_is_rejected(monkeypatch, exposure_time):
     m = make_microscope(monkeypatch)
     with pytest.raises(ValueError, match="exposure_time"):
-        m.run_spot_burn(coordinates=[Point(0.5, 0.5)], exposure_time=exposure_time)
+        run_burn(m, coordinates=[Point(0.5, 0.5)], exposure_time=exposure_time)


### PR DESCRIPTION
## Summary

`fibsem.imaging.spot.run_spot_burn` hardcoded the blank → park → unblank primitive sequence. That sequence cannot exist on the TESCAN ion beam — `FIB.Scan` is a strict subset of `SEM.Scan`, missing exactly `SetBlanker`/`GetBlanker`/`SetBeamPosition` — so the DrawBeam implementation added in #115 was dormant and the **Run Spot Burn** button silently no-op'd on Tescan. This wires the burn through a polymorphic seam (FIB-297), the same pattern as the live-imaging `_acquisition_worker` override.

## Changes

- **`FibsemMicroscope.run_spot_burn(settings, beam_type, stop_event)`** — the primitive body moves onto the base class, byte-for-byte, as the default implementation (Thermo + simulator). It takes the `SpotBurnSettings` payload, which is already the shared currency of the widget/task/module function.
- **`spot.py::run_spot_burn`** — now a one-line delegate to `microscope.run_spot_burn(...)`. Both callers (`FibsemSpotBurnWidget`, the spot-burn workflow task) and all imports untouched.
- **`TescanMicroscope.run_spot_burn`** — signature matches the base, and progress is retargeted from `milling_progress_signal` to **`spot_burn_progress_signal`** in the dict shape the widget parses (`current_point/total_points/remaining_time/total_remaining_time/total_estimated_time`, then `{"finished": True}`). The consumer defines the contract; without this the widget showed a dead progress bar on Tescan. DrawBeam has no per-dot callback, so the point index is derived from elapsed time — the dots burn sequentially at `exposure_time` each.

Net effect: on Tescan the widget button and the workflow task now reach the DrawBeam burn with a live progress bar. Thermo/simulator behavior is identical — same body, one indirection.

## Test plan

- [x] `tests/test_tescan_spot_burn.py` (17) — all calls through the settings payload; progress test asserts the widget shape end-to-end (initial 0/N → keyed updates → finished)
- [x] `tests/autolamella/test_spot_burn.py` (18) — the primitive-path tests target `FibsemMicroscope.run_spot_burn` directly (that is where the body lives now); new test proves the module function delegates polymorphically
- [x] Mutation-checked: emitting finished on the old signal fails the Tescan progress test; dropping the base's finished-emit fails the progress test
- [x] ruff clean on all five files
- [ ] On-hardware (FIB-507 / T12): `DepthUnit.Second` per-dot vs per-layer semantics, poll-loop startup race
