### PR TITLE
[refactor] Declare a typed contract for tiled acquisition progress (FIB-402)

### DIFF
--- a/fibsem/imaging/tiling/progress.py
+++ b/fibsem/imaging/tiling/progress.py
@@ -28,9 +28,39 @@ Use :func:`is_modality`, not `payload["modality"]`. The key is new, and a consum
 demands it would ignore every payload emitted by an older producer -- including anything
 outside this repository subscribing to a public signal. Absent means beam, which is what
 it was before this existed.
+
+# The typed contract (FIB-402)
+
+`TiledStatus` and `TiledProgress` below are what replaces the dict. They are unused for
+now: producers still emit dicts and consumers still read them, and the two live side by
+side until the consumers move (PR 2) and the producers flip (PR 3).
+
+One class, not a hierarchy of one per payload shape. Every consumer asks the same three
+questions -- is this mine, does it carry counts, is there something to draw -- and none
+of them dispatches on an exhaustive set of types, so a set of types buys nothing that
+optional fields do not. A hierarchy also has a failure mode a flat record does not: a
+`isinstance(event, Terminal)` that quietly misses a sibling class is a run that never
+finishes, with no error anywhere.
+
+`modality` is a field and only a field, for the same reason. Encoding it in the type as
+well -- a `BeamTileCompleted` alongside a `FluorescenceTileCompleted` -- gives two
+discriminators that can disagree, and the one that disagrees silently paints a
+fluorescence mosaic into the beam overview.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    # Annotation-only, so this module stays free of a runtime dependency on either image
+    # type. `fibsem.microscope` imports it to type the signal, and it is imported in turn
+    # by both producers -- a runtime import here would put `fibsem.fm.structures` in the
+    # path of every one of them for a name that is never called.
+    from fibsem.fm.structures import FluorescenceImage
+    from fibsem.structures import FibsemImage
 
 # The beam tiler: SEM or FIB, since no consumer distinguishes them -- both draw into the
 # same overview.
@@ -38,7 +68,141 @@ MODALITY_BEAM = "beam"
 # The fluorescence tileset runner.
 MODALITY_FLUORESCENCE = "fluorescence"
 
