### PR TITLE
[refactor] Teach the tiled progress consumers the typed contract (FIB-402)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -77,6 +77,7 @@ from fibsem.applications.autolamella.workflows.workflow_estimate import (
     estimate_addition,
     estimate_workflow,
 )
+from fibsem.imaging.tiling.progress import TiledProgress, TiledStatus
 from fibsem.structures import BeamType
 from fibsem.ui import notification_service
 from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
@@ -1593,6 +1594,70 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             # widget alone if another operation has started rendering progress since
             QTimer.singleShot(2000, self.progress_widget.reset_if_finished)
 
+    # What the status bar calls each state of a run. One table for both modalities and
+    # deliberately generic: this is read at a glance from another tab, so it says what
+    # kind of thing is happening rather than repeating the producer's own wording. It is
+    # also the seam FIB-742 needs -- saying *which* run is going is a modality prefix on
+    # these, which is only possible now the words live here instead of arriving baked
+    # into the report.
+    _STATUS_LABELS = {
+        TiledStatus.STARTING: "Collecting tiles",
+        TiledStatus.MOVING: "Moving stage",
+        TiledStatus.TILE_STARTED: "Collecting tiles",
+        TiledStatus.TILE_COLLECTED: "Collecting tiles",
+        TiledStatus.TILES_ACQUIRED: "Collecting tiles",
+        TiledStatus.STITCHING: "Stitching tiles",
+        TiledStatus.SAVING: "Saving overview",
+        TiledStatus.FINISHED: "Complete",
+        TiledStatus.CANCELLED: "Cancelled",
+        TiledStatus.FAILED: "Failed",
+    }
+
+    @ensure_main_thread
+    def _on_tiled_progress(self, event: TiledProgress) -> None:
+        """The typed form of `_on_tile_acquisition_progress` (FIB-402).
+
+        Not reached until the producers flip. Deliberately **not** filtered by modality,
+        unlike the two overview widgets: they each drive one modality's canvas and must
+        ignore the other's run, while the status bar is the one consumer that wants both
+        (FIB-725).
+        """
+        message = self._STATUS_LABELS.get(event.status, "Collecting tiles")
+
+        if event.status.is_terminal:
+            self.progress_widget.update_progress(
+                self._tiled_outcome(event.status, message)
+            )
+            # Hide the Done state after a moment, the same way spot burn does above.
+            QTimer.singleShot(2000, self.progress_widget.reset_if_finished)
+            return
+
+        if event.completed is None or not event.total:
+            # A state that carries no counts: a stage move, a stitch, a save. Nothing is
+            # drawn for them, which leaves the last real count standing -- still true
+            # while the stage moves or the mosaic is written.
+            return
+
+        if event.completed >= event.total:
+            self.progress_widget.update_progress(ProgressUpdate.indeterminate(message))
+        else:
+            self.progress_widget.update_progress(
+                ProgressUpdate.numeric(event.completed, event.total, message)
+            )
+
+    @staticmethod
+    def _tiled_outcome(status: TiledStatus, message: str) -> ProgressUpdate:
+        """How a finished tiled acquisition reads once the bar is full.
+
+        A cancel is deliberately not `failed`, which paints the bar red: it is someone
+        getting what they asked for.
+        """
+        if status is TiledStatus.FAILED:
+            return ProgressUpdate.failed(message)
+        if status is TiledStatus.CANCELLED:
+            return ProgressUpdate(finished=True, message=message)
+        return ProgressUpdate.done()
+
     @ensure_main_thread
     def _on_tile_acquisition_progress(self, ddict: dict) -> None:
         """Handle tiled acquisition progress updates from the microscope.
@@ -1603,7 +1668,14 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         whole job is saying what is happening while you are looking at another tab
         (FIB-725). What it will need, once a fluorescence run emits here, is to say
         *which* -- not to drop one.
+
+        Dicts only -- a typed `TiledProgress` goes to `_on_tiled_progress` above. The
+        two sit side by side until the producers flip (FIB-402).
         """
+        if isinstance(ddict, TiledProgress):
+            self._on_tiled_progress(ddict)
+            return
+
         counter = ddict.get("counter")
         total = ddict.get("total")
         msg = ddict.get("msg", "Collecting tiles")

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -48,7 +48,12 @@ from fibsem.applications.autolamella.ui.lamella_name_list_widget import (
 )
 from fibsem.conversions import is_inside_image_bounds
 from fibsem.imaging import tiled
-from fibsem.imaging.tiling.progress import MODALITY_BEAM, is_modality
+from fibsem.imaging.tiling.progress import (
+    MODALITY_BEAM,
+    TiledProgress,
+    TiledStatus,
+    is_modality,
+)
 from fibsem.microscope import FibsemMicroscope
 from fibsem.milling import FibsemMillingStage
 from fibsem.structures import (
@@ -680,6 +685,65 @@ class FibsemMinimapWidget(QWidget):
             }
             self._acquisition_finished.emit(result)
 
