### PR TITLE
[fix] Skip cleanly when the autofocus sweep is declined, instead of crashing on None

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -504,6 +504,17 @@ class AutoLamellaTask(ABC):
             settings=settings,
             stop_event=self._stop_event,
         )
+        if result is None:
+            # run_auto_focus declined the sweep (the working distance is not settable
+            # for this beam on this backend -- TESCAN ION, see FIB-508). Say "skipped"
+            # and save nothing: a placeholder result would write a completed-looking
+            # artifact directory and log a working distance that was never applied.
+            self.log_status_message(
+                "AUTOFOCUS",
+                f"Autofocus skipped: the {beam_type.name} working distance is not settable on this system.",
+                f"Autofocus skipped ({beam_type.name})",
+            )
+            return
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         result.save(path=os.path.join(self.lamella.path, "autofunctions"), name=f"{self.task_name}_autofocus_{ts}")
         self.log_status_message(

--- a/tests/autolamella/test_spot_burn_autofocus.py
+++ b/tests/autolamella/test_spot_burn_autofocus.py
@@ -201,3 +201,44 @@ def test_run_autofocus_lets_cancellation_propagate(tmp_path, monkeypatch):
         task._run_autofocus(BeamType.ION, hfw=150e-6)
 
     assert task._is_cancellation(OperationCancelledError("stopped")) is True
+
+
+# --- the None skip (FIB-508: backends that cannot set the working distance) --
+
+
+def test_run_autofocus_skips_cleanly_when_the_sweep_is_declined(tmp_path, monkeypatch):
+    """run_auto_focus returns None where the working distance is not settable
+    (TESCAN ION). The task must say "skipped" and save nothing — before the guard
+    this was an AttributeError on result.save, killing the task the first time a
+    Tescan protocol enabled autofocus. A placeholder result instead of None would
+    be worse: it would write a completed-looking artifact directory and log a
+    working distance that was never applied."""
+    import os
+
+    import fibsem.autofunctions.autofocus as af
+
+    task = _make_task(tmp_path, autofocus=True)
+    (tmp_path / "lam").mkdir(parents=True, exist_ok=True)
+    messages = []
+    task.log_status_message = lambda *a, **k: messages.append((a, k))
+    monkeypatch.setattr(af, "run_auto_focus", lambda microscope, **kwargs: None)
+
+    task._run_autofocus(BeamType.ION, hfw=150e-6)  # must not raise
+
+    assert any("skipped" in str(m).lower() for m in messages)
+    assert not os.path.exists(os.path.join(task.lamella.path, "autofunctions"))
+
+
+def test_run_autofocus_still_saves_when_the_sweep_ran(tmp_path, monkeypatch):
+    """The guard must not swallow real results: a returned result is still saved."""
+    import fibsem.autofunctions.autofocus as af
+
+    task = _make_task(tmp_path, autofocus=True)
+    (tmp_path / "lam").mkdir(parents=True, exist_ok=True)
+    task.log_status_message = lambda *a, **k: None
+    result = MagicMock(working_distance=16.5e-3, focus_score=1.0)
+    monkeypatch.setattr(af, "run_auto_focus", lambda microscope, **kwargs: result)
+
+    task._run_autofocus(BeamType.ION, hfw=150e-6)
+
+    result.save.assert_called_once()


### PR DESCRIPTION
## What

`run_auto_focus` returns `None` on backends where the working distance is not settable for the requested beam (TESCAN ION — the #541 gate), but `_run_autofocus` in tasks/base.py passed the result straight to `result.save(...)` → AttributeError that kills the task the first time a Tescan protocol enables autofocus (`select_position` and `spot_burn` both run the ION leg). Config-gated, off by default — but tonight's hardware session shouldn't have a loaded footgun.

Guards at the caller: logs an explicit **skipped** status (visible in the workflow status UI) and saves nothing.

## Why not an empty result instead

Considered and rejected: `AutoFocusResult` requires a working distance, a focus score, and an image; `save()` writes a completed-looking artifact directory (`data.json`/`best.tif`/`plot.png`); and the next status line logs `Autofocus complete: WD=…` — a placeholder result fabricates all three for a sweep that never ran, which is exactly the fake success the #541 gate removed. `None` means nothing happened; the caller now says so.

## Verification

- 2 new tests in `tests/autolamella/test_spot_burn_autofocus.py` (the file that owns `_run_autofocus` coverage): the skip path (no raise, 'skipped' status, nothing written) and the guard-doesn't-swallow-results path. 16/16 pass.
- Mutation: disabling the guard fails exactly the skip test (AttributeError), everything else stays green.
- `ruff check` clean; both files carry **pre-existing** format dirt (dirty at HEAD before this change) — deliberately left for the tescan→main sync formatting pass rather than churning a hot core file here.
