### PR TITLE
[fix] Project a stage delta's height, not just its slide (FIB-766)

### DIFF
--- a/fibsem/transformations.py
+++ b/fibsem/transformations.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
     from fibsem.structures import FibsemHardwareGeometry
 
+
 def convert_milling_angle_to_stage_tilt(
     milling_angle: float, pretilt: float, column_tilt: float = np.deg2rad(52)
 ) -> float:
@@ -45,7 +46,7 @@ def convert_stage_tilt_to_milling_angle(
 
 
 def get_stage_tilt_from_milling_angle(
-    microscope: 'FibsemMicroscope', milling_angle: float
+    microscope: "FibsemMicroscope", milling_angle: float
 ) -> float:
     """Get the stage tilt angle from the milling angle, based on pretilt and column tilt.
     Args:
@@ -61,8 +62,9 @@ def get_stage_tilt_from_milling_angle(
     )
     return stage_tilt
 
+
 def is_close_to_milling_angle(
-    microscope: 'FibsemMicroscope', milling_angle: float, atol: float = np.deg2rad(2)
+    microscope: "FibsemMicroscope", milling_angle: float, atol: float = np.deg2rad(2)
 ) -> bool:
     """Check if the stage tilt is close to the milling angle, within a tolerance.
     Args:
@@ -214,7 +216,7 @@ def inverse_view_corrected_dy(
     stage_rotation: float,
     stage_tilt: float,
 ) -> float:
-    """Recover an in-image y-displacement from a y/z stage movement.
+    """Where a y/z stage movement lands in the image, as an in-image y-displacement.
 
     The microscope-free form of
     :meth:`FibsemMicroscope._inverse_view_corrected_stage_movement`, parameterised by
@@ -222,6 +224,25 @@ def inverse_view_corrected_dy(
     together by a parity test across the full pose matrix, because a projection that
     silently disagrees with the one used to move the stage puts every overlay in the
     wrong place.
+
+    Not just the algebraic undo of :func:`view_corrected_stage_movement`, and the
+    difference is the point (FIB-766). The forward map only ever *produces* in-plane
+    movements -- a click slides the sample along its own surface -- but this is fed
+    arbitrary position deltas: two saved positions can differ in height, and a
+    coincidence correction is a chamber-vertical move. So the delta is resolved into
+    its in-plane and surface-normal components and each is projected through the view:
+
+        u   = dy*cos(a) - dz*sin(a)       in-plane component
+        n   = dy*sin(a) + dz*cos(a)       surface-normal component
+        e_y = u*cos(phi) - n*sin(phi)     phi = folded_tilt - a - view_tilt
+
+    On in-plane deltas (n = 0) this agrees exactly with inverting the forward, which
+    is what the parity tests pin. Off-plane it is what the old form was not: a
+    chamber-vertical move projects to zero in the SEM view (its u and n image shifts
+    cancel -- the old form kept only the u half, showing a phantom shift), and to
+    sin(view_tilt) times the height in a tilted view (the FIB really does see a
+    height change move; the old form discarded dz and showed nothing). Verified
+    against an independently calibrated 3D model in tests/test_projection_height.py.
 
     Args:
         dy: stage y movement, in metres.
@@ -232,24 +253,21 @@ def inverse_view_corrected_dy(
         stage_tilt: stage tilt at acquisition, in radians.
 
     Returns:
-        The in-image y-displacement that would produce that stage movement, in metres.
+        The in-image y-displacement produced by that stage movement, in metres.
     """
     compustage_sign, corrected_pretilt_angle, stage_tilt = _projection_terms(
         geometry, stage_rotation, stage_tilt
     )
 
     perspective_tilt_adjustment = -corrected_pretilt_angle - view_tilt
+    phi = stage_tilt + perspective_tilt_adjustment
 
-    # Undo y_move = y_sample_move * cos(a) and z_move = -y_sample_move * sin(a),
-    # taking whichever component is larger so the division stays conditioned.
     cos_pretilt = np.cos(corrected_pretilt_angle)
     sin_pretilt = np.sin(corrected_pretilt_angle)
-    if abs(cos_pretilt) > abs(sin_pretilt):
-        y_sample_move = dy / cos_pretilt
-    else:
-        y_sample_move = -dz / sin_pretilt
+    in_plane = dy * cos_pretilt - dz * sin_pretilt
+    normal = dy * sin_pretilt + dz * cos_pretilt
 
-    expected_y = y_sample_move * np.cos(stage_tilt + perspective_tilt_adjustment)
+    expected_y = in_plane * np.cos(phi) - normal * np.sin(phi)
 
     if geometry.is_compustage:
         expected_y *= compustage_sign

--- a/tests/test_projection_height.py
+++ b/tests/test_projection_height.py
@@ -1,0 +1,289 @@
+"""The inverse projection answers height, not just slide (FIB-766).
+
+`view_corrected_stage_movement` (the forward) only ever *produces* in-plane
+movements -- a click slides the sample along its own surface. Its inverse is fed
+arbitrary position deltas: saved positions that differ in height, and coincidence
+corrections, which are chamber-vertical. The old inverse read stage `dy` and
+discarded `dz`, so it was exact on the forward's line and wrong off it -- and the
+existing parity tests, which round-trip through the forward, were structurally
+blind to that (they only ever generate the inputs where every candidate agrees).
+
+These tests hold the inverse to an **independently calibrated 3D model** instead.
+The model is plain geometry -- chamber frame, orthographic views, stage axes
+rotated by the tilt -- with every sign convention left free, then *fitted* by
+requiring it to reproduce the existing forward map exactly over the full pose
+matrix, both configured geometries, both beams. The forward is the anchor because
+it drives real stage moves from clicks every day; a wrong convention there would
+walk the stage the wrong way and could not survive. Calibration is part of the
+test: if the forward's conventions ever change, `test_the_oracle_calibrates`
+fails first and says why everything else is failing.
+
+Run directly:
+    python -m pytest tests/test_projection_height.py
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import numpy as np
+import pytest
+
+from fibsem.structures import FibsemHardwareGeometry
+from fibsem.transformations import (
+    inverse_view_corrected_dy,
+    view_corrected_stage_movement,
+)
+
+# The two geometries the app actually runs: the compustage (Arctis) and the
+# pre-tilted autoloader shuttle. The autoloader matters even though the reported
+# defect was found on the Arctis: its 35 deg pretilt exercises the in-plane /
+# normal resolution that the Arctis (pretilt 0) never reaches.
+ARCTIS = FibsemHardwareGeometry(
+    column_tilt=0,
+    fib_column_tilt=52,
+    shuttle_pre_tilt=0.0,
+    rotation_reference=0,
+    rotation_180=0,
+    is_compustage=True,
+    camera_tilt=0.0,
+)
+AUTOLOADER = FibsemHardwareGeometry(
+    column_tilt=0,
+    fib_column_tilt=52,
+    shuttle_pre_tilt=35.0,
+    rotation_reference=0,
+    rotation_180=180,
+    is_compustage=False,
+    camera_tilt=0.0,
+)
+
+VIEW_TILTS = {"SEM": 0.0, "FIB": np.deg2rad(52.0)}
+
+# Sweep the configured orientations plus fillers, never just round numbers: both
+# geometry defects fixed in this module's history were exact at 0 and 180 and
+# wrong at -128 and -23, which nobody picks by hand.
+TILTS_DEG = (
+    -180.0,
+    -160.0,
+    -128.0,
+    -90.0,
+    -60.0,
+    -23.0,
+    -10.0,
+    0.0,
+    10.0,
+    20.0,
+    38.0,
+    52.0,
+)
+
+
+def _rot(theta: float) -> np.ndarray:
+    c, s = np.cos(theta), np.sin(theta)
+    return np.array([[c, -s], [s, c]])  # rotates (y, z) by theta
+
+
+def _pose_matrix():
+    for geometry in (ARCTIS, AUTOLOADER):
+        rotations = (0.0,) if geometry.is_compustage else (0.0, np.pi)
+        for rotation in rotations:
+            for tilt_deg in TILTS_DEG:
+                yield geometry, rotation, np.deg2rad(tilt_deg)
+
+
+class _Oracle:
+    """Orthographic projection of a stage delta into a view, in the chamber y-z plane.
+
+    ``d = dy * y_stage + dz * z_stage`` in chamber coordinates; the image shift is
+    ``flip * (y_image . d)``. Six discrete conventions are left free and fitted:
+
+    * ``s_t``    -- which way the stage tilt rotates
+    * ``s_v``    -- which side of vertical the tilted view leans
+    * ``s_img``  -- the image-y handedness
+    * ``k_fold`` -- whether the compustage half-turn adds pi to the physical tilt
+    * ``m_r``    -- whether a 180 deg stage rotation flips the raw y-axis
+    * ``m_cs``   -- whether the compustage sign flips the image frame
+    """
+
+    def __init__(self, s_t, s_v, s_img, k_fold, m_r, m_cs):
+        self.s_t, self.s_v, self.s_img = s_t, s_v, s_img
+        self.k_fold, self.m_r, self.m_cs = k_fold, m_r, m_cs
+
+    def _stage_axes(self, geometry, rotation, tilt):
+        tau = self.s_t * tilt + (np.pi * self.k_fold if geometry.is_compustage else 0.0)
+        y_stage = _rot(tau) @ np.array([1.0, 0.0])
+        z_stage = _rot(tau) @ np.array([0.0, 1.0])
+        near_180 = abs((np.rad2deg(rotation) % 360.0) - 180.0) < 5.0
+        if self.m_r and near_180:
+            y_stage = -y_stage
+        return y_stage, z_stage
+
+    def _flip(self, geometry, rotation, tilt) -> float:
+        if not (geometry.is_compustage and self.m_cs):
+            return 1.0
+        from fibsem.transformations import _projection_terms
+
+        sign, _, _ = _projection_terms(geometry, rotation, tilt)
+        return sign
+
+    def project(self, geometry, rotation, tilt, view_tilt, dy, dz) -> float:
+        y_stage, z_stage = self._stage_axes(geometry, rotation, tilt)
+        d = dy * y_stage + dz * z_stage
+        y_image = self.s_img * (_rot(self.s_v * view_tilt) @ np.array([1.0, 0.0]))
+        return float(y_image @ d) * self._flip(geometry, rotation, tilt)
+
+    def vertical_as_stage_delta(self, geometry, rotation, tilt, height):
+        """A chamber-vertical displacement, expressed as a stage (dy, dz)."""
+        y_stage, z_stage = self._stage_axes(geometry, rotation, tilt)
+        up = np.array([0.0, 1.0])
+        return float(height * (up @ y_stage)), float(height * (up @ z_stage))
+
+
+def _calibrate():
+    survivors = []
+    for combo in itertools.product([1, -1], [1, -1], [1, -1], [0, 1], [0, 1], [0, 1]):
+        oracle = _Oracle(*combo)
+        if all(
+            abs(
+                oracle.project(
+                    g,
+                    r,
+                    t,
+                    view_tilt,
+                    *view_corrected_stage_movement(1.0, view_tilt, g, r, t),
+                )
+                - 1.0
+            )
+            < 1e-9
+            for g, r, t in _pose_matrix()
+            for view_tilt in VIEW_TILTS.values()
+            if abs(view_corrected_stage_movement(1.0, view_tilt, g, r, t)[0]) < 50
+        ):
+            survivors.append(oracle)
+    return survivors
+
+
+@pytest.fixture(scope="module")
+def oracle():
+    survivors = _calibrate()
+    assert len(survivors) == 1, (
+        f"{len(survivors)} sign conventions reproduce the forward map; the "
+        "calibration no longer pins the geometry and nothing below means anything"
+    )
+    return survivors[0]
+
+
+def test_the_oracle_calibrates(oracle):
+    """One and only one convention tuple reproduces the forward map.
+
+    This is the load-bearing assertion: the fitted model is only an authority on
+    off-plane deltas because the forward map -- which drives real stage moves from
+    clicks -- pins every one of its sign choices.
+    """
+    assert (
+        oracle.s_t,
+        oracle.s_v,
+        oracle.s_img,
+        oracle.k_fold,
+        oracle.m_r,
+        oracle.m_cs,
+    ) == (1, 1, 1, 1, 0, 1)
+
+
+def _inverse(geometry, rotation, tilt, view_tilt, dy, dz) -> float:
+    return inverse_view_corrected_dy(
+        dy=dy,
+        dz=dz,
+        view_tilt=view_tilt,
+        geometry=geometry,
+        stage_rotation=rotation,
+        stage_tilt=tilt,
+    )
+
+
+class TestAgainstTheOracle:
+    def test_every_delta_everywhere(self, oracle):
+        """The full contract: the code and the model are the same linear map --
+        on-plane, off-plane, both beams, both geometries, every pose."""
+        rng = np.random.default_rng(766)
+        for geometry, rotation, tilt in _pose_matrix():
+            for view_tilt in VIEW_TILTS.values():
+                for _ in range(8):
+                    dy, dz = rng.uniform(-50e-6, 50e-6, size=2)
+                    want = oracle.project(geometry, rotation, tilt, view_tilt, dy, dz)
+                    got = _inverse(geometry, rotation, tilt, view_tilt, dy, dz)
+                    assert got == pytest.approx(want, abs=1e-15), (
+                        f"compustage={geometry.is_compustage} r={np.rad2deg(rotation):.0f} "
+                        f"t={np.rad2deg(tilt):.1f} view={np.rad2deg(view_tilt):.0f} "
+                        f"delta=({dy:.2e}, {dz:.2e})"
+                    )
+
+    def test_in_plane_deltas_round_trip_the_forward(self):
+        """The domain statement: on the forward's own outputs, the new inverse
+        answers exactly as inverting the forward -- so every marker whose position
+        delta came from a click or a stable move draws precisely where it did
+        before this fix. The visible change is confined to off-plane deltas."""
+        for geometry, rotation, tilt in _pose_matrix():
+            for view_tilt in VIEW_TILTS.values():
+                for expected_y in (25e-6, -60e-6):
+                    dy, dz = view_corrected_stage_movement(
+                        expected_y, view_tilt, geometry, rotation, tilt
+                    )
+                    if abs(dy) > 50:  # near-singular pose for this view
+                        continue
+                    assert _inverse(
+                        geometry, rotation, tilt, view_tilt, dy, dz
+                    ) == pytest.approx(expected_y, rel=1e-12)
+
+
+class TestTheTwoPhysicalInvariants:
+    """The convention-free facts the old code got wrong, stated as physics."""
+
+    @pytest.mark.parametrize("height", [20e-6, -35e-6])
+    def test_the_sem_is_blind_to_a_chamber_vertical_move(self, oracle, height):
+        """The electron column looks straight down, so a vertical move shifts
+        nothing in its image. The delta's u and n image shifts cancel exactly --
+        the old code kept only the u half and showed a phantom shift of up to
+        9.7 um per 20 um of coincidence correction."""
+        for geometry, rotation, tilt in _pose_matrix():
+            dy, dz = oracle.vertical_as_stage_delta(geometry, rotation, tilt, height)
+            assert _inverse(geometry, rotation, tilt, VIEW_TILTS["SEM"], dy, dz) == (
+                pytest.approx(0.0, abs=1e-18)
+            ), f"phantom SEM shift at t={np.rad2deg(tilt):.1f}"
+
+    @pytest.mark.parametrize("height", [20e-6, -35e-6])
+    def test_the_fib_sees_sin52_of_a_chamber_vertical_move(self, oracle, height):
+        """A view tilted 52 deg from vertical sees sin(52 deg) of a vertical
+        displacement -- at every pose, because the view axis is fixed in the
+        chamber and does not care where the stage is tilted to. The old code
+        showed nothing for a bare height change (dz discarded) and a wrong,
+        pose-dependent value for a coincidence move."""
+        expected = abs(height) * np.sin(np.deg2rad(52.0))
+        for geometry, rotation, tilt in _pose_matrix():
+            dy, dz = oracle.vertical_as_stage_delta(geometry, rotation, tilt, height)
+            shift = _inverse(geometry, rotation, tilt, VIEW_TILTS["FIB"], dy, dz)
+            assert abs(shift) == pytest.approx(expected, rel=1e-12), (
+                f"t={np.rad2deg(tilt):.1f}"
+            )
+
+
+class TestGoldenValuesAtTheConfiguredOrientations:
+    """Signed values at the poses the app actually uses, pinned so a future sign
+    slip cannot pass the magnitude checks by flipping direction. From the
+    calibrated oracle, on the Arctis, for a +20 um chamber-vertical move."""
+
+    @pytest.mark.parametrize(
+        "tilt_deg, fib_shift_um",
+        [
+            (-128.0, +15.760254),  # FIB orientation
+            (-23.0, -15.760254),  # MILLING orientation
+            (0.0, -15.760254),  # SEM orientation
+            (-180.0, -15.760254),  # FM orientation
+        ],
+    )
+    def test_fib_view_response(self, oracle, tilt_deg, fib_shift_um):
+        tilt = np.deg2rad(tilt_deg)
+        dy, dz = oracle.vertical_as_stage_delta(ARCTIS, 0.0, tilt, 20e-6)
+        shift = _inverse(ARCTIS, 0.0, tilt, VIEW_TILTS["FIB"], dy, dz)
+        assert shift * 1e6 == pytest.approx(fib_shift_um, abs=1e-4)

--- a/tests/test_view_corrected_movement.py
+++ b/tests/test_view_corrected_movement.py
@@ -10,15 +10,25 @@ Two different properties are pinned here, and they are deliberately kept apart:
 
 *Inert* -- the view parameterisation itself changed nothing. `_reference_y_corrected`
 and `_reference_inverse_y_corrected` are the original formulae copied verbatim, and
-the sweeps assert the current code agrees with them (for the inverse, on the
-non-compustage path, which the fix below leaves untouched).
+the sweeps assert the current code agrees with them. For the inverse that agreement
+now holds **on in-plane movements only**, which is the whole domain the forward can
+produce; see the second deliberate change below.
 
-*Deliberately changed* -- the inverse was never a faithful inverse of the forward on
-a compustage: the forward flips `expected_y` again at the FIB orientation, while the
-inverse used a stage-tilt threshold and never consulted orientation, so it returned
-the wrong sign there. The correctness criterion is round-trip identity, so those
-tests assert the round-trip rather than agreement with the old formula, and one test
-pins the old formula's wrong answer so the defect cannot creep back.
+*Deliberately changed (1)* -- the inverse was never a faithful inverse of the forward
+on a compustage: the forward flips `expected_y` again at the FIB orientation, while
+the inverse used a stage-tilt threshold and never consulted orientation, so it
+returned the wrong sign there. The correctness criterion is round-trip identity, so
+those tests assert the round-trip rather than agreement with the old formula, and one
+test pins the old formula's wrong answer so the defect cannot creep back.
+
+*Deliberately changed (2), FIB-766* -- the inverse is also fed movements the forward
+cannot produce. A click slides the sample along its own surface, but two saved
+positions can differ in height and a coincidence correction is chamber-vertical. The
+old form read stage `dy` and discarded `dz`, so it was exact on the forward's line
+and wrong off it, on **both** stage kinds. Same treatment as (1): the parity sweep is
+held to in-plane movements, round-trip identity is asserted separately, and
+`TestTheInverseCarriesHeight` pins the old formula's wrong answer off-plane. The full
+derivation and its oracle live in `tests/test_projection_height.py`.
 """
 
 from unittest.mock import Mock, patch
@@ -59,9 +69,9 @@ def _reference_y_corrected(microscope, expected_y: float, beam_type: BeamType):
     stage_rotation_flat_to_eb = np.deg2rad(
         microscope.system.stage.rotation_reference
     ) % (2 * np.pi)
-    stage_rotation_flat_to_ion = np.deg2rad(
-        microscope.system.stage.rotation_180
-    ) % (2 * np.pi)
+    stage_rotation_flat_to_ion = np.deg2rad(microscope.system.stage.rotation_180) % (
+        2 * np.pi
+    )
 
     current_stage_position = microscope.get_stage_position()
     stage_rotation = current_stage_position.r % (2 * np.pi)
@@ -72,9 +82,13 @@ def _reference_y_corrected(microscope, expected_y: float, beam_type: BeamType):
         stage_tilt += np.pi
 
     PRETILT_SIGN = 1.0
-    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
+    if movement.rotation_angle_is_smaller(
+        stage_rotation, stage_rotation_flat_to_eb, atol=5
+    ):
         PRETILT_SIGN = 1.0
-    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
+    if movement.rotation_angle_is_smaller(
+        stage_rotation, stage_rotation_flat_to_ion, atol=5
+    ):
         PRETILT_SIGN = -1.0
 
     if microscope.stage_is_compustage and microscope.get_stage_orientation() == "FIB":
@@ -86,7 +100,7 @@ def _reference_y_corrected(microscope, expected_y: float, beam_type: BeamType):
     if beam_type == BeamType.ELECTRON:
         perspective_tilt_adjustment = -corrected_pretilt_angle
     elif beam_type == BeamType.ION:
-        perspective_tilt_adjustment = (-corrected_pretilt_angle - fib_column_tilt)
+        perspective_tilt_adjustment = -corrected_pretilt_angle - fib_column_tilt
 
     y_sample_move = expected_y / np.cos(stage_tilt + perspective_tilt_adjustment)
 
@@ -96,13 +110,21 @@ def _reference_y_corrected(microscope, expected_y: float, beam_type: BeamType):
     return FibsemStagePosition(x=0, y=y_move, z=z_move)
 
 
-def _reference_inverse_y_corrected(microscope, dy: float, dz: float, beam_type: BeamType):
+def _reference_inverse_y_corrected(
+    microscope, dy: float, dz: float, beam_type: BeamType
+):
     """Pre-*fix* `_inverse_y_corrected_stage_movement`, copied verbatim.
 
-    Retained to pin that the non-compustage path is untouched, and to document the
-    compustage behaviour this branch deliberately changes (see
-    TestCompustageInverseRoundTrip): the old form used a stage-tilt threshold and
-    never consulted orientation, so it inverted the sign at the FIB pose.
+    Retained to pin the two behaviour changes since, and the domain on which nothing
+    changed at all:
+
+    * agreement still holds exactly for **in-plane** movements on a pre-tilted
+      shuttle -- the whole domain the forward map can produce
+    * the compustage sign at the FIB pose (see `TestCompustageInverseRoundTrip`): the
+      old form used a stage-tilt threshold and never consulted orientation
+    * the discarded height component (see `TestTheInverseCarriesHeight`): the
+      `dy / cos` branch below drops `dz` whenever the pretilt cosine dominates, which
+      on the Arctis (pretilt 0) is every pose
     """
     sem_column_tilt = np.deg2rad(microscope.system.electron.column_tilt)
     fib_column_tilt = np.deg2rad(microscope.system.ion.column_tilt)
@@ -112,13 +134,19 @@ def _reference_inverse_y_corrected(microscope, dy: float, dz: float, beam_type: 
     stage_rotation_flat_to_eb = np.deg2rad(
         microscope.system.stage.rotation_reference
     ) % (2 * np.pi)
-    stage_rotation_flat_to_ion = np.deg2rad(
-        microscope.system.stage.rotation_180
-    ) % (2 * np.pi)
+    stage_rotation_flat_to_ion = np.deg2rad(microscope.system.stage.rotation_180) % (
+        2 * np.pi
+    )
 
     current_stage_position = microscope.get_stage_position()
-    stage_rotation = current_stage_position.r % (2 * np.pi) if current_stage_position.r is not None else 0.0
-    stage_tilt = current_stage_position.t if current_stage_position.t is not None else 0.0
+    stage_rotation = (
+        current_stage_position.r % (2 * np.pi)
+        if current_stage_position.r is not None
+        else 0.0
+    )
+    stage_tilt = (
+        current_stage_position.t if current_stage_position.t is not None else 0.0
+    )
 
     compustage_sign = 1.0
     if microscope.stage_is_compustage:
@@ -127,9 +155,13 @@ def _reference_inverse_y_corrected(microscope, dy: float, dz: float, beam_type: 
         stage_tilt += np.pi
 
     PRETILT_SIGN = 1.0
-    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_eb, atol=5):
+    if movement.rotation_angle_is_smaller(
+        stage_rotation, stage_rotation_flat_to_eb, atol=5
+    ):
         PRETILT_SIGN = 1.0
-    if movement.rotation_angle_is_smaller(stage_rotation, stage_rotation_flat_to_ion, atol=5):
+    if movement.rotation_angle_is_smaller(
+        stage_rotation, stage_rotation_flat_to_ion, atol=5
+    ):
         PRETILT_SIGN = -1.0
 
     corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)
@@ -137,7 +169,7 @@ def _reference_inverse_y_corrected(microscope, dy: float, dz: float, beam_type: 
     if beam_type == BeamType.ELECTRON:
         perspective_tilt_adjustment = -corrected_pretilt_angle
     elif beam_type == BeamType.ION:
-        perspective_tilt_adjustment = (-corrected_pretilt_angle - fib_column_tilt)
+        perspective_tilt_adjustment = -corrected_pretilt_angle - fib_column_tilt
 
     cos_pretilt = np.cos(corrected_pretilt_angle)
     sin_pretilt = np.sin(corrected_pretilt_angle)
@@ -168,7 +200,9 @@ def _configure(microscope, *, pretilt_deg, rotation_deg, tilt_deg, compustage):
     microscope._update_orientations()
 
     position = FibsemStagePosition(
-        x=0.0, y=0.0, z=0.0,
+        x=0.0,
+        y=0.0,
+        z=0.0,
         r=np.deg2rad(rotation_deg),
         t=np.deg2rad(tilt_deg),
     )
@@ -224,10 +258,21 @@ class TestRefactorParity:
     @pytest.mark.parametrize("pretilt_deg", PRETILTS_DEG)
     @pytest.mark.parametrize("rotation_deg", ROTATIONS_DEG)
     @pytest.mark.parametrize("beam_type", BEAM_TYPES)
-    def test_inverse_parity_non_compustage(
+    def test_inverse_parity_non_compustage_in_plane(
         self, microscope, tilt_deg, pretilt_deg, rotation_deg, beam_type
     ):
-        """Pre-tilted shuttle stages are untouched by the compustage sign fix."""
+        """Pre-tilted shuttle stages are untouched, on in-plane movements.
+
+        The movement is taken from the forward map rather than written down, which is
+        what makes it in-plane: the forward only ever slides the sample along its own
+        surface, and that is the entire domain a click or a stable move can reach. On
+        it, the current inverse and the pre-fix formula agree to ~1e-20 at every pose.
+
+        Off that domain they deliberately disagree, and the old answer is the wrong
+        one -- FIB-766, pinned in `TestTheInverseCarriesHeight`. This test used to use
+        a hardcoded `(12e-6, -3e-6)`, which is off-plane, so it was asserting the
+        discarded-height behaviour without meaning to.
+        """
         _configure(
             microscope,
             pretilt_deg=pretilt_deg,
@@ -235,28 +280,159 @@ class TestRefactorParity:
             tilt_deg=tilt_deg,
             compustage=False,
         )
-        dy, dz = 12e-6, -3e-6
+        move = microscope._y_corrected_stage_movement(25e-6, beam_type=beam_type)
+        if abs(move.y) > 1e-2:
+            pytest.skip("near-singular pose for this view; the forward blows up")
 
-        got = microscope._inverse_y_corrected_stage_movement(dy=dy, dz=dz, beam_type=beam_type)
-        want = _reference_inverse_y_corrected(microscope, dy=dy, dz=dz, beam_type=beam_type)
+        got = microscope._inverse_y_corrected_stage_movement(
+            dy=move.y, dz=move.z, beam_type=beam_type
+        )
+        want = _reference_inverse_y_corrected(
+            microscope, dy=move.y, dz=move.z, beam_type=beam_type
+        )
 
         assert got == pytest.approx(want, rel=1e-12, abs=1e-18)
+        assert got == pytest.approx(25e-6, rel=1e-9), "and it round-trips"
+
+
+class TestTheInverseCarriesHeight:
+    """FIB-766. The deliberate off-plane change, on the pre-tilted shuttle path.
+
+    The old form recovered a movement from stage `dy` alone -- `dy / cos(pretilt)`
+    whenever the cosine dominated, `-dz / sin(pretilt)` otherwise -- so it read one
+    axis and discarded the other. That is exact for the in-plane movements the forward
+    produces and wrong for everything else, and the inverse is fed everything else:
+    two saved positions can differ in height, and a coincidence correction is
+    chamber-vertical.
+
+    Held here as physics, so it does not depend on this codebase's sign conventions
+    being right. The conventions themselves are pinned against a calibrated 3D model
+    in `tests/test_projection_height.py`.
+    """
+
+    def test_the_old_form_discarded_the_height_component(self, microscope):
+        """Pin the specific defect, so it cannot be reintroduced silently.
+
+        A pure stage-z movement projected to exactly nothing, in every view, at every
+        pose -- which is the failure that leaves no trace: the overview desynchronises
+        from the sample and no marker moves to say so.
+        """
+        for tilt_deg in (-128, -50, -23, 0, 15, 35):
+            _configure(
+                microscope,
+                pretilt_deg=0,
+                rotation_deg=0,
+                tilt_deg=tilt_deg,
+                compustage=False,
+            )
+            for beam_type in BEAM_TYPES:
+                old = _reference_inverse_y_corrected(
+                    microscope, dy=0.0, dz=20e-6, beam_type=beam_type
+                )
+                assert old == pytest.approx(0.0, abs=1e-18), (
+                    f"the pre-fix formula moved at t={tilt_deg} / {beam_type.name}; "
+                    "this test no longer pins the defect it was written for"
+                )
+
+    @pytest.mark.parametrize("tilt_deg", [-128, -50, -23, 0, 15, 35, 52])
+    def test_a_bare_height_change_now_projects_somewhere(self, microscope, tilt_deg):
+        """And the current form does not discard it.
+
+        Stated as "at least one view sees it", which is the invariant that actually
+        holds: the two view axes are 52 deg apart, so a height change cannot be
+        invisible to both. It *can* be invisible to one -- at t = -128 stage z lies
+        exactly along the ion column's line of sight, and the ion view is correctly
+        blind to it there, as the electron view is at t = 0. Asserting "the ion beam
+        always sees it" looks stronger and is simply false; that version of this test
+        failed at t = -128 and the code was right.
+
+        Not asserted against values, which is the calibrated suite's job. The point
+        here is only that the axis is no longer thrown away -- the old form showed
+        nothing in *either* view at *every* pose.
+        """
+        _configure(
+            microscope,
+            pretilt_deg=0,
+            rotation_deg=0,
+            tilt_deg=tilt_deg,
+            compustage=False,
+        )
+        shifts = {
+            beam_type.name: microscope._inverse_y_corrected_stage_movement(
+                dy=0.0, dz=20e-6, beam_type=beam_type
+            )
+            for beam_type in BEAM_TYPES
+        }
+        assert any(abs(shift) > 1e-9 for shift in shifts.values()), (
+            f"height discarded in every view at t={tilt_deg}: {shifts}"
+        )
+
+    @pytest.mark.parametrize("pretilt_deg", PRETILTS_DEG)
+    @pytest.mark.parametrize("tilt_deg", [-50, -23, 0, 15, 35])
+    def test_the_projection_is_the_view_frame_horizontal(
+        self, microscope, tilt_deg, pretilt_deg
+    ):
+        """What the new form reduces to, and why it is credible.
+
+        On a pre-tilted shuttle it collapses to the horizontal component of the stage
+        movement measured in the view's own frame:
+
+            expected_y = dy*cos(t - view_tilt) - dz*sin(t - view_tilt)
+
+        The pretilt cancels out entirely -- which is the right shape, because where a
+        *chamber* displacement lands in an orthographic view depends only on the view's
+        angle from vertical and on the stage tilt that orients the stage axes in the
+        chamber. The sample's own pretilt says how the stage axes relate to the
+        surface, which this question does not ask.
+
+        Recorded because FIB-766 rejected `dy*cos(t) - dz*sin(t)` as a candidate on the
+        grounds that it disagreed with the old answer for in-plane movements. It does --
+        the term it was missing is the view tilt, and with that the disagreement is
+        confined to exactly the off-plane movements the old form got wrong.
+        """
+        _configure(
+            microscope,
+            pretilt_deg=pretilt_deg,
+            rotation_deg=0,
+            tilt_deg=tilt_deg,
+            compustage=False,
+        )
+        tilt = np.deg2rad(tilt_deg)
+        for beam_type, view_tilt in (
+            (BeamType.ELECTRON, 0.0),
+            (BeamType.ION, np.deg2rad(microscope.system.ion.column_tilt)),
+        ):
+            for dy, dz in ((12e-6, -3e-6), (0.0, 20e-6), (-7e-6, 9e-6)):
+                got = microscope._inverse_y_corrected_stage_movement(
+                    dy=dy, dz=dz, beam_type=beam_type
+                )
+                want = dy * np.cos(tilt - view_tilt) - dz * np.sin(tilt - view_tilt)
+                assert got == pytest.approx(want, rel=1e-9, abs=1e-18), (
+                    f"pretilt {pretilt_deg} did not cancel at t={tilt_deg} / "
+                    f"{beam_type.name}"
+                )
 
 
 class TestViewTiltEquivalence:
     """A beam is just a view with a particular axis tilt."""
 
     def test_zero_view_tilt_is_the_electron_column(self, microscope):
-        _configure(microscope, pretilt_deg=35, rotation_deg=0, tilt_deg=20, compustage=False)
+        _configure(
+            microscope, pretilt_deg=35, rotation_deg=0, tilt_deg=20, compustage=False
+        )
 
         by_view = microscope._view_corrected_stage_movement(25e-6, view_tilt=0.0)
-        by_beam = microscope._y_corrected_stage_movement(25e-6, beam_type=BeamType.ELECTRON)
+        by_beam = microscope._y_corrected_stage_movement(
+            25e-6, beam_type=BeamType.ELECTRON
+        )
 
         assert by_view.y == pytest.approx(by_beam.y)
         assert by_view.z == pytest.approx(by_beam.z)
 
     def test_column_tilt_view_is_the_ion_column(self, microscope):
-        _configure(microscope, pretilt_deg=35, rotation_deg=0, tilt_deg=20, compustage=False)
+        _configure(
+            microscope, pretilt_deg=35, rotation_deg=0, tilt_deg=20, compustage=False
+        )
         view_tilt = np.deg2rad(microscope.system.ion.column_tilt)
 
         by_view = microscope._view_corrected_stage_movement(25e-6, view_tilt=view_tilt)
@@ -273,11 +449,15 @@ class TestViewTiltEquivalence:
 
     @pytest.mark.parametrize("view_tilt_deg", [0, 38, 52, 180])
     def test_inverse_round_trips(self, microscope, view_tilt_deg):
-        _configure(microscope, pretilt_deg=35, rotation_deg=0, tilt_deg=20, compustage=False)
+        _configure(
+            microscope, pretilt_deg=35, rotation_deg=0, tilt_deg=20, compustage=False
+        )
         view_tilt = np.deg2rad(view_tilt_deg)
         expected_y = 25e-6
 
-        move = microscope._view_corrected_stage_movement(expected_y, view_tilt=view_tilt)
+        move = microscope._view_corrected_stage_movement(
+            expected_y, view_tilt=view_tilt
+        )
         recovered = microscope._inverse_view_corrected_stage_movement(
             dy=move.y, dz=move.z, view_tilt=view_tilt
         )
@@ -301,13 +481,21 @@ class TestCompustageInverseRoundTrip:
     def test_round_trips_at_every_compustage_orientation(
         self, microscope, tilt_deg, orientation, view_tilt_deg
     ):
-        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=tilt_deg, compustage=True)
+        _configure(
+            microscope,
+            pretilt_deg=0,
+            rotation_deg=0,
+            tilt_deg=tilt_deg,
+            compustage=True,
+        )
         assert microscope.get_stage_orientation() == orientation, "test pose drifted"
 
         view_tilt = np.deg2rad(view_tilt_deg)
         expected_y = 25e-6
 
-        move = microscope._view_corrected_stage_movement(expected_y, view_tilt=view_tilt)
+        move = microscope._view_corrected_stage_movement(
+            expected_y, view_tilt=view_tilt
+        )
         recovered = microscope._inverse_view_corrected_stage_movement(
             dy=move.y, dz=move.z, view_tilt=view_tilt
         )
@@ -319,11 +507,19 @@ class TestCompustageInverseRoundTrip:
         self, microscope, tilt_deg, orientation
     ):
         """The same property through the public beam-typed wrappers."""
-        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=tilt_deg, compustage=True)
+        _configure(
+            microscope,
+            pretilt_deg=0,
+            rotation_deg=0,
+            tilt_deg=tilt_deg,
+            compustage=True,
+        )
         expected_y = 25e-6
 
         for beam_type in BEAM_TYPES:
-            move = microscope._y_corrected_stage_movement(expected_y, beam_type=beam_type)
+            move = microscope._y_corrected_stage_movement(
+                expected_y, beam_type=beam_type
+            )
             recovered = microscope._inverse_y_corrected_stage_movement(
                 dy=move.y, dz=move.z, beam_type=beam_type
             )
@@ -337,11 +533,15 @@ class TestCompustageInverseRoundTrip:
         This is the behaviour change this branch makes, stated explicitly so it cannot
         be reintroduced silently.
         """
-        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-128, compustage=True)
+        _configure(
+            microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-128, compustage=True
+        )
         assert microscope.get_stage_orientation() == "FIB"
         expected_y = 25e-6
 
-        move = microscope._y_corrected_stage_movement(expected_y, beam_type=BeamType.ELECTRON)
+        move = microscope._y_corrected_stage_movement(
+            expected_y, beam_type=BeamType.ELECTRON
+        )
         pre_fix = _reference_inverse_y_corrected(
             microscope, dy=move.y, dz=move.z, beam_type=BeamType.ELECTRON
         )
@@ -349,7 +549,9 @@ class TestCompustageInverseRoundTrip:
             dy=move.y, dz=move.z, beam_type=BeamType.ELECTRON
         )
 
-        assert pre_fix == pytest.approx(-expected_y, rel=1e-9), "pre-fix formula was sign-inverted"
+        assert pre_fix == pytest.approx(-expected_y, rel=1e-9), (
+            "pre-fix formula was sign-inverted"
+        )
         assert fixed == pytest.approx(expected_y, rel=1e-9), "fixed formula round-trips"
 
     def test_non_compustage_round_trips_across_orientations(self, microscope):
@@ -363,7 +565,9 @@ class TestCompustageInverseRoundTrip:
                 compustage=False,
             )
             for beam_type in BEAM_TYPES:
-                move = microscope._y_corrected_stage_movement(25e-6, beam_type=beam_type)
+                move = microscope._y_corrected_stage_movement(
+                    25e-6, beam_type=beam_type
+                )
                 recovered = microscope._inverse_y_corrected_stage_movement(
                     dy=move.y, dz=move.z, beam_type=beam_type
                 )
@@ -401,7 +605,11 @@ class TestTiledInverseMatchesMicroscope:
         )
 
         position = _configure(
-            microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=tilt_deg, compustage=True
+            microscope,
+            pretilt_deg=0,
+            rotation_deg=0,
+            tilt_deg=tilt_deg,
+            compustage=True,
         )
         _sync_image_metadata(image, microscope, position, is_compustage=True)
 
@@ -418,19 +626,29 @@ class TestTiledInverseMatchesMicroscope:
     @pytest.mark.parametrize(
         "tilt_deg, orientation", TestCompustageInverseRoundTrip.COMPUSTAGE_POSES
     )
-    def test_round_trips_against_the_forward(self, microscope, image, tilt_deg, orientation):
+    def test_round_trips_against_the_forward(
+        self, microscope, image, tilt_deg, orientation
+    ):
         from fibsem.imaging.tiled import (
             _inverse_y_corrected_stage_movement as tiled_inverse,
         )
 
         position = _configure(
-            microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=tilt_deg, compustage=True
+            microscope,
+            pretilt_deg=0,
+            rotation_deg=0,
+            tilt_deg=tilt_deg,
+            compustage=True,
         )
         _sync_image_metadata(image, microscope, position, is_compustage=True)
         expected_y = 25e-6
 
-        move = microscope._y_corrected_stage_movement(expected_y, beam_type=BeamType.ELECTRON)
-        recovered = tiled_inverse(image, dy=move.y, dz=move.z, beam_type=BeamType.ELECTRON)
+        move = microscope._y_corrected_stage_movement(
+            expected_y, beam_type=BeamType.ELECTRON
+        )
+        recovered = tiled_inverse(
+            image, dy=move.y, dz=move.z, beam_type=BeamType.ELECTRON
+        )
 
         assert recovered == pytest.approx(expected_y, rel=1e-9)
 
@@ -552,7 +770,9 @@ class TestCameraImageTransformIsFlipOnly:
         from fibsem.fm.structures import CameraSettings
 
         for transform in CameraImageTransform:
-            restored = CameraSettings.from_dict(CameraSettings(transform=transform).to_dict())
+            restored = CameraSettings.from_dict(
+                CameraSettings(transform=transform).to_dict()
+            )
             assert restored.transform is transform
 
 
@@ -566,7 +786,9 @@ class TestFmStableMove:
 
     def test_uses_the_camera_tilt_projection(self, microscope):
         """The move must match the shared projection at the camera's own axis tilt."""
-        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
+        _configure(
+            microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True
+        )
         microscope.fm = FluorescenceMicroscope(parent=microscope)
         moved = []
         microscope.move_stage_relative = lambda p: moved.append(p)  # type: ignore[method-assign]
@@ -583,7 +805,9 @@ class TestFmStableMove:
 
     def test_undoes_the_display_transform(self, microscope):
         """A flipped display must not send the stage the wrong way."""
-        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
+        _configure(
+            microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True
+        )
         microscope.fm = FluorescenceMicroscope(parent=microscope)
         moved = []
         microscope.move_stage_relative = lambda p: moved.append(p)  # type: ignore[method-assign]
@@ -593,12 +817,16 @@ class TestFmStableMove:
         microscope.fm.set_image_transform(CameraImageTransform.FLIP_X)
         microscope.fm_stable_move(dx=4e-6, dy=25e-6)
 
-        assert moved[1].x == pytest.approx(-moved[0].x), "flip in x should reverse the x move"
+        assert moved[1].x == pytest.approx(-moved[0].x), (
+            "flip in x should reverse the x move"
+        )
         assert moved[1].y == pytest.approx(moved[0].y), "flip in x should leave y alone"
 
     def test_reads_the_transform_live(self, microscope):
         """Changing the dropdown mid-session takes effect on the next move."""
-        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
+        _configure(
+            microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True
+        )
         microscope.fm = FluorescenceMicroscope(parent=microscope)
         moved = []
         microscope.move_stage_relative = lambda p: moved.append(p)  # type: ignore[method-assign]
@@ -611,7 +839,9 @@ class TestFmStableMove:
 
     def test_does_not_touch_working_distance(self, microscope):
         """Working distance is beam bookkeeping; the FM move must leave it alone."""
-        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
+        _configure(
+            microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True
+        )
         microscope.fm = FluorescenceMicroscope(parent=microscope)
         microscope.move_stage_relative = lambda p: None  # type: ignore[method-assign]
         calls = []
@@ -665,7 +895,9 @@ class TestProjectFmStableMove:
         compustage_fm.move_stage_relative = lambda p: moved.append(p)  # type: ignore[method-assign]
         compustage_fm.move_stage_absolute = lambda p: moved.append(p)  # type: ignore[method-assign]
 
-        compustage_fm.project_fm_stable_move(4e-6, 25e-6, FibsemStagePosition(x=0, y=0, z=0))
+        compustage_fm.project_fm_stable_move(
+            4e-6, 25e-6, FibsemStagePosition(x=0, y=0, z=0)
+        )
 
         assert moved == []
 
@@ -682,7 +914,9 @@ class TestProjectFmStableMove:
         """
         scope = request.getfixturevalue(mount)
         scope.fm.set_image_transform(transform)
-        base = FibsemStagePosition(x=1e-3, y=-2e-3, z=5e-4, r=0, t=0, coordinate_system="RAW")
+        base = FibsemStagePosition(
+            x=1e-3, y=-2e-3, z=5e-4, r=0, t=0, coordinate_system="RAW"
+        )
 
         moved = []
         scope.move_stage_relative = lambda p: moved.append(p)  # type: ignore[method-assign]
@@ -756,7 +990,9 @@ class TestProjectFmStableMove:
 
     def test_offset_mount_uses_the_ion_column_tilt(self, offset_fm):
         """The offset optical axis is parallel to the FIB column, so it must project like one."""
-        assert offset_fm.fm.camera_tilt == pytest.approx(offset_fm.system.ion.column_tilt)
+        assert offset_fm.fm.camera_tilt == pytest.approx(
+            offset_fm.system.ion.column_tilt
+        )
 
         base = FibsemStagePosition(x=0.0, y=0.0, z=0.0)
         projected = offset_fm.project_fm_stable_move(0.0, 25e-6, base)
@@ -788,7 +1024,9 @@ class TestFmConsumersUseTheFmProjection:
         """
         from fibsem.fm import acquisition
 
-        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
+        _configure(
+            microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True
+        )
         microscope.fm = FluorescenceMicroscope(parent=microscope)
         # A fresh objective is retracted, and a run refuses that (FIB-417) before it
         # projects anything. This test is about which projection tiles are placed with,
@@ -810,26 +1048,36 @@ class TestFmConsumersUseTheFmProjection:
             acquisition.acquire_tileset(
                 microscope=microscope,
                 channel_settings=ChannelSettings(
-                    name="DAPI", excitation_wavelength=358, emission_wavelength=461,
-                    power=0.1, exposure_time=0.1,
+                    name="DAPI",
+                    excitation_wavelength=358,
+                    emission_wavelength=461,
+                    power=0.1,
+                    exposure_time=0.1,
                 ),
                 overview_parameters=OverviewParameters(
-                    rows=2, cols=2, overlap=0.1,
-                    use_zstack=False, autofocus_mode=AutoFocusMode.NONE,
+                    rows=2,
+                    cols=2,
+                    overlap=0.1,
+                    use_zstack=False,
+                    autofocus_mode=AutoFocusMode.NONE,
                 ),
             )
 
         assert len(fm_calls) == 4, "one FM projection per tile"
         assert beam_calls == [], "nothing may position a tile via a beam projection"
 
-    def test_fm_projection_differs_from_the_sem_projection_when_it_matters(self, microscope):
+    def test_fm_projection_differs_from_the_sem_projection_when_it_matters(
+        self, microscope
+    ):
         """Guard the reason for the switch: the two projections really do differ.
 
         At the FIB-flat orientation on an offset mount, stepping via the electron
         column foreshortens differently from the camera. If this ever became a
         no-op the switch would be pointless -- and a regression would be invisible.
         """
-        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=0, compustage=False)
+        _configure(
+            microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=0, compustage=False
+        )
         microscope.system.electron.column_tilt = 0.0
         microscope.system.ion.column_tilt = 52.0
         fm = FluorescenceMicroscope(parent=microscope)
@@ -870,7 +1118,9 @@ class TestCameraTilt:
         compustage has no pre-tilt, so the projection should come out flat-on to the
         camera: no foreshortening, pure y move.
         """
-        _configure(microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True)
+        _configure(
+            microscope, pretilt_deg=0, rotation_deg=0, tilt_deg=-180, compustage=True
+        )
         microscope.system.electron.column_tilt = 0.0
 
         fm = FluorescenceMicroscope(parent=microscope)
@@ -912,7 +1162,8 @@ class TestMountTransform:
         """A driver overriding mount_transform gets it applied first."""
         fm = FluorescenceMicroscope()
         monkeypatch.setattr(
-            type(fm), "mount_transform",
+            type(fm),
+            "mount_transform",
             property(lambda self: CameraImageTransform.FLIP_Y),
         )
         fm.set_image_transform(CameraImageTransform.FLIP_X)


### PR DESCRIPTION
From the 2026-08-20 bench session: *"need to refresh the view projection when the user adjusts the coincidence (vertical move)"*. FIB-766 established it is not a refresh problem: the inverse projection reads stage `dy` and discards `dz`, so any position delta with a height component projects wrongly — on both beams, at every orientation except SEM and FM, which are exactly the two poses anyone sanity-checks at.

Step 1 (#492) collapsed the three copies of the inverse into one implementation. This is step 2: make that one implementation right.

## The fix

A stage delta has two physically distinct components and the beams respond to them differently — the SEM looks straight down so height is invisible to it; the FIB views at 52° so height *is* lateral to it. The inverse now resolves the delta and projects both:

```
u   = dy·cos(a) − dz·sin(a)       in-plane (slide along the surface)
n   = dy·sin(a) + dz·cos(a)       surface-normal (height)
e_y = u·cos(φ) − n·sin(φ)          φ = folded_tilt − a − view_tilt
```

The old form kept only the `u`-ish term (on the Arctis, where `a = 0`, it degenerated to literally `dy`). One function body in `transformations.py`; the conditioned-division branch disappears entirely, and with it the near-singular pose concern.

**The domain statement that bounds the blast radius:** on in-plane deltas (`n = 0`) the new form is *identical* to the old one — every pose, both beams, both geometries, to the last digit. Every marker placed by a click or stable move draws exactly where it did. Only deltas with a height component change, and those are exactly the ones drawn wrong today.

## What changes on screen

For a 20 µm coincidence correction on the Arctis (px at a 500 µm / 1536 px overview):

| pose | view | old showed | now shows | change |
|---|---|---|---|---|
| FIB | SEM | **+9.70 µm** (phantom) | 0 | 30 px |
| MILLING | SEM | **+7.19 µm** (phantom) | 0 | 22 px |
| MILLING | FIB | +2.02 µm | **−15.76 µm** | **55 px** |
| SEM / FM | FIB | 0 | −15.76 µm | 48 px |
| FIB | FIB | +15.76 µm | +15.76 µm | — (old was accidentally right here) |

The worst case is where it matters most: at the MILLING pose in the FIB view — where coincidence is adjusted and milling happens — the marker sat 17.8 µm from the feature, a lamella's width. And a **bare stage-z change previously moved nothing anywhere** (the silent desync); it now projects truly, with physically coherent structure — at the FIB orientation stage-z lies along the FIB's line of sight, so the FIB sees 0 and the SEM sees the full sin(52°) component.

Also affected, correctly: the anchor of placed images (`frame.offset(tile.position)`). Within one tileset nothing changes — a run holds one pose — but an overview acquired after a coincidence change now registers correctly against one acquired before.

**Display only.** Every consumer of the inverse — canvas markers and overlays, minimap reprojection, FM markers and planning, placed-image anchors — maps a stage position to pixels. No move path reads it; clicks and moves go through the forward map, untouched.

## How it was verified: a calibrated oracle, not derived signs

This module carries a compustage half-turn fold, a compustage sign, a pretilt sign and a rotation flip; hand-deriving the missing term was attempted twice during investigation and was wrong both times. Instead:

1. An independent 3D model — chamber frame, orthographic views, stage axes rotated by the tilt — with **every sign convention left free** (six discrete parameters, 64 combinations).
2. The parameters are **fitted** by requiring the model to reproduce the existing *forward* map exactly over the full pose matrix, both configured geometries (Arctis compustage and 35° autoloader), both beams. The forward is the anchor because clicks drive real stage moves through it daily — a wrong convention there could not survive.
3. **Exactly one tuple survives**, and the closed form above matches it to 3e-20 on random deltas everywhere. The wrong sign on the `n` term fails at 1.3e-4 — the discrimination is sharp.

The calibration runs *inside* `tests/test_projection_height.py`: if the forward's conventions ever change, the calibration test fails first and says why everything else is failing.

## Why the existing tests could not catch this

The forward map is 1-D → 2-D, so it only ever *generates* in-plane deltas — round-tripping it (which is what the parity suite does) exercises precisely the subset where every candidate form, including the broken one, agrees. The new tests generate the inputs the forward cannot produce:

- **oracle agreement everywhere** — random deltas over the full matrix
- **the two physical invariants** the old code violated: a chamber-vertical move projects to zero in the SEM view (its `u` and `n` image shifts cancel exactly; the old code kept one half of the pair), and to sin(52°)·h in the FIB view, at every pose
- **the in-plane round-trip** — the "markers from clicks don't move a pixel" guarantee
- **signed goldens** at the configured orientations (−128°, −23°), so a future sign slip cannot pass the magnitude checks by flipping direction

Five hand-planted mutations (n-sign flip, dropped normal term = the old bug, dropped compustage flip, wrong view-tilt sign, swapped components) are each killed by the suite. Adjacent suites all green: 249 geometry/movement/reprojection + 540 overview UI.

## A test that was pinning the old behaviour

The first CI run went red with 66 failures, all in one test:
`test_inverse_parity_non_compustage`, which compares the inverse against
`_reference_inverse_y_corrected` — the pre-fix formula copied verbatim — using a
hardcoded `(dy, dz) = (12e-6, -3e-6)`. **That pair is off-plane**, so the test was
asserting the discarded-height behaviour this PR removes. Its real subject is FIB-133
(that parameterising the projection by view tilt changed nothing), and that property
still holds exactly — it just has to be asked on the domain the forward map can reach.
The movement now comes from the forward rather than being written down, and agreement
with the pre-fix formula holds to ~1e-20 at every pose in the sweep.

The failure pattern was itself confirmation: ELECTRON failed at every tilt except
`t = 0`, ION at every tilt except `t = 52` and `t = −128` — precisely where
`sin(t − view_tilt) = 0`, i.e. where the height term vanishes.

Same treatment this file already gave the compustage sign change: hold the parity
sweep to where agreement is still expected, assert round-trip identity as the
correctness criterion, and pin the old formula's wrong answer separately.
`TestTheInverseCarriesHeight` is that pin.

### A simplification worth recording

On a pre-tilted shuttle the new form reduces exactly to

```
expected_y = dy·cos(t − view_tilt) − dz·sin(t − view_tilt)
```

with **the pretilt cancelling out entirely** (verified to 6e-21 across pretilts
0/12/35/45, both rotations, both views). That is the right shape: where a *chamber*
displacement lands in an orthographic view depends only on the view's angle from
vertical and the stage tilt that orients the stage axes in the chamber — the sample's
pretilt describes how the stage axes relate to the surface, which this question does
not ask.

It is also the candidate FIB-766 rejected, for disagreeing with the old answer on
ordinary in-plane movements. It does disagree — **the term it was missing is the view
tilt**, and with that restored the disagreement is confined to exactly the off-plane
movements the old form got wrong. Recorded in the issue and pinned in the test.

One of my own new tests was wrong before it was right: asserting "the ion beam always
sees a height change" failed at `t = −128`, where stage z lies along the ion column's
line of sight and the ion view is *correctly* blind to it. The invariant that holds is
that the two view axes are 52° apart, so at least one view must see it.

## Verification

Full non-UI suite green locally (3864 passed) — the same set CI runs, rather than the
files I picked by name pattern, which is how the parity test slipped through the first
time. Two failures in `tests/ui/test_coincidence_viewer_layering.py` on a full
`tests/ui/` run are **pre-existing on `origin/main`** (confirmed by running it there)
and order-dependent — they pass in isolation. Unrelated to this change; CI does not run
`tests/ui/` at all, since it installs `.[test]` without PyQt5.

## For the next bench session (FIB-755)

Centre a feature in the FIB view at the milling pose, adjust coincidence: the FIB markers should now track the feature. **A small residual drift of the SEM marker is expected and correct** — `vertical_move` is not exactly chamber-vertical (FIB-773, the 1/cos-vs-cos axis error), and the projection now displays the move the stage actually made, honestly. Do not read that residual as this bug surviving.

One correction to FIB-766 as filed: its verdict table called the FIB-view value at the FIB orientation wrong; it was accidentally correct there (the phantom at that pose was on the SEM side). The issue is updated.
