### PR TITLE
Retire the last manufacturer band-aids; validation accepts any spelling

### DIFF
--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -1870,7 +1870,8 @@ class FibsemMillingSettings:
         }
 
     def get_parameters_for_manufacturer(self, manufacturer: str) -> tuple[str, ...]:
-        """Get all parameter names for a specific manufacturer."""
+        """Get all parameter names for a specific manufacturer (any known spelling)."""
+        manufacturer = normalize_manufacturer(manufacturer)
         if manufacturer not in self._SUPPORTED_MANUFACTURERS:
             raise ValueError(
                 f"Manufacturer must be one of: {', '.join(self._SUPPORTED_MANUFACTURERS)}"

--- a/fibsem/ui/widgets/beam_settings_widget.py
+++ b/fibsem/ui/widgets/beam_settings_widget.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import (
 from superqt.utils import qdebounced
 
 from fibsem import config as cfg
-from fibsem import constants, utils
+from fibsem import constants, manufacturers, utils
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamSettings, BeamType, Point
 from fibsem.ui import notification_service
@@ -568,7 +568,7 @@ class FibsemBeamSettingsWidget(QWidget):
 
     def _update_visibility(self):
         """Apply visibility based on manufacturer and advanced-mode state."""
-        is_tescan = self.microscope.manufacturer.upper() == "TESCAN"
+        is_tescan = manufacturers.is_tescan(self.microscope.manufacturer)
         adv = self._advanced_visible
 
         for w in self._adv_widgets:

--- a/fibsem/ui/widgets/milling_stages_widget.py
+++ b/fibsem/ui/widgets/milling_stages_widget.py
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from fibsem import manufacturers
 from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.base import FibsemMillingStage, MillingStrategy, get_strategy
 from fibsem.milling.patterning import get_pattern
@@ -28,7 +29,7 @@ class FibsemMillingStagesWidget(QWidget):
     """
 
     stages_changed = pyqtSignal(list)  # List[FibsemMillingStage]
-    eye_toggled = pyqtSignal(bool)     # True = patterns visible
+    eye_toggled = pyqtSignal(bool)  # True = patterns visible
 
     def __init__(
         self,
@@ -59,9 +60,13 @@ class FibsemMillingStagesWidget(QWidget):
 
         # Stage list. Tescan mills by preset — milling_current is a no-op on that backend —
         # so it gets a Preset column where every other backend gets Current.
-        _show_preset = self.microscope.manufacturer.upper() == "TESCAN"
-        _current_values = self.microscope.get_available_values_cached("current", BeamType.ION)
-        _preset_values = self.microscope.get_available_values_cached("preset", BeamType.ION)
+        _show_preset = manufacturers.is_tescan(self.microscope.manufacturer)
+        _current_values = self.microscope.get_available_values_cached(
+            "current", BeamType.ION
+        )
+        _preset_values = self.microscope.get_available_values_cached(
+            "preset", BeamType.ION
+        )
         self._list = MillingStageListWidget(
             current_values=_current_values,
             preset_values=_preset_values,
@@ -133,10 +138,14 @@ class FibsemMillingStagesWidget(QWidget):
 
     def _connect_signals(self) -> None:
         self._list.stage_selected.connect(self._on_row_selected)
-        self._list.stage_added.connect(lambda _: self.stages_changed.emit(self._list.get_stages()))
+        self._list.stage_added.connect(
+            lambda _: self.stages_changed.emit(self._list.get_stages())
+        )
         self._list.stage_removed.connect(self._on_stage_removed)
         self._list.order_changed.connect(self.stages_changed.emit)
-        self._list.enabled_changed.connect(lambda _: self.stages_changed.emit(self._list.get_stages()))
+        self._list.enabled_changed.connect(
+            lambda _: self.stages_changed.emit(self._list.get_stages())
+        )
         self._list.stage_changed.connect(self._on_inline_stage_changed)
         self._list.eye_toggled.connect(self.eye_toggled)
         self._milling_widget.settings_changed.connect(self._on_milling_settings_changed)

--- a/tests/test_manufacturers.py
+++ b/tests/test_manufacturers.py
@@ -158,18 +158,13 @@ def test_module_namespace_access():
 
 def test_no_upper_tescan_band_aids_outside_the_allowlist():
     """`.upper() == "TESCAN"` was each call site's local coping mechanism for the
-    casing split; new comparisons go through `manufacturers.is_tescan`. The two
-    widget sites remain until the validation/config part lands -- the allowlist
-    then empties and never grows."""
+    casing split; every comparison now goes through `manufacturers.is_tescan`."""
     import os
     from pathlib import Path
 
     import fibsem
 
-    ALLOWED = {
-        "fibsem/ui/widgets/milling_stages_widget.py",
-        "fibsem/ui/widgets/beam_settings_widget.py",
-    }
+    ALLOWED = set()  # emptied when the widget sites converted; never grows
     root = Path(fibsem.__file__).parent
     offenders = []
     for path in root.rglob("*.py"):
@@ -199,3 +194,19 @@ def test_setup_session_accepts_any_demo_spelling(tmp_path):
     assert type(microscope).__name__ == "DemoMicroscope"
     assert settings.system.info.manufacturer == DEMO
     microscope.disconnect()
+
+
+def test_milling_parameters_accept_any_manufacturer_spelling():
+    """get_parameters_for_manufacturer used to raise on "Thermo" and "TESCAN" --
+    the exact spellings configs and live image headers carry."""
+    from fibsem.structures import FibsemMillingSettings
+
+    s = FibsemMillingSettings()
+    assert s.get_parameters_for_manufacturer(
+        "Thermo"
+    ) == s.get_parameters_for_manufacturer("ThermoFisher")
+    assert s.get_parameters_for_manufacturer(
+        "TESCAN"
+    ) == s.get_parameters_for_manufacturer("Tescan")
+    with pytest.raises(ValueError):
+        s.get_parameters_for_manufacturer("Hitachi")


### PR DESCRIPTION
## Summary

Part 3 of the manufacturer canonicalisation (follows #536, #537; the Linear issue stays open until the config flag-day lands, so its key is deliberately not referenced).

- The last two `.upper() == "TESCAN"` sites — the milling-stage list's Preset/Current column choice and the beam-settings visibility gate — move to `manufacturers.is_tescan`.
- The ratchet's allowlist **empties permanently**: no `.upper()` band-aid exists anywhere in `fibsem/`, and the test keeps it that way.
- `FibsemMillingSettings.get_parameters_for_manufacturer` normalises its argument: `"Thermo"` and `"TESCAN"` — the exact spellings configs and live image headers carry — no longer raise.

Remaining after this: the config surface flag-day (`AVAILABLE_MANUFACTURERS`, `DEFAULT_CONFIGURATION_VALUES` keys, the wizard) — the only user-visible piece, split into its own PR.

## Test plan
- [x] `tests/test_manufacturers.py` (+1: validation accepts every spelling, unknown still raises; 32 total)
- [x] Widget suites: `test_beam_settings_preset` (visibility gates through the predicate), viewer-less widgets — green
- [x] ruff check + format clean