-__all__ = ["MODALITY_BEAM", "MODALITY_FLUORESCENCE", "modality_of", "is_modality"]
+__all__ = [
+    "MODALITY_BEAM",
+    "MODALITY_FLUORESCENCE",
+    "TiledStatus",
+    "TiledProgress",
+    "modality_of",
+    "is_modality",
+]
+
+
+class TiledStatus(str, Enum):
+    """Where a tiled run has got to.
+
+    One vocabulary covering the whole run rather than a phase enum plus an outcome enum.
+    Splitting them means a consumer needs both fields to know whether a run is over, and
+    the two overlap on the word "finished" -- which is what the split was protecting
+    against in the first place. Both members survive here under names that cannot be
+    confused: `TILES_ACQUIRED` is the runner saying the last tile is in and the stage is
+    parked, `FINISHED` is the whole run being over, mosaic written.
+
+    A `str` mixin so a member compares equal to its own value: these are persisted
+    nowhere, but they do end up in log lines, and `"finished"` reads better than
+    `TiledStatus.FINISHED`.
+    """
+
+    # The run's opening report: nothing acquired, how many there are to do, and an ETA
+    # if the producer has one. One member for both producers even though they reach it
+    # differently -- the beam tiler before it computes the grid, the fluorescence runner
+    # after -- because what a consumer does with it is identical.
+    STARTING = "starting"
+    MOVING = "moving"
+    # A tile is beginning. Deliberately not a progress report: emitted *before* the tile,
+    # a count taken from it is always one short, and a bar driven off it stopped at 3/4
+    # for a whole four-tile run (FIB-736).
+    TILE_STARTED = "tile-started"
+    # A tile is in and painted into the mosaic. The one report per tile that carries
+    # counts, and the only one that carries a preview.
+    TILE_COLLECTED = "tile-collected"
+    # The runner is done and the stage is back where it started. Not the end of the run:
+    # the mosaic still has to be stitched and written, and on the fluorescence side those
+    # happen in the widget rather than the runner.
+    TILES_ACQUIRED = "tiles-acquired"
+    STITCHING = "stitching"
+    SAVING = "saving"
+    FINISHED = "finished"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether this ends the run.
+
+        On the status rather than restated at each consumer. Three of them need the
+        question answered, and a membership tuple copied into three files is a tuple
+        that drifts -- the next status added to the enum is one somebody forgets to add
+        to one of them, and the symptom is a progress bar that never clears.
+        """
+        return self in _TERMINAL_STATUSES
+
+
+_TERMINAL_STATUSES = frozenset(
+    {TiledStatus.FINISHED, TiledStatus.CANCELLED, TiledStatus.FAILED}
+)
+
+
+# `eq=False`, so equality and hashing stay identity-based.
+#
+# The generated `__eq__` compares every field, and `preview` holds an image whose own
+# `__eq__` compares a numpy array elementwise -- `FluorescenceImage` is a dataclass, so
+# it has one. Comparing two events then raises `ValueError: truth value of an array with
+# more than one element is ambiguous`, and only sometimes: comparing an event to *itself*
+# short-circuits on identity and returns True, so the naive test passes and the failure
+# waits for two distinct events. `hash()` raises `TypeError` outright. Identity semantics
+# are both honest and what a one-shot progress report actually wants.
+@dataclass(frozen=True, eq=False)
+class TiledProgress:
+    """One report from a tiled acquisition.
+
+    Most fields are absent on most reports, and that is the point: a stage move carries
+    no counts, a tile carries no error, and a consumer reads whichever it understands.
+    `status` is the only thing every report has, and it is the only required field --
+    which is also what keeps this constructible on Python 3.8, where `kw_only` does not
+    exist and required fields have to come first.
+
+    Tile indices are 0-based on the wire, matching every other index in the codebase.
+    `display_tile` is the only thing that adds one.
+    """
+
+    status: TiledStatus
+    modality: str = MODALITY_BEAM
+    # Tiles **completed**, not the tile in flight. The beam tiler increments and then
+    # emits, so its count has always meant this; the fluorescence side used to say it
+    # twice per tile with two meanings, and a consumer choosing between them got a bar
+    # that changed scale at every boundary (FIB-736, FIB-739).
+    completed: Optional[int] = None
+    # Tiles that will actually be acquired, not grid cells: a progress bar that stops at
+    # 9/25 on a successful sparse run reads as a failure.
+    total: Optional[int] = None
+    # The mosaic so far, as a placeable image -- whole canvas rather than the single
+    # tile, so the receiver needs no state of its own and simply redisplays what it is
+    # given, which is also what makes a late subscriber correct.
+    #
+    # The type varies with the modality, and that is not overloading: both sides mean
+    # "the mosaic so far", and each carries the pixel size and stage position that place
+    # it. A `FibsemImage` cannot hold the fluorescence one -- `check_data_format` accepts
+    # `ndim == 2` only, and a fluorescence preview is (channels, y, x).
+    #
+    # Decimated, and the decimation is already in the metadata's pixel size. Coarser
+    # pixels over a smaller count cover the same ground, so a real-space display needs
+    # nothing else to put it in the right place at the right size.
+    preview: Optional[Union["FibsemImage", "FluorescenceImage"]] = None
+    row_index: Optional[int] = None
+    column_index: Optional[int] = None
+    rows: Optional[int] = None
+    columns: Optional[int] = None
+    estimated_total_seconds: float = 0.0
+    estimated_remaining_seconds: float = 0.0
+    # Why a run ended, when the status alone does not say enough -- an exception's text,
+    # or a stage-limits rejection naming every offending tile. The *reason*, never the
+    # label: a consumer words `FAILED` itself, and puts this behind it.
+    error: Optional[str] = None
+
+    @property
+    def display_tile(self) -> Optional[Tuple[int, int]]:
+        """`(row, column)` of the tile this report is about, 1-based, for people.
+
+        The one place the offset is applied. Tile 0 is "1" to a reader and 0 to a
+        `_ordered[...]` lookup, and the two spellings sat one function apart on the
+        fluorescence runner -- the log said `[1/3][1/3]` while the payload said row 0 --
+        so the conversion belongs somewhere single and testable rather than inline at
+        whichever call site happens to need it.
+        """
+        if self.row_index is None or self.column_index is None:
+            return None
+        return self.row_index + 1, self.column_index + 1
 
 
 def modality_of(payload: dict) -> str:

--- a/tests/test_tiled_progress.py
+++ b/tests/test_tiled_progress.py
@@ -1,0 +1,233 @@
+"""The typed contract carried by ``tiled_acquisition_signal`` (FIB-402).
+
+Nothing emits or reads a ``TiledProgress`` yet -- the producers still build dicts and the
+consumers still read them. What is worth pinning before either moves is the shape itself,
+and in particular the three things that are cheap to get wrong and expensive to notice:
+an event that cannot be compared, a status set that cannot answer "is this over", and a
+tile index that is 0-based in one place and 1-based in another.
+"""
+
+import dataclasses
+
+import numpy as np
+import pytest
+
+from fibsem.imaging.tiling.progress import (
+    MODALITY_BEAM,
+    MODALITY_FLUORESCENCE,
+    TiledProgress,
+    TiledStatus,
+)
+
+TERMINAL = {TiledStatus.FINISHED, TiledStatus.CANCELLED, TiledStatus.FAILED}
+
+
+def _fluorescence_preview(channels: int = 2, size: int = 8):
+    """A stand-in for what the fluorescence runner will put on `preview`.
+
+    A real `FluorescenceImage`, not a mock: it is a dataclass, so it brings a generated
+    `__eq__` that compares its `data` array elementwise -- which is the whole reason
+    `TiledProgress` sets `eq=False`, and a stub would not reproduce it.
+
+    The channel metadata is not decoration. `FluorescenceImageMetadata.__post_init__`
+    rejects an empty `channels`, so the producer building this preview has to carry its
+    channels into it -- which is convenient, because the consumer wants their names and
+    colours anyway.
+    """
+    from fibsem.fm.structures import (
+        FluorescenceChannelMetadata,
+        FluorescenceImage,
+        FluorescenceImageMetadata,
+    )
+
+    return FluorescenceImage(
+        data=np.zeros((channels, size, size), dtype=np.uint16),
+        metadata=FluorescenceImageMetadata(
+            acquisition_date="2026-08-25T09:00:00",
+            pixel_size_x=1e-7,
+            pixel_size_y=1e-7,
+            channels=[
+                FluorescenceChannelMetadata(
+                    name=f"channel-{index}",
+                    excitation_wavelength=488.0,
+                    power=0.5,
+                    exposure_time=0.1,
+                    gain=1.0,
+                    offset=0.0,
+                )
+                for index in range(channels)
+            ],
+        ),
+    )
+
+
+class TestTheStatusVocabulary:
+    def test_a_terminal_status_says_so_itself(self):
+        """The question three consumers ask, answered once.
+
+        Restated as a membership tuple at each of them, it drifts: the next status added
+        is the one somebody forgets to add to one of the three, and the symptom is a
+        progress bar that never clears.
+        """
+        for status in TiledStatus:
+            assert status.is_terminal is (status in TERMINAL), status
+
+    def test_finishing_the_tiles_is_not_finishing_the_run(self):
+        """The collision that a single vocabulary has to survive.
+
+        The runner's "the last tile is in and the stage is parked" and the widget's "the
+        mosaic is written" were both spelled `finished` when they lived in separate
+        phase/outcome vocabularies. Merging the two without renaming one would have
+        made a mid-run report read as the end of the run.
+        """
+        assert TiledStatus.TILES_ACQUIRED is not TiledStatus.FINISHED
+        assert not TiledStatus.TILES_ACQUIRED.is_terminal
+        assert TiledStatus.FINISHED.is_terminal
+
+    def test_a_member_compares_equal_to_its_own_value(self):
+        """The `str` mixin, which is what keeps these readable in a log line."""
+        assert TiledStatus.STITCHING == "stitching"
+
+    def test_starting_a_tile_and_finishing_one_are_different_reports(self):
+        """Two reports per tile, and only one of them is a progress report.
+
+        Saying it twice with one name is what made a bar change scale at every tile
+        boundary (FIB-739): a consumer choosing between them got the tile in flight
+        half the time and the tally the other half.
+        """
+        assert TiledStatus.TILE_STARTED is not TiledStatus.TILE_COLLECTED
+        assert not TiledStatus.TILE_STARTED.is_terminal
+        assert not TiledStatus.TILE_COLLECTED.is_terminal
+
+    def test_one_tile_landing_is_not_every_tile_landing(self):
+        """`TILE_COLLECTED` happens N times; `TILES_ACQUIRED` happens once.
+
+        Adjacent names for genuinely adjacent things, so the distinction is worth a
+        test rather than a comment: confusing them means either a run that reports
+        completion N times or a bar that only moves once.
+        """
+        assert TiledStatus.TILE_COLLECTED is not TiledStatus.TILES_ACQUIRED
+        assert not TiledStatus.TILES_ACQUIRED.is_terminal
+
+
+class TestTheEventShape:
+    def test_status_is_the_only_thing_every_report_carries(self):
+        """Everything else is absent on some report, so everything else has a default.
+
+        Also what keeps this constructible on Python 3.8: `kw_only` does not exist
+        there, so exactly one required field, and it has to be first.
+        """
+        event = TiledProgress(status=TiledStatus.MOVING)
+
+        assert event.status is TiledStatus.MOVING
+        assert event.completed is None and event.total is None
+        assert event.preview is None
+        assert event.error is None
+
+        required = [
+            f.name
+            for f in dataclasses.fields(TiledProgress)
+            if f.default is dataclasses.MISSING
+            and f.default_factory is dataclasses.MISSING
+        ]
+        assert required == ["status"]
+
+    def test_an_unlabelled_report_is_a_beam_report(self):
+        """What the signal carried for its whole life, kept as the default."""
+        assert TiledProgress(status=TiledStatus.MOVING).modality == MODALITY_BEAM
+
+    def test_a_report_cannot_be_written_to(self):
+        event = TiledProgress(status=TiledStatus.MOVING)
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            event.status = TiledStatus.FINISHED
+
+
+class TestComparingReports:
+    """`eq=False` is load-bearing, not incidental.
+
+    A generated `__eq__` compares every field, `preview` holds an image that compares its
+    numpy data elementwise, and the result is a `ValueError` from inside a Qt slot -- but
+    only for two *distinct* events, because comparing one to itself short-circuits on
+    identity. That asymmetry is what makes it worth a test: the obvious check passes
+    while the real case raises.
+    """
+
+    def test_two_reports_carrying_previews_can_be_compared(self):
+        first = TiledProgress(
+            status=TiledStatus.TILE_COLLECTED,
+            modality=MODALITY_FLUORESCENCE,
+            preview=_fluorescence_preview(),
+        )
+        second = TiledProgress(
+            status=TiledStatus.TILE_COLLECTED,
+            modality=MODALITY_FLUORESCENCE,
+            preview=_fluorescence_preview(),
+        )
+
+        assert first != second
+        assert first == first
+        assert (first in [second]) is False
+
+    def test_a_report_carrying_a_preview_can_be_hashed(self):
+        """A `set` of reports, or one used as a dict key, must not take the run out."""
+        event = TiledProgress(
+            status=TiledStatus.TILE_COLLECTED,
+            modality=MODALITY_FLUORESCENCE,
+            preview=_fluorescence_preview(),
+        )
+
+        assert {event, event} == {event}
+
+    def test_the_preview_image_alone_still_raises_on_comparison(self):
+        """The hazard is real and lives in the image type, not imagined here.
+
+        If this ever stops raising, `eq=False` on the event has lost its reason and the
+        comment explaining it is wrong -- which is worth finding out from a red test
+        rather than from the docstring.
+        """
+        with pytest.raises(ValueError):
+            bool(_fluorescence_preview() == _fluorescence_preview())
+
+
+class TestTileCoordinates:
+    def test_the_wire_is_zero_based(self):
+        """Matching `_ordered[...]` and every other index in the codebase."""
+        event = TiledProgress(
+            status=TiledStatus.TILE_STARTED,
+            row_index=0,
+            column_index=0,
+            rows=3,
+            columns=4,
+        )
+
+        assert (event.row_index, event.column_index) == (0, 0)
+
+    def test_the_display_form_is_one_based(self):
+        """Shown as 1 of 10, never 0 of 9 -- the reader counts from one."""
+        event = TiledProgress(
+            status=TiledStatus.TILE_STARTED,
+            row_index=0,
+            column_index=9,
+            rows=1,
+            columns=10,
+        )
+
+        assert event.display_tile == (1, 10)
+        assert f"{event.display_tile[1]}/{event.columns}" == "10/10"
+
+    def test_the_last_tile_of_a_grid_displays_as_the_count(self):
+        """The off-by-one that makes a run look like it stopped one short."""
+        event = TiledProgress(
+            status=TiledStatus.TILE_STARTED,
+            row_index=2,
+            column_index=3,
+            rows=3,
+            columns=4,
+        )
+
+        assert event.display_tile == (3, 4)
+
+    def test_a_report_about_no_tile_has_no_display_form(self):
+        """A stage move is not about a tile, so there is nothing to number."""
+        assert TiledProgress(status=TiledStatus.MOVING).display_tile is None


### PR DESCRIPTION
**Second of four stacked PRs.** Targets #547. Nothing imports these types yet — the producers still build dicts and the consumers still read them.

`tiled_acquisition_signal` carries a bare dict with no declared shape, so every consumer works out what it received from which keys happen to be present. That held while `imaging.tiled` was the only emitter; with the fluorescence runner reporting there too, the same key means different things depending on who sent it — the root of FIB-736 and FIB-739.

Adds `TiledStatus` and `TiledProgress`.

### Why one flat record, not a class per payload shape

Every consumer asks the same three questions — is this mine, does it carry counts, is there something to draw — and none dispatches over an exhaustive set of types. So types buy nothing that optional fields don't. The give-away is that the isinstance check and the value check always appear together: `isinstance(event, counted_types) and event.total`. The second clause does the work.

A hierarchy also fails in a way a flat record can't: an `isinstance` check that quietly misses a sibling class is a run that never finishes, with nothing raised anywhere.

`modality` is a field and only a field. Encoding it in the type as well gives two discriminators that can disagree, and the one that disagrees silently paints a fluorescence mosaic into the beam overview.

### Three details worth the review time

- **`eq=False`.** The generated `__eq__` compares every field, and `preview` holds an image that compares its numpy data elementwise, so comparing two reports raises `ValueError` from inside a Qt slot — but only for two *distinct* reports, because comparing one to itself short-circuits on identity. The obvious test passes while the real case raises. Both directions are pinned, plus a test asserting the underlying image still raises, so the comment justifying `eq=False` goes red rather than stale.
- **Tile indices are 0-based on the wire**, matching every other index in the codebase. `display_tile` is the only place that adds one, so "1 of 10, never 0 of 9" has a single home.
- **No `kw_only`** (3.10+). One required field, first, keeps this constructible on the 3.8 and 3.9 CI jobs.

### Verification

82 passed on this commit alone. `ruff check` and `ruff format --check` clean.