### PR TITLE
[style] Format the files the tiled progress work touches (FIB-402)

### DIFF
--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -134,17 +134,20 @@ OVERLAY_CONFIG = {
     },
     "circle_style": {
         "edge_width": 40,
-        "face_color": "transparent", 
+        "face_color": "transparent",
         "opacity": 0.7,
     },
 }
 
 LABEL_INSTRUCTIONS = {
     "image-available": "Instructions: \nRight Click to Add/Move a Lamella Position or Double Click to Move the Stage...",
-    "no-image": "Please take or load an overview image..."
+    "no-image": "Please take or load an overview image...",
 }
 
-def generate_gridbar_image(shape: Tuple[int, int], pixelsize: float, spacing: float, width: float) -> FibsemImage:
+
+def generate_gridbar_image(
+    shape: Tuple[int, int], pixelsize: float, spacing: float, width: float
+) -> FibsemImage:
     """Generate an synthetic image of cryo gridbars."""
     arr = np.zeros(shape=shape, dtype=np.uint8)
 
@@ -152,26 +155,27 @@ def generate_gridbar_image(shape: Tuple[int, int], pixelsize: float, spacing: fl
     thickness_px = int(width / pixelsize)
     spacing_px = int(spacing / pixelsize)
     for i in range(0, arr.shape[0], spacing_px):
-        arr[i:i+thickness_px, :] = 255
-        arr[:, i:i+thickness_px] = 255
+        arr[i : i + thickness_px, :] = 255
+        arr[:, i : i + thickness_px] = 255
 
     # TODO: add metadata
     return FibsemImage(data=arr)
+
 
 # TODO: migrate to properly scaled infinite canvas
 # TODO: allow acquiring multiple overview images
 # TODO: deprecate the need for the movement_widget widgets...
 # TODO: update layer name for correlation layers, set from file?
-# TODO: set combobox to all images in viewer 
+# TODO: set combobox to all images in viewer
 class FibsemMinimapWidget(QWidget):
     _acquisition_finished = pyqtSignal(dict)
 
     def __init__(
         self,
         viewer: napari.Viewer,
-        parent: 'AutoLamellaUI',
+        parent: "AutoLamellaUI",
     ):
-        super().__init__(parent=parent) # type: ignore
+        super().__init__(parent=parent)  # type: ignore
         self._setup_ui()
 
         self.parent_widget = parent
@@ -181,7 +185,7 @@ class FibsemMinimapWidget(QWidget):
         self.viewer.window._qt_viewer.dockLayerControls.setVisible(False)
 
         self.image: Optional[FibsemImage] = None
-        self.image_layer: Optional[NapariImageLayer]  = None
+        self.image_layer: Optional[NapariImageLayer] = None
         self.correlation_image_layers: List[str] = []
 
         self.correlation_mode_enabled: bool = False
@@ -197,7 +201,9 @@ class FibsemMinimapWidget(QWidget):
         self.show_circle_overlays: bool = True
         self.show_tem_stage_limits: bool = False
 
-        self.parent_widget.system_widget.connected_signal.connect(self._on_microscope_connected)
+        self.parent_widget.system_widget.connected_signal.connect(
+            self._on_microscope_connected
+        )
 
         self.setup_connections()
         self.draw_blank_image()
@@ -274,7 +280,9 @@ class FibsemMinimapWidget(QWidget):
         self.label_correlation_selected_layer = QLabel("Selected Layer")
         self.comboBox_correlation_selected_layer = ValueComboBox()
         self.gridLayout_4.addWidget(self.label_correlation_selected_layer, 0, 0)
-        self.gridLayout_4.addWidget(self.comboBox_correlation_selected_layer, 0, 1, 1, 2)
+        self.gridLayout_4.addWidget(
+            self.comboBox_correlation_selected_layer, 0, 1, 1, 2
+        )
 
         # row 1 skipped (matches original .ui)
         self.checkBox_gridbar = QCheckBox("Show Grid Overlay")
@@ -336,15 +344,15 @@ class FibsemMinimapWidget(QWidget):
             return
         image: Optional[FibsemImage] = None
         orientation = self.microscope.get_stage_orientation()
-        if orientation == "SEM": 
-            beam_type = BeamType.ELECTRON 
-        else: 
+        if orientation == "SEM":
+            beam_type = BeamType.ELECTRON
+        else:
             beam_type = BeamType.ION
         ms = self.microscope.get_microscope_state(beam_type=beam_type)
         image = FibsemImage.generate_blank_image(resolution=(4096, 4096), hfw=4000e-6)
         image.metadata.image_settings.beam_type = beam_type  # type: ignore
-        image.metadata.microscope_state = ms                            # type: ignore
-        image.metadata.system_info = self.microscope.system.info        # type: ignore
+        image.metadata.microscope_state = ms  # type: ignore
+        image.metadata.system_info = self.microscope.system.info  # type: ignore
         image.metadata.hardware_geometry = self.microscope.hardware_geometry()  # type: ignore
         self.update_viewer(image=image)
 
@@ -383,10 +391,14 @@ class FibsemMinimapWidget(QWidget):
         self.pushButton_load_image.clicked.connect(self.load_image)
 
         # initialise overview acquisition widget with defaults
-        self.overview_acquisition_widget.settings_changed.connect(self.update_imaging_display)
+        self.overview_acquisition_widget.settings_changed.connect(
+            self.update_imaging_display
+        )
 
         # position list signals
-        self.lamella_list.lamella_selected.connect(self.update_current_selected_position)
+        self.lamella_list.lamella_selected.connect(
+            self.update_current_selected_position
+        )
         self.lamella_list.move_to_requested.connect(self._on_move_to_requested)
         self.lamella_list.remove_requested.connect(self._on_remove_requested)
         self.lamella_list.defect_changed.connect(self._on_defect_changed)
@@ -395,45 +407,75 @@ class FibsemMinimapWidget(QWidget):
         self._acquisition_finished.connect(self.tile_collection_finished)
 
         # pattern overlay
-        self.comboBox_pattern_overlay.currentIndexChanged.connect(self._draw_milling_pattern_overlay)
-        self.checkBox_pattern_overlay.stateChanged.connect(self._draw_milling_pattern_overlay)
+        self.comboBox_pattern_overlay.currentIndexChanged.connect(
+            self._draw_milling_pattern_overlay
+        )
+        self.checkBox_pattern_overlay.stateChanged.connect(
+            self._draw_milling_pattern_overlay
+        )
 
         # correlation
         self.pushButton_load_correlation_image.clicked.connect(self.load_image)
-        self.comboBox_correlation_selected_layer.currentIndexChanged.connect(self.update_correlation_ui)
-        self.pushButton_enable_correlation.clicked.connect(self._toggle_correlation_mode)
-        self.pushButton_enable_correlation.setEnabled(False) # disabled until correlation images added
+        self.comboBox_correlation_selected_layer.currentIndexChanged.connect(
+            self.update_correlation_ui
+        )
+        self.pushButton_enable_correlation.clicked.connect(
+            self._toggle_correlation_mode
+        )
+        self.pushButton_enable_correlation.setEnabled(
+            False
+        )  # disabled until correlation images added
 
         # gridbar controls
-        self.correlation_panel.setEnabled(True) # only grid-bar overlay enabled
+        self.correlation_panel.setEnabled(True)  # only grid-bar overlay enabled
         self.checkBox_gridbar.setEnabled(True)
         self.checkBox_gridbar.stateChanged.connect(self.toggle_gridbar_display)
         self.label_gb_spacing.setVisible(False)
         self.label_gb_width.setVisible(False)
         self.doubleSpinBox_gb_spacing.setVisible(False)
         self.doubleSpinBox_gb_width.setVisible(False)
-        self.doubleSpinBox_gb_spacing.setValue(GRIDBAR_IMAGE_LAYER_PROPERTIES["spacing"])
+        self.doubleSpinBox_gb_spacing.setValue(
+            GRIDBAR_IMAGE_LAYER_PROPERTIES["spacing"]
+        )
         self.doubleSpinBox_gb_width.setValue(GRIDBAR_IMAGE_LAYER_PROPERTIES["width"])
         self.doubleSpinBox_gb_spacing.setKeyboardTracking(False)
         self.doubleSpinBox_gb_width.setKeyboardTracking(False)
         self.doubleSpinBox_gb_spacing.valueChanged.connect(self.update_gridbar_layer)
         self.doubleSpinBox_gb_width.valueChanged.connect(self.update_gridbar_layer)
-        self.correlation_panel.setToolTip("Correlation Controls are disabled until an image is acquired or loaded.")
+        self.correlation_panel.setToolTip(
+            "Correlation Controls are disabled until an image is acquired or loaded."
+        )
 
         # set styles
-        self.pushButton_run_tile_collection.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
-        self.pushButton_cancel_acquisition.setStyleSheet(stylesheets.DANGER_BUTTON_STYLESHEET)
+        self.pushButton_run_tile_collection.setStyleSheet(
+            stylesheets.PRIMARY_BUTTON_STYLESHEET
+        )
+        self.pushButton_cancel_acquisition.setStyleSheet(
+            stylesheets.DANGER_BUTTON_STYLESHEET
+        )
         self.progressBar_acquisition.setStyleSheet(stylesheets.PROGRESS_BAR_STYLESHEET)
-        self.pushButton_enable_correlation.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
-        self.pushButton_load_image.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
-        self.pushButton_load_correlation_image.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.pushButton_enable_correlation.setStyleSheet(
+            stylesheets.SECONDARY_BUTTON_STYLESHEET
+        )
+        self.pushButton_load_image.setStyleSheet(
+            stylesheets.SECONDARY_BUTTON_STYLESHEET
+        )
+        self.pushButton_load_correlation_image.setStyleSheet(
+            stylesheets.SECONDARY_BUTTON_STYLESHEET
+        )
 
         # display option checkboxes
         self.checkBox_show_overview_fov.toggled.connect(self._on_display_option_toggled)
-        self.checkBox_show_saved_positions_fov.toggled.connect(self._on_display_option_toggled)
+        self.checkBox_show_saved_positions_fov.toggled.connect(
+            self._on_display_option_toggled
+        )
         self.checkBox_show_stage_limits.toggled.connect(self._on_display_option_toggled)
-        self.checkBox_show_circle_overlays.toggled.connect(self._on_display_option_toggled)
-        self.checkBox_show_tem_stage_limits.toggled.connect(self._on_display_option_toggled)
+        self.checkBox_show_circle_overlays.toggled.connect(
+            self._on_display_option_toggled
+        )
+        self.checkBox_show_tem_stage_limits.toggled.connect(
+            self._on_display_option_toggled
+        )
 
         # set italics for instructions
         self.label_instructions.setStyleSheet(stylesheets.LABEL_INSTRUCTIONS_STYLE)
@@ -452,14 +494,20 @@ class FibsemMinimapWidget(QWidget):
         if self.microscope is None:
             return
         try:
-            self.microscope.tiled_acquisition_signal.disconnect(self.handle_tile_acquisition_progress)
+            self.microscope.tiled_acquisition_signal.disconnect(
+                self.handle_tile_acquisition_progress
+            )
         except Exception:
             pass
-        try:    
-            self.microscope.stage_position_changed.disconnect(self._on_stage_position_changed)
+        try:
+            self.microscope.stage_position_changed.disconnect(
+                self._on_stage_position_changed
+            )
         except Exception:
             pass
-        self.microscope.tiled_acquisition_signal.connect(self.handle_tile_acquisition_progress)
+        self.microscope.tiled_acquisition_signal.connect(
+            self.handle_tile_acquisition_progress
+        )
         self.microscope.stage_position_changed.connect(self._on_stage_position_changed)
 
     def _on_experiment_changed(self):
@@ -471,14 +519,22 @@ class FibsemMinimapWidget(QWidget):
         settings.image_settings.path = str(self.parent_widget.experiment.path)
         self.overview_acquisition_widget.update_from_settings(settings)
         try:
-            self.parent_widget.experiment.positions.events.disconnect(self._on_experiment_position_changed) # type: ignore
+            self.parent_widget.experiment.positions.events.disconnect(
+                self._on_experiment_position_changed
+            )  # type: ignore
         except Exception:
             pass
-        self.parent_widget.experiment.positions.events.connect(self._on_experiment_position_changed) # type: ignore
+        self.parent_widget.experiment.positions.events.connect(
+            self._on_experiment_position_changed
+        )  # type: ignore
 
         available_task_names = []
         if self.protocol is not None:
-            available_task_names = [name for name in self.protocol.task_config.keys() if self.protocol.task_config[name].milling]
+            available_task_names = [
+                name
+                for name in self.protocol.task_config.keys()
+                if self.protocol.task_config[name].milling
+            ]
             self.comboBox_pattern_overlay.blockSignals(True)
             self.comboBox_pattern_overlay.clear()
             self.comboBox_pattern_overlay.addItems(available_task_names)
@@ -496,7 +552,9 @@ class FibsemMinimapWidget(QWidget):
 
     def _on_display_option_toggled(self):
         self.show_overview_fov = self.checkBox_show_overview_fov.isChecked()
-        self.show_saved_positions_fov = self.checkBox_show_saved_positions_fov.isChecked()
+        self.show_saved_positions_fov = (
+            self.checkBox_show_saved_positions_fov.isChecked()
+        )
         self.show_stage_limits = self.checkBox_show_stage_limits.isChecked()
         self.show_circle_overlays = self.checkBox_show_circle_overlays.isChecked()
         self.show_tem_stage_limits = self.checkBox_show_tem_stage_limits.isChecked()
@@ -543,7 +601,9 @@ class FibsemMinimapWidget(QWidget):
             self._update_position_display()
         except Exception as e:
             logging.error(f"Error logging experiment position change: {e}")
-            self.parent_widget.experiment.positions.events.disconnect(self._on_experiment_position_changed) # type: ignore
+            self.parent_widget.experiment.positions.events.disconnect(
+                self._on_experiment_position_changed
+            )  # type: ignore
 
     def get_overview_settings(self) -> OverviewAcquisitionSettings:
         """Get the current overview acquisition settings from the UI."""
@@ -562,7 +622,9 @@ class FibsemMinimapWidget(QWidget):
         image_settings.save = True
 
         if not image_settings.filename:
-            notification_service.show_toast("Please enter a filename for the image", "error")
+            notification_service.show_toast(
+                "Please enter a filename for the image", "error"
+            )
             return
 
         # ui feedback
@@ -669,7 +731,9 @@ class FibsemMinimapWidget(QWidget):
     @property
     def is_acquiring(self) -> bool:
         """Check if the acquisition thread is running."""
-        return self._acquisition_worker is not None and self._acquisition_worker.is_alive()
+        return (
+            self._acquisition_worker is not None and self._acquisition_worker.is_alive()
+        )
 
     def toggle_gridbar_display(self):
         """Toggle the display of the synthetic grid bar overlay."""
@@ -689,8 +753,16 @@ class FibsemMinimapWidget(QWidget):
 
             self.comboBox_correlation_selected_layer.currentIndexChanged.disconnect()
             self.comboBox_correlation_selected_layer.clear()
-            self.comboBox_correlation_selected_layer.addItems([layer.name for layer in self.viewer.layers if "correlation-image" in layer.name ])
-            self.comboBox_correlation_selected_layer.currentIndexChanged.connect(self.update_correlation_ui)
+            self.comboBox_correlation_selected_layer.addItems(
+                [
+                    layer.name
+                    for layer in self.viewer.layers
+                    if "correlation-image" in layer.name
+                ]
+            )
+            self.comboBox_correlation_selected_layer.currentIndexChanged.connect(
+                self.update_correlation_ui
+            )
             # if no correlation layers left, disable enable correlation
             if self.comboBox_correlation_selected_layer.count() == 0:
                 self.pushButton_enable_correlation.setEnabled(False)
@@ -700,9 +772,12 @@ class FibsemMinimapWidget(QWidget):
         # update gridbars image
         spacing = self.doubleSpinBox_gb_spacing.value() * constants.MICRO_TO_SI
         width = self.doubleSpinBox_gb_width.value() * constants.MICRO_TO_SI
-        gridbars_image = generate_gridbar_image(shape=self.image.data.shape,  # type: ignore
-                                                pixelsize=self.image.metadata.pixel_size.x, 
-                                                spacing=spacing, width=width)
+        gridbars_image = generate_gridbar_image(
+            shape=self.image.data.shape,  # type: ignore
+            pixelsize=self.image.metadata.pixel_size.x,
+            spacing=spacing,
+            width=width,
+        )
 
         # update gridbar layer
         gridbar_layer = GRIDBAR_IMAGE_LAYER_PROPERTIES["name"]
@@ -720,7 +795,9 @@ class FibsemMinimapWidget(QWidget):
         self.progressBar_acquisition.setValue(0)
 
         if enable:
-            self.pushButton_run_tile_collection.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+            self.pushButton_run_tile_collection.setStyleSheet(
+                stylesheets.PRIMARY_BUTTON_STYLESHEET
+            )
             self.pushButton_run_tile_collection.setText("Run Tile Collection")
         else:
             self.pushButton_run_tile_collection.setText("Running Tile Collection...")
@@ -734,9 +811,13 @@ class FibsemMinimapWidget(QWidget):
 
         filename = ui_utils.open_existing_file_dialog(
             msg="Select image to load",
-            path=str(self.overview_acquisition_widget.get_settings().image_settings.path or os.getcwd()),
+            path=str(
+                self.overview_acquisition_widget.get_settings().image_settings.path
+                or os.getcwd()
+            ),
             _filter="Image Files (*.tif *.tiff)",
-            parent=self)
+            parent=self,
+        )
 
         if filename == "":
             notification_service.show_toast("No file selected..", "error")
