### PR TITLE
[refactor] Type tiled acquisition progress events (FIB-402)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -80,6 +80,16 @@ from fibsem.applications.autolamella.workflows.workflow_estimate import (
     estimate_addition,
     estimate_workflow,
 )
+from fibsem.imaging.tiling.progress import (
+    BeamTileCompletedEvent,
+    CountedTiledPhaseEvent,
+    CountedTiledTerminalEvent,
+    FluorescenceTileCompletedEvent,
+    FluorescenceTileCountEvent,
+    TiledAcquisitionEvent,
+    TiledOutcome,
+    TiledTerminalEvent,
+)
 from fibsem.structures import BeamType
 from fibsem.ui import notification_service
 from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
@@ -1620,49 +1630,53 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             QTimer.singleShot(2000, self.progress_widget.reset_if_finished)
 
     @ensure_main_thread
-    def _on_tile_acquisition_progress(self, ddict: dict) -> None:
+    def _on_tile_acquisition_progress(self, event: TiledAcquisitionEvent) -> None:
         """Handle tiled acquisition progress updates from the microscope.
 
         Deliberately **not** filtered by `modality`, unlike the two overview widgets
         that read this signal. They each drive one modality's canvas and must ignore the
         other's run; the status bar is the one consumer that wants both, because its
         whole job is saying what is happening while you are looking at another tab
-        (FIB-725). What it will need, once a fluorescence run emits here, is to say
-        *which* -- not to drop one.
+        (FIB-725). Modality-specific presentation belongs here rather than in either
+        producer; FIB-742 adds that wording after the typed contract is in place.
         """
-        counter = ddict.get("counter")
-        total = ddict.get("total")
-        msg = ddict.get("msg", "Collecting tiles")
+        terminal_types = (TiledTerminalEvent, CountedTiledTerminalEvent)
+        if isinstance(event, terminal_types):
+            self.progress_widget.update_progress(self._overview_outcome(event))
+            # Hide the Done state after a moment, the same way spot burn does above.
+            QTimer.singleShot(2000, self.progress_widget.reset_if_finished)
+            return
 
-        if not ddict.get("finished") and (counter is None or not total):
+        counted_types = (
+            CountedTiledPhaseEvent,
+            BeamTileCompletedEvent,
+            FluorescenceTileCountEvent,
+            FluorescenceTileCompletedEvent,
+        )
+        if not isinstance(event, counted_types):
             # A phase that carries no counts: a stage move, a stitch, a save. The
             # fluorescence runner reports several of these and the beam tiler none, so
             # this only started mattering when both reported here (FIB-725).
             #
             # Nothing is drawn for them, which leaves the last real count standing --
-            # still true while the stage moves or the mosaic is written. Defaulting
-            # instead, as this did, meant `counter=0, total=1` on every such payload:
-            # the bar snapped back to zero at every tile boundary.
+            # still true while the stage moves or the mosaic is written.
             return
 
-        if ddict.get("finished"):
-            self.progress_widget.update_progress(self._overview_outcome(ddict, msg))
-            # Hide the Done state after a moment, the same way spot burn does above.
-            # It used to be cleared by `_on_tile_acquisition_finished`, which is wired
-            # to the napari minimap's own signal -- so a run driven from anywhere else
-            # left "Done" in the status bar for the rest of the session. Doing it from
-            # the progress signal covers every producer of it, and `reset_if_finished`
-            # leaves the widget alone if something else has started reporting since.
-            QTimer.singleShot(2000, self.progress_widget.reset_if_finished)
-        elif counter >= total:
+        if not event.total:
+            return
+
+        msg = getattr(event, "message", "") or "Collecting tiles"
+        if event.completed >= event.total:
             self.progress_widget.update_progress(ProgressUpdate.indeterminate(msg))
         else:
             self.progress_widget.update_progress(
-                ProgressUpdate.numeric(counter, total, msg)
+                ProgressUpdate.numeric(event.completed, event.total, msg)
             )
 
     @staticmethod
-    def _overview_outcome(ddict: dict, msg: str) -> ProgressUpdate:
+    def _overview_outcome(
+        event: TiledTerminalEvent | CountedTiledTerminalEvent,
+    ) -> ProgressUpdate:
         """How a finished tiled acquisition reads once the bar is full.
 
         Everything terminal used to take one branch and say "Done", so a run that was
@@ -1673,11 +1687,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         A cancel is deliberately not `failed`, which paints the bar red: it is someone
         getting what they asked for.
         """
-        outcome = ddict.get("outcome")
-        if outcome == "failed":
-            return ProgressUpdate.failed(msg)
-        if outcome == "cancelled":
-            return ProgressUpdate(finished=True, message=msg)
+        if event.outcome is TiledOutcome.FAILED:
+            return ProgressUpdate.failed(event.message)
+        if event.outcome is TiledOutcome.CANCELLED:
+            return ProgressUpdate(finished=True, message=event.message)
         return ProgressUpdate.done()
 
     def _on_tile_acquisition_finished(self, result: dict) -> None:

--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -33,7 +33,15 @@ from fibsem.imaging.tiling.geometry import (
     order_tiles,
     raise_if_outside_stage_limits,
 )
-from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
+from fibsem.imaging.tiling.progress import (
+    MODALITY_FLUORESCENCE,
+    FluorescenceTileCompletedEvent,
+    FluorescenceTileCountEvent,
+    TiledAcquisitionEvent,
+    TiledPhase,
+    TiledPhaseEvent,
+    TileStartedEvent,
+)
 from fibsem.structures import BeamType, FibsemStagePosition, TileOrderStrategy
 
 if TYPE_CHECKING:
@@ -478,7 +486,11 @@ class FMTiledAcquisitionRunner:
         # in the same place; it is only that the fluorescence stitch and save happen in
         # two different objects, so they are announced separately -- the save from the
         # widget that performs it.
