### PR TITLE
One canonical spelling per manufacturer, normalised at the boundaries

### DIFF
--- a/fibsem/manufacturers.py
+++ b/fibsem/manufacturers.py
@@ -1,0 +1,58 @@
+"""Canonical manufacturer names and the one alias map (FIB-300).
+
+The same vendor arrives spelled differently depending on the source: live TESCAN
+hardware reports "TESCAN" in image headers while the driver property and configs say
+"Tescan"; ThermoFisher appears as "Thermo" (configs), "ThermoFisher" (driver
+property) and "Thermo Fisher Scientific" (session setup). Comparisons scattered
+across the codebase each coped locally -- defensive ``.upper()``, hand-rolled alias
+lists -- or didn't cope and silently took the wrong branch (a live inverted-UI bug
+on PR #115). One canonical form, normalised at the boundaries (``SystemInfo.from_dict``
+and the driver assignments), retires all of that.
+
+Canonical *strings* rather than an Enum, on purpose: CI runs Python 3.8 (no
+``StrEnum``), the ``(str, Enum)`` mixin diverges between ``str()`` and ``format()``
+on 3.8-3.10 exactly where YAML/dict serialisation would hit it, and strings keep
+every existing ``to_dict``/``from_dict``/config round-trip shape-identical.
+"""
+
+from typing import Optional
+
+THERMOFISHER = "ThermoFisher"
+TESCAN = "Tescan"
+DEMO = "Demo"
+ODEMIS = "Odemis"
+ZEISS = "Zeiss"
+
+# every known spelling, lowercased -> canonical
+_ALIASES = {
+    "thermo": THERMOFISHER,
+    "thermofisher": THERMOFISHER,
+    "thermo fisher": THERMOFISHER,
+    "thermo fisher scientific": THERMOFISHER,
+    "tescan": TESCAN,
+    "demo": DEMO,
+    "odemis": ODEMIS,
+    "zeiss": ZEISS,
+}
+
+
+def normalize_manufacturer(raw: Optional[str]) -> Optional[str]:
+    """Return the canonical spelling for any known manufacturer alias.
+
+    Unknown, empty and non-string values pass through unchanged -- normalisation is
+    lenient so reading old data can never fail. Validation sites keep their own
+    membership checks against the canonical names.
+    """
+    if not isinstance(raw, str):
+        return raw
+    return _ALIASES.get(raw.strip().lower(), raw)
+
+
+def is_tescan(value: Optional[str]) -> bool:
+    """Whether *value* names TESCAN, in any known spelling."""
+    return normalize_manufacturer(value) == TESCAN
+
+
+def is_thermo(value: Optional[str]) -> bool:
+    """Whether *value* names ThermoFisher, in any known spelling."""
+    return normalize_manufacturer(value) == THERMOFISHER

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -100,6 +100,7 @@ except Exception:
 
 
 import fibsem.constants as constants