@@ -744,7 +825,7 @@ class FibsemMinimapWidget(QWidget):
 
         # load the image
         image = FibsemImage.load(filename)
-        
+
         if is_correlation:
             self.add_correlation_image(image)
         else:
@@ -753,25 +834,28 @@ class FibsemMinimapWidget(QWidget):
     def update_viewer(self, image: Optional[FibsemImage] = None, tmp: bool = False):
         """Update the viewer with the image and positions."""
         if image is not None:
-
             if not tmp:
                 self.image = image
                 arr = image.filtered_data
             else:
-                arr = image # np.array(image)
+                arr = image  # np.array(image)
 
             try:
                 self.image_layer.data = arr
             except Exception as e:
-                self.image_layer = self.viewer.add_image(arr, 
-                                                         name=OVERVIEW_IMAGE_LAYER_PROPERTIES["name"],
-                                                         colormap=OVERVIEW_IMAGE_LAYER_PROPERTIES["colormap"],
-                                                         blending=OVERVIEW_IMAGE_LAYER_PROPERTIES["blending"])  # type: ignore
+                self.image_layer = self.viewer.add_image(
+                    arr,
+                    name=OVERVIEW_IMAGE_LAYER_PROPERTIES["name"],
+                    colormap=OVERVIEW_IMAGE_LAYER_PROPERTIES["colormap"],
+                    blending=OVERVIEW_IMAGE_LAYER_PROPERTIES["blending"],
+                )  # type: ignore
 
             if tmp:
-                return # don't update the rest of the UI, we are just updating the image
+                return  # don't update the rest of the UI, we are just updating the image
             if self.image_layer is None:
-                notification_service.show_toast("Error adding image layer to viewer.", "error")
+                notification_service.show_toast(
+                    "Error adding image layer to viewer.", "error"
+                )
                 return
 
             self.viewer.reset_view()
@@ -784,12 +868,14 @@ class FibsemMinimapWidget(QWidget):
 
         if self.image:
             self.draw_current_stage_position()  # draw the current stage position on the image
-            self._draw_milling_pattern_overlay()         # draw the reprojected positions on the image
+            self._draw_milling_pattern_overlay()  # draw the reprojected positions on the image
             self.label_instructions.setText(LABEL_INSTRUCTIONS["image-available"])
         update_text_overlay(self.viewer, self.microscope)
         self.set_active_layer_for_movement()
 
-    def get_coordinate_in_microscope_coordinates(self, layer: NapariLayer, event: NapariEvent) -> Tuple[np.ndarray, Point]:
+    def get_coordinate_in_microscope_coordinates(
+        self, layer: NapariLayer, event: NapariEvent
+    ) -> Tuple[np.ndarray, Point]:
         """Validate if event position is inside image, and convert to microscope coords
         Args:
             layer (NapariLayer): The image layer.
@@ -805,12 +891,15 @@ class FibsemMinimapWidget(QWidget):
 
         # check if clicked point is inside image
         if not is_inside_image_bounds(coords=coords, shape=self.image.data.shape):
-            notification_service.show_toast("Clicked outside image dimensions. Please click inside the image to move.", "warning")
+            notification_service.show_toast(
+                "Clicked outside image dimensions. Please click inside the image to move.",
+                "warning",
+            )
             return False, False
 
         point = conversions.image_to_microscope_image_coordinates(
-            coord=Point(x=coords[1], y=coords[0]), 
-            image=self.image.data, 
+            coord=Point(x=coords[1], y=coords[0]),
+            image=self.image.data,
             pixelsize=self.image.metadata.pixel_size.x,
         )
 
@@ -822,18 +911,24 @@ class FibsemMinimapWidget(QWidget):
             return
         if self.image_layer is None or self.image_layer not in self.viewer.layers:
             return
-        coords, point = self.get_coordinate_in_microscope_coordinates(self.image_layer, event)
+        coords, point = self.get_coordinate_in_microscope_coordinates(
+            self.image_layer, event
+        )
         if point is False:
             return
         if self.image is None or self.image.metadata is None:
             return
         stage_position = self.microscope.project_stable_move(
-            dx=point.x, dy=point.y,
+            dx=point.x,
+            dy=point.y,
             beam_type=self.image.metadata.image_settings.beam_type,
-            base_position=self.image.metadata.stage_position)
+            base_position=self.image.metadata.stage_position,
+        )
         self.check_closest_experiment_position(stage_position)
 
-    def check_closest_experiment_position(self, clicked_position: FibsemStagePosition) -> None:
+    def check_closest_experiment_position(
+        self, clicked_position: FibsemStagePosition
+    ) -> None:
         """Check and print distances to all experiment positions, highlighting the closest one.
 
         Args:
@@ -865,7 +960,9 @@ class FibsemMinimapWidget(QWidget):
     def on_double_click(self, viewer, event: NapariEvent) -> None:
         """Callback for double click on the viewer. Moves the stage to the clicked position."""
         if self.parent_widget.is_workflow_running:
-            notification_service.show_toast("Cannot move stage while workflow is running.", "warning")
+            notification_service.show_toast(
+                "Cannot move stage while workflow is running.", "warning"
+            )
             return
 
         if event.button != 1:
@@ -874,9 +971,11 @@ class FibsemMinimapWidget(QWidget):
         if self.image_layer is None or self.image_layer not in self.viewer.layers:
             return
 
-        coords, point = self.get_coordinate_in_microscope_coordinates(self.image_layer, event)
+        coords, point = self.get_coordinate_in_microscope_coordinates(
+            self.image_layer, event
+        )
 
-        if point is False: # clicked outside image
+        if point is False:  # clicked outside image
             return
 
         if self.image is None or self.image.metadata is None:
@@ -884,13 +983,20 @@ class FibsemMinimapWidget(QWidget):
 
         beam_type = self.image.metadata.image_settings.beam_type
         stage_position = self.microscope.project_stable_move(
-            dx=point.x, dy=point.y,
+            dx=point.x,
+            dy=point.y,
             beam_type=beam_type,
-            base_position=self.image.metadata.stage_position)
+            base_position=self.image.metadata.stage_position,
+        )
 
         # check if position is within stage limits