-        self._emit({"state": "stitching", "task": "tileset"})
+        self._emit(
+            TiledPhaseEvent(
+                modality=MODALITY_FLUORESCENCE, phase=TiledPhase.STITCHING
+            )
+        )
         return stitch_tileset(
             self.tileset,
             self.overview_parameters.overlap,
@@ -748,7 +760,11 @@ class FMTiledAcquisitionRunner:
 
         self._init_preview_canvas()
 
-        self._emit({"state": "moving", "task": "tileset"})
+        self._emit(
+            TiledPhaseEvent(
+                modality=MODALITY_FLUORESCENCE, phase=TiledPhase.MOVING
+            )
+        )
         # The run's opening report: nothing acquired, and how long it should take. A
         # progress report rather than an announcement -- it carries no tile coordinates,
         # because it is not about a tile. It used to name the first one *and* claim a
@@ -758,14 +774,14 @@ class FMTiledAcquisitionRunner:
         # `total` counts tiles that will actually be acquired, not grid cells -- a
         # progress bar that stops at 9/25 on a successful sparse run reads as a failure.
         self._emit(
-            {
-                "state": "acquiring",
-                "task": "tileset",
-                "counter": 0,
-                "total": len(self._ordered),
-                "estimated_total_time": self._total_estimated_time,
-                "estimated_remaining_time": self._total_estimated_time,
-            }
+            FluorescenceTileCountEvent(
+                modality=MODALITY_FLUORESCENCE,
+                completed=0,
+                total=len(self._ordered),
+                estimated_total_seconds=self._total_estimated_time,
+                estimated_remaining_seconds=self._total_estimated_time,
+                elapsed_seconds=0.0,
+            )
         )
 
     def _init_preview_canvas(self) -> None:
@@ -867,7 +883,11 @@ class FMTiledAcquisitionRunner:
             self._emit_preview(tile)
 
             if tile is not self._ordered[-1]:
-                self._emit({"state": "moving", "task": "tileset"})
+                self._emit(
+                    TiledPhaseEvent(
+                        modality=MODALITY_FLUORESCENCE, phase=TiledPhase.MOVING
+                    )
+                )
 
     def _acquire_tile(self, row: int, col: int) -> FluorescenceImage:
         """Move to one tile and acquire it.
@@ -944,11 +964,16 @@ class FMTiledAcquisitionRunner:
         logging.info("Returning to initial position")
         self.microscope.safe_absolute_stage_movement(self._initial_position)
         self.microscope.fm.objective.move_absolute(self._initial_objective_position)
-        self._emit({"state": "finished"})
+        self._emit(
+            TiledPhaseEvent(
+                modality=MODALITY_FLUORESCENCE,
+                phase=TiledPhase.TILES_ACQUIRED,
+            )
+        )
 
     # ── helpers ──────────────────────────────────────────────────────────
 
-    def _emit(self, payload: dict) -> None:
+    def _emit(self, event: TiledAcquisitionEvent) -> None:
         """Report a phase of this run.
 
         On `tiled_acquisition_signal`, not the detector's own progress signal. This is
@@ -961,22 +986,17 @@ class FMTiledAcquisitionRunner:
         What stays on the detector's signal is the work *inside* a tile: those are a
         different scale, and `FMOverviewWidget` draws them in a different bar.
 
-        Stamped with the modality on the way out, so no consumer has to remember to. Two
-        of them draw a beam overview from this signal and would otherwise paint a
-        fluorescence mosaic into it.
+        Events are constructed with their modality at the call site, where the typed
+        variant and its required fields are visible together.
         """
-        self.microscope.tiled_acquisition_signal.emit(
-            {"modality": MODALITY_FLUORESCENCE, **payload}
-        )
+        self.microscope.tiled_acquisition_signal.emit(event)
 
     def _emit_preview(self, tile: TilePosition) -> None:
         """Publish the mosaic-so-far, so a viewer can watch it fill in.
 
-        Keyed `image`, matching what `TiledAcquisitionRunner` emits and what
-        `FibsemMinimapWidget.handle_tile_acquisition_progress` already reads, so a
-        consumer of one reads the other. The whole canvas goes out rather than the
-        single tile: the receiver then needs no state of its own and simply redisplays
-        what it is given, which is also what makes a late subscriber correct.
+        The completed-tile event carries the whole canvas rather than one tile: the
+        receiver needs no state of its own and simply redisplays what it is given,
+        which is also what makes a late subscriber correct.
 
         A *copy* goes out, unlike the beam tiler, which emits its live canvas directly.
         The acquisition runs on a worker thread, so the signal is queued and the slot
@@ -987,30 +1007,29 @@ class FMTiledAcquisitionRunner:
         """
         estimated_total, estimated_remaining, elapsed = self._time_estimate()
         self._emit(
-            {
-                "state": "tile",
-                "task": "tileset",
-                "row": tile.row,
-                "col": tile.col,
-                "total_rows": self._rows,
-                "total_cols": self._cols,
+            FluorescenceTileCompletedEvent(
+                modality=MODALITY_FLUORESCENCE,
+                row_index=tile.row,
+                column_index=tile.col,
+                rows=self._rows,
+                columns=self._cols,
                 # **Tiles completed**, which is what `counter` means on this signal -- the
                 # beam tiler increments and then emits, so its count has always meant this.
                 # The fluorescence side used to say it twice per tile with two meanings: the
                 # tile *starting* before the acquisition and the tally after. One key cannot
                 # be both, and a consumer choosing between them got a bar that changed scale
                 # at every boundary (FIB-736, FIB-739).
-                "counter": self._n_acquired,
-                "total": len(self._ordered),
+                completed=self._n_acquired,
+                total=len(self._ordered),
                 # The estimate rides with the count rather than with the announcement below,
                 # so one payload carries the whole picture and a consumer never has to
                 # assemble progress from two.
-                "estimated_total_time": estimated_total,
-                "estimated_remaining_time": estimated_remaining,
-                "elapsed_time": elapsed,
-                "image": self._preview.canvas.copy(),
-                "preview_stride": self._preview.stride,
-            }
+                estimated_total_seconds=estimated_total,
+                estimated_remaining_seconds=estimated_remaining,
+                elapsed_seconds=elapsed,
+                image=self._preview.canvas.copy(),
+                preview_stride=self._preview.stride,
+            )
         )
 
     def _time_estimate(self):
@@ -1044,14 +1063,13 @@ class FMTiledAcquisitionRunner:
         the tile, with the preview.
         """
         self._emit(
-            {
-                "state": "acquiring",
-                "task": "tileset",
-                "row": row + 1,
-                "col": col + 1,
-                "total_rows": self._rows,
-                "total_cols": self._cols,
-            }
+            TileStartedEvent(
+                modality=MODALITY_FLUORESCENCE,
+                row_index=row,
+                column_index=col,
+                rows=self._rows,
+                columns=self._cols,
+            )
         )
 
 

--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -30,7 +30,14 @@ from fibsem.imaging.tiling.plotting import (  # noqa: E402,F401
     plot_stage_positions_on_image,
     plot_tile_positions,
 )
-from fibsem.imaging.tiling.progress import MODALITY_BEAM
+from fibsem.imaging.tiling.progress import (
+    MODALITY_BEAM,
+    BeamTileCompletedEvent,
+    CountedTiledPhaseEvent,
+    CountedTiledTerminalEvent,
+    TiledOutcome,
+    TiledPhase,
+)
 from fibsem.imaging.tiling.reprojection import (  # noqa: E402,F401
     _inverse_y_corrected_stage_movement,
     _inverse_y_corrected_stage_movement_tescan,
@@ -127,16 +134,16 @@ class TiledAcquisitionRunner:
             )
         self._setup()
         self._compute_grid()
-        outcome, message = "finished", "Acquisition Complete"
+        outcome, message = TiledOutcome.FINISHED, "Acquisition Complete"
         try:
             self._autofocus_if_mode(AutoFocusMode.ONCE)
             self._run_tile_loop()
         except OperationCancelledError:
-            outcome, message = "cancelled", "Acquisition Cancelled"
+            outcome, message = TiledOutcome.CANCELLED, "Acquisition Cancelled"
             logging.info("Tiled acquisition cancelled")
             raise
         except Exception as e:
-            outcome, message = "failed", "Acquisition Failed"
+            outcome, message = TiledOutcome.FAILED, "Acquisition Failed"
             logging.error(f"Tiled acquisition failed: {e}")
             raise
         finally:
@@ -148,29 +155,22 @@ class TiledAcquisitionRunner:
             self._emit_terminal(outcome, message)
         self._image_settings.path = self._prev_path
 
-    def _emit_terminal(self, outcome: str, message: str) -> None:
+    def _emit_terminal(self, outcome: TiledOutcome, message: str) -> None:
         """Emit the final progress update for the acquisition.
 
-        Carries `counter`/`total`/`msg` because consumers read those unconditionally --
-        `FibsemMinimapWidget.handle_tile_acquisition_progress` indexes them directly
-        and would raise on a payload without them. `finished` is what
-        `AutoLamellaMainUI._on_tile_acquisition_progress` already branches on; it was
-        previously only ever set by `_stitch`. `outcome` is the addition, so a consumer can distinguish a
-        cancel from a failure rather than seeing both as "stopped". Deliberately not
-        called `state`: the fluorescence progress signal already uses that key for the
-        current *phase* (moving / acquiring / finished), and reusing it here for a
-        terminal *outcome* would collide on "finished" while meaning something else.
+        A counted terminal retains partial progress on cancellation or failure. The
+        typed outcome distinguishes those cases from success without overloading the
+        phase vocabulary.
         """
         total_tiles = self.settings.n_enabled_tiles
         self.microscope.tiled_acquisition_signal.emit(
-            {
-                "modality": MODALITY_BEAM,
-                "msg": message,
-                "counter": getattr(self, "_n_tiles_acquired", 0),
-                "total": total_tiles,
-                "finished": True,
-                "outcome": outcome,
-            }
+            CountedTiledTerminalEvent(
+                modality=MODALITY_BEAM,
+                message=message,
+                completed=getattr(self, "_n_tiles_acquired", 0),
+                total=total_tiles,
+                outcome=outcome,
+            )
         )
 
     def run_and_stitch(self) -> FibsemImage:
@@ -201,12 +201,13 @@ class TiledAcquisitionRunner:
 
         # notify the UI immediately so the progress bar appears before the first move
         self.microscope.tiled_acquisition_signal.emit(
-            {
-                "modality": MODALITY_BEAM,
-                "msg": "Computing Tile Positions",
-                "counter": 0,
-                "total": self.settings.n_enabled_tiles,
-            }
+            CountedTiledPhaseEvent(
+                modality=MODALITY_BEAM,
+                phase=TiledPhase.COMPUTING_POSITIONS,
+                message="Computing Tile Positions",
+                completed=0,
+                total=self.settings.n_enabled_tiles,
+            )
         )
 
     def _compute_grid(self) -> None:
@@ -438,14 +439,14 @@ class TiledAcquisitionRunner:
             self._paint_preview(tile, image)
             self._n_tiles_acquired += 1
             self.microscope.tiled_acquisition_signal.emit(
-                {
-                    "modality": MODALITY_BEAM,
-                    "msg": "Tile Collected",
-                    "i": tile.row,
-                    "j": tile.col,
-                    "n_rows": self.settings.nrows,
-                    "n_cols": self.settings.ncols,
-                    "image": self._canvas,
+                BeamTileCompletedEvent(
+                    modality=MODALITY_BEAM,
+                    message="Tile Collected",
+                    row_index=tile.row,
+                    column_index=tile.col,
+                    rows=self.settings.nrows,
+                    columns=self.settings.ncols,
+                    image=self._canvas,
                     # The mosaic so far, decimated, and carrying metadata -- so a
                     # real-space display can place it as one image rather than assembling
                     # tiles of its own. One artist per run instead of one per tile, which
@@ -455,10 +456,10 @@ class TiledAcquisitionRunner:
                     # Additive, and `image` above is deliberately untouched: the napari
                     # minimap assigns it straight into a layer, so it has to stay a bare
                     # array until that tab goes.
-                    "preview": self._preview_image(),
-                    "counter": self._n_tiles_acquired,
-                    "total": total_tiles,
-                }
+                    preview=self._preview_image(),
+                    completed=self._n_tiles_acquired,
+                    total=total_tiles,
+                )
             )
 
     def _acquire_tile(self, tile: TilePosition) -> FibsemImage:
@@ -480,7 +481,13 @@ class TiledAcquisitionRunner:
         signal = self.microscope.tiled_acquisition_signal
         total_tiles = self.settings.n_enabled_tiles
         signal.emit(
-            {"msg": "Stitching Tiles", "counter": total_tiles, "total": total_tiles}
+            CountedTiledPhaseEvent(
+                modality=MODALITY_BEAM,
+                phase=TiledPhase.STITCHING,
+                message="Stitching Tiles",
+                completed=total_tiles,
+                total=total_tiles,
+            )
         )
         # The metadata `_compute_grid` built, not a patched copy of the first tile's.
         # deepcopy so the stitched image gets its own snapshot rather than sharing the
@@ -501,12 +508,13 @@ class TiledAcquisitionRunner:
         image.save(filename)
 
         signal.emit(
-            {
-                "msg": "Done",
-                "counter": total_tiles,
-                "total": total_tiles,
-                "finished": True,
-            }
+            CountedTiledTerminalEvent(
+                modality=MODALITY_BEAM,
+                outcome=TiledOutcome.FINISHED,
+                message="Done",
+                completed=total_tiles,
+                total=total_tiles,
+            )
         )
         return image
 

--- a/fibsem/imaging/tiling/progress.py
+++ b/fibsem/imaging/tiling/progress.py
@@ -1,61 +1,199 @@
-"""What a tiled acquisition says about itself while it runs.
+"""Typed events emitted while a tiled acquisition runs.
 
-`FibsemMicroscope.tiled_acquisition_signal` carries a bare dict and has no declared
-contract, so a consumer works out what it received from which keys are present. That was
-survivable while `imaging.tiled` was its only emitter: three payload shapes, all from one
-class, all carrying the same keys.
-
-It stops being survivable with a second producer. The fluorescence tileset runner reports
-the same thing -- tile *n* of *N*, and a mosaic so far -- and reports it somewhere else
-entirely, on a signal hanging off the detector that also carries z-stacks, channel
-acquisitions and autofocus sweeps (FIB-725). Bringing it here needs consumers to be able
-to tell whose run they are looking at, because most of them want exactly one:
-
-* `FibsemMinimapWidget` and `FibsemOverviewWidget` each drive a *beam* overview, and hand
-  the payload's mosaic straight to their own canvas. Handed a fluorescence one they would
-  draw it into the beam mosaic -- and the fluorescence preview is keyed `image` already,
-  deliberately, to match this signal.
-* `AutoLamellaSingleWindowUI` shows whichever is running in the status bar, and needs to
-  say *which*, or a glance tells you a run is going and not what it is.
-
-Hence `modality`: the one thing that differs, in the word this codebase already uses for
-it. Everything on this signal is a tiled run by definition -- that is what the signal is
-named for -- so the kind of *work* needs no discriminator; what varies is what is imaging.
-
-# Reading a payload
-
-Use :func:`is_modality`, not `payload["modality"]`. The key is new, and a consumer that
-demands it would ignore every payload emitted by an older producer -- including anything
-outside this repository subscribing to a public signal. Absent means beam, which is what
-it was before this existed.
+``FibsemMicroscope.tiled_acquisition_signal`` is shared by the beam and fluorescence
+tilers. The event class identifies what happened; ``modality`` identifies which
+imaging path produced it. Missing modality retains the signal's historical meaning:
+beam.
 """
 
 from __future__ import annotations
 
-# The beam tiler: SEM or FIB, since no consumer distinguishes them -- both draw into the
-# same overview.
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Union
+
+import numpy as np
+
+from fibsem.structures import FibsemImage
+
 MODALITY_BEAM = "beam"
-# The fluorescence tileset runner.
 MODALITY_FLUORESCENCE = "fluorescence"
 
-__all__ = ["MODALITY_BEAM", "MODALITY_FLUORESCENCE", "modality_of", "is_modality"]
+
+class TiledEventType(str, Enum):
+    """Closed set of event shapes carried by the tiled signal."""
+
+    PHASE = "phase"
+    COUNTED_PHASE = "counted-phase"
+    TILE_STARTED = "tile-started"
+    FLUORESCENCE_TILE_COUNT = "fluorescence-tile-count"
+    BEAM_TILE_COMPLETED = "beam-tile-completed"
+    FLUORESCENCE_TILE_COMPLETED = "fluorescence-tile-completed"
+    TERMINAL = "terminal"
+    COUNTED_TERMINAL = "counted-terminal"
 
 
-def modality_of(payload: dict) -> str:
-    """Which imaging modality produced *payload*.
+class TiledPhase(str, Enum):
+    """Non-terminal work surrounding the completed-tile tally."""
 
-    Defaults to the beam rather than raising or returning None: this signal carried
-    nothing else for its whole life, so an unlabelled payload is a beam run from a
-    producer that predates the key.
+    COMPUTING_POSITIONS = "computing-positions"
+    MOVING = "moving"
+    ACQUIRING = "acquiring"
+    TILES_ACQUIRED = "tiles-acquired"
+    STITCHING = "stitching"
+    SAVING = "saving"
+
+
+class TiledOutcome(str, Enum):
+    """How an originating tiled acquisition ended."""
+
+    FINISHED = "finished"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, kw_only=True)
+class TiledAcquisitionEvent:
+    """Base type for every event on ``tiled_acquisition_signal``.
+
+    ``modality`` intentionally remains a string rather than an enum: consumers can
+    safely ignore or generically present a future modality, and omitting it continues
+    to mean beam for callers constructing an event with the default.
     """
-    return payload.get("modality") or MODALITY_BEAM
+
+    modality: str = MODALITY_BEAM
 
 
-def is_modality(payload: dict, modality: str) -> bool:
-    """Whether *payload* came from *modality*, treating unlabelled as beam.
+@dataclass(frozen=True, kw_only=True)
+class TiledPhaseEvent(TiledAcquisitionEvent):
+    event_type: TiledEventType = field(init=False, default=TiledEventType.PHASE)
+    phase: TiledPhase
 
-    The form consumers should use. `payload.get("modality") == MODALITY_BEAM` looks
-    equivalent and is not: it drops every payload from a producer that has not been
-    taught the key, which on a public signal is not only the ones in this repository.
-    """
-    return modality_of(payload) == modality
+
+@dataclass(frozen=True, kw_only=True)
+class CountedTiledPhaseEvent(TiledAcquisitionEvent):
+    event_type: TiledEventType = field(
+        init=False, default=TiledEventType.COUNTED_PHASE
+    )
+    phase: TiledPhase
+    completed: int
+    total: int
+    message: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class TileStartedEvent(TiledAcquisitionEvent):
+    event_type: TiledEventType = field(init=False, default=TiledEventType.TILE_STARTED)
+    row_index: int
+    column_index: int
+    rows: int
+    columns: int
+
+
+@dataclass(frozen=True, kw_only=True)
+class FluorescenceTileCountEvent(TiledAcquisitionEvent):
+    event_type: TiledEventType = field(
+        init=False, default=TiledEventType.FLUORESCENCE_TILE_COUNT
+    )
+    completed: int
+    total: int
+    estimated_total_seconds: float
+    estimated_remaining_seconds: float
+    elapsed_seconds: float
+
+
+@dataclass(frozen=True, kw_only=True)
+class BeamTileCompletedEvent(TiledAcquisitionEvent):
+    event_type: TiledEventType = field(
+        init=False, default=TiledEventType.BEAM_TILE_COMPLETED
+    )
+    completed: int
+    total: int
+    row_index: int
+    column_index: int
+    rows: int
+    columns: int
+    image: np.ndarray
+    preview: FibsemImage
+    message: str
+
+
+@dataclass(frozen=True, kw_only=True)
+class FluorescenceTileCompletedEvent(TiledAcquisitionEvent):
+    event_type: TiledEventType = field(
+        init=False, default=TiledEventType.FLUORESCENCE_TILE_COMPLETED
+    )
+    completed: int
+    total: int
+    row_index: int
+    column_index: int
+    rows: int
+    columns: int
+    image: np.ndarray
+    preview_stride: int
+    estimated_total_seconds: float
+    estimated_remaining_seconds: float
+    elapsed_seconds: float
+
+
+@dataclass(frozen=True, kw_only=True)
+class TiledTerminalEvent(TiledAcquisitionEvent):
+    event_type: TiledEventType = field(init=False, default=TiledEventType.TERMINAL)
+    outcome: TiledOutcome
+    message: str
+    error: str | None = None
+
+
+@dataclass(frozen=True, kw_only=True)
+class CountedTiledTerminalEvent(TiledAcquisitionEvent):
+    event_type: TiledEventType = field(
+        init=False, default=TiledEventType.COUNTED_TERMINAL
+    )
+    outcome: TiledOutcome
+    message: str
+    completed: int
+    total: int
+    error: str | None = None
+
+
+TiledEvent = Union[
+    TiledPhaseEvent,
+    CountedTiledPhaseEvent,
+    TileStartedEvent,
+    FluorescenceTileCountEvent,
+    BeamTileCompletedEvent,
+    FluorescenceTileCompletedEvent,
+    TiledTerminalEvent,
+    CountedTiledTerminalEvent,
+]
+
+
+def modality_of(event: TiledAcquisitionEvent) -> str:
+    """Return the producer modality, with the legacy beam default."""
+    return event.modality or MODALITY_BEAM
+
+
+def is_modality(event: TiledAcquisitionEvent, modality: str) -> bool:
+    """Whether *event* came from *modality*."""
+    return modality_of(event) == modality
+
+
+__all__ = [
+    "MODALITY_BEAM",
+    "MODALITY_FLUORESCENCE",
+    "TiledEventType",
+    "TiledPhase",
+    "TiledOutcome",
+    "TiledAcquisitionEvent",
+    "TiledPhaseEvent",
+    "CountedTiledPhaseEvent",
+    "TileStartedEvent",
+    "FluorescenceTileCountEvent",
+    "BeamTileCompletedEvent",
+    "FluorescenceTileCompletedEvent",
+    "TiledTerminalEvent",
+    "CountedTiledTerminalEvent",
+    "TiledEvent",
+    "modality_of",
+    "is_modality",
+]

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -101,6 +101,7 @@ except Exception:
 
 import fibsem.constants as constants
 from fibsem.fm.microscope import FluorescenceMicroscope
