### PR TITLE
Hide the Tescan SEM preset control; activate presets off the GUI thread (FIB-787)

### DIFF
--- a/fibsem/ui/widgets/beam_settings_widget.py
+++ b/fibsem/ui/widgets/beam_settings_widget.py
@@ -16,6 +16,8 @@ from fibsem import config as cfg
 from fibsem import constants, utils
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamSettings, BeamType, Point
+from fibsem.ui import notification_service
+from fibsem.ui.qt.threading import FunctionWorker
 from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.custom_widgets import _create_combobox_control
 
@@ -94,7 +96,9 @@ class FibsemBeamSettingsWidget(QWidget):
         # updates immediately for feedback, the hardware move is debounced so a burst of
         # scroll notches coalesces into a single move.
         self._wd_wheel_target_mm: float = self.working_distance_spinbox.value()
-        self._execute_wd_wheel_move = qdebounced(self._execute_wd_wheel_move_impl, timeout=150)
+        self._execute_wd_wheel_move = qdebounced(
+            self._execute_wd_wheel_move_impl, timeout=150
+        )
 
     # ------------------------------------------------------------------
     # UI setup
@@ -188,10 +192,14 @@ class FibsemBeamSettingsWidget(QWidget):
 
         # All widgets that are shown only when advanced mode is active
         self._adv_widgets = [
-            self.scan_rotation_label, self.scan_rotation_spinbox,
-            self.shift_label, self.shift_row,
-            self.stigmation_label, self.stigmation_row,
-            self.beam_voltage_label, self.beam_voltage_combo,
+            self.scan_rotation_label,
+            self.scan_rotation_spinbox,
+            self.shift_label,
+            self.shift_row,
+            self.stigmation_label,
+            self.stigmation_row,
+            self.beam_voltage_label,
+            self.beam_voltage_combo,
         ]
 
     # ------------------------------------------------------------------
@@ -202,10 +210,16 @@ class FibsemBeamSettingsWidget(QWidget):
         self.hfw_spinbox.valueChanged.connect(self._on_hfw_changed)
         self.dwell_time_spinbox.valueChanged.connect(self._on_dwell_time_changed)
         self.resolution_combo.currentIndexChanged.connect(self._on_resolution_changed)
-        self.beam_current_combo.currentIndexChanged.connect(self._on_beam_current_changed)
-        self.beam_voltage_combo.currentIndexChanged.connect(self._on_beam_voltage_changed)
+        self.beam_current_combo.currentIndexChanged.connect(
+            self._on_beam_current_changed
+        )
+        self.beam_voltage_combo.currentIndexChanged.connect(
+            self._on_beam_voltage_changed
+        )
         self.preset_combo.currentIndexChanged.connect(self._on_preset_changed)
-        self.working_distance_spinbox.valueChanged.connect(self._on_working_distance_changed)
+        self.working_distance_spinbox.valueChanged.connect(
+            self._on_working_distance_changed
+        )
         self.scan_rotation_spinbox.valueChanged.connect(self._on_scan_rotation_changed)
         self.shift_x_spinbox.valueChanged.connect(self._on_shift_changed)
         self.shift_y_spinbox.valueChanged.connect(self._on_shift_changed)
@@ -218,46 +232,112 @@ class FibsemBeamSettingsWidget(QWidget):
 
     def _on_hfw_changed(self, value: float):
         self.microscope.set_field_of_view(value * constants.MICRO_TO_SI, self.beam_type)
-        logging.info({"msg": "_on_hfw_changed", "beam_type": self.beam_type.name, "hfw": value})
+        logging.info(
+            {"msg": "_on_hfw_changed", "beam_type": self.beam_type.name, "hfw": value}
+        )
         self.settings_changed.emit(self.get_settings())
 
     def _on_dwell_time_changed(self, value: float):
         self.microscope.set_dwell_time(value * constants.MICRO_TO_SI, self.beam_type)
-        logging.info({"msg": "_on_dwell_time_changed", "beam_type": self.beam_type.name, "dwell_time": value})
+        logging.info(
+            {
+                "msg": "_on_dwell_time_changed",
+                "beam_type": self.beam_type.name,
+                "dwell_time": value,
+            }
+        )
         self.settings_changed.emit(self.get_settings())
 
     def _on_resolution_changed(self, index: int):
         resolution = self.resolution_combo.itemData(index)
         if resolution is not None:
             self.microscope.set_resolution(resolution, self.beam_type)