+    # What this tab calls each state of a run. Its own table rather than a shared one:
+    # the words belong to whoever is showing them, and this bar is read while watching
+    # the acquisition it describes -- the status bar in the main window is read from
+    # another tab entirely and says something shorter (FIB-402).
+    #
+    # Only the states a beam run actually reaches. `.get` with a fallback, so a state
+    # this table has not been taught degrades to a generic label rather than a KeyError
+    # inside a Qt slot.
+    _STATUS_LABELS = {
+        TiledStatus.STARTING: "Computing Tile Positions",
+        TiledStatus.MOVING: "Moving Stage",
+        TiledStatus.TILE_STARTED: "Acquiring",
+        TiledStatus.TILE_COLLECTED: "Tile Collected",
+        TiledStatus.TILES_ACQUIRED: "Tiles Acquired",
+        TiledStatus.STITCHING: "Stitching Tiles",
+        TiledStatus.SAVING: "Saving",
+        TiledStatus.FINISHED: "Done",
+        TiledStatus.CANCELLED: "Acquisition Cancelled",
+        TiledStatus.FAILED: "Acquisition Failed",
+    }
+
+    def _apply_tile_progress(self, event: TiledProgress) -> None:
+        """The typed form of `handle_tile_acquisition_progress` (FIB-402).
+
+        Not reached yet: the producers still emit dicts, and this runs only once
+        `imaging.tiled` flips. It is written and tested now so that the flip is a
+        change to one producer rather than to a producer and three consumers at once.
+
+        `total` is guarded because it is a divisor: a run reporting nothing to do would
+        take the bar out with a `ZeroDivisionError`. Nothing is drawn for a report that
+        cannot say how far along it is, which leaves the last real progress standing --
+        true, rather than reset to zero.
+        """
+        if event.modality != MODALITY_BEAM:
+            # Beam runs only. This tab drives a beam overview and assigns the mosaic
+            # straight into its napari layer, so a fluorescence run reaching here would
+            # be drawn into the beam minimap (FIB-725).
+            return
+
+        if event.completed is not None and event.total:
+            self._tiles_acquired = event.completed
+            self._tile_total_count = event.total
+
+            label = self._STATUS_LABELS.get(event.status, "Acquiring")
+            self.progressBar_acquisition.setMaximum(100)
+            self.progressBar_acquisition.setValue(
+                int(event.completed / event.total * 100)
+            )
+            self.progressBar_acquisition.setFormat(
+                f"{label} — {event.completed}/{event.total} tiles (%p%)"
+            )
+
+        if event.preview is not None:
+            # `.data`, so this tab shows the decimated mosaic rather than the live
+            # full-resolution canvas it used to be handed. Deliberate: a preview is a
+            # preview, this tab is being retired, and the array it was given before was
+            # the one the acquisition thread was still writing into.
+            self.update_viewer(event.preview.data, tmp=True)
+
     @ensure_main_thread
     def handle_tile_acquisition_progress(self, ddict: dict) -> None:
         """Callback for handling the tile acquisition progress.
@@ -701,7 +765,16 @@ class FibsemMinimapWidget(QWidget):
         straight into its napari layer, so a fluorescence run reaching here would be
         drawn into the beam minimap -- and the fluorescence preview is keyed `image`
         already, deliberately, to match this signal (FIB-725).
+
+        Dicts only. A typed `TiledProgress` goes to `_apply_tile_progress` above, which
+        is where this method is heading -- the two paths sit side by side until the
+        producers flip, so that the dict path this branch guards is provably the one
+        still running (FIB-402).
         """
+        if isinstance(ddict, TiledProgress):
+            self._apply_tile_progress(ddict)
+            return
+
         if not is_modality(ddict, MODALITY_BEAM):
             return
 

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -42,7 +42,12 @@ from fibsem.fm.structures import (
 )
 from fibsem.imaging.tiling import unreachable_tiles
 from fibsem.imaging.tiling.geometry import TilePosition, compute_tile_grid_from_fov
-from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE, is_modality
+from fibsem.imaging.tiling.progress import (
+    MODALITY_FLUORESCENCE,
+    TiledProgress,
+    TiledStatus,
+    is_modality,
+)
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import FibsemStagePosition
 from fibsem.ui import notification_service, stylesheets
@@ -221,7 +226,10 @@ class FMOverviewWidget(QWidget):
     #
     # One per source, because the two describe different things at different scales and
     # each drives its own bar: the run as a whole, and the tile currently being taken.
-    _tile_progress_received = pyqtSignal(dict)
+    # `object`, not `dict`: carries a dict today and a `TiledProgress` once the
+    # producers flip (FIB-402). Both marshal to `PyQt_PyObject`, so this changes nothing
+    # at the Qt level -- it stops the declaration lying.
+    _tile_progress_received = pyqtSignal(object)
     _fm_progress_received = pyqtSignal(dict)
     # Same hop for stage moves: `stage_position_changed` is a psygnal, so it fires
     # on whichever thread moved the stage -- a worker, during an acquisition.
@@ -2735,11 +2743,101 @@ class FMOverviewWidget(QWidget):
         if payload.get("operation") in ("z-stack", "channels", "autofocus"):
             self.progress_tile_detail.update_progress(self._tile_detail_update(payload))
 