+from fibsem.imaging.tiling.progress import TiledAcquisitionEvent
 from fibsem.microscopes.autoscript import (
     fibsem_image_from_adorned_image,
     manipulator_position_from_autoscript,
@@ -162,7 +163,7 @@ class FibsemMicroscope(ABC):
     # @superqt.ensure_main_thread; a bare .connect() of a GUI handler is a
     # crash-on-hardware bug that won't reproduce on a dev machine.
     milling_progress_signal = Signal(dict)
-    tiled_acquisition_signal = Signal(dict)
+    tiled_acquisition_signal = Signal(TiledAcquisitionEvent)
     spot_burn_progress_signal = Signal(dict)
     _last_imaging_settings: ImageSettings
     system: SystemSettings

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -48,7 +48,14 @@ from fibsem.applications.autolamella.ui.lamella_name_list_widget import (
 )
 from fibsem.conversions import is_inside_image_bounds
 from fibsem.imaging import tiled
-from fibsem.imaging.tiling.progress import MODALITY_BEAM, is_modality
+from fibsem.imaging.tiling.progress import (
+    MODALITY_BEAM,
+    BeamTileCompletedEvent,
+    CountedTiledPhaseEvent,
+    CountedTiledTerminalEvent,
+    TiledAcquisitionEvent,
+    is_modality,
+)
 from fibsem.microscope import FibsemMicroscope
 from fibsem.milling import FibsemMillingStage
 from fibsem.structures import (
@@ -619,47 +626,40 @@ class FibsemMinimapWidget(QWidget):
             self._acquisition_finished.emit(result)
 
     @ensure_main_thread
-    def handle_tile_acquisition_progress(self, ddict: dict) -> None:
+    def handle_tile_acquisition_progress(self, event: TiledAcquisitionEvent) -> None:
         """Callback for handling the tile acquisition progress.
 
-        Read with `.get`, not indexed. This signal has no discriminator -- a consumer
-        works out what it received from which keys are present -- so a payload shape
-        that omits any of these is not a degraded label here, it is a `KeyError` inside
-        a Qt slot, mid-acquisition. All three shapes `tiled.py` emits happen to carry
-        them today, which is the only reason indexing has held (FIB-402).
-
-        `total` is guarded rather than defaulted, because it is a divisor: a payload
-        reporting nothing to do would take the bar out with a `ZeroDivisionError`
-        instead. Nothing is drawn for a payload that cannot say how far along it is,
-        which leaves the last real progress standing -- true, rather than reset to zero.
-
-        `FibsemOverviewWidget._apply_progress` reads the same signal the same way.
+        Count-bearing beam variants update the bar; only a completed-tile event carries
+        a beam canvas to draw. Other shapes cannot accidentally masquerade as either.
 
         Beam runs only. This tab drives a beam overview and assigns the payload's mosaic
         straight into its napari layer, so a fluorescence run reaching here would be
         drawn into the beam minimap -- and the fluorescence preview is keyed `image`
         already, deliberately, to match this signal (FIB-725).
         """
-        if not is_modality(ddict, MODALITY_BEAM):
+        if not is_modality(event, MODALITY_BEAM):
             return
 
-        # track counts for result dict
-        counter = ddict.get("counter")
-        total = ddict.get("total")
-        if counter is not None and total:
-            self._tiles_acquired = counter
-            self._tile_total_count = total
+        counted_types = (
+            CountedTiledPhaseEvent,
+            BeamTileCompletedEvent,
+            CountedTiledTerminalEvent,
+        )
+        if isinstance(event, counted_types) and event.total:
+            self._tiles_acquired = event.completed
+            self._tile_total_count = event.total
 
             # progress bar
             self.progressBar_acquisition.setMaximum(100)
-            self.progressBar_acquisition.setValue(int(counter / total * 100))
+            self.progressBar_acquisition.setValue(
+                int(event.completed / event.total * 100)
+            )
             self.progressBar_acquisition.setFormat(
-                f"{ddict.get('msg', 'Acquiring')} — {counter}/{total} tiles (%p%)"
+                f"{event.message} — {event.completed}/{event.total} tiles (%p%)"
             )
 
-        image = ddict.get("image", None)
-        if image is not None:
-            self.update_viewer(image, tmp=True)
+        if isinstance(event, BeamTileCompletedEvent):
+            self.update_viewer(event.image, tmp=True)
 
     def cancel_acquisition(self):
         """Cancel the tiled acquisition."""

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -42,7 +42,18 @@ from fibsem.fm.structures import (
 )
 from fibsem.imaging.tiling import unreachable_tiles
 from fibsem.imaging.tiling.geometry import TilePosition, compute_tile_grid_from_fov
-from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE, is_modality
+from fibsem.imaging.tiling.progress import (
+    MODALITY_FLUORESCENCE,
+    FluorescenceTileCompletedEvent,
+    FluorescenceTileCountEvent,
+    TiledAcquisitionEvent,
+    TiledOutcome,
+    TiledPhase,
+    TiledPhaseEvent,
+    TiledTerminalEvent,
+    TileStartedEvent,
+    is_modality,
+)
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import FibsemStagePosition
 from fibsem.ui import notification_service, stylesheets
@@ -180,9 +191,9 @@ class PlacedOverviewImageRecord:
 # way and for the same reason: the bar keeps its last count, which stays true
 # throughout, and the phase goes to the status label instead.
 PHASE_LABELS = {
-    "moving": "Moving stage…",
-    "stitching": "Stitching tiles…",
-    "saving": "Saving overview…",
+    TiledPhase.MOVING: "Moving stage…",
+    TiledPhase.STITCHING: "Stitching tiles…",
+    TiledPhase.SAVING: "Saving overview…",
 }
 
 
@@ -221,7 +232,7 @@ class FMOverviewWidget(QWidget):
     #
     # One per source, because the two describe different things at different scales and
     # each drives its own bar: the run as a whole, and the tile currently being taken.
-    _tile_progress_received = pyqtSignal(dict)
+    _tile_progress_received = pyqtSignal(object)
     _fm_progress_received = pyqtSignal(dict)
     # Same hop for stage moves: `stage_position_changed` is a psygnal, so it fires
     # on whichever thread moved the stage -- a worker, during an acquisition.
@@ -2588,7 +2599,7 @@ class FMOverviewWidget(QWidget):
             )
             return None
 
-    def _emit_state(self, state: str) -> None:
+    def _emit_state(self, phase: TiledPhase) -> None:
         """Announce a phase of this run that carries no counts.
 
         The tile bar keeps whatever it last showed -- N/N is still true while the mosaic
@@ -2597,42 +2608,26 @@ class FMOverviewWidget(QWidget):
         *full* bar, which is exactly the "it finished" impression they exist to correct.
         """
         self.microscope.tiled_acquisition_signal.emit(
-            {"modality": MODALITY_FLUORESCENCE, "state": state, "task": "tileset"}
+            TiledPhaseEvent(modality=MODALITY_FLUORESCENCE, phase=phase)
         )
 
     # What a finished run is called on the shared signal, per outcome.
     TERMINAL_MESSAGES = {
-        "finished": "Overview Complete",
-        "cancelled": "Overview Cancelled",
-        "failed": "Overview Failed",
+        TiledOutcome.FINISHED: "Overview Complete",
+        TiledOutcome.CANCELLED: "Overview Cancelled",
+        TiledOutcome.FAILED: "Overview Failed",
     }
 
-    def _emit_terminal(self, state: str, outcome: str, error: str = "") -> None:
-        """Say how the run ended, in both vocabularies.
-
-        `state` is this widget's own -- `_apply_tile_progress` and `_finish` branch on it,
-        and it distinguishes "the mosaic is saved" from the runner's "the tiles are in".
-
-        `finished` and `outcome` are the shared signal's, which the beam tiler has used
-        since it learned to report every outcome. Carried as well, not instead: a
-        consumer reads whichever it understands, and the window's status bar reads the
-        second (FIB-725). Redundant on purpose -- collapsing the two vocabularies into
-        one is the typed-payload work, not this.
-
-        Without `finished`, the status bar would never clear after a fluorescence run:
-        the terminal it recognises is a key this widget did not send.
-        """
-        payload = {
-            "modality": MODALITY_FLUORESCENCE,
-            "state": state,
-            "task": "tileset",
-            "finished": True,
-            "outcome": outcome,
-            "msg": self.TERMINAL_MESSAGES.get(outcome, "Overview"),
-        }
-        if error:
-            payload["error"] = error
-        self.microscope.tiled_acquisition_signal.emit(payload)
+    def _emit_terminal(self, outcome: TiledOutcome, error: str | None = None) -> None:
+        """Say how the originating overview run ended."""
+        self.microscope.tiled_acquisition_signal.emit(
+            TiledTerminalEvent(
+                modality=MODALITY_FLUORESCENCE,
+                outcome=outcome,
+                message=self.TERMINAL_MESSAGES[outcome],
+                error=error,
+            )
+        )
 
     def _acquire_worker(self) -> None:
         """Runs off the GUI thread. Only signals may cross back."""
@@ -2649,16 +2644,16 @@ class FMOverviewWidget(QWidget):
                 # the stitch is a memcpy into a preallocated canvas (~0.3 s for 1.3 GB)
                 # and the write is most of the rest (~2.3 s for the same). Silent until
                 # now, so a big run appeared to hang just as it completed.
-                self._emit_state("saving")
+                self._emit_state(TiledPhase.SAVING)
                 self._saved_path = self._destination.save_mosaic(mosaic)
             self.overview_acquired.emit(mosaic)
-            self._emit_terminal("overview-finished", "finished")
+            self._emit_terminal(TiledOutcome.FINISHED)
         except OperationCancelledError:
             logging.info("Overview acquisition cancelled")
-            self._emit_terminal("overview-cancelled", "cancelled")
+            self._emit_terminal(TiledOutcome.CANCELLED)
         except Exception as e:
             logging.error(f"Overview acquisition failed: {e}", exc_info=True)
-            self._emit_terminal("overview-failed", "failed", str(e))
+            self._emit_terminal(TiledOutcome.FAILED, str(e))
         finally:
             # A run that ends still marked as acquiring leaves the FM unusable for
             # the rest of the session, with nothing on screen to say why -- so this goes
@@ -2712,9 +2707,9 @@ class FMOverviewWidget(QWidget):
 
     # ── progress ─────────────────────────────────────────────────────────
 
-    def _on_tile_progress(self, payload: dict) -> None:
+    def _on_tile_progress(self, event: TiledAcquisitionEvent) -> None:
         """Called by psygnal, on whichever thread emitted. Touches no widgets."""
-        self._tile_progress_received.emit(payload)
+        self._tile_progress_received.emit(event)
 
     def _on_fm_progress(self, payload: dict) -> None:
         """Called by psygnal, on whichever thread emitted. Touches no widgets."""
@@ -2733,26 +2728,27 @@ class FMOverviewWidget(QWidget):
         if payload.get("operation") in ("z-stack", "channels", "autofocus"):
             self.progress_tile_detail.update_progress(self._tile_detail_update(payload))
 
-    def _apply_tile_progress(self, payload: dict) -> None:
+    def _apply_tile_progress(self, event: TiledAcquisitionEvent) -> None:
         """The run as a whole, on the tile bar.
 
         Runs on the GUI thread, queued via `_tile_progress_received`.
         """
-        if not is_modality(payload, MODALITY_FLUORESCENCE):
+        if not is_modality(event, MODALITY_FLUORESCENCE):
             # A beam run, on the signal this shares with the beam tiler. Checked before
             # anything else, terminal states included: the two tilers write into
             # different canvases and different bars, and the only payload this widget
             # has any business acting on is its own (FIB-725).
             return
 
-        state = payload.get("state")
-
-        if state in ("overview-finished", "overview-cancelled", "overview-failed"):
-            self._finish(state, payload.get("error"))
+        if isinstance(event, TiledTerminalEvent):
+            self._finish(event.outcome, event.error)
             return
 
-        label = PHASE_LABELS.get(state or "")
-        if label is not None:
+        if isinstance(event, TiledPhaseEvent):
+            label = PHASE_LABELS.get(event.phase)
+            if label is None:
+                self.status.setText("")
+                return
             # Deliberately not `indeterminate`: that paints a *full* bar with a
             # spinner, so every stage move looked like the run had just completed.
             # The bar keeps the last tile count -- which is still true between tiles,
@@ -2763,14 +2759,13 @@ class FMOverviewWidget(QWidget):
 
         self.status.setText("")
 
-        if state == "tile":
+        if isinstance(event, FluorescenceTileCompletedEvent):
             # Deliberately does *not* clear the within-tile bar. It used to, which made
             # it vanish and reappear at every tile boundary -- a flicker for the whole
             # run. The next tile's first payload overwrites it a moment later anyway.
-            self._show_preview(payload)
+            self._show_preview(event)
 
-        current, total = payload.get("counter"), payload.get("total")
-        if current is None or not total:
+        if isinstance(event, TileStartedEvent):
             # An announcement rather than a progress report: the payload that says which
             # tile is starting carries no counts, because emitted *before* the tile it
             # could only ever be one short -- a bar driven from it stopped at 3/4 for the
@@ -2782,27 +2777,34 @@ class FMOverviewWidget(QWidget):
             # changed scale at every boundary (FIB-739); now exactly one of them does.
             return
 
+        if not isinstance(
+            event, (FluorescenceTileCountEvent, FluorescenceTileCompletedEvent)
+        ):
+            return
+
         # The final payload of a run reports 0 remaining and so renders as a plain
         # count -- `FibsemProgressWidget` picks the shape from `remaining_seconds > 0`,
         # not from the caller. That is the run finishing rather than a flicker: one
         # transition at the end, where the bar is full either way.
-        remaining = payload.get("estimated_remaining_time")
+        remaining = event.estimated_remaining_seconds
         # The widget renders the count itself, so the message says what is being
         # counted and nothing more -- otherwise it reads "Tile 4/9 — 4/9".
         message = "Tiles"
         if remaining:
             self.progress_tiles.update_progress(
                 ProgressUpdate.combined(
-                    current=current,
-                    total=total,
+                    current=event.completed,
+                    total=event.total,
                     remaining_seconds=remaining,
-                    total_seconds=payload.get("estimated_total_time", 0.0),
+                    total_seconds=event.estimated_total_seconds,
                     message=message,
                 )
             )
         else:
             self.progress_tiles.update_progress(
-                ProgressUpdate.numeric(current=current, total=total, message=message)
+                ProgressUpdate.numeric(
+                    current=event.completed, total=event.total, message=message
+                )
             )
 
     def _tile_detail_update(self, payload: dict) -> ProgressUpdate:
@@ -2836,18 +2838,15 @@ class FMOverviewWidget(QWidget):
             current=index, total=total, message=f"{channel} channels"
         )
 
