### PR TITLE
Refuse SEM-view vertical moves on backends without move_coincident_from_sem

### DIFF
--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -591,7 +591,9 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             and vertical_move
             and not hasattr(self.microscope, "move_coincident_from_sem")
         ):
-            logging.warning("Vertical move from the SEM view is not supported on this system.")
+            logging.warning(
+                "Vertical move from the SEM view is not supported on this system."
+            )
             notification_service.show_toast(
                 "Vertical move from the SEM view is not supported on this system - use the FIB view.",
                 "warning",

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -457,11 +457,26 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             "coords": coords,                           # coords in image coordinates
         })
 
+        # refuse rather than silently fall through to stable_move below: on backends
+        # without move_coincident_from_sem (e.g. TESCAN) the operator would ask to
+        # restore coincidence and get a sample-plane move instead
+        if (
+            beam_type is BeamType.ELECTRON
+            and vertical_move
+            and not hasattr(self.microscope, "move_coincident_from_sem")
+        ):
+            logging.warning("Vertical move from the SEM view is not supported on this system.")
+            notification_service.show_toast(
+                "Vertical move from the SEM view is not supported on this system - use the FIB view.",
+                "warning",
+            )
+            return
+
         self.movement_progress_signal.emit({"msg": "Moving stage..."})
         # eucentric is only supported for ION beam
         if beam_type is BeamType.ION and vertical_move:
             self.microscope.vertical_move(dx=point.x, dy=point.y)
-        elif beam_type is BeamType.ELECTRON and vertical_move and hasattr(self.microscope, "move_coincident_from_sem"):
+        elif beam_type is BeamType.ELECTRON and vertical_move:
             # move coincident from SEM
             self.microscope.move_coincident_from_sem(dx=0, dy=point.y) # TMP: disable dx for now
         else:

--- a/tests/test_movement_widget_vertical_gate.py
+++ b/tests/test_movement_widget_vertical_gate.py
@@ -1,0 +1,110 @@
+"""The SEM-view vertical-move gate (FIB-507 T4a).
+
+``FibsemMovementWidget._execute_stage_move`` dispatches an Alt-click vertical move
+to ``move_coincident_from_sem`` for the ELECTRON view -- a method only some
+backends implement (ThermoFisher, Odemis). Backends without it (e.g. TESCAN) used
+to fall through to ``stable_move`` silently: the operator asked to restore
+coincidence and got a sample-plane move instead. The widget must refuse with a
+toast, and leave every other dispatch branch untouched.
+
+No Qt event loop or microscope required: the widget is created without __init__
+and only the attributes ``_execute_stage_move`` touches are provided.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+try:
+    from fibsem.ui import notification_service
+    from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget
+    _MISSING_UI_DEPS = None
+except ImportError as e:  # pragma: no cover - exercised only on UI-less CI
+    _MISSING_UI_DEPS = str(e)
+
+from fibsem.structures import BeamType, Point
+
+pytestmark = pytest.mark.skipif(
+    bool(_MISSING_UI_DEPS), reason=f"UI dependencies not installed: {_MISSING_UI_DEPS}"
+)
+
+
+class RecordingMicroscope:
+    """Records move calls; has no move_coincident_from_sem (the TESCAN case)."""
+
+    def __init__(self):
+        self.calls = []
+
+    def stable_move(self, dx, dy, beam_type):
+        self.calls.append(("stable_move", dx, dy, beam_type))
+
+    def vertical_move(self, dx, dy):
+        self.calls.append(("vertical_move", dx, dy))
+
+
+class SemCoincidentMicroscope(RecordingMicroscope):
+    """A backend that implements the SEM-view coincidence move (Thermo/Odemis)."""
+
+    def move_coincident_from_sem(self, dx, dy):
+        self.calls.append(("move_coincident_from_sem", dx, dy))
+
+
+@pytest.fixture
+def toasts(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        notification_service, "show_toast",
+        lambda msg, notification_type="info": events.append((msg, notification_type)),
+    )
+    return events
+
+
+def make_widget(microscope):
+    # sip forbids object.__new__ on QWidget subclasses; the class's own __new__
+    # allocates just the Python wrapper (no QApplication / C++ widget needed)
+    widget = FibsemMovementWidget.__new__(FibsemMovementWidget)
+    widget.microscope = microscope
+    widget.movement_progress_signal = Mock()
+    widget.update_ui_after_movement = Mock()
+    return widget
+
+
+def execute(widget, beam_type, vertical):
+    widget._execute_stage_move(
+        beam_type=beam_type, point=Point(1e-6, 2e-6), vertical_move=vertical
+    )
+
+
+def test_sem_vertical_without_backend_support_refuses_with_a_toast(toasts):
+    m = RecordingMicroscope()
+    execute(make_widget(m), BeamType.ELECTRON, vertical=True)
+
+    assert m.calls == []  # no silent stable_move fallback
+    assert len(toasts) == 1
+    msg, level = toasts[0]
+    assert "not supported" in msg and "FIB view" in msg
+    assert level == "warning"
+
+
+def test_sem_vertical_with_backend_support_moves_coincident(toasts):
+    m = SemCoincidentMicroscope()
+    execute(make_widget(m), BeamType.ELECTRON, vertical=True)
+
+    assert [c[0] for c in m.calls] == ["move_coincident_from_sem"]
+    assert toasts == []
+
+
+def test_fib_vertical_is_unaffected(toasts):
+    m = RecordingMicroscope()
+    execute(make_widget(m), BeamType.ION, vertical=True)
+
+    assert [c[0] for c in m.calls] == ["vertical_move"]
+    assert toasts == []
+
+
+def test_sem_stable_move_is_unaffected(toasts):
+    m = RecordingMicroscope()
+    execute(make_widget(m), BeamType.ELECTRON, vertical=False)
+
+    assert [c[0] for c in m.calls] == ["stable_move"]
+    assert toasts == []

--- a/tests/test_movement_widget_vertical_gate.py
+++ b/tests/test_movement_widget_vertical_gate.py
@@ -18,6 +18,7 @@ import pytest
 try:
     from fibsem.ui import notification_service
     from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget
+
     _MISSING_UI_DEPS = None
 except ImportError as e:  # pragma: no cover - exercised only on UI-less CI
     _MISSING_UI_DEPS = str(e)
@@ -53,7 +54,8 @@ class SemCoincidentMicroscope(RecordingMicroscope):
 def toasts(monkeypatch):
     events = []
     monkeypatch.setattr(
-        notification_service, "show_toast",
+        notification_service,
+        "show_toast",
         lambda msg, notification_type="info": events.append((msg, notification_type)),
     )
     return events


### PR DESCRIPTION
## Summary

An Alt-click **vertical move from the SEM view** dispatches to `move_coincident_from_sem`, which only ThermoFisher and Odemis implement. On any other backend (TESCAN, Demo, Zeiss) the `hasattr` dispatch silently fell through to `stable_move` — the operator asks to restore coincidence and gets a sample-plane move with no feedback. Found while cross-checking the Tescan hardware-session notes ("vertical movement in SEM not supported") against the code: it was worse than unsupported.

`_execute_stage_move` now refuses instead: a warning toast ("Vertical move from the SEM view is not supported on this system - use the FIB view.") plus a log line, and no move runs. The toast uses the existing `notification_service` bus, which is already called from this same worker thread two functions up and queues cross-thread emits to the GUI thread. The `hasattr` check moved out of the `elif` into the gate, so every supported dispatch branch is byte-identical.

Interim measure by design: the API-level fix (folding `move_coincident_from_sem` into a view-parameterised `vertical_move` so backends declare support instead of being sniffed with `hasattr`) is tracked separately in Linear.

**Visible behaviour change on the simulator too**: Demo lacks the method, so SEM Alt-click now toasts instead of silently stable-moving — the honest behaviour, but it is a change in dev.

## Test plan

- [x] `tests/test_movement_widget_vertical_gate.py` (new, 4 tests, SDK-free): refuse-with-toast on the unsupported case; the three other dispatch branches (Thermo-style SEM coincident, FIB vertical, SEM stable) proven untouched. Widget built via `FibsemMovementWidget.__new__` — no QApplication needed; skips cleanly on UI-less CI.
- [x] Mutation-checked: disabling the gate condition fails exactly the refuse test (file hash verified identical after restore).
- [x] Existing widget tests unaffected: `tests/ui/test_objective_display_signal.py` + `tests/ui/test_viewer_less_widgets.py` — 36 passed.
- [x] ruff clean.
- [ ] On the instrument day: confirm the toast appears in the SEM view and no move runs (validation checklist T4a).