+    # This widget's words for the states a fluorescence run passes through. The states
+    # with nothing worth saying are absent on purpose: `.get` returning None is what
+    # clears the label rather than leaving a stale one up.
+    _STATUS_LABELS = {
+        TiledStatus.MOVING: "Moving stage…",
+        TiledStatus.STITCHING: "Stitching tiles…",
+        TiledStatus.SAVING: "Saving overview…",
+    }
+
+    # Temporary bridge, deleted when `_finish` learns to take a status directly (FIB-402).
+    # `_finish` keeps its string vocabulary for now so that neither it nor the tests
+    # driving it move in this PR.
+    _FINISH_STATES = {
+        TiledStatus.FINISHED: "overview-finished",
+        TiledStatus.CANCELLED: "overview-cancelled",
+        TiledStatus.FAILED: "overview-failed",
+    }
+
+    def _apply_tiled_progress(self, event: TiledProgress) -> None:
+        """The typed form of `_apply_tile_progress` (FIB-402).
+
+        Not reached until the fluorescence producers flip. Written and tested now so the
+        flip is a change to the producers alone.
+        """
+        if event.modality != MODALITY_FLUORESCENCE:
+            # A beam run, on the signal this shares with the beam tiler. Checked before
+            # anything else, terminal states included: the two tilers write into
+            # different canvases and different bars (FIB-725).
+            return
+
+        if event.status.is_terminal:
+            self._finish(self._FINISH_STATES[event.status], event.error)
+            return
+
+        label = self._STATUS_LABELS.get(event.status)
+        if label is not None:
+            # Deliberately not `indeterminate`: that paints a *full* bar with a spinner,
+            # so every stage move looked like the run had just completed. The bar keeps
+            # the last tile count -- still true between tiles, and while the mosaic is
+            # being stitched and written -- and the transient state goes to the label.
+            self.status.setText(label)
+            return
+
+        self.status.setText("")
+
+        if event.status is TiledStatus.TILE_COLLECTED and event.preview is not None:
+            # Deliberately does *not* clear the within-tile bar. It used to, which made
+            # it vanish and reappear at every tile boundary -- a flicker for the whole
+            # run. The next tile's first report overwrites it a moment later anyway.
+            self._show_typed_preview(event.preview)
+
+        if event.completed is None or not event.total:
+            # An announcement rather than a progress report: the report that says which
+            # tile is starting carries no counts, because emitted *before* the tile it
+            # could only ever be one short -- a bar driven from it stopped at 3/4 for the
+            # whole run (FIB-736). It has already done its job above, clearing the label
+            # the stage move put up.
+            return
+
+        # The final report of a run gives 0 remaining and so renders as a plain count --
+        # `FibsemProgressWidget` picks the shape from `remaining_seconds > 0`, not from
+        # the caller. That is the run finishing rather than a flicker.
+        remaining = event.estimated_remaining_seconds
+        # The widget renders the count itself, so the message says what is being counted
+        # and nothing more -- otherwise it reads "Tile 4/9 — 4/9".
+        message = "Tiles"
+        if remaining:
+            self.progress_tiles.update_progress(
+                ProgressUpdate.combined(
+                    current=event.completed,
+                    total=event.total,
+                    remaining_seconds=remaining,
+                    total_seconds=event.estimated_total_seconds,
+                    message=message,
+                )
+            )
+        else:
+            self.progress_tiles.update_progress(
+                ProgressUpdate.numeric(
+                    current=event.completed, total=event.total, message=message
+                )
+            )
+
     def _apply_tile_progress(self, payload: dict) -> None:
         """The run as a whole, on the tile bar.
 
         Runs on the GUI thread, queued via `_tile_progress_received`.
+
+        Dicts only -- a typed `TiledProgress` goes to `_apply_tiled_progress` above.
+        The two sit side by side until the producers flip (FIB-402).
         """
+        if isinstance(payload, TiledProgress):
+            self._apply_tiled_progress(payload)
+            return
+
         if not is_modality(payload, MODALITY_FLUORESCENCE):
             # A beam run, on the signal this shares with the beam tiler. Checked before
             # anything else, terminal states included: the two tilers write into
@@ -2837,6 +2935,61 @@ class FMOverviewWidget(QWidget):
         return ProgressUpdate.numeric(
             current=index, total=total, message=f"{channel} channels"
         )