-    def _show_preview(self, payload: dict) -> None:
+    def _show_preview(self, event: FluorescenceTileCompletedEvent) -> None:
         """Paint the mosaic-so-far onto the canvas.
 
         The runner publishes the whole preview canvas each tile, so this stays
         stateless -- it redisplays what it is given rather than accumulating tiles of
         its own, which is also what makes it correct if a frame is dropped.
         """
-        image = payload.get("image")
-        if image is None:
-            return
         try:
-            planes = np.asarray(image)
+            planes = np.asarray(event.image)
             if planes.ndim == 2:
                 planes = planes[np.newaxis]
 
@@ -2872,7 +2871,7 @@ class FMOverviewWidget(QWidget):
             # `preview_stride` times coarser than a tile's. Placement is by pixel size,
             # so saying so is all that is needed: coarser pixels over the same count
             # cover the same ground, and the mosaic lands at the size it represents.
-            stride = payload.get("preview_stride", 1) or 1
+            stride = event.preview_stride or 1
             # Off the kept projection: read from the camera this is an `active_channel()`
             # scope, and this runs once a tile *during the run* -- so the display was
             # taking the shared channel from the acquisition that was using it. `acquire`
@@ -2916,7 +2915,7 @@ class FMOverviewWidget(QWidget):
             return "  ·  not saved", "Could not be written to disk — see the log."
         return "", ""
 
-    def _finish(self, state: str, error: Optional[str]) -> None:
+    def _finish(self, outcome: TiledOutcome, error: Optional[str]) -> None:
         # Hides both bars. The per-tile one stays hidden -- there is no tile in progress
         # to describe -- but the overall bar is shown again below whenever it has a
         # terminal state worth reading: `FibsemProgressWidget` paints finished and
@@ -2925,7 +2924,7 @@ class FMOverviewWidget(QWidget):
         self._worker = None
         self.progress_tile_detail.reset()
 
-        if state == "overview-finished" and self._mosaic is not None:
+        if outcome is TiledOutcome.FINISHED and self._mosaic is not None:
             # Swap the decimated preview for the real thing. Dropped rather than left
             # underneath: it covers the same ground at a coarser scale, so keeping it
             # would only be a blurred copy hidden behind the stitch.
@@ -2939,7 +2938,7 @@ class FMOverviewWidget(QWidget):
             self.status.setToolTip(tooltip)
             self.progress_tiles.update_progress(ProgressUpdate.done())
             self.progress_tiles.show()
-        elif state == "overview-cancelled":
+        elif outcome is TiledOutcome.CANCELLED:
             self.status.setText("Cancelled. Tiles acquired so far are still shown.")
             # Nothing to show: a cancel has no terminal state of its own, and the status
             # line already says what happened.

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -65,7 +65,14 @@ from fibsem.fm.composite import auto_clim
 from fibsem.imaging import tiled
 from fibsem.imaging.reduce import downsample, downsample_mask
 from fibsem.imaging.tiling import unreachable_tiles