-            logging.info({"msg": "_on_resolution_changed", "beam_type": self.beam_type.name, "resolution": resolution})
+            logging.info(
+                {
+                    "msg": "_on_resolution_changed",
+                    "beam_type": self.beam_type.name,
+                    "resolution": resolution,
+                }
+            )
             self.settings_changed.emit(self.get_settings())
 
     def _on_beam_current_changed(self, index: int):
         current = self.beam_current_combo.itemData(index)
         if current is not None:
             self.microscope.set_beam_current(current, self.beam_type)
-            logging.info({"msg": "_on_beam_current_changed", "beam_type": self.beam_type.name, "current": current})
+            logging.info(
+                {
+                    "msg": "_on_beam_current_changed",
+                    "beam_type": self.beam_type.name,
+                    "current": current,
+                }
+            )
             self.settings_changed.emit(self.get_settings())
 
     def _on_beam_voltage_changed(self, index: int):
         voltage = self.beam_voltage_combo.itemData(index)
         if voltage is not None:
             self.microscope.set_beam_voltage(voltage, self.beam_type)
-            logging.info({"msg": "_on_beam_voltage_changed", "beam_type": self.beam_type.name, "voltage": voltage})
+            logging.info(
+                {
+                    "msg": "_on_beam_voltage_changed",
+                    "beam_type": self.beam_type.name,
+                    "voltage": voltage,
+                }
+            )
             self.settings_changed.emit(self.get_settings())
 
     def _on_preset_changed(self, index: int):
         preset = self.preset_combo.itemData(index)
-        if preset is not None:
-            self.microscope.set_preset(preset, self.beam_type)
-            logging.info({"msg": "_on_preset_changed", "beam_type": self.beam_type.name, "preset": preset})
-            self.settings_changed.emit(self.get_settings())
+        if preset is None:
+            return
+        # Preset activation is a multi-second SharkSEM round trip (with the settle-wait
+        # from #82), so it must not run on the GUI thread -- and it can fail: the
+        # simulator enumerates SEM presets that Activate then refuses (PresetNotFound),
+        # which must surface as a toast rather than an exception in a Qt slot.
+        self.preset_combo.setEnabled(False)
+        worker = FunctionWorker(self.microscope.set_preset, preset, self.beam_type)
+        worker.returned.connect(lambda _result, p=preset: self._on_preset_applied(p))
+        worker.errored.connect(lambda exc, p=preset: self._on_preset_failed(p, exc))
+        worker.finished.connect(lambda: self.preset_combo.setEnabled(True))
+        worker.start()
+
+    def _on_preset_applied(self, preset: str) -> None:
+        logging.info(
+            {
+                "msg": "_on_preset_changed",
+                "beam_type": self.beam_type.name,
+                "preset": preset,
+            }
+        )
+        self.settings_changed.emit(self.get_settings())
+
+    def _on_preset_failed(self, preset: str, exc: Exception) -> None:
+        """Toast the failure and put the combo back on the preset the microscope reports.
+
+        On Tescan ``get("preset")`` is served from the cached beam parameters, so the
+        revert makes no SDK call. If nothing was ever activated, clear the selection --
+        leaving the refused preset displayed would show state the microscope is not in.
+        """
+        notification_service.show_toast(
+            f"Failed to activate preset {preset}: {exc}", "error"
+        )
+        current = self.microscope.get("preset", self.beam_type)
+        self.preset_combo.blockSignals(True)
+        idx = self.preset_combo.findData(current) if current is not None else -1
+        self.preset_combo.setCurrentIndex(idx)
+        self.preset_combo.blockSignals(False)
 
     def _on_working_distance_changed(self, value: float):
         wd = value * constants.MILLI_TO_SI
         self.microscope.set_working_distance(wd, self.beam_type)
-        logging.info({"msg": "_on_working_distance_changed", "beam_type": self.beam_type.name, "working_distance": wd})
+        logging.info(
+            {
+                "msg": "_on_working_distance_changed",
+                "beam_type": self.beam_type.name,
+                "working_distance": wd,
+            }
+        )
         self.settings_changed.emit(self.get_settings())
 
     # ------------------------------------------------------------------
