### PR TITLE
Add a floating log viewer for the microscope tab

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -559,7 +559,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         layer_controls_menu.addAction(self.action_layer_controls_overview)
 
         view_menu.addAction(self.action_show_minimap)
-        view_menu.addAction(self.action_show_log)
+        # Not exposed yet -- land the log viewer disabled, flip this on once it's
+        # had more review. self.action_show_log / _on_toggle_log_widget / the
+        # floating log_panel_widget are all still built and wired.
+        # view_menu.addAction(self.action_show_log)
 
         # Quad-view display controls. The F5/Esc shortcuts live on these QActions — one
         # source of truth for the menu item and its keybinding (Qt renders the shortcut

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -539,6 +539,11 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # Hidden pending rework of the minimap widget itself.
         self.action_show_minimap.setVisible(False)
 
+        self.action_show_log = QAction("Show Log", self)
+        self.action_show_log.setCheckable(True)
+        self.action_show_log.setChecked(False)
+        self.action_show_log.triggered.connect(self._on_toggle_log_widget)
+
         layer_controls_menu = view_menu.addMenu("Show Layer Controls")
 
         self.action_layer_controls_overview = QAction("Overview", self)
@@ -554,6 +559,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         layer_controls_menu.addAction(self.action_layer_controls_overview)
 
         view_menu.addAction(self.action_show_minimap)
+        view_menu.addAction(self.action_show_log)
 
         # Quad-view display controls. The F5/Esc shortcuts live on these QActions — one
         # source of truth for the menu item and its keybinding (Qt renders the shortcut
@@ -1043,6 +1049,14 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         ):
             self.autolamella_ui.minimap_plot_widget.setVisible(checked)
             self.autolamella_ui.minimap_plot_widget.activateWindow()