-from fibsem.imaging.tiling.progress import MODALITY_BEAM, is_modality
+from fibsem.imaging.tiling.progress import (
+    MODALITY_BEAM,
+    BeamTileCompletedEvent,
+    CountedTiledPhaseEvent,
+    CountedTiledTerminalEvent,
+    TiledAcquisitionEvent,
+    is_modality,
+)
 from fibsem.microscope import FibsemMicroscope
 from fibsem.projection import BeamStageProjection
 from fibsem.structures import (
@@ -486,7 +493,7 @@ class FibsemOverviewWidget(QWidget):
     # synchronously on whichever thread emitted -- during a run, the acquisition
     # worker. Touching widgets from there is a cross-thread GUI access; re-emitting as
     # a Qt signal gets it queued onto the GUI thread, because this widget lives there.
-    _progress_received = pyqtSignal(dict)
+    _progress_received = pyqtSignal(object)
     _stage_moved = pyqtSignal(object)
     _acquisition_finished = pyqtSignal(dict)
 
@@ -3064,47 +3071,46 @@ class FibsemOverviewWidget(QWidget):
 
     # ── progress ─────────────────────────────────────────────────────────
 
-    def _on_progress(self, payload: dict) -> None:
+    def _on_progress(self, event: TiledAcquisitionEvent) -> None:
         """Called by psygnal, on whichever thread emitted. Touches no widgets."""
-        self._progress_received.emit(payload)
+        self._progress_received.emit(event)
 
     @ensure_main_thread
-    @pyqtSlot(dict)
-    def _apply_progress(self, payload: dict) -> None:
+    @pyqtSlot(object)
+    def _apply_progress(self, event: TiledAcquisitionEvent) -> None:
         """Runs on the GUI thread, queued via `_progress_received`.
-
-        Reads with `.get`, not indexing: this signal is emitted from several places with
-        several shapes, and the terminal update carries none of the per-tile keys.
 
         Beam runs only. This widget places the payload's mosaic on its own canvas and
         counts the tiles into its own record, so a fluorescence run reaching here would
         be drawn as one of this tab's overviews (FIB-725).
         """
-        if not is_modality(payload, MODALITY_BEAM):
+        if not is_modality(event, MODALITY_BEAM):
             return
 
-        counter = payload.get("counter")
-        total = payload.get("total")
-        if counter is not None and total:
-            self._tiles_acquired = counter
+        counted_types = (
+            CountedTiledPhaseEvent,
+            BeamTileCompletedEvent,
+            CountedTiledTerminalEvent,
+        )
+        if isinstance(event, counted_types) and event.total:
+            self._tiles_acquired = event.completed
             self.progress.update_progress(
                 ProgressUpdate.numeric(
-                    current=counter,
-                    total=total,
-                    message=payload.get("msg", "Acquiring"),
+                    current=event.completed,
+                    total=event.total,
+                    message=event.message,
                 )
             )
 
-        preview = payload.get("preview")
         record = self._records.get(getattr(self, "_active_record", None) or "")
-        if preview is not None and record is not None:
-            self._show_preview(preview)
+        if isinstance(event, BeamTileCompletedEvent) and record is not None:
+            self._show_preview(event.preview)
             # The row says how many tiles this run has, and it says it while the run is
             # going -- a row reading "0 tiles" beside a filling mosaic is the list
             # contradicting the canvas.
-            if counter:
-                record.tiles = counter
-                record.pixel_size = self._pixel_size_of(preview)
+            if event.completed:
+                record.tiles = event.completed
+                record.pixel_size = self._pixel_size_of(event.preview)
                 self._refresh_overview_list()
 
     # ── lifecycle ────────────────────────────────────────────────────────

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -32,6 +32,13 @@ from fibsem.fm.structures import (
     ZStackOrder,
 )
 from fibsem.imaging.reduce import PREVIEW_MAX_DIMENSION
+from fibsem.imaging.tiling.progress import (
+    FluorescenceTileCompletedEvent,
+    FluorescenceTileCountEvent,
+    TiledPhase,
+    TiledPhaseEvent,
+    TileStartedEvent,
+)
 from fibsem.structures import FibsemStagePosition, TileOrderStrategy
 
 
@@ -1233,13 +1240,18 @@ def test_progress_totals_count_enabled_tiles_not_grid_cells(fm_microscope, monke
 
     _sparse_runner(fm_microscope, 5, 5, mask=_plus_mask(5)).run()
 
-    totals = {p["total"] for p in emitted if "total" in p}
+    counted = [
+        event
+        for event in emitted
+        if isinstance(event, (FluorescenceTileCountEvent, FluorescenceTileCompletedEvent))
+    ]
+    totals = {event.total for event in counted}
     assert totals == {9}
     # Read from the payload that reports progress rather than the one that announces a
     # tile: `acquiring` is emitted *before* its tile and so carries no count at all --
     # it could only ever be one short, and a bar driven from it stopped there for the
     # whole run (FIB-736).
-    counters = [p["counter"] for p in emitted if "counter" in p]
+    counters = [event.completed for event in counted]
     assert counters[-1] == 9, "the bar never reached the last tile"
     assert counters == sorted(counters), f"the count went backwards: {counters}"
 
@@ -1447,7 +1459,9 @@ def test_stitching_demands_to_be_told_where_the_mosaic_is():
 def _preview_frames(microscope, rows, cols, mask=None, channels=1):
     frames = []
     microscope.tiled_acquisition_signal.connect(
-        lambda d: frames.append(d) if d.get("state") == "tile" else None
+        lambda event: frames.append(event)
+        if isinstance(event, FluorescenceTileCompletedEvent)
+        else None
     )
     channel_settings = [
         ChannelSettings(name=f"CH{i}", exposure_time=0.001) for i in range(channels)
@@ -1468,15 +1482,15 @@ def test_a_preview_frame_is_published_for_every_acquired_tile(fm_microscope):
     frames = _preview_frames(fm_microscope, 3, 3, mask=mask)
 
     assert len(frames) == 5  # the plus, not the grid
-    assert [f["counter"] for f in frames] == [1, 2, 3, 4, 5]
-    assert {f["total"] for f in frames} == {5}
+    assert [frame.completed for frame in frames] == [1, 2, 3, 4, 5]
+    assert {frame.total for frame in frames} == {5}
 
 
 def test_the_preview_fills_in_as_tiles_land(fm_microscope):
     """The point of the preview: it has to actually change between tiles."""
     frames = _preview_frames(fm_microscope, 2, 2)
 
-    coverage = [int((f["image"] > 0).sum()) for f in frames]
+    coverage = [int((frame.image > 0).sum()) for frame in frames]
     assert all(b > a for a, b in zip(coverage, coverage[1:])), coverage
 
 
@@ -1489,18 +1503,18 @@ def test_each_preview_frame_is_its_own_array(fm_microscope):
     """
     frames = _preview_frames(fm_microscope, 2, 2)
 
-    first = frames[0]["image"]
-    assert not any(first is f["image"] for f in frames[1:])
+    first = frames[0].image
+    assert not any(first is frame.image for frame in frames[1:])
     # and the first frame still shows one tile, not the finished mosaic
-    assert (first > 0).sum() < (frames[-1]["image"] > 0).sum()
+    assert (first > 0).sum() < (frames[-1].image > 0).sum()
 
 
 def test_the_preview_is_decimated(fm_microscope):
     frames = _preview_frames(fm_microscope, 5, 5)
 
-    image = frames[-1]["image"]
+    image = frames[-1].image
     assert max(image.shape[-2:]) <= PREVIEW_MAX_DIMENSION
-    assert frames[-1]["preview_stride"] > 1
+    assert frames[-1].preview_stride > 1
 
 
 def test_the_preview_leaves_skipped_tiles_blank(fm_microscope):
@@ -1509,7 +1523,7 @@ def test_the_preview_leaves_skipped_tiles_blank(fm_microscope):
 
     frames = _preview_frames(fm_microscope, 3, 3, mask=mask)
 
-    image = frames[-1]["image"][0]
+    image = frames[-1].image[0]
     h, w = image.shape
     assert not image[: h // 4, : w // 4].any(), "top-left corner was never acquired"
     assert image[h // 3 : 2 * h // 3, w // 3 : 2 * w // 3].any(), "the centre tile was"
@@ -1518,7 +1532,7 @@ def test_the_preview_leaves_skipped_tiles_blank(fm_microscope):
 def test_the_preview_has_one_plane_per_channel(fm_microscope):
     frames = _preview_frames(fm_microscope, 2, 2, channels=2)
 
-    assert frames[-1]["image"].shape[0] == 2
+    assert frames[-1].image.shape[0] == 2
 
 
 @pytest.mark.parametrize(
@@ -2252,13 +2266,22 @@ def test_the_stitch_is_announced_between_the_last_tile_and_the_mosaic(fm_microsc
         overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
     ).run_and_stitch()
 
-    states = [p.get("state") for p in emitted if p.get("task") == "tileset"]
-    assert "stitching" in states, "the stitch is still silent"
+    phases = [
+        event.phase for event in emitted if isinstance(event, TiledPhaseEvent)
+    ]
+    assert TiledPhase.STITCHING in phases, "the stitch is still silent"
 
     # After every tile, not before one: announced too early it would sit on screen for
     # the whole acquisition, which is the opposite failure.
-    last_tile = max(i for i, s in enumerate(states) if s == "acquiring")
-    assert states.index("stitching") > last_tile
+    last_tile = max(
+        i for i, event in enumerate(emitted)
+        if isinstance(event, FluorescenceTileCompletedEvent)
+    )
+    stitching = next(
+        i for i, event in enumerate(emitted)
+        if isinstance(event, TiledPhaseEvent) and event.phase is TiledPhase.STITCHING
+    )
+    assert stitching > last_tile
 
 
 def test_the_stitch_announcement_carries_no_counts(fm_microscope):
@@ -2274,10 +2297,15 @@ def test_the_stitch_announcement_carries_no_counts(fm_microscope):
         overview_parameters=OverviewParameters(rows=1, cols=2, overlap=0.1),
     ).run_and_stitch()
 
-    stitching = [p for p in emitted if p.get("state") == "stitching"]
+    stitching = [
+        event
+        for event in emitted
+        if isinstance(event, TiledPhaseEvent)
+        and event.phase is TiledPhase.STITCHING
+    ]
     assert len(stitching) == 1
-    assert "current" not in stitching[0]
-    assert "total" not in stitching[0]
+    assert not hasattr(stitching[0], "completed")
+    assert not hasattr(stitching[0], "total")
 
 
 def test_a_run_that_never_reaches_the_stitch_does_not_announce_one(fm_microscope):
@@ -2292,7 +2320,11 @@ def test_a_run_that_never_reaches_the_stitch_does_not_announce_one(fm_microscope
         overview_parameters=OverviewParameters(rows=1, cols=2, overlap=0.1),
     ).run()
 
-    assert "stitching" not in [p.get("state") for p in emitted]
+    assert not any(
+        isinstance(event, TiledPhaseEvent)
+        and event.phase is TiledPhase.STITCHING
+        for event in emitted
+    )
 
 
 def test_the_count_reaches_the_last_tile(fm_microscope):
@@ -2313,9 +2345,36 @@ def test_the_count_reaches_the_last_tile(fm_microscope):
         overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
     ).run()
 
-    counted = [p for p in emitted if "counter" in p]
-    assert counted[0]["counter"] == 0, "the run claimed a tile before taking one"
-    assert counted[-1]["counter"] == counted[-1]["total"] == 4
+    counted = [
+        event
+        for event in emitted
+        if isinstance(event, (FluorescenceTileCountEvent, FluorescenceTileCompletedEvent))
+    ]
+    assert counted[0].completed == 0, "the run claimed a tile before taking one"
+    assert counted[-1].completed == counted[-1].total == 4
+
+
+def test_restoration_announces_that_tile_acquisition_has_ended(fm_microscope):
+    emitted = []
+    fm_microscope.tiled_acquisition_signal.connect(emitted.append)
+    try:
+        _runner(fm_microscope, 1, 2).run()
+    finally:
+        fm_microscope.tiled_acquisition_signal.disconnect(emitted.append)
+
+    restored = [
+        index
+        for index, event in enumerate(emitted)
+        if isinstance(event, TiledPhaseEvent)
+        and event.phase is TiledPhase.TILES_ACQUIRED
+    ]
+    last_tile = max(
+        index
+        for index, event in enumerate(emitted)
+        if isinstance(event, FluorescenceTileCompletedEvent)
+    )
+    assert restored == [len(emitted) - 1]
+    assert restored[0] > last_tile
 
 
 def test_the_announcement_carries_no_progress(fm_microscope):
@@ -2330,16 +2389,13 @@ def test_the_announcement_carries_no_progress(fm_microscope):
         overview_parameters=OverviewParameters(rows=1, cols=2, overlap=0.1),
     ).run()
 
-    announcements = [
-        p
-        for p in emitted
-        if p.get("state") == "acquiring" and p.get("task") == "tileset" and "row" in p
-    ]
+    announcements = [event for event in emitted if isinstance(event, TileStartedEvent)]
     assert announcements, "nothing announces the tile being acquired"
-    for payload in announcements:
-        assert "counter" not in payload
-        assert "estimated_remaining_time" not in payload
-        assert payload["row"] and payload["col"], "it should still say which tile"
+    for event in announcements:
+        assert not hasattr(event, "completed")
+        assert not hasattr(event, "estimated_remaining_seconds")
+        assert 0 <= event.row_index < event.rows
+        assert 0 <= event.column_index < event.columns
 
 
 def test_every_counted_payload_carries_an_estimate(fm_microscope):
@@ -2354,6 +2410,12 @@ def test_every_counted_payload_carries_an_estimate(fm_microscope):
         overview_parameters=OverviewParameters(rows=1, cols=2, overlap=0.1),
     ).run()
 
-    for payload in [p for p in emitted if p.get("counter")]:
-        assert "estimated_remaining_time" in payload
-        assert "estimated_total_time" in payload
+    counted = [
+        event
+        for event in emitted
+        if isinstance(event, (FluorescenceTileCountEvent, FluorescenceTileCompletedEvent))
+    ]
+    assert counted
+    for event in counted:
+        assert event.estimated_remaining_seconds >= 0
+        assert event.estimated_total_seconds >= 0

--- a/tests/test_tiled.py
+++ b/tests/test_tiled.py
@@ -293,6 +293,11 @@ from unittest.mock import MagicMock
 
 from fibsem.cancellation import OperationCancelledError
 from fibsem.imaging.tiled import TiledAcquisitionRunner
+from fibsem.imaging.tiling.progress import (
+    CountedTiledPhaseEvent,
+    CountedTiledTerminalEvent,
+    TiledOutcome,
+)
 
 
 def _runner_with_recorded_signal(monkeypatch, settings=None):
@@ -326,10 +331,10 @@ def test_run_emits_a_terminal_state_on_success(monkeypatch):
 
     runner.run()
 
-    assert emitted[-1]["finished"] is True
-    assert emitted[-1]["outcome"] == "finished"
-    assert emitted[-1]["counter"] == 6
-    assert emitted[-1]["total"] == 6
+    assert isinstance(emitted[-1], CountedTiledTerminalEvent)
+    assert emitted[-1].outcome is TiledOutcome.FINISHED
+    assert emitted[-1].completed == 6
+    assert emitted[-1].total == 6
 
 
 def test_run_emits_a_terminal_state_when_cancelled(monkeypatch):
@@ -344,8 +349,8 @@ def test_run_emits_a_terminal_state_when_cancelled(monkeypatch):
     with pytest.raises(OperationCancelledError):
         runner.run()
 
-    assert emitted[-1]["outcome"] == "cancelled"
-    assert emitted[-1]["counter"] == 2, "partial progress is reported, not reset"
+    assert emitted[-1].outcome is TiledOutcome.CANCELLED
+    assert emitted[-1].completed == 2, "partial progress is reported, not reset"
 
 
 def test_run_emits_a_terminal_state_when_it_fails(monkeypatch):
@@ -360,18 +365,19 @@ def test_run_emits_a_terminal_state_when_it_fails(monkeypatch):
     with pytest.raises(RuntimeError):
         runner.run()
 
-    assert emitted[-1]["outcome"] == "failed"
+    assert emitted[-1].outcome is TiledOutcome.FAILED
 
 
-def test_the_terminal_payload_satisfies_existing_consumers(monkeypatch):
-    """The minimap handler indexes counter/total/msg directly and would raise."""
+def test_the_terminal_event_satisfies_typed_consumers(monkeypatch):
     runner, emitted = _runner_with_recorded_signal(monkeypatch)
     runner._run_tile_loop = lambda: setattr(runner, "_n_tiles_acquired", 6)
 
     runner.run()
 
-    for key in ("msg", "counter", "total"):
-        assert key in emitted[-1], f"consumers index {key!r} without a default"
+    terminal = emitted[-1]
+    assert isinstance(terminal, CountedTiledTerminalEvent)
+    assert terminal.message == "Acquisition Complete"
+    assert terminal.completed == terminal.total == 6
 
 
 # ---------------------------------------------------------------------------
@@ -461,17 +467,18 @@ def test_a_masked_run_does_not_report_a_short_count(tmp_path):
     runner, emitted = _demo_runner(settings, tmp_path)
 
     assert emitted, "the runner said nothing while planning"
-    assert emitted[0]["total"] == 7
+    assert isinstance(emitted[0], CountedTiledPhaseEvent)
+    assert emitted[0].total == 7
 
     runner._n_tiles_acquired = 7
-    runner._emit_terminal("finished", "Acquisition Complete")
-    assert emitted[-1]["counter"] == emitted[-1]["total"] == 7
+    runner._emit_terminal(TiledOutcome.FINISHED, "Acquisition Complete")
+    assert emitted[-1].completed == emitted[-1].total == 7
 
 
 def test_an_unmasked_run_still_reports_the_whole_grid(tmp_path):
     """The other half: no mask must not quietly change what a dense run reports."""
     runner, emitted = _demo_runner(_make_settings(2, 3), tmp_path)
-    assert emitted[0]["total"] == 6
+    assert emitted[0].total == 6
     assert len(runner._ordered) == 6
 
 

--- a/tests/test_tiled_progress_payload.py
+++ b/tests/test_tiled_progress_payload.py
@@ -1,19 +1,10 @@
-"""What the tiled acquisition tells its consumers, per tile.
+"""The typed contract carried by ``tiled_acquisition_signal``."""
 
-`tiled_acquisition_signal` is shared: the FIB/SEM overview places tiles from it, the
-AutoLamella window branches on it, and a progress bar reads its counters. So the shape
-of the payload is a contract between modules that never see each other, and the sort of
-thing that gets edited by someone looking at one consumer.
-
-Deliberately **not** under `tests/ui`. The overview widget is the only consumer of the
-`tile` key today and it is a Qt widget, so this test naturally wanted to live beside it
--- where CI, which installs `.[test]` and so has no PyQt5, would have skipped the whole
-module and never checked the acquisition code at all.
-
-Run directly:
-    python -m pytest tests/test_tiled_progress_payload.py
-"""
 from __future__ import annotations
+
+import ast
+from dataclasses import MISSING, FrozenInstanceError, fields
+from pathlib import Path
 
 import pytest
 
@@ -22,14 +13,24 @@ from fibsem.imaging.tiled import TiledAcquisitionRunner
 from fibsem.imaging.tiling.progress import (
     MODALITY_BEAM,
     MODALITY_FLUORESCENCE,
+    BeamTileCompletedEvent,
+    CountedTiledPhaseEvent,
+    CountedTiledTerminalEvent,
+    FluorescenceTileCompletedEvent,
+    FluorescenceTileCountEvent,
+    TiledAcquisitionEvent,
+    TiledEventType,
+    TiledOutcome,
+    TiledPhase,
+    TiledPhaseEvent,
+    TiledTerminalEvent,
+    TileStartedEvent,
     is_modality,
     modality_of,
 )
-from fibsem.structures import (
-    BeamType,
-    ImageSettings,
-    OverviewAcquisitionSettings,
-)
+from fibsem.structures import BeamType, ImageSettings, OverviewAcquisitionSettings
+
+FIBSEM_ROOT = Path(__import__("fibsem").__file__).parent
 
 
 @pytest.fixture(scope="module")
@@ -39,9 +40,7 @@ def microscope():
 
 
 @pytest.fixture(scope="module")
-def payloads(microscope, tmp_path_factory):
-    """One small run, captured. Module-scoped: the simulator sleeps per tile, and every
-    assertion below reads the same run rather than paying for its own."""
+def events(microscope, tmp_path_factory):
     collected = []
     microscope.tiled_acquisition_signal.connect(collected.append)
     try:
@@ -49,10 +48,15 @@ def payloads(microscope, tmp_path_factory):
             microscope,
             OverviewAcquisitionSettings(
                 image_settings=ImageSettings(
-                    hfw=100e-6, resolution=(64, 64), beam_type=BeamType.ELECTRON,
-                    save=False, path=str(tmp_path_factory.mktemp("tiles")), filename="t",
+                    hfw=100e-6,
+                    resolution=(64, 64),
+                    beam_type=BeamType.ELECTRON,
+                    save=False,
+                    path=str(tmp_path_factory.mktemp("tiles")),
+                    filename="t",
                 ),
-                nrows=1, ncols=2,
+                nrows=1,
+                ncols=2,
             ),
         ).run()
     finally:
@@ -60,100 +64,255 @@ def payloads(microscope, tmp_path_factory):
     return collected
 
 
-def _per_tile(payloads):
-    return [p for p in payloads if p.get("msg") == "Tile Collected"]
+def _per_tile(events):
+    return [event for event in events if isinstance(event, BeamTileCompletedEvent)]
 
 
-def test_every_tile_update_carries_the_keys_its_consumers_index(payloads):
-    """`counter`, `total` and `msg` are what every consumer draws its bar from.
+def _all_event_variants():
+    image = object()
+    common_fm = dict(modality=MODALITY_FLUORESCENCE)
+    return [
+        TiledPhaseEvent(phase=TiledPhase.MOVING),
+        CountedTiledPhaseEvent(
+            phase=TiledPhase.COMPUTING_POSITIONS,
+            completed=0,
+            total=2,
+            message="Computing Tile Positions",
+        ),
+        TileStartedEvent(
+            **common_fm, row_index=0, column_index=0, rows=1, columns=2
+        ),
+        FluorescenceTileCountEvent(
+            **common_fm,
+            completed=0,
+            total=2,
+            estimated_total_seconds=10.0,
+            estimated_remaining_seconds=10.0,
+            elapsed_seconds=0.0,
+        ),
+        BeamTileCompletedEvent(
+            completed=1,
+            total=2,
+            row_index=0,
+            column_index=0,
+            rows=1,
+            columns=2,
+            image=image,
+            preview=image,
+            message="Tile Collected",
+        ),
+        FluorescenceTileCompletedEvent(
+            **common_fm,
+            completed=1,
+            total=2,
+            row_index=0,
+            column_index=0,
+            rows=1,
+            columns=2,
+            image=image,
+            preview_stride=2,
+            estimated_total_seconds=10.0,
+            estimated_remaining_seconds=5.0,
+            elapsed_seconds=5.0,
+        ),
+        TiledTerminalEvent(
+            **common_fm, outcome=TiledOutcome.FINISHED, message="Overview Complete"
+        ),
+        CountedTiledTerminalEvent(
+            outcome=TiledOutcome.FINISHED,
+            message="Acquisition Complete",
+            completed=2,
+            total=2,
+        ),
+    ]
 
-    They used to be *indexed* -- `FibsemMinimapWidget.handle_tile_acquisition_progress`
-    raised on a payload without them, so this test stood between that consumer and a
-    `KeyError` mid-acquisition. Both consumers now read with `.get` and skip the update
-    instead (FIB-402), so the stake is lower: a per-tile payload missing these shows no
-    progress rather than taking the widget out. Still a contract, and still worth
-    asserting -- a run whose progress silently stops moving is its own bug."""
-    updates = _per_tile(payloads)
-    assert len(updates) == 2, "expected one update per tile"
-    for payload in updates:
-        assert {"counter", "total", "msg", "image"} <= set(payload)
-        assert payload["total"] == 2
 
-    # Present is not enough: a counter stuck at its initial value satisfies every
-    # structural check above while every consumer shows "0 / 2" for the whole run.
-    assert [p["counter"] for p in updates] == [1, 2]
+def test_every_variant_is_frozen_and_tagged():
+    variants = _all_event_variants()
+    assert {event.event_type for event in variants} == set(TiledEventType)
+    for event in variants:
+        with pytest.raises(FrozenInstanceError):
+            event.modality = "changed"
 
 
-def test_a_tile_update_carries_a_placeable_preview(payloads):
-    """The key the real-space overview places from.
+@pytest.mark.parametrize(
+    "event_class, required",
+    [
+        (TiledPhaseEvent, {"phase"}),
+        (
+            CountedTiledPhaseEvent,
+            {"phase", "completed", "total", "message"},
+        ),
+        (TileStartedEvent, {"row_index", "column_index", "rows", "columns"}),
+        (
+            FluorescenceTileCountEvent,
+            {
+                "completed",
+                "total",
+                "estimated_total_seconds",
+                "estimated_remaining_seconds",
+                "elapsed_seconds",
+            },
+        ),
+        (
+            BeamTileCompletedEvent,
+            {
+                "completed",
+                "total",
+                "row_index",
+                "column_index",
+                "rows",
+                "columns",
+                "image",
+                "preview",
+                "message",
+            },
+        ),
+        (
+            FluorescenceTileCompletedEvent,
+            {
+                "completed",
+                "total",
+                "row_index",
+                "column_index",
+                "rows",
+                "columns",
+                "image",
+                "preview_stride",
+                "estimated_total_seconds",
+                "estimated_remaining_seconds",
+                "elapsed_seconds",
+            },
+        ),
+        (TiledTerminalEvent, {"outcome", "message"}),
+        (
+            CountedTiledTerminalEvent,
+            {"outcome", "message", "completed", "total"},
+        ),
+    ],
+)
+def test_each_event_shape_declares_its_required_fields(event_class, required):
+    actual = {
+        item.name
+        for item in fields(event_class)
+        if item.init and item.default is MISSING and item.default_factory is MISSING
+    }
+    assert actual == required
+    with pytest.raises(TypeError):
+        event_class()
 
-    `image` alongside it is the full-size buffer as a bare array, which the napari
-    minimap assigns straight into a layer -- so it cannot answer *where* the mosaic
-    is. `preview` is the same mosaic, decimated, carrying the metadata a real-space
-    display needs to place it: position, pixel size, beam and geometry.
-    """
-    for payload in _per_tile(payloads):
-        preview = payload.get("preview")
-        assert preview is not None, "the per-tile update stopped carrying its preview"
+
+def test_phase_and_outcome_vocabularies_are_closed():
+    assert set(TiledPhase) == {
+        TiledPhase.COMPUTING_POSITIONS,
+        TiledPhase.MOVING,
+        TiledPhase.ACQUIRING,
+        TiledPhase.TILES_ACQUIRED,
+        TiledPhase.STITCHING,
+        TiledPhase.SAVING,
+    }
+    assert set(TiledOutcome) == {
+        TiledOutcome.FINISHED,
+        TiledOutcome.CANCELLED,
+        TiledOutcome.FAILED,
+    }
+
+
+def test_modality_defaults_to_beam_and_unknown_values_are_retained():
+    beam = TiledPhaseEvent(phase=TiledPhase.MOVING)
+    future = TiledPhaseEvent(modality="future", phase=TiledPhase.MOVING)
+    assert modality_of(beam) == MODALITY_BEAM
+    assert is_modality(beam, MODALITY_BEAM)
+    assert modality_of(future) == "future"
+    assert not is_modality(future, MODALITY_BEAM)
+
+
+def test_every_beam_emit_is_a_typed_beam_event(events):
+    assert events
+    assert all(modality_of(event) == MODALITY_BEAM for event in events)
+    assert isinstance(events[0], CountedTiledPhaseEvent)
+    assert events[0].phase is TiledPhase.COMPUTING_POSITIONS
+    assert isinstance(events[-1], CountedTiledTerminalEvent)
+    assert events[-1].outcome is TiledOutcome.FINISHED
+
+
+def test_every_completed_tile_has_the_full_contract(events):
+    updates = _per_tile(events)
+    assert len(updates) == 2
+    assert [event.completed for event in updates] == [1, 2]
+    assert all(event.total == 2 for event in updates)
+    assert all(event.message == "Tile Collected" for event in updates)
+    assert [(event.row_index, event.column_index) for event in updates] == [(0, 0), (0, 1)]
+
+
+def test_a_tile_update_carries_a_placeable_preview(events):
+    for event in _per_tile(events):
+        preview = event.preview
         assert preview.metadata.stage_position is not None
-        assert preview.metadata.pixel_size.x, "a mosaic with no scale cannot be placed"
+        assert preview.metadata.pixel_size.x
         assert preview.metadata.hardware_geometry is not None
         assert preview.metadata.image_settings.beam_type is not None
 
 
-def test_the_preview_fills_as_the_run_goes(payloads):
-    """A preview that never changed would satisfy every structural check above while
-    showing the same empty mosaic for the length of the run."""
-    filled = [
-        int((p["preview"].data > 0).sum()) for p in _per_tile(payloads)
-    ]
-    assert filled[-1] > filled[0], f"the preview did not fill: {filled}"
+def test_the_preview_fills_without_changing_shape(events):
+    previews = [event.preview for event in _per_tile(events)]
+    filled = [int((preview.data > 0).sum()) for preview in previews]
+    assert filled[-1] > filled[0]
+    assert len({preview.data.shape for preview in previews}) == 1
 
 
-def test_the_preview_describes_the_whole_grid_from_the_first_tile(payloads):
-    """It is the mosaic, not the tile: its shape is the finished grid's from the
-    start, so a display places it once rather than resizing it on every update."""
-    shapes = {p["preview"].data.shape for p in _per_tile(payloads)}
-    assert len(shapes) == 1, f"the preview changed shape mid-run: {shapes}"
+def test_the_signal_declaration_names_the_event_contract():
+    from fibsem.microscope import FibsemMicroscope
+
+    source = (FIBSEM_ROOT / "microscope.py").read_text(encoding="utf-8")
+    assert "tiled_acquisition_signal = Signal(TiledAcquisitionEvent)" in source
+    parameter = next(iter(FibsemMicroscope.tiled_acquisition_signal.signature.parameters.values()))
+    assert parameter.annotation is TiledAcquisitionEvent
 
 
-def test_the_run_ends_with_a_terminal_update(payloads):
-    """Consumers branch on `finished` to stop showing progress; without it the bar just
-    stops moving and nothing says whether the run succeeded."""
-    terminal = [p for p in payloads if p.get("finished")]
-    assert terminal, "no terminal update was emitted"
-    assert terminal[-1].get("outcome") == "finished"
+def test_producers_no_longer_emit_dicts_or_the_vestigial_task_tag():
+    for relative in (
+        "imaging/tiled.py",
+        "fm/acquisition.py",
+        "ui/fm/widgets/fm_overview_widget.py",
+    ):
+        source = (FIBSEM_ROOT / relative).read_text(encoding="utf-8")
+        assert '"task": "tileset"' not in source
+        tree = ast.parse(source)
+        for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+            function = call.func
+            if not (
+                isinstance(function, ast.Attribute)
+                and function.attr == "emit"
+                and isinstance(function.value, ast.Attribute)
+                and function.value.attr == "tiled_acquisition_signal"
+            ):
+                continue
+            assert not call.args or not isinstance(call.args[0], ast.Dict), relative
 
 
-def test_every_payload_says_which_modality_produced_it(payloads):
-    """The discriminator this signal never had.
-
-    Consumers used to work out what they had received from which keys were present,
-    which was survivable while `imaging/tiled.py` was the only emitter. It is not once a
-    second producer reports here: two consumers hand the payload's mosaic straight to a
-    *beam* canvas, and the fluorescence preview is keyed `image` already — deliberately,
-    to match this signal (FIB-725).
-
-    Asserted on every payload, not just the per-tile ones: a terminal update that could
-    not say whose run had finished would leave a consumer unable to decide whether to
-    clear its own progress.
-    """
-    assert payloads, "the run emitted nothing"
-    for payload in payloads:
-        assert payload.get("modality") == MODALITY_BEAM, payload.get("msg")
-
-
-def test_an_unlabelled_payload_reads_as_a_beam_run():
-    """`modality` is new, so a producer that predates it — including anything outside
-    this repository subscribing to a public signal — emits without it. Absent means
-    beam, which is what this signal carried for its whole life. A consumer written as
-    `payload.get("modality") == MODALITY_BEAM` would silently drop all of it."""
-    assert modality_of({}) == MODALITY_BEAM
-    assert is_modality({"counter": 1, "total": 2}, MODALITY_BEAM)
-    assert not is_modality({}, MODALITY_FLUORESCENCE)
-
-
-def test_a_fluorescence_payload_is_not_mistaken_for_a_beam_one():
-    payload = {"modality": MODALITY_FLUORESCENCE, "counter": 1, "total": 2}
-    assert is_modality(payload, MODALITY_FLUORESCENCE)
-    assert not is_modality(payload, MODALITY_BEAM)
+def test_tiled_consumers_use_typed_attributes_not_mapping_access():
+    consumers = {
+        "ui/FibsemMinimapWidget.py": "handle_tile_acquisition_progress",
+        "ui/widgets/overview_widget.py": "_apply_progress",
+        "ui/fm/widgets/fm_overview_widget.py": "_apply_tile_progress",
+        "applications/autolamella/ui/AutoLamellaMainUI.py": (
+            "_on_tile_acquisition_progress"
+        ),
+    }
+    for relative, method_name in consumers.items():
+        tree = ast.parse((FIBSEM_ROOT / relative).read_text(encoding="utf-8"))
+        method = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == method_name
+        )
+        assert not any(isinstance(node, ast.Subscript) for node in ast.walk(method))
+        assert not any(
+            isinstance(node, ast.Attribute)
+            and node.attr == "get"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "event"
+            for node in ast.walk(method)
+        )

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -20,11 +20,23 @@ pytest.importorskip("PyQt5")
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtWidgets import QApplication, QLabel
 
+from fibsem.cancellation import OperationCancelledError
 from fibsem.fm.structures import (
     AutoFocusMode,
     ChannelSettings,
     OverviewParameters,
     ZParameters,
+)
+from fibsem.imaging.tiling.progress import (
+    MODALITY_FLUORESCENCE,
+    BeamTileCompletedEvent,
+    FluorescenceTileCompletedEvent,
+    FluorescenceTileCountEvent,
+    TiledOutcome,
+    TiledPhase,
+    TiledPhaseEvent,
+    TiledTerminalEvent,
+    TileStartedEvent,
 )
 from fibsem.structures import CameraImageTransform, TileOrderStrategy
 from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
@@ -334,18 +346,51 @@ def _bar(widget):
     return widget._bar
 
 
+def _fm_count(
+    completed,
+    total,
+    remaining=0.0,
+    estimated_total=0.0,
+    modality=MODALITY_FLUORESCENCE,
+):
+    return FluorescenceTileCountEvent(
+        modality=modality,
+        completed=completed,
+        total=total,
+        estimated_total_seconds=estimated_total,
+        estimated_remaining_seconds=remaining,
+        elapsed_seconds=max(estimated_total - remaining, 0.0),
+    )
+
+
+def _fm_completed(
+    completed,
+    total,
+    remaining=0.0,
+    estimated_total=0.0,
+    image=None,
+    preview_stride=1,
+):
+    return FluorescenceTileCompletedEvent(
+        modality=MODALITY_FLUORESCENCE,
+        completed=completed,
+        total=total,
+        row_index=0,
+        column_index=max(completed - 1, 0),
+        rows=1,
+        columns=total,
+        image=image if image is not None else np.zeros((1, 2, 2), dtype=np.uint8),
+        preview_stride=preview_stride,
+        estimated_total_seconds=estimated_total,
+        estimated_remaining_seconds=remaining,
+        elapsed_seconds=max(estimated_total - remaining, 0.0),
+    )
+
+
 def test_a_tileset_payload_moves_only_the_tile_bar(qapp):
     router = _Router()
 
-    router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 4,
-            "total": 9,
-        }
-    )
+    router._apply_tile_progress(_fm_count(4, 9))
 
     # value/maximum directly, not a percentage -- the widget counts items.
     assert (
@@ -412,15 +457,7 @@ def test_a_completed_tile_leaves_the_detail_bar_alone(qapp):
         }
     )
 
-    router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "tile",
-            "task": "tileset",
-            "current": 1,
-            "total": 9,
-        }
-    )
+    router._apply_tile_progress(_fm_completed(1, 9))
 
     assert router.progress_tile_detail.isVisible()
 
@@ -450,13 +487,27 @@ def test_a_beam_payload_moves_neither_bar(qapp):
     router = _Router()
 
     router._apply_tile_progress(
-        {
-            "modality": "beam",
-            "counter": 8,
-            "total": 9,
-            "msg": "Tile Collected",
-        }
+        BeamTileCompletedEvent(
+            completed=8,
+            total=9,
+            row_index=0,
+            column_index=7,
+            rows=1,
+            columns=9,
+            image=object(),
+            preview=object(),
+            message="Tile Collected",
+        )
     )
+
+    assert not router.progress_tiles.isVisible()
+    assert not router.progress_tile_detail.isVisible()
+
+
+def test_an_unknown_modality_moves_neither_bar(qapp):
+    router = _Router()
+
+    router._apply_tile_progress(_fm_count(2, 9, modality="future"))
 
     assert not router.progress_tiles.isVisible()
     assert not router.progress_tile_detail.isVisible()
@@ -465,17 +516,7 @@ def test_a_beam_payload_moves_neither_bar(qapp):
 def test_the_estimate_is_shown_when_the_payload_carries_one(qapp):
     router = _Router()
 
-    router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 2,
-            "total": 9,
-            "estimated_remaining_time": 134.0,
-            "estimated_total_time": 180.0,
-        }
-    )
+    router._apply_tile_progress(_fm_count(2, 9, 134.0, 180.0))
 
     assert "remaining" in _bar(router.progress_tiles).format()
 
@@ -487,18 +528,12 @@ def test_a_stage_move_does_not_fill_the_bar(qapp):
     goes to the status label.
     """
     router = _Router()
-    router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 3,
-            "total": 9,
-        }
-    )
+    router._apply_tile_progress(_fm_count(3, 9))
 
     router._apply_tile_progress(
-        {"modality": "fluorescence", "state": "moving", "task": "tileset"}
+        TiledPhaseEvent(
+            modality=MODALITY_FLUORESCENCE, phase=TiledPhase.MOVING
+        )
     )
 
     assert (
@@ -509,13 +544,13 @@ def test_a_stage_move_does_not_fill_the_bar(qapp):
 
 
 @pytest.mark.parametrize(
-    "state, label",
+    "phase, label",
     [
-        ("stitching", "Stitching tiles…"),
-        ("saving", "Saving overview…"),
+        (TiledPhase.STITCHING, "Stitching tiles…"),
+        (TiledPhase.SAVING, "Saving overview…"),
     ],
 )
-def test_the_end_of_a_run_is_not_silent(qapp, state, label):
+def test_the_end_of_a_run_is_not_silent(qapp, phase, label):
     """Between the last tile and a finished run the app builds and writes a mosaic —
     ~2.1 s per GB, about 7 s for a 5x5 at ARCTIS resolution in four channels. That was
     reported as nothing at all, so a long run appeared to hang just as it completed.
@@ -526,18 +561,10 @@ def test_the_end_of_a_run_is_not_silent(qapp, state, label):
     impression these phases exist to correct.
     """
     router = _Router()
-    router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 9,
-            "total": 9,
-        }
-    )
+    router._apply_tile_progress(_fm_count(9, 9))
 
     router._apply_tile_progress(
-        {"modality": "fluorescence", "state": state, "task": "tileset"}
+        TiledPhaseEvent(modality=MODALITY_FLUORESCENCE, phase=phase)
     )
 
     assert router.status.text() == label