@@ -273,7 +353,9 @@ class FibsemBeamSettingsWidget(QWidget):
             return
         sb = self.working_distance_spinbox
         new_val = float(
-            np.clip(sb.value() + WD_WHEEL_STEP_MM * direction, sb.minimum(), sb.maximum())
+            np.clip(
+                sb.value() + WD_WHEEL_STEP_MM * direction, sb.minimum(), sb.maximum()
+            )
         )
         # immediate visual feedback without a hardware call; debounce the actual move
         sb.blockSignals(True)
@@ -291,10 +373,16 @@ class FibsemBeamSettingsWidget(QWidget):
         WD is beam focus (lens), not a physical objective, so a big move isn't a collision risk."""
         target_m = self._wd_wheel_target_mm * constants.MILLI_TO_SI
         logging.info(
-            {"msg": "_on_canvas_scroll", "beam_type": self.beam_type.name, "working_distance": target_m}
+            {
+                "msg": "_on_canvas_scroll",
+                "beam_type": self.beam_type.name,
+                "working_distance": target_m,
+            }
         )
         self.microscope.set_working_distance(target_m, self.beam_type)
-        self._set_working_distance_spinbox(self.microscope.get_working_distance(self.beam_type))
+        self._set_working_distance_spinbox(
+            self.microscope.get_working_distance(self.beam_type)
+        )
         self.settings_changed.emit(self.get_settings())
 
     def _set_working_distance_spinbox(self, wd_m: float) -> None:
@@ -305,7 +393,13 @@ class FibsemBeamSettingsWidget(QWidget):
 
     def _on_scan_rotation_changed(self, value: float):
         self.microscope.set_scan_rotation(np.deg2rad(value), self.beam_type)
-        logging.info({"msg": "_on_scan_rotation_changed", "beam_type": self.beam_type.name, "rotation": value})
+        logging.info(
+            {
+                "msg": "_on_scan_rotation_changed",
+                "beam_type": self.beam_type.name,
+                "rotation": value,
+            }
+        )
         self.settings_changed.emit(self.get_settings())
 
     def _on_shift_changed(self):
@@ -314,7 +408,13 @@ class FibsemBeamSettingsWidget(QWidget):
             y=self.shift_y_spinbox.value() * constants.MICRO_TO_SI,
         )
         self.microscope.set_beam_shift(shift, self.beam_type)
-        logging.info({"msg": "_on_shift_changed", "beam_type": self.beam_type.name, "shift": shift})
+        logging.info(
+            {
+                "msg": "_on_shift_changed",
+                "beam_type": self.beam_type.name,
+                "shift": shift,
+            }
+        )
         self.settings_changed.emit(self.get_settings())
 
     def _on_stigmation_changed(self):
@@ -323,7 +423,13 @@ class FibsemBeamSettingsWidget(QWidget):
             y=self.stigmation_y_spinbox.value(),
         )
         self.microscope.set_stigmation(stigmation, self.beam_type)
-        logging.info({"msg": "_on_stigmation_changed", "beam_type": self.beam_type.name, "stigmation": stigmation})
+        logging.info(
+            {
+                "msg": "_on_stigmation_changed",
+                "beam_type": self.beam_type.name,
+                "stigmation": stigmation,
+            }
+        )
         self.settings_changed.emit(self.get_settings())
 
     # ------------------------------------------------------------------