+
+    def _show_typed_preview(self, preview: FluorescenceImage) -> None:
+        """Paint the mosaic-so-far onto the canvas, from a self-describing preview.
+
+        The typed form of `_show_preview` (FIB-402), and the reason the preview became a
+        `FluorescenceImage` rather than a bare array plus a stride. Everything this needs
+        to place the mosaic now arrives with it:
+
+        * where -- `metadata.stage_position`, instead of reaching into `self._runner` for
+          the centre it resolved when the run started;
+        * at what scale -- `metadata.pixel_size_x`, with the preview's decimation already
+          folded in by the producer, instead of `self._projection().pixel_size * stride`;
+        * which channels -- `metadata.channels`, instead of this widget's own list.
+
+        Dropping the `_projection()` call is the part that matters beyond tidiness. It
+        reads from the camera under an `active_channel()` scope, and this runs once a
+        tile *during* a run, so the display was taking the shared channel from the
+        acquisition that was using it.
+        """
+        try:
+            planes = np.asarray(preview.data)
+            if planes.ndim == 2:
+                planes = planes[np.newaxis]
+
+            # Where, and at what scale, *before* any pixels: `set_channels` composites
+            # and places immediately, so anything established after it applies a tick
+            # late -- the first frame of a run would land under the previous run's key
+            # at the previous run's pixel size.
+            #
+            # Its own key, so the in-progress preview neither replaces a finished
+            # overview nor survives as one: it is swapped for the real stitch at the end.
+            self.canvas.set_composite_key(PREVIEW_KEY)
+            centre = preview.metadata.stage_position
+            self.canvas.set_placement(
+                self._offset_from_origin(centre) if centre is not None else (0.0, 0.0)
+            )
+            pixel_size = preview.metadata.pixel_size_x
+            if not pixel_size:
+                return
+            self.canvas.set_pixel_size(pixel_size)
+
+            # This run's channels, and only these. `set_channel` upserts, so a channel
+            # switched off since the last run would otherwise keep its layer -- still
+            # holding the previous overview's pixels -- and be blended into this one.
+            channels = preview.metadata.channels
+            self.canvas.retain_channels([channel.name for channel in channels])
+            # One composite for the whole update, not one per channel.
+            self.canvas.set_channels(
+                [
+                    (channel.name, plane, channel.color)
+                    for channel, plane in zip(channels, planes)
+                ]
+            )
+        except Exception as e:
+            logging.debug(f"Could not display the overview preview: {e}")
 
     def _show_preview(self, payload: dict) -> None:
         """Paint the mosaic-so-far onto the canvas.

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -65,7 +65,12 @@ from fibsem.fm.composite import auto_clim
 from fibsem.imaging import tiled
 from fibsem.imaging.reduce import downsample, downsample_mask
 from fibsem.imaging.tiling import unreachable_tiles
-from fibsem.imaging.tiling.progress import MODALITY_BEAM, is_modality
+from fibsem.imaging.tiling.progress import (
+    MODALITY_BEAM,
+    TiledProgress,
+    TiledStatus,
+    is_modality,
+)
 from fibsem.microscope import FibsemMicroscope
 from fibsem.projection import BeamStageProjection
 from fibsem.structures import (
@@ -527,7 +532,10 @@ class FibsemOverviewWidget(QWidget):
     # synchronously on whichever thread emitted -- during a run, the acquisition
     # worker. Touching widgets from there is a cross-thread GUI access; re-emitting as
     # a Qt signal gets it queued onto the GUI thread, because this widget lives there.
-    _progress_received = pyqtSignal(dict)
+    # `object`, not `dict`: this carries a dict today and a `TiledProgress` once the
+    # producers flip (FIB-402). Both marshal to `PyQt_PyObject` either way, so widening
+    # it changes nothing at the Qt level -- it just stops the declaration lying.
+    _progress_received = pyqtSignal(object)
     _stage_moved = pyqtSignal(object)
     _acquisition_finished = pyqtSignal(dict)
 
@@ -3109,8 +3117,56 @@ class FibsemOverviewWidget(QWidget):
         """Called by psygnal, on whichever thread emitted. Touches no widgets."""
         self._progress_received.emit(payload)
 
+    # This tab's own words for each state of a run, for the same reason the minimap has
+    # its own: the words belong to whoever shows them (FIB-402).
+    _STATUS_LABELS = {
+        TiledStatus.STARTING: "Computing Tile Positions",
+        TiledStatus.MOVING: "Moving Stage",
+        TiledStatus.TILE_STARTED: "Acquiring",
+        TiledStatus.TILE_COLLECTED: "Tile Collected",
+        TiledStatus.TILES_ACQUIRED: "Tiles Acquired",
+        TiledStatus.STITCHING: "Stitching Tiles",
+        TiledStatus.SAVING: "Saving",
+        TiledStatus.FINISHED: "Done",
+        TiledStatus.CANCELLED: "Acquisition Cancelled",
+        TiledStatus.FAILED: "Acquisition Failed",
+    }
+
+    def _apply_tiled_progress(self, event: TiledProgress) -> None:
+        """The typed form of `_apply_progress` (FIB-402).
+
+        Not reached until `imaging.tiled` flips; written and tested now so that the flip
+        touches one producer rather than a producer and three consumers at once.
+        """
+        if event.modality != MODALITY_BEAM:
+            # Beam runs only: this widget places the mosaic on its own canvas and counts
+            # the tiles into its own record, so a fluorescence run reaching here would be
+            # drawn as one of this tab's overviews (FIB-725).
+            return
+
+        if event.completed is not None and event.total:
+            self._tiles_acquired = event.completed
+            self.progress.update_progress(
+                ProgressUpdate.numeric(
+                    current=event.completed,
+                    total=event.total,
+                    message=self._STATUS_LABELS.get(event.status, "Acquiring"),
+                )
+            )
+
+        record = self._records.get(getattr(self, "_active_record", None) or "")
+        if event.preview is not None and record is not None:
+            self._show_preview(event.preview)
+            # The row says how many tiles this run has, and it says it while the run is
+            # going -- a row reading "0 tiles" beside a filling mosaic is the list
+            # contradicting the canvas.
+            if event.completed:
+                record.tiles = event.completed
+                record.pixel_size = self._pixel_size_of(event.preview)
+                self._refresh_overview_list()
+
     @ensure_main_thread
-    @pyqtSlot(dict)
+    @pyqtSlot(object)
     def _apply_progress(self, payload: dict) -> None:
         """Runs on the GUI thread, queued via `_progress_received`.
 
@@ -3120,7 +3176,14 @@ class FibsemOverviewWidget(QWidget):
         Beam runs only. This widget places the payload's mosaic on its own canvas and
         counts the tiles into its own record, so a fluorescence run reaching here would
         be drawn as one of this tab's overviews (FIB-725).