@@ -551,19 +578,13 @@ def test_a_phase_label_is_cleared_by_the_next_tile(qapp):
     """Otherwise "Stitching tiles…" would still be on screen through the next run."""
     router = _Router()
     router._apply_tile_progress(
-        {"modality": "fluorescence", "state": "saving", "task": "tileset"}
+        TiledPhaseEvent(
+            modality=MODALITY_FLUORESCENCE, phase=TiledPhase.SAVING
+        )
     )
     assert router.status.text() == "Saving overview…"
 
-    router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 1,
-            "total": 9,
-        }
-    )
+    router._apply_tile_progress(_fm_count(1, 9))
     assert router.status.text() == ""
 
 
@@ -1001,7 +1022,7 @@ def test_the_first_preview_frame_lands_at_the_right_scale(qapp, overview_widget)
     tile_ps = widget.fm.camera.pixel_size[0]
     preview = np.zeros((1, 64, 128), dtype=np.uint8)  # (C, H, W), already decimated
 
-    widget._show_preview({"image": preview, "preview_stride": stride})
+    widget._show_preview(_fm_completed(1, 1, image=preview, preview_stride=stride))
     qapp.processEvents()
 
     placed = widget.canvas.canvas._placed
@@ -2459,7 +2480,7 @@ def test_a_finished_run_keeps_its_outcome_on_screen(qapp):
     qapp.processEvents()
     widget._set_running(True)
 