-        if not stage_position.is_within_limits(self.microscope._stage.limits, axes=["x", "y"]):
-            notification_service.show_toast("Position is outside stage limits. Please select a position within the stage limits.", "warning")
+        if not stage_position.is_within_limits(
+            self.microscope._stage.limits, axes=["x", "y"]
+        ):
+            notification_service.show_toast(
+                "Position is outside stage limits. Please select a position within the stage limits.",
+                "warning",
+            )
             return
 
         self.move_to_stage_position(stage_position)
@@ -919,7 +1025,10 @@ class FibsemMinimapWidget(QWidget):
 
         # Check if clicked point is inside image
         if not is_inside_image_bounds(coords=coords, shape=self.image.data.shape):
-            notification_service.show_toast("Position is outside image bounds. Please select a position within the image.", "warning")
+            notification_service.show_toast(
+                "Position is outside image bounds. Please select a position within the image.",
+                "warning",
+            )
             return
 
         event.handled = True
@@ -933,13 +1042,20 @@ class FibsemMinimapWidget(QWidget):
 
         # Calculate the stage position for the clicked point
         stage_position = self.microscope.project_stable_move(
-            dx=point.x, dy=point.y,
+            dx=point.x,
+            dy=point.y,
             beam_type=self.image.metadata.image_settings.beam_type,
-            base_position=self.image.metadata.stage_position)
+            base_position=self.image.metadata.stage_position,
+        )
 
         # Check if position is within stage limits
-        if not stage_position.is_within_limits(self.microscope._stage.limits, axes=["x", "y"]):
-            notification_service.show_toast("Position is outside stage limits. Please select a position within the stage limits.", "warning")
+        if not stage_position.is_within_limits(
+            self.microscope._stage.limits, axes=["x", "y"]
+        ):
+            notification_service.show_toast(
+                "Position is outside stage limits. Please select a position within the stage limits.",
+                "warning",
+            )
             return
 
         # Build context menu
@@ -960,7 +1076,9 @@ class FibsemMinimapWidget(QWidget):
         menu = ContextMenu(config, parent=self)
         menu.show_at_cursor()
 
-    def _add_position_at_stage_position(self, stage_position: FibsemStagePosition) -> None:
+    def _add_position_at_stage_position(
+        self, stage_position: FibsemStagePosition
+    ) -> None:
         """Add a new position at the given stage position."""
         if self.parent_widget is None or self.parent_widget.experiment is None:
             return
@@ -999,7 +1117,9 @@ class FibsemMinimapWidget(QWidget):
         if lam is None:
             return
 
-        self.label_position_info.setText(f"{lam.name}: {lam.stage_position.pretty_string}")
+        self.label_position_info.setText(
+            f"{lam.name}: {lam.stage_position.pretty_string}"
+        )
 
         # redraw the positions to show the selected one
         self.draw_current_stage_position()
@@ -1011,7 +1131,9 @@ class FibsemMinimapWidget(QWidget):
         has_positions = len(lamellas) > 0
         self.positions_panel.setEnabled(has_positions)
         if not has_positions:
-            self.positions_panel.setToolTip("No positions available. Please add a position via Right Click on the image.")
+            self.positions_panel.setToolTip(
+                "No positions available. Please add a position via Right Click on the image."
+            )
         else:
             self.positions_panel.setToolTip("")
 
@@ -1058,14 +1180,20 @@ class FibsemMinimapWidget(QWidget):
     def _on_stage_position_changed(self, stage_position: FibsemStagePosition):
         """Callback for when the stage position is changed."""
         if self.is_acquiring:
-            return # do not update while acquiring
+            return  # do not update while acquiring
         try:
             self.draw_current_stage_position(stage_position=stage_position)
-            update_text_overlay(self.viewer, self.microscope, stage_position=stage_position)
+            update_text_overlay(
+                self.viewer, self.microscope, stage_position=stage_position
+            )
             self.set_active_layer_for_movement()
         except Exception as e:
-            self.microscope.stage_position_changed.disconnect(self._on_stage_position_changed)
-            logging.error(f"Error updating viewer on stage position change, signal disconnected: {e}")
+            self.microscope.stage_position_changed.disconnect(
+                self._on_stage_position_changed
+            )
+            logging.error(
+                f"Error updating viewer on stage position change, signal disconnected: {e}"
+            )
 
     def _hide_overlay_layers(self):
         """Hide all overlay layers."""
@@ -1077,7 +1205,9 @@ class FibsemMinimapWidget(QWidget):
             self.viewer.layers[MILLING_PATTERN_LAYER_NAME].visible = False
         return
 
-    def draw_current_stage_position(self, stage_position: Optional[FibsemStagePosition] = None):
+    def draw_current_stage_position(
+        self, stage_position: Optional[FibsemStagePosition] = None
+    ):
         """Draws the current stage position on the image."""
         if self.image is None or self.image.metadata is None:
             return
@@ -1099,24 +1229,29 @@ class FibsemMinimapWidget(QWidget):
         self._draw_position_crosshairs()
         self._draw_milling_pattern_overlay()
 
-    def _collect_all_overlays(self, stage_position: FibsemStagePosition) -> List[NapariShapeOverlay]:
+    def _collect_all_overlays(
+        self, stage_position: FibsemStagePosition
+    ) -> List[NapariShapeOverlay]:
         """Collect all overlay shapes to be drawn on the image."""
 
         if self.image is None or self.image.metadata is None:
             return []
 
         # If no overlays are to be shown, return empty list
-        if not (self.show_current_fov or
-                self.show_overview_fov or
-                self.show_saved_positions_fov or
-                self.show_stage_limits or
-                self.show_circle_overlays or
-                self.show_tem_stage_limits
-                ):
+        if not (
+            self.show_current_fov
+            or self.show_overview_fov
+            or self.show_saved_positions_fov
+            or self.show_stage_limits
+            or self.show_circle_overlays
+            or self.show_tem_stage_limits
+        ):
             return []
 
         stage_position.name = "Current Position"
-        points = tiled.reproject_stage_positions_onto_image2(self.image, [stage_position])
+        points = tiled.reproject_stage_positions_onto_image2(
+            self.image, [stage_position]
+        )
 
         pixelsize = self.image.metadata.pixel_size.x
         current_position = points[0]
@@ -1129,73 +1264,98 @@ class FibsemMinimapWidget(QWidget):
             width = overview_settings.total_fov_x / pixelsize
             height = overview_settings.total_fov_y / pixelsize
             rect = create_rectangle_shape(current_position, width, height)