+
+        Dicts only -- a typed `TiledProgress` is handed to `_apply_tiled_progress`
+        above. The two paths sit side by side until the producers flip (FIB-402).
         """
+        if isinstance(payload, TiledProgress):
+            self._apply_tiled_progress(payload)
+            return
+
         if not is_modality(payload, MODALITY_BEAM):
             return
 

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -322,9 +322,17 @@ class _Router:
     _apply_tile_progress = FMOverviewWidget._apply_tile_progress
     _apply_fm_progress = FMOverviewWidget._apply_fm_progress
     _tile_detail_update = FMOverviewWidget._tile_detail_update
+    # The typed path the dict one is heading for (FIB-402), borrowed the same way.
+    _apply_tiled_progress = FMOverviewWidget._apply_tiled_progress
+    _STATUS_LABELS = FMOverviewWidget._STATUS_LABELS
+    _FINISH_STATES = FMOverviewWidget._FINISH_STATES
 
     def _show_preview(self, payload):
         pass
+
+    def _show_typed_preview(self, preview):
+        self.previews = getattr(self, "previews", [])
+        self.previews.append(preview)
 
     def _finish(self, state, error):
         self.finished = (state, error)
@@ -5710,3 +5718,250 @@ def test_the_fm_tab_finishes_the_drag_when_the_overlay_says_so(qapp, grid_of):
         widget.canvas.set_world_extent = original
 
     assert calls, "drag_finished is not wired to anything on this tab"
+
+
+# ── the typed contract (FIB-402) ─────────────────────────────────────────────
+#
+# Nothing emits a `TiledProgress` yet. The dict tests above are what proves that path
+# has not moved; these drive the typed path directly, so the producer flip is a change
+# to the producers alone.
+
+
+def _fm(status, **fields):
+    from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE, TiledProgress
+
+    fields.setdefault("modality", MODALITY_FLUORESCENCE)
+    return TiledProgress(status=status, **fields)
+
+
+def _fm_preview(channels=("DAPI", "GFP"), size=4, pixel_size=2e-7, position=None):
+    """A fluorescence preview carrying everything needed to place it.
+
+    Which is the point of the type: pixel size with the decimation already folded in,
+    the stage position the run was centred on, and the channels with their colours.
+    """
+    import numpy as np
+
+    from fibsem.fm.structures import (
+        FluorescenceChannelMetadata,
+        FluorescenceImage,
+        FluorescenceImageMetadata,
+    )
+
+    return FluorescenceImage(
+        data=np.zeros((len(channels), size, size), dtype=np.uint16),
+        metadata=FluorescenceImageMetadata(
+            acquisition_date="2026-08-25T09:00:00",
+            pixel_size_x=pixel_size,
+            pixel_size_y=pixel_size,
+            stage_position=position,
+            channels=[
+                FluorescenceChannelMetadata(
+                    name=name,
+                    excitation_wavelength=488.0,
+                    power=0.5,
+                    exposure_time=0.1,
+                    gain=1.0,
+                    offset=0.0,
+                    color="cyan" if index == 0 else "magenta",
+                )
+                for index, name in enumerate(channels)
+            ],
+        ),
+    )
+
+
+def test_a_typed_tile_report_moves_only_the_tile_bar(qapp):
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    router = _Router()
+
+    router._apply_tile_progress(_fm(TiledStatus.TILE_COLLECTED, completed=4, total=9))
+
+    assert (
+        _bar(router.progress_tiles).value(),
+        _bar(router.progress_tiles).maximum(),
+    ) == (4, 9)
+    assert not router.progress_tile_detail.isVisible()
+
+
+def test_a_typed_beam_report_is_ignored_entirely(qapp):
+    """The two tilers write into different canvases and different bars, so the modality
+    is checked before anything else — terminal states included (FIB-725)."""
+    from fibsem.imaging.tiling.progress import MODALITY_BEAM, TiledStatus
+
+    router = _Router()
+
+    router._apply_tile_progress(
+        _fm(TiledStatus.FINISHED, modality=MODALITY_BEAM, completed=9, total=9)
+    )
+
+    assert not hasattr(router, "finished")
+    assert _bar(router.progress_tiles).maximum() != 9
+
+
+def test_a_typed_stage_move_labels_rather_than_filling_the_bar(qapp):
+    """`indeterminate` paints a *full* bar with a spinner, so every stage move looked
+    like the run had just completed. The count stays; the state goes to the label."""
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    router = _Router()
+    router._apply_tile_progress(_fm(TiledStatus.TILE_COLLECTED, completed=4, total=9))
+
+    router._apply_tile_progress(_fm(TiledStatus.MOVING))
+
+    assert router.status.text() == "Moving stage…"
+    assert (
+        _bar(router.progress_tiles).value(),
+        _bar(router.progress_tiles).maximum(),
+    ) == (4, 9)
+
+
+def test_a_typed_state_with_nothing_to_say_clears_the_label(qapp):
+    """`TILES_ACQUIRED` is a real transition with no wording of its own — the label the
+    stage move put up has to come down rather than sit there through the stitch."""
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    router = _Router()
+    router._apply_tile_progress(_fm(TiledStatus.MOVING))
+    assert router.status.text() == "Moving stage…"
+
+    router._apply_tile_progress(_fm(TiledStatus.TILES_ACQUIRED))
+
+    assert router.status.text() == ""
+
+
+def test_a_typed_tile_announcement_does_not_move_the_bar(qapp):
+    """Emitted *before* the tile, so a count taken from it is always one short — a bar
+    driven off it stopped at 3/4 for a whole four-tile run (FIB-736)."""
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    router = _Router()
+    router._apply_tile_progress(_fm(TiledStatus.TILE_COLLECTED, completed=4, total=9))
+
+    router._apply_tile_progress(
+        _fm(TiledStatus.TILE_STARTED, row_index=1, column_index=2, rows=3, columns=3)
+    )
+
+    assert (
+        _bar(router.progress_tiles).value(),
+        _bar(router.progress_tiles).maximum(),
+    ) == (4, 9)
+
+
+@pytest.mark.parametrize(
+    "status, expected",
+    [
+        ("FINISHED", "overview-finished"),
+        ("CANCELLED", "overview-cancelled"),
+        ("FAILED", "overview-failed"),
+    ],
+)
+def test_every_typed_terminal_state_finishes_the_run(qapp, status, expected):
+    """`_finish` is this widget's only exit path: it swaps the preview for the stitch,
+    clears the worker and re-enables the tab. A terminal state that misses it leaves the
+    FM unusable for the rest of the session with nothing on screen to say why."""
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    router = _Router()
+
+    router._apply_tile_progress(
+        _fm(getattr(TiledStatus, status), error="why" if status == "FAILED" else None)
+    )
+
+    assert router.finished == (expected, "why" if status == "FAILED" else None)
+
+
+def test_a_typed_preview_is_drawn_once_per_completed_tile(qapp):
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    router = _Router()
+    preview = _fm_preview()
+
+    router._apply_tile_progress(
+        _fm(TiledStatus.TILE_COLLECTED, completed=1, total=9, preview=preview)
+    )
+
+    assert router.previews == [preview]
+
+
+class _FakeCanvas:
+    def __init__(self):
+        self.composite_key = None
+        self.placement = None
+        self.pixel_size = None
+        self.retained = None
+        self.channels = None
+
+    def set_composite_key(self, key):
+        self.composite_key = key
+
+    def set_placement(self, offset):
+        self.placement = offset
+
+    def set_pixel_size(self, size):
+        self.pixel_size = size
+
+    def retain_channels(self, names):
+        self.retained = list(names)
+
+    def set_channels(self, channels):
+        self.channels = list(channels)
+
+
+class _PreviewHost:
+    """Only what `_show_typed_preview` is allowed to touch.
+
+    Deliberately missing `_runner`, `_projection` and `channels`. The dict version read
+    all three; if the typed one still reaches for any of them it raises `AttributeError`
+    into the method's own `except`, the canvas is never touched, and the assertions
+    below fail. That absence is the test.
+    """
+
+    _show_typed_preview = FMOverviewWidget._show_typed_preview
+
+    def __init__(self):
+        self.canvas = _FakeCanvas()
+        self.offsets = []
+
+    def _offset_from_origin(self, position):
+        self.offsets.append(position)
+        return (1.0, 2.0)
+
+
+def test_a_typed_preview_places_itself_from_its_own_metadata(qapp):
+    """Where, at what scale, and which channels — all off the preview.
+
+    The dict form took the centre from `self._runner`, the pixel size from
+    `self._projection().pixel_size * stride`, and the channels from the widget. The
+    middle one reads the camera under an `active_channel()` scope once a tile *during*
+    a run, so the display was taking the shared channel from the acquisition using it.
+    """
+    from fibsem.structures import FibsemStagePosition
+    from fibsem.ui.fm.widgets.fm_overview_widget import PREVIEW_KEY
+
+    host = _PreviewHost()
+    position = FibsemStagePosition(x=1e-3, y=2e-3, z=0.0)
+
+    host._show_typed_preview(_fm_preview(pixel_size=2e-7, position=position))
+
+    assert host.canvas.composite_key == PREVIEW_KEY
+    assert host.offsets == [position]
+    assert host.canvas.placement == (1.0, 2.0)
+    # Already stride-scaled by the producer: no multiply on this side.
+    assert host.canvas.pixel_size == 2e-7
+    assert host.canvas.retained == ["DAPI", "GFP"]
+    assert [name for name, _, _ in host.canvas.channels] == ["DAPI", "GFP"]
+    assert [colour for _, _, colour in host.canvas.channels] == ["cyan", "magenta"]
+
+
+def test_a_typed_preview_without_a_position_still_draws(qapp):
+    """A run that could not resolve a centre lands at the origin rather than not at
+    all — the same fallback the dict form had."""
+    host = _PreviewHost()
+
+    host._show_typed_preview(_fm_preview(position=None))
+
+    assert host.offsets == []
+    assert host.canvas.placement == (0.0, 0.0)
+    assert host.canvas.channels is not None

--- a/tests/ui/test_minimap_progress_payload_safety.py
+++ b/tests/ui/test_minimap_progress_payload_safety.py
@@ -36,6 +36,9 @@ def handler(qapp):
         handle_tile_acquisition_progress = (
             FibsemMinimapWidget.handle_tile_acquisition_progress
         )
+        # The typed path the dict one is heading for (FIB-402), borrowed the same way.
+        _apply_tile_progress = FibsemMinimapWidget._apply_tile_progress
+        _STATUS_LABELS = FibsemMinimapWidget._STATUS_LABELS
 
         def __init__(self):
             self.progressBar_acquisition = QProgressBar()
@@ -136,3 +139,120 @@ def test_a_preview_is_still_shown_when_the_counts_are_missing(handler):
     sentinel = object()
     handler.handle_tile_acquisition_progress({"image": sentinel})
     assert handler.shown == [sentinel]
+
+
+# ── the typed contract (FIB-402) ─────────────────────────────────────────────
+#
+# Nothing emits a `TiledProgress` yet: `imaging/tiled.py` still builds dicts, and the
+# tests above are what proves that path has not moved. These drive the typed path
+# directly, so that when the producer flips there is no consumer left to change.
+
+
+def _beam(status, **fields):
+    from fibsem.imaging.tiling.progress import MODALITY_BEAM, TiledProgress
+
+    fields.setdefault("modality", MODALITY_BEAM)
+    return TiledProgress(status=status, **fields)
+
+
+def _preview(width: int = 4, height: int = 4):
+    """A beam preview: a `FibsemImage`, which is what the tiler will attach."""
+    import numpy as np
+
+    from fibsem.structures import FibsemImage
+
+    return FibsemImage(data=np.zeros((height, width), dtype=np.uint8))
+
+
+def test_a_typed_tile_report_draws_the_bar(handler):
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    handler.handle_tile_acquisition_progress(
+        _beam(TiledStatus.TILE_COLLECTED, completed=3, total=9)
+    )
+
+    assert handler._tiles_acquired == 3
+    assert handler._tile_total_count == 9
+    assert handler.progressBar_acquisition.value() == 33
+    assert "3/9 tiles" in handler.progressBar_acquisition.format()
+
+
+def test_the_wording_comes_from_this_tab_not_the_producer(handler):
+    """The whole point of dropping `message` from the wire.
+
+    The producer says `TILE_COLLECTED`; what a reader sees is this tab's choice, and a
+    different consumer of the same report is free to word it differently.
+    """
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    handler.handle_tile_acquisition_progress(
+        _beam(TiledStatus.STITCHING, completed=9, total=9)
+    )
+
+    assert "Stitching Tiles" in handler.progressBar_acquisition.format()
+
+
+def test_a_typed_report_with_nothing_to_do_does_not_take_the_bar_out(handler):
+    """`total` is a divisor. A run reporting 0/0 must not raise in a Qt slot."""
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    handler.progressBar_acquisition.setValue(42)
+
+    handler.handle_tile_acquisition_progress(
+        _beam(TiledStatus.STARTING, completed=0, total=0)
+    )
+
+    assert handler.progressBar_acquisition.value() == 42
+
+
+def test_a_typed_report_with_no_counts_leaves_the_last_progress_standing(handler):
+    """A stage move is still true progress-wise: the last count has not stopped being
+    the last count, so nothing is drawn rather than resetting to zero."""
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    handler.handle_tile_acquisition_progress(
+        _beam(TiledStatus.TILE_COLLECTED, completed=4, total=9)
+    )
+    before = handler.progressBar_acquisition.value()
+
+    handler.handle_tile_acquisition_progress(_beam(TiledStatus.MOVING))
+
+    assert handler.progressBar_acquisition.value() == before
+    assert handler._tiles_acquired == 4
+
+
+def test_a_typed_preview_is_drawn_from_the_decimated_mosaic(handler):
+    """`preview.data`, not the live full-resolution canvas this used to be handed.
+
+    A deliberate change: the array it got before was the one the acquisition thread was
+    still painting into, and this tab is being retired anyway.
+    """
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    preview = _preview()
+
+    handler.handle_tile_acquisition_progress(
+        _beam(TiledStatus.TILE_COLLECTED, completed=1, total=9, preview=preview)
+    )
+
+    assert len(handler.shown) == 1
+    assert handler.shown[0] is preview.data
+
+
+def test_a_typed_fluorescence_report_is_not_drawn_into_the_beam_minimap(handler):
+    """This tab drives a beam overview; the other modality's mosaic is not its to
+    draw, whatever else the report carries (FIB-725)."""
+    from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE, TiledStatus
+
+    handler.handle_tile_acquisition_progress(
+        _beam(
+            TiledStatus.TILE_COLLECTED,
+            modality=MODALITY_FLUORESCENCE,
+            completed=3,
+            total=9,
+            preview=_preview(),
+        )
+    )
+
+    assert handler.shown == []
+    assert handler._tiles_acquired == 0

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -4150,3 +4150,99 @@ class TestItOnlyDrawsItsOwnRuns:
         widget._tiles_acquired = 0
         widget._apply_progress({"counter": 7, "total": 9, "msg": "Tile Collected"})
         assert widget._tiles_acquired == 7
+
+
+# ── the typed contract (FIB-402) ─────────────────────────────────────────────
+#
+# Nothing emits a `TiledProgress` yet: `imaging/tiled.py` still builds dicts, and the
+# tests above are what proves that path has not moved. These drive the typed path
+# directly, so the producer flip touches the producer alone.
+
+
+def _beam_report(status, **fields):
+    from fibsem.imaging.tiling.progress import MODALITY_BEAM, TiledProgress
+
+    fields.setdefault("modality", MODALITY_BEAM)
+    return TiledProgress(status=status, **fields)
+
+
+class TestTheTypedProgressContract:
+    def test_a_typed_tile_report_drives_the_bar(self, widget):
+        from fibsem.imaging.tiling.progress import TiledStatus
+
+        widget._tiles_acquired = 0
+
+        widget._apply_progress(
+            _beam_report(TiledStatus.TILE_COLLECTED, completed=7, total=9)
+        )
+
+        assert widget._tiles_acquired == 7
+
+    def test_the_wording_comes_from_this_tab_not_the_producer(self, widget):
+        """`message` is gone from the wire; the tab that shows the words owns them."""
+        from fibsem.imaging.tiling.progress import TiledStatus
+
+        widget._apply_progress(
+            _beam_report(TiledStatus.STITCHING, completed=9, total=9)
+        )
+
+        assert "Stitching Tiles" in widget.progress._bar.format()
+
+    def test_a_typed_fluorescence_run_is_not_drawn_as_one_of_this_tabs_overviews(
+        self, widget, microscope
+    ):
+        """This widget places the mosaic on its own canvas and counts the tiles into its
+        own record, so the other modality's run is not its to draw (FIB-725)."""
+        from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE, TiledStatus
+
+        widget._tiles_acquired = 0
+
+        widget._apply_progress(
+            _beam_report(
+                TiledStatus.TILE_COLLECTED,
+                modality=MODALITY_FLUORESCENCE,
+                completed=7,
+                total=9,
+                preview=_tile(microscope, microscope.get_stage_position()),
+            )
+        )
+
+        assert widget._tiles_acquired == 0
+
+    def test_a_typed_report_with_nothing_to_do_does_not_take_the_bar_out(self, widget):
+        """`total` is a divisor on the sibling consumer and a guard here; a run
+        reporting 0/0 must not raise inside a Qt slot either way."""
+        from fibsem.imaging.tiling.progress import TiledStatus
+
+        widget._tiles_acquired = 4
+
+        widget._apply_progress(_beam_report(TiledStatus.STARTING, completed=0, total=0))
+
+        assert widget._tiles_acquired == 4
+
+    def test_a_typed_preview_fills_the_row_while_the_run_is_going(
+        self, widget, microscope
+    ):
+        """A row reading "0 tiles" beside a filling mosaic is the list contradicting the
+        canvas."""
+        from fibsem.imaging.tiling.progress import TiledStatus
+        from fibsem.ui.widgets.overview_widget import OverviewRecord
+
+        base = microscope.get_stage_position()
+        widget._records["run"] = OverviewRecord("run", "run", [])
+        widget._active_record = "run"
+        widget._refresh_overview_list()
+
+        for index in (1, 2, 3):
+            widget._apply_progress(
+                _beam_report(
+                    TiledStatus.TILE_COLLECTED,
+                    completed=index,
+                    total=3,
+                    preview=_tile(microscope, _at(base)),
+                )
+            )
+            row = widget.overview_list._rows["run"]
+            assert row.detail_label.text().startswith(f"{index} tile"), (
+                f"after {index} tile(s) the row still reads {row.detail_label.text()!r}"
+            )