@@ -340,7 +446,9 @@ class FibsemBeamSettingsWidget(QWidget):
         self.beam_current_combo.clear()
         _create_combobox_control(
             value=self.microscope.get_beam_current(self.beam_type),
-            items=self.microscope.get_available_values_cached("current", self.beam_type),
+            items=self.microscope.get_available_values_cached(
+                "current", self.beam_type
+            ),
             units="A",
             format_fn=utils.format_value,
             control=self.beam_current_combo,
@@ -351,7 +459,9 @@ class FibsemBeamSettingsWidget(QWidget):
         self.beam_voltage_combo.clear()
         _create_combobox_control(
             value=self.microscope.get_beam_voltage(self.beam_type),
-            items=self.microscope.get_available_values_cached("voltage", self.beam_type),
+            items=self.microscope.get_available_values_cached(
+                "voltage", self.beam_type
+            ),
             units="V",
             format_fn=utils.format_value,
             control=self.beam_voltage_combo,
@@ -379,7 +489,8 @@ class FibsemBeamSettingsWidget(QWidget):
         """Return a BeamSettings built from the current widget values."""
         return BeamSettings(
             beam_type=self.beam_type,
-            working_distance=self.working_distance_spinbox.value() * constants.MILLI_TO_SI,
+            working_distance=self.working_distance_spinbox.value()
+            * constants.MILLI_TO_SI,
             hfw=self.hfw_spinbox.value() * constants.MICRO_TO_SI,
             dwell_time=self.dwell_time_spinbox.value() * constants.MICRO_TO_SI,
             resolution=self.resolution_combo.currentData(),
@@ -417,11 +528,15 @@ class FibsemBeamSettingsWidget(QWidget):
             w.blockSignals(True)
 
         if settings.working_distance is not None:
-            self.working_distance_spinbox.setValue(settings.working_distance * constants.METRE_TO_MILLIMETRE)
+            self.working_distance_spinbox.setValue(
+                settings.working_distance * constants.METRE_TO_MILLIMETRE
+            )
         if settings.hfw is not None:
             self.hfw_spinbox.setValue(settings.hfw * constants.SI_TO_MICRO)
         if settings.dwell_time is not None:
-            self.dwell_time_spinbox.setValue(settings.dwell_time * constants.SI_TO_MICRO)
+            self.dwell_time_spinbox.setValue(
+                settings.dwell_time * constants.SI_TO_MICRO
+            )
         if settings.resolution is not None:
             idx = self.resolution_combo.findData(tuple(settings.resolution))
             if idx != -1:
@@ -472,19 +587,24 @@ class FibsemBeamSettingsWidget(QWidget):
         for w in [self.beam_current_label, self.beam_current_combo]:
             w.setVisible(not is_tescan)
 
-        # Preset: TESCAN only, and only where the beam actually has presets.
-        # Tescan exposes them on the FIB but not the SEM, and an empty combo
-        # reads as a control the user simply failed to set.
+        # Preset: TESCAN ION only, and only when presets exist. Enumerability is not
+        # settability: the simulator's SEM enumerates presets but activating one raises
+        # PresetNotFound, and the hardware session found SEM presets cannot be set --
+        # so the SEM never shows the control, regardless of what Enum() returns. An
+        # empty FIB combo also hides (it reads as a control the user failed to set).
         has_presets = self.preset_combo.count() > 0
+        show_preset = is_tescan and self.beam_type is BeamType.ION and has_presets
         for w in [self.preset_label, self.preset_combo]:
-            w.setVisible(is_tescan and has_presets)
+            w.setVisible(show_preset)
 
         # Working distance: not settable on the TESCAN FIB -- _set("working_distance")
         # is a no-op there -- so show it read-only rather than as a live control.
         wd_settable = not (is_tescan and self.beam_type is BeamType.ION)
         self.working_distance_spinbox.setEnabled(wd_settable)
         self.working_distance_spinbox.setToolTip(
-            "" if wd_settable else "Not settable on the TESCAN FIB (use the TESCAN autofocus)"
+            ""
+            if wd_settable
+            else "Not settable on the TESCAN FIB (use the TESCAN autofocus)"
         )
 
     @staticmethod
@@ -508,7 +628,9 @@ if __name__ == "__main__":
 
     app = QApplication(sys.argv)
 
-    microscope, settings = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    microscope, settings = utils.setup_session(
+        manufacturer="Demo", ip_address="localhost"
+    )
 
     main_widget = QWidget()
     layout = QVBoxLayout()
@@ -517,7 +639,9 @@ if __name__ == "__main__":
     header1 = QLabel("Electron Beam Settings")
     header1.setStyleSheet("font-weight: bold; font-size: 16px;")
     layout.addWidget(header1)
-    widget = FibsemBeamSettingsWidget(microscope=microscope, beam_type=BeamType.ELECTRON)
+    widget = FibsemBeamSettingsWidget(
+        microscope=microscope, beam_type=BeamType.ELECTRON
+    )
     widget.populate_beam_combos()
     widget.update_from_settings(microscope.get_beam_settings(BeamType.ELECTRON))
     layout.addWidget(widget)
@@ -531,6 +655,7 @@ if __name__ == "__main__":
     layout.addWidget(widget2)
 
     from pprint import pprint
+
     def print_settings():
         s = widget.get_settings()
         pprint(s.to_dict())

--- a/tests/ui/test_beam_settings_preset.py
+++ b/tests/ui/test_beam_settings_preset.py
@@ -1,0 +1,173 @@
+"""SEM preset hiding and worker-thread preset activation (Tescan).
+
+Two facts from the 2026-08 simulator session drive these tests. The simulator's SEM
+*enumerates* presets, so the old count-based gate showed the combo -- but activating
+one raises ``PresetNotFound``: enumerability is not settability, and the hardware
+session had already established SEM presets cannot be set. And ``_on_preset_changed``
+ran ``set_preset`` synchronously in the Qt slot, so that raise propagated out of a
+slot (an abort, per the fail-fast policy) instead of surfacing as a toast.
+
+The widget is the real ``FibsemBeamSettingsWidget``; only the microscope is faked.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtCore import QEventLoop, QTimer
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.structures import BeamType
+from fibsem.ui import notification_service
+from fibsem.ui.widgets.beam_settings_widget import FibsemBeamSettingsWidget
+
+_app = QApplication.instance() or QApplication([])
+
+
+def _pump(ms: int = 50) -> None:
+    """Let queued cross-thread signals deliver."""
+    loop = QEventLoop()
+    QTimer.singleShot(ms, loop.quit)
+    loop.exec_()
+
+
+class FakeTescan:
+    """The slice of the microscope the beam-settings widget touches, Tescan-flavoured."""
+
+    manufacturer = "Tescan"
+
+    def __init__(self, presets, current_preset, fail_activation=False):
+        self.presets = presets
+        self.current_preset = current_preset
+        self.fail_activation = fail_activation
+        self.activated = []
+        self.activation_threads = []
+
+    def get_beam_current(self, beam_type):
+        return 1e-9
+
+    def get_beam_voltage(self, beam_type):
+        return 30000.0
+
+    def get_available_values_cached(self, key, beam_type):
+        if key == "preset":
+            return list(self.presets)
+        if key == "current":
+            return [1e-9]
+        if key == "voltage":
+            return [30000.0]
+        return []
+
+    def get(self, key, beam_type=None):
+        assert key == "preset"
+        return self.current_preset
+
+    def set_preset(self, preset, beam_type):
+        self.activation_threads.append(threading.current_thread())
+        if self.fail_activation:
+            raise RuntimeError("PresetNotFound (5)")
+        self.activated.append(preset)
+        self.current_preset = preset
+
+
+def make_widget(beam_type, presets, current_preset="A", fail_activation=False):
+    microscope = FakeTescan(presets, current_preset, fail_activation)
+    widget = FibsemBeamSettingsWidget(microscope=microscope, beam_type=beam_type)
+    widget.populate_beam_combos()
+    return widget, microscope
+
+
+@pytest.fixture
+def toasts(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        notification_service,
+        "show_toast",
+        lambda msg, notification_type="info": events.append((msg, notification_type)),
+    )
+    return events
+
+
+# ---------------------------------------------------------------------------
+# visibility: the SEM never shows the preset control
+# ---------------------------------------------------------------------------
+
+
+def test_sem_preset_hidden_even_when_presets_enumerate():
+    """The simulator case: SEM Enum() returns presets, the control must still hide."""
+    widget, _ = make_widget(BeamType.ELECTRON, presets=["A", "B"])
+    assert widget.preset_combo.isHidden()
+    assert widget.preset_label.isHidden()
+
+
+def test_fib_preset_visible_with_presets():
+    widget, _ = make_widget(BeamType.ION, presets=["A", "B"])
+    assert not widget.preset_combo.isHidden()
+
+
+def test_fib_preset_hidden_without_presets():
+    widget, _ = make_widget(BeamType.ION, presets=[])
+    assert widget.preset_combo.isHidden()
+
+
+# ---------------------------------------------------------------------------
+# activation: off the GUI thread, failure toasts and reverts
+# ---------------------------------------------------------------------------
+
+
+def _wait_for(condition, timeout_ms=2000):
+    for _ in range(timeout_ms // 25):
+        if condition():
+            return True
+        _pump(25)
+    return condition()
+
+
+def test_preset_activation_runs_off_the_gui_thread(toasts):
+    widget, microscope = make_widget(
+        BeamType.ION, presets=["A", "B"], current_preset="A"
+    )
+    applied = []
+    widget.settings_changed.connect(lambda s: applied.append(s))
+
+    widget.preset_combo.setCurrentIndex(widget.preset_combo.findData("B"))
+
+    assert _wait_for(lambda: microscope.activated == ["B"] and applied)
+    assert microscope.activation_threads[0] is not threading.main_thread()
+    assert widget.preset_combo.isEnabled()
+    assert toasts == []
+
+
+def test_preset_failure_toasts_and_reverts(toasts):
+    widget, microscope = make_widget(
+        BeamType.ION, presets=["A", "B"], current_preset="A", fail_activation=True
+    )
+    changed = []
+    widget.settings_changed.connect(lambda s: changed.append(s))
+
+    widget.preset_combo.setCurrentIndex(widget.preset_combo.findData("B"))
+
+    assert _wait_for(lambda: bool(toasts))
+    msg, level = toasts[0]
+    assert "B" in msg and "PresetNotFound" in msg
+    assert level == "error"
+    # reverted to the preset the microscope still reports, control usable again,
+    # and no settings_changed for a preset that never applied
+    assert _wait_for(lambda: widget.preset_combo.currentData() == "A")
+    assert widget.preset_combo.isEnabled()
+    assert changed == []
+
+
+def test_preset_failure_with_no_prior_preset_clears_selection(toasts):
+    widget, microscope = make_widget(
+        BeamType.ION, presets=["A", "B"], current_preset=None, fail_activation=True
+    )
+
+    widget.preset_combo.setCurrentIndex(widget.preset_combo.findData("B"))
+
+    assert _wait_for(lambda: bool(toasts))
+    assert _wait_for(lambda: widget.preset_combo.currentIndex() == -1)


### PR DESCRIPTION
## Summary

Fixes FIB-787 (the 2026-08-24 simulator finding): the SEM preset combo showed on the Image tab and selecting a preset raised `tescanautomation.Preset.Exception: PresetNotFound (5)` out of a Qt slot.

Two changes, both in the beam-settings widget:

1. **The SEM never shows the preset control.** The old gate was count-based, and the simulator's SEM *enumerates* presets — but activating one raises `PresetNotFound`, and the 2026-07 hardware session had already established SEM presets cannot be set. Enumerability is not settability. The preset row now requires Tescan **and** ION **and** a non-empty list; the FIB keeps the count gate.
2. **Activation runs off the GUI thread, and failure is a toast, not an escaped exception.** `_on_preset_changed` disables the combo and runs `set_preset` on a `FunctionWorker` (activation is a multi-second SharkSEM round trip with #82's settle-wait). Success emits `settings_changed` from the worker's queued `returned` signal; failure toasts an error and reverts the combo to `microscope.get("preset")` — the cached value on Tescan, no SDK call — or clears the selection if nothing was ever activated. The combo re-enables on `finished` either way.

Checked the real host chain (`ImageSettingsWidget → DualBeamWidget.populate_combos → beam_widget → populate_beam_combos`) reaches this code, and `settings_changed`/`beam_settings_changed` currently has no in-app consumer, so the now-asynchronous emission cannot break ordering anywhere.

~150 lines of the widget diff are mechanical `ruff format` of pre-existing code — forced by the lint lane, which formats whole changed files.

Remaining on the issue after this: confirming on the instrument that the hardware also enumerates-but-refuses (FIB-507 T6), and the separate SharkSEM serialisation bug (FIB-786).

## Test plan

- [x] `tests/ui/test_beam_settings_preset.py` (new, 6 tests; real widget, faked microscope): the sim regression case (SEM hidden even when presets enumerate), FIB shown/hidden by count, activation off the GUI thread, failure → toast + revert + re-enable + no `settings_changed`, no-prior-preset clears selection
- [x] Mutation-checked: removing the ION gate term, making the worker synchronous, and dropping the revert each fail exactly their target test
- [x] ruff check + format clean
- [x] Full `tests/ui/` suite locally (this PR's base gets no CI — the workflow only triggers on PRs to main)