-    widget._finish("overview-failed", "nope")
+    widget._finish(TiledOutcome.FAILED, "nope")
     qapp.processEvents()
 
     assert widget.progress_tiles.isVisible()
@@ -4482,7 +4503,7 @@ def test_the_live_preview_never_becomes_a_record(qapp, blank_canvas):
     import numpy as np
 
     widget._show_preview(
-        {"image": np.zeros((4, 4), dtype=np.uint16), "preview_stride": 1}
+        _fm_completed(1, 1, image=np.zeros((4, 4), dtype=np.uint16))
     )
     qapp.processEvents()
 
@@ -5215,11 +5236,52 @@ def test_the_worker_announces_the_save_before_it_writes(
             saved,
         )
 
-    states = [p.get("state") for p in seen if p.get("task") == "tileset"]
-    assert "saving" in states, "the write is still silent"
-    assert states.index("saving") < states.index("overview-finished"), (
+    saving = next(
+        i for i, event in enumerate(seen)
+        if isinstance(event, TiledPhaseEvent) and event.phase is TiledPhase.SAVING
+    )
+    finished = next(
+        i for i, event in enumerate(seen)
+        if isinstance(event, TiledTerminalEvent)
+        and event.outcome is TiledOutcome.FINISHED
+    )
+    assert saving < finished, (
         "the save was announced after it had already happened"
     )
+
+
+@pytest.mark.parametrize(
+    "exception, outcome, error",
+    [
+        (
+            OperationCancelledError("stopped"),
+            TiledOutcome.CANCELLED,
+            None,
+        ),
+        (RuntimeError("camera failed"), TiledOutcome.FAILED, "camera failed"),
+    ],
+)
+def test_the_worker_emits_typed_cancel_and_failure_terminals(
+    overview_widget, exception, outcome, error
+):
+    class _StubRunner:
+        def run_and_stitch(self):
+            raise exception
+
+    widget = overview_widget
+    seen = []
+    widget.microscope.tiled_acquisition_signal.connect(seen.append)
+    original_runner = widget._runner
+    try:
+        widget._runner = _StubRunner()
+        widget._acquire_worker()
+    finally:
+        widget._runner = original_runner
+        widget.microscope.tiled_acquisition_signal.disconnect(seen.append)
+
+    terminal = next(event for event in seen if isinstance(event, TiledTerminalEvent))
+    assert terminal.outcome is outcome
+    assert terminal.error == error
 
 
 def test_a_tileset_payload_reaches_the_real_widget(qapp, overview_widget):
@@ -5232,15 +5294,7 @@ def test_a_tileset_payload_reaches_the_real_widget(qapp, overview_widget):
     test noticing.
     """
     widget = overview_widget
-    widget.microscope.tiled_acquisition_signal.emit(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 4,
-            "total": 9,
-        }
-    )
+    widget.microscope.tiled_acquisition_signal.emit(_fm_count(4, 9))
     qapp.processEvents()
 
     assert "4 / 9" in _bar(widget.progress_tiles).format()
@@ -5298,26 +5352,22 @@ def test_a_beam_run_does_not_drive_the_fluorescence_bar(qapp, overview_widget):
     a `task` key would be a reasonable thing for it to do.
     """
     widget = overview_widget
-    widget.microscope.tiled_acquisition_signal.emit(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 4,
-            "total": 9,
-        }
-    )
+    widget.microscope.tiled_acquisition_signal.emit(_fm_count(4, 9))
     qapp.processEvents()
     before = _bar(widget.progress_tiles).format()
 
     widget.microscope.tiled_acquisition_signal.emit(
-        {
-            "modality": "beam",
-            "task": "tileset",
-            "counter": 8,
-            "total": 9,
-            "msg": "Tile Collected",
-        }
+        BeamTileCompletedEvent(
+            completed=8,
+            total=9,
+            row_index=0,
+            column_index=7,
+            rows=1,
+            columns=9,
+            image=object(),
+            preview=object(),
+            message="Tile Collected",
+        )
     )
     qapp.processEvents()
 
@@ -5339,17 +5389,7 @@ def test_the_announcement_payload_does_not_redraw_the_tile_bar(qapp):
     counts at all, which settles both.
     """
     router = _Router()
-    router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "tile",
-            "task": "tileset",
-            "counter": 2,
-            "total": 4,
-            "estimated_remaining_time": 18.0,
-            "estimated_total_time": 24.0,
-        }
-    )
+    router._apply_tile_progress(_fm_completed(2, 4, 18.0, 24.0))
     before = (
         _bar(router.progress_tiles).value(),
         _bar(router.progress_tiles).maximum(),
@@ -5357,15 +5397,13 @@ def test_the_announcement_payload_does_not_redraw_the_tile_bar(qapp):
     )
 
     router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "row": 2,
-            "col": 3,
-            "total_rows": 2,
-            "total_cols": 2,
-        }
+        TileStartedEvent(
+            modality=MODALITY_FLUORESCENCE,
+            row_index=1,
+            column_index=2,
+            rows=2,
+            columns=3,
+        )
     )
 
     after = (
@@ -5383,16 +5421,10 @@ def test_the_preview_is_still_shown(qapp):
     router = _Router()
     router._show_preview = shown.append
 
-    payload = {
-        "modality": "fluorescence",
-        "state": "tile",
-        "task": "tileset",
-        "counter": 2,
-        "total": 4,
-    }
-    router._apply_tile_progress(payload)
+    event = _fm_completed(2, 4)
+    router._apply_tile_progress(event)
 
-    assert shown == [payload]
+    assert shown == [event]
 
 
 # ── a grid beyond the stage's travel (FIB-741) ───────────────────────────

--- a/tests/ui/test_minimap_progress_payload_safety.py
+++ b/tests/ui/test_minimap_progress_payload_safety.py
@@ -1,19 +1,5 @@
-"""The napari minimap survives a progress payload it did not expect.
+"""Typed tiled events consumed by the legacy napari beam minimap."""
 