--- a/tests/ui/test_status_bar_tile_outcome.py
+++ b/tests/ui/test_status_bar_tile_outcome.py
@@ -37,6 +37,10 @@ def status(qapp):
         # A staticmethod reached through the class is a plain function, which would
         # bind as a method here and eat `self`.
         _overview_outcome = staticmethod(_Real._overview_outcome)
+        # The typed path the dict one is heading for (FIB-402), borrowed the same way.
+        _on_tiled_progress = _Real._on_tiled_progress
+        _tiled_outcome = staticmethod(_Real._tiled_outcome)
+        _STATUS_LABELS = _Real._STATUS_LABELS
 
         def __init__(self):
             self.progress_widget = FibsemProgressWidget()
@@ -96,3 +100,106 @@ def test_a_producer_that_reports_no_outcome_still_says_done(status):
     )
     assert "Done" in _text(status)
     assert not _is_red(status)
+
+
+# ── the typed contract (FIB-402) ─────────────────────────────────────────────
+#
+# The status bar is the one consumer that watches both modalities, so it is also the one
+# that has to keep working while the two producers flip one at a time. The dict tests
+# above prove that path is untouched; these drive the typed path directly.
+
+
+def _report(status, **fields):
+    from fibsem.imaging.tiling.progress import TiledProgress
+
+    return TiledProgress(status=status, **fields)
+
+
+def test_a_typed_completed_run_says_done(status):
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    status._on_tile_acquisition_progress(
+        _report(TiledStatus.FINISHED, completed=9, total=9)
+    )
+
+    assert "Done" in _text(status)
+    assert not _is_red(status)
+
+
+def test_a_typed_cancelled_run_does_not_claim_to_have_finished(status):
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    status._on_tile_acquisition_progress(
+        _report(TiledStatus.CANCELLED, completed=3, total=9)
+    )
+
+    assert "Cancelled" in _text(status)
+    assert "Done" not in _text(status)
+
+
+def test_a_typed_cancelled_run_is_not_painted_as_a_failure(status):
+    """A cancel is someone getting what they asked for, so the bar does not go red."""
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    status._on_tile_acquisition_progress(
+        _report(TiledStatus.CANCELLED, completed=3, total=9)
+    )
+
+    assert not _is_red(status)
+
+
+def test_a_typed_failed_run_is_painted_as_a_failure(status):
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    status._on_tile_acquisition_progress(
+        _report(TiledStatus.FAILED, completed=3, total=9, error="stage limits")
+    )
+
+    assert _is_red(status)
+
+
+def test_a_terminal_report_needs_no_counts(status):
+    """The fluorescence terminal carries none, and it still has to clear the bar.
+
+    Under the dict contract this was the `finished` key being checked before the counts;
+    under the typed one it is `status.is_terminal`, and getting the order wrong means a
+    cancelled fluorescence run leaves the status bar mid-run for the whole session.
+    """
+    from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE, TiledStatus
+
+    status._on_tile_acquisition_progress(
+        _report(TiledStatus.CANCELLED, modality=MODALITY_FLUORESCENCE)
+    )
+
+    assert "Cancelled" in _text(status)
+
+
+def test_both_modalities_reach_the_status_bar(status):
+    """Deliberately unfiltered, unlike the two overview widgets: its whole job is saying
+    what is happening while you are looking at another tab (FIB-725)."""
+    from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE, TiledStatus
+
+    status._on_tile_acquisition_progress(
+        _report(
+            TiledStatus.TILE_COLLECTED,
+            modality=MODALITY_FLUORESCENCE,
+            completed=4,
+            total=9,
+        )
+    )
+
+    assert _text(status) == "Collecting tiles — 4 / 9"
+
+
+def test_a_state_carrying_no_counts_leaves_the_last_count_standing(status):
+    """A stage move must not snap the bar back to zero."""
+    from fibsem.imaging.tiling.progress import TiledStatus
+
+    status._on_tile_acquisition_progress(
+        _report(TiledStatus.TILE_COLLECTED, completed=4, total=9)
+    )
+    before = _text(status)
+
+    status._on_tile_acquisition_progress(_report(TiledStatus.MOVING))
+
+    assert _text(status) == before


