### PR TITLE
Serialise every SharkSEM call on the connection lock (FIB-786)

### DIFF
--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -341,7 +341,8 @@ class TescanMicroscope(FibsemMicroscope):
         )
 
     def disconnect(self) -> None:
-        self.connection.Disconnect()
+        with self._connection_lock:
+            self.connection.Disconnect()
         del self.connection
         self.connection = None
 
@@ -477,28 +478,35 @@ class TescanMicroscope(FibsemMicroscope):
 
         image_roi = effective_image_settings.reduced_area
 
-        if image_roi is not None:
-            left, top, right, bottom = to_tescan_image_roi(
-                rect=image_roi, image_shape=(image_width, image_height)
-            )
-            image: Document = beam.Scan.AcquireROI(
-                Detector=self._active_detector[effective_beam_type],
-                Width=image_width,
-                Height=image_height,
-                Left=left,
-                Top=top,
-                Right=right,
-                Bottom=bottom,
-                DwellTime=dwell_time_ns,
-            )
-        else:
-            image: Document = beam.Scan.AcquireImage(
-                Detector=self._active_detector[effective_beam_type],
-                Bpp=Bpp.Grayscale_8_bit,
-                Width=image_width,
-                Height=image_height,
-                DwellTime=dwell_time_ns,
-            )
+        # The frame transfer is the longest SharkSEM operation there is, and the SDK
+        # has no locking of its own: every Recv is a paired send+receive on the shared
+        # control socket, and AcquireImage mixes control exchanges (ScScanXY) with the
+        # data-socket fetch inside one call. The whole SDK call is therefore the
+        # smallest unit an external lock can protect -- holding it for the full frame
+        # is what keeps other threads' calls from tearing the stream (FIB-786).
+        with self._connection_lock:
+            if image_roi is not None:
+                left, top, right, bottom = to_tescan_image_roi(
+                    rect=image_roi, image_shape=(image_width, image_height)
+                )
+                image: Document = beam.Scan.AcquireROI(
+                    Detector=self._active_detector[effective_beam_type],
+                    Width=image_width,
+                    Height=image_height,
+                    Left=left,
+                    Top=top,
+                    Right=right,
+                    Bottom=bottom,
+                    DwellTime=dwell_time_ns,
+                )
+            else:
+                image: Document = beam.Scan.AcquireImage(
+                    Detector=self._active_detector[effective_beam_type],
+                    Bpp=Bpp.Grayscale_8_bit,
+                    Width=image_width,
+                    Height=image_height,
+                    DwellTime=dwell_time_ns,
+                )
 
         if image is None:
             raise ValueError("Failed to acquire image from microscope.")
@@ -551,8 +559,9 @@ class TescanMicroscope(FibsemMicroscope):
         API (SEM.Scan/FIB.Scan expose single AcquireImage calls), so this simply re-acquires
         with the current beam settings -- the same shape as the simulator worker.
 
-        acquire_image already serialises its SharkSEM traffic through the connection lock, so
-        the loop is safe against the UI thread's own socket use.
+        acquire_image holds the connection lock for the whole frame transfer (FIB-786), so
+        the loop is safe against other threads' socket use -- their calls queue between
+        frames rather than interleaving bytes mid-transfer.
         """
         try:
             while not self._stop_acquisition_event.is_set():
@@ -594,7 +603,8 @@ class TescanMicroscope(FibsemMicroscope):
     def acquire_chamber_image(self) -> FibsemImage:
         """Acquire an image of the chamber inside."""
         return NotImplemented
-        image = self.connection.Camera.AcquireImage()
+        with self._connection_lock:
+            image = self.connection.Camera.AcquireImage()
         logging.debug({"msg": "acquire_chamber_image"})
         return FibsemImage(data=np.array(image.Image), metadata=None)
 
@@ -608,7 +618,8 @@ class TescanMicroscope(FibsemMicroscope):
         """
         beam = self._prepare_beam(beam_type=beam_type)
         logging.info(f"Running autocontrast on {beam_type.name}.")
-        beam.Detector.AutoSignal(Detector=self._active_detector[beam_type])
+        with self._connection_lock:
+            beam.Detector.AutoSignal(Detector=self._active_detector[beam_type])
         return
 
     def auto_focus(
@@ -620,7 +631,8 @@ class TescanMicroscope(FibsemMicroscope):
             )
             return
         beam = self._prepare_beam(beam_type=beam_type)
-        beam.AutoWDFine(self._active_detector[beam_type])
+        with self._connection_lock:
+            beam.AutoWDFine(self._active_detector[beam_type])
         return
 
     def beam_shift(
@@ -971,7 +983,8 @@ class TescanMicroscope(FibsemMicroscope):
 
     def get_manipulator_position(self) -> FibsemManipulatorPosition:
         index = 0
-        output_position = self.connection.Nanomanipulator.GetPosition(Index=index)
+        with self._connection_lock:
+            output_position = self.connection.Nanomanipulator.GetPosition(Index=index)
 
         # GetPosition returns tuple in the form (x, y, z, r)
         # x,y,z in mm and r in degrees, no tilt information
@@ -1006,13 +1019,15 @@ class TescanMicroscope(FibsemMicroscope):
 
         index = 0
         logging.info(f"Inserting Nanomanipulator to {name} position")
-        self.connection.Nanomanipulator.MoveToPosition(
-            Index=index, Position=insert_position
-        )
+        with self._connection_lock:
+            self.connection.Nanomanipulator.MoveToPosition(
+                Index=index, Position=insert_position
+            )
 
     def _check_manipulator_limits(self, x, y, z, r):
 
-        limits = self.connection.Nanomanipulator.GetLimits(Index=0, Type=0)
+        with self._connection_lock:
+            limits = self.connection.Nanomanipulator.GetLimits(Index=0, Type=0)
 
         xmin = limits[0]
         xmax = limits[1]
@@ -1039,17 +1054,19 @@ class TescanMicroscope(FibsemMicroscope):
     def retract_manipulator(self):
         retract_position = getattr(self.connection.Nanomanipulator.Position, "Parking")
         index = 0
-        self.connection.Nanomanipulator.MoveToPosition(
-            Index=index, Position=retract_position
-        )
+        with self._connection_lock:
+            self.connection.Nanomanipulator.MoveToPosition(
+                Index=index, Position=retract_position
+            )
 
     def move_manipulator_relative(
         self, position: FibsemManipulatorPosition, name: str = None
     ):
 
-        if self.connection.Nanomanipulator.IsCalibrated(0) is False:
-            logging.info("Calibrating manipulator")
-            self.connection.Nanomanipulator.Calibrate(0)
+        with self._connection_lock:
+            if self.connection.Nanomanipulator.IsCalibrated(0) is False:
+                logging.info("Calibrating manipulator")
+                self.connection.Nanomanipulator.Calibrate(0)
 
         current_position = self.get_manipulator_position()
 
@@ -1063,7 +1080,10 @@ class TescanMicroscope(FibsemMicroscope):
 
         logging.info(f"moving manipulator by {position}")
         try:
-            self.connection.Nanomanipulator.MoveTo(Index=index, X=x, Y=y, Z=z, Rot=r)
+            with self._connection_lock:
+                self.connection.Nanomanipulator.MoveTo(
+                    Index=index, X=x, Y=y, Z=z, Rot=r
+                )
         except Exception as e:
             logging.error(e)
             return e
@@ -1072,9 +1092,10 @@ class TescanMicroscope(FibsemMicroscope):
         self, position: FibsemManipulatorPosition, name: str = None
     ):
 
