### PR TITLE
[fix] Tescan stable_move: the y-axis rides the tilt module, z stays chamber-vertical

### DIFF
--- a/fibsem/imaging/tiling/reprojection.py
+++ b/fibsem/imaging/tiling/reprojection.py
@@ -338,8 +338,9 @@ def _inverse_y_corrected_stage_movement(
             "Image metadata or hardware geometry is not set. Cannot calculate inverse y corrected stage movement."
         )
 
-    # Tescan stages have a different geometry (z below the tilt axis), so the inverse
-    # is a separate derivation, not the compustage-aware path below.
+    # Tescan stages have a different geometry (y rides the tilt module, z stays
+    # chamber-vertical), so the inverse is a separate derivation, not the
+    # compustage-aware path below.
     system_info = image.metadata.system_info
     if system_info is not None and manufacturers.is_tescan(system_info.manufacturer):
         return _inverse_y_corrected_stage_movement_tescan(
@@ -399,38 +400,17 @@ def _inverse_y_corrected_stage_movement_tescan(
     )
 
 
-def y_corrected_stage_movement_tescan_from_geometry(
+def _tescan_pose_angles(
     geometry: FibsemHardwareGeometry,
     stage_position: FibsemStagePosition,
-    expected_y: float,
-    beam_type: BeamType = BeamType.ELECTRON,
-) -> Tuple[float, float]:
-    """Tescan forward of the sample-plane move — the microscope-free form.
+) -> Tuple[float, float, float]:
+    """(stage_tilt, corrected_pretilt_angle, sample_inclination), all in radians.
 
-    The counterpart of :func:`inverse_y_corrected_stage_movement_tescan_from_geometry`,
-    and the microscope-free form of :meth:`TescanMicroscope._y_corrected_stage_movement`.
-    Added so a caller that has an image but no live instrument -- an overview canvas
-    resolving a click on a saved image -- can run the same projection the stage would.
-
-    Thermo's pair is parameterised by a *view tilt* and lives in
-    :mod:`fibsem.transformations`; Tescan cannot join it, because its z-axis sits below
-    the tilt axis and the decomposition uses the full chamber-frame sample inclination
-    rather than the pre-tilt alone. Same reason ``TescanMicroscope`` overrides the
-    method instead of passing a different view tilt.
-
-    Args:
-        geometry: fixed instrument geometry (column tilts, pre-tilt, rotation refs).
-        stage_position: stage pose at acquisition (rotation r and tilt t, radians).
-        expected_y: distance along the image y-axis, in metres.
-        beam_type: beam perspective to correct for.
-
-    Returns:
-        (y_move, z_move) in the **chamber** frame, in metres -- before the stage-axis
-        inversion ``stable_move`` applies (``y_stage = -y_chamber``, z unchanged). The
-        inverse undoes that same inversion on its way in, so the two compose.
+    The pre-tilt sign flips when the stage is rotated 180 deg to face the ion beam.
+    Single home for that rule: the forward, the inverse, and the microscope's debug
+    logging all read these three angles from here, so they cannot drift apart.
     """
     sem_column_tilt = np.deg2rad(geometry.column_tilt)
-    fib_column_tilt = np.deg2rad(geometry.fib_column_tilt)
     stage_pretilt = np.deg2rad(geometry.shuttle_pre_tilt)
 
     stage_rotation_flat_to_eb = np.deg2rad(geometry.rotation_reference) % (2 * np.pi)
@@ -453,17 +433,61 @@ def y_corrected_stage_movement_tescan_from_geometry(
 
     corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)
     sample_inclination = stage_tilt - corrected_pretilt_angle
+    return stage_tilt, corrected_pretilt_angle, sample_inclination
 
+
+def y_corrected_stage_movement_tescan_from_geometry(
+    geometry: FibsemHardwareGeometry,
+    stage_position: FibsemStagePosition,
+    expected_y: float,
+    beam_type: BeamType = BeamType.ELECTRON,
+) -> Tuple[float, float]:
+    """Tescan forward of the sample-plane move — the single source of the math.
+
+    The counterpart of :func:`inverse_y_corrected_stage_movement_tescan_from_geometry`.
+    ``TescanMicroscope._y_corrected_stage_movement`` and the overview canvas
+    (``fibsem/projection.py``) are thin adapters over this function.
+
+    Tescan stage axes (corrected 2026-08-25 from the 2026-07-22 session log): the
+    y-axis is mounted ON the tilt module -- a y command travels along the tilted stage
+    plate -- while z stays chamber-vertical (+z is DOWN, verified on hardware
+    2026-07-23). The two translation axes are therefore non-orthogonal at tilt: the
+    in-plane move needs 1/cos(stage_tilt) on y, and the z command cancels only the
+    vertical the tilted y-axis introduces beyond the sample plane, which depends on
+    the (signed) pre-tilt alone. The previous chamber-fixed-y model overshot the ion
+    view 1.65x at the milling pose; a chamber-fixed model cannot overshoot at all, so
+    the observation refutes it. See
+    https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414
+    for the derivation, the sign chain, and the hardware evidence.
+
+    Thermo's pair is parameterised by a *view tilt* and lives in
+    :mod:`fibsem.transformations`; Tescan cannot join it, because its axes decompose
+    against the stage tilt and pre-tilt separately rather than the pre-tilt alone.
+
+    Args:
+        geometry: fixed instrument geometry (column tilts, pre-tilt, rotation refs).
+        stage_position: stage pose at acquisition (rotation r and tilt t, radians).
+        expected_y: distance along the image y-axis, in metres.
+        beam_type: beam perspective to correct for.
+
+    Returns:
+        (y_move, z_move) in metres -- before the stage-axis inversion ``stable_move``
+        applies (``y_stage = -y_move``, z unchanged). The inverse undoes that same
+        inversion on its way in, so the two compose.
+    """
+    stage_tilt, corrected_pretilt_angle, sample_inclination = _tescan_pose_angles(
+        geometry, stage_position
+    )
+    sem_column_tilt = np.deg2rad(geometry.column_tilt)
+    fib_column_tilt = np.deg2rad(geometry.fib_column_tilt)
     beam_tilt = sem_column_tilt if beam_type is BeamType.ELECTRON else fib_column_tilt
 
+    # perspective: image-projected dy -> true distance along the sample plane
     y_sample_move = expected_y / np.cos(sample_inclination - beam_tilt)
 
-    # z is negated because Tescan +z increases downward -- see
-    # TescanMicroscope._y_corrected_stage_movement, verified on hardware 2026-07-23.
-    return (
-        float(y_sample_move * np.cos(sample_inclination)),
-        float(-y_sample_move * np.sin(sample_inclination)),
-    )
+    y_move = y_sample_move * np.cos(sample_inclination) / np.cos(stage_tilt)
+    z_move = y_sample_move * np.sin(corrected_pretilt_angle) / np.cos(stage_tilt)
+    return float(y_move), float(z_move)
 
 
 def inverse_y_corrected_stage_movement_tescan_from_geometry(
@@ -482,9 +506,8 @@ def inverse_y_corrected_stage_movement_tescan_from_geometry(
     adapters over this function; the microscope builds `geometry` from
     `self.hardware_geometry()`, whose fields are the same ones the image carries.
 
-    Tescan stages have the z-axis BELOW the tilt axis: the y/z translation axes are fixed in
-    the chamber frame, so the inversion uses the full chamber-frame sample inclination (stage
-    tilt + pre-tilt) rather than just the pre-tilt. See
+    Tescan stage axes: y rides ON the tilt module, z is chamber-vertical (+z down) --
+    see :func:`y_corrected_stage_movement_tescan_from_geometry` and
     https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414 for the derivation.
 
     Args:
@@ -497,54 +520,27 @@ def inverse_y_corrected_stage_movement_tescan_from_geometry(
     Returns:
         float: expected_y input that would produce the given dy, dz movements.
     """
-    # undo the stage-axis inversion applied in stable_move (y_stage = -y_chamber)
+    # undo the stage-axis inversion applied in stable_move (y_stage = -y_move)
     # TODO(hardware-verify): keep in sync with the x/y inversion in TescanMicroscope.stable_move.
     dy = -dy
 
-    # all angles in radians
+    stage_tilt, corrected_pretilt_angle, sample_inclination = _tescan_pose_angles(
+        geometry, stage_position
+    )
     sem_column_tilt = np.deg2rad(geometry.column_tilt)
     fib_column_tilt = np.deg2rad(geometry.fib_column_tilt)
-
-    stage_pretilt = np.deg2rad(geometry.shuttle_pre_tilt)
-
-    stage_rotation_flat_to_eb = np.deg2rad(geometry.rotation_reference) % (2 * np.pi)
-    stage_rotation_flat_to_ion = np.deg2rad(geometry.rotation_180) % (2 * np.pi)
-
-    # stage pose at acquisition
-    stage_rotation = (
-        stage_position.r % (2 * np.pi) if stage_position.r is not None else 0.0
-    )
-    stage_tilt = stage_position.t if stage_position.t is not None else 0.0
-
-    PRETILT_SIGN = 1.0
-    # pretilt angle depends on rotation
-    if movement.rotation_angle_is_smaller(
-        stage_rotation, stage_rotation_flat_to_eb, atol=5
-    ):
-        PRETILT_SIGN = 1.0
-    if movement.rotation_angle_is_smaller(
-        stage_rotation, stage_rotation_flat_to_ion, atol=5
-    ):
-        PRETILT_SIGN = -1.0
-
-    corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)
-
-    # inclination of the sample plane relative to the chamber horizontal
-    # TODO(hardware-verify): tilt sense and z direction, see
-    # TescanMicroscope._y_corrected_stage_movement.
-    sample_inclination = stage_tilt - corrected_pretilt_angle
-
     beam_tilt = sem_column_tilt if beam_type is BeamType.ELECTRON else fib_column_tilt
 
-    # invert: forward is y = d*cos(incl), z = -d*sin(incl);
-    # recover d from the larger component for numerical stability. The sin branch must
-    # negate dz to match the forward's negated z.
+    # invert: forward is y = d*cos(incl)/cos(tilt), z = d*sin(pretilt)/cos(tilt);
+    # recover d from the better-conditioned component. With zero corrected pre-tilt
+    # the z move is identically zero and carries no information, so ties (and every
+    # pose where |cos(incl)| dominates) go to the y branch.
     cos_incl = np.cos(sample_inclination)
-    sin_incl = np.sin(sample_inclination)
-    if abs(cos_incl) > abs(sin_incl):
-        y_sample_move = dy / cos_incl
+    sin_pretilt = np.sin(corrected_pretilt_angle)
+    if abs(cos_incl) >= abs(sin_pretilt):
+        y_sample_move = dy * np.cos(stage_tilt) / cos_incl
     else:
-        y_sample_move = -dz / sin_incl
+        y_sample_move = dz * np.cos(stage_tilt) / sin_pretilt
 
     # re-project the sample-plane distance into the image plane
     expected_y = y_sample_move * np.cos(sample_inclination - beam_tilt)

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -840,79 +840,53 @@ class TescanMicroscope(FibsemMicroscope):
         beam_type: BeamType = BeamType.ELECTRON,
     ) -> FibsemStagePosition:
         """
-        Calculate the y corrected stage movement for a move along the sample plane,
-        corrected for the shuttle pre-tilt and the current stage tilt.
+        Calculate the stage command for a move along the sample plane, corrected for
+        the shuttle pre-tilt, the current stage tilt, and the viewing beam's
+        perspective.
 
-        Tescan stages have the z-axis BELOW the tilt axis: the y/z translation axes
-        are fixed in the chamber frame and do not rotate with stage tilt (unlike
-        ThermoFisher, where y/z ride on the tilt module and only the pre-tilt
-        appears in the decomposition). The sample-plane move must therefore be
-        decomposed using the full chamber-frame inclination of the sample.
-        See https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414 for the derivation.
+        Tescan stage axes (corrected 2026-08-25 from the 2026-07-22 session log): the
+        y-axis is mounted ON the tilt module -- a y command travels along the tilted
+        stage plate -- while z stays chamber-vertical (+z down, verified on hardware
+        2026-07-23). The axes are therefore non-orthogonal at tilt. The math lives in
+        reprojection.py (single source, shared with the image-metadata path and the
+        overview canvas). See
+        https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414
+        for the derivation, the sign chain, and the hardware evidence.
+
+        TODO(hardware-verify): the tilted-y model is corroborated (it reproduces the
+        observed 1.65x ion-view overshoot at the milling pose, which the previous
+        chamber-fixed model cannot produce at all) but awaits one confirming stable
+        move at tilt: the feature must land centred AND stay in focus, in both views.
 
         Args:
             expected_y (float): distance along the image y-axis.
             beam_type (BeamType, optional): beam perspective to correct for. Defaults to BeamType.ELECTRON.
 
         Returns:
-            FibsemStagePosition: relative stage movement in the chamber frame
-                (before the stage-axis inversion applied by the caller).
+            FibsemStagePosition: relative stage movement (before the stage-axis
+                inversion applied by the caller).
         """
