### PR TITLE
Compare manufacturers through the canonical predicates, not .upper()

### DIFF
--- a/fibsem/acquire.py
+++ b/fibsem/acquire.py
@@ -4,6 +4,7 @@ import copy
 import os
 from typing import Optional, Tuple
 
+from fibsem import manufacturers
 from fibsem.autofunctions.acb import run_auto_contrast_brightness
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import (
@@ -39,9 +40,8 @@ def new_image(
     # run autocontrast
     if settings.autocontrast:
         microscope.autocontrast(
-                beam_type=settings.beam_type,
-                reduced_area=settings.reduced_area
-            )
+            beam_type=settings.beam_type, reduced_area=settings.reduced_area
+        )
 
     # acquire the image
     image = microscope.acquire_image(
@@ -99,7 +99,7 @@ def take_reference_images(
 
     # acquire ion image
     image_settings.beam_type = BeamType.ION
-    if microscope.manufacturer.upper() == "TESCAN":
+    if manufacturers.is_tescan(microscope.manufacturer):
         import time
 
         time.sleep(1)

--- a/fibsem/imaging/tiling/reprojection.py
+++ b/fibsem/imaging/tiling/reprojection.py
@@ -13,7 +13,7 @@ from typing import List, Tuple
 
 import numpy as np
 
-from fibsem import movement
+from fibsem import manufacturers, movement
 from fibsem.conversions import is_inside_image_bounds
 from fibsem.structures import (
     BeamType,
@@ -169,12 +169,9 @@ def calculate_reprojected_stage_position2(
         )
 
     # Tescan stage x is inverted wrt image coordinates (see TescanMicroscope.stable_move);
-    # the y inversion is handled inside _inverse_y_corrected_stage_movement_tescan. Match
-    # case-insensitively — a live scope reports "TESCAN", config/saved images "Tescan"; an
-    # exact check silently fell back to Thermo math and placed added positions at the
-    # opposite corner. (band-aid string check, tracked in FIB-300)
+    # the y inversion is handled inside _inverse_y_corrected_stage_movement_tescan.
     system_info = image.metadata.system_info
-    if system_info is not None and system_info.manufacturer.upper() == "TESCAN":
+    if system_info is not None and manufacturers.is_tescan(system_info.manufacturer):
         dx = -dx
 
     # dy = microscope._inverse_y_corrected_stage_movement(dy=delta.y, dz=delta.z, beam_type=beam_type) # type: ignore
@@ -342,11 +339,9 @@ def _inverse_y_corrected_stage_movement(
         )
 
     # Tescan stages have a different geometry (z below the tilt axis), so the inverse
-    # is a separate derivation, not the compustage-aware path below. Match
-    # case-insensitively: a live scope reports "TESCAN", config/saved images "Tescan".
-    # (band-aid string check, tracked in FIB-300)
+    # is a separate derivation, not the compustage-aware path below.
     system_info = image.metadata.system_info
-    if system_info is not None and system_info.manufacturer.upper() == "TESCAN":
+    if system_info is not None and manufacturers.is_tescan(system_info.manufacturer):
         return _inverse_y_corrected_stage_movement_tescan(
             image, dy=dy, dz=dz, beam_type=beam_type
         )

--- a/fibsem/projection.py
+++ b/fibsem/projection.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Optional, Protocol, Tuple
 
 import numpy as np
 
+from fibsem import manufacturers
 from fibsem.fm.reprojection import project_image_point, project_stage_position
 from fibsem.imaging.tiling.reprojection import (
     inverse_y_corrected_stage_movement_tescan_from_geometry,
@@ -76,10 +77,12 @@ def surface_foreshortening(
     every Arctis, and every test written against one -- and 22% at 35 degrees (FIB-657).
     """
     moved = projection.from_plane(0.0, _FORESHORTENING_PROBE, base)
-    travel = float(np.hypot(
-        (moved.y or 0.0) - (base.y or 0.0),
-        (moved.z or 0.0) - (base.z or 0.0),
-    ))
+    travel = float(
+        np.hypot(
+            (moved.y or 0.0) - (base.y or 0.0),
+            (moved.z or 0.0) - (base.z or 0.0),
+        )
+    )
     if not travel:
         return 1.0
     return _FORESHORTENING_PROBE / travel
@@ -257,7 +260,7 @@ class BeamStageProjection:
                 geometry=microscope.hardware_geometry(),
                 beam_type=beam_type,
                 scan_rotation=microscope.get_scan_rotation(beam_type=beam_type),
-                is_tescan=microscope.system.info.manufacturer.upper() == "TESCAN",
+                is_tescan=manufacturers.is_tescan(microscope.system.info.manufacturer),
             )
         except Exception as e:
             logging.debug(f"Could not read the live beam geometry: {e}")
@@ -291,7 +294,7 @@ class BeamStageProjection:
                 beam_type=beam_type,
                 scan_rotation=beam.scan_rotation,
                 is_tescan=(
-                    info is not None and info.manufacturer.upper() == "TESCAN"
+                    info is not None and manufacturers.is_tescan(info.manufacturer)
                 ),
             )
         except Exception as e:
@@ -397,9 +400,7 @@ class BeamStageProjection:
             return 0.0
         return np.deg2rad(self.geometry.fib_column_tilt)
 
-    def _expected_y(
-        self, dy: float, dz: float, base: FibsemStagePosition
-    ) -> float:
+    def _expected_y(self, dy: float, dz: float, base: FibsemStagePosition) -> float:
         """The image-space y-displacement a y/z stage movement corresponds to."""
         if self.is_tescan:
             return inverse_y_corrected_stage_movement_tescan_from_geometry(

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -13,6 +13,7 @@ import yaml
 from PIL import Image
 
 from fibsem import config as cfg
+from fibsem import manufacturers
 from fibsem.constants import DATETIME_LOG, TIME_FILE
 from fibsem.structures import (
     BeamType,
@@ -30,7 +31,9 @@ def current_timestamp():
     Returns:
         String: Current time
     """
-    return datetime.datetime.fromtimestamp(time.time()).strftime(DATETIME_LOG) #PM/AM doesnt work?
+    return datetime.datetime.fromtimestamp(time.time()).strftime(
+        DATETIME_LOG
+    )  # PM/AM doesnt work?
 
 
 def current_timestamp_v2():
@@ -41,6 +44,7 @@ def current_timestamp_v2():
     """
     return str(time.time()).replace(".", "_")
 
+
 def current_timestamp_v3(timeonly: bool = True) -> str:
     """Return the current time in a specific string formats: HH-MM-SS or YYYY-MM-DD-HH-MM-SSAM/PM"""
     now = datetime.datetime.now()
@@ -48,9 +52,11 @@ def current_timestamp_v3(timeonly: bool = True) -> str:
         return now.strftime(TIME_FILE)
     return now.strftime(DATETIME_LOG)
 
+
 def _format_time_seconds(seconds: float) -> str:
     """Format a time delta in seconds to proper string format."""
     return str(datetime.timedelta(seconds=seconds)).split(".")[0]
+
 
 def format_duration(seconds: float) -> str:
     """Format a duration given in seconds into a human-readable string (hours, minutes, seconds)."""
@@ -92,6 +98,7 @@ def format_time_remaining(seconds: float, pad: bool = False) -> str:
         return f"{minutes}m {secs:{width}}s"
     return f"{secs}s"
 
+
 SI_PREFIXES = {
     -12: "p",
     -9: "n",
@@ -118,6 +125,7 @@ def format_resolution_as_str(resolution: List[int]) -> str:
     """
     return f"{resolution[0]} x {resolution[1]}"
 
+
 def _get_scale_from_value(val: float) -> float:
     """Return the scale multiplier corresponding to the SI prefix for a value."""
     if val == 0:
@@ -141,13 +149,20 @@ def _get_prefix_from_scale(scale: float) -> Tuple[str, float]:
     multiplier = (10 ** (-exponent)) / scale
     return prefix, multiplier
 
+
 def _get_display_unit(scale: float, unit: Optional[str] = None) -> str:
     """Return the formatted unit string using the scale-derived SI prefix."""
     unit = unit or ""
     prefix, _ = _get_prefix_from_scale(scale)
     return f"{prefix}{unit}"
 
-def format_value(val: float, unit: Optional[str] = None, precision: int = 2, scale: Optional[float] = None) -> str:
+
+def format_value(
+    val: float,
+    unit: Optional[str] = None,
+    precision: int = 2,
+    scale: Optional[float] = None,
+) -> str:
     """Format a numerical value as a string with nearest SI unit.
 
     Args:
@@ -165,28 +180,35 @@ def format_value(val: float, unit: Optional[str] = None, precision: int = 2, sca
     unit = unit or ""
     return f"{scaled_val:.{precision}f} {prefix}{unit}"
 
+
 def make_logging_directory(path: Optional[Path] = None, name="run"):
     """
-    Create a logging directory with the specified name at the specified file path. 
+    Create a logging directory with the specified name at the specified file path.
     If no path is given, it creates the directory at the default base path.
 
     Args:
-        path (Path, optional): The file path to create the logging directory at. If None, default base path is used. 
+        path (Path, optional): The file path to create the logging directory at. If None, default base path is used.
         name (str, optional): The name of the logging directory to create. Default is "run".
 
     Returns:
         str: The file path to the created logging directory.
-        """
-    
+    """
+
     if path is None:
         path = os.path.join(cfg.BASE_PATH, "log")
     directory = os.path.join(path, name)
     os.makedirs(directory, exist_ok=True)
     return directory
 
+
 # TODO: better logs: https://www.toptal.com/python/in-depth-python-logging
 # https://stackoverflow.com/questions/61483056/save-logging-debug-and-show-only-logging-info-python
-def configure_logging(path: Path = "", log_filename="logfile", log_level=logging.DEBUG, _DEBUG: bool = False):
+def configure_logging(
+    path: Path = "",
+    log_filename="logfile",
+    log_level=logging.DEBUG,
+    _DEBUG: bool = False,
+):
     """Log to the terminal and to file simultaneously."""
     logfile = os.path.join(path, f"{log_filename}.log")
 
@@ -238,14 +260,16 @@ def save_yaml(path: Path, data: dict) -> None:
     with open(path, "w") as f:
         yaml.dump(data, f, indent=4)
 
+
 def save_json(path: Union[Path, os.PathLike, str], data: dict) -> None:
     """Saves a python dictionary object to a json file
     Args:
         path (Path): path location to save json file
         data (dict): dictionary object
     """
-    with open(path, 'w') as f:
+    with open(path, "w") as f:
         json.dump(data, f, indent=4)
+
 
 def create_gif(path: Path, search: str, gif_fname: str, loop: int = 0) -> None:
     """Creates a GIF from a set of images. Images must be in same folder
@@ -268,8 +292,6 @@ def create_gif(path: Path, search: str, gif_fname: str, loop: int = 0) -> None:
         loop=loop,
     )
 
-VALID_THERMO_FISHER = ["Thermo", "Thermo Fisher Scientific", "Thermo Fisher Scientific"]
-VALID_TESCAN = ["Tescan", "TESCAN" ]
 
 def setup_session(
     session_path: Path = None,
@@ -279,12 +301,12 @@ def setup_session(
     ip_address: str = None,
     manufacturer: str = None,
     debug: bool = False,
-) -> Tuple['FibsemMicroscope', 'MicroscopeSettings']:
+) -> Tuple["FibsemMicroscope", "MicroscopeSettings"]:
     """Setup microscope session
 
     Args:
         session_path (Path): path to logging directory
-        config_path (Path): path to config directory 
+        config_path (Path): path to config directory
         protocol_path (Path): path to protocol file
 
     Returns:
@@ -295,7 +317,7 @@ def setup_session(
     settings = load_microscope_configuration(config_path, protocol_path)
 
     # create session directories
-    session = f'{settings.protocol.get("name", "fibsem-os")}_{current_timestamp()}'
+    session = f"{settings.protocol.get('name', 'fibsem-os')}_{current_timestamp()}"
     if protocol_path is None:
         protocol_path = os.getcwd()
 
@@ -314,37 +336,40 @@ def setup_session(
     # cheap overloading
     if ip_address:
         settings.system.info.ip_address = ip_address
-    
+
     if manufacturer:
-        settings.system.info.manufacturer = manufacturer
+        # normalise the override the same way SystemInfo.from_dict normalises the
+        # config value, so system.info always carries the canonical spelling
+        settings.system.info.manufacturer = manufacturers.normalize_manufacturer(
+            manufacturer
+        )
 
     manufacturer = settings.system.info.manufacturer
     ip_address = settings.system.info.ip_address
 
-    if manufacturer in VALID_THERMO_FISHER:
+    if manufacturer == manufacturers.THERMOFISHER:
         microscope = fibsem_microscope.ThermoMicroscope(settings.system)
-        microscope.connect_to_microscope(
-            ip_address=ip_address, port=7520
-        )
+        microscope.connect_to_microscope(ip_address=ip_address, port=7520)
 
-    elif manufacturer in VALID_TESCAN:
+    elif manufacturer == manufacturers.TESCAN:
         from fibsem.microscopes.tescan import TescanMicroscope
+
         microscope = TescanMicroscope(settings.system)
-        microscope.connect_to_microscope(
-            ip_address=ip_address, port=8300
-        )
-    elif manufacturer in ["Odemis"]:
+        microscope.connect_to_microscope(ip_address=ip_address, port=8300)
+    elif manufacturer == manufacturers.ODEMIS:
         from fibsem.microscopes.odemis_microscope import OdemisThermoMicroscope
+
         microscope = OdemisThermoMicroscope(settings.system)
 
-    elif manufacturer == "Demo":
+    elif manufacturer == manufacturers.DEMO:
         from fibsem.microscopes.simulator import DemoMicroscope
+
         microscope = DemoMicroscope(settings.system)
         microscope.connect_to_microscope(ip_address, port=7520)
 
     else:
         raise NotImplementedError(f"Manufacturer {manufacturer} not supported.")
-    
+
     # set default image_settings path
     settings.image.path = session_path
 
@@ -367,8 +392,9 @@ def load_microscope_configuration(
     """
     if config_path is None:
         from fibsem.config import DEFAULT_CONFIGURATION_PATH
+
         config_path = DEFAULT_CONFIGURATION_PATH
-    
+
     # load config
     config = load_yaml(os.path.join(config_path))
 
@@ -379,6 +405,7 @@ def load_microscope_configuration(
     settings = MicroscopeSettings.from_dict(config, protocol=protocol)
 
     return settings
+
 
 def load_protocol(protocol_path: Path = None) -> dict:
     """Load the protocol file from yaml
@@ -394,7 +421,7 @@ def load_protocol(protocol_path: Path = None) -> dict:
     else:
         protocol = {"name": "demo"}
 
-    #protocol = _format_dictionary(protocol)
+    # protocol = _format_dictionary(protocol)
 
     return protocol
 
@@ -429,6 +456,7 @@ def _format_dictionary(dictionary: dict) -> dict:
                     pass
     return dictionary
 
+
 def get_params(main_str: str) -> list:
     """Helper function to access relevant metadata parameters from sub field
 
@@ -444,7 +472,6 @@ def get_params(main_str: str) -> list:
     i = main_str.find("\n")
     i += 1
     while i < len(main_str):
-
         if main_str[i] == "=":
             cats.append(cat_str)
             cat_str = ""
@@ -457,7 +484,7 @@ def get_params(main_str: str) -> list:
 
 
 def _get_position(name: str):
-    
+
     import os
 
     from fibsem import config as cfg
@@ -470,8 +497,9 @@ def _get_position(name: str):
             return FibsemStagePosition.from_dict(d)
     return None
 
-def _get_positions(fname: str = None) -> List[str]:    
-    
+
+def _get_positions(fname: str = None) -> List[str]:
+
     import os
 
     from fibsem import config as cfg
@@ -497,24 +525,26 @@ def save_positions(positions: list, path: str = None, overwrite: bool = False) -
     if path is None:
         path = cfg.POSITION_PATH
 
-    # get existing positions    
+    # get existing positions
     pdict = []
     if not overwrite:
         pdict = load_yaml(fname=path)
 
-    
     # append new positions
     for position in positions:
         pdict.append(position.to_dict())
-    
+
     # save
     save_yaml(path, pdict)
 
+
 # TODO: re-think this, dont like the pop ups
-def _register_metadata(microscope: 'FibsemMicroscope',
-                       application_software: str,
-                       experiment_name: str,
-                       experiment_id: Optional[str] = None) -> None:
+def _register_metadata(
+    microscope: "FibsemMicroscope",
+    application_software: str,
+    experiment_name: str,
+    experiment_id: Optional[str] = None,
+) -> None:
     """Stamp user, experiment and application identity onto what ``microscope`` acquires.
 
     ``experiment_id`` is the stable join key and should always be supplied; it is

--- a/tests/test_manufacturers.py
+++ b/tests/test_manufacturers.py
@@ -149,3 +149,53 @@ def test_module_namespace_access():
     """Call sites use `manufacturers.TESCAN` -- keep the module-level names stable."""
     assert manufacturers.TESCAN == "Tescan"
     assert manufacturers.THERMOFISHER == "ThermoFisher"
+
+
+# ---------------------------------------------------------------------------
+# the ratchet: no new .upper() band-aids
+# ---------------------------------------------------------------------------
+
+
+def test_no_upper_tescan_band_aids_outside_the_allowlist():
+    """`.upper() == "TESCAN"` was each call site's local coping mechanism for the
+    casing split; new comparisons go through `manufacturers.is_tescan`. The two
+    widget sites remain until the validation/config part lands -- the allowlist
+    then empties and never grows."""
+    import os
+    from pathlib import Path
+
+    import fibsem
+
+    ALLOWED = {
+        "fibsem/ui/widgets/milling_stages_widget.py",
+        "fibsem/ui/widgets/beam_settings_widget.py",
+    }
+    root = Path(fibsem.__file__).parent
+    offenders = []
+    for path in root.rglob("*.py"):
+        rel = "fibsem/" + str(path.relative_to(root)).replace(os.sep, "/")
+        if (
+            'upper() == "TESCAN"' in path.read_text(encoding="utf-8")
+            and rel not in ALLOWED
+        ):
+            offenders.append(rel)
+    assert offenders == [], (
+        'new `.upper() == "TESCAN"` band-aid(s) -- use manufacturers.is_tescan: '
+        f"{offenders}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# boundary: setup_session dispatches on canonical, whatever the caller spelled
+# ---------------------------------------------------------------------------
+
+
+def test_setup_session_accepts_any_demo_spelling(tmp_path):
+    from fibsem import utils
+
+    microscope, settings = utils.setup_session(
+        session_path=str(tmp_path), manufacturer="DEMO", setup_logging=False
+    )
+    assert type(microscope).__name__ == "DemoMicroscope"
+    assert settings.system.info.manufacturer == DEMO
+    microscope.disconnect()


### PR DESCRIPTION
## Summary

Part 2 of the manufacturer canonicalisation (follows #536; the Linear issue stays open until every part lands, so its key is deliberately not referenced).

- Retires **five of the seven** defensive `.upper() == "TESCAN"` band-aids — `acquire.py`, `projection.py` (×2), `imaging/tiling/reprojection.py` (×2) — behind `manufacturers.is_tescan`. The reprojection comments lose their band-aid apologies.
- Collapses `setup_session`'s hand-rolled `VALID_THERMO_FISHER`/`VALID_TESCAN` alias lists (one carried a duplicated entry) into the one alias map, and normalises the `manufacturer` override argument before it lands in `system.info` — same treatment `SystemInfo.from_dict` gives the config value.
- Adds a **ratchet test**: no `.upper() == "TESCAN"` may exist in `fibsem/` outside the two remaining widget sites (mutation-checked: adding one anywhere else fails it). That allowlist empties in part 3 and never grows.

The Tescan reprojection dispatch behaviour is pinned by the existing suites, whose fixtures deliberately mix "TESCAN" and "Tescan" spellings — they now flow through the predicate.

## Test plan
- [x] `tests/test_manufacturers.py`: +ratchet, +`setup_session(manufacturer="DEMO")` end-to-end alias dispatch (31 total)
- [x] Affected suites: reprojection, tiled, tiling package, beam-stage projection, projection-paths-agree, tescan movement — 493 passed
- [x] Ratchet mutation-checked; ruff check + format clean