-        if self.connection.Nanomanipulator.IsCalibrated(0) is False:
-            logging.info("Calibrating manipulator")
-            self.connection.Nanomanipulator.Calibrate(0)
+        with self._connection_lock:
+            if self.connection.Nanomanipulator.IsCalibrated(0) is False:
+                logging.info("Calibrating manipulator")
+                self.connection.Nanomanipulator.Calibrate(0)
 
         x = position.x * constants.METRE_TO_MILLIMETRE
         y = position.y * constants.METRE_TO_MILLIMETRE
@@ -1086,11 +1107,13 @@ class TescanMicroscope(FibsemMicroscope):
 
         logging.info(f"moving manipulator to {position}")
 
-        self.connection.Nanomanipulator.MoveTo(Index=index, X=x, Y=y, Z=z, Rot=r)
+        with self._connection_lock:
+            self.connection.Nanomanipulator.MoveTo(Index=index, X=x, Y=y, Z=z, Rot=r)
 
     def calibrate_manipulator(self):
         logging.info("Calibrating manipulator")
-        self.connection.Nanomanipulator.Calibrate(0)
+        with self._connection_lock:
+            self.connection.Nanomanipulator.Calibrate(0)
 
     def _x_corrected_needle_movement(
         self, expected_x: float
@@ -1155,9 +1178,10 @@ class TescanMicroscope(FibsemMicroscope):
             beam_type (BeamType, optional): the beam type to move in. Defaults to BeamType.ELECTRON.
         """
 
-        if self.connection.Nanomanipulator.IsCalibrated(0) is False:
-            logging.info("Calibrating manipulator")
-            self.connection.Nanomanipulator.Calibrate(0)
+        with self._connection_lock:
+            if self.connection.Nanomanipulator.IsCalibrated(0) is False:
+                logging.info("Calibrating manipulator")
+                self.connection.Nanomanipulator.Calibrate(0)
         stage_tilt = self.get_stage_position().t
 
         # # xy
@@ -1235,7 +1259,8 @@ class TescanMicroscope(FibsemMicroscope):
         )
 
         # TODO: change the layer name to milling stage name
-        self.layer = self.connection.DrawBeam.Layer("Layer1", layer_settings)
+        with self._connection_lock:
+            self.layer = self.connection.DrawBeam.Layer("Layer1", layer_settings)
 
     def run_milling(
         self, milling_current: float, milling_voltage: float, asynch: bool = False
@@ -1251,7 +1276,8 @@ class TescanMicroscope(FibsemMicroscope):
         """
         self._prepare_beam(self.milling_channel)
 
-        self.connection.DrawBeam.LoadLayer(self.layer)
+        with self._connection_lock:
+            self.connection.DrawBeam.LoadLayer(self.layer)
         logging.info("running ion beam milling now...")
 
         # estimate milling time (must be done before starting milling, but after loading layer)
@@ -1260,17 +1286,18 @@ class TescanMicroscope(FibsemMicroscope):
         remaining_time = estimated_time
 
         # start milling
-        self.connection.DrawBeam.Start()
+        with self._connection_lock:
+            self.connection.DrawBeam.Start()
 
-        # display progress bar in tescan ui
-        self.connection.Progress.Show(
-            Title="DrawBeam Milling (OpenFIBSEM)",
-            Text="Layer 1 in progress",
-            HideButton=True,
-            Marquee=False,
-            ProgressMin=0,
-            ProgressMax=100,
-        )
+            # display progress bar in tescan ui
+            self.connection.Progress.Show(
+                Title="DrawBeam Milling (OpenFIBSEM)",
+                Text="Layer 1 in progress",
+                HideButton=True,
+                Marquee=False,
+                ProgressMin=0,
+                ProgressMax=100,
+            )
 
         if asynch:
             return  # up to the user to monitor the milling process/progress
@@ -1279,13 +1306,19 @@ class TescanMicroscope(FibsemMicroscope):
         err = None
         try:
             while self.get_milling_state() in ACTIVE_MILLING_STATES:
-                status = self.connection.DrawBeam.GetStatus()  # status, total, elapsed
+                # lock per call, never across the sleep: the poll loop runs for the
+                # whole mill and must let other threads' calls through between polls
+                with self._connection_lock:
+                    status = (
+                        self.connection.DrawBeam.GetStatus()
+                    )  # status, total, elapsed
                 milling_status, total_time, elapsed_time = status
                 if self.get_milling_state() is MillingState.RUNNING:
                     progress = 0
                     if total_time > 0:
                         progress = min(100, elapsed_time / total_time * 100)
-                    self.connection.Progress.SetPercents(progress)
+                    with self._connection_lock:
+                        self.connection.Progress.SetPercents(progress)
                     remaining_time -= MILLING_SLEEP_TIME
                 time.sleep(MILLING_SLEEP_TIME)
 
@@ -1306,9 +1339,11 @@ class TescanMicroscope(FibsemMicroscope):
             logging.error(f"Error in run_milling: {err}")
             pass
         finally:
-            self.connection.Progress.Hide()
+            with self._connection_lock:
+                self.connection.Progress.Hide()
             if err:
-                self.connection.DrawBeam.Stop()
+                with self._connection_lock:
+                    self.connection.DrawBeam.Stop()
                 self.clear_patterns()
 
     # def run_milling_drift_corrected(self, milling_current: float,
@@ -1434,21 +1469,26 @@ class TescanMicroscope(FibsemMicroscope):
         clear patterns without first tracking whether a layer exists.
         """
         try:
-            self.connection.DrawBeam.UnloadLayer()
+            with self._connection_lock:
+                self.connection.DrawBeam.UnloadLayer()
         except Exception as e:
             logging.debug(f"Error unloading layer: {e}")
 
     def start_milling(self) -> None:
-        self.connection.DrawBeam.Start()
+        with self._connection_lock:
+            self.connection.DrawBeam.Start()
 
     def pause_milling(self):
-        self.connection.DrawBeam.Pause()
+        with self._connection_lock:
+            self.connection.DrawBeam.Pause()
 
     def resume_milling(self):
-        self.connection.DrawBeam.Resume()
+        with self._connection_lock:
+            self.connection.DrawBeam.Resume()
 
     def get_milling_state(self):
-        state = self.connection.DrawBeam.GetStatus()[0]
+        with self._connection_lock:
+            state = self.connection.DrawBeam.GetStatus()[0]
         return DrawBeamStatusToPatterningState[state]
 
     @staticmethod
@@ -1504,7 +1544,8 @@ class TescanMicroscope(FibsemMicroscope):
             preset=SPOT_BURN_PRESET,
             spacing=defaults.spacing,
         )
-        layer = self.connection.DrawBeam.Layer("SpotBurn", layer_settings)
+        with self._connection_lock:
+            layer = self.connection.DrawBeam.Layer("SpotBurn", layer_settings)
 
         # DepthUnit.Second makes Depth an exposure time rather than a depth, which is
         # exactly a spot burn -- park on the point and expose for this long.
@@ -1597,7 +1638,8 @@ class TescanMicroscope(FibsemMicroscope):
         estimated_time = total_points * exposure_time
         start_time = time.time()
 
-        self.connection.DrawBeam.LoadLayer(layer)
+        with self._connection_lock:
+            self.connection.DrawBeam.LoadLayer(layer)
         logging.info(
             f"running spot burn now: {total_points} point(s), "
             f"{exposure_time}s each, {estimated_time}s total..."
@@ -1613,7 +1655,8 @@ class TescanMicroscope(FibsemMicroscope):
             }
         )
 
-        self.connection.DrawBeam.Start()
+        with self._connection_lock:
+            self.connection.DrawBeam.Start()
 
         try:
             while self.get_milling_state() in ACTIVE_MILLING_STATES:
@@ -1657,7 +1700,8 @@ class TescanMicroscope(FibsemMicroscope):
         # self.connection.DrawBeam.LoadLayer(self.layer)
         est_time = 0
         try:
-            est_time = self.connection.DrawBeam.EstimateTime()
+            with self._connection_lock:
+                est_time = self.connection.DrawBeam.EstimateTime()
         except Exception as e:
             logging.error(f"Error in estimating milling time: {e}")
 
@@ -1838,7 +1882,11 @@ class TescanMicroscope(FibsemMicroscope):
     ) -> None:
         """Wait for the beam to become ready (not busy)."""
         start_time = time.monotonic()
-        while beam.IsBusy():
+        while True:
+            with self._connection_lock:
+                busy = beam.IsBusy()
+            if not busy:
+                break
             logging.debug(
                 f"Waiting for the {beam_type.name} beam to become ready after {operation}."
             )
@@ -1855,29 +1903,32 @@ class TescanMicroscope(FibsemMicroscope):
         """Prepare the beam for imaging, milling, or other operations."""
         beam = self._get_beam(beam_type)
 
-        # check the beam is on
-        status = beam.Beam.GetStatus()
-        if status != beam.Beam.Status.BeamOn:
-            beam.Beam.On()
+        with self._connection_lock:
+            # check the beam is on
+            status = beam.Beam.GetStatus()
+            if status != beam.Beam.Status.BeamOn:
+                beam.Beam.On()
 
-        # stop the scanning before we start scanning or before automatic procedures,
-        beam.Scan.Stop()
+            # stop the scanning before we start scanning or before automatic procedures,
+            beam.Scan.Stop()
 
         self._wait_for_beam_ready(beam, beam_type, operation="preparation")
 
         return beam
 
     def _get_presets(self, beam_type: BeamType) -> List[str]:
-        presets = self._get_beam(beam_type=beam_type).Preset.Enum()
+        with self._connection_lock:
+            presets = self._get_beam(beam_type=beam_type).Preset.Enum()
         return sorted(presets)
 
     def _get_available_detectors(self, beam_type: BeamType) -> List[str]:
         """Get a list of available detectors for the given beam type."""
         detectors = []
-        if beam_type == BeamType.ELECTRON:
-            detectors = self.connection.SEM.Detector.Enum()
-        elif beam_type == BeamType.ION:
-            detectors = self.connection.FIB.Detector.Enum()
+        with self._connection_lock:
+            if beam_type == BeamType.ELECTRON:
+                detectors = self.connection.SEM.Detector.Enum()
+            elif beam_type == BeamType.ION:
+                detectors = self.connection.FIB.Detector.Enum()
         return detectors
 
     def _get_detector(
@@ -2089,7 +2140,9 @@ class TescanMicroscope(FibsemMicroscope):
     ) -> None:
         """Activate a preset, preserving rotation/FOV/shift when self._preserve_settings_on_preset_change is set."""
         # Check if preset is available
-        if not beam.Preset.IsAvailable(preset_name):
+        with self._connection_lock:
+            available = beam.Preset.IsAvailable(preset_name)
+        if not available:
             logging.warning(f"Preset {preset_name} not available for {beam_type}.")
             return
 
@@ -2102,18 +2155,20 @@ class TescanMicroscope(FibsemMicroscope):
         image_shift_y = None
 
         if preserve_settings:
-            image_rotation = beam.Optics.GetImageRotation()
+            with self._connection_lock:
+                image_rotation = beam.Optics.GetImageRotation()
+                view_field = beam.Optics.GetViewfield()
+                image_shift_x, image_shift_y = beam.Optics.GetImageShift()
             logging.debug(f"Image rotation before changing preset: {image_rotation}.")
-            view_field = beam.Optics.GetViewfield()
             logging.debug(f"FOV before changing preset: {view_field}.")
-            image_shift_x, image_shift_y = beam.Optics.GetImageShift()
             logging.debug(
                 f"XY shift before changing preset: {image_shift_x}, {image_shift_y}."
             )
 
         try:
             # Activate preset
-            beam.Preset.Activate(preset_name)
+            with self._connection_lock:
+                beam.Preset.Activate(preset_name)
             logging.info(f"Preset {preset_name} activated for {beam_type}.")
 
             # Wait for preset to fully apply
@@ -2132,15 +2187,16 @@ class TescanMicroscope(FibsemMicroscope):
             # Restore settings if requested
             if preserve_settings:
                 try:
-                    beam.Optics.SetImageRotation(image_rotation)
+                    with self._connection_lock:
+                        beam.Optics.SetImageRotation(image_rotation)
+                        beam.Optics.SetViewfield(view_field)
+                        beam.Optics.SetImageShift(image_shift_x, image_shift_y)
                     logging.debug(
                         f"Restored image rotation after changing preset to {image_rotation}."
                     )
-                    beam.Optics.SetViewfield(view_field)
                     logging.debug(
                         f"Restored FOV after changing preset to {view_field}."
                     )
-                    beam.Optics.SetImageShift(image_shift_x, image_shift_y)
                     logging.debug(
                         f"Restored XY shift after changing preset to {image_shift_x}, {image_shift_y}."
                     )

--- a/tests/test_tescan_connection_lock.py
+++ b/tests/test_tescan_connection_lock.py
@@ -1,0 +1,225 @@
+"""Every SharkSEM call in the Tescan driver is serialised on _connection_lock (FIB-786).
+
+SharkSEM is one socket. A long call (a frame transfer) running while another thread
+issues any other call interleaves request/response bytes on the shared stream, and
+whichever side reads next gets a torn buffer -- observed on the simulator as
+``struct.error: unpack requires a buffer of 4 bytes`` inside ``Recv`` when a position
+was added while reference images were being acquired.
+
+Two guards here:
+
+* an AST rule: every SDK call site in ``tescan.py`` must sit lexically inside a
+  ``with self._connection_lock:`` block, so a new unlocked call site fails this test
+  rather than shipping as a latent race. ``_get_impl``/``_set_impl`` are the one
+  allowed exception -- their public wrappers ``_get``/``_set`` hold the lock.
+* a behavioural check: real driver methods hammered from two threads against a fake
+  connection that detects overlapping SDK entry.
+"""
+
+import ast
+import inspect
+import threading
+import time
+
+from fibsem.microscopes import tescan as tescan_module
+from fibsem.microscopes.tescan import TescanMicroscope
+from fibsem.structures import BeamType, MillingState
+
+# Their callers (_get/_set) take the lock around the whole dispatch, so these two are
+# exempt from the lexical rule. Nothing else may join this list without the same
+# always-locked-caller property.
+LOCKED_BY_CALLER = {"_get_impl", "_set_impl"}
+
+
+# ---------------------------------------------------------------------------
+# AST rule
+# ---------------------------------------------------------------------------
+
+
+def _chain_of(node):
+    parts = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    return node, list(reversed(parts))
+
+
+def _is_sdk_call(func_node) -> bool:
+    """A Call whose func is an attribute chain reaching the SharkSEM connection."""
+    root, chain = _chain_of(func_node)
+    if isinstance(root, ast.Name):
+        # self.connection.X.Y(...) has root `self` and chain starting "connection"
+        if root.id == "self" and chain and chain[0] == "connection":
+            return True
+        # beam = self._get_beam(...); beam.X.Y(...)
+        if root.id in ("beam", "sem", "fib") and chain:
+            return True
+    if isinstance(root, ast.Call):
+        # inline chains: self._get_beam(...).Preset.Enum(...)
+        inner_root, inner_chain = _chain_of(root.func)
+        if (
+            isinstance(inner_root, ast.Name)
+            and inner_root.id == "self"
+            and inner_chain == ["_get_beam"]
+        ):
+            return True
+    return False
+
+
+class _LockAudit(ast.NodeVisitor):
+    def __init__(self):
+        self.violations = []
+        self._func_stack = []
+        self._lock_depth = 0
+
+    def visit_FunctionDef(self, node):
+        self._func_stack.append(node.name)
+        self.generic_visit(node)
+        self._func_stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_With(self, node):
+        is_lock = any(
+            "_connection_lock" in ast.dump(item.context_expr) for item in node.items
+        )
+        if is_lock:
+            self._lock_depth += 1
+        self.generic_visit(node)
+        if is_lock:
+            self._lock_depth -= 1
+
+    def visit_Call(self, node):
+        if _is_sdk_call(node.func) and self._lock_depth == 0:
+            func = self._func_stack[-1] if self._func_stack else "<module>"
+            if func not in LOCKED_BY_CALLER:
+                _, chain = _chain_of(node.func)
+                self.violations.append(f"{func}:{node.lineno} {'.'.join(chain)}")
+        self.generic_visit(node)
+
+
+def test_every_sdk_call_site_is_under_the_connection_lock():
+    tree = ast.parse(inspect.getsource(tescan_module))
+    audit = _LockAudit()
+    audit.visit(tree)
+    assert audit.violations == [], (
+        "SharkSEM call sites outside `with self._connection_lock:` "
+        "(one socket -- unlocked calls tear the protocol):\n  "
+        + "\n  ".join(audit.violations)
+    )
+
+
+def test_the_allowlist_is_only_the_impl_pair():
+    """The exemption exists for _get_impl/_set_impl alone; growing it silently would
+    reopen the hole the lexical rule closes."""
+    assert LOCKED_BY_CALLER == {"_get_impl", "_set_impl"}
+
+
+# ---------------------------------------------------------------------------
+# behavioural: two threads, one fake connection, no overlapping SDK entry
+# ---------------------------------------------------------------------------
+
+
+class OverlapDetector:
+    def __init__(self):
+        self._busy = threading.Lock()
+        self.overlaps = 0
+
+    def __enter__(self):
+        if not self._busy.acquire(blocking=False):
+            self.overlaps += 1
+            self._acquired = False
+        else:
+            self._acquired = True
+        time.sleep(0.005)  # widen the race window: a real SDK call is not instant
+        return self
+
+    def __exit__(self, *exc):
+        if self._acquired:
+            self._busy.release()
+
+
+class RacingDrawBeam:
+    """Every method body runs inside the shared overlap detector."""
+
+    def __init__(self, detector: OverlapDetector):
+        self._detector = detector
+
+    def GetStatus(self):
+        with self._detector:
+            return ("IDLE", 1.0, 0.0)
+
+    def UnloadLayer(self):
+        with self._detector:
+            return None
+
+    def EstimateTime(self):
+        with self._detector:
+            return 1.0
+
+
+def make_microscope(monkeypatch):
+    m = object.__new__(TescanMicroscope)
+    m._connection_lock = threading.RLock()
+    detector = OverlapDetector()
+
+    class Conn:
+        DrawBeam = RacingDrawBeam(detector)
+
+    m.connection = Conn()
+    # the status mapping is defined inside the SDK-gated import block, absent
+    # without tescanautomation installed (same pattern as the spot-burn tests)
+    monkeypatch.setattr(
+        tescan_module,
+        "DrawBeamStatusToPatterningState",
+        {"IDLE": MillingState.IDLE},
+        raising=False,
+    )
+    return m, detector
+
+
+def test_concurrent_driver_calls_never_overlap_on_the_connection(monkeypatch):
+    m, detector = make_microscope(monkeypatch)
+    stop = threading.Event()
+
+    def hammer():
+        while not stop.is_set():
+            m.get_milling_state()
+            m.clear_patterns()
+            m.estimate_milling_time()
+
+    thread = threading.Thread(target=hammer, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        assert m.get_milling_state() is MillingState.IDLE
+        m.estimate_milling_time()
+    stop.set()
+    thread.join(timeout=5)
+
+    assert detector.overlaps == 0, (
+        f"{detector.overlaps} overlapping SDK calls -- the connection lock is not "
+        "covering every call site"
+    )
+
+
+def test_the_detector_itself_catches_overlap():
+    """Prove the harness can see the failure it guards against: two bare threads
+    hitting the fake connection without the driver's lock must overlap."""
+    detector = OverlapDetector()
+    draw_beam = RacingDrawBeam(detector)
+    stop = threading.Event()
+
+    def hammer():
+        while not stop.is_set():
+            draw_beam.GetStatus()
+
+    thread = threading.Thread(target=hammer, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 0.5
+    while time.monotonic() < deadline and detector.overlaps == 0:
+        draw_beam.GetStatus()
+    stop.set()
+    thread.join(timeout=5)
+
+    assert detector.overlaps > 0

--- a/tests/test_tescan_live_imaging.py
+++ b/tests/test_tescan_live_imaging.py
@@ -22,6 +22,7 @@ from fibsem.structures import BeamType, FibsemImage
 def make_microscope(acquire_side_effect=None):
     """Create a TescanMicroscope whose acquire_image returns a sentinel per beam."""
     m = object.__new__(TescanMicroscope)
+    m._connection_lock = threading.RLock()
     # per-instance event/thread so tests don't share the class-level defaults
     m._stop_acquisition_event = threading.Event()
     m._acquisition_thread = None
@@ -67,6 +68,7 @@ def run_worker_briefly(m, beam_type, frames=3):
     The worker checks the stop event between acquire and emit, so the acquisition that
     trips the stop is deliberately not emitted; stop one acquire later so `frames` emit.
     """
+
     def stop_after(n):
         if n > frames:
             m._stop_acquisition_event.set()
@@ -81,6 +83,7 @@ def run_worker_briefly(m, beam_type, frames=3):
 
 
 # --------------------------------------------------------------------------
+
 
 def test_worker_stops_when_event_is_set_before_start():
     """A stop event set up-front means zero acquisitions."""
@@ -137,7 +140,7 @@ def test_no_frame_emitted_when_stopped_mid_iteration():
     m._acquisition_worker(BeamType.ELECTRON)
 
     assert m._test_calls["n"] == 1  # acquired once
-    assert len(sem) == 0            # but the stop check dropped it before emit
+    assert len(sem) == 0  # but the stop check dropped it before emit
 
 
 def test_worker_survives_acquire_errors_without_raising():

--- a/tests/test_tescan_milling_lifecycle.py
+++ b/tests/test_tescan_milling_lifecycle.py
@@ -8,6 +8,7 @@ No hardware or Tescan SDK required: the microscope object is created without __i
 connection is stubbed, and the SDK names the driver imports are monkeypatched in.
 """
 
+import threading
 from typing import List, Optional
 
 import pytest
@@ -46,6 +47,7 @@ def make_microscope(monkeypatch, current_preset="30 keV; 20 pA", unload_error=No
     step raising while leaving setup's own preset set intact.
     """
     microscope = object.__new__(TescanMicroscope)
+    microscope._connection_lock = threading.RLock()
     microscope.connection = FakeConnection(unload_error)
     microscope.milling_channel = BeamType.ION
     microscope._preset_before_milling = None
@@ -68,7 +70,9 @@ def make_microscope(monkeypatch, current_preset="30 keV; 20 pA", unload_error=No
     microscope.set = fake_set
     # set_preset (real base method) resolves via the class MRO and routes through fake_set
 
-    monkeypatch.setattr(tescan_module, "IEtching", lambda **kwargs: kwargs, raising=False)
+    monkeypatch.setattr(
+        tescan_module, "IEtching", lambda **kwargs: kwargs, raising=False
+    )
     return microscope
 
 
@@ -80,6 +84,7 @@ def preset_restores(m) -> List[str]:
 # --------------------------------------------------------------------------
 # clear_patterns
 # --------------------------------------------------------------------------
+
 
 def test_clear_patterns_unloads_the_layer(monkeypatch):
     m = make_microscope(monkeypatch)
@@ -104,6 +109,7 @@ def test_clear_patterns_is_idempotent(monkeypatch):
 # --------------------------------------------------------------------------
 # preset snapshot / restore
 # --------------------------------------------------------------------------
+
 
 def test_setup_milling_snapshots_the_active_preset(monkeypatch):
     m = make_microscope(monkeypatch, current_preset="30 keV; 20 pA")
@@ -148,8 +154,10 @@ def test_finish_milling_clears_the_snapshot_for_the_next_cycle(monkeypatch):
 
     # the two restores are the two different snapshots, not a repeat of the first
     assert preset_restores(m) == [
-        "30 keV; 2 nA", "30 keV; 20 pA",     # cycle 1: mill, restore
-        "30 keV; 2 nA", "30 keV; 100 pA",    # cycle 2: mill, restore
+        "30 keV; 2 nA",
+        "30 keV; 20 pA",  # cycle 1: mill, restore
+        "30 keV; 2 nA",
+        "30 keV; 100 pA",  # cycle 2: mill, restore
     ]
 
 
@@ -176,6 +184,7 @@ def test_finish_milling_falls_back_when_snapshot_is_none(monkeypatch):
 # --------------------------------------------------------------------------
 # cleanup independence
 # --------------------------------------------------------------------------
+
 
 def test_finish_milling_unloads_the_layer_even_if_the_preset_fails(monkeypatch):
     """The whole point of splitting the try blocks: a fragile preset restore must not

--- a/tests/test_tescan_movement.py
+++ b/tests/test_tescan_movement.py
@@ -18,6 +18,7 @@ __init__ and the stage state is stubbed.
 """
 
 import os
+import threading
 
 import numpy as np
 import pytest
@@ -47,7 +48,7 @@ TESCAN_CONFIG_PATH = os.path.join(cfg.CONFIG_PATH, "tescan-configuration.yaml")
 
 # rotation conventions from tescan-configuration.yaml
 ROTATION_FLAT_TO_EB = np.deg2rad(180)  # stage.rotation_reference
-ROTATION_FLAT_TO_ION = np.deg2rad(0)   # stage.rotation_180
+ROTATION_FLAT_TO_ION = np.deg2rad(0)  # stage.rotation_180
 
 FIB_COLUMN_TILT = np.deg2rad(55)
 
@@ -62,6 +63,7 @@ def make_microscope(
     system.stage.shuttle_pre_tilt = pretilt_deg
 
     microscope = object.__new__(TescanMicroscope)  # skip __init__ (requires SDK)
+    microscope._connection_lock = threading.RLock()
     microscope.system = system
     microscope.stage_is_compustage = False
 
@@ -74,7 +76,9 @@ def make_microscope(
     microscope.get_stage_position = lambda: microscope._test_stage_position
     # get_scan_rotation returns radians (codebase convention); the test param is degrees
     microscope.get_scan_rotation = lambda beam_type: np.deg2rad(scan_rotation_deg)
-    microscope.move_stage_relative = lambda position: microscope._recorded_moves.append(position)
+    microscope.move_stage_relative = lambda position: microscope._recorded_moves.append(
+        position
+    )
     return microscope
 
 
@@ -93,17 +97,26 @@ def make_image(
     """
     state = MicroscopeState(
         stage_position=stage_position,
-        electron_beam=BeamSettings(beam_type=BeamType.ELECTRON, scan_rotation=scan_rotation),
+        electron_beam=BeamSettings(
+            beam_type=BeamType.ELECTRON, scan_rotation=scan_rotation
+        ),
         ion_beam=BeamSettings(beam_type=BeamType.ION, scan_rotation=scan_rotation),
     )
     # v6 (FIB-481) split the old `system` metadata into system_info (identity, carries
     # manufacturer) + hardware_geometry (the tilt/rotation geometry the inverse needs).
     system_info = SystemInfo(
-        name="test", ip_address="localhost", manufacturer="Tescan", model="test",
-        serial_number="test", hardware_version="test", software_version="test",
+        name="test",
+        ip_address="localhost",
+        manufacturer="Tescan",
+        model="test",
+        serial_number="test",
+        hardware_version="test",
+        software_version="test",
     )
     md = FibsemImageMetadata(
-        image_settings=ImageSettings(resolution=(shape[1], shape[0]), beam_type=beam_type),
+        image_settings=ImageSettings(
+            resolution=(shape[1], shape[0]), beam_type=beam_type
+        ),
         pixel_size=Point(pixel_size, pixel_size),
         microscope_state=state,
         system_info=system_info,
@@ -112,7 +125,9 @@ def make_image(
     return FibsemImage(data=np.zeros(shape, dtype=np.uint8), metadata=md)
 
 
-def stage_at(tilt_deg: float, rotation: float = ROTATION_FLAT_TO_EB) -> FibsemStagePosition:
+def stage_at(
+    tilt_deg: float, rotation: float = ROTATION_FLAT_TO_EB
+) -> FibsemStagePosition:
     return FibsemStagePosition(
         x=0, y=0, z=0, r=rotation, t=np.deg2rad(tilt_deg), coordinate_system="RAW"
     )
@@ -121,6 +136,7 @@ def stage_at(tilt_deg: float, rotation: float = ROTATION_FLAT_TO_EB) -> FibsemSt
 # ---------------------------------------------------------------------------
 # _y_corrected_stage_movement (forward)
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("tilt_deg", [0.0, 10.0, 17.0, 30.0, 45.0])
 @pytest.mark.parametrize("pretilt_deg", [0.0, 20.0, 35.0])
@@ -201,6 +217,7 @@ def test_pretilt_sign_flips_when_facing_ion():
 # stable_move / project_stable_move
 # ---------------------------------------------------------------------------
 
+
 def test_stable_move_applies_axis_inversion():
     """stable_move applies the empirical stage-axis inversion (x=-dx, y=-y_chamber)
     after the trig, leaving z independent."""
@@ -240,7 +257,9 @@ def test_project_stable_move_matches_stable_move(beam_type):
     m = make_microscope(pretilt_deg=35.0, stage_position=base)
     dx, dy = 1e-6, 2e-6
 
-    projected = m.project_stable_move(dx=dx, dy=dy, beam_type=beam_type, base_position=base)
+    projected = m.project_stable_move(
+        dx=dx, dy=dy, beam_type=beam_type, base_position=base
+    )
     m.stable_move(dx=dx, dy=dy, beam_type=beam_type)
     applied = m._recorded_moves[0]
 
@@ -252,6 +271,7 @@ def test_project_stable_move_matches_stable_move(beam_type):
 # ---------------------------------------------------------------------------
 # inverse round trips
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("beam_type", [BeamType.ELECTRON, BeamType.ION])
 @pytest.mark.parametrize("rotation", [ROTATION_FLAT_TO_EB, ROTATION_FLAT_TO_ION])
@@ -266,7 +286,9 @@ def test_microscope_inverse_round_trip(beam_type, rotation, tilt_deg, pretilt_de
     chamber = m._y_corrected_stage_movement(expected_y=dy, beam_type=beam_type)
     dy_raw, dz_raw = -chamber.y, chamber.z  # as applied by stable_move
 
-    recovered = m._inverse_y_corrected_stage_movement(dy=dy_raw, dz=dz_raw, beam_type=beam_type)
+    recovered = m._inverse_y_corrected_stage_movement(
+        dy=dy_raw, dz=dz_raw, beam_type=beam_type
+    )
 
     assert recovered == pytest.approx(dy)
 
@@ -288,7 +310,9 @@ def test_inverse_uses_sin_branch_past_45_degrees(beam_type):
 
     chamber = m._y_corrected_stage_movement(expected_y=dy, beam_type=beam_type)
     inclination = np.deg2rad(tilt_deg + pretilt_deg)
-    assert abs(np.sin(inclination)) > abs(np.cos(inclination)), "fixture must hit the sin branch"
+    assert abs(np.sin(inclination)) > abs(np.cos(inclination)), (
+        "fixture must hit the sin branch"
+    )
 
     recovered = m._inverse_y_corrected_stage_movement(
         dy=-chamber.y, dz=chamber.z, beam_type=beam_type
@@ -306,7 +330,9 @@ def test_standalone_inverse_matches_microscope(beam_type, tilt_deg):
     image = make_image(m.system, stage_position, beam_type=beam_type)
     dy_raw, dz_raw = -1.5e-6, 0.5e-6
 
-    from_microscope = m._inverse_y_corrected_stage_movement(dy=dy_raw, dz=dz_raw, beam_type=beam_type)
+    from_microscope = m._inverse_y_corrected_stage_movement(
+        dy=dy_raw, dz=dz_raw, beam_type=beam_type
+    )
     from_metadata = _inverse_y_corrected_stage_movement_tescan(
         image, dy=dy_raw, dz=dz_raw, beam_type=beam_type
     )
@@ -331,10 +357,14 @@ def test_standalone_inverse_matches_microscope_sin_branch(beam_type):
     image = make_image(m.system, stage_position, beam_type=beam_type)
 
     inclination = np.deg2rad(tilt_deg + pretilt_deg)  # 50 deg -> sin branch
-    assert abs(np.sin(inclination)) > abs(np.cos(inclination)), "fixture must hit the sin branch"
+    assert abs(np.sin(inclination)) > abs(np.cos(inclination)), (
+        "fixture must hit the sin branch"
+    )
 
     dy_raw, dz_raw = -1.5e-6, 0.5e-6
-    from_microscope = m._inverse_y_corrected_stage_movement(dy=dy_raw, dz=dz_raw, beam_type=beam_type)
+    from_microscope = m._inverse_y_corrected_stage_movement(
+        dy=dy_raw, dz=dz_raw, beam_type=beam_type
+    )
     from_metadata = _inverse_y_corrected_stage_movement_tescan(
         image, dy=dy_raw, dz=dz_raw, beam_type=beam_type
     )
@@ -355,8 +385,12 @@ def test_inverse_dispatches_on_manufacturer(manufacturer):
     image.metadata.system_info.manufacturer = manufacturer
     dy_raw, dz_raw = -1.5e-6, 0.5e-6
 
-    generic = _inverse_y_corrected_stage_movement(image, dy=dy_raw, dz=dz_raw, beam_type=BeamType.ELECTRON)
-    tescan = _inverse_y_corrected_stage_movement_tescan(image, dy=dy_raw, dz=dz_raw, beam_type=BeamType.ELECTRON)
+    generic = _inverse_y_corrected_stage_movement(
+        image, dy=dy_raw, dz=dz_raw, beam_type=BeamType.ELECTRON
+    )
+    tescan = _inverse_y_corrected_stage_movement_tescan(
+        image, dy=dy_raw, dz=dz_raw, beam_type=BeamType.ELECTRON
+    )
 
     assert generic == pytest.approx(tescan)
 
@@ -397,8 +431,9 @@ def test_reprojection_round_trip_scan_rotation_180(beam_type):
     m = make_microscope(pretilt_deg=35.0, stage_position=base, scan_rotation_deg=180.0)
     pixel_size = 1e-7
     # image metadata stores scan_rotation in radians (as get_beam_settings does)
-    image = make_image(m.system, base, beam_type=beam_type,
-                       pixel_size=pixel_size, scan_rotation=np.pi)
+    image = make_image(
+        m.system, base, beam_type=beam_type, pixel_size=pixel_size, scan_rotation=np.pi
+    )
     dx, dy = 1e-6, 2e-6
 
     pos = m.project_stable_move(dx=dx, dy=dy, beam_type=beam_type, base_position=base)

--- a/tests/test_tescan_spot_burn.py
+++ b/tests/test_tescan_spot_burn.py
@@ -29,6 +29,7 @@ RESOLUTION = (1536, 1024)  # (width, height)
 # fakes
 # --------------------------------------------------------------------------
 
+
 @dataclass
 class FakeDot:
     x: float
@@ -89,9 +90,12 @@ class FakeConnection:
         self.DrawBeam = FakeDrawBeam(busy_polls=busy_polls)
 
 
-def make_microscope(monkeypatch, busy_polls: int = 1, resolution: Tuple[int, int] = RESOLUTION):
+def make_microscope(
+    monkeypatch, busy_polls: int = 1, resolution: Tuple[int, int] = RESOLUTION
+):
     """Create a TescanMicroscope with the SDK and connection stubbed out."""
     microscope = object.__new__(TescanMicroscope)
+    microscope._connection_lock = threading.RLock()
     microscope.connection = FakeConnection(busy_polls=busy_polls)
     microscope.milling_channel = BeamType.ION
 
@@ -116,8 +120,15 @@ def make_microscope(monkeypatch, busy_polls: int = 1, resolution: Tuple[int, int
     microscope.stop_milling = lambda: microscope.connection.DrawBeam.Stop()
 
     # the SDK names the driver imports are absent without the SDK installed
-    monkeypatch.setattr(tescan_module, "IEtching", lambda **kwargs: kwargs, raising=False)
-    monkeypatch.setattr(tescan_module, "DepthUnit", type("DepthUnit", (), {"Second": "Second"}), raising=False)
+    monkeypatch.setattr(
+        tescan_module, "IEtching", lambda **kwargs: kwargs, raising=False
+    )
+    monkeypatch.setattr(
+        tescan_module,
+        "DepthUnit",
+        type("DepthUnit", (), {"Second": "Second"}),
+        raising=False,
+    )
     monkeypatch.setattr(tescan_module.time, "sleep", lambda s: None)
 
     return microscope
@@ -140,25 +151,32 @@ def run_burn(m, coordinates, exposure_time, **kwargs):
 # coordinate conversion
 # --------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize(
     "normalised, expected",
     [
-        (Point(0.5, 0.5), Point(0.0, 0.0)),          # centre
-        (Point(0.0, 0.5), Point(-HFW / 2, 0.0)),     # left edge
-        (Point(1.0, 0.5), Point(HFW / 2, 0.0)),      # right edge
+        (Point(0.5, 0.5), Point(0.0, 0.0)),  # centre
+        (Point(0.0, 0.5), Point(-HFW / 2, 0.0)),  # left edge
+        (Point(1.0, 0.5), Point(HFW / 2, 0.0)),  # right edge
     ],
 )
 def test_point_to_metres_maps_normalised_to_centre_origin(normalised, expected):
     """(0-1, top-left origin) -> metres from the image centre."""
-    got = TescanMicroscope._spot_burn_point_to_metres(normalised, hfw=HFW, resolution=RESOLUTION)
+    got = TescanMicroscope._spot_burn_point_to_metres(
+        normalised, hfw=HFW, resolution=RESOLUTION
+    )
     assert got.x == pytest.approx(expected.x)
     assert got.y == pytest.approx(expected.y)
 
 
 def test_point_to_metres_y_axis_points_up():
     """Image y grows downwards, DrawBeam y grows upwards, so the sign must flip."""
-    top = TescanMicroscope._spot_burn_point_to_metres(Point(0.5, 0.0), hfw=HFW, resolution=RESOLUTION)
-    bottom = TescanMicroscope._spot_burn_point_to_metres(Point(0.5, 1.0), hfw=HFW, resolution=RESOLUTION)
+    top = TescanMicroscope._spot_burn_point_to_metres(
+        Point(0.5, 0.0), hfw=HFW, resolution=RESOLUTION
+    )
+    bottom = TescanMicroscope._spot_burn_point_to_metres(
+        Point(0.5, 1.0), hfw=HFW, resolution=RESOLUTION
+    )
     assert top.y > 0
     assert bottom.y < 0
     assert top.y == pytest.approx(-bottom.y)
@@ -167,13 +185,16 @@ def test_point_to_metres_y_axis_points_up():
 def test_point_to_metres_uses_pixel_aspect_not_hfw_for_y():
     """y extent is hfw scaled by the pixel aspect ratio, not hfw itself."""
     width, height = RESOLUTION
-    bottom = TescanMicroscope._spot_burn_point_to_metres(Point(0.5, 1.0), hfw=HFW, resolution=RESOLUTION)
+    bottom = TescanMicroscope._spot_burn_point_to_metres(
+        Point(0.5, 1.0), hfw=HFW, resolution=RESOLUTION
+    )
     assert bottom.y == pytest.approx(-(HFW / width) * (height / 2))
 
 
 # --------------------------------------------------------------------------
 # exposure
 # --------------------------------------------------------------------------
+
 
 def test_all_points_go_into_one_layer_as_timed_dots(monkeypatch):
     """A single layer holds one time-based dot per point."""
@@ -202,7 +223,12 @@ def test_layer_is_loaded_started_and_unloaded_once(monkeypatch):
     run_burn(m, coordinates=[Point(0.5, 0.5), Point(0.4, 0.4)], exposure_time=1.0)
 
     # leading UnloadLayer clears any layer left loaded by a previous job
-    assert m.connection.DrawBeam.calls == ["UnloadLayer", "LoadLayer", "Start", "UnloadLayer"]
+    assert m.connection.DrawBeam.calls == [
+        "UnloadLayer",
+        "LoadLayer",
+        "Start",
+        "UnloadLayer",
+    ]
 
 
 def test_beam_is_prepared_once(monkeypatch):
@@ -250,6 +276,7 @@ def test_layer_settings_use_the_spot_burn_preset_and_configured_defaults(monkeyp
 # cancellation
 # --------------------------------------------------------------------------
 
+
 def test_stop_event_during_exposure_stops_the_exposition(monkeypatch):
     """Cancelling mid-exposure must stop DrawBeam and still unload the layer."""
     m = make_microscope(monkeypatch, busy_polls=10)
@@ -281,6 +308,7 @@ def test_stop_event_during_exposure_stops_the_exposition(monkeypatch):
 # progress + validation
 # --------------------------------------------------------------------------
 
+
 def test_progress_uses_the_spot_burn_widget_shape(monkeypatch):
     """Progress goes out on spot_burn_progress_signal in the dict shape the widget parses."""
     m = make_microscope(monkeypatch, busy_polls=2)
@@ -297,8 +325,11 @@ def test_progress_uses_the_spot_burn_widget_shape(monkeypatch):
 
     for update in updates:
         assert set(update) == {
-            "current_point", "total_points", "remaining_time",
-            "total_remaining_time", "total_estimated_time",
+            "current_point",
+            "total_points",
+            "remaining_time",
+            "total_remaining_time",
+            "total_estimated_time",
         }
         assert 1 <= update["current_point"] <= 2
         assert 0.0 <= update["remaining_time"] <= 2.0
@@ -325,7 +356,10 @@ def test_electron_beam_is_rejected(monkeypatch):
     m = make_microscope(monkeypatch)
     with pytest.raises(ValueError, match="ion beam"):
         run_burn(
-            m, coordinates=[Point(0.5, 0.5)], exposure_time=1.0, beam_type=BeamType.ELECTRON
+            m,
+            coordinates=[Point(0.5, 0.5)],
+            exposure_time=1.0,
+            beam_type=BeamType.ELECTRON,
         )
 
 


### PR DESCRIPTION
## Summary

Fixes FIB-786: the simulator crash (`struct.error: unpack requires a buffer of 4 bytes` inside SharkSEM's `Recv`) when a position was added while reference images were being acquired.

**Root cause, confirmed from SDK source** (`tescansharksem` 3.2.16): `SemConnection` has **zero internal locking**; every `Recv` is a paired send-request + receive-response on the shared control socket, and `AcquireImage` mixes control exchanges (`ScScanXY`) with the data-socket fetch inside one Python call. Two threads issuing SDK calls concurrently interleave those pairs and tear the stream. A separate image data socket exists (`socket_d`) but doesn't help an external locker — the whole SDK call is the smallest protectable unit.

The driver locked only `_get`/`_set`/`move_stage_absolute`; `acquire_image`'s frame call ran bare (and the live-imaging worker's docstring wrongly claimed otherwise — that false claim shipped on #115 and this crash is it failing).

## The change

Every SharkSEM call site in `tescan.py` now sits under `_connection_lock` — 34 wraps across 25 functions, placement following the driver's existing model:

- **Long atomic operations hold the lock for their duration**: the `AcquireImage`/`AcquireROI` frame transfer, manipulator moves, auto-focus/contrast — same as `move_stage_absolute` and `_set` (which already holds it across the preset settle-wait) do today.
- **Poll loops lock per call, never across the sleep**: `run_milling`'s status/progress polls, `_wait_for_beam_ready`'s `IsBusy` loop (restructured so the sleep sits outside), spot burn via `get_milling_state`. Other threads' calls get through between polls.
- Includes the sites a grep-based audit would miss, e.g. `_get_presets`' inline `self._get_beam(...).Preset.Enum()` chain.

**Behavioural consequence worth knowing:** a stage-position read issued mid-frame now blocks until the frame lands (seconds) instead of corrupting the stream. Correct for one socket; visible on hardware as UI reads queuing behind acquisitions.

## Enforcement (new `tests/test_tescan_connection_lock.py`)

1. **AST rule**: every SDK call site in `tescan.py` must sit lexically inside a `with self._connection_lock:` block (catches `self.connection.*`, `beam.*` locals, and inline `_get_beam(...)` chains). Allowlist is exactly `{_get_impl, _set_impl}` — their `_get`/`_set` wrappers hold the lock — and a second test pins the allowlist so it can't grow silently. A future unlocked call site fails the suite instead of shipping as a latent race.
2. **Behavioural**: real driver methods hammered from two threads against a fake connection with an overlap detector → zero overlapping SDK entries; a companion test proves the detector catches overlap when the lock is absent.

## Test plan

- [x] `tests/test_tescan_connection_lock.py` (new, 4 tests)
- [x] Mutation-checked: unlocking the frame call fails the AST rule; unlocking `get_milling_state` fails both the AST rule **and** the live overlap test
- [x] All existing Tescan suites pass through the new locks (spot burn, movement, live imaging, milling lifecycle — their call-order assertions pin that the wraps changed no SDK call sequence): 146 passed incl. reprojection
- [x] The four `object.__new__` test harnesses now provide `_connection_lock` (real instances get it in `__init__`)
- [x] ruff check + format clean
- [ ] On-hardware (FIB-507): overview navigation + add-position during acquisition, and live imaging with concurrent UI use — the two flows that crashed