-
-        # all angles in radians
-        sem_column_tilt = np.deg2rad(self.system.electron.column_tilt)
-        fib_column_tilt = np.deg2rad(self.system.ion.column_tilt)
-
-        stage_pretilt = np.deg2rad(self.system.stage.shuttle_pre_tilt)
-
-        stage_rotation_flat_to_eb = np.deg2rad(self.system.stage.rotation_reference) % (
-            2 * np.pi
-        )
-        stage_rotation_flat_to_ion = np.deg2rad(self.system.stage.rotation_180) % (
-            2 * np.pi
+        from fibsem.imaging.tiling.reprojection import (
+            _tescan_pose_angles,
+            y_corrected_stage_movement_tescan_from_geometry,
         )
 
-        # current stage position
+        geometry = self.hardware_geometry()
         current_stage_position = self.get_stage_position()
-        stage_rotation = current_stage_position.r % (2 * np.pi)
-        stage_tilt = current_stage_position.t
 
-        # pre-tilt sign flips when the stage is rotated 180 deg to face the ion beam
-        PRETILT_SIGN = 1.0
-        from fibsem import movement
-
-        if movement.rotation_angle_is_smaller(
-            stage_rotation, stage_rotation_flat_to_eb, atol=5
-        ):
-            PRETILT_SIGN = 1.0
-        if movement.rotation_angle_is_smaller(
-            stage_rotation, stage_rotation_flat_to_ion, atol=5
-        ):
-            PRETILT_SIGN = -1.0
-
-        corrected_pretilt_angle = PRETILT_SIGN * (stage_pretilt + sem_column_tilt)
-
-        # inclination of the sample plane relative to the chamber horizontal
-        # (sample is flat to the SEM when stage_tilt == corrected_pretilt_angle)
-        # TODO(hardware-verify): assumes positive stage tilt tips the sample
-        # toward the FIB (same sense as ThermoFisher). If opposite, negate stage_tilt here.
-        sample_inclination = stage_tilt - corrected_pretilt_angle
-
-        beam_tilt = (
-            sem_column_tilt if beam_type is BeamType.ELECTRON else fib_column_tilt
+        y_move, z_move = y_corrected_stage_movement_tescan_from_geometry(
+            geometry=geometry,
+            stage_position=current_stage_position,
+            expected_y=expected_y,
+            beam_type=beam_type,
         )
 
-        # perspective: image-projected dy -> true distance along the sample plane
-        y_sample_move = expected_y / np.cos(sample_inclination - beam_tilt)
-
-        # decompose the sample-plane move into the chamber-fixed stage axes
-        y_move = y_sample_move * np.cos(sample_inclination)
-        # Tescan +z increases DOWNWARD (away from the SEM column), opposite to Thermo
-        # RAW — hence the negation. Verified on hardware 2026-07-23: flipping the z
-        # sign alone corrected the coincidence move, while the tilt sense was already
-        # right. Keep _inverse_y_corrected_stage_movement's sin branch in sync.
-        z_move = -y_sample_move * np.sin(sample_inclination)
-
+        # the angle terms are logged so a session log alone can reconstruct the
+        # geometry the move was computed under (this is how the 2026-07-22 ion-view
+        # overshoot was diagnosed after the fact)
+        stage_tilt, corrected_pretilt_angle, sample_inclination = _tescan_pose_angles(
+            geometry, current_stage_position
+        )
         logging.debug(
             {
                 "msg": "_y_corrected_stage_movement",

--- a/tests/test_beam_stage_projection.py
+++ b/tests/test_beam_stage_projection.py
@@ -398,15 +398,16 @@ class TestRoundTrip:
     @pytest.mark.parametrize("tilt_deg", TESCAN_TILTS)
     def test_tescan_survives_a_round_trip_too(self, beam_type, tilt_deg):
         """Tescan gets its own case because it is a genuinely different derivation --
-        z below the tilt axis, and stage x inverted against image x -- so it shares
-        none of the arithmetic the cases above exercise.
+        the y-axis rides the tilt module while z stays chamber-vertical, and stage x
+        is inverted against image x -- so it shares none of the arithmetic the cases
+        above exercise.
 
         Built from an explicit geometry rather than the shared microscope fixture. That
         fixture is module-scoped and every pose test mutates its pre-tilt and
         orientations, so a Tescan case reading it was really testing whatever the
-        previous parameter left behind -- which is how it ended up at a sample
-        inclination past 45 degrees, where `test_the_chamber_frame_inversion_is_pinned`
-        explains this round trip goes blind.
+        previous parameter left behind -- which is how it ended up at a pose where the
+        inverse's z branch made the round trip blind to the y sign
+        (`test_the_chamber_frame_inversion_is_pinned` explains).
         """
         projection = BeamStageProjection(
             geometry=_TESCAN_GEOMETRY, beam_type=beam_type, scan_rotation=0.0,
@@ -423,15 +424,15 @@ class TestRoundTrip:
 
     @pytest.mark.parametrize("tilt_deg", TESCAN_TILTS)
     def test_the_chamber_frame_inversion_is_pinned(self, tilt_deg):
-        """`stable_move` inverts stage y against the chamber frame; assert it directly.
+        """`stable_move` inverts stage y against the stage frame; assert it directly.
 
         A round trip cannot be trusted to catch this. The Tescan inverse recovers the
-        sample-plane move from whichever of dy/dz is the larger component, so once the
-        sample inclination passes 45 degrees it reads **dz alone** and never looks at
-        dy -- at which point flipping the y sign changes nothing that comes back, and
-        the round-trip test passes over a projection that would drive the stage the
-        wrong way. Verified: this assertion fails under that flip at every tilt here,
-        while the round trip above only fails below 45 degrees.
+        sample-plane move from whichever forward component is better conditioned (y
+        carries cos(inclination), z carries sin(pretilt)); whenever the z branch is
+        selected it never looks at dy -- at which point flipping the y sign changes
+        nothing that comes back, and the round-trip test passes over a projection
+        that would drive the stage the wrong way. Pinning the inversion directly is
+        immune to the branch choice.
         """
         projection = BeamStageProjection(
             geometry=_TESCAN_GEOMETRY, beam_type=BeamType.ELECTRON, scan_rotation=0.0,

--- a/tests/test_beam_stage_projection.py
+++ b/tests/test_beam_stage_projection.py
@@ -17,6 +17,7 @@ agreements:
 Run directly:
     PYTHONPATH=$PWD python -m pytest tests/test_beam_stage_projection.py
 """
+
 from __future__ import annotations
 
 import itertools
@@ -40,7 +41,10 @@ from fibsem.structures import (
     ImageSettings,
 )
 
-SHAPE = (1024, 1536)  # (height, width) -- deliberately non-square, so an axis swap shows
+SHAPE = (
+    1024,
+    1536,
+)  # (height, width) -- deliberately non-square, so an axis swap shows
 PIXEL_SIZE = 2e-7
 
 
@@ -75,7 +79,9 @@ def _pose(microscope, *, compustage, pretilt_deg, rotation_deg, tilt_deg):
     microscope.system.stage.shuttle_pre_tilt = pretilt_deg
     microscope._update_orientations()
     position = FibsemStagePosition(
-        x=0.0, y=0.0, z=0.0,
+        x=0.0,
+        y=0.0,
+        z=0.0,
         r=np.deg2rad(rotation_deg),
         t=np.deg2rad(tilt_deg),
     )
@@ -132,12 +138,22 @@ class TestParityWithTheLiveMicroscope:
     @pytest.mark.parametrize("beam_type", BEAMS)
     @pytest.mark.parametrize("scan_rotation", SCAN_ROTATIONS)
     def test_the_inverse_matches_project_stable_move(
-        self, microscope, compustage, pretilt, rot, tilt, beam_type, scan_rotation,
+        self,
+        microscope,
+        compustage,
+        pretilt,
+        rot,
+        tilt,
+        beam_type,
+        scan_rotation,
         monkeypatch,
     ):
         base = _pose(
-            microscope, compustage=compustage, pretilt_deg=pretilt,
-            rotation_deg=rot, tilt_deg=tilt,
+            microscope,
+            compustage=compustage,
+            pretilt_deg=pretilt,
+            rotation_deg=rot,
+            tilt_deg=tilt,
         )
         monkeypatch.setattr(
             microscope, "get_scan_rotation", lambda beam_type: scan_rotation
@@ -175,7 +191,9 @@ class TestParityWithTheLiveMicroscope:
 
         monkeypatch.setattr(microscope, "get_scan_rotation", counting)
         projection = BeamStageProjection.from_microscope(microscope, BeamType.ELECTRON)
-        assert len(calls) == 1, "construction should read the scan rotation exactly once"
+        assert len(calls) == 1, (
+            "construction should read the scan rotation exactly once"
+        )
 
         base = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0)
         for _ in range(20):
@@ -212,16 +230,30 @@ class TestParityWithTheTiledReprojection:
     @pytest.mark.parametrize("beam_type", BEAMS)
     @pytest.mark.parametrize("scan_rotation", SCAN_ROTATIONS)
     def test_the_forward_matches_the_tiled_reprojection(
-        self, microscope, compustage, pretilt, rot, tilt, beam_type, scan_rotation,
+        self,
+        microscope,
+        compustage,
+        pretilt,
+        rot,
+        tilt,
+        beam_type,
+        scan_rotation,
     ):
         base = _pose(
-            microscope, compustage=compustage, pretilt_deg=pretilt,
-            rotation_deg=rot, tilt_deg=tilt,
+            microscope,
+            compustage=compustage,
+            pretilt_deg=pretilt,
+            rotation_deg=rot,
+            tilt_deg=tilt,
         )
         image = self._image(microscope, base, beam_type, scan_rotation)
 
         target = FibsemStagePosition(
-            x=base.x + 120e-6, y=base.y - 45e-6, z=base.z + 8e-6, r=base.r, t=base.t,
+            x=base.x + 120e-6,
+            y=base.y - 45e-6,
+            z=base.z + 8e-6,
+            r=base.r,
+            t=base.t,
         )
         (point,) = reproject_stage_positions_onto_image2(image, [target])
         # The tiled function answers in pixels from the image corner; the projection
@@ -255,9 +287,7 @@ class TestParityWithTheTiledReprojection:
         from_image = BeamStageProjection.from_image(image)
         from_live = BeamStageProjection.from_microscope(microscope, BeamType.ELECTRON)
 
-        target = FibsemStagePosition(
-            x=100e-6, y=0.0, z=0.0, r=base.r, t=base.t
-        )
+        target = FibsemStagePosition(x=100e-6, y=0.0, z=0.0, r=base.r, t=base.t)
         assert from_image.to_plane(target, base)[0] == pytest.approx(100e-6)
         assert from_live.to_plane(target, base)[0] == pytest.approx(-100e-6), (
             "the live projection should have flipped -- otherwise this test proves nothing"
@@ -376,11 +406,21 @@ class TestRoundTrip:
     @pytest.mark.parametrize("beam_type", BEAMS)
     @pytest.mark.parametrize("scan_rotation", SCAN_ROTATIONS)
     def test_a_position_survives_a_round_trip(
-        self, microscope, compustage, pretilt, rot, tilt, beam_type, scan_rotation,
+        self,
+        microscope,
+        compustage,
+        pretilt,
+        rot,
+        tilt,
+        beam_type,
+        scan_rotation,
     ):
         base = _pose(
-            microscope, compustage=compustage, pretilt_deg=pretilt,
-            rotation_deg=rot, tilt_deg=tilt,
+            microscope,
+            compustage=compustage,
+            pretilt_deg=pretilt,
+            rotation_deg=rot,
+            tilt_deg=tilt,
         )
         projection = BeamStageProjection(
             geometry=_geometry(microscope, compustage),
@@ -410,7 +450,9 @@ class TestRoundTrip:
         (`test_the_chamber_frame_inversion_is_pinned` explains).
         """
         projection = BeamStageProjection(
-            geometry=_TESCAN_GEOMETRY, beam_type=beam_type, scan_rotation=0.0,
+            geometry=_TESCAN_GEOMETRY,
+            beam_type=beam_type,
+            scan_rotation=0.0,
             is_tescan=True,
         )
         base = FibsemStagePosition(
@@ -435,15 +477,17 @@ class TestRoundTrip:
         immune to the branch choice.
         """
         projection = BeamStageProjection(
-            geometry=_TESCAN_GEOMETRY, beam_type=BeamType.ELECTRON, scan_rotation=0.0,
+            geometry=_TESCAN_GEOMETRY,
+            beam_type=BeamType.ELECTRON,
+            scan_rotation=0.0,
             is_tescan=True,
         )
-        base = FibsemStagePosition(
-            x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(tilt_deg)
-        )
+        base = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=0.0, t=np.deg2rad(tilt_deg))
         # The canvas plane's y runs down, so this is +30 um in the microscope's image y.
         y_chamber, z_chamber = y_corrected_stage_movement_tescan_from_geometry(
-            geometry=_TESCAN_GEOMETRY, stage_position=base, expected_y=30e-6,
+            geometry=_TESCAN_GEOMETRY,
+            stage_position=base,
+            expected_y=30e-6,
             beam_type=BeamType.ELECTRON,
         )
 
@@ -567,6 +611,8 @@ class TestSurfaceForeshortening:
         )
         projection = BeamStageProjection(
             geometry=_geometry(microscope, compustage=False),
-            beam_type=BeamType.ELECTRON, scan_rotation=0.0, is_tescan=False,
+            beam_type=BeamType.ELECTRON,
+            scan_rotation=0.0,
+            is_tescan=False,
         )
         assert surface_foreshortening(projection, base) == pytest.approx(1.0, abs=1e-6)

--- a/tests/test_tescan_movement.py
+++ b/tests/test_tescan_movement.py
@@ -1,17 +1,24 @@
 """Tests for the Tescan sample-plane stage movement geometry.
 
-Tescan stages have the z-axis below the tilt axis (chamber-fixed y/z translation
-axes), so stable_move decomposes the sample-plane move using the full chamber-frame
-sample inclination. See https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414 for the derivation.
+Tescan stage axes: the y-axis rides ON the tilt module (a y command travels along
+the tilted stage plate) while z stays chamber-vertical (+z down, verified on
+hardware 2026-07-23) -- the translation axes are non-orthogonal at tilt. The
+forward decomposition is therefore
+
+    d = dy / cos(inclination - beam_tilt)          # perspective correction
+    y = d * cos(inclination) / cos(stage_tilt)     # along the plate
+    z = d * sin(corrected_pretilt) / cos(stage_tilt)
+
+where inclination = stage_tilt - corrected_pretilt. Corrected 2026-08-25 after the
+2026-07-22 session log showed the previous chamber-fixed-y model overshooting the
+ion view ~1.65x at the milling pose (a chamber-fixed model cannot overshoot at
+all, so the observation refuted it). See
+https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414 for the derivation.
 
 These tests lock in the derived math and the internal sign contracts
-(stable_move <-> inverse round trips).
-
-Tescan +z increases DOWNWARD (away from the SEM column), opposite to Thermo RAW,
-so the forward decomposition is y = d*cos(incl), z = -d*sin(incl). Verified on
-hardware 2026-07-23. The remaining hardware sign conventions (tilt sense, stage
-x/y inversion) are flagged with TODO(hardware-verify) in code and can only be
-confirmed on an instrument.
+(stable_move <-> inverse round trips). The remaining hardware confirmation (a
+stable move at tilt must centre the feature AND hold focus, in both views) is
+flagged with TODO(hardware-verify) in code.
 
 No hardware or Tescan SDK required: the microscope object is created without
 __init__ and the stage state is stubbed.
@@ -140,68 +147,82 @@ def stage_at(
 
 @pytest.mark.parametrize("tilt_deg", [0.0, 10.0, 17.0, 30.0, 45.0])
 @pytest.mark.parametrize("pretilt_deg", [0.0, 20.0, 35.0])
-def test_sem_y_move_equals_expected_y(tilt_deg, pretilt_deg):
-    """For the vertical SEM beam the y stage move equals the image dy exactly
-    (chamber-fixed y axis), and z compensates with -dy * tan(sample_inclination)."""
+def test_sem_y_move_is_dy_over_cos_tilt(tilt_deg, pretilt_deg):
+    """For the vertical SEM beam the perspective and inclination cosines cancel:
+    y = dy / cos(tilt) along the plate (dy exactly, measured horizontally), plus
+    the pre-tilt z compensation."""
     m = make_microscope(pretilt_deg=pretilt_deg, stage_position=stage_at(tilt_deg))
     dy = 2e-6
 
     move = m._y_corrected_stage_movement(expected_y=dy, beam_type=BeamType.ELECTRON)
 
-    inclination = np.deg2rad(tilt_deg) - np.deg2rad(pretilt_deg)
-    assert move.y == pytest.approx(dy)
-    assert move.z == pytest.approx(-dy * np.tan(inclination))
+    tilt = np.deg2rad(tilt_deg)
+    pretilt = np.deg2rad(pretilt_deg)
+    d = dy / np.cos(tilt - pretilt)
+    assert move.y == pytest.approx(dy / np.cos(tilt))
+    assert move.z == pytest.approx(d * np.sin(pretilt) / np.cos(tilt))
 
 
 @pytest.mark.parametrize("beam_type", [BeamType.ELECTRON, BeamType.ION])
-def test_flat_sample_has_no_z_move(beam_type):
-    """When the sample is flat to the SEM (tilt == pre-tilt) the move stays in-plane,
-    matching the previous placeholder implementation (y only, z = 0)."""
-    m = make_microscope(pretilt_deg=35.0, stage_position=stage_at(35.0))
+@pytest.mark.parametrize("tilt_deg", [0.0, 20.0, 55.0])
+def test_no_pretilt_move_is_pure_y(beam_type, tilt_deg):
+    """With no shuttle pre-tilt the plate IS the sample plane: the whole move is a
+    single y command of the sample-plane distance, and z is exactly zero at any
+    tilt (the stage does the geometry itself)."""
+    m = make_microscope(pretilt_deg=0.0, stage_position=stage_at(tilt_deg))
     dy = 2e-6
 
     move = m._y_corrected_stage_movement(expected_y=dy, beam_type=beam_type)
 
+    beam_tilt = 0.0 if beam_type is BeamType.ELECTRON else FIB_COLUMN_TILT
+    d = dy / np.cos(np.deg2rad(tilt_deg) - beam_tilt)
+    assert move.y == pytest.approx(d)
     assert move.z == pytest.approx(0.0, abs=1e-12)
-    if beam_type is BeamType.ELECTRON:
-        assert move.y == pytest.approx(dy)
-    else:
-        # FIB views the flat sample at the column tilt -> perspective stretch
-        assert move.y == pytest.approx(dy / np.cos(FIB_COLUMN_TILT))
 
 
 def test_fib_move_explicit_values():
     """Explicit numeric check of the FIB case against the derivation:
-    d = dy / cos(incl - column_tilt); y = d*cos(incl); z = -d*sin(incl)."""
+    d = dy / cos(incl - column_tilt); y = d*cos(incl)/cos(tilt);
+    z = d*sin(pretilt)/cos(tilt)."""
     tilt_deg, pretilt_deg = 17.0, 35.0
     m = make_microscope(pretilt_deg=pretilt_deg, stage_position=stage_at(tilt_deg))
     dy = 2e-6
 
     move = m._y_corrected_stage_movement(expected_y=dy, beam_type=BeamType.ION)
 
+    tilt = np.deg2rad(tilt_deg)
     inclination = np.deg2rad(tilt_deg - pretilt_deg)  # -18 deg
     d = dy / np.cos(inclination - FIB_COLUMN_TILT)
-    assert move.y == pytest.approx(d * np.cos(inclination))
-    assert move.z == pytest.approx(-d * np.sin(inclination))
+    assert move.y == pytest.approx(d * np.cos(inclination) / np.cos(tilt))
+    assert move.z == pytest.approx(d * np.sin(np.deg2rad(pretilt_deg)) / np.cos(tilt))
 
 
-def test_move_magnitude_equals_sample_plane_distance():
-    """The (y, z) stage move has the same magnitude as the sample-plane distance."""
-    m = make_microscope(pretilt_deg=35.0, stage_position=stage_at(17.0))
-    dy = 2e-6
+def test_logged_milling_pose_regression():
+    """The 2026-07-22 hardware session, ion view at the milling pose: stage tilt
+    20 deg, shuttle pre-tilt 40 deg, inclination -20 deg (15 deg grazing), a
+    +33.3 um click. The chamber-fixed model commanded y=121.0/z=+44.0 um and the
+    feature overshot ~1.65x; the corrected command is y=128.7/z=+88.0 um -- z on
+    the same side, twice the size. Pinned in absolute microns so a regression in
+    any angle term fails loudly here first."""
+    m = make_microscope(pretilt_deg=40.0, stage_position=stage_at(20.0))
+    dy = 33.3e-6
 
     move = m._y_corrected_stage_movement(expected_y=dy, beam_type=BeamType.ION)
 
-    inclination = np.deg2rad(17.0 - 35.0)
-    d = dy / np.cos(inclination - FIB_COLUMN_TILT)
-    assert np.hypot(move.y, move.z) == pytest.approx(abs(d))
+    d = dy / np.cos(np.deg2rad(-20.0) - FIB_COLUMN_TILT)  # 128.66 um
+    assert move.y == pytest.approx(d)  # cos(incl) == cos(tilt) at this exact pose
+    assert move.y == pytest.approx(128.66e-6, rel=1e-3)
+    assert move.z == pytest.approx(88.01e-6, rel=1e-3)
+    assert move.z > 0
 
 
 def test_pretilt_sign_flips_when_facing_ion():
-    """Rotating 180 deg (facing the FIB) flips the pre-tilt sign, changing the
-    sample inclination from (tilt - pretilt) to (tilt + pretilt)."""
+    """Rotating 180 deg (facing the FIB) flips the pre-tilt sign: the sample
+    inclination changes from (tilt - pretilt) to (tilt + pretilt) and the z
+    compensation changes side with it."""
     dy = 2e-6
     tilt_deg, pretilt_deg = 10.0, 35.0
+    tilt, pretilt = np.deg2rad(tilt_deg), np.deg2rad(pretilt_deg)
 
     m_eb = make_microscope(pretilt_deg, stage_at(tilt_deg, ROTATION_FLAT_TO_EB))
     m_ion = make_microscope(pretilt_deg, stage_at(tilt_deg, ROTATION_FLAT_TO_ION))
@@ -209,8 +230,11 @@ def test_pretilt_sign_flips_when_facing_ion():
     move_eb = m_eb._y_corrected_stage_movement(dy, BeamType.ELECTRON)
     move_ion = m_ion._y_corrected_stage_movement(dy, BeamType.ELECTRON)
 
-    assert move_eb.z == pytest.approx(-dy * np.tan(np.deg2rad(tilt_deg - pretilt_deg)))
-    assert move_ion.z == pytest.approx(-dy * np.tan(np.deg2rad(tilt_deg + pretilt_deg)))
+    d_eb = dy / np.cos(tilt - pretilt)
+    d_ion = dy / np.cos(tilt + pretilt)
+    assert move_eb.z == pytest.approx(d_eb * np.sin(pretilt) / np.cos(tilt))
+    assert move_ion.z == pytest.approx(-d_ion * np.sin(pretilt) / np.cos(tilt))
+    assert move_eb.z > 0 > move_ion.z
 
 
 # ---------------------------------------------------------------------------
@@ -219,7 +243,7 @@ def test_pretilt_sign_flips_when_facing_ion():
 
 
 def test_stable_move_applies_axis_inversion():
-    """stable_move applies the empirical stage-axis inversion (x=-dx, y=-y_chamber)
+    """stable_move applies the empirical stage-axis inversion (x=-dx, y=-y_move)
     after the trig, leaving z independent."""
     m = make_microscope(pretilt_deg=35.0, stage_position=stage_at(17.0))
     dx, dy = 1e-6, 2e-6
@@ -228,10 +252,11 @@ def test_stable_move_applies_axis_inversion():
 
     assert len(m._recorded_moves) == 1
     move = m._recorded_moves[0]
-    inclination = np.deg2rad(17.0 - 35.0)
+    tilt, pretilt = np.deg2rad(17.0), np.deg2rad(35.0)
+    d = dy / np.cos(tilt - pretilt)
     assert move.x == pytest.approx(-dx)
-    assert move.y == pytest.approx(-dy)  # SEM: y_chamber == dy, inverted
-    assert move.z == pytest.approx(-dy * np.tan(inclination))  # z not inverted
+    assert move.y == pytest.approx(-dy / np.cos(tilt))  # SEM y, inverted
+    assert move.z == pytest.approx(d * np.sin(pretilt) / np.cos(tilt))  # z not inverted
 
 
 def test_stable_move_scan_rotation_180_flips_xy():
@@ -244,10 +269,11 @@ def test_stable_move_scan_rotation_180_flips_xy():
     m.stable_move(dx=dx, dy=dy, beam_type=BeamType.ELECTRON)
 
     move = m._recorded_moves[0]
-    inclination = np.deg2rad(17.0 - 35.0)
+    tilt, pretilt = np.deg2rad(17.0), np.deg2rad(35.0)
+    d = dy / np.cos(tilt - pretilt)
     assert move.x == pytest.approx(dx)
-    assert move.y == pytest.approx(dy)
-    assert move.z == pytest.approx(dy * np.tan(inclination))
+    assert move.y == pytest.approx(dy / np.cos(tilt))
+    assert move.z == pytest.approx(-d * np.sin(pretilt) / np.cos(tilt))
 
 
 @pytest.mark.parametrize("beam_type", [BeamType.ELECTRON, BeamType.ION])
@@ -294,24 +320,25 @@ def test_microscope_inverse_round_trip(beam_type, rotation, tilt_deg, pretilt_de
 
 
 @pytest.mark.parametrize("beam_type", [BeamType.ELECTRON, BeamType.ION])
-def test_inverse_uses_sin_branch_past_45_degrees(beam_type):
-    """Round trip through the |sin| > |cos| branch of the inverse.
+def test_inverse_uses_z_branch_when_pretilt_dominates(beam_type):
+    """Round trip through the |sin(pretilt)| > |cos(inclination)| branch of the inverse.
 
-    The inverse picks whichever of dy/dz is the larger component, so the sin
-    branch only runs once |sample_inclination| > 45 deg. Facing the ion beam
-    flips the pre-tilt sign, making the inclination (tilt + pretilt) — 50 deg
-    here. That branch encodes the z sign independently of the cos branch, so
+    The inverse recovers the sample-plane distance from whichever forward component
+    is better conditioned: y carries cos(inclination), z carries sin(pretilt). The
+    z branch only engages when the inclination approaches vertical — facing the ion
+    beam flips the pre-tilt sign, making the inclination (tilt + pretilt) = 95 deg
+    here. That branch encodes the z convention independently of the y branch, so
     without this case a z-convention change can pass every other test while
     silently inverting the recovered dy.
     """
-    tilt_deg, pretilt_deg = 30.0, 20.0
+    tilt_deg, pretilt_deg = 60.0, 35.0
     m = make_microscope(pretilt_deg, stage_at(tilt_deg, ROTATION_FLAT_TO_ION))
     dy = 2e-6
 
     chamber = m._y_corrected_stage_movement(expected_y=dy, beam_type=beam_type)
     inclination = np.deg2rad(tilt_deg + pretilt_deg)
-    assert abs(np.sin(inclination)) > abs(np.cos(inclination)), (
-        "fixture must hit the sin branch"
+    assert abs(np.sin(np.deg2rad(pretilt_deg))) > abs(np.cos(inclination)), (
+        "fixture must hit the z branch"
     )
 
     recovered = m._inverse_y_corrected_stage_movement(
@@ -341,24 +368,23 @@ def test_standalone_inverse_matches_microscope(beam_type, tilt_deg):
 
 
 @pytest.mark.parametrize("beam_type", [BeamType.ELECTRON, BeamType.ION])
-def test_standalone_inverse_matches_microscope_sin_branch(beam_type):
-    """The standalone must match the microscope method in the |sin| > |cos| branch too.
+def test_standalone_inverse_matches_microscope_z_branch(beam_type):
+    """The standalone must match the microscope method in the z branch too.
 
-    The standalone (reprojection.py) and the microscope method are mirror copies. The sin
-    branch — reachable only when |inclination| > 45 deg, i.e. facing the ion beam — encodes
-    the z sign independently, and it once diverged: the microscope method was fixed to
-    -dz/sin while the standalone kept dz/sin, silently placing reprojected positions at the
-    opposite corner. Every other reprojection fixture sits below 45 deg, so without this
-    case the two can drift apart again unnoticed.
+    The z branch encodes the z convention independently of the y branch, and the two
+    copies of the inverse once diverged in exactly that branch (dz vs -dz), silently
+    placing reprojected positions at the opposite corner. The microscope method now
+    delegates to the reprojection core, so this pins the delegation and the
+    metadata-path geometry staying equivalent.
     """
-    tilt_deg, pretilt_deg = 30.0, 20.0
+    tilt_deg, pretilt_deg = 60.0, 35.0
     stage_position = stage_at(tilt_deg, ROTATION_FLAT_TO_ION)
     m = make_microscope(pretilt_deg=pretilt_deg, stage_position=stage_position)
     image = make_image(m.system, stage_position, beam_type=beam_type)
 
-    inclination = np.deg2rad(tilt_deg + pretilt_deg)  # 50 deg -> sin branch
-    assert abs(np.sin(inclination)) > abs(np.cos(inclination)), (
-        "fixture must hit the sin branch"
+    inclination = np.deg2rad(tilt_deg + pretilt_deg)  # 95 deg -> z branch
+    assert abs(np.sin(np.deg2rad(pretilt_deg))) > abs(np.cos(inclination)), (
+        "fixture must hit the z branch"
     )
 
     dy_raw, dz_raw = -1.5e-6, 0.5e-6


### PR DESCRIPTION
## What

Corrects the Tescan `stable_move` stage decomposition. The stage's **y-axis rides the tilt module** (a y command travels along the tilted stage plate) while **z stays chamber-vertical** — the previous model assumed both axes are chamber-fixed. The two models coincide at zero tilt, which is why every zero-tilt check passed.

With `d = dy / cos(inclination − beam_tilt)` the perspective-corrected sample-plane distance (unchanged):

```
y = d · cos(inclination) / cos(stage_tilt)          # along the plate
z = d · sin(corrected_pretilt) / cos(stage_tilt)    # cancels the vertical the tilted y-axis drags in
```

`vertical_move` is untouched (z really is chamber-vertical — why its 1/sin(55°) factor verified cleanly on hardware while stable moves did not).

## Why

The July hardware session showed ion-view stable moves overshooting **~1.65×** at the milling pose (stage tilt 20°, shuttle pre-tilt 40° → 15° grazing) while electron-view moves landed close. The session log pinned it: for a +33.3 µm click the code commanded y=121.0 µm / z=+44.0 µm; the operator's two corrective re-clicks measured −21.7 / −20.5 µm of residual. Under the chamber-fixed model, *any* command it produces projects back to exactly the requested image displacement — it cannot overshoot for any sign convention — so the observation refutes the model outright. The corrected command at that pose is y=128.7 µm / z=+88.0 µm (same z side, twice the size; the error was mostly in z). The sign chain is fully determined by the two hardware-verified anchors (electron-view centring + `vertical_move`); derivation and evidence: [stable-move derivation doc](https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414).

## How

- The math now lives **once** in `reprojection.py` (`_tescan_pose_angles` + the forward); `TescanMicroscope._y_corrected_stage_movement` delegates instead of carrying a copy (the two inverse copies diverged once before). The angle terms stay in the debug log — that logging is how this defect was diagnosed from the session log alone.
- Inverse branch rule follows the new forward: y carries cos(inclination), z carries sin(pretilt); ties go to y because zero pre-tilt makes the z move identically zero.
- Second commit is a format-only pass over `test_beam_stage_projection.py` (pre-existing `ruff format` dirt; two docstrings touched here make it a changed file in the eventual main PR's lint lane). Proved AST-identical.

## Verification

- `tests/test_tescan_movement.py` reworked to the new model (94 pass), including a **logged-milling-pose regression test** pinned in absolute microns from the session log.
- Round trips (forward↔inverse, microscope↔metadata-standalone, reprojection end-to-end): 352 + 105 + 580 tests pass across the movement/projection/reprojection/tescan suites.
- Mutation checks: dropping the `1/cos(stage_tilt)` on y → 60 failures; reverting z to the old `−d·sin(inclination)` → 25 failures (including the z-branch contract test). Both restored byte-identical (shasum-verified).
- `ruff check` + `ruff format --check` clean on all four files.

## Remaining

Hardware confirmation next session (flagged `TODO(hardware-verify)`): a stable move at tilt must land centred **and stay in focus**, in both views; the electron view should now land exact rather than cos(tilt) short.
