### PR TITLE
Skip the autofocus sweep on beams whose working distance cannot be set

### DIFF
--- a/fibsem/autofunctions/autofocus.py
+++ b/fibsem/autofunctions/autofocus.py
@@ -1,4 +1,5 @@
 """Image-based auto-focus for FIB-SEM images."""
+
 from __future__ import annotations
 
 import dataclasses
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 class FocusMethod(str, Enum):
     """Focus measurement methods for autofocus algorithms."""
+
     LAPLACIAN = "laplacian"
     SOBEL = "sobel"
     VARIANCE = "variance"
@@ -37,8 +39,9 @@ class FocusSweepPass:
     A pass sweeps ``search_range`` metres (±range/2) about its centre, sampling
     one image every ``step_size`` metres.
     """
-    search_range: float = 5e-3      # metres (total span; positions cover ±range/2)
-    step_size: float = 0.5e-3       # metres
+
+    search_range: float = 5e-3  # metres (total span; positions cover ±range/2)
+    step_size: float = 0.5e-3  # metres
     enabled: bool = True
 
     @property
@@ -52,8 +55,8 @@ class FocusSweepPass:
 # default coarse/fine passes (FM scale); FIB-SEM callers pass explicit passes
 def _default_passes() -> "list[FocusSweepPass]":
     return [
-        FocusSweepPass(search_range=50e-6, step_size=5e-6),   # coarse
-        FocusSweepPass(search_range=10e-6, step_size=1e-6),   # fine
+        FocusSweepPass(search_range=50e-6, step_size=5e-6),  # coarse
+        FocusSweepPass(search_range=10e-6, step_size=1e-6),  # fine
     ]
 
 
@@ -89,11 +92,12 @@ class AutoFocusSettings:
     FM uses ``channel_name``; FIB-SEM uses ``probe_resolution`` /
     ``probe_dwell_time`` / ``use_autocontrast``.
     """
+
     method: "FocusMethod" = FocusMethod.TENENGRAD
-    passes: list = None             # list[FocusSweepPass]; None → default coarse/fine
+    passes: list = None  # list[FocusSweepPass]; None → default coarse/fine
     probe_resolution: tuple = (768, 512)
     probe_dwell_time: float = 0.5e-6
-    reduced_area: 'FibsemRectangle' = None
+    reduced_area: "FibsemRectangle" = None
     use_autocontrast: bool = True
     channel_name: Optional[str] = None
 
@@ -123,8 +127,12 @@ class AutoFocusSettings:
     ) -> "AutoFocusSettings":
         """Build a two-pass (coarse + fine) AutoFocusSettings."""
         passes = [
-            FocusSweepPass(search_range=coarse_range, step_size=coarse_step, enabled=coarse_enabled),
-            FocusSweepPass(search_range=fine_range, step_size=fine_step, enabled=fine_enabled),
+            FocusSweepPass(
+                search_range=coarse_range, step_size=coarse_step, enabled=coarse_enabled
+            ),
+            FocusSweepPass(
+                search_range=fine_range, step_size=fine_step, enabled=fine_enabled
+            ),
         ]
         return cls(method=method, passes=passes, channel_name=channel_name, **kwargs)
 
@@ -134,7 +142,9 @@ class AutoFocusSettings:
             "passes": [dataclasses.asdict(p) for p in self.passes],
             "probe_resolution": list(self.probe_resolution),
             "probe_dwell_time": self.probe_dwell_time,
-            "reduced_area": dataclasses.asdict(self.reduced_area) if self.reduced_area is not None else None,
+            "reduced_area": dataclasses.asdict(self.reduced_area)
+            if self.reduced_area is not None
+            else None,
             "use_autocontrast": self.use_autocontrast,
             "channel_name": self.channel_name,
         }
@@ -142,6 +152,7 @@ class AutoFocusSettings:
     @classmethod
     def from_dict(cls, d: dict) -> "AutoFocusSettings":
         from fibsem.structures import FibsemRectangle
+
         d = dict(d)
 
         # Legacy coarse/fine schema → passes
@@ -157,7 +168,9 @@ class AutoFocusSettings:
                 channel_name=d.get("channel_name"),
             )
 
-        passes = [_sweep_pass_from_dict(p) for p in d.pop("passes", [])] or _default_passes()
+        passes = [
+            _sweep_pass_from_dict(p) for p in d.pop("passes", [])
+        ] or _default_passes()
         ra = d.pop("reduced_area", None)
         method = d.pop("method", FocusMethod.TENENGRAD.value)
         obj = cls(method=FocusMethod(method), passes=passes, **d)