-`tiled_acquisition_signal` has no discriminator: a consumer works out what it received
-from which keys are present. This handler indexed `counter`, `total` and `msg` directly,
-so any payload shape omitting one was a `KeyError` inside a Qt slot, mid-acquisition —
-and `total` is a divisor, so a payload reporting nothing to do took the bar out with a
-`ZeroDivisionError` instead (FIB-402).
-
-That was latent while `imaging/tiled.py` was the signal's only emitter. It stops being
-latent the moment a second producer emits there, which is what FIB-725 proposes.
-
-The whole widget cannot be built here — it constructs a `napari.Viewer`, which segfaults
-under the offscreen platform — so the handler is borrowed onto a host carrying the four
-attributes it touches. The progress bar is a real `QProgressBar`, which is the part
-under test.
-"""
 from __future__ import annotations
 
 import os
@@ -25,6 +11,29 @@ import pytest
 pytest.importorskip("PyQt5")
 
 from PyQt5.QtWidgets import QProgressBar  # noqa: E402
+
+from fibsem.imaging.tiling.progress import (  # noqa: E402
+    MODALITY_FLUORESCENCE,
+    BeamTileCompletedEvent,
+    CountedTiledPhaseEvent,
+    TiledPhase,
+)
+
+
+def _tile(**overrides):
+    values = dict(
+        completed=3,
+        total=9,
+        row_index=0,
+        column_index=2,
+        rows=1,
+        columns=9,
+        image=object(),
+        preview=object(),
+        message="Tile Collected",
+    )
+    values.update(overrides)
+    return BeamTileCompletedEvent(**values)
 
 
 @pytest.fixture
@@ -50,78 +59,49 @@ def handler(qapp):
     host.progressBar_acquisition.deleteLater()
 
 
-def test_a_normal_tile_update_still_draws_the_bar(handler):
-    handler.handle_tile_acquisition_progress(
-        {"counter": 3, "total": 9, "msg": "Tile Collected"}
-    )
+def test_a_normal_tile_update_draws_the_existing_wording(handler):
+    event = _tile()
+    handler.handle_tile_acquisition_progress(event)
+
     assert handler._tiles_acquired == 3
     assert handler._tile_total_count == 9
     assert handler.progressBar_acquisition.value() == 33
     assert "Tile Collected" in handler.progressBar_acquisition.format()
     assert "3/9 tiles" in handler.progressBar_acquisition.format()
+    assert handler.shown == [event.image]
 
 
-@pytest.mark.parametrize(
-    "payload",
-    [
-        {},
-        {"total": 9, "msg": "Tile Collected"},          # no counter
-        {"counter": 3, "msg": "Tile Collected"},        # no total
-        {"counter": 3, "total": 9},                     # no msg
-        {"counter": 0, "total": 0, "msg": "Nothing"},   # nothing to do
-        {"current": 3, "total": 9, "task": "tileset"},  # the fluorescence spelling
-    ],
-)
-def test_an_unexpected_payload_does_not_take_the_bar_out(handler, payload):
-    """Each of these was a crash: the first four a `KeyError`, the fifth a
-    `ZeroDivisionError`, and the last is what a fluorescence run would send if it
-    emitted here — the case that turns all of this from latent into live."""
-    handler.handle_tile_acquisition_progress(payload)
-
-
-def test_a_payload_with_no_counts_leaves_the_last_progress_standing(handler):
-    """Not reset to zero. The run has not gone backwards, and the terminal payload from
-    a cancelled run carries no counts — so zeroing here would end every cancelled run by
-    claiming it never started."""
+def test_a_counted_phase_leaves_the_last_preview_standing(handler):
+    event = _tile(completed=4)
+    handler.handle_tile_acquisition_progress(event)
     handler.handle_tile_acquisition_progress(
-        {"counter": 4, "total": 9, "msg": "Tile Collected"}
+        CountedTiledPhaseEvent(
+            phase=TiledPhase.STITCHING,
+            completed=9,
+            total=9,
+            message="Stitching Tiles",
+        )
     )
-    before = handler.progressBar_acquisition.value()
-    handler.handle_tile_acquisition_progress({"msg": "Stitching Tiles"})
-    assert handler.progressBar_acquisition.value() == before
-    assert handler._tiles_acquired == 4
+
+    assert handler.progressBar_acquisition.value() == 100
+    assert "Stitching Tiles" in handler.progressBar_acquisition.format()
+    assert handler.shown == [event.image]
 
 
-def test_a_fluorescence_run_is_not_drawn_into_the_beam_minimap(handler):
-    """This tab drives a *beam* overview and assigns the payload's mosaic straight into
-    its napari layer. The fluorescence preview is keyed `image` already — deliberately,
-    to match this signal — so once a fluorescence run reports here, nothing but the
-    modality stops it being painted into the beam minimap (FIB-725)."""
-    from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
-
-    sentinel = object()
-    handler.handle_tile_acquisition_progress({
-        "modality": MODALITY_FLUORESCENCE,
-        "counter": 3, "total": 9, "msg": "Tile Collected", "image": sentinel,
-    })
-    assert handler.shown == [], "a fluorescence mosaic was drawn into the beam minimap"
-    assert handler._tiles_acquired == 0, "a fluorescence run moved the beam tile count"
+def test_a_fluorescence_event_is_not_drawn_into_the_beam_minimap(handler):
+    event = _tile(modality=MODALITY_FLUORESCENCE)
+    handler.handle_tile_acquisition_progress(event)
+    assert handler.shown == []
+    assert handler._tiles_acquired == 0
 
 
-def test_a_beam_run_is_still_drawn(handler):
-    """The filter must not cost the thing it guards."""
-    sentinel = object()
-    handler.handle_tile_acquisition_progress({
-        "modality": "beam",
-        "counter": 3, "total": 9, "msg": "Tile Collected", "image": sentinel,
-    })
-    assert handler.shown == [sentinel]
-    assert handler._tiles_acquired == 3
+def test_an_unknown_modality_is_safely_ignored(handler):
+    handler.handle_tile_acquisition_progress(_tile(modality="future"))
+    assert handler.shown == []
+    assert handler._tiles_acquired == 0
 
 
-def test_a_preview_is_still_shown_when_the_counts_are_missing(handler):
-    """The image and the counters are independent: dropping the bar update must not
-    drop the picture with it."""
-    sentinel = object()
-    handler.handle_tile_acquisition_progress({"image": sentinel})
-    assert handler.shown == [sentinel]
+def test_default_modality_remains_beam(handler):
+    event = _tile()
+    handler.handle_tile_acquisition_progress(event)
+    assert handler.shown == [event.image]

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -35,6 +35,11 @@ from PyQt5.QtWidgets import QApplication, QDialog  # noqa: E402
 
 from fibsem import utils  # noqa: E402
 from fibsem.imaging import tiled  # noqa: E402
+from fibsem.imaging.tiling.progress import (  # noqa: E402
+    MODALITY_FLUORESCENCE,
+    BeamTileCompletedEvent,
+    FluorescenceTileCountEvent,
+)
 from fibsem.structures import (  # noqa: E402
     BeamType,
     FibsemImage,
@@ -118,6 +123,21 @@ def _tile(microscope, position: FibsemStagePosition, shape=(64, 64), hfw=100e-6)
     image.metadata.system_info = microscope.system.info
     image.metadata.hardware_geometry = microscope.hardware_geometry()
     return image
+
+
+def _beam_progress(completed, total, preview=None, modality="beam"):
+    return BeamTileCompletedEvent(
+        modality=modality,
+        completed=completed,
+        total=total,
+        row_index=0,
+        column_index=max(completed - 1, 0),
+        rows=1,
+        columns=total,
+        image=object(),
+        preview=preview if preview is not None else object(),
+        message="Tile Collected",
+    )
 
 
 def _at(base: FibsemStagePosition, dx: float = 0.0, dy: float = 0.0, name=None):
@@ -731,10 +751,9 @@ class TestThingsOnlyRunningItFound:
         assert widget.overview_list._list.count() == 1
 
         for i in (1, 2, 3):
-            widget._apply_progress({
-                "msg": "Tile Collected", "counter": i, "total": 3,
-                "preview": _tile(microscope, _at(base)),
-            })
+            widget._apply_progress(
+                _beam_progress(i, 3, _tile(microscope, _at(base)))
+            )
             row = widget.overview_list._rows["run"]
             assert row.detail_label.text().startswith(f"{i} tile"), (
                 f"after {i} tile(s) the row still reads {row.detail_label.text()!r}"
@@ -750,7 +769,7 @@ class TestThingsOnlyRunningItFound:
         widget._set_running(True)
         assert widget.label_status.text() == "", "a stale outcome survived into the run"
 
-        widget._apply_progress({"counter": 2, "total": 9, "msg": "Tile Collected"})
+        widget._apply_progress(_beam_progress(2, 9))
         assert widget.label_status.text() == "", "the label competed with the bar"
 
         widget._on_finished({})
@@ -1985,10 +2004,7 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
     def _run_a_tile(self, widget, microscope, position):
         """One tile of a run: the stage arrives, then a preview lands."""
         widget._on_stage_moved(position)
-        widget._apply_progress({
-            "msg": "Tile Collected", "counter": 1, "total": 3,
-            "preview": _tile(microscope, position),
-        })
+        widget._apply_progress(_beam_progress(1, 3, _tile(microscope, position)))
 
     def test_the_planned_grid_does_not_follow_the_stage(self, widget, microscope):
         from fibsem.ui.widgets.overview_widget import OverviewRecord
@@ -2082,10 +2098,9 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         # The stage sets off, and the first preview arrives from a tile away -- which is
         # the redraw, because it is what un-provisions the origin.
         widget._on_stage_moved(_at(base, dx=300e-6, dy=300e-6))
-        widget._apply_progress({
-            "msg": "Tile Collected", "counter": 1, "total": 9,
-            "preview": _tile(microscope, _at(base)),
-        })
+        widget._apply_progress(
+            _beam_progress(1, 9, _tile(microscope, _at(base)))
+        )
 
         assert widget.tile_grid_overlay._anchor() == pytest.approx(anchored_at), (
             "the plan was redrawn around the tile being acquired, not around the run"
@@ -2206,10 +2221,9 @@ class TestARunDoesNotReFrameTheCanvas:
         widget._active_record = "run"
         widget._set_running(True)
         for counter in range(1, tiles + 1):
-            widget._apply_progress({
-                "msg": "Tile Collected", "counter": counter, "total": tiles,
-                "preview": _tile(microscope, _at(base)),
-            })
+            widget._apply_progress(
+                _beam_progress(counter, tiles, _tile(microscope, _at(base)))
+            )
         widget._mosaic = _tile(microscope, _at(base), shape=(128, 128))
         widget._on_finished({})
 
@@ -4007,26 +4021,30 @@ class TestItOnlyDrawsItsOwnRuns:
     """
 
     def test_a_fluorescence_run_is_ignored(self, widget):
-        from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
-
         widget._tiles_acquired = 0
-        widget._apply_progress({
-            "modality": MODALITY_FLUORESCENCE,
-            "counter": 7, "total": 9, "msg": "Tile Collected",
-        })
+        widget._apply_progress(
+            FluorescenceTileCountEvent(
+                modality=MODALITY_FLUORESCENCE,
+                completed=7,
+                total=9,
+                estimated_total_seconds=9.0,
+                estimated_remaining_seconds=2.0,
+                elapsed_seconds=7.0,
+            )
+        )
         assert widget._tiles_acquired == 0, "a fluorescence run moved this tab's count"
 
     def test_a_beam_run_is_still_drawn(self, widget):
         widget._tiles_acquired = 0
-        widget._apply_progress({
-            "modality": "beam",
-            "counter": 7, "total": 9, "msg": "Tile Collected",
-        })
+        widget._apply_progress(_beam_progress(7, 9))
         assert widget._tiles_acquired == 7
 
-    def test_an_unlabelled_run_is_still_drawn(self, widget):
-        """Anything predating the key — including a producer outside this repository
-        subscribing to a public signal — must keep working."""
+    def test_the_default_modality_is_still_drawn(self, widget):
         widget._tiles_acquired = 0
-        widget._apply_progress({"counter": 7, "total": 9, "msg": "Tile Collected"})
+        widget._apply_progress(_beam_progress(7, 9))
         assert widget._tiles_acquired == 7
+
+    def test_an_unknown_modality_is_ignored(self, widget):
+        widget._tiles_acquired = 0
+        widget._apply_progress(_beam_progress(7, 9, modality="future"))
+        assert widget._tiles_acquired == 0

--- a/tests/ui/test_status_bar_tile_outcome.py
+++ b/tests/ui/test_status_bar_tile_outcome.py
@@ -20,6 +20,15 @@ import pytest
 
 pytest.importorskip("PyQt5")
 
+from fibsem.imaging.tiling.progress import (  # noqa: E402
+    MODALITY_FLUORESCENCE,
+    BeamTileCompletedEvent,
+    FluorescenceTileCountEvent,
+    TiledOutcome,
+    TiledPhase,
+    TiledPhaseEvent,
+    TiledTerminalEvent,
+)
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget  # noqa: E402
 
 RED = "#99121F"
@@ -53,19 +62,22 @@ def _is_red(host) -> bool:
     return RED in host.progress_widget._bar.styleSheet()
 
 
-def _terminal(outcome: str, msg: str) -> dict:
-    """What `TiledAcquisitionRunner._emit_terminal` sends for each outcome."""
-    return {"msg": msg, "counter": 3, "total": 9, "finished": True, "outcome": outcome}
+def _terminal(outcome: TiledOutcome, message: str):
+    return TiledTerminalEvent(outcome=outcome, message=message)
 
 
 def test_a_completed_run_says_done(status):
-    status._on_tile_acquisition_progress(_terminal("finished", "Acquisition Complete"))
+    status._on_tile_acquisition_progress(
+        _terminal(TiledOutcome.FINISHED, "Acquisition Complete")
+    )
     assert "Done" in _text(status)
     assert not _is_red(status)
 
 
 def test_a_cancelled_run_does_not_claim_to_have_finished(status):
-    status._on_tile_acquisition_progress(_terminal("cancelled", "Acquisition Cancelled"))
+    status._on_tile_acquisition_progress(
+        _terminal(TiledOutcome.CANCELLED, "Acquisition Cancelled")
+    )
     assert "Cancelled" in _text(status)
     assert "Done" not in _text(status)
 
@@ -73,21 +85,71 @@ def test_a_cancelled_run_does_not_claim_to_have_finished(status):
 def test_a_cancelled_run_is_not_painted_as_a_failure(status):
     """A cancel is someone getting what they asked for, so the bar does not go red —
     the distinction FIB-375 drew between a completed operation and a failed one."""
-    status._on_tile_acquisition_progress(_terminal("cancelled", "Acquisition Cancelled"))
+    status._on_tile_acquisition_progress(
+        _terminal(TiledOutcome.CANCELLED, "Acquisition Cancelled")
+    )
     assert not _is_red(status)
 
 
 def test_a_failed_run_is_red_and_says_so(status):
-    status._on_tile_acquisition_progress(_terminal("failed", "Acquisition Failed"))
+    status._on_tile_acquisition_progress(
+        _terminal(TiledOutcome.FAILED, "Acquisition Failed")
+    )
     assert "Failed" in _text(status)
     assert _is_red(status)
 
 
-def test_a_producer_that_reports_no_outcome_still_says_done(status):
-    """The napari minimap drives the same runner and the same signal, and older payloads
-    carry no `outcome` at all. Absent, the bar reads as it always did."""
+def test_a_beam_count_uses_its_existing_message(status):
     status._on_tile_acquisition_progress(
-        {"msg": "Done", "counter": 9, "total": 9, "finished": True}
+        BeamTileCompletedEvent(
+            completed=3,
+            total=9,
+            row_index=0,
+            column_index=2,
+            rows=1,
+            columns=9,
+            image=object(),
+            preview=object(),
+            message="Tile Collected",
+        )
     )
-    assert "Done" in _text(status)
-    assert not _is_red(status)
+    assert "Tile Collected" in _text(status)
+
+
+def test_a_fluorescence_count_uses_the_existing_fallback(status):
+    status._on_tile_acquisition_progress(
+        FluorescenceTileCountEvent(
+            modality=MODALITY_FLUORESCENCE,
+            completed=3,
+            total=9,
+            estimated_total_seconds=9.0,
+            estimated_remaining_seconds=6.0,
+            elapsed_seconds=3.0,
+        )
+    )
+    assert "Collecting tiles" in _text(status)
+
+
+def test_an_unknown_modality_is_still_shown_by_the_application_status(status):
+    status._on_tile_acquisition_progress(
+        FluorescenceTileCountEvent(
+            modality="future",
+            completed=3,
+            total=9,
+            estimated_total_seconds=9.0,
+            estimated_remaining_seconds=6.0,
+            elapsed_seconds=3.0,
+        )
+    )
+    assert "Collecting tiles" in _text(status)
+
+
+def test_a_countless_phase_does_not_reset_the_bar(status):
+    test_a_fluorescence_count_uses_the_existing_fallback(status)
+    before = status.progress_widget._bar.value()
+    status._on_tile_acquisition_progress(
+        TiledPhaseEvent(
+            modality=MODALITY_FLUORESCENCE, phase=TiledPhase.MOVING
+        )
+    )
+    assert status.progress_widget._bar.value() == before


### PR DESCRIPTION
## Summary

- replace tiled acquisition dictionaries with a frozen, keyword-only tagged event model
- type the shared psygnal contract and all beam/FM producers
- migrate the two beam overviews, FM overview, main status bar, and queued Qt bridges to class/attribute dispatch
- remove dictionary compatibility and the unused tileset task tag
- preserve existing wording, counts, ETA, event ordering, previews, cancellation, stitching, saving, and terminal behavior; FIB-742 presentation remains deferred

## Verification

- 166 passed, 1 deselected: beam runner, FM acquisition, and typed payload suites (the deselected OME schema test requires network access)
- 479 passed: four tiled UI consumer suites
- 381 passed, 1 skipped: broader tiling/import/isolation suites
- Ruff and git diff checks pass