+
+    def _on_toggle_log_widget(self, checked: bool):
+        """Toggle the floating log window's visibility."""
+        if self.autolamella_ui is not None and hasattr(
+            self.autolamella_ui, "log_panel_widget"
+        ):
+            self.autolamella_ui.log_panel_widget.setVisible(checked)
+            self.autolamella_ui.log_panel_widget.activateWindow()
 
     def _sync_view_menu(self) -> None:
         """Refresh the View menu's dynamic state right before it opens: reflect whether a

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -439,6 +439,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # Read once, here, because both the menu entry and the header chip are gated
         # on it and the menu is built before the tabs are.
         self._connection_chip_enabled = self._preferences.features.connection_chip
+        self._log_viewer_enabled = self._preferences.features.log_viewer_enabled
 
         # User attention tracking
         self._user_interaction_sound_played = False  # Track if sound was played
@@ -559,10 +560,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         layer_controls_menu.addAction(self.action_layer_controls_overview)
 
         view_menu.addAction(self.action_show_minimap)
-        # Not exposed yet -- land the log viewer disabled, flip this on once it's
-        # had more review. self.action_show_log / _on_toggle_log_widget / the
-        # floating log_panel_widget are all still built and wired.
-        # view_menu.addAction(self.action_show_log)
+        # Behind features.log_viewer_enabled (off by default) -- see FeatureFlags.
+        # The action is built either way; nothing offers it until the flag is on.
+        if self._log_viewer_enabled:
+            view_menu.addAction(self.action_show_log)
 
         # Quad-view display controls. The F5/Esc shortcuts live on these QActions — one
         # source of truth for the menu item and its keybinding (Qt renders the shortcut

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -100,6 +100,7 @@ from fibsem.applications.autolamella.ui.autolamella_load_task_protocol_widget im
 from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
 from fibsem.hooks import HookManager
 from fibsem.ui.fm.widgets import MinimapPlotWidget
+from fibsem.ui.widgets.canvas.log_panel import LogPanelWidget
 from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget
 from fibsem.ui.widgets.workflow_summary_dialog import WorkflowSummaryDialog
 
@@ -214,6 +215,16 @@ class AutoLamellaUI(QMainWindow):
         self.minimap_plot_widget.setWindowFlags(Qt.Tool)
         self.minimap_plot_widget.setWindowTitle("Minimap Plot")
         self.minimap_plot_widget.hide()
+
+        # log widget — a floating tool window, hidden by default. Raw DEBUG/INFO
+        # logging is a power-user/diagnostic view, not something a normal user
+        # should see unasked; kept out of the always-visible quad grid for that
+        # reason (Patrick, 2026-08-25).
+        self.log_panel_widget = LogPanelWidget(self)
+        self.log_panel_widget.setWindowFlags(Qt.Tool)
+        self.log_panel_widget.setWindowTitle("Log")
+        self.log_panel_widget.resize(520, 380)
+        self.log_panel_widget.hide()
 
         # add widgets to tabs.
         #
@@ -589,8 +600,9 @@ class AutoLamellaUI(QMainWindow):
         # Assign the experiment
         self.experiment = experiment
 
-        experiment.configure_logging()
+        logfile = experiment.configure_logging()
         logging.info(f"Logging to experiment {experiment.name} at {experiment.path}")
+        self.log_panel_widget.set_log_path(logfile)
 
         # Setup experiment connections and update UI
         self._setup_experiment_connections()

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -201,6 +201,9 @@ class AutoLamellaUI(QMainWindow):
         self._connection_chip_enabled = (
             fibsem_cfg.load_user_preferences().features.connection_chip
         )
+        self._log_viewer_enabled = (
+            fibsem_cfg.load_user_preferences().features.log_viewer_enabled
+        )
         self.system_widget = FibsemSystemSetupWidget(parent=self)
         self.image_widget: Optional[FibsemImageSettingsWidget] = None
         self.movement_widget: Optional[FibsemMovementWidget] = None
@@ -602,7 +605,12 @@ class AutoLamellaUI(QMainWindow):
 
         logfile = experiment.configure_logging()
         logging.info(f"Logging to experiment {experiment.name} at {experiment.path}")
-        self.log_panel_widget.set_log_path(logfile)
+        # Gated on the flag, not just the menu item that opens the window: without this,
+        # a "disabled" log viewer still backfills + tails the real logfile (a live
+        # QFileSystemWatcher, up to 2000 QListWidgetItems rebuilt on every experiment
+        # load) for the whole session with nothing offering a way to see it.
+        if self._log_viewer_enabled:
+            self.log_panel_widget.set_log_path(logfile)
 
         # Setup experiment connections and update UI
         self._setup_experiment_connections()

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -409,6 +409,12 @@ class FeatureFlags:
     # goes, and the geometry it rests on is only checkable against real data
     # (FIB-597). Staging, like the flag above -- deleted when it ships, not kept.
     sparse_fm_selection: bool = False
+    # View -> Show Log: a floating window tailing the raw per-experiment logfile
+    # (DEBUG and up), independent of the quad-view microscope tab. Off while it has
+    # had no bench time: raw hardware/workflow logging is a power-user/diagnostic
+    # view, not something a normal user should be offered unasked. Staging, like the
+    # flags above -- deleted (made unconditional) once it's had review, not kept.
+    log_viewer_enabled: bool = False
 
 
 @dataclass

--- a/fibsem/ui/widgets/canvas/log_panel.py
+++ b/fibsem/ui/widgets/canvas/log_panel.py
@@ -1,0 +1,299 @@
+"""Live-tailing viewer for the process logfile, for the quad-view 4th cell.
+
+Reads whatever ``fibsem.utils.configure_logging`` is currently writing to
+(``<experiment>/logfile.log``) -- this is the real Python ``logging`` output
+(every module, DEBUG and up), not the toast/notification bus. Tails the file
+with a ``QFileSystemWatcher`` rather than attaching a logging.Handler, so it
+is unaffected by ``logging.basicConfig(..., force=True)`` re-pointing the
+root logger at a new experiment.
+"""
+from __future__ import annotations
+
+import os
+import re
+from collections import deque
+from dataclasses import dataclass
+from typing import List, Optional
+
+from PyQt5.QtCore import QFileSystemWatcher, Qt, QTimer
+from PyQt5.QtGui import QColor, QFont
+from PyQt5.QtWidgets import (
+    QComboBox,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QVBoxLayout,
+)
+
+from fibsem.ui.tokens import (
+    ACCENT_COLOR,
+    BORDER_COLOR,
+    ERROR_COLOR,
+    GRAY_CONSOLE_COLOR,
+    NEUTRAL_650,
+    PANEL_COLOR,
+    ROW_ALT_COLOR,
+    TEXT_COLOR,
+    TEXT_MUTED_COLOR,
+    WARN_COLOR,
+)
+
+# Matches fibsem.utils.configure_logging's format string exactly:
+#   "%(asctime)s — %(name)s — %(levelname)s — %(funcName)s:%(lineno)d — %(message)s"
+_LOG_LINE_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}) — "
+    r"(?P<name>.+?) — "
+    r"(?P<level>DEBUG|INFO|WARNING|ERROR|CRITICAL) — "
+    r"(?P<func>.+?) — "
+    r"(?P<msg>.*)$"
+)
+
+_SEVERITY = {"DEBUG": 10, "INFO": 20, "WARNING": 30, "ERROR": 40, "CRITICAL": 50}
+_LEVEL_COLOR = {
+    "DEBUG": NEUTRAL_650,
+    "INFO": ACCENT_COLOR,
+    "WARNING": WARN_COLOR,
+    "ERROR": ERROR_COLOR,
+    "CRITICAL": ERROR_COLOR,
+}
+_FILTER_LEVELS = [("Debug", 10), ("Info", 20), ("Warning", 30), ("Error", 40)]
+
+_MAX_ENTRIES = 2000  # bounded scrollback, so a long session can't grow this unbounded
+_MAX_INITIAL_BYTES = 200_000  # how much of an existing (resumed) logfile to backfill on attach
+_DEBOUNCE_MS = 200  # coalesce a burst of writes (e.g. a running workflow logging at
+                     # DEBUG on every hardware call) into one read+render pass
+
+
+@dataclass
+class _LogEntry:
+    timestamp: str
+    level: str
+    message: str
+
+    @property
+    def severity(self) -> int:
+        return _SEVERITY.get(self.level, 0)
+
+
+def _format_entry(entry: _LogEntry) -> str:
+    time_only = entry.timestamp[11:19] if len(entry.timestamp) >= 19 else entry.timestamp
+    return f"{time_only}  {entry.level:<8}{entry.message}"
+
+
+class LogPanelWidget(QFrame):
+    """Tails a logfile and renders it as a filterable, auto-scrolling list.
+
+    Call :meth:`set_log_path` when the active experiment (and therefore the
+    logfile ``fibsem.utils.configure_logging`` points at) changes; pass
+    ``None`` to detach and clear.
+    """
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setStyleSheet(f"background: {GRAY_CONSOLE_COLOR};")
+
+        self._log_path: Optional[str] = None
+        self._offset = 0
+        self._entries: deque = deque(maxlen=_MAX_ENTRIES)
+        self._last_item: Optional[QListWidgetItem] = None
+        self._min_severity = 20  # "Info" default: hides DEBUG noise until asked for
+
+        self._watcher = QFileSystemWatcher(self)
+        self._watcher.fileChanged.connect(self._on_file_changed)
+        # Debounced: QFileSystemWatcher does not guarantee one signal per write, and a
+        # workflow logging at DEBUG on every hardware call can write far faster than the
+        # GUI thread should be reacting to individual notifications.
+        self._pending_timer = QTimer(self)
+        self._pending_timer.setSingleShot(True)
+        self._pending_timer.setInterval(_DEBOUNCE_MS)
+        self._pending_timer.timeout.connect(self._read_new_lines)
+
+        self._filter = QComboBox()
+        self._filter.setStyleSheet(
+            f"QComboBox {{ background: transparent; color: {TEXT_COLOR}; "
+            f"border: 1px solid {BORDER_COLOR}; border-radius: 3px; padding: 1px 6px; "
+            f"font-size: 11px; }} "
+            f"QComboBox QAbstractItemView {{ background: {PANEL_COLOR}; color: {TEXT_COLOR}; "
+            f"selection-background-color: {ROW_ALT_COLOR}; }}"
+        )
+        for label, severity in _FILTER_LEVELS:
+            self._filter.addItem(label, severity)
+        self._filter.setCurrentIndex(1)  # "Info"
+        self._filter.currentIndexChanged.connect(self._on_filter_changed)
+
+        top = QHBoxLayout()
+        top.setContentsMargins(6, 3, 6, 3)
+        top.addWidget(QLabel("Level:", styleSheet=f"color: {TEXT_MUTED_COLOR}; font-size: 11px;"))
+        top.addWidget(self._filter)
+        top.addStretch(1)
+
+        self._list = QListWidget()
+        self._list.setStyleSheet(
+            f"QListWidget {{ background: {GRAY_CONSOLE_COLOR}; color: {TEXT_COLOR}; "
+            f"border: none; }} QListWidget::item {{ padding: 0px 6px; }}"
+        )
+        font = QFont("Menlo")
+        font.setStyleHint(QFont.Monospace)
+        font.setPointSize(9)
+        self._list.setFont(font)
+        self._list.setSelectionMode(QListWidget.NoSelection)
+        self._list.setVerticalScrollMode(QListWidget.ScrollPerPixel)
+
+        self._empty_label = QLabel("No logfile open", alignment=Qt.AlignCenter)
+        self._empty_label.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 11px;")
+
+        lay = QVBoxLayout(self)
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.setSpacing(0)
+        lay.addLayout(top)
+        lay.addWidget(self._list, stretch=1)
+        lay.addWidget(self._empty_label)
+        self._empty_label.setVisible(True)
+        self._list.setVisible(False)
+
+    # ── attach / detach ───────────────────────────────────────────────────
+    def set_log_path(self, path: Optional[str]) -> None:
+        """Point the tail at *path* (the current experiment's logfile), or
+        ``None`` to detach and clear."""
+        self._pending_timer.stop()
+        if self._log_path and self._log_path in self._watcher.files():
+            self._watcher.removePath(self._log_path)
+        self._log_path = path
+        self._offset = 0
+        self._entries.clear()
+        self._list.clear()
+        self._last_item = None
+
+        if not path:
+            self._empty_label.setVisible(True)
+            self._list.setVisible(False)
+            return
+
+        self._empty_label.setVisible(False)
+        self._list.setVisible(True)
+
+        if os.path.exists(path):
+            self._backfill(path)
+            self._watcher.addPath(path)
+
+    def teardown(self) -> None:
+        """Stop tailing. Safe to call repeatedly."""
+        self._pending_timer.stop()
+        if self._log_path and self._log_path in self._watcher.files():
+            self._watcher.removePath(self._log_path)
+
+    def showEvent(self, event) -> None:
+        """A widget hosted in a hidden-by-default floating window can accumulate a
+        long backlog while never laid out; re-assert the scroll position on every
+        transition to visible rather than trusting scrollToBottom() calls made
+        while unshown (see the quad-view screenshot bug this class started with)."""
+        super().showEvent(event)
+        self._list.scrollToBottom()
+
+    # ── tailing ────────────────────────────────────────────────────────────
+    def _backfill(self, path: str) -> None:
+        """Load the tail end of an already-existing (e.g. resumed) logfile."""
+        size = os.path.getsize(path)
+        start = max(0, size - _MAX_INITIAL_BYTES)
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                f.seek(start)
+                if start:
+                    f.readline()  # drop a line we likely seeked into the middle of
+                chunk = f.read()
+                self._offset = f.tell()
+        except OSError:
+            return
+        self._ingest_batch(chunk.splitlines())
+
+    def _on_file_changed(self, path: str) -> None:
+        if path != self._log_path:
+            return
+        # Coalesce a burst of near-simultaneous notifications into one read pass,
+        # restarting the window on every new signal.
+        self._pending_timer.start()
+        # Some platforms drop a path from the watch list after it's modified
+        # (e.g. editors that replace-on-write); re-arm defensively.
+        if self._log_path and self._log_path not in self._watcher.files():
+            if os.path.exists(self._log_path):
+                self._watcher.addPath(self._log_path)
+
+    def _read_new_lines(self) -> None:
+        if not self._log_path or not os.path.exists(self._log_path):
+            return
+        try:
+            with open(self._log_path, "r", encoding="utf-8", errors="replace") as f:
+                f.seek(self._offset)
+                chunk = f.read()
+                self._offset = f.tell()
+        except OSError:
+            return
+        if not chunk:
+            return
+        self._ingest_batch(chunk.splitlines())
+
+    def _ingest_batch(self, lines: List[str]) -> None:
+        """Parse *lines* and render them as one batch: a single "was I scrolled to the
+        bottom" check and a single scroll/prune pass at the end, rather than one per
+        line. Doing this per-line is what made a burst of DEBUG-level writes (a
+        workflow logging on every hardware call) hang the GUI thread -- each
+        ``scrollToBottom()`` forces a full layout pass."""
+        at_bottom = self._is_scrolled_to_bottom()
+        added_any = False
+        for line in lines:
+            if self._ingest_line(line):
+                added_any = True
+        if not added_any:
+            return
+        while self._list.count() > _MAX_ENTRIES:
+            self._list.takeItem(0)
+        if at_bottom:
+            self._list.scrollToBottom()
+
+    def _ingest_line(self, line: str) -> bool:
+        """Parse *line* and, if it passes the current filter, append (or fold into
+        the previous entry) a row. Returns whether a visible row changed, so the
+        caller knows whether a scroll/prune pass is warranted."""
+        if not line.strip():
+            return False
+        m = _LOG_LINE_RE.match(line)
+        if m:
+            entry = _LogEntry(timestamp=m.group("ts"), level=m.group("level"), message=m.group("msg"))
+            self._entries.append(entry)
+            if entry.severity < self._min_severity:
+                self._last_item = None
+                return False
+            item = QListWidgetItem(_format_entry(entry))
+            item.setForeground(QColor(_LEVEL_COLOR.get(entry.level, TEXT_COLOR)))
+            self._list.addItem(item)
+            self._last_item = item
+            return True
+        elif self._entries:
+            # Continuation line (e.g. a traceback from logging.exception) --
+            # fold into the previous entry rather than showing as a bare row.
+            self._entries[-1].message += "\n" + line
+            if self._last_item is not None:
+                self._last_item.setText(_format_entry(self._entries[-1]))
+                return True
+        return False
+
+    def _is_scrolled_to_bottom(self) -> bool:
+        bar = self._list.verticalScrollBar()
+        return bar.value() >= bar.maximum() - 2
+
+    def _on_filter_changed(self) -> None:
+        self._min_severity = self._filter.currentData()
+        self._rebuild_list()
+
+    def _rebuild_list(self) -> None:
+        self._list.clear()
+        self._last_item = None
+        for entry in self._entries:
+            if entry.severity >= self._min_severity:
+                item = QListWidgetItem(_format_entry(entry))
+                item.setForeground(QColor(_LEVEL_COLOR.get(entry.level, TEXT_COLOR)))
+                self._list.addItem(item)
+                self._last_item = item
+        self._list.scrollToBottom()

--- a/fibsem/ui/widgets/canvas/log_panel.py
+++ b/fibsem/ui/widgets/canvas/log_panel.py
@@ -7,6 +7,7 @@ with a ``QFileSystemWatcher`` rather than attaching a logging.Handler, so it
 is unaffected by ``logging.basicConfig(..., force=True)`` re-pointing the
 root logger at a new experiment.
 """
+
 from __future__ import annotations
 
 import os
@@ -61,9 +62,11 @@ _LEVEL_COLOR = {
 _FILTER_LEVELS = [("Debug", 10), ("Info", 20), ("Warning", 30), ("Error", 40)]
 
 _MAX_ENTRIES = 2000  # bounded scrollback, so a long session can't grow this unbounded
-_MAX_INITIAL_BYTES = 200_000  # how much of an existing (resumed) logfile to backfill on attach
+_MAX_INITIAL_BYTES = (
+    200_000  # how much of an existing (resumed) logfile to backfill on attach
+)
 _DEBOUNCE_MS = 200  # coalesce a burst of writes (e.g. a running workflow logging at
-                     # DEBUG on every hardware call) into one read+render pass
+# DEBUG on every hardware call) into one read+render pass
 
 
 @dataclass
@@ -78,7 +81,9 @@ class _LogEntry:
 
 
 def _format_entry(entry: _LogEntry) -> str:
-    time_only = entry.timestamp[11:19] if len(entry.timestamp) >= 19 else entry.timestamp
+    time_only = (
+        entry.timestamp[11:19] if len(entry.timestamp) >= 19 else entry.timestamp
+    )
     return f"{time_only}  {entry.level:<8}{entry.message}"
 
 
@@ -125,7 +130,9 @@ class LogPanelWidget(QFrame):
 
         top = QHBoxLayout()
         top.setContentsMargins(6, 3, 6, 3)
-        top.addWidget(QLabel("Level:", styleSheet=f"color: {TEXT_MUTED_COLOR}; font-size: 11px;"))
+        top.addWidget(
+            QLabel("Level:", styleSheet=f"color: {TEXT_MUTED_COLOR}; font-size: 11px;")
+        )
         top.addWidget(self._filter)
         top.addStretch(1)
 
@@ -260,7 +267,9 @@ class LogPanelWidget(QFrame):
             return False
         m = _LOG_LINE_RE.match(line)
         if m:
-            entry = _LogEntry(timestamp=m.group("ts"), level=m.group("level"), message=m.group("msg"))
+            entry = _LogEntry(
+                timestamp=m.group("ts"), level=m.group("level"), message=m.group("msg")
+            )
             self._entries.append(entry)
             if entry.severity < self._min_severity:
                 self._last_item = None

--- a/fibsem/ui/widgets/canvas/quad_view.py
+++ b/fibsem/ui/widgets/canvas/quad_view.py
@@ -10,6 +10,7 @@ control widgets in place of the napari ``Viewer``. Its surface is intentionally
 small in Phase 0 (image routing only) and grows in later phases (overlays,
 per-beam click signals).
 """
+
 from __future__ import annotations
 
 import logging
@@ -153,7 +154,10 @@ class QuadViewWidget(QWidget):
         self._splitters = {"left": left, "right": right}
         self._all_panels = [sem_panel, fm_panel, fib_panel, placeholder_panel]
         self._panel_splitter = {
-            sem_panel: left, fm_panel: left, fib_panel: right, placeholder_panel: right,
+            sem_panel: left,
+            fm_panel: left,
+            fib_panel: right,
+            placeholder_panel: right,
         }
         self._fullscreen: Optional[object] = None
         self._saved_sizes: dict = {}
@@ -169,8 +173,12 @@ class QuadViewWidget(QWidget):
             self.fib_canvas: BeamType.ION,
             self.fm_canvas: "fm",
         }
-        self._key_canvas: Dict[object, QWidget] = {v: k for k, v in self._canvas_keys.items()}
-        self._live: set = set()  # view keys currently live-acquiring (green border + LIVE badge)
+        self._key_canvas: Dict[object, QWidget] = {
+            v: k for k, v in self._canvas_keys.items()
+        }
+        self._live: set = (
+            set()
+        )  # view keys currently live-acquiring (green border + LIVE badge)
         self._selected: Optional[object] = None
         for canvas in self._canvas_keys:
             canvas.installEventFilter(self)
@@ -549,7 +557,9 @@ class MicroscopeViewController(QObject):
         state.armed_icon = icon
         self._mark_dirty(canvas)
 
-    def set_overlay_visible(self, beam: BeamType, overlay_id: str, visible: bool) -> None:
+    def set_overlay_visible(
+        self, beam: BeamType, overlay_id: str, visible: bool
+    ) -> None:
         """Toggle an overlay's visibility without replacing its spec (keeps points /
         value). Applies to specs with a ``visible`` field (e.g. PointsSpec)."""
         canvas = self._canvases.get(beam)
@@ -665,7 +675,9 @@ class MicroscopeViewController(QObject):
         """Upsert an info-bar field on the FM canvas (FM isn't a BeamType)."""
         self._set_info_on(self._widget.fm_canvas, key, text)
 
-    def _set_info_on(self, canvas: FibsemImageCanvas, key: str, text: Optional[str]) -> None:
+    def _set_info_on(
+        self, canvas: FibsemImageCanvas, key: str, text: Optional[str]
+    ) -> None:
         info = self._states[canvas].info
         for i, (k, _) in enumerate(info):
             if k == key:
@@ -679,7 +691,9 @@ class MicroscopeViewController(QObject):
             info.append((key, text))
             self._mark_dirty(canvas)
 
-    def update_info(self, microscope, stage_position=None, objective_position=None) -> None:
+    def update_info(
+        self, microscope, stage_position=None, objective_position=None
+    ) -> None:
         """Refresh the info bar from microscope state (mirrors napari
         ``update_text_overlay``): STAGE on SEM+FIB, MILLING ANGLE on FIB, OBJECTIVE on
         FM. It goes through the model + debounced render, so it is safe to call from an
@@ -690,14 +704,22 @@ class MicroscopeViewController(QObject):
                 return  # no stage-position display yet
             if stage_position is None:
                 stage_position = microscope._stage_position
-            orientation = microscope.get_stage_orientation(stage_position=stage_position)
+            orientation = microscope.get_stage_orientation(
+                stage_position=stage_position
+            )
             grid = microscope.current_grid
-            milling_angle = microscope.get_current_milling_angle(stage_position=stage_position)
-            stage_txt = f"STAGE: {stage_position.pretty_string} [{orientation}] [{grid}]"
+            milling_angle = microscope.get_current_milling_angle(
+                stage_position=stage_position
+            )
+            stage_txt = (
+                f"STAGE: {stage_position.pretty_string} [{orientation}] [{grid}]"
+            )
             self.set_info(BeamType.ELECTRON, "stage", stage_txt)
             self.set_info(BeamType.ION, "stage", stage_txt)
             self.set_fm_info("stage", stage_txt)  # universal context (before objective)
-            self.set_info(BeamType.ION, "milling", f"MILLING ANGLE: {milling_angle:.1f}°")
+            self.set_info(
+                BeamType.ION, "milling", f"MILLING ANGLE: {milling_angle:.1f}°"
+            )
             if microscope.fm is not None:
                 # Remembered rather than read. This runs on every stage-position update
                 # (`FibsemMovementWidget._update_position_readout`, which passes no
@@ -728,7 +750,9 @@ class MicroscopeViewController(QObject):
                         f"OBJECTIVE: {self._objective_position * constants.METRE_TO_MICRON:.1f} µm",
                     )
         except Exception:
-            _logger.warning("MicroscopeViewController.update_info failed", exc_info=True)
+            _logger.warning(
+                "MicroscopeViewController.update_info failed", exc_info=True
+            )
 
     # ── render loop ───────────────────────────────────────────────────────
     def _mark_dirty(self, canvas: FibsemImageCanvas) -> None:
@@ -772,7 +796,9 @@ class MicroscopeViewController(QObject):
         if (canvas._info_text or "") != info_text:
             canvas.set_info_text(info_text)
 
-    def _create_overlay(self, canvas: FibsemImageCanvas, overlay_id: str, spec: OverlaySpec):
+    def _create_overlay(
+        self, canvas: FibsemImageCanvas, overlay_id: str, spec: OverlaySpec
+    ):
         """Construct the overlay object for *spec* and wire its edit signal (if any)
         back to :attr:`overlay_edited` (one branch per migrated slice)."""
         if isinstance(spec, MillingSpec):
@@ -820,8 +846,8 @@ class MicroscopeViewController(QObject):
                     )
                 )
             obj.point_selected.connect(
-                lambda idx, x, y, b=beam, i=overlay_id: self.overlay_point_selected.emit(
-                    b, i, idx
+                lambda idx, x, y, b=beam, i=overlay_id: (
+                    self.overlay_point_selected.emit(b, i, idx)
                 )
             )
             return obj
@@ -830,7 +856,9 @@ class MicroscopeViewController(QObject):
         )
         return None
 
-    def _drive_overlay(self, obj, spec: OverlaySpec, image: Optional[FibsemImage]) -> None:
+    def _drive_overlay(
+        self, obj, spec: OverlaySpec, image: Optional[FibsemImage]
+    ) -> None:
         """Push *spec* data into its overlay object, injecting the canvas image."""
         if isinstance(spec, MillingSpec):
             if image is None or not spec.visible:
@@ -857,8 +885,12 @@ class MicroscopeViewController(QObject):
             # non-destructive, so it always runs.
             sig = self._points_signature(spec)
             if getattr(obj, "_reducer_pts_sig", None) != sig:
-                obj.set_points(list(spec.points), colors=spec.colors, labels=spec.labels)
-                obj.set_selected(spec.selected)  # set_points nulls the selection; re-apply
+                obj.set_points(
+                    list(spec.points), colors=spec.colors, labels=spec.labels
+                )
+                obj.set_selected(
+                    spec.selected
+                )  # set_points nulls the selection; re-apply
                 obj._reducer_pts_sig = sig
             obj.set_visible(spec.visible)
         elif isinstance(spec, MaskSpec):
@@ -872,7 +904,9 @@ class MicroscopeViewController(QObject):
         pts = [(float(p[0]), float(p[1])) for p in spec.points]
         return repr((pts, spec.colors, spec.labels, spec.selected))
 
-    def _apply_arming(self, canvas: FibsemImageCanvas, state: CanvasState, objs) -> None:
+    def _apply_arming(
+        self, canvas: FibsemImageCanvas, state: CanvasState, objs
+    ) -> None:
         """Make the model's armed overlay the canvas's active input mode (single
         arbiter). Toggles only on change; the exit is scoped to the overlay we armed,
         so it never tears down a mode another (still-direct) consumer owns."""
@@ -883,10 +917,14 @@ class MicroscopeViewController(QObject):
             return
         if desired is not None:
             canvas.enter_overlay_mode(
-                desired, state.armed_label, icon=state.armed_icon or "mdi:cursor-default-click"
+                desired,
+                state.armed_label,
+                icon=state.armed_icon or "mdi:cursor-default-click",
             )
         elif prev is not None:
-            canvas.exit_overlay_mode(prev)  # scoped: no-op unless prev still owns the mode
+            canvas.exit_overlay_mode(
+                prev
+            )  # scoped: no-op unless prev still owns the mode
         self._armed_applied[canvas] = desired
 
     def _on_overlay_edited(self, beam, overlay_id: str, value) -> None:

--- a/fibsem/ui/widgets/canvas/quad_view.py
+++ b/fibsem/ui/widgets/canvas/quad_view.py
@@ -61,7 +61,6 @@ _logger = logging.getLogger(__name__)
 _TITLE_STYLE = (
     f"color: #888; font-size: 11px; padding: 2px 6px; background: {CANVAS_BG};"
 )
-_PLACEHOLDER_STYLE = "color: #777; font-size: 12px;"
 # Selected-view border: the primary accent (matches PRIMARY_BUTTON_STYLESHEET), kept subtle.
 # A transparent border of the same width is always present so selection causes no layout shift,
 # and it's scoped via the #viewPanel object name so it never cascades onto the title / canvas.
@@ -103,7 +102,7 @@ class PlaceholderPanel(QFrame):
         super().__init__()
         self.setStyleSheet(f"background: {_BG};")
         lbl = QLabel(text, alignment=Qt.AlignCenter)
-        lbl.setStyleSheet(_PLACEHOLDER_STYLE)
+        lbl.setStyleSheet("color: #777; font-size: 12px;")
         lay = QVBoxLayout(self)
         lay.addWidget(lbl)
 

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -80,6 +80,13 @@ _TIP_CONNECTION_CHIP = (
     "reconnecting and disconnecting. The Connection tab still works and is still "
     "where connecting happens; this is the header half of replacing it."
 )
+_LBL_LOG_VIEWER = "Enable Log Viewer"
+_TIP_LOG_VIEWER = (
+    "Add View > Show Log, a floating window tailing the raw per-experiment logfile "
+    "(DEBUG and up), independent of the microscope tab. Off until it has had bench "
+    "time: raw hardware/workflow logging is a power-user/diagnostic view, not "
+    "something a normal user should be offered unasked."
+)
 _LBL_SCRIPTS = "Enable User Scripts"
 _TIP_SCRIPTS = (
     "Show Tools > Scripts, for running your own .py files against the open "
@@ -189,6 +196,8 @@ class PreferencesDialog(QDialog):
         self._chk_sparse_fm.setToolTip(_TIP_SPARSE_FM)
         self._chk_connection_chip = QCheckBox()
         self._chk_connection_chip.setToolTip(_TIP_CONNECTION_CHIP)
+        self._chk_log_viewer = QCheckBox()
+        self._chk_log_viewer.setToolTip(_TIP_LOG_VIEWER)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
         features_form.addRow(_LBL_SAMPLE_HOLDER, self._chk_sample_holder)
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
@@ -196,6 +205,7 @@ class PreferencesDialog(QDialog):
         features_form.addRow(_LBL_OVERVIEW_CANVAS, self._chk_overview_canvas)
         features_form.addRow(_LBL_SPARSE_FM, self._chk_sparse_fm)
         features_form.addRow(_LBL_CONNECTION_CHIP, self._chk_connection_chip)
+        features_form.addRow(_LBL_LOG_VIEWER, self._chk_log_viewer)
         self._stack.addWidget(features_page)
 
         # --- Experiment Defaults ---
@@ -270,6 +280,7 @@ class PreferencesDialog(QDialog):
         self._chk_overview_canvas.setChecked(f.overview_canvas_tab)
         self._chk_sparse_fm.setChecked(f.sparse_fm_selection)
         self._chk_connection_chip.setChecked(f.connection_chip)
+        self._chk_log_viewer.setChecked(f.log_viewer_enabled)
 
         e = prefs.experiment
         self._dir_experiment.setText(e.default_experiment_directory)
@@ -343,6 +354,7 @@ class PreferencesDialog(QDialog):
                 overview_canvas_tab=self._chk_overview_canvas.isChecked(),
                 connection_chip=self._chk_connection_chip.isChecked(),
                 sparse_fm_selection=self._chk_sparse_fm.isChecked(),
+                log_viewer_enabled=self._chk_log_viewer.isChecked(),
             ),
             movement=MovementPreferences(
                 acquire_sem_after_stage_movement=self._chk_acquire_sem.isChecked(),

--- a/fibsem/ui/widgets/tests/test_log_panel.py
+++ b/fibsem/ui/widgets/tests/test_log_panel.py
@@ -1,0 +1,181 @@
+"""Standalone demo + scripted checks: LogPanelWidget tailing a real logfile.
+
+Run:
+    PYTHONPATH=<worktree> python fibsem/ui/widgets/tests/test_log_panel.py
+
+Writes to a temp file using the exact format fibsem.utils.configure_logging
+produces, backfills a LogPanelWidget from it, then shows a window with an
+"Append line" button (writes + simulates the file-change tick deterministically,
+rather than relying on inotify timing) so you can watch the level filter and
+auto-scroll live.
+"""
+import logging
+import os
+import sys
+import tempfile
+import time
+
+from PyQt5.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.ui.widgets.canvas.log_panel import LogPanelWidget
+
+_FMT = "%(asctime)s — %(name)s — %(levelname)s — %(funcName)s:%(lineno)d — %(message)s"
+
+
+def _write_seed_lines(path: str) -> None:
+    logger = logging.getLogger("test_log_panel.seed")
+    handler = logging.FileHandler(path, encoding="utf-8")
+    handler.setFormatter(logging.Formatter(_FMT))
+    logger.handlers = [handler]
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+
+    logger.debug("polling stage position")
+    logger.info("connected to microscope: Demo")
+    logger.warning("autofocus below threshold, retrying")
+    logger.error("failed to acquire image: timeout")
+    try:
+        raise ValueError("bad pixel size")
+    except ValueError:
+        logger.exception("alignment failed")
+    logger.info("trench milling started")
+    handler.close()
+
+
+def _run_checks(path: str) -> None:
+    app = QApplication.instance() or QApplication(sys.argv)
+    w = LogPanelWidget()
+    w.set_log_path(path)
+
+    assert len(w._entries) == 6, f"expected 6 parsed entries, got {len(w._entries)}"
+    assert w._entries[0].level == "DEBUG"
+    assert w._entries[3].level == "ERROR"
+    assert "\n" in w._entries[4].message, "traceback lines should fold into the exception entry"
+    # default filter is Info: the DEBUG row should be backfilled but not rendered
+    assert w._list.count() == 5, f"expected 5 rows at Info level, got {w._list.count()}"
+
+    w._filter.setCurrentIndex(0)  # Debug: show everything
+    assert w._list.count() == 6
+
+    w._filter.setCurrentIndex(3)  # Error: only ERROR/CRITICAL-severity rows
+    assert w._list.count() == 2, f"expected 2 error-or-worse rows, got {w._list.count()}"
+
+    w.set_log_path(None)
+    assert w._list.count() == 0
+    assert not w._empty_label.isHidden()
+
+    _check_burst_does_not_hang()
+    _check_scroll_survives_hidden_start(path)
+
+    print("all checks passed")
+    w.deleteLater()
+
+
+def _check_scroll_survives_hidden_start(path: str) -> None:
+    """Regression guard: the log widget now lives in a floating window hidden by
+    default (a normal user shouldn't see raw DEBUG/INFO output unasked), so it can
+    accumulate a long backlog before ever being laid out. Confirms the first
+    show() still lands scrolled to the true latest entry, not wherever a
+    scrollToBottom() call made while unshown happened to leave it."""
+    w = LogPanelWidget()
+    w.hide()
+    w.set_log_path(path)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write("2026-08-25 12:00:00,000 — root — INFO — poll:1 — freshest line while hidden\n")
+    w._read_new_lines()
+
+    w.show()
+    last = w._list.item(w._list.count() - 1)
+    assert last is not None and "freshest line while hidden" in last.text(), (
+        "scroll position did not land on the true last entry after the first show()"
+    )
+    w.deleteLater()
+
+
+def _check_burst_does_not_hang() -> None:
+    """Regression guard: a running workflow can log DEBUG on every hardware call,
+    so a burst of thousands of lines can land between watcher ticks. Rendering
+    them used to call scrollToBottom() (a full layout pass) per line -- this
+    checks the batched path stays fast even in the worst case (Debug filter,
+    nothing filtered out)."""
+    tmp_dir = tempfile.mkdtemp(prefix="log_panel_burst_")
+    path = os.path.join(tmp_dir, "logfile.log")
+    open(path, "w").close()
+
+    w = LogPanelWidget()
+    w.set_log_path(path)
+    w._filter.setCurrentIndex(0)  # Debug: worst case
+
+    n = 5000
+    with open(path, "a", encoding="utf-8") as f:
+        for i in range(n):
+            f.write(f"2026-08-25 11:00:00,000 — root — DEBUG — poll:1 — hardware poll {i}\n")
+
+    start = time.perf_counter()
+    w._read_new_lines()
+    elapsed = time.perf_counter() - start
+    assert elapsed < 2.0, f"burst of {n} lines took {elapsed:.2f}s -- likely back to per-line scrollToBottom()"
+    last = w._list.item(w._list.count() - 1)
+    assert last is not None and f"hardware poll {n - 1}" in last.text()
+    w.deleteLater()
+
+
+def main() -> None:
+    tmp_dir = tempfile.mkdtemp(prefix="log_panel_demo_")
+    path = os.path.join(tmp_dir, "logfile.log")
+    _write_seed_lines(path)
+    _run_checks(path)
+
+    if os.environ.get("QT_QPA_PLATFORM") == "offscreen":
+        return  # headless CI/agent run: scripted checks above are the point
+
+    app = QApplication(sys.argv)
+    win = QWidget()
+    win.resize(420, 380)
+    win.setWindowTitle("LogPanelWidget demo")
+
+    panel = LogPanelWidget()
+    panel.set_log_path(path)
+
+    counter = {"n": 0}
+
+    def append_line():
+        counter["n"] += 1
+        levels = ["DEBUG", "INFO", "WARNING", "ERROR"]
+        level = levels[counter["n"] % 4]
+        line = (
+            f'2026-08-25 12:00:{counter["n"]:02d},000 — demo — {level} — append_line:1 — '
+            f'live line {counter["n"]}\n'
+        )
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(line)
+        panel._on_file_changed(path)  # deterministic, doesn't depend on OS watch timing
+
+    btn = QPushButton("Append line")
+    btn.clicked.connect(append_line)
+
+    info = QLabel("Backfilled from a seeded logfile. Use the level filter, or append new lines.")
+    info.setWordWrap(True)
+
+    bar = QHBoxLayout()
+    bar.addWidget(btn)
+    bar.addStretch(1)
+
+    lay = QVBoxLayout(win)
+    lay.addWidget(info)
+    lay.addLayout(bar)
+    lay.addWidget(panel, stretch=1)
+
+    win.show()
+    app.exec_()
+
+
+if __name__ == "__main__":
+    main()

--- a/fibsem/ui/widgets/tests/test_log_panel.py
+++ b/fibsem/ui/widgets/tests/test_log_panel.py
@@ -9,6 +9,7 @@ produces, backfills a LogPanelWidget from it, then shows a window with an
 rather than relying on inotify timing) so you can watch the level filter and
 auto-scroll live.
 """
+
 import logging
 import os
 import sys
@@ -57,7 +58,9 @@ def _run_checks(path: str) -> None:
     assert len(w._entries) == 6, f"expected 6 parsed entries, got {len(w._entries)}"
     assert w._entries[0].level == "DEBUG"
     assert w._entries[3].level == "ERROR"
-    assert "\n" in w._entries[4].message, "traceback lines should fold into the exception entry"
+    assert "\n" in w._entries[4].message, (
+        "traceback lines should fold into the exception entry"
+    )
     # default filter is Info: the DEBUG row should be backfilled but not rendered
     assert w._list.count() == 5, f"expected 5 rows at Info level, got {w._list.count()}"
 
@@ -65,7 +68,9 @@ def _run_checks(path: str) -> None:
     assert w._list.count() == 6
 
     w._filter.setCurrentIndex(3)  # Error: only ERROR/CRITICAL-severity rows
-    assert w._list.count() == 2, f"expected 2 error-or-worse rows, got {w._list.count()}"
+    assert w._list.count() == 2, (
+        f"expected 2 error-or-worse rows, got {w._list.count()}"
+    )
 
     w.set_log_path(None)
     assert w._list.count() == 0
@@ -88,7 +93,9 @@ def _check_scroll_survives_hidden_start(path: str) -> None:
     w.hide()
     w.set_log_path(path)
     with open(path, "a", encoding="utf-8") as f:
-        f.write("2026-08-25 12:00:00,000 — root — INFO — poll:1 — freshest line while hidden\n")
+        f.write(
+            "2026-08-25 12:00:00,000 — root — INFO — poll:1 — freshest line while hidden\n"
+        )
     w._read_new_lines()
 
     w.show()
@@ -116,12 +123,16 @@ def _check_burst_does_not_hang() -> None:
     n = 5000
     with open(path, "a", encoding="utf-8") as f:
         for i in range(n):
-            f.write(f"2026-08-25 11:00:00,000 — root — DEBUG — poll:1 — hardware poll {i}\n")
+            f.write(
+                f"2026-08-25 11:00:00,000 — root — DEBUG — poll:1 — hardware poll {i}\n"
+            )
 
     start = time.perf_counter()
     w._read_new_lines()
     elapsed = time.perf_counter() - start
-    assert elapsed < 2.0, f"burst of {n} lines took {elapsed:.2f}s -- likely back to per-line scrollToBottom()"
+    assert elapsed < 2.0, (
+        f"burst of {n} lines took {elapsed:.2f}s -- likely back to per-line scrollToBottom()"
+    )
     last = w._list.item(w._list.count() - 1)
     assert last is not None and f"hardware poll {n - 1}" in last.text()
     w.deleteLater()
@@ -151,8 +162,8 @@ def main() -> None:
         levels = ["DEBUG", "INFO", "WARNING", "ERROR"]
         level = levels[counter["n"] % 4]
         line = (
-            f'2026-08-25 12:00:{counter["n"]:02d},000 — demo — {level} — append_line:1 — '
-            f'live line {counter["n"]}\n'
+            f"2026-08-25 12:00:{counter['n']:02d},000 — demo — {level} — append_line:1 — "
+            f"live line {counter['n']}\n"
         )
         with open(path, "a", encoding="utf-8") as f:
             f.write(line)
@@ -161,7 +172,9 @@ def main() -> None:
     btn = QPushButton("Append line")
     btn.clicked.connect(append_line)
 
-    info = QLabel("Backfilled from a seeded logfile. Use the level filter, or append new lines.")
+    info = QLabel(
+        "Backfilled from a seeded logfile. Use the level filter, or append new lines."
+    )
     info.setWordWrap(True)
 
     bar = QHBoxLayout()


### PR DESCRIPTION
## Summary
- Adds a live-tailing viewer for the real per-experiment logfile (`fibsem.utils.configure_logging`'s output, not the toast/notification bus), with a Debug/Info/Warning/Error level filter — `fibsem/ui/widgets/canvas/log_panel.py`.
- Lives in a floating `Qt.Tool` window (View > Show Log), not embedded in the always-visible quad grid — raw DEBUG/INFO output is a power-user/diagnostic view, not something to show a normal user unasked.
- Gated behind `features.log_viewer_enabled` (off by default), following this repo's standard staging-flag pattern: `FeatureFlags` field + preferences-dialog checkbox, no third or fourth site.

## Notable fixes found during live verification (against a real, running experiment)
- Scroll-to-bottom after backfilling an existing logfile could land mid-file rather than at the true latest entry — `scrollToBottom()` calls made before the widget is shown/laid out don't reliably hold. Fixed with a single authoritative scroll per batch, plus a `showEvent` override (the window can sit hidden through a long backlog before ever being opened).
- Viewing Debug level while a workflow was running hung the app: a running workflow logs at DEBUG on every hardware call, and the old code called `scrollToBottom()` (a full layout pass) per line. Fixed by batching (one scroll per read pass) and debouncing the raw `QFileSystemWatcher` signal (200ms), since it doesn't guarantee one signal per write.

## Test plan
- [x] `fibsem/ui/widgets/tests/test_log_panel.py` — scripted checks (parsing, backfill, level filtering, traceback folding, detach, the DEBUG-burst regression, the hidden-window-then-first-show regression) + an interactive demo
- [x] `tests/ui/test_preferences_dialog.py` — full suite green, including the new `log_viewer_enabled` round trip
- [x] Live-tested against a real running app + a real (4.9MB) experiment logfile