### PR DESCRIPTION
**Third of four stacked PRs.** Targets #548.

All four consumers gain a `TiledProgress` path beside their existing dict path. The producers are untouched and still emit dicts, so **the dict path is the one that runs** and every pre-existing test still exercises it — which is the point of the split. When the producers flip in the next PR, there is no consumer left to change.

| consumer | typed entry point |
|---|---|
| `FibsemMinimapWidget` | `_apply_tile_progress` |
| `FibsemOverviewWidget` | `_apply_tiled_progress` |
| `FMOverviewWidget` | `_apply_tiled_progress`, `_show_typed_preview` |
| `AutoLamellaSingleWindowUI` | `_on_tiled_progress`, `_tiled_outcome` |

### `message` does not survive onto the typed contract

User-facing English was being built in `imaging/tiled.py` — a headless module with no UI dependency — then rendered by three widgets that each wanted different wording. The drift showed: `"Stitching Tiles"` from one producer, `"Stitching tiles…"` from the other, for the same state. Each consumer now owns its own status→text table, so words live where they are shown. That is also what FIB-742 needs in order to say *which* run is going.

### The substantive one

`FMOverviewWidget._show_typed_preview`. The dict form reconstructed placement from three places: the centre from `self._runner`, the pixel size from `self._projection().pixel_size * stride`, and the channels from the widget's own state. All three now arrive on the preview itself.

Dropping the `_projection()` call matters beyond tidiness — it reads the camera under an `active_channel()` scope, once a tile *during* a run, so the display was taking the shared channel from the acquisition that was using it. Its test host deliberately has no `_runner`, `_projection` or `channels` attribute, so reaching for any of them fails the test.

### Two user-visible changes, neither incidental

- The status bar reads "Collecting tiles" for every counting state, where beam runs previously showed the producer's per-tile "Tile Collected". Fluorescence already read this way; the two now agree. The minimap and overview tab keep their existing wording.
- The napari minimap is handed `preview.data` — the decimated mosaic — rather than the live full-resolution canvas, which was the array the acquisition thread was still painting into.

Also widens the two internal Qt bridge signals from `pyqtSignal(dict)` to `pyqtSignal(object)`. Both already marshal to `PyQt_PyObject`, so nothing changes at the Qt level; it stops the declaration lying.

### Verification

705 passed — including every pre-existing dict test unchanged, which is the proof the live path did not move, plus 39 new tests driving the typed path. `ruff check` and `ruff format --check` clean.