@@ -169,6 +182,7 @@ class AutoFocusSettings:
 @dataclass
 class AutoFocusIteration:
     """State captured at a single working-distance position in the sweep."""
+
     working_distance: float
     focus_score: float
     pass_index: int
@@ -186,6 +200,7 @@ class AutoFocusIteration:
     @classmethod
     def from_dict(cls, d: dict, result_dir: Path) -> "AutoFocusIteration":
         from fibsem.structures import load_tiff
+
         return cls(
             pass_index=d.get("pass_index", 0),
             working_distance=d["working_distance"],
@@ -197,6 +212,7 @@ class AutoFocusIteration:
 @dataclass
 class AutoFocusResult:
     """Result of an image-based auto-focus run."""
+
     image: np.ndarray
     working_distance: float
     initial_working_distance: float
@@ -211,9 +227,12 @@ class AutoFocusResult:
 
     def plot(self, save_path: str = "autofocus.png") -> None:
         from fibsem.autofunctions.plotting import plot_autofocus_result
+
         plot_autofocus_result(self, save_path=save_path)
 
-    def save(self, path: str = ".", name: str = "autofocus", save_plot: bool = True) -> Path:
+    def save(
+        self, path: str = ".", name: str = "autofocus", save_plot: bool = True
+    ) -> Path:
         """Save the result to ``<path>/<name>/``.
 
         The directory contains:
@@ -239,6 +258,7 @@ class AutoFocusResult:
             json.dump(data, f, indent=2)
 
         from fibsem.structures import save_tiff
+
         for i, it in enumerate(self.iterations):
             save_tiff(it.image, result_dir / f"iter_{i:02d}.tif")
 
@@ -254,6 +274,7 @@ class AutoFocusResult:
     def load(cls, result_dir: str) -> "AutoFocusResult":
         """Load a result previously saved with :meth:`save`."""
         from fibsem.structures import load_tiff
+
         result_dir = Path(result_dir)
 
         with open(result_dir / "data.json") as f:
@@ -266,12 +287,18 @@ class AutoFocusResult:
 
         best_image = load_tiff(result_dir / "best.tif")
         settings_data = data.get("settings")
-        settings = AutoFocusSettings.from_dict(settings_data) if settings_data is not None else None
+        settings = (
+            AutoFocusSettings.from_dict(settings_data)
+            if settings_data is not None
+            else None
+        )
 
         return cls(
             image=best_image,
             working_distance=data["working_distance"],
-            initial_working_distance=data.get("initial_working_distance", data["working_distance"]),
+            initial_working_distance=data.get(
+                "initial_working_distance", data["working_distance"]
+            ),
             focus_score=data["focus_score"],
             iterations=iterations,
             settings=settings,
@@ -291,37 +318,53 @@ def _run_sweep(
 ) -> "tuple[list[AutoFocusIteration], float]":
     """Acquire images across a WD range and return iterations + best WD."""
     half_range = sweep_pass.search_range / 2
-    wds = np.linspace(centre_wd - half_range, centre_wd + half_range, sweep_pass.n_steps + 1)
+    wds = np.linspace(
+        centre_wd - half_range, centre_wd + half_range, sweep_pass.n_steps + 1
+    )
 
     iterations = []
     for i, wd in enumerate(wds):
-        raise_if_cancelled(stop_event, "AutoFocus cancelled by user.")  # abort between WD steps
+        raise_if_cancelled(
+            stop_event, "AutoFocus cancelled by user."
+        )  # abort between WD steps
         microscope.set_working_distance(wd, beam_type)
         probe = microscope.acquire_image(image_settings=probe_settings)
         score = float(np.mean(focus_fn(probe.filtered_data.astype(np.float32))))
-        iterations.append(AutoFocusIteration(
-            pass_index=pass_index,
-            working_distance=float(wd),
-            focus_score=score,
-            image=probe.data,
-        ))
-        logger.debug("AutoFocus pass %d step %d/%d: wd=%.4e score=%.4f",
-                     pass_index, i, sweep_pass.n_steps, wd, score)
+        iterations.append(
+            AutoFocusIteration(
+                pass_index=pass_index,
+                working_distance=float(wd),
+                focus_score=score,
+                image=probe.data,
+            )
+        )
+        logger.debug(
+            "AutoFocus pass %d step %d/%d: wd=%.4e score=%.4f",
+            pass_index,
+            i,
+            sweep_pass.n_steps,
+            wd,
+            score,
+        )
 
     best_idx = int(np.argmax([it.focus_score for it in iterations]))
     best_wd = iterations[best_idx].working_distance
-    logger.info("AutoFocus pass %d complete: best WD=%.4e score=%.4f",
-                pass_index, best_wd, iterations[best_idx].focus_score)
+    logger.info(
+        "AutoFocus pass %d complete: best WD=%.4e score=%.4f",
+        pass_index,
+        best_wd,
+        iterations[best_idx].focus_score,
+    )
     return iterations, best_wd
 
 
 def run_auto_focus(
-    microscope: 'FibsemMicroscope',
+    microscope: "FibsemMicroscope",
     beam_type: BeamType = BeamType.ELECTRON,
     hfw: float = 150e-6,
     settings: AutoFocusSettings = None,
     stop_event: Optional[threading.Event] = None,
-) -> AutoFocusResult:
+) -> Optional[AutoFocusResult]:
     """Multi-pass image-based auto-focus sweep.
 
     Each pass sweeps working distance over a range centred on the best WD
@@ -340,7 +383,9 @@ def run_auto_focus(
 
     Returns:
         ``AutoFocusResult`` with the best probe image, winning working
-        distance, focus score, and full per-pass iteration history.
+        distance, focus score, and full per-pass iteration history — or ``None``
+        when the backend cannot set the working distance for this beam (the sweep
+        is skipped with a warning rather than faking a completed focus, FIB-508).
 
     Raises:
         OperationCancelledError: if ``stop_event`` is set during the sweep.
@@ -352,6 +397,19 @@ def run_auto_focus(
         beam_type = BeamType.ELECTRON
     if settings is None:
         settings = AutoFocusSettings()
+
+    # Skip rather than fake success: on backends where the working-distance write is
+    # a best-effort no-op (TESCAN ION), the sweep would run to completion, score
+    # images against a focus that never moved, and log an applied WD that was never
+    # applied (FIB-508). Gate before touching the hardware at all; None says nothing
+    # happened, unlike the completed-looking result the sweep used to fabricate.
+    if not microscope.is_working_distance_settable(beam_type):
+        logger.warning(
+            "AutoFocus skipped: %s cannot set the working distance for the %s beam.",
+            type(microscope).__name__,
+            beam_type.name,
+        )
+        return None
 
     focus_fn = get_focus_measure_function(settings.method.value)
 
@@ -377,7 +435,10 @@ def run_auto_focus(
             logger.warning(
                 "Pass %d range (%.2e m) >= pass %d range (%.2e m) — "
                 "later passes should be narrower than earlier ones",
-                i, curr.search_range, i - 1, prev.search_range,
+                i,
+                curr.search_range,
+                i - 1,
+                prev.search_range,
             )
 
     initial_wd = microscope.get_working_distance(beam_type)
@@ -389,10 +450,17 @@ def run_auto_focus(
 
     try:
         for pass_index, sweep_pass in enumerate(active_passes):
-            raise_if_cancelled(stop_event, "AutoFocus cancelled by user.")  # abort between passes
+            raise_if_cancelled(
+                stop_event, "AutoFocus cancelled by user."
+            )  # abort between passes
             pass_iters, centre_wd = _run_sweep(
-                microscope, probe_settings, focus_fn,
-                centre_wd, sweep_pass, pass_index, beam_type,
+                microscope,
+                probe_settings,
+                focus_fn,
+                centre_wd,
+                sweep_pass,
+                pass_index,
+                beam_type,
                 stop_event=stop_event,
             )
             iterations.extend(pass_iters)
@@ -411,7 +479,10 @@ def run_auto_focus(
     microscope.set_working_distance(best.working_distance, beam_type)
     logger.info(
         "AutoFocus complete: best WD=%.4e score=%.4f (%d passes, %d steps total)",
-        best.working_distance, best.focus_score, len(settings.passes), len(iterations),
+        best.working_distance,
+        best.focus_score,
+        len(settings.passes),
+        len(iterations),
     )
 
     return AutoFocusResult(

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1270,6 +1270,16 @@ class FibsemMicroscope(ABC):
         self.set("working_distance", wd, beam_type)
         return self.get("working_distance", beam_type)
 
+    def is_working_distance_settable(self, beam_type: BeamType) -> bool:
+        """Whether set_working_distance actually reaches the hardware for this beam.
+
+        The image-based autofocus sweep gates on this: on backends where the write is
+        a best-effort no-op (TESCAN ION -- focus there is preset-driven, the SDK has
+        no FIB working-distance control), the sweep would score images against a focus
+        that never moved and report a working distance that was never applied (FIB-508).
+        """
+        return True
+
     def get_dwell_time(self, beam_type: BeamType) -> float:
         """Get the dwell time for the specified beam type."""
         return self.get("dwell_time", beam_type)

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -624,6 +624,14 @@ class TescanMicroscope(FibsemMicroscope):
             beam.Detector.AutoSignal(Detector=self._active_detector[beam_type])
         return
 
+    def is_working_distance_settable(self, beam_type: BeamType) -> bool:
+        """ION working distance is not settable: the SDK's FIB class has no WD or
+        focus control anywhere (FIB.Optics carries only rotation/shift/viewfield) --
+        ion focus on TESCAN is preset-driven. _set("working_distance", ION) is a
+        best-effort no-op so state restores keep working; anything that *depends* on
+        the write landing (the autofocus sweep) must gate on this instead."""
+        return beam_type is not BeamType.ION
+
     def auto_focus(
         self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None
     ) -> None:

--- a/tests/test_autofunctions.py
+++ b/tests/test_autofunctions.py
@@ -1,4 +1,5 @@
 """Tests for fibsem/autofunctions: ACB, autofocus, and plotting."""
+
 from __future__ import annotations
 
 import os
@@ -29,6 +30,7 @@ from fibsem.structures import BeamType, FibsemImage, FibsemRectangle
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
+
 def make_image(mean_frac: float = 0.5, size: int = 64, dtype=np.uint16) -> FibsemImage:
     dtype_max = np.iinfo(dtype).max if np.issubdtype(dtype, np.integer) else 1.0
     base = int(dtype_max * mean_frac)
@@ -36,7 +38,8 @@ def make_image(mean_frac: float = 0.5, size: int = 64, dtype=np.uint16) -> Fibse
     rng = np.random.default_rng(42)
     data = np.clip(
         rng.integers(base - noise, base + noise + 1, size=(size, size), dtype=np.int64),
-        0, dtype_max,
+        0,
+        dtype_max,
     ).astype(dtype)
     return FibsemImage(data=data, metadata=None)
 
@@ -74,20 +77,31 @@ def mock_microscope(best_wd: float = 4.5e-3, initial_wd: float = 7.0e-3):
 
 def make_acb_result(n_iters: int = 3) -> AutoContrastBrightnessResult:
     from fibsem.structures import ImageStats
+
     iters = []
     for i in range(n_iters):
         mean = 0.3 + i * 0.07
         stats = ImageStats(
-            mean=mean, std=0.05, median=mean, p01=mean - 0.1, p99=mean + 0.1,
-            saturation_lo=0.0, saturation_hi=0.0, contrast_ratio=0.1,
-            range_utilisation=0.2, snr=10.0, entropy=4.0,
+            mean=mean,
+            std=0.05,
+            median=mean,
+            p01=mean - 0.1,
+            p99=mean + 0.1,
+            saturation_lo=0.0,
+            saturation_hi=0.0,
+            contrast_ratio=0.1,
+            range_utilisation=0.2,
+            snr=10.0,
+            entropy=4.0,
         )
-        iters.append(AutoContrastBrightnessIteration(
-            brightness=0.3 + i * 0.05,
-            contrast=0.5,
-            stats=stats,
-            image=make_image(mean_frac=mean),
-        ))
+        iters.append(
+            AutoContrastBrightnessIteration(
+                brightness=0.3 + i * 0.05,
+                contrast=0.5,
+                stats=stats,
+                image=make_image(mean_frac=mean),
+            )
+        )
     final_stats = iters[-1].stats
     return AutoContrastBrightnessResult(
         image=iters[-1].image,
@@ -101,7 +115,9 @@ def make_acb_result(n_iters: int = 3) -> AutoContrastBrightnessResult:
 def make_autofocus_result(n_passes: int = 1) -> AutoFocusResult:
     best_wd = 4.5e-3
     initial_wd = 7.0e-3
-    passes = [FocusSweepPass(search_range=2.5e-3, step_size=0.5e-3) for _ in range(n_passes)]
+    passes = [
+        FocusSweepPass(search_range=2.5e-3, step_size=0.5e-3) for _ in range(n_passes)
+    ]
     settings = AutoFocusSettings(method="laplacian", passes=passes)
     iters = []
     centre_wd = initial_wd
@@ -110,10 +126,14 @@ def make_autofocus_result(n_passes: int = 1) -> AutoFocusResult:
         wds = np.linspace(centre_wd - half, centre_wd + half, sp.n_steps + 1)
         scores = [_sharpness_score(wd, best_wd) for wd in wds]
         for wd, score in zip(wds, scores):
-            iters.append(AutoFocusIteration(
-                pass_index=pi, working_distance=float(wd),
-                focus_score=score, image=make_image().data,
-            ))
+            iters.append(
+                AutoFocusIteration(
+                    pass_index=pi,
+                    working_distance=float(wd),
+                    focus_score=score,
+                    image=make_image().data,
+                )
+            )
         centre_wd = float(wds[int(np.argmax(scores))])
     best_idx = int(np.argmax([it.focus_score for it in iters]))
     best = iters[best_idx]
@@ -128,6 +148,7 @@ def make_autofocus_result(n_passes: int = 1) -> AutoFocusResult:
 
 
 # ── ImageStats / compute_stats ────────────────────────────────────────────────
+
 
 def test_compute_stats_mid_exposure():
     img = make_image(mean_frac=0.5)
@@ -159,25 +180,40 @@ def test_compute_stats_uint8():
 
 def test_image_stats_converged():
     from fibsem.structures import ImageStats
+
     stats = ImageStats(
-        mean=0.5, std=0.05, median=0.5, p01=0.4, p99=0.6,
-        saturation_lo=0.0, saturation_hi=0.0, contrast_ratio=0.1,
-        range_utilisation=0.2, snr=10.0, entropy=4.0,
+        mean=0.5,
+        std=0.05,
+        median=0.5,
+        p01=0.4,
+        p99=0.6,
+        saturation_lo=0.0,
+        saturation_hi=0.0,
+        contrast_ratio=0.1,
+        range_utilisation=0.2,
+        snr=10.0,
+        entropy=4.0,
     )
     assert stats.converged(mean_target=0.5, mean_tolerance=0.05, saturation_limit=0.005)
-    assert not stats.converged(mean_target=0.8, mean_tolerance=0.05, saturation_limit=0.005)
+    assert not stats.converged(
+        mean_target=0.8, mean_tolerance=0.05, saturation_limit=0.005
+    )
 
 
 # ── ACB settings serialisation ────────────────────────────────────────────────
 
+
 def test_acb_settings_round_trip():
     s = AutoContrastBrightnessSettings(
-        n_iterations=8, brightness_step=0.03, mean_target=0.45,
+        n_iterations=8,
+        brightness_step=0.03,
+        mean_target=0.45,
     )
     assert AutoContrastBrightnessSettings.from_dict(s.to_dict()) == s
 
 
 # ── run_auto_contrast_brightness ──────────────────────────────────────────────
+
 
 def test_run_acb_basic():
     m = MagicMock()
@@ -206,12 +242,15 @@ def test_run_acb_preserves_initial_settings():
     m.get_detector_contrast.return_value = 0.9
     m.acquire_image.return_value = make_image(mean_frac=0.5)
 
-    result = run_auto_contrast_brightness(m, settings=AutoContrastBrightnessSettings(n_iterations=2))
+    result = run_auto_contrast_brightness(
+        m, settings=AutoContrastBrightnessSettings(n_iterations=2)
+    )
     assert result.iterations[0].brightness == pytest.approx(0.7)
     assert result.iterations[0].contrast == pytest.approx(0.9)
 
 
 # ── ACB result serialisation ──────────────────────────────────────────────────
+
 
 def test_acb_result_save_load(tmp_path):
     result = make_acb_result(n_iters=3)
@@ -226,30 +265,41 @@ def test_acb_result_save_load(tmp_path):
 
 # ── Autofocus settings serialisation ─────────────────────────────────────────
 
+
 def test_autofocus_settings_round_trip():
     s = AutoFocusSettings(
         method="sobel",
         passes=[FocusSweepPass(8e-3, 1e-3), FocusSweepPass(1e-3, 0.1e-3)],
     )
-    assert AutoFocusSettings.from_dict(s.to_dict()).passes[0].step_size == pytest.approx(1e-3)
+    assert AutoFocusSettings.from_dict(s.to_dict()).passes[
+        0
+    ].step_size == pytest.approx(1e-3)
     assert AutoFocusSettings.from_dict(s.to_dict()).method == "sobel"
 
 
 def test_autofocus_settings_from_dict_legacy_passes_n_steps():
     # passes serialized by the prior FocusSweepPass(n_steps, step_size) schema
-    s = AutoFocusSettings.from_dict({
-        "method": "laplacian",
-        "passes": [{"n_steps": 10, "step_size": 0.5e-3}],
-    })
+    s = AutoFocusSettings.from_dict(
+        {
+            "method": "laplacian",
+            "passes": [{"n_steps": 10, "step_size": 0.5e-3}],
+        }
+    )
     assert s.passes[0].step_size == pytest.approx(0.5e-3)
     assert s.passes[0].search_range == pytest.approx(10 * 0.5e-3)
     assert s.passes[0].n_steps == 10
 
 
 def test_autofocus_settings_default_pass():
-    s = AutoFocusSettings.from_dict({"method": "laplacian", "passes": [],
-                                      "probe_resolution": [768, 512],
-                                      "probe_dwell_time": 0.5e-6, "reduced_area": None})
+    s = AutoFocusSettings.from_dict(
+        {
+            "method": "laplacian",
+            "passes": [],
+            "probe_resolution": [768, 512],
+            "probe_dwell_time": 0.5e-6,
+            "reduced_area": None,
+        }
+    )
     # empty passes falls back to the default coarse/fine pair
     assert len(s.passes) == 2
 
@@ -263,6 +313,7 @@ def test_autofocus_settings_reduced_area_round_trip():
 
 # ── run_auto_focus ────────────────────────────────────────────────────────────
 
+
 def _mean_focus_fn(arr):
     """Focus function that returns mean — peaks at best_wd in make_sharp_image."""
     return np.array([np.mean(arr)])
@@ -275,10 +326,15 @@ def test_run_auto_focus_single_pass():
         method="laplacian",
         passes=[FocusSweepPass(search_range=5e-3, step_size=0.5e-3)],
     )
-    with patch("fibsem.autofunctions.metrics.get_focus_measure_function", return_value=_mean_focus_fn):
+    with patch(
+        "fibsem.autofunctions.metrics.get_focus_measure_function",
+        return_value=_mean_focus_fn,
+    ):
         result = run_auto_focus(m, settings=settings)
 
-    assert result.working_distance == pytest.approx(best_wd, abs=settings.passes[0].step_size)
+    assert result.working_distance == pytest.approx(
+        best_wd, abs=settings.passes[0].step_size
+    )
     assert result.initial_working_distance == pytest.approx(4.5e-3)
     assert result.settings is settings
     assert len(result.iterations) == settings.passes[0].n_steps + 1
@@ -287,27 +343,37 @@ def test_run_auto_focus_single_pass():
 def test_run_auto_focus_multi_pass_converges():
     best_wd = 4.5e-3
     single = AutoFocusSettings(passes=[FocusSweepPass(20e-3, 2e-3)])
-    multi = AutoFocusSettings(passes=[
-        FocusSweepPass(20e-3, 2e-3),
-        FocusSweepPass(2e-3, 0.2e-3),
-        FocusSweepPass(0.2e-3, 0.02e-3),
-    ])
+    multi = AutoFocusSettings(
+        passes=[
+            FocusSweepPass(20e-3, 2e-3),
+            FocusSweepPass(2e-3, 0.2e-3),
+            FocusSweepPass(0.2e-3, 0.02e-3),
+        ]
+    )
 
     m_single = mock_microscope(best_wd=best_wd, initial_wd=7.0e-3)
     m_multi = mock_microscope(best_wd=best_wd, initial_wd=7.0e-3)
 
-    with patch("fibsem.autofunctions.metrics.get_focus_measure_function", return_value=_mean_focus_fn):
+    with patch(
+        "fibsem.autofunctions.metrics.get_focus_measure_function",
+        return_value=_mean_focus_fn,
+    ):
         r_single = run_auto_focus(m_single, settings=single)
         r_multi = run_auto_focus(m_multi, settings=multi)
 
-    assert abs(r_multi.working_distance - best_wd) <= abs(r_single.working_distance - best_wd)
+    assert abs(r_multi.working_distance - best_wd) <= abs(
+        r_single.working_distance - best_wd
+    )
 
 
 def test_run_auto_focus_iteration_count():
     m = mock_microscope()
     passes = [FocusSweepPass(5e-3, 1e-3), FocusSweepPass(0.4e-3, 0.1e-3)]
     settings = AutoFocusSettings(passes=passes)
-    with patch("fibsem.autofunctions.metrics.get_focus_measure_function", return_value=_mean_focus_fn):
+    with patch(
+        "fibsem.autofunctions.metrics.get_focus_measure_function",
+        return_value=_mean_focus_fn,
+    ):
         result = run_auto_focus(m, settings=settings)
     expected = sum(p.n_steps + 1 for p in passes)
     assert len(result.iterations) == expected
@@ -329,20 +395,28 @@ def test_run_auto_focus_restores_wd_on_error():
 def test_run_auto_focus_cancelled_at_entry_restores_wd():
     """A stop event set before autofocus starts aborts before any sweep and restores the WD."""
     from fibsem.cancellation import OperationCancelledError
+
     initial_wd = 7.0e-3
     m = mock_microscope(initial_wd=initial_wd)
-    ev = threading.Event(); ev.set()
+    ev = threading.Event()
+    ev.set()
     settings = AutoFocusSettings(passes=[FocusSweepPass(2.5e-3, 0.5e-3)])
-    with patch("fibsem.autofunctions.metrics.get_focus_measure_function", return_value=_mean_focus_fn):
+    with patch(
+        "fibsem.autofunctions.metrics.get_focus_measure_function",
+        return_value=_mean_focus_fn,
+    ):
         with pytest.raises(OperationCancelledError):
             run_auto_focus(m, settings=settings, stop_event=ev)
     m.acquire_image.assert_not_called()  # aborted before any sweep image
-    assert m.set_working_distance.call_args[0][0] == pytest.approx(initial_wd)  # WD restored
+    assert m.set_working_distance.call_args[0][0] == pytest.approx(
+        initial_wd
+    )  # WD restored
 
 
 def test_run_auto_focus_cancelled_mid_sweep_restores_wd():
     """A stop event set *during* the sweep aborts partway (not all steps) and restores the WD."""
     from fibsem.cancellation import OperationCancelledError
+
     initial_wd = 7.0e-3
     m = mock_microscope(initial_wd=initial_wd)
     ev = threading.Event()
@@ -357,14 +431,22 @@ def test_run_auto_focus_cancelled_mid_sweep_restores_wd():
 
     m.acquire_image.side_effect = acquire_then_cancel
     settings = AutoFocusSettings(passes=[FocusSweepPass(2.5e-3, 0.1e-3)])  # ~26 steps
-    with patch("fibsem.autofunctions.metrics.get_focus_measure_function", return_value=_mean_focus_fn):
+    with patch(
+        "fibsem.autofunctions.metrics.get_focus_measure_function",
+        return_value=_mean_focus_fn,
+    ):
         with pytest.raises(OperationCancelledError):
             run_auto_focus(m, settings=settings, stop_event=ev)
-    assert calls["n"] < settings.passes[0].n_steps + 1  # stopped before completing the sweep
-    assert m.set_working_distance.call_args[0][0] == pytest.approx(initial_wd)  # WD restored
+    assert (
+        calls["n"] < settings.passes[0].n_steps + 1
+    )  # stopped before completing the sweep
+    assert m.set_working_distance.call_args[0][0] == pytest.approx(
+        initial_wd
+    )  # WD restored
 
 
 # ── AutoFocusResult serialisation ─────────────────────────────────────────────
+
 
 def test_autofocus_result_save_load(tmp_path):
     result = make_autofocus_result(n_passes=2)
@@ -372,13 +454,16 @@ def test_autofocus_result_save_load(tmp_path):
     loaded = AutoFocusResult.load(str(saved_dir))
 
     assert loaded.working_distance == pytest.approx(result.working_distance)
-    assert loaded.initial_working_distance == pytest.approx(result.initial_working_distance)
+    assert loaded.initial_working_distance == pytest.approx(
+        result.initial_working_distance
+    )
     assert loaded.focus_score == pytest.approx(result.focus_score)
     assert len(loaded.iterations) == len(result.iterations)
     assert loaded.settings.method == result.settings.method
 
 
 # ── Plotting ──────────────────────────────────────────────────────────────────
+
 
 def test_plot_acb_minimal(tmp_path):
     result = make_acb_result(n_iters=1)
@@ -438,8 +523,10 @@ def test_plot_autofocus_threadsafe(tmp_path):
 
 # ── Charge neutralisation ─────────────────────────────────────────────────────
 
+
 def test_auto_charge_neutralisation():
     from fibsem.structures import ImageSettings
+
     m = MagicMock()
     image_settings = MagicMock(spec=ImageSettings)
     image_settings.hfw = 150e-6
@@ -447,3 +534,62 @@ def test_auto_charge_neutralisation():
     with patch("fibsem.acquire.new_image", return_value=make_image()) as mock_new_image:
         auto_charge_neutralisation(m, image_settings, n_iterations=3)
         assert mock_new_image.call_count == 4  # 3 discharge + 1 final
+
+
+# ── run_auto_focus: skip-don't-fake on unsupported backends (FIB-508) ─────────
+
+
+def test_run_auto_focus_skips_when_wd_not_settable(caplog):
+    """On backends where the working-distance write is a best-effort no-op (TESCAN
+    ION), the sweep used to run to completion, score images against a focus that
+    never moved, and log an applied WD that was never applied. It must instead do
+    nothing at all: no hardware touched beyond the capability query, a None result,
+    and a warning that says why."""
+    import logging as _logging
+    from unittest.mock import call
+
+    m = mock_microscope()
+    m.is_working_distance_settable.return_value = False
+
+    with caplog.at_level(_logging.WARNING):
+        result = run_auto_focus(m, beam_type=BeamType.ION)
+
+    assert result is None
+    assert m.method_calls == [call.is_working_distance_settable(BeamType.ION)]
+    assert any("skipped" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_run_auto_focus_queries_capability_for_the_requested_beam():
+    m = mock_microscope()
+    m.is_working_distance_settable.return_value = True
+    settings = AutoFocusSettings(
+        method="laplacian",
+        passes=[FocusSweepPass(search_range=5e-3, step_size=0.5e-3)],
+    )
+    with patch(
+        "fibsem.autofunctions.metrics.get_focus_measure_function",
+        return_value=_mean_focus_fn,
+    ):
+        result = run_auto_focus(m, beam_type=BeamType.ELECTRON, settings=settings)
+
+    assert result is not None
+    m.is_working_distance_settable.assert_called_once_with(BeamType.ELECTRON)
+
+
+def test_wd_settable_capability_matrix():
+    """Tescan: preset-driven ion focus, no FIB WD control anywhere in the SDK.
+    Everything else inherits the base's True."""
+    from fibsem.microscope import FibsemMicroscope
+    from fibsem.microscopes.simulator import DemoMicroscope
+    from fibsem.microscopes.tescan import TescanMicroscope
+
+    tescan = object.__new__(TescanMicroscope)
+    assert tescan.is_working_distance_settable(BeamType.ELECTRON) is True
+    assert tescan.is_working_distance_settable(BeamType.ION) is False
+
+    demo = object.__new__(DemoMicroscope)
+    assert demo.is_working_distance_settable(BeamType.ION) is True
+    assert (
+        DemoMicroscope.is_working_distance_settable
+        is FibsemMicroscope.is_working_distance_settable
+    )


### PR DESCRIPTION
## Summary

On TESCAN, the ION working-distance write is a best-effort no-op — confirmed from SDK source (tescanautomation 3.2.16): the `FIB` class has **no WD or focus control anywhere** (`FIB.Optics` carries only rotation/shift/viewfield; the only `Auto*` method is `Detector.AutoSignal`). Ion focus on this backend is preset-driven. The image-based autofocus sweep therefore ran to completion, scored probe images against a focus that never moved, and logged "AutoFocus complete: WD=…" for a working distance that was never applied.

Minimal fix, one early gate:

- `FibsemMicroscope.is_working_distance_settable(beam_type)` — base True; TESCAN overrides ION → False. The driver answers a question; callers stay driver-ignorant.
- `run_auto_focus` gates on it **before touching the hardware at all**: logs a warning and returns `None` (return type now `Optional[AutoFocusResult]`, documented). No raise — a skip, in the same best-effort family as the driver's own state-restore no-ops, which are deliberately untouched (`set_microscope_state` restores ION beam state on every Tescan pose restore and must keep working).

Not in scope (remaining on the tracking issue): the UI completion toast still says "Complete" after a skip, and the native-ION-autofocus idea is now recorded as impossible in this SDK.

## Test plan
- [x] `tests/test_autofunctions.py` (3 new, 30 total): the skip touches nothing but the capability query (`method_calls == [call.is_working_distance_settable(ION)]`); the capability is queried for the requested beam; driver matrix (TESCAN ION False / ELECTRON True, Demo inherits base True)
- [x] Mutation-checked: disabling the gate fails two tests; flipping the TESCAN override fails the matrix
- [x] Tescan suites re-run green (connection lock, spot burn)
- [x] ruff check + format clean