-            overlays.append(NapariShapeOverlay(
-                shape=rect,
-                color="magenta",
-                label="Overview FoV",
-                shape_type='rectangle')
+            overlays.append(
+                NapariShapeOverlay(
+                    shape=rect,
+                    color="magenta",
+                    label="Overview FoV",
+                    shape_type="rectangle",
+                )
             )
 
         # stage limits
-        if (self.show_stage_limits or self.show_circle_overlays) and self.microscope.stage_is_compustage:
+        if (
+            self.show_stage_limits or self.show_circle_overlays
+        ) and self.microscope.stage_is_compustage:
             stage_limits = self.microscope._stage.limits
             xmin, xmax = stage_limits["x"].min, stage_limits["x"].max
             ymin, ymax = stage_limits["y"].min, stage_limits["y"].max
-            centre_grid = FibsemStagePosition(name="Grid Centre", x=0, y=0, z=0, r=0, t=0)
-            top_limit = FibsemStagePosition(name="Top Limit", x=0, y=ymin, z=0, r=0, t=0)
-            bottom_limit = FibsemStagePosition(name="Bottom Limit", x=0, y=ymax, z=0, r=0, t=0)
-            points = tiled.reproject_stage_positions_onto_image2(self.image, [centre_grid, top_limit, bottom_limit])
-            width = (xmax-xmin) / pixelsize
+            centre_grid = FibsemStagePosition(
+                name="Grid Centre", x=0, y=0, z=0, r=0, t=0
+            )
+            top_limit = FibsemStagePosition(
+                name="Top Limit", x=0, y=ymin, z=0, r=0, t=0
+            )
+            bottom_limit = FibsemStagePosition(
+                name="Bottom Limit", x=0, y=ymax, z=0, r=0, t=0
+            )
+            points = tiled.reproject_stage_positions_onto_image2(
+                self.image, [centre_grid, top_limit, bottom_limit]
+            )
+            width = (xmax - xmin) / pixelsize
             height = points[1].y - points[2].y
             grid_centre = points[0]
             if self.show_stage_limits:
                 rect = create_rectangle_shape(grid_centre, width, height)
-                overlays.append(NapariShapeOverlay(
-                    shape=rect,
-                    color="yellow",
-                    label="Stage Limits",
-                    shape_type='rectangle')
+                overlays.append(
+                    NapariShapeOverlay(
+                        shape=rect,
+                        color="yellow",
+                        label="Stage Limits",
+                        shape_type="rectangle",
+                    )
                 )
             if self.show_circle_overlays:
                 # grid boundary circle (red)
                 origin_radius = 1000e-6 / pixelsize  # 1000μm in meters
                 origin_circle = create_circle_shape(grid_centre, origin_radius, None)
-                overlays.append(NapariShapeOverlay(
-                    shape=origin_circle,
-                    color="red",
-                    label="Grid Boundary",
-                    shape_type="ellipse"
-                ))
+                overlays.append(
+                    NapariShapeOverlay(
+                        shape=origin_circle,
+                        color="red",
+                        label="Grid Boundary",
+                        shape_type="ellipse",
+                    )
+                )
 
             # TEM stage limits (800µm × 800µm magenta rectangle centred on grid)
             if self.show_tem_stage_limits:
                 TEM_LIMIT_M = 1600e-6  # 800µm in meters
                 size_px = TEM_LIMIT_M / pixelsize
                 rect = create_rectangle_shape(grid_centre, size_px, size_px)
-                overlays.append(NapariShapeOverlay(
-                    shape=rect,
-                    color="orange",
-                    label="TEM Stage Limits",
-                    shape_type="rectangle",
-                ))
+                overlays.append(
+                    NapariShapeOverlay(
+                        shape=rect,
+                        color="orange",
+                        label="TEM Stage Limits",
+                        shape_type="rectangle",
+                    )
+                )
 
         if self.show_saved_positions_fov:
-            points = tiled.reproject_stage_positions_onto_image2(self.image, self.positions)
-            width = 80e-6 / pixelsize # TODO: make this match the milling fov
-            height = 1024/1536 * width
+            points = tiled.reproject_stage_positions_onto_image2(
+                self.image, self.positions
+            )
+            width = 80e-6 / pixelsize  # TODO: make this match the milling fov
+            height = 1024 / 1536 * width
             selected_index = self.lamella_list.selected_index
             for i, (lam, point) in enumerate(zip(self.lamellas, points)):
-                overlays.append(NapariShapeOverlay(
-                    shape=create_rectangle_shape(point, width=width, height=height),
-                    color=self._lamella_color(lam, selected=i == selected_index),
-                    label=point.name,
-                    shape_type='rectangle')
+                overlays.append(
+                    NapariShapeOverlay(
+                        shape=create_rectangle_shape(point, width=width, height=height),
+                        color=self._lamella_color(lam, selected=i == selected_index),
+                        label=point.name,
+                        shape_type="rectangle",
+                    )
                 )
 
         return overlays
 
-    def _draw_overlay_shapes(self, stage_position: FibsemStagePosition,
-                             layer_scale: Optional[Tuple[float, float]] = None):
+    def _draw_overlay_shapes(
+        self,
+        stage_position: FibsemStagePosition,
+        layer_scale: Optional[Tuple[float, float]] = None,
+    ):
         """Draw all overlay shapes (FOV boxes and circles) on a single layer.
 
         Creates overlays for:
@@ -1230,13 +1390,13 @@ class FibsemMinimapWidget(QWidget):
             # Prepare text properties for labels
             text_properties = {
                 "string": all_labels,
-                **OVERLAY_CONFIG["text_properties"]
+                **OVERLAY_CONFIG["text_properties"],
             }
 
             if layer_name in self.viewer.layers:
                 # Update existing layer
                 layer: NapariShapesLayer = self.viewer.layers[layer_name]
-                layer.data = [] # clear to reset shape type
+                layer.data = []  # clear to reset shape type
                 layer.data = all_shapes
                 layer.shape_type = all_shape_types
                 layer.edge_color = all_colors
@@ -1268,14 +1428,18 @@ class FibsemMinimapWidget(QWidget):
             if layer_name in self.viewer.layers:
                 self.viewer.layers[layer_name].visible = False
 
-    def _collect_crosshair_overlays(self, layer_scale: Optional[Tuple[float, float]] = None):
+    def _collect_crosshair_overlays(
+        self, layer_scale: Optional[Tuple[float, float]] = None
+    ):
         """Collect crosshair overlays for current and saved positions."""
         if self.image is None or self.image.metadata is None:
             return
 
         current_stage_position = deepcopy(self.microscope._stage_position)
         stage_origin = FibsemStagePosition(name="Origin", x=0, y=0, z=0, r=0, t=0)
-        points = tiled.reproject_stage_positions_onto_image2(self.image, [current_stage_position, stage_origin])
+        points = tiled.reproject_stage_positions_onto_image2(
+            self.image, [current_stage_position, stage_origin]
+        )
 
         origin_point = points[1]
         current_point = points[0]
@@ -1286,35 +1450,47 @@ class FibsemMinimapWidget(QWidget):
         # grid centre
         origin_lines = create_crosshair_shape(origin_point, crosshair_size, layer_scale)
         for line, txt in zip(origin_lines, ["Origin (0, 0)", ""]):
-            overlays.append(NapariShapeOverlay(
-                shape=line,
-                color=CROSSHAIR_CONFIG["colors"]["origin"],
-                label=txt,
-                shape_type="line"
-            ))
+            overlays.append(
+                NapariShapeOverlay(
+                    shape=line,
+                    color=CROSSHAIR_CONFIG["colors"]["origin"],
+                    label=txt,
+                    shape_type="line",
+                )
+            )
 
         # grid positions
-        grid_positions = [s.position for s in self.microscope._stage.holder.slots.values()]
-        grid_points = tiled.reproject_stage_positions_onto_image2(self.image, grid_positions)
+        grid_positions = [
+            s.position for s in self.microscope._stage.holder.slots.values()
+        ]
+        grid_points = tiled.reproject_stage_positions_onto_image2(
+            self.image, grid_positions
+        )
         for i, grid_point in enumerate(grid_points):
             grid_lines = create_crosshair_shape(grid_point, crosshair_size, layer_scale)
             for line, txt in zip(grid_lines, [grid_positions[i].name, ""]):
-                overlays.append(NapariShapeOverlay(
-                    shape=line,
-                    color=CROSSHAIR_CONFIG["colors"]["grid"],
-                    label=txt,
-                    shape_type="line"
-                ))
+                overlays.append(
+                    NapariShapeOverlay(
+                        shape=line,
+                        color=CROSSHAIR_CONFIG["colors"]["grid"],
+                        label=txt,
+                        shape_type="line",
+                    )
+                )
 
         # current stage position
-        current_lines = create_crosshair_shape(current_point, crosshair_size, layer_scale)
+        current_lines = create_crosshair_shape(
+            current_point, crosshair_size, layer_scale
+        )
         for line, txt in zip(current_lines, ["Stage Position", ""]):
-            overlays.append(NapariShapeOverlay(
-                shape=line,
-                color=CROSSHAIR_CONFIG["colors"]["current"],
-                label=txt,
-                shape_type="line"
-            ))
+            overlays.append(
+                NapariShapeOverlay(
+                    shape=line,
+                    color=CROSSHAIR_CONFIG["colors"]["current"],
+                    label=txt,
+                    shape_type="line",
+                )
+            )
 
         # saved positions
         selected_index = self.lamella_list.selected_index
@@ -1322,24 +1498,27 @@ class FibsemMinimapWidget(QWidget):
         positions = self.positions
         pts = tiled.reproject_stage_positions_onto_image2(self.image, positions)
         for i, (lam, saved_point) in enumerate(zip(lamellas, pts)):
-            saved_lines = create_crosshair_shape(saved_point, crosshair_size, layer_scale)
+            saved_lines = create_crosshair_shape(
+                saved_point, crosshair_size, layer_scale
+            )
             color = self._lamella_color(lam, selected=i == selected_index)
 
             # Show position name on crosshair if saved position FOV is disabled
             label = lam.name if not self.show_saved_positions_fov else ""
 
             for line, txt in zip(saved_lines, [label, ""]):
-                overlays.append(NapariShapeOverlay(
-                    shape=line,
-                    color=color,
-                    label=txt,
-                    shape_type="line"
-                ))
+                overlays.append(
+                    NapariShapeOverlay(
+                        shape=line, color=color, label=txt, shape_type="line"
+                    )
+                )
 
         return overlays
 
-    def _draw_position_crosshairs(self, layer_scale: Optional[Tuple[float, float]] = None):
-        """Draw crosshair overlays for current and saved positions on a single layer. """
+    def _draw_position_crosshairs(
+        self, layer_scale: Optional[Tuple[float, float]] = None
+    ):
+        """Draw crosshair overlays for current and saved positions on a single layer."""
 
         # Collect all crosshair overlays
         layer_name = CROSSHAIR_CONFIG["layer_name"]
@@ -1351,10 +1530,7 @@ class FibsemMinimapWidget(QWidget):
         labels = [overlay.label for overlay in crosshair_overlays]
 
         # Prepare text properties for labels
-        text_properties = {
-            "string": labels,
-            **CROSSHAIR_CONFIG["text_properties"]
-        }
+        text_properties = {"string": labels, **CROSSHAIR_CONFIG["text_properties"]}
 
         # Update or create the napari layer
         if layer_name in self.viewer.layers:
@@ -1395,20 +1571,23 @@ class FibsemMinimapWidget(QWidget):
                 self.viewer.layers[MILLING_PATTERN_LAYER_NAME].visible = False
             return
 
-        if not (self.image
-                and self.image.metadata 
-                and self.image_layer 
-                and self.positions):
+        if not (
+            self.image and self.image.metadata and self.image_layer and self.positions
+        ):
             return
 
         if self.protocol is None:
-            notification_service.show_toast("No milling patterns found in protocol...", "warning")
+            notification_service.show_toast(
+                "No milling patterns found in protocol...", "warning"
+            )
             return
 
         selected_pattern = self.comboBox_pattern_overlay.currentText()
         selected_milling_stages: List[FibsemMillingStage] = []
         if selected_pattern == "":
-            notification_service.show_toast("Please select a milling pattern to overlay...", "warning")
+            notification_service.show_toast(
+                "Please select a milling pattern to overlay...", "warning"
+            )
             return
 
         task_config = self.protocol.task_config
@@ -1424,9 +1603,11 @@ class FibsemMinimapWidget(QWidget):
         # then, changes in the protocol would be reflected in the minimap
         milling_stages: List[FibsemMillingStage] = []
         for point in points:
-            pt = conversions.image_to_microscope_image_coordinates(coord=point,
-                                                                image=self.image.data,
-                                                                pixelsize=self.image.metadata.pixel_size.x)
+            pt = conversions.image_to_microscope_image_coordinates(
+                coord=point,
+                image=self.image.data,
+                pixelsize=self.image.metadata.pixel_size.x,
+            )
             stages = deepcopy(selected_milling_stages)
             for i, stage in enumerate(stages):
                 stage.name = f"{point.name}-{stage.name}"
@@ -1439,8 +1620,8 @@ class FibsemMinimapWidget(QWidget):
             pixelsize=self.image.metadata.pixel_size.x,
             milling_stages=milling_stages,
             draw_crosshair=False,
-            colors=MILLING_PATTERN_COLOURS[:len(selected_milling_stages)],
-            )
+            colors=MILLING_PATTERN_COLOURS[: len(selected_milling_stages)],
+        )
         if MILLING_PATTERN_LAYER_NAME in self.viewer.layers:
             self.viewer.layers[MILLING_PATTERN_LAYER_NAME].visible = True
 
@@ -1456,7 +1637,7 @@ class FibsemMinimapWidget(QWidget):
         idx = 1
         layer_name = f"{basename}-{idx:02d}"
         while layer_name in self.viewer.layers:
-            idx+=1
+            idx += 1
             layer_name = f"{basename}-{idx:02d}"
 
         # if grid bar in _name, idx = 3
@@ -1465,11 +1646,13 @@ class FibsemMinimapWidget(QWidget):
             idx = 3
 
         # add the image layer
-        self.viewer.add_image(image.data, 
-                        name=layer_name, 
-                        colormap=COLOURS[idx%len(COLOURS)], 
-                        blending=CORRELATION_IMAGE_LAYER_PROPERTIES["blending"], 
-                        opacity=CORRELATION_IMAGE_LAYER_PROPERTIES["opacity"])
+        self.viewer.add_image(
+            image.data,
+            name=layer_name,
+            colormap=COLOURS[idx % len(COLOURS)],
+            blending=CORRELATION_IMAGE_LAYER_PROPERTIES["blending"],
+            opacity=CORRELATION_IMAGE_LAYER_PROPERTIES["opacity"],
+        )
         self.correlation_image_layers.append(layer_name)
 
         # update the combobox
@@ -1479,11 +1662,15 @@ class FibsemMinimapWidget(QWidget):
         self.comboBox_correlation_selected_layer.addItems(self.correlation_image_layers)
         if idx != -1:
             self.comboBox_correlation_selected_layer.setCurrentIndex(idx)
-        self.comboBox_correlation_selected_layer.currentIndexChanged.connect(self.update_correlation_ui)
+        self.comboBox_correlation_selected_layer.currentIndexChanged.connect(
+            self.update_correlation_ui
+        )
 
         # set the image layer as the active layer
         self.set_active_layer_for_movement()
-        self.correlation_panel.setEnabled(True) # TODO: allow enabling grid-bar overlay separately
+        self.correlation_panel.setEnabled(
+            True
+        )  # TODO: allow enabling grid-bar overlay separately
         self.checkBox_gridbar.setEnabled(True)
         self.pushButton_enable_correlation.setEnabled(True)
 
@@ -1494,28 +1681,38 @@ class FibsemMinimapWidget(QWidget):
         layer_name = self.comboBox_correlation_selected_layer.currentText()
         self.pushButton_enable_correlation.setEnabled(layer_name != "")
         if layer_name == "":
-            notification_service.show_toast("Please select a layer to correlate with update data...")
+            notification_service.show_toast(
+                "Please select a layer to correlate with update data..."
+            )
             return
 
     def _toggle_correlation_mode(self, event: Optional[NapariEvent] = None):
         """Toggle correlation mode on or off."""
         if self.image is None:
-            notification_service.show_toast("Please acquire an image first...", "warning")
+            notification_service.show_toast(
+                "Please acquire an image first...", "warning"
+            )
             return
 
         if not self.correlation_image_layers:
-            notification_service.show_toast("Please load a correlation image first...", "warning")
+            notification_service.show_toast(
+                "Please load a correlation image first...", "warning"
+            )
             return
 
         # toggle correlation mode
         self.correlation_mode_enabled = not self.correlation_mode_enabled
 
         if self.correlation_mode_enabled:
-            self.pushButton_enable_correlation.setStyleSheet(stylesheets.USER_ATTENTION_BUTTON_STYLESHEET)
+            self.pushButton_enable_correlation.setStyleSheet(
+                stylesheets.USER_ATTENTION_BUTTON_STYLESHEET
+            )
             self.pushButton_enable_correlation.setText("Disable Correlation Mode")
             self.comboBox_correlation_selected_layer.setEnabled(False)
         else:
-            self.pushButton_enable_correlation.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+            self.pushButton_enable_correlation.setStyleSheet(
+                stylesheets.SECONDARY_BUTTON_STYLESHEET
+            )
             self.pushButton_enable_correlation.setText("Enable Correlation Mode")
             self.comboBox_correlation_selected_layer.setEnabled(True)
 
@@ -1527,13 +1724,13 @@ class FibsemMinimapWidget(QWidget):
         # get current correlation layer
         layer_name = self.comboBox_correlation_selected_layer.currentText()
         correlation_layer = self.viewer.layers[layer_name]
-        
+
         # set transformation mode on
         if self.correlation_mode_enabled:
-            correlation_layer.mode = 'transform'
+            correlation_layer.mode = "transform"
             self.viewer.layers.selection.active = correlation_layer
         else:
-            correlation_layer.mode = 'pan_zoom'
+            correlation_layer.mode = "pan_zoom"
             self.set_active_layer_for_movement()
 
     def set_active_layer_for_movement(self) -> None:

--- a/tests/test_tiled.py
+++ b/tests/test_tiled.py
@@ -22,10 +22,13 @@ from fibsem.structures import (
 # compute_tile_grid
 # ---------------------------------------------------------------------------
 
+
 def _make_settings(nrows, ncols, hfw=100e-6, resolution=(1024, 1024), overlap=0.0):
     return OverviewAcquisitionSettings(
         image_settings=ImageSettings(resolution=resolution, hfw=hfw),
-        nrows=nrows, ncols=ncols, overlap=overlap,
+        nrows=nrows,
+        ncols=ncols,
+        overlap=overlap,
     )
 
 
@@ -66,7 +69,7 @@ def test_compute_tile_grid_dy_no_overlap():
     hfw = 100e-6
     s = _make_settings(3, 1, hfw=hfw, resolution=(1024, 1024), overlap=0.0)
     tiles = compute_tile_grid(s)
-    assert tiles[1].dy == pytest.approx(-hfw)   # row 1, one step down
+    assert tiles[1].dy == pytest.approx(-hfw)  # row 1, one step down
     assert tiles[2].dy == pytest.approx(-2 * hfw)
 
 
@@ -77,8 +80,8 @@ def test_compute_tile_grid_with_overlap():
     s = _make_settings(2, 2, hfw=hfw, overlap=overlap)
     tiles = compute_tile_grid(s)
     step = hfw * (1 - overlap)
-    assert tiles[1].dx == pytest.approx(step)    # col 1
-    assert tiles[2].dy == pytest.approx(-step)   # row 1 (index 2 in row-major for 2x2)
+    assert tiles[1].dx == pytest.approx(step)  # col 1
+    assert tiles[2].dy == pytest.approx(-step)  # row 1 (index 2 in row-major for 2x2)
 
 
 def test_compute_tile_grid_non_square_dy():
@@ -128,6 +131,7 @@ def test_compute_tile_grid_single_tile():
 # ---------------------------------------------------------------------------
 # order_tiles
 # ---------------------------------------------------------------------------
+
 
 def _grid_3x4():
     return compute_tile_grid(_make_settings(3, 4))
@@ -215,7 +219,15 @@ def test_order_tiles_spiral_same_set():
 
 def test_spiral_order_helper_3x3():
     assert _spiral_order(3, 3) == [
-        (1, 1), (1, 2), (2, 2), (2, 1), (2, 0), (1, 0), (0, 0), (0, 1), (0, 2)
+        (1, 1),
+        (1, 2),
+        (2, 2),
+        (2, 1),
+        (2, 0),
+        (1, 0),
+        (0, 0),
+        (0, 1),
+        (0, 2),
     ]
 
 
@@ -227,12 +239,17 @@ def test_spiral_order_helper_1x1():
 # plot_tile_positions
 # ---------------------------------------------------------------------------
 
+
 def test_plot_tile_positions_returns_figure():
     import matplotlib
+
     matplotlib.use("Agg")
     s = OverviewAcquisitionSettings(
         image_settings=ImageSettings(resolution=(1536, 1024), hfw=150e-6),
-        nrows=3, ncols=4, overlap=0.1, tile_order=TileOrderStrategy.SERPENTINE,
+        nrows=3,
+        ncols=4,
+        overlap=0.1,
+        tile_order=TileOrderStrategy.SERPENTINE,
     )
     tiles = order_tiles(compute_tile_grid(s), s.tile_order)
     fig = plot_tile_positions(tiles, s)
@@ -243,6 +260,7 @@ def test_plot_tile_positions_returns_figure():
 # validate_tile_stage_positions
 # ---------------------------------------------------------------------------
 
+
 def _make_limits(x_max=100e-3, y_max=100e-3):
     return {
         "x": RangeLimit(min=-x_max, max=x_max),
@@ -252,8 +270,10 @@ def _make_limits(x_max=100e-3, y_max=100e-3):
 
 def _make_pairs(positions_xy):
     """Build (TilePosition list, FibsemStagePosition list) from (x, y) tuples."""
-    tiles = [TilePosition(row=i, col=0, dx=0, dy=0, canvas_x=0, canvas_y=0)
-             for i in range(len(positions_xy))]
+    tiles = [
+        TilePosition(row=i, col=0, dx=0, dy=0, canvas_x=0, canvas_y=0)
+        for i in range(len(positions_xy))
+    ]
     stage_positions = [FibsemStagePosition(x=x, y=y) for x, y in positions_xy]
     return tiles, stage_positions
 
@@ -494,9 +514,7 @@ def test_the_grid_is_measured_from_the_centre_it_is_given(tmp_path):
     settings = _make_settings(1, 1)
     settings.image_settings.path = str(tmp_path)
     settings.image_settings.filename = "overview-image"
-    runner = TiledAcquisitionRunner(
-        microscope, settings, centre_position=elsewhere
-    )
+    runner = TiledAcquisitionRunner(microscope, settings, centre_position=elsewhere)
     runner._setup()
     runner._compute_grid()
 
@@ -616,9 +634,15 @@ def test_the_helper_asks_about_the_offsets_the_runner_projects(tmp_path, monkeyp
 def test_a_grid_within_the_travel_is_not_flagged():
     settings = _make_settings(3, 3, hfw=100e-6, resolution=(1024, 1024))
     tiles = compute_tile_grid(settings)
-    assert unreachable_tiles(
-        tiles, settings.tile_order, _identity_projection, _make_limits(150e-6, 150e-6)
-    ) == []
+    assert (
+        unreachable_tiles(
+            tiles,
+            settings.tile_order,
+            _identity_projection,
+            _make_limits(150e-6, 150e-6),
+        )
+        == []
+    )
 
 
 def test_masking_off_what_cannot_be_reached_makes_a_grid_acquirable():
@@ -641,17 +665,24 @@ def test_masking_off_what_cannot_be_reached_makes_a_grid_acquirable():
     assert sorted(flagged) == [(0, 2), (1, 2), (2, 2)]
 
     mask = [[True, True, False] for _ in range(3)]
-    assert unreachable_tiles(
-        compute_tile_grid(settings, mask=mask),
-        settings.tile_order,
-        _identity_projection,
-        limits,
-    ) == []
+    assert (
+        unreachable_tiles(
+            compute_tile_grid(settings, mask=mask),
+            settings.tile_order,
+            _identity_projection,
+            limits,
+        )
+        == []
+    )
 
 
 @pytest.mark.parametrize(
     "strategy",
-    [TileOrderStrategy.TYPEWRITER, TileOrderStrategy.SERPENTINE, TileOrderStrategy.SPIRAL],
+    [
+        TileOrderStrategy.TYPEWRITER,
+        TileOrderStrategy.SERPENTINE,
+        TileOrderStrategy.SPIRAL,
+    ],
 )
 def test_the_traversal_does_not_change_which_tiles_are_out_of_range(strategy):
     """Order decides the sequence, not the reach. Pinned because the check goes through
@@ -696,12 +727,15 @@ def test_a_grid_with_nothing_enabled_is_not_asked_about():
     "nothing is out of range" for it would be true and useless."""
     settings = _make_settings(2, 2)
     mask = [[False, False], [False, False]]
-    assert unreachable_tiles(
-        compute_tile_grid(settings, mask=mask),
-        settings.tile_order,
-        _identity_projection,
-        _make_limits(1e-9, 1e-9),
-    ) == []
+    assert (
+        unreachable_tiles(
+            compute_tile_grid(settings, mask=mask),
+            settings.tile_order,
+            _identity_projection,
+            _make_limits(1e-9, 1e-9),
+        )
+        == []
+    )
 
 
 def test_the_centring_comes_from_the_grid_it_is_given():

--- a/tests/ui/test_minimap_progress_payload_safety.py
+++ b/tests/ui/test_minimap_progress_payload_safety.py
@@ -14,6 +14,7 @@ under the offscreen platform — so the handler is borrowed onto a host carrying
 attributes it touches. The progress bar is a real `QProgressBar`, which is the part
 under test.
 """
+
 from __future__ import annotations
 
 import os
@@ -65,10 +66,10 @@ def test_a_normal_tile_update_still_draws_the_bar(handler):
     "payload",
     [
         {},
-        {"total": 9, "msg": "Tile Collected"},          # no counter
-        {"counter": 3, "msg": "Tile Collected"},        # no total
-        {"counter": 3, "total": 9},                     # no msg
-        {"counter": 0, "total": 0, "msg": "Nothing"},   # nothing to do
+        {"total": 9, "msg": "Tile Collected"},  # no counter
+        {"counter": 3, "msg": "Tile Collected"},  # no total
+        {"counter": 3, "total": 9},  # no msg
+        {"counter": 0, "total": 0, "msg": "Nothing"},  # nothing to do
         {"current": 3, "total": 9, "task": "tileset"},  # the fluorescence spelling
     ],
 )
@@ -100,10 +101,15 @@ def test_a_fluorescence_run_is_not_drawn_into_the_beam_minimap(handler):
     from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
 
     sentinel = object()
-    handler.handle_tile_acquisition_progress({
-        "modality": MODALITY_FLUORESCENCE,
-        "counter": 3, "total": 9, "msg": "Tile Collected", "image": sentinel,
-    })
+    handler.handle_tile_acquisition_progress(
+        {
+            "modality": MODALITY_FLUORESCENCE,
+            "counter": 3,
+            "total": 9,
+            "msg": "Tile Collected",
+            "image": sentinel,
+        }
+    )
     assert handler.shown == [], "a fluorescence mosaic was drawn into the beam minimap"
     assert handler._tiles_acquired == 0, "a fluorescence run moved the beam tile count"
 
@@ -111,10 +117,15 @@ def test_a_fluorescence_run_is_not_drawn_into_the_beam_minimap(handler):
 def test_a_beam_run_is_still_drawn(handler):
     """The filter must not cost the thing it guards."""
     sentinel = object()
-    handler.handle_tile_acquisition_progress({
-        "modality": "beam",
-        "counter": 3, "total": 9, "msg": "Tile Collected", "image": sentinel,
-    })
+    handler.handle_tile_acquisition_progress(
+        {
+            "modality": "beam",
+            "counter": 3,
+            "total": 9,
+            "msg": "Tile Collected",
+            "image": sentinel,
+        }
+    )
     assert handler.shown == [sentinel]
     assert handler._tiles_acquired == 3
 

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -14,6 +14,7 @@ where it matters.
 Run directly (no display needed):
     QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_overview_widget.py
 """
+
 from __future__ import annotations
 
 import os
@@ -92,7 +93,9 @@ def microscope():
     import fibsem.config as fibsem_config
 
     path = os.path.join(
-        os.path.dirname(fibsem_config.__file__), "config", "sim-arctis-configuration.yaml"
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "sim-arctis-configuration.yaml",
     )
     scope, _ = utils.setup_session(manufacturer="Demo", config_path=path)
     assert scope.stage_is_compustage, "the config stopped being a compustage"
@@ -224,8 +227,9 @@ class TestTheInversion:
         # 256 px at this hfw, so the canvas's 512 px cap does not reduce it and only
         # the deliberate reduction below can shrink anything.
         hfw = 256 * 4e-7
-        widget.place_image(_tile(microscope, _at(base), shape=(256, 256), hfw=hfw),
-                           key="a")
+        widget.place_image(
+            _tile(microscope, _at(base), shape=(256, 256), hfw=hfw), key="a"
+        )
         widget.place_image(
             _tile(microscope, _at(base, dx=hfw), shape=(256, 256), hfw=hfw), key="b"
         )
@@ -245,8 +249,9 @@ class TestTheInversion:
         _hold_at(widget, cap)
         big = cap + cap // 2  # over the cap, so it reduces; not so far over it is slow
         hfw = big * 1e-7
-        widget.place_image(_tile(microscope, _at(base), shape=(big, big), hfw=hfw),
-                           key="big")
+        widget.place_image(
+            _tile(microscope, _at(base), shape=(big, big), hfw=hfw), key="big"
+        )
 
         extent = widget.canvas._placed["big"].extent
         drawn_width_m = (extent[1] - extent[0]) * widget.canvas.reference_pixel_size
@@ -314,9 +319,13 @@ class TestTheTwoCaps:
 
         assert wide * wide * 2 <= widget._store_budget_bytes
         assert deep * deep * 3 <= widget._store_budget_bytes
-        assert deep < wide, "a 16-bit detector was given the same pixel count as an 8-bit"
+        assert deep < wide, (
+            "a 16-bit detector was given the same pixel count as an 8-bit"
+        )
 
-    def test_the_budget_holds_the_complained_about_mosaic_whole(self, widget, microscope):
+    def test_the_budget_holds_the_complained_about_mosaic_whole(
+        self, widget, microscope
+    ):
         """The case behind FIB-658: a 5x5 of 1024 px tiles is 5120 px, and the point of
         the budget is that it is held at its acquired resolution rather than reduced."""
         assert widget._store_cap(np.uint8) >= 5 * 1024, (
@@ -428,7 +437,6 @@ class TestOneDerivationForBothDirections:
         x, y = frame.to_canvas(_at(base, 0.0, 0.0))
         assert widget._position_at(x + 4000, y + 4000) is None
 
-
     def test_a_hidden_marker_is_not_a_target(self, widget, microscope):
         """Turned off means gone, not merely invisible.
 
@@ -478,7 +486,8 @@ class TestAnOverviewIsReducedOnce:
         calls = []
         original = widget._stored_tile
         monkeypatch.setattr(
-            widget, "_stored_tile",
+            widget,
+            "_stored_tile",
             lambda image: calls.append(image) or original(image),
         )
 
@@ -503,9 +512,10 @@ class TestAnOverviewIsReducedOnce:
         placed = []
         original = widget._place_on_canvas
         monkeypatch.setattr(
-            widget, "_place_on_canvas",
-            lambda tile, view, **kwargs: placed.append(tile) or original(
-                tile, view, **kwargs
+            widget,
+            "_place_on_canvas",
+            lambda tile, view, **kwargs: (
+                placed.append(tile) or original(tile, view, **kwargs)
             ),
         )
 
@@ -560,7 +570,8 @@ class TestItDoesNotReadHardwareOnUiEvents:
         reads = []
         original = microscope.get_scan_rotation
         monkeypatch.setattr(
-            microscope, "get_scan_rotation",
+            microscope,
+            "get_scan_rotation",
             lambda beam_type: (reads.append(beam_type), original(beam_type))[1],
         )
 
@@ -592,9 +603,12 @@ class TestWhatIsDrawn:
         every point the same, so the selection has to be its own layer."""
         base = microscope.get_stage_position()
         widget.place_image(_tile(microscope, _at(base)))
-        widget.set_positions([
-            _at(base, 0.0, 0.0, "A"), _at(base, 30e-6, 0.0, "B"),
-        ])
+        widget.set_positions(
+            [
+                _at(base, 0.0, 0.0, "A"),
+                _at(base, 30e-6, 0.0, "B"),
+            ]
+        )
         widget.set_selected_position("B")
 
         assert len(widget.position_overlay._points) == 1
@@ -731,10 +745,14 @@ class TestThingsOnlyRunningItFound:
         assert widget.overview_list._list.count() == 1
 
         for i in (1, 2, 3):
-            widget._apply_progress({
-                "msg": "Tile Collected", "counter": i, "total": 3,
-                "preview": _tile(microscope, _at(base)),
-            })
+            widget._apply_progress(
+                {
+                    "msg": "Tile Collected",
+                    "counter": i,
+                    "total": 3,
+                    "preview": _tile(microscope, _at(base)),
+                }
+            )
             row = widget.overview_list._rows["run"]
             assert row.detail_label.text().startswith(f"{i} tile"), (
                 f"after {i} tile(s) the row still reads {row.detail_label.text()!r}"
@@ -768,8 +786,9 @@ class TestTheRunOwnsItsSettings:
     which set the run's output path back to None.
     """
 
-    def test_reading_the_settings_does_not_disturb_a_run(self, widget, microscope,
-                                                         monkeypatch, tmp_path):
+    def test_reading_the_settings_does_not_disturb_a_run(
+        self, widget, microscope, monkeypatch, tmp_path
+    ):
         """The reported sequence, end to end: start a run, then do everything a stage
         move between tiles does, and check the run's settings still name a path.
 
@@ -812,8 +831,9 @@ class TestTheRunOwnsItsSettings:
             "the second tile would die in os.path.join(None, filename)"
         )
 
-    def test_the_runner_gets_its_own_copy_of_the_settings(self, widget, microscope,
-                                                          monkeypatch, tmp_path):
+    def test_the_runner_gets_its_own_copy_of_the_settings(
+        self, widget, microscope, monkeypatch, tmp_path
+    ):
         """Even with nothing else reading, handing a background runner the widget's own
         instance means any later edit reaches into a run in progress."""
         captured = {}
@@ -857,9 +877,7 @@ class TestTheRunOwnsItsSettings:
         An empty box is also what made `get_settings()` read the path back as None.
         """
         widget.set_save_directory(str(tmp_path))
-        assert widget.settings_widget.path_edit.text() == str(
-            tmp_path
-        )
+        assert widget.settings_widget.path_edit.text() == str(tmp_path)
         assert widget._settings().image_settings.path == str(tmp_path)
 
     def test_a_run_always_has_somewhere_to_write(self, widget, monkeypatch):
@@ -919,10 +937,7 @@ class TestTheRunOwnsItsSettings:
         widget.acquire()
         assert captured["settings"].image_settings.filename.startswith("overview-image")
         # And visible, so it can be changed before a run rather than discovered after.
-        assert (
-            widget.settings_widget.filename_edit.text()
-            == "overview-image"
-        )
+        assert widget.settings_widget.filename_edit.text() == "overview-image"
 
     def test_a_run_starts_from_the_overview_defaults(self, widget, monkeypatch):
         """A 500 um tile with autocontrast, not `ImageSettings`'s generic 150 um.
@@ -1077,7 +1092,9 @@ class TestViews:
     def _image(self, scope, orientation, beam_type, dx=0.0):
         position = self._at_orientation(scope, orientation, dx)
         image = FibsemImage.generate_blank_image(resolution=(128, 128), hfw=128 * 2e-7)
-        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(np.uint8)
+        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(
+            np.uint8
+        )
         state = scope.get_microscope_state(beam_type=beam_type)
         state.stage_position = position
         image.metadata.image_settings = ImageSettings(
@@ -1124,7 +1141,9 @@ class TestViews:
         assert widget.show_view(sem_view) is True
         assert widget.current_view == sem_view
         assert len(widget.canvas.placed_keys) == 2, "the SEM images did not come back"
-        assert widget.show_view(sem_view) is False, "switching to the current view is a no-op"
+        assert widget.show_view(sem_view) is False, (
+            "switching to the current view is a no-op"
+        )
 
     def test_each_view_keeps_its_own_origin(self, widget):
         """Everything in a view is placed relative to that view's anchor. One shared
@@ -1212,7 +1231,9 @@ class TestViews:
         scope = widget.microscope
         widget._stage_position = self._at_orientation(scope, "SEM")
         widget.set_image(self._image(scope, "SEM", BeamType.ELECTRON))
-        assert widget._stage_position_at(0.0, 0.0) is not None, "blocked in its own view"
+        assert widget._stage_position_at(0.0, 0.0) is not None, (
+            "blocked in its own view"
+        )
 
         widget._stage_position = self._at_orientation(scope, "FIB")
         assert widget._stage_position_at(0.0, 0.0) is None, (
@@ -1410,7 +1431,9 @@ class TestOverlaysAreDrawnInTheView:
         position = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
         hfw = 128 * 2e-7
         image = FibsemImage.generate_blank_image(resolution=(128, 128), hfw=hfw)
-        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(np.uint8)
+        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(
+            np.uint8
+        )
         state = scope.get_microscope_state(beam_type=beam_type)
         state.stage_position = position
         image.metadata.image_settings = ImageSettings(hfw=hfw, beam_type=beam_type)
@@ -1467,7 +1490,9 @@ class TestOverlaysAreDrawnInTheView:
         assert abs(corner[0] - box.cx) == pytest.approx(box.width / 2, rel=1e-9)
         assert abs(corner[1] - box.cy) == pytest.approx(box.height / 2, rel=1e-9)
 
-    def test_the_limits_box_is_shorter_in_a_foreshortened_view(self, widget, microscope):
+    def test_the_limits_box_is_shorter_in_a_foreshortened_view(
+        self, widget, microscope
+    ):
         """The bug, pinned. The box was `frame.length(ymax - ymin)` in every view, so
         it was the same height at the milling pose as at the SEM one -- nearly four
         times too tall in the view you mill in."""
@@ -1580,7 +1605,8 @@ class TestTheHolderIsDrawnOnEveryStage:
         from fibsem.microscopes._stage import GridSlot
 
         return GridSlot(
-            name=name, index=0,
+            name=name,
+            index=0,
             position=FibsemStagePosition(name=name, x=x, y=y, z=0.0),
         )
 
@@ -1591,16 +1617,21 @@ class TestTheHolderIsDrawnOnEveryStage:
         a `property` object where a dict belongs.
         """
         holder = widget.microscope._stage.holder
-        slots = {"Slot-01": self._slot("Slot-01", -5.0e-3),
-                 "Slot-02": self._slot("Slot-02", 5.0e-3)}
+        slots = {
+            "Slot-01": self._slot("Slot-01", -5.0e-3),
+            "Slot-02": self._slot("Slot-02", 5.0e-3),
+        }
         monkeypatch.setattr(holder, "slots", slots)
         widget._refresh_context_overlays()
         return slots
 
     @staticmethod
     def _specs(widget, kind, label=None):
-        return [s for s in widget.context_overlay._specs
-                if s.kind == kind and (label is None or s.label == label)]
+        return [
+            s
+            for s in widget.context_overlay._specs
+            if s.kind == kind and (label is None or s.label == label)
+        ]
 
     def test_the_travel_box_draws_on_a_stage_that_is_not_a_compustage(
         self, widget, microscope, monkeypatch
@@ -1640,15 +1671,18 @@ class TestTheHolderIsDrawnOnEveryStage:
         with a shuttle that is 10 mm across, a full grid's width from either of them."""
         self._two_slots(widget, monkeypatch)
         boundaries = self._specs(widget, "ellipse", "Grid Boundary")
-        crosshairs = [s for s in self._specs(widget, "crosshair")
-                      if s.label.startswith("Slot-")]
+        crosshairs = [
+            s for s in self._specs(widget, "crosshair") if s.label.startswith("Slot-")
+        ]
 
         centres = sorted((round(s.cx, 6), round(s.cy, 6)) for s in boundaries)
         markers = sorted((round(s.cx, 6), round(s.cy, 6)) for s in crosshairs)
         assert centres == markers, "a boundary is not concentric with its slot marker"
         assert len({c[0] for c in centres}) == 2, "both circles landed in one place"
 
-    def test_a_slot_carries_the_orientation_it_was_defined_in(self, widget, monkeypatch):
+    def test_a_slot_carries_the_orientation_it_was_defined_in(
+        self, widget, monkeypatch
+    ):
         """The holder file is written in the SEM orientation, so that is the pose a
         slot has to carry. Without it the position is a bare x/y and `to_canvas` has
         nothing to compare against -- which is both why the shipped holder crashed and
@@ -1674,8 +1708,9 @@ class TestTheHolderIsDrawnOnEveryStage:
         """The compustage case, unchanged: one slot at the origin, one circle on it.
         The simulator's own holder, so this is the behaviour that shipped."""
         boundaries = self._specs(widget, "ellipse", "Grid Boundary")
-        crosshairs = [s for s in self._specs(widget, "crosshair")
-                      if s.label.startswith("Slot-")]
+        crosshairs = [
+            s for s in self._specs(widget, "crosshair") if s.label.startswith("Slot-")
+        ]
 
         assert len(boundaries) == 1
         assert (boundaries[0].cx, boundaries[0].cy) == pytest.approx(
@@ -1861,8 +1896,11 @@ class TestThePlannedTileset:
         """
         origin = widget._origins[widget.current_view]
         drifted = FibsemStagePosition(
-            x=origin.x, y=origin.y, z=origin.z,
-            r=origin.r, t=origin.t + np.deg2rad(0.4),
+            x=origin.x,
+            y=origin.y,
+            z=origin.z,
+            r=origin.r,
+            t=origin.t + np.deg2rad(0.4),
         )
         widget._stage_position = drifted
 
@@ -1985,10 +2023,14 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
     def _run_a_tile(self, widget, microscope, position):
         """One tile of a run: the stage arrives, then a preview lands."""
         widget._on_stage_moved(position)
-        widget._apply_progress({
-            "msg": "Tile Collected", "counter": 1, "total": 3,
-            "preview": _tile(microscope, position),
-        })
+        widget._apply_progress(
+            {
+                "msg": "Tile Collected",
+                "counter": 1,
+                "total": 3,
+                "preview": _tile(microscope, position),
+            }
+        )
 
     def test_the_planned_grid_does_not_follow_the_stage(self, widget, microscope):
         from fibsem.ui.widgets.overview_widget import OverviewRecord
@@ -2047,7 +2089,9 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         widget.place_image(_tile(microscope, _at(base, dx=100e-6)), key="preview")
         widget.place_image(_tile(microscope, _at(base, dx=200e-6)), key="preview")
 
-        assert calls == [], f"{len(calls)} overlay refresh(es) for images already framed"
+        assert calls == [], (
+            f"{len(calls)} overlay refresh(es) for images already framed"
+        )
 
     def test_the_plan_is_pinned_to_what_the_run_is_acquiring(
         self, widget, microscope, monkeypatch, tmp_path
@@ -2061,6 +2105,7 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         against a real 3x3 run of 80 um tiles, one tile off, and it stayed there for the
         rest of the acquisition. So a run pins the centre it was started with.
         """
+
         def fake_worker(fn, *args):
             class _W:
                 def start(self_inner):
@@ -2082,10 +2127,14 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         # The stage sets off, and the first preview arrives from a tile away -- which is
         # the redraw, because it is what un-provisions the origin.
         widget._on_stage_moved(_at(base, dx=300e-6, dy=300e-6))
-        widget._apply_progress({
-            "msg": "Tile Collected", "counter": 1, "total": 9,
-            "preview": _tile(microscope, _at(base)),
-        })
+        widget._apply_progress(
+            {
+                "msg": "Tile Collected",
+                "counter": 1,
+                "total": 9,
+                "preview": _tile(microscope, _at(base)),
+            }
+        )
 
         assert widget.tile_grid_overlay._anchor() == pytest.approx(anchored_at), (
             "the plan was redrawn around the tile being acquired, not around the run"
@@ -2159,7 +2208,8 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         )
         monkeypatch.setattr(
             overview_confirmation_dialog.OverviewConfirmationDialog,
-            "exec_", moves_the_stage,
+            "exec_",
+            moves_the_stage,
         )
 
         widget.acquire()
@@ -2206,10 +2256,14 @@ class TestARunDoesNotReFrameTheCanvas:
         widget._active_record = "run"
         widget._set_running(True)
         for counter in range(1, tiles + 1):
-            widget._apply_progress({
-                "msg": "Tile Collected", "counter": counter, "total": tiles,
-                "preview": _tile(microscope, _at(base)),
-            })
+            widget._apply_progress(
+                {
+                    "msg": "Tile Collected",
+                    "counter": counter,
+                    "total": tiles,
+                    "preview": _tile(microscope, _at(base)),
+                }
+            )
         widget._mosaic = _tile(microscope, _at(base), shape=(128, 128))
         widget._on_finished({})
 
@@ -2303,7 +2357,9 @@ class TestTheCanvasFollowsTheBeamYouPlanWith:
         position = scope.get_stage_position()
         hfw = 128 * 2e-7
         image = FibsemImage.generate_blank_image(resolution=(128, 128), hfw=hfw)
-        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(np.uint8)
+        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(
+            np.uint8
+        )
         state = scope.get_microscope_state(beam_type=beam_type)
         state.stage_position = position
         image.metadata.image_settings = ImageSettings(hfw=hfw, beam_type=beam_type)
@@ -2327,10 +2383,14 @@ class TestTheCanvasFollowsTheBeamYouPlanWith:
         assert len(widget.canvas.placed_keys) == 1
 
         widget.settings_widget.combo_beam.set_value(BeamType.ION)
-        assert len(widget.canvas.placed_keys) == 0, "the ion view is empty, as it should be"
+        assert len(widget.canvas.placed_keys) == 0, (
+            "the ion view is empty, as it should be"
+        )
 
         widget.settings_widget.combo_beam.set_value(BeamType.ELECTRON)
-        assert len(widget.canvas.placed_keys) == 1, "the electron overview did not come back"
+        assert len(widget.canvas.placed_keys) == 1, (
+            "the electron overview did not come back"
+        )
 
     def test_re_posing_the_stage_moves_the_canvas_with_it(self, widget, microscope):
         """Reported from the tab: moving to the milling orientation left the display and
@@ -2351,7 +2411,9 @@ class TestTheCanvasFollowsTheBeamYouPlanWith:
         assert widget.current_view.orientation == "MILLING"
         assert widget.tile_grid_overlay._tiles, "the planned grid did not come with it"
 
-    def test_a_move_within_an_orientation_leaves_the_view_alone(self, widget, microscope):
+    def test_a_move_within_an_orientation_leaves_the_view_alone(
+        self, widget, microscope
+    ):
         """The other half, and why following an orientation change is safe: steering
         around inside a view -- which is what clicking the canvas does -- must not
         reshuffle what is on screen."""
@@ -2361,7 +2423,9 @@ class TestTheCanvasFollowsTheBeamYouPlanWith:
 
         here = microscope.get_stage_position()
         widget._on_stage_moved(
-            FibsemStagePosition(x=here.x + 250e-6, y=here.y, z=here.z, r=here.r, t=here.t)
+            FibsemStagePosition(
+                x=here.x + 250e-6, y=here.y, z=here.z, r=here.r, t=here.t
+            )
         )
         assert widget.current_view == showing
         assert len(widget.canvas.placed_keys) == placed
@@ -2384,7 +2448,9 @@ class TestTheCanvasFollowsTheBeamYouPlanWith:
         widget._refresh_context_overlays()
         assert widget.current_view == sem, "the redraw undid the choice"
 
-    def test_the_view_the_run_would_land_in_is_always_selectable(self, widget, microscope):
+    def test_the_view_the_run_would_land_in_is_always_selectable(
+        self, widget, microscope
+    ):
         """And when a stage move does take the plan elsewhere, there has to be a way to
         go and look at it -- the selector only listed views something had been placed
         in, so an empty one was unreachable."""
@@ -2421,7 +2487,9 @@ class TestTheViewChips:
         position = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
         hfw = 128 * 2e-7
         image = FibsemImage.generate_blank_image(resolution=(128, 128), hfw=hfw)
-        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(np.uint8)
+        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(
+            np.uint8
+        )
         state = scope.get_microscope_state(beam_type=beam_type)
         state.stage_position = position
         image.metadata.image_settings = ImageSettings(hfw=hfw, beam_type=beam_type)
@@ -2440,7 +2508,9 @@ class TestTheViewChips:
             ("SEM", BeamType.ION, "FIB @ SEM"),
         ],
     )
-    def test_a_view_names_both_facts_in_the_same_shape(self, orientation, beam, expected):
+    def test_a_view_names_both_facts_in_the_same_shape(
+        self, orientation, beam, expected
+    ):
         """Beam then orientation, always both. Dropping the orientation when it matched
         the beam read well until you met the ones it kept, and then "FIB · SEM pose" had
         to be decoded rather than read."""
@@ -2454,7 +2524,9 @@ class TestTheViewChips:
     def test_orientations_are_shown_as_the_microscope_names_them(self):
         """Title-casing rendered the two acronyms as "Sem" and "Fib"; casing by rule
         instead means a rule to remember, and a new orientation to add to it."""
-        assert OverviewView(beam_type=BeamType.ION, orientation="SEM").label == "FIB @ SEM"
+        assert (
+            OverviewView(beam_type=BeamType.ION, orientation="SEM").label == "FIB @ SEM"
+        )
         assert (
             OverviewView(beam_type=BeamType.ION, orientation="MILLING").label
             == "FIB @ MILLING"
@@ -2494,11 +2566,15 @@ class TestTheViewChips:
         assert widget.current_view == sem
         assert len(widget.canvas.placed_keys) == 1, "the overview did not come back"
 
-    def test_the_chip_for_the_displayed_view_is_the_checked_one(self, widget, microscope):
+    def test_the_chip_for_the_displayed_view_is_the_checked_one(
+        self, widget, microscope
+    ):
         widget.set_image(self._image(microscope, "SEM", BeamType.ELECTRON))
         widget.settings_widget.combo_beam.set_value(BeamType.ION)
 
-        checked = {b.text() for b in widget._view_chip_buttons.values() if b.isChecked()}
+        checked = {
+            b.text() for b in widget._view_chip_buttons.values() if b.isChecked()
+        }
         assert checked == {widget.current_view.label}
 
     def test_the_view_the_run_would_land_in_is_marked_apart(self, widget, microscope):
@@ -2549,7 +2625,9 @@ class TestTheViewChips:
         ]
         before = widget.minimumSizeHint().width()
         monkeypatch.setattr(
-            type(widget), "views", property(lambda self: views)  # read-only
+            type(widget),
+            "views",
+            property(lambda self: views),  # read-only
         )
         widget._refresh_view_selector()
         _app.processEvents()
@@ -2638,10 +2716,13 @@ class TestTheMillingAngleIsOnTheBeamTab:
         assert widget.canvas._info_text != before
         assert "milling" in widget.canvas._info_text
 
-    def test_a_pose_with_no_tilt_drops_the_angle_not_the_line(self, widget, monkeypatch):
+    def test_a_pose_with_no_tilt_drops_the_angle_not_the_line(
+        self, widget, monkeypatch
+    ):
         """It can refuse, and the position is the half of the line that always works."""
         monkeypatch.setattr(
-            widget.microscope, "get_current_milling_angle",
+            widget.microscope,
+            "get_current_milling_angle",
             lambda **kwargs: (_ for _ in ()).throw(ValueError("no tilt")),
         )
         widget._refresh_stage_info()
@@ -2652,7 +2733,8 @@ class TestTheMillingAngleIsOnTheBeamTab:
         """This runs on every overlay refresh. `get_current_milling_angle` is arithmetic
         over the pose it is handed -- but only if it is handed one."""
         monkeypatch.setattr(
-            microscope, "get_stage_position",
+            microscope,
+            "get_stage_position",
             lambda *a, **k: pytest.fail("the info bar polled the stage"),
         )
         widget._refresh_stage_info()
@@ -2697,9 +2779,7 @@ class TestARunIsConfirmedFirst:
         assert len(confirmations) == 1, "the run started without asking"
         assert "args" in captured, "the run was refused after the dialog was accepted"
 
-    def test_declining_leaves_everything_as_it_was(
-        self, widget, monkeypatch, tmp_path
-    ):
+    def test_declining_leaves_everything_as_it_was(self, widget, monkeypatch, tmp_path):
         """Not merely "no worker": a refused run must leave no record behind either, or
         the overview list grows a row for something that never happened."""
         captured = {}
@@ -2792,7 +2872,8 @@ class TestARunIsConfirmedFirst:
             self._fake_worker(captured),
         )
         monkeypatch.setattr(
-            widget.microscope, "get_stage_position",
+            widget.microscope,
+            "get_stage_position",
             lambda *a, **k: pytest.fail("the confirmation dialog polled the stage"),
         )
         widget.acquire()
@@ -3094,7 +3175,9 @@ class TestTheAcquisitionButtons:
         scrolled = scroll.widget()
         for name in ("button_acquire", "button_cancel", "progress", "label_status"):
             child = getattr(widget, name)
-            assert not scrolled.isAncestorOf(child), f"{name} scrolls away with the column"
+            assert not scrolled.isAncestorOf(child), (
+                f"{name} scrolls away with the column"
+            )
 
     def test_they_stay_on_screen_in_a_window_too_short_for_the_column(
         self, microscope, qapp
@@ -3153,10 +3236,14 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
         )
 
         data = self._partial()
-        rgba = _as_colour_and_coverage(data, data > 0, _contrast_limits(data.astype(float), data > 0))
+        rgba = _as_colour_and_coverage(
+            data, data > 0, _contrast_limits(data.astype(float), data > 0)
+        )
         alpha = rgba[..., 3]
-        assert (alpha[: data.shape[0] // 3] == 255).all(), "acquired tiles went see-through"
-        assert (alpha[data.shape[0] // 3:] == 0).all(), (
+        assert (alpha[: data.shape[0] // 3] == 255).all(), (
+            "acquired tiles went see-through"
+        )
+        assert (alpha[data.shape[0] // 3 :] == 0).all(), (
             "unacquired ground is still opaque, so it paints over what is beneath"
         )
 
@@ -3170,7 +3257,9 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
         )
 
         data = np.array([[1, 40, 128, 255]], dtype=np.uint8)
-        rgba = _as_colour_and_coverage(data, data > 0, _contrast_limits(data.astype(float), data > 0))
+        rgba = _as_colour_and_coverage(
+            data, data > 0, _contrast_limits(data.astype(float), data > 0)
+        )
         assert (rgba[..., 3] == 255).all(), (
             f"alpha followed intensity: {rgba[..., 3].tolist()}"
         )
@@ -3183,7 +3272,12 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
         )
 
         data = np.zeros((16, 16), dtype=np.uint8)
-        assert (_as_colour_and_coverage(data, data > 0, _contrast_limits(data.astype(float), data > 0))[..., 3] == 0).all()
+        assert (
+            _as_colour_and_coverage(
+                data, data > 0, _contrast_limits(data.astype(float), data > 0)
+            )[..., 3]
+            == 0
+        ).all()
 
     def test_the_unacquired_zeros_do_not_set_the_contrast(self):
         """They are most of a part-finished mosaic and they are not drawn, so letting
@@ -3196,7 +3290,9 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
 
         data = self._partial()
         acquired = data > 0
-        grey = _as_colour_and_coverage(data, acquired, _contrast_limits(data.astype(float), acquired))[..., 0][acquired]
+        grey = _as_colour_and_coverage(
+            data, acquired, _contrast_limits(data.astype(float), acquired)
+        )[..., 0][acquired]
         assert grey.mean() == pytest.approx(128, abs=25), (
             f"the acquired tiles render at a mean of {grey.mean():.0f}/255"
         )
@@ -3212,8 +3308,11 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
 
         rng = np.random.default_rng(11)
         data = (rng.random((64, 64)) * 110 + 90).astype(np.uint8)
-        rgba = _as_colour_and_coverage(data, np.ones_like(data, dtype=bool),
-                                       _contrast_limits(data.astype(float), np.ones_like(data, dtype=bool)))
+        rgba = _as_colour_and_coverage(
+            data,
+            np.ones_like(data, dtype=bool),
+            _contrast_limits(data.astype(float), np.ones_like(data, dtype=bool)),
+        )
         assert (rgba[..., 3] == 255).all()
         assert rgba[..., 0].min() == 0 and rgba[..., 0].max() == 255
 
@@ -3256,7 +3355,9 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
         assert shown.ndim == 3 and shown.shape[-1] == 4, (
             f"the canvas was handed {shown.shape}, so it composites opaquely"
         )
-        assert shown[..., 3].min() == 0, "no part of a half-finished mosaic is transparent"
+        assert shown[..., 3].min() == 0, (
+            "no part of a half-finished mosaic is transparent"
+        )
 
 
 class TestTwoRunsCannotLandOnEachOther:
@@ -3334,10 +3435,7 @@ class TestTwoRunsCannotLandOnEachOther:
         """Stamped at the run, not in the control: a box that rewrote itself on every
         acquisition would make the name unusable as a thing you set once."""
         self._capture(widget, monkeypatch, tmp_path)
-        assert (
-            widget.settings_widget.filename_edit.text()
-            == "overview-image"
-        )
+        assert widget.settings_widget.filename_edit.text() == "overview-image"
 
     def test_the_dialog_reports_where_it_will_actually_land(
         self, widget, monkeypatch, tmp_path, confirmations
@@ -3390,7 +3488,9 @@ class TestContrastActsOnEveryOverview:
         before = self._drawn(widget, key)[..., 0].astype(float).std()
         self._narrow(widget)
         after = self._drawn(widget, key)[..., 0].astype(float).std()
-        assert after > before * 1.2, f"contrast did nothing: {before:.1f} -> {after:.1f}"
+        assert after > before * 1.2, (
+            f"contrast did nothing: {before:.1f} -> {after:.1f}"
+        )
 
     def test_contrast_cannot_change_what_was_acquired(self, widget, microscope):
         """The invariant. Alpha is coverage, not brightness: run the same curve over it
@@ -3578,7 +3678,9 @@ class TestAnOverviewIsDrawnFromWhatIsHeld:
         assert np.asarray(tile.acquired).dtype == np.bool_
         assert tile.clim[0] < tile.clim[1]
 
-    def test_zooming_in_recovers_detail_it_could_not_have_held(self, widget, microscope):
+    def test_zooming_in_recovers_detail_it_could_not_have_held(
+        self, widget, microscope
+    ):
         """The payoff, stated exactly: framed whole you see the *draw* cap's worth, and
         zoomed in you see everything *held*. Under a store-time reduction the two are
         necessarily the same number, so a zoom could only magnify.
@@ -3777,11 +3879,19 @@ class TestTheOverlaysCanBeTurnedOff:
         says which part of the sample you are looking at. Hiding it would make the
         canvas harder to read rather than cleaner."""
         base = microscope.get_stage_position()
-        widget.set_positions([
-            FibsemStagePosition(name=f"L{i}", x=base.x + i * 20e-6, y=base.y,
-                                z=base.z, r=base.r, t=base.t)
-            for i in range(3)
-        ])
+        widget.set_positions(
+            [
+                FibsemStagePosition(
+                    name=f"L{i}",
+                    x=base.x + i * 20e-6,
+                    y=base.y,
+                    z=base.z,
+                    r=base.r,
+                    t=base.t,
+                )
+                for i in range(3)
+            ]
+        )
         assert len(widget.position_overlay._points) == 3
 
         widget.overlay_controls.set_visible("positions", False)
@@ -3789,7 +3899,9 @@ class TestTheOverlaysCanBeTurnedOff:
         assert widget.position_overlay._points == []
         assert len(widget.current_position_overlay._points) == 1
 
-    def test_the_grid_bar_pitch_controls_match_the_checkbox_from_the_start(self, widget):
+    def test_the_grid_bar_pitch_controls_match_the_checkbox_from_the_start(
+        self, widget
+    ):
         """They were live from construction over a lattice that was not drawn, because
         the toggle handler had never run -- so adjusting them appeared to do nothing."""
         assert widget.overlay_controls.is_visible("gridbars") is False
@@ -4010,18 +4122,26 @@ class TestItOnlyDrawsItsOwnRuns:
         from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
 
         widget._tiles_acquired = 0
-        widget._apply_progress({
-            "modality": MODALITY_FLUORESCENCE,
-            "counter": 7, "total": 9, "msg": "Tile Collected",
-        })
+        widget._apply_progress(
+            {
+                "modality": MODALITY_FLUORESCENCE,
+                "counter": 7,
+                "total": 9,
+                "msg": "Tile Collected",
+            }
+        )
         assert widget._tiles_acquired == 0, "a fluorescence run moved this tab's count"
 
     def test_a_beam_run_is_still_drawn(self, widget):
         widget._tiles_acquired = 0
-        widget._apply_progress({
-            "modality": "beam",
-            "counter": 7, "total": 9, "msg": "Tile Collected",
-        })
+        widget._apply_progress(
+            {
+                "modality": "beam",
+                "counter": 7,
+                "total": 9,
+                "msg": "Tile Collected",
+            }
+        )
         assert widget._tiles_acquired == 7
 
     def test_an_unlabelled_run_is_still_drawn(self, widget):

--- a/tests/ui/test_status_bar_tile_outcome.py
+++ b/tests/ui/test_status_bar_tile_outcome.py
@@ -10,6 +10,7 @@ The window cannot be constructed here — it builds the napari minimap, and a
 a host holding a real `FibsemProgressWidget`. That is enough: the handler's whole job is
 turning a payload into a rendered bar, and the bar here is the real one.
 """
+
 from __future__ import annotations
 
 import os
@@ -65,7 +66,9 @@ def test_a_completed_run_says_done(status):
 
 
 def test_a_cancelled_run_does_not_claim_to_have_finished(status):
-    status._on_tile_acquisition_progress(_terminal("cancelled", "Acquisition Cancelled"))
+    status._on_tile_acquisition_progress(
+        _terminal("cancelled", "Acquisition Cancelled")
+    )
     assert "Cancelled" in _text(status)
     assert "Done" not in _text(status)
 
@@ -73,7 +76,9 @@ def test_a_cancelled_run_does_not_claim_to_have_finished(status):
 def test_a_cancelled_run_is_not_painted_as_a_failure(status):
     """A cancel is someone getting what they asked for, so the bar does not go red —
     the distinction FIB-375 drew between a completed operation and a failed one."""
-    status._on_tile_acquisition_progress(_terminal("cancelled", "Acquisition Cancelled"))
+    status._on_tile_acquisition_progress(
+        _terminal("cancelled", "Acquisition Cancelled")
+    )
     assert not _is_red(status)
 
 


### PR DESCRIPTION
`ruff format` only. No behaviour, no logic, no renames.

**First of four stacked PRs** for the typed tiled-progress contract. Split out ahead of the work so the three behind it carry signal rather than churn: the format-on-touch lint gate reformats a file the moment anything in it is edited, and these five carry ~1080 lines of pre-existing debt between them — against ~180 lines of actual change in the PR that follows.

### Reviewing this

Read the message, not the diff. I verified it behaviour-preserving at the AST level rather than by eye: every file parses to an identical tree, with one exception that is not one — a single docstring in `FibsemMinimapWidget` whose continuation lines were re-indented, which moves `__doc__` whitespace and nothing else.

Checked by comparing `ast.dump` before and after for all five files. Node counts match exactly (8404 for `FibsemMinimapWidget.py`); of its 300 string constants, exactly one differs, and it is a docstring.

### Verification

- 276 passed on this commit alone (`test_tiled`, `test_minimap_progress_payload_safety`, `test_status_bar_tile_outcome`, `test_overview_widget`)
- `ruff check` and `ruff format --check` clean