+from fibsem import manufacturers
 from fibsem.fm.microscope import FluorescenceMicroscope
 from fibsem.microscopes.autoscript import (
     fibsem_image_from_adorned_image,
@@ -1178,12 +1179,15 @@ class FibsemMicroscope(ABC):
         self.set_beam_current(current=milling_current, beam_type=beam_type)
 
         for i, pt in enumerate(coordinates, 1):
-
             if stop_event is not None and stop_event.is_set():
-                logging.info(f"Spot burn cancelled before point {i}/{len(coordinates)}.")
+                logging.info(
+                    f"Spot burn cancelled before point {i}/{len(coordinates)}."
+                )
                 break
 
-            logging.info(f'burning spot {i}: {pt}, exposure time: {exposure_time}, milling current: {milling_current}')
+            logging.info(
+                f"burning spot {i}: {pt}, exposure time: {exposure_time}, milling current: {milling_current}"
+            )
 
             self.blank(beam_type=beam_type)
             self.set_spot_scanning_mode(point=pt, beam_type=beam_type)
@@ -1194,7 +1198,9 @@ class FibsemMicroscope(ABC):
             while remaining_time > 0:
                 if stop_event is not None and stop_event.is_set():
                     self.blank(beam_type=beam_type)
-                    logging.info(f"Spot burn cancelled during point {i}/{len(coordinates)}.")
+                    logging.info(
+                        f"Spot burn cancelled during point {i}/{len(coordinates)}."
+                    )
                     break
                 time.sleep(SLEEP_TIME)
                 remaining_time -= SLEEP_TIME
@@ -2071,7 +2077,10 @@ class FibsemMicroscope(ABC):
 
     @property
     def manufacturer(self) -> str:
-        return "ThermoFisher"
+        # NOTE: this base default means every backend that does not override the
+        # property (Demo, Zeiss, Odemis) reports ThermoFisher -- FIB-300 tracks
+        # whether it should serve self.system.info.manufacturer instead.
+        return manufacturers.THERMOFISHER
 
 
 def _thermo_application_file_wrapper_for_drawing_functions(

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import numpy as np
 
 import fibsem.constants as constants
+from fibsem import manufacturers
 from fibsem.microscope import FibsemMicroscope
 
 TESCAN_API_AVAILABLE = False
@@ -377,8 +378,9 @@ class TescanMicroscope(FibsemMicroscope):
         )
         self.set_detector_type(self._default_detector_names[BeamType.ION], BeamType.ION)
 
-        # system info
-        self.system.info.manufacturer = "TESCAN"  # only available from image
+        # system info: the hardware reports "TESCAN" in image headers; store the
+        # canonical spelling so downstream comparisons never meet the raw form
+        self.system.info.manufacturer = manufacturers.TESCAN
         info = self.system.info
         logging.info(
             f"Microscope client connected to model {info.model} with serial number {info.serial_number} and software version {info.software_version}."
@@ -405,7 +407,7 @@ class TescanMicroscope(FibsemMicroscope):
 
     @property
     def manufacturer(self) -> str:
-        return "Tescan"
+        return manufacturers.TESCAN
 
     def acquire_image(
         self,

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -38,6 +38,7 @@ from fibsem.config import (
     SUPPORTED_COORDINATE_SYSTEMS,
     UNVERSIONED_METADATA,
 )
+from fibsem.manufacturers import normalize_manufacturer
 from fibsem.versioning import get_revision
 
 TFibsemPatternSettings = TypeVar(
@@ -2090,7 +2091,11 @@ class SystemInfo:
         return SystemInfo(
             name=settings.get("name", "Unknown"),
             ip_address=settings.get("ip_address", "Unknown"),
-            manufacturer=settings.get("manufacturer", "Unknown"),
+            # normalise on read: configs and old experiments carry "Thermo"/"TESCAN"
+            # etc.; everything downstream compares against the canonical spellings
+            manufacturer=normalize_manufacturer(
+                settings.get("manufacturer", "Unknown")
+            ),
             model=settings.get("model", "Unknown"),
             serial_number=settings.get("serial_number", "Unknown"),
             hardware_version=settings.get("hardware_version", "Unknown"),

--- a/tests/test_manufacturers.py
+++ b/tests/test_manufacturers.py
@@ -1,0 +1,151 @@
+"""Canonical manufacturer names (FIB-300, PR 1: the foundation).
+
+Three spellings of ThermoFisher and two of TESCAN circulate through configs, image
+headers and driver properties; every comparison used to cope locally (defensive
+``.upper()``, hand-rolled alias lists) or silently took the wrong branch. These pin
+the one alias map and the two normalisation boundaries: ``SystemInfo.from_dict``
+(configs and old experiments read canonical) and the driver assignments/properties
+(live values are born canonical).
+"""
+
+import pytest
+
+from fibsem import manufacturers
+from fibsem.manufacturers import (
+    DEMO,
+    ODEMIS,
+    TESCAN,
+    THERMOFISHER,
+    ZEISS,
+    is_tescan,
+    is_thermo,
+    normalize_manufacturer,
+)
+from fibsem.structures import SystemInfo
+
+CANONICAL = {THERMOFISHER, TESCAN, DEMO, ODEMIS, ZEISS}
+
+
+# ---------------------------------------------------------------------------
+# the alias map
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw, canonical",
+    [
+        # ThermoFisher: the three spellings found in the codebase, plus case noise
+        ("Thermo", THERMOFISHER),
+        ("ThermoFisher", THERMOFISHER),
+        ("Thermo Fisher Scientific", THERMOFISHER),
+        ("thermo", THERMOFISHER),
+        ("THERMOFISHER", THERMOFISHER),
+        # TESCAN: config/property spelling and the live image-header spelling
+        ("Tescan", TESCAN),
+        ("TESCAN", TESCAN),
+        ("tescan", TESCAN),
+        ("  Tescan  ", TESCAN),
+        ("Demo", DEMO),
+        ("DEMO", DEMO),
+        ("Odemis", ODEMIS),
+        ("zeiss", ZEISS),
+    ],
+)
+def test_known_aliases_normalise(raw, canonical):
+    assert normalize_manufacturer(raw) == canonical
+
+
+@pytest.mark.parametrize("raw", ["Hitachi", "", "Unknown"])
+def test_unknown_values_pass_through_unchanged(raw):
+    """Lenient by design: reading old or foreign data must never fail here.
+    Validation sites keep their own membership checks."""
+    assert normalize_manufacturer(raw) == raw
+
+
+def test_non_strings_pass_through_unchanged():
+    assert normalize_manufacturer(None) is None
+    assert normalize_manufacturer(42) == 42
+
+
+def test_predicates_accept_every_spelling():
+    assert is_tescan("TESCAN") and is_tescan("Tescan") and is_tescan("tescan")
+    assert not is_tescan("ThermoFisher") and not is_tescan(None)
+    assert is_thermo("Thermo") and is_thermo("Thermo Fisher Scientific")
+    assert not is_thermo("Tescan")
+
+
+def test_every_canonical_name_normalises_to_itself():
+    for name in CANONICAL:
+        assert normalize_manufacturer(name) == name
+
+
+# ---------------------------------------------------------------------------
+# boundary: SystemInfo.from_dict normalises on read
+# ---------------------------------------------------------------------------
+
+
+def _info_dict(manufacturer):
+    return {
+        "name": "test",
+        "ip_address": "localhost",
+        "manufacturer": manufacturer,
+        "model": "model",
+        "serial_number": "sn",
+        "hardware_version": "hw",
+        "software_version": "sw",
+    }
+
+
+@pytest.mark.parametrize(
+    "stored, expected",
+    [
+        ("TESCAN", TESCAN),  # live image header, pre-normalisation experiments
+        ("Thermo", THERMOFISHER),  # config-file spelling
+        ("Tescan", TESCAN),
+        ("Demo", DEMO),
+        ("Hitachi", "Hitachi"),  # unknown: kept verbatim, never dropped
+    ],
+)
+def test_system_info_from_dict_normalises_manufacturer(stored, expected):
+    info = SystemInfo.from_dict(_info_dict(stored))
+    assert info.manufacturer == expected
+
+
+def test_system_info_round_trip_stores_canonical():
+    info = SystemInfo.from_dict(_info_dict("Thermo"))
+    assert info.to_dict()["manufacturer"] == THERMOFISHER
+    # and a second read is a fixed point
+    assert SystemInfo.from_dict(info.to_dict()).manufacturer == THERMOFISHER
+
+
+def test_system_info_missing_manufacturer_defaults_unknown():
+    d = _info_dict("x")
+    del d["manufacturer"]
+    assert SystemInfo.from_dict(d).manufacturer == "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# boundary: driver properties are born canonical
+# ---------------------------------------------------------------------------
+
+
+def test_thermo_property_is_canonical():
+    from fibsem.microscope import FibsemMicroscope, ThermoMicroscope
+
+    # the base-class property (which ThermoMicroscope inherits) -- evaluated
+    # without an instance, since it returns a constant
+    value = FibsemMicroscope.manufacturer.fget(object.__new__(ThermoMicroscope))
+    assert value == THERMOFISHER
+
+
+def test_tescan_property_is_canonical():
+    from fibsem.microscopes.tescan import TescanMicroscope
+
+    value = TescanMicroscope.manufacturer.fget(object.__new__(TescanMicroscope))
+    assert value == TESCAN
+
+
+def test_module_namespace_access():
+    """Call sites use `manufacturers.TESCAN` -- keep the module-level names stable."""
+    assert manufacturers.TESCAN == "Tescan"
+    assert manufacturers.THERMOFISHER == "ThermoFisher"


### PR DESCRIPTION
## Summary

Part 1 of the manufacturer-string canonicalisation (the Linear issue stays open until all three parts land, so the key is deliberately not referenced here).

Three spellings of ThermoFisher (`Thermo` in configs, `ThermoFisher` on the driver property, `Thermo Fisher Scientific` accepted by `setup_session`) and two of TESCAN (`Tescan`, plus `TESCAN` born from live image headers) circulate through the codebase. Every comparison copes locally — seven defensive `.upper() == "TESCAN"` sites, a hand-rolled alias list with a duplicated entry — or doesn't cope and silently takes the wrong branch (a live inverted-UI bug on #115 came from exactly this).

This PR is the foundation: **one canonical spelling per vendor, normalised at the boundaries**, so every later comparison can be an ordinary `==`.

- **`fibsem/manufacturers.py`** (new leaf module): canonical constants, one case-insensitive alias map, `normalize_manufacturer()` — lenient, unknown values pass through unchanged so reading old data can never fail — and `is_tescan`/`is_thermo` predicates for one-liner call sites. Canonical **strings**, not an Enum: CI runs Python 3.8 (no `StrEnum`), and the `(str, Enum)` mixin diverges between `str()` and `format()` on 3.8–3.10 exactly where YAML/dict serialisation would hit it. Strings keep every existing round-trip shape-identical.
- **`SystemInfo.from_dict` normalises on read** — configs and old experiments carrying `Thermo`/`TESCAN` load canonical; nothing is rewritten on disk. This also fixes Demo and Odemis for free: their `manufacturer` is served from `system.info`.
- **Born canonical**: the TESCAN connect-time assignment (was the raw header spelling `"TESCAN"`) and both driver properties now use the constants.
- One discovery documented in place rather than changed: the `"ThermoFisher"` property lives on the **base class**, so Demo/Zeiss/Odemis report ThermoFisher via the property today. Making it serve `system.info.manufacturer` is behaviour-visible and deferred (noted at the site).

Parts 2 and 3 (separate PRs): retire the seven `.upper()` band-aids behind the predicates plus a ratchet test, then the validation/config surface (`AVAILABLE_MANUFACTURERS`, `_SUPPORTED_MANUFACTURERS`, the `configuration.py` assert) moves to canonical with aliases accepted on read.

Sequenced after #535 (the `structures.py` format flag-day) so the `structures.py` diff here is 7 lines, not 1000.

## Test plan

- [x] `tests/test_manufacturers.py` (new, 29 tests): the full alias table incl. case/whitespace noise, unknown/non-string passthrough, predicates, `SystemInfo.from_dict` normalisation + fixed-point round-trip, driver properties canonical
- [x] Existing Tescan suites unaffected (spot burn + connection lock re-run green)
- [x] ruff check + format clean
