### PR TITLE
[fix] Point the minimap toggle at minimap_plot_widget, hide the menu entry

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -536,6 +536,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.action_show_minimap.setCheckable(True)
         self.action_show_minimap.setChecked(False)
         self.action_show_minimap.triggered.connect(self._on_toggle_minimap_widget)
+        # Hidden pending rework of the minimap widget itself.
+        self.action_show_minimap.setVisible(False)
 
         layer_controls_menu = view_menu.addMenu("Show Layer Controls")
 
@@ -1041,12 +1043,12 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         PluginsDialog(parent=self).exec_()
 
     def _on_toggle_minimap_widget(self, checked: bool):
-        """Toggle the minimap plot dock widget visibility."""
+        """Toggle the minimap plot widget visibility."""
         if self.autolamella_ui is not None and hasattr(
-            self.autolamella_ui, "minimap_plot_dock"
+            self.autolamella_ui, "minimap_plot_widget"
         ):
-            self.autolamella_ui.minimap_plot_dock.setVisible(checked)
-            self.autolamella_ui.minimap_plot_dock.activateWindow()
+            self.autolamella_ui.minimap_plot_widget.setVisible(checked)
+            self.autolamella_ui.minimap_plot_widget.activateWindow()
 
     def _sync_view_menu(self) -> None:
         """Refresh the View menu's dynamic state right before it opens: reflect whether a


### PR DESCRIPTION
## Summary
- `_on_toggle_minimap_widget` checked for a `minimap_plot_dock` attribute that no longer exists — the minimap was moved out of a napari dock into a floating `Qt.Tool` window (`minimap_plot_widget`) but the toggle handler was never updated, so "Show Minimap Widget" in the View menu silently did nothing.
- Fixed the attribute reference to `minimap_plot_widget`, mirroring the pattern used for other floating-widget toggles in the same class.
- Hid the "Show Minimap Widget" menu action for now — this floating widget (`fibsem/ui/fm/widgets/minimap_plot_widget.py`) needs a rework/retire decision before it's exposed again, tracked in FIB-795. (Different widget from the Overview-tab minimap covered by FIB-405/355/94.)

## Test plan
- [x] Launched the app (Demo microscope) and confirmed it starts cleanly with no errors.
- [ ] Manually confirm the menu entry no longer appears in View menu.
- [ ] Once FIB-795 is resolved, re-enable or remove the action accordingly.