### PR TITLE
[refactor] Flip the tiled progress producers to the typed contract (FIB-402)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1614,10 +1614,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
     }
 
     @ensure_main_thread
-    def _on_tiled_progress(self, event: TiledProgress) -> None:
-        """The typed form of `_on_tile_acquisition_progress` (FIB-402).
+    def _on_tile_acquisition_progress(self, event: TiledProgress) -> None:
+        """Handle tiled acquisition progress updates from the microscope.
 
-        Not reached until the producers flip. Deliberately **not** filtered by modality,
+        Deliberately **not** filtered by modality,
         unlike the two overview widgets: they each drive one modality's canvas and must
         ignore the other's run, while the status bar is the one consumer that wants both
         (FIB-725).
@@ -1626,7 +1626,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         if event.status.is_terminal:
             self.progress_widget.update_progress(
-                self._tiled_outcome(event.status, message)
+                self._overview_outcome(event.status, message)
             )
             # Hide the Done state after a moment, the same way spot burn does above.
             QTimer.singleShot(2000, self.progress_widget.reset_if_finished)
@@ -1646,7 +1646,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             )
 
     @staticmethod
-    def _tiled_outcome(status: TiledStatus, message: str) -> ProgressUpdate:
+    def _overview_outcome(status: TiledStatus, message: str) -> ProgressUpdate:
         """How a finished tiled acquisition reads once the bar is full.
 
         A cancel is deliberately not `failed`, which paints the bar red: it is someone
@@ -1656,74 +1656,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             return ProgressUpdate.failed(message)
         if status is TiledStatus.CANCELLED:
             return ProgressUpdate(finished=True, message=message)
-        return ProgressUpdate.done()
-
-    @ensure_main_thread
-    def _on_tile_acquisition_progress(self, ddict: dict) -> None:
-        """Handle tiled acquisition progress updates from the microscope.
-
-        Deliberately **not** filtered by `modality`, unlike the two overview widgets
-        that read this signal. They each drive one modality's canvas and must ignore the
-        other's run; the status bar is the one consumer that wants both, because its
-        whole job is saying what is happening while you are looking at another tab
-        (FIB-725). What it will need, once a fluorescence run emits here, is to say
-        *which* -- not to drop one.
-
-        Dicts only -- a typed `TiledProgress` goes to `_on_tiled_progress` above. The
-        two sit side by side until the producers flip (FIB-402).
-        """
-        if isinstance(ddict, TiledProgress):
-            self._on_tiled_progress(ddict)
-            return
-
-        counter = ddict.get("counter")
-        total = ddict.get("total")
-        msg = ddict.get("msg", "Collecting tiles")
-
-        if not ddict.get("finished") and (counter is None or not total):
-            # A phase that carries no counts: a stage move, a stitch, a save. The
-            # fluorescence runner reports several of these and the beam tiler none, so
-            # this only started mattering when both reported here (FIB-725).
-            #
-            # Nothing is drawn for them, which leaves the last real count standing --
-            # still true while the stage moves or the mosaic is written. Defaulting
-            # instead, as this did, meant `counter=0, total=1` on every such payload:
-            # the bar snapped back to zero at every tile boundary.
-            return
-
-        if ddict.get("finished"):
-            self.progress_widget.update_progress(self._overview_outcome(ddict, msg))
-            # Hide the Done state after a moment, the same way spot burn does above.
-            # It used to be cleared by `_on_tile_acquisition_finished`, which is wired
-            # to the napari minimap's own signal -- so a run driven from anywhere else
-            # left "Done" in the status bar for the rest of the session. Doing it from
-            # the progress signal covers every producer of it, and `reset_if_finished`
-            # leaves the widget alone if something else has started reporting since.
-            QTimer.singleShot(2000, self.progress_widget.reset_if_finished)
-        elif counter >= total:
-            self.progress_widget.update_progress(ProgressUpdate.indeterminate(msg))
-        else:
-            self.progress_widget.update_progress(
-                ProgressUpdate.numeric(counter, total, msg)
-            )
-
-    @staticmethod
-    def _overview_outcome(ddict: dict, msg: str) -> ProgressUpdate:
-        """How a finished tiled acquisition reads once the bar is full.
-
-        Everything terminal used to take one branch and say "Done", so a run that was
-        cancelled — or that failed — told the status bar it had completed. The runner
-        has reported which it was since it learned to emit a terminal payload for every
-        outcome (`TiledAcquisitionRunner._emit_terminal`); nothing was reading it.
-
-        A cancel is deliberately not `failed`, which paints the bar red: it is someone
-        getting what they asked for.
-        """
-        outcome = ddict.get("outcome")
-        if outcome == "failed":
-            return ProgressUpdate.failed(msg)
-        if outcome == "cancelled":
-            return ProgressUpdate(finished=True, message=msg)
         return ProgressUpdate.done()
 
     def _on_tile_acquisition_finished(self, result: dict) -> None:

--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -17,6 +17,7 @@ from fibsem.fm.structures import (
     AutoFocusSettings,
     ChannelSettings,
     FluorescenceImage,
+    FluorescenceImageMetadata,
     FMStagePosition,
     ObjectiveStartPosition,
     OverviewParameters,
@@ -33,7 +34,11 @@ from fibsem.imaging.tiling.geometry import (
     order_tiles,
     raise_if_outside_stage_limits,
 )
-from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
+from fibsem.imaging.tiling.progress import (
+    MODALITY_FLUORESCENCE,
+    TiledProgress,
+    TiledStatus,
+)
 from fibsem.structures import BeamType, FibsemStagePosition, TileOrderStrategy
 from fibsem.util.filename import remove_suffix
 
@@ -479,7 +484,7 @@ class FMTiledAcquisitionRunner:
         # in the same place; it is only that the fluorescence stitch and save happen in
         # two different objects, so they are announced separately -- the save from the
         # widget that performs it.
-        self._emit({"state": "stitching", "task": "tileset"})
+        self._emit(TiledStatus.STITCHING)
         return stitch_tileset(
             self.tileset,
             self.overview_parameters.overlap,
@@ -749,7 +754,7 @@ class FMTiledAcquisitionRunner:
 
         self._init_preview_canvas()
 
-        self._emit({"state": "moving", "task": "tileset"})
+        self._emit(TiledStatus.MOVING)
         # The run's opening report: nothing acquired, and how long it should take. A
         # progress report rather than an announcement -- it carries no tile coordinates,
         # because it is not about a tile. It used to name the first one *and* claim a
@@ -759,14 +764,11 @@ class FMTiledAcquisitionRunner:
         # `total` counts tiles that will actually be acquired, not grid cells -- a
         # progress bar that stops at 9/25 on a successful sparse run reads as a failure.
         self._emit(
-            {
-                "state": "acquiring",
-                "task": "tileset",
-                "counter": 0,
-                "total": len(self._ordered),
-                "estimated_total_time": self._total_estimated_time,
-                "estimated_remaining_time": self._total_estimated_time,
-            }
+            TiledStatus.STARTING,
+            completed=0,
+            total=len(self._ordered),
+            estimated_total_seconds=self._total_estimated_time,
+            estimated_remaining_seconds=self._total_estimated_time,
         )
 
     def _init_preview_canvas(self) -> None:
@@ -788,6 +790,10 @@ class FMTiledAcquisitionRunner:
         self._preview = PreviewMosaic(
             full_w, full_h, dtype=np.uint16, channels=len(self.channel_settings)
         )
+        # Built from the first tile that lands, not here: the channel metadata a
+        # consumer needs -- names and display colours -- comes off a real acquisition
+        # rather than being assembled from settings.
+        self._preview_metadata: Optional[FluorescenceImageMetadata] = None
         logging.debug(f"{self._preview.describe()} (full {full_h}x{full_w})")
 
     def _paint_preview(self, tile: TilePosition, image: FluorescenceImage) -> None:
@@ -804,6 +810,8 @@ class FMTiledAcquisitionRunner:
             if data.shape[0] != self._preview.canvas.shape[0]:
                 data = data[: self._preview.canvas.shape[0]]
             self._preview.paint(data, tile.canvas_x, tile.canvas_y)
+            if self._preview_metadata is None:
+                self._build_preview_metadata(image)
         except Exception as e:  # pragma: no cover - preview is never load-bearing
             logging.debug(
                 f"Could not paint tile ({tile.row}, {tile.col}) into preview: {e}"
@@ -868,7 +876,7 @@ class FMTiledAcquisitionRunner:
             self._emit_preview(tile)
 
             if tile is not self._ordered[-1]:
-                self._emit({"state": "moving", "task": "tileset"})
+                self._emit(TiledStatus.MOVING)
 
     def _acquire_tile(self, row: int, col: int) -> FluorescenceImage:
         """Move to one tile and acquire it.
@@ -945,12 +953,12 @@ class FMTiledAcquisitionRunner:
         logging.info("Returning to initial position")
         self.microscope.safe_absolute_stage_movement(self._initial_position)
         self.microscope.fm.objective.move_absolute(self._initial_objective_position)
-        self._emit({"state": "finished"})
+        self._emit(TiledStatus.TILES_ACQUIRED)
 
     # ── helpers ──────────────────────────────────────────────────────────
 
-    def _emit(self, payload: dict) -> None:
-        """Report a phase of this run.
+    def _emit(self, status: TiledStatus, **fields) -> None:
+        """Report a state of this run.
 
         On `tiled_acquisition_signal`, not the detector's own progress signal. This is
         tile *n* of *N* and a mosaic so far -- the same event the beam tiler reports,
@@ -962,56 +970,95 @@ class FMTiledAcquisitionRunner:
         What stays on the detector's signal is the work *inside* a tile: those are a
         different scale, and `FMOverviewWidget` draws them in a different bar.
 
-        Stamped with the modality on the way out, so no consumer has to remember to. Two
-        of them draw a beam overview from this signal and would otherwise paint a
-        fluorescence mosaic into it.
+        Takes the status and the fields rather than a finished event, so that the
+        modality is still stamped in exactly one place. Constructing the event at each
+        call site would read more directly and would mean seven chances to leave the
+        modality off -- and the default is beam, so the failure is silent and wrong:
+        two consumers draw a beam overview from this signal and would paint a
+        fluorescence mosaic into it, which is the FIB-725 bug the field exists to stop.
         """
         self.microscope.tiled_acquisition_signal.emit(
-            {"modality": MODALITY_FLUORESCENCE, **payload}
+            TiledProgress(status=status, modality=MODALITY_FLUORESCENCE, **fields)
         )
+
+    def _preview_image(self) -> Optional[FluorescenceImage]:
+        """The mosaic so far, as an image that says where and how big it is.
+
+        A *copy* of the canvas, unlike the beam tiler, which emits its live one. The
+        acquisition runs on a worker thread, so the signal is queued and the slot runs
+        later on the GUI thread -- by which time the shared array has been painted into
+        again. Sending the buffer itself is a read/write race for the sake of the one
+        thing that does not need to be fast: at ~10 MB against a tile exposure, the copy
+        does not show.
+
+        The metadata is built once and shared across every emit of a run. It describes
+        the canvas, which does not change shape, so rebuilding it per tile would deep-
+        copy a channel list N times to produce the same answer.
+        """
+        if self._preview_metadata is None:
+            # No tile has been painted yet, so there is nothing to describe. Painting is
+            # best-effort and never raises into the tile loop, so this is reachable --
+            # and a report with no preview is a report the consumer simply does not draw.
+            return None
+        return FluorescenceImage(
+            data=self._preview.canvas.copy(), metadata=self._preview_metadata
+        )
+
+    def _build_preview_metadata(self, reference: FluorescenceImage) -> None:
+        """Describe the preview canvas, once, from the first tile that lands in it.
+
+        Modelled on what `stitch_tileset` does for the finished mosaic: take a real
+        tile's metadata and correct the three things the canvas changes. Taking it from
+        a tile rather than assembling one is what gets the channels -- names and display
+        colours -- without this having to know how to build them, and
+        `FluorescenceImageMetadata` rejects an empty channel list anyway.
+
+        The pixel size carries the decimation. Coarser pixels over a smaller count cover
+        the same ground, so a display that places by pixel size needs nothing else told
+        to it -- which is what lets the consumer stop multiplying by a stride it had to
+        be sent separately, and stop reading the camera mid-run to find the other factor.
+        """
+        metadata = deepcopy(reference.metadata)
+        stride = self._preview.stride
+        metadata.pixel_size_x = reference.metadata.pixel_size_x * stride
+        metadata.pixel_size_y = reference.metadata.pixel_size_y * stride
+        canvas = self._preview.canvas
+        metadata.resolution = (canvas.shape[-1], canvas.shape[-2])
+        # The grid is laid out centred on this, so it is exact by construction --
+        # unlike averaging the acquired tiles, which is only right for a full grid and
+        # out by up to a whole tile for a masked or cancelled one.
+        metadata.stage_position = deepcopy(self.centre_position)
+        self._preview_metadata = metadata
 
     def _emit_preview(self, tile: TilePosition) -> None:
         """Publish the mosaic-so-far, so a viewer can watch it fill in.
 
-        Keyed `image`, matching what `TiledAcquisitionRunner` emits and what
-        `FibsemMinimapWidget.handle_tile_acquisition_progress` already reads, so a
-        consumer of one reads the other. The whole canvas goes out rather than the
-        single tile: the receiver then needs no state of its own and simply redisplays
-        what it is given, which is also what makes a late subscriber correct.
-
-        A *copy* goes out, unlike the beam tiler, which emits its live canvas directly.
-        The acquisition runs on a worker thread, so the signal is queued and the slot
-        runs later on the GUI thread -- by which time the shared array has been painted
-        into again. Sending the buffer itself is a read/write race for the sake of the
-        one thing that does not need to be fast: at ~10 MB against a tile exposure, the
-        copy does not show.
+        The whole canvas goes out rather than the single tile: the receiver then needs
+        no state of its own and simply redisplays what it is given, which is also what
+        makes a late subscriber correct.
         """
-        estimated_total, estimated_remaining, elapsed = self._time_estimate()
+        estimated_total, estimated_remaining, _ = self._time_estimate()
         self._emit(
-            {
-                "state": "tile",
-                "task": "tileset",
-                "row": tile.row,
-                "col": tile.col,
-                "total_rows": self._rows,
-                "total_cols": self._cols,
-                # **Tiles completed**, which is what `counter` means on this signal -- the
-                # beam tiler increments and then emits, so its count has always meant this.
-                # The fluorescence side used to say it twice per tile with two meanings: the
-                # tile *starting* before the acquisition and the tally after. One key cannot
-                # be both, and a consumer choosing between them got a bar that changed scale
-                # at every boundary (FIB-736, FIB-739).
-                "counter": self._n_acquired,
-                "total": len(self._ordered),
-                # The estimate rides with the count rather than with the announcement below,
-                # so one payload carries the whole picture and a consumer never has to
-                # assemble progress from two.
-                "estimated_total_time": estimated_total,
-                "estimated_remaining_time": estimated_remaining,
-                "elapsed_time": elapsed,
-                "image": self._preview.canvas.copy(),
-                "preview_stride": self._preview.stride,
-            }
+            TiledStatus.TILE_COLLECTED,
+            row_index=tile.row,
+            column_index=tile.col,
+            rows=self._rows,
+            columns=self._cols,
+            # **Tiles completed**, not the tile in flight -- the beam tiler increments
+            # and then emits, so the count has always meant this. The fluorescence side
+            # used to say it twice per tile with two meanings: the tile *starting*
+            # before the acquisition, and the tally after. One field cannot be both, and
+            # a consumer choosing between them got a bar that changed scale at every
+            # boundary (FIB-736, FIB-739). `TILE_STARTED` carries no counts at all now,
+            # so there is nothing to choose between.
+            completed=self._n_acquired,
+            total=len(self._ordered),
+            # The estimate rides with the count rather than with the announcement, so
+            # one report carries the whole picture and a consumer never has to assemble
+            # progress from two.
+            estimated_total_seconds=estimated_total,
+            estimated_remaining_seconds=estimated_remaining,
+            preview=self._preview_image(),
         )
 
     def _time_estimate(self):
@@ -1045,14 +1092,15 @@ class FMTiledAcquisitionRunner:
         the tile, with the preview.
         """
         self._emit(
-            {
-                "state": "acquiring",
-                "task": "tileset",
-                "row": row + 1,
-                "col": col + 1,
-                "total_rows": self._rows,
-                "total_cols": self._cols,
-            }
+            TiledStatus.TILE_STARTED,
+            # 0-based, matching `_ordered[...]` and the completed-tile report above.
+            # This used to send `row + 1`, one function away from a sibling sending
+            # `tile.row`, so the same signal described the same grid two ways.
+            # `TiledProgress.display_tile` is where the offset for a reader lives now.
+            row_index=row,
+            column_index=col,
+            rows=self._rows,
+            columns=self._cols,
         )
 
 

--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -31,7 +31,11 @@ from fibsem.imaging.tiling.plotting import (  # noqa: E402,F401
     plot_stage_positions_on_image,
     plot_tile_positions,
 )
-from fibsem.imaging.tiling.progress import MODALITY_BEAM
+from fibsem.imaging.tiling.progress import (
+    MODALITY_BEAM,
+    TiledProgress,
+    TiledStatus,
+)
 from fibsem.imaging.tiling.reprojection import (  # noqa: E402,F401
     _inverse_y_corrected_stage_movement,
     _inverse_y_corrected_stage_movement_tescan,
@@ -128,16 +132,19 @@ class TiledAcquisitionRunner:
             )
         self._setup()
         self._compute_grid()
-        outcome, message = "finished", "Acquisition Complete"
+        status, error = TiledStatus.FINISHED, None
         try:
             self._autofocus_if_mode(AutoFocusMode.ONCE)
             self._run_tile_loop()
         except OperationCancelledError:
-            outcome, message = "cancelled", "Acquisition Cancelled"
+            status, error = TiledStatus.CANCELLED, None
             logging.info("Tiled acquisition cancelled")
             raise
         except Exception as e:
-            outcome, message = "failed", "Acquisition Failed"
+            # The reason travels with the report now. It was caught, logged and
+            # thrown away, so a failed run told the UI "Acquisition Failed" and nothing
+            # about why -- and a stage-limits rejection names every offending tile.
+            status, error = TiledStatus.FAILED, str(e)
             logging.error(f"Tiled acquisition failed: {e}")
             raise
         finally:
@@ -146,32 +153,26 @@ class TiledAcquisitionRunner:
                 f"{self._start_state.stage_position.pretty}"
             )
             self.microscope.set_microscope_state(self._start_state)
-            self._emit_terminal(outcome, message)
+            self._emit_terminal(status, error)
         self._image_settings.path = self._prev_path
 
-    def _emit_terminal(self, outcome: str, message: str) -> None:
-        """Emit the final progress update for the acquisition.
+    def _emit_terminal(self, status: TiledStatus, error: Optional[str]) -> None:
+        """Report how the acquisition ended.
 
-        Carries `counter`/`total`/`msg` because consumers read those unconditionally --
-        `FibsemMinimapWidget.handle_tile_acquisition_progress` indexes them directly
-        and would raise on a payload without them. `finished` is what
-        `AutoLamellaMainUI._on_tile_acquisition_progress` already branches on; it was
-        previously only ever set by `_stitch`. `outcome` is the addition, so a consumer can distinguish a
-        cancel from a failure rather than seeing both as "stopped". Deliberately not
-        called `state`: the fluorescence progress signal already uses that key for the
-        current *phase* (moving / acquiring / finished), and reusing it here for a
-        terminal *outcome* would collide on "finished" while meaning something else.
+        Counts ride along so a cancel or a failure keeps the progress it did make: the
+        run stopped, it did not un-happen. `status` distinguishes the three, so a
+        consumer can paint a failure red and leave a cancel alone rather than calling
+        both "stopped".
         """
         total_tiles = self.settings.n_enabled_tiles
         self.microscope.tiled_acquisition_signal.emit(
-            {
-                "modality": MODALITY_BEAM,
-                "msg": message,
-                "counter": getattr(self, "_n_tiles_acquired", 0),
-                "total": total_tiles,
-                "finished": True,
-                "outcome": outcome,
-            }
+            TiledProgress(
+                status=status,
+                modality=MODALITY_BEAM,
+                completed=getattr(self, "_n_tiles_acquired", 0),
+                total=total_tiles,
+                error=error,
+            )
         )
 
     def run_and_stitch(self) -> FibsemImage:
@@ -216,12 +217,12 @@ class TiledAcquisitionRunner:
 
         # notify the UI immediately so the progress bar appears before the first move
         self.microscope.tiled_acquisition_signal.emit(
-            {
-                "modality": MODALITY_BEAM,
-                "msg": "Computing Tile Positions",
-                "counter": 0,
-                "total": self.settings.n_enabled_tiles,
-            }
+            TiledProgress(
+                status=TiledStatus.STARTING,
+                modality=MODALITY_BEAM,
+                completed=0,
+                total=self.settings.n_enabled_tiles,
+            )
         )
 
     def _compute_grid(self) -> None:
@@ -453,27 +454,27 @@ class TiledAcquisitionRunner:
             self._paint_preview(tile, image)
             self._n_tiles_acquired += 1
             self.microscope.tiled_acquisition_signal.emit(
-                {
-                    "modality": MODALITY_BEAM,
-                    "msg": "Tile Collected",
-                    "i": tile.row,
-                    "j": tile.col,
-                    "n_rows": self.settings.nrows,
-                    "n_cols": self.settings.ncols,
-                    "image": self._canvas,
+                TiledProgress(
+                    status=TiledStatus.TILE_COLLECTED,
+                    modality=MODALITY_BEAM,
+                    row_index=tile.row,
+                    column_index=tile.col,
+                    rows=self.settings.nrows,
+                    columns=self.settings.ncols,
                     # The mosaic so far, decimated, and carrying metadata -- so a
                     # real-space display can place it as one image rather than assembling
                     # tiles of its own. One artist per run instead of one per tile, which
                     # is what stops the canvas slowing down as tilesets accumulate
                     # (FIB-627).
                     #
-                    # Additive, and `image` above is deliberately untouched: the napari
-                    # minimap assigns it straight into a layer, so it has to stay a bare
-                    # array until that tab goes.
-                    "preview": self._preview_image(),
-                    "counter": self._n_tiles_acquired,
-                    "total": total_tiles,
-                }
+                    # The live `self._canvas` used to go out beside this, as a bare array,
+                    # because the napari minimap assigned it straight into a layer. That
+                    # array is the one this loop keeps painting into, so the tab was
+                    # rendering half-written tiles; it reads `preview.data` now.
+                    preview=self._preview_image(),
+                    completed=self._n_tiles_acquired,
+                    total=total_tiles,
+                )
             )
 
     def _acquire_tile(self, tile: TilePosition) -> FibsemImage:
@@ -495,7 +496,12 @@ class TiledAcquisitionRunner:
         signal = self.microscope.tiled_acquisition_signal
         total_tiles = self.settings.n_enabled_tiles
         signal.emit(
-            {"msg": "Stitching Tiles", "counter": total_tiles, "total": total_tiles}
+            TiledProgress(
+                status=TiledStatus.STITCHING,
+                modality=MODALITY_BEAM,
+                completed=total_tiles,
+                total=total_tiles,
+            )
         )
         # The metadata `_compute_grid` built, not a patched copy of the first tile's.
         # deepcopy so the stitched image gets its own snapshot rather than sharing the
@@ -516,12 +522,12 @@ class TiledAcquisitionRunner:
         image.save(filename)
 
         signal.emit(
-            {
-                "msg": "Done",
-                "counter": total_tiles,
-                "total": total_tiles,
-                "finished": True,
-            }
+            TiledProgress(
+                status=TiledStatus.FINISHED,
+                modality=MODALITY_BEAM,
+                completed=total_tiles,
+                total=total_tiles,
+            )
         )
         return image
 

--- a/fibsem/imaging/tiling/progress.py
+++ b/fibsem/imaging/tiling/progress.py
@@ -1,51 +1,32 @@
 """What a tiled acquisition says about itself while it runs.
 
-`FibsemMicroscope.tiled_acquisition_signal` carries a bare dict and has no declared
-contract, so a consumer works out what it received from which keys are present. That was
-survivable while `imaging.tiled` was its only emitter: three payload shapes, all from one
-class, all carrying the same keys.
+`FibsemMicroscope.tiled_acquisition_signal` is shared by the beam tiler and the
+fluorescence tileset runner. It used to carry a bare dict with no declared shape, so
+every consumer worked out what it had received from which keys happened to be present.
+That held while `imaging.tiled` was the only emitter; with a second producer the same
+key came to mean different things depending on who sent it, which is the root of
+FIB-736 and FIB-739.
 
-It stops being survivable with a second producer. The fluorescence tileset runner reports
-the same thing -- tile *n* of *N*, and a mosaic so far -- and reports it somewhere else
-entirely, on a signal hanging off the detector that also carries z-stacks, channel
-acquisitions and autofocus sweeps (FIB-725). Bringing it here needs consumers to be able
-to tell whose run they are looking at, because most of them want exactly one:
+`TiledProgress` is the whole contract, and `TiledStatus` is the whole vocabulary.
 
-* `FibsemMinimapWidget` and `FibsemOverviewWidget` each drive a *beam* overview, and hand
-  the payload's mosaic straight to their own canvas. Handed a fluorescence one they would
-  draw it into the beam mosaic -- and the fluorescence preview is keyed `image` already,
-  deliberately, to match this signal.
-* `AutoLamellaSingleWindowUI` shows whichever is running in the status bar, and needs to
-  say *which*, or a glance tells you a run is going and not what it is.
+One flat record rather than a class per payload shape. Every consumer asks the same
+three questions -- is this mine, does it carry counts, is there something to draw --
+and none dispatches over an exhaustive set of types, so types buy nothing that optional
+fields do not. A hierarchy also fails in a way a flat record cannot: an `isinstance`
+check that quietly misses a sibling class is a run that never finishes, with nothing
+raised anywhere.
 
-Hence `modality`: the one thing that differs, in the word this codebase already uses for
-it. Everything on this signal is a tiled run by definition -- that is what the signal is
-named for -- so the kind of *work* needs no discriminator; what varies is what is imaging.
+`modality` is a field and only a field. Encoding it in the type as well -- a
+`BeamTileCompleted` beside a `FluorescenceTileCompleted` -- gives two discriminators
+that can disagree, and the one that disagrees silently paints a fluorescence mosaic
+into the beam overview (FIB-725).
 
-# Reading a payload
-
-Use :func:`is_modality`, not `payload["modality"]`. The key is new, and a consumer that
-demands it would ignore every payload emitted by an older producer -- including anything
-outside this repository subscribing to a public signal. Absent means beam, which is what
-it was before this existed.
-
-# The typed contract (FIB-402)
-
-`TiledStatus` and `TiledProgress` below are what replaces the dict. They are unused for
-now: producers still emit dicts and consumers still read them, and the two live side by
-side until the consumers move (PR 2) and the producers flip (PR 3).
-
-One class, not a hierarchy of one per payload shape. Every consumer asks the same three
-questions -- is this mine, does it carry counts, is there something to draw -- and none
-of them dispatches on an exhaustive set of types, so a set of types buys nothing that
-optional fields do not. A hierarchy also has a failure mode a flat record does not: a
-`isinstance(event, Terminal)` that quietly misses a sibling class is a run that never
-finishes, with no error anywhere.
-
-`modality` is a field and only a field, for the same reason. Encoding it in the type as
-well -- a `BeamTileCompleted` alongside a `FluorescenceTileCompleted` -- gives two
-discriminators that can disagree, and the one that disagrees silently paints a
-fluorescence mosaic into the beam overview.
+Presentation is not on the wire. A producer reports *what happened*; each consumer
+words it. `imaging.tiled` is a headless module and was building English for three
+widgets that each wanted different wording, so the two producers had drifted to
+"Stitching Tiles" and "Stitching tiles..." for the same state. `error` is the one free
+string, and it carries a *reason* -- an exception, a stage-limits rejection naming
+every offending tile -- never a label.
 """
 
 from __future__ import annotations
@@ -73,8 +54,6 @@ __all__ = [
     "MODALITY_FLUORESCENCE",
     "TiledStatus",
     "TiledProgress",
-    "modality_of",
-    "is_modality",
 ]
 
 
@@ -203,23 +182,3 @@ class TiledProgress:
         if self.row_index is None or self.column_index is None:
             return None
         return self.row_index + 1, self.column_index + 1
-
-
-def modality_of(payload: dict) -> str:
-    """Which imaging modality produced *payload*.
-
-    Defaults to the beam rather than raising or returning None: this signal carried
-    nothing else for its whole life, so an unlabelled payload is a beam run from a
-    producer that predates the key.
-    """
-    return payload.get("modality") or MODALITY_BEAM
-
-
-def is_modality(payload: dict, modality: str) -> bool:
-    """Whether *payload* came from *modality*, treating unlabelled as beam.
-
-    The form consumers should use. `payload.get("modality") == MODALITY_BEAM` looks
-    equivalent and is not: it drops every payload from a producer that has not been
-    taught the key, which on a public signal is not only the ones in this repository.
-    """
-    return modality_of(payload) == modality

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -102,6 +102,7 @@ except Exception:
 import fibsem.constants as constants
 from fibsem import manufacturers
 from fibsem.fm.microscope import FluorescenceMicroscope
+from fibsem.imaging.tiling.progress import TiledProgress
 from fibsem.microscopes.autoscript import (
     fibsem_image_from_adorned_image,
     manipulator_position_from_autoscript,
@@ -163,7 +164,7 @@ class FibsemMicroscope(ABC):
     # @superqt.ensure_main_thread; a bare .connect() of a GUI handler is a
     # crash-on-hardware bug that won't reproduce on a dev machine.
     milling_progress_signal = Signal(dict)
-    tiled_acquisition_signal = Signal(dict)
+    tiled_acquisition_signal = Signal(TiledProgress)
     spot_burn_progress_signal = Signal(dict)
     _last_imaging_settings: ImageSettings
     system: SystemSettings

--- a/fibsem/ui/FibsemMinimapWidget.py
+++ b/fibsem/ui/FibsemMinimapWidget.py
@@ -52,7 +52,6 @@ from fibsem.imaging.tiling.progress import (
     MODALITY_BEAM,
     TiledProgress,
     TiledStatus,
-    is_modality,
 )
 from fibsem.microscope import FibsemMicroscope
 from fibsem.milling import FibsemMillingStage
@@ -706,12 +705,9 @@ class FibsemMinimapWidget(QWidget):
         TiledStatus.FAILED: "Acquisition Failed",
     }
 
-    def _apply_tile_progress(self, event: TiledProgress) -> None:
-        """The typed form of `handle_tile_acquisition_progress` (FIB-402).
-
-        Not reached yet: the producers still emit dicts, and this runs only once
-        `imaging.tiled` flips. It is written and tested now so that the flip is a
-        change to one producer rather than to a producer and three consumers at once.
+    @ensure_main_thread
+    def handle_tile_acquisition_progress(self, event: TiledProgress) -> None:
+        """Callback for handling the tile acquisition progress.
 
         `total` is guarded because it is a divisor: a run reporting nothing to do would
         take the bar out with a `ZeroDivisionError`. Nothing is drawn for a report that
@@ -743,58 +739,6 @@ class FibsemMinimapWidget(QWidget):
             # preview, this tab is being retired, and the array it was given before was
             # the one the acquisition thread was still writing into.
             self.update_viewer(event.preview.data, tmp=True)
-
-    @ensure_main_thread
-    def handle_tile_acquisition_progress(self, ddict: dict) -> None:
-        """Callback for handling the tile acquisition progress.
-
-        Read with `.get`, not indexed. This signal has no discriminator -- a consumer
-        works out what it received from which keys are present -- so a payload shape
-        that omits any of these is not a degraded label here, it is a `KeyError` inside
-        a Qt slot, mid-acquisition. All three shapes `tiled.py` emits happen to carry
-        them today, which is the only reason indexing has held (FIB-402).
-
-        `total` is guarded rather than defaulted, because it is a divisor: a payload
-        reporting nothing to do would take the bar out with a `ZeroDivisionError`
-        instead. Nothing is drawn for a payload that cannot say how far along it is,
-        which leaves the last real progress standing -- true, rather than reset to zero.
-
-        `FibsemOverviewWidget._apply_progress` reads the same signal the same way.
-
-        Beam runs only. This tab drives a beam overview and assigns the payload's mosaic
-        straight into its napari layer, so a fluorescence run reaching here would be
-        drawn into the beam minimap -- and the fluorescence preview is keyed `image`
-        already, deliberately, to match this signal (FIB-725).
-
-        Dicts only. A typed `TiledProgress` goes to `_apply_tile_progress` above, which
-        is where this method is heading -- the two paths sit side by side until the
-        producers flip, so that the dict path this branch guards is provably the one
-        still running (FIB-402).
-        """
-        if isinstance(ddict, TiledProgress):
-            self._apply_tile_progress(ddict)
-            return
-
-        if not is_modality(ddict, MODALITY_BEAM):
-            return
-
-        # track counts for result dict
-        counter = ddict.get("counter")
-        total = ddict.get("total")
-        if counter is not None and total:
-            self._tiles_acquired = counter
-            self._tile_total_count = total
-
-            # progress bar
-            self.progressBar_acquisition.setMaximum(100)
-            self.progressBar_acquisition.setValue(int(counter / total * 100))
-            self.progressBar_acquisition.setFormat(
-                f"{ddict.get('msg', 'Acquiring')} — {counter}/{total} tiles (%p%)"
-            )
-
-        image = ddict.get("image", None)
-        if image is not None:
-            self.update_viewer(image, tmp=True)
 
     def cancel_acquisition(self):
         """Cancel the tiled acquisition."""

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -46,7 +46,6 @@ from fibsem.imaging.tiling.progress import (
     MODALITY_FLUORESCENCE,
     TiledProgress,
     TiledStatus,
-    is_modality,
 )
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import FibsemStagePosition
@@ -184,11 +183,6 @@ class PlacedOverviewImageRecord:
 # What each countless phase of a run is called on screen. All three are handled the same
 # way and for the same reason: the bar keeps its last count, which stays true
 # throughout, and the phase goes to the status label instead.
-PHASE_LABELS = {
-    "moving": "Moving stage…",
-    "stitching": "Stitching tiles…",
-    "saving": "Saving overview…",
-}
 
 
 class FMOverviewWidget(QWidget):
@@ -2598,51 +2592,30 @@ class FMOverviewWidget(QWidget):
             )
             return None
 
-    def _emit_state(self, state: str) -> None:
-        """Announce a phase of this run that carries no counts.
+    def _emit_state(self, status: TiledStatus) -> None:
+        """Announce a state of this run that carries no counts.
 
         The tile bar keeps whatever it last showed -- N/N is still true while the mosaic
         is being written -- and the state goes to the status label, which is how
-        `moving` has always been handled. Rendering these as indeterminate would paint a
+        `MOVING` has always been handled. Rendering these as indeterminate would paint a
         *full* bar, which is exactly the "it finished" impression they exist to correct.
         """
         self.microscope.tiled_acquisition_signal.emit(
-            {"modality": MODALITY_FLUORESCENCE, "state": state, "task": "tileset"}
+            TiledProgress(status=status, modality=MODALITY_FLUORESCENCE)
         )
 
-    # What a finished run is called on the shared signal, per outcome.
-    TERMINAL_MESSAGES = {
-        "finished": "Overview Complete",
-        "cancelled": "Overview Cancelled",
-        "failed": "Overview Failed",
-    }
+    def _emit_terminal(self, status: TiledStatus, error: Optional[str] = None) -> None:
+        """Say how the run ended.
 
-    def _emit_terminal(self, state: str, outcome: str, error: str = "") -> None:
-        """Say how the run ended, in both vocabularies.
-
-        `state` is this widget's own -- `_apply_tile_progress` and `_finish` branch on it,
-        and it distinguishes "the mosaic is saved" from the runner's "the tiles are in".
-
-        `finished` and `outcome` are the shared signal's, which the beam tiler has used
-        since it learned to report every outcome. Carried as well, not instead: a
-        consumer reads whichever it understands, and the window's status bar reads the
-        second (FIB-725). Redundant on purpose -- collapsing the two vocabularies into
-        one is the typed-payload work, not this.
-
-        Without `finished`, the status bar would never clear after a fluorescence run:
-        the terminal it recognises is a key this widget did not send.
+        One vocabulary now. This used to send two -- its own `state` strings for its own
+        handler, plus the shared signal's `finished`/`outcome` for the window's status
+        bar -- because the two had grown separately and collided on the word "finished".
+        A single `TiledStatus` says it once, and `error` carries the reason rather than
+        a second phrasing of the fact.
         """
-        payload = {
-            "modality": MODALITY_FLUORESCENCE,
-            "state": state,
-            "task": "tileset",
-            "finished": True,
-            "outcome": outcome,
-            "msg": self.TERMINAL_MESSAGES.get(outcome, "Overview"),
-        }
-        if error:
-            payload["error"] = error
-        self.microscope.tiled_acquisition_signal.emit(payload)
+        self.microscope.tiled_acquisition_signal.emit(
+            TiledProgress(status=status, modality=MODALITY_FLUORESCENCE, error=error)
+        )
 
     def _acquire_worker(self) -> None:
         """Runs off the GUI thread. Only signals may cross back."""
@@ -2659,16 +2632,16 @@ class FMOverviewWidget(QWidget):
                 # the stitch is a memcpy into a preallocated canvas (~0.3 s for 1.3 GB)
                 # and the write is most of the rest (~2.3 s for the same). Silent until
                 # now, so a big run appeared to hang just as it completed.
-                self._emit_state("saving")
+                self._emit_state(TiledStatus.SAVING)
                 self._saved_path = self._destination.save_mosaic(mosaic)
             self.overview_acquired.emit(mosaic)
-            self._emit_terminal("overview-finished", "finished")
+            self._emit_terminal(TiledStatus.FINISHED)
         except OperationCancelledError:
             logging.info("Overview acquisition cancelled")
-            self._emit_terminal("overview-cancelled", "cancelled")
+            self._emit_terminal(TiledStatus.CANCELLED)
         except Exception as e:
             logging.error(f"Overview acquisition failed: {e}", exc_info=True)
-            self._emit_terminal("overview-failed", "failed", str(e))
+            self._emit_terminal(TiledStatus.FAILED, str(e))
         finally:
             # A run that ends still marked as acquiring leaves the FM unusable for
             # the rest of the session, with nothing on screen to say why -- so this goes
@@ -2752,20 +2725,10 @@ class FMOverviewWidget(QWidget):
         TiledStatus.SAVING: "Saving overview…",
     }
 
-    # Temporary bridge, deleted when `_finish` learns to take a status directly (FIB-402).
-    # `_finish` keeps its string vocabulary for now so that neither it nor the tests
-    # driving it move in this PR.
-    _FINISH_STATES = {
-        TiledStatus.FINISHED: "overview-finished",
-        TiledStatus.CANCELLED: "overview-cancelled",
-        TiledStatus.FAILED: "overview-failed",
-    }
+    def _apply_tile_progress(self, event: TiledProgress) -> None:
+        """The run as a whole, on the tile bar.
 
-    def _apply_tiled_progress(self, event: TiledProgress) -> None:
-        """The typed form of `_apply_tile_progress` (FIB-402).
-
-        Not reached until the fluorescence producers flip. Written and tested now so the
-        flip is a change to the producers alone.
+        Runs on the GUI thread, queued via `_tile_progress_received`.
         """
         if event.modality != MODALITY_FLUORESCENCE:
             # A beam run, on the signal this shares with the beam tiler. Checked before
@@ -2774,7 +2737,7 @@ class FMOverviewWidget(QWidget):
             return
 
         if event.status.is_terminal:
-            self._finish(self._FINISH_STATES[event.status], event.error)
+            self._finish(event.status, event.error)
             return
 
         label = self._STATUS_LABELS.get(event.status)
@@ -2792,7 +2755,7 @@ class FMOverviewWidget(QWidget):
             # Deliberately does *not* clear the within-tile bar. It used to, which made
             # it vanish and reappear at every tile boundary -- a flicker for the whole
             # run. The next tile's first report overwrites it a moment later anyway.
-            self._show_typed_preview(event.preview)
+            self._show_preview(event.preview)
 
         if event.completed is None or not event.total:
             # An announcement rather than a progress report: the report that says which
@@ -2826,85 +2789,6 @@ class FMOverviewWidget(QWidget):
                 )
             )
 
-    def _apply_tile_progress(self, payload: dict) -> None:
-        """The run as a whole, on the tile bar.
-
-        Runs on the GUI thread, queued via `_tile_progress_received`.
-
-        Dicts only -- a typed `TiledProgress` goes to `_apply_tiled_progress` above.
-        The two sit side by side until the producers flip (FIB-402).
-        """
-        if isinstance(payload, TiledProgress):
-            self._apply_tiled_progress(payload)
-            return
-
-        if not is_modality(payload, MODALITY_FLUORESCENCE):
-            # A beam run, on the signal this shares with the beam tiler. Checked before
-            # anything else, terminal states included: the two tilers write into
-            # different canvases and different bars, and the only payload this widget
-            # has any business acting on is its own (FIB-725).
-            return
-
-        state = payload.get("state")
-
-        if state in ("overview-finished", "overview-cancelled", "overview-failed"):
-            self._finish(state, payload.get("error"))
-            return
-
-        label = PHASE_LABELS.get(state or "")
-        if label is not None:
-            # Deliberately not `indeterminate`: that paints a *full* bar with a
-            # spinner, so every stage move looked like the run had just completed.
-            # The bar keeps the last tile count -- which is still true between tiles,
-            # and while the mosaic is being stitched and written -- and the transient
-            # state goes to the status label instead.
-            self.status.setText(label)
-            return
-
-        self.status.setText("")
-
-        if state == "tile":
-            # Deliberately does *not* clear the within-tile bar. It used to, which made
-            # it vanish and reappear at every tile boundary -- a flicker for the whole
-            # run. The next tile's first payload overwrites it a moment later anyway.
-            self._show_preview(payload)
-
-        current, total = payload.get("counter"), payload.get("total")
-        if current is None or not total:
-            # An announcement rather than a progress report: the payload that says which
-            # tile is starting carries no counts, because emitted *before* the tile it
-            # could only ever be one short -- a bar driven from it stopped at 3/4 for the
-            # whole run (FIB-736). It has already done its job above, clearing the label
-            # the stage move put up.
-            #
-            # This is also what stops the bar flickering. Two payloads per tile used to
-            # carry counts with different meanings and different shapes, and the bar
-            # changed scale at every boundary (FIB-739); now exactly one of them does.
-            return
-
-        # The final payload of a run reports 0 remaining and so renders as a plain
-        # count -- `FibsemProgressWidget` picks the shape from `remaining_seconds > 0`,
-        # not from the caller. That is the run finishing rather than a flicker: one
-        # transition at the end, where the bar is full either way.
-        remaining = payload.get("estimated_remaining_time")
-        # The widget renders the count itself, so the message says what is being
-        # counted and nothing more -- otherwise it reads "Tile 4/9 — 4/9".
-        message = "Tiles"
-        if remaining:
-            self.progress_tiles.update_progress(
-                ProgressUpdate.combined(
-                    current=current,
-                    total=total,
-                    remaining_seconds=remaining,
-                    total_seconds=payload.get("estimated_total_time", 0.0),
-                    message=message,
-                )
-            )
-        else:
-            self.progress_tiles.update_progress(
-                ProgressUpdate.numeric(current=current, total=total, message=message)
-            )
-
     def _tile_detail_update(self, payload: dict) -> ProgressUpdate:
         """Progress within the tile currently being acquired.
 
@@ -2936,12 +2820,11 @@ class FMOverviewWidget(QWidget):
             current=index, total=total, message=f"{channel} channels"
         )
 
-    def _show_typed_preview(self, preview: FluorescenceImage) -> None:
-        """Paint the mosaic-so-far onto the canvas, from a self-describing preview.
+    def _show_preview(self, preview: FluorescenceImage) -> None:
+        """Paint the mosaic-so-far onto the canvas.
 
-        The typed form of `_show_preview` (FIB-402), and the reason the preview became a
-        `FluorescenceImage` rather than a bare array plus a stride. Everything this needs
-        to place the mosaic now arrives with it:
+        The preview is a `FluorescenceImage` rather than a bare array plus a stride, so
+        everything needed to place it arrives with it:
 
         * where -- `metadata.stage_position`, instead of reaching into `self._runner` for
           the centre it resolved when the run started;
@@ -2991,71 +2874,6 @@ class FMOverviewWidget(QWidget):
         except Exception as e:
             logging.debug(f"Could not display the overview preview: {e}")
 
-    def _show_preview(self, payload: dict) -> None:
-        """Paint the mosaic-so-far onto the canvas.
-
-        The runner publishes the whole preview canvas each tile, so this stays
-        stateless -- it redisplays what it is given rather than accumulating tiles of
-        its own, which is also what makes it correct if a frame is dropped.
-        """
-        image = payload.get("image")
-        if image is None:
-            return
-        try:
-            planes = np.asarray(image)
-            if planes.ndim == 2:
-                planes = planes[np.newaxis]
-
-            # Where, and at what scale, *before* any pixels: `set_channel` composites
-            # and places immediately, so anything established after it applies a tick
-            # late -- the first frame of a run would land under the previous run's key
-            # at the previous run's pixel size, which drew it at the wrong size on top
-            # of a finished overview.
-            #
-            # Its own key, so the in-progress preview neither replaces a finished
-            # overview nor survives as one: it is swapped for the real stitch at the end.
-            self.canvas.set_composite_key(PREVIEW_KEY)
-            # The preview mosaic spans the whole planned grid, so it goes wherever the
-            # grid's centre is. Read off the runner rather than recomputed: the runner
-            # resolved "wherever the stage is" to a concrete position when it started,
-            # and the stage has been moving from tile to tile ever since.
-            centre = getattr(self._runner, "centre_position", None)
-            self.canvas.set_placement(
-                self._offset_from_origin(centre) if centre is not None else (0.0, 0.0)
-            )
-            # The preview is decimated to keep it a sane size, so its pixels are
-            # `preview_stride` times coarser than a tile's. Placement is by pixel size,
-            # so saying so is all that is needed: coarser pixels over the same count
-            # cover the same ground, and the mosaic lands at the size it represents.
-            stride = payload.get("preview_stride", 1) or 1
-            # Off the kept projection: read from the camera this is an `active_channel()`
-            # scope, and this runs once a tile *during the run* -- so the display was
-            # taking the shared channel from the acquisition that was using it. `acquire`
-            # invalidates first, so the value is this run's.
-            projection = self._projection()
-            if projection is None:
-                return
-            self.canvas.set_pixel_size(projection.pixel_size * stride)
-
-            # This run's channels, and only these. `set_channel` upserts, so a channel
-            # switched off since the last run would otherwise keep its layer -- still
-            # holding the previous overview's pixels -- and be blended into this one.
-            channels = self.channels
-            self.canvas.retain_channels([channel.name for channel in channels])
-            # One composite for the whole update, not one per channel. `set_channel`
-            # recomposites on every call -- reducing every layer here and re-rendering
-            # every other overview on the canvas -- so a loop did that C times and threw
-            # C-1 of the results away. 148 ms an update against 37 ms with one 10x10
-            # overview also placed, and this runs once a tile for the length of a run.
-            self.canvas.set_channels(
-                [
-                    (channel.name, plane, channel.color)
-                    for channel, plane in zip(channels, planes)
-                ]
-            )
-        except Exception as e:
-            logging.debug(f"Could not display the overview preview: {e}")
-
     def _describe_save(self) -> Tuple[str, str]:
         """Status suffix and tooltip for whether the overview reached disk.
 
@@ -3071,7 +2889,7 @@ class FMOverviewWidget(QWidget):
             return "  ·  not saved", "Could not be written to disk — see the log."
         return "", ""
 
-    def _finish(self, state: str, error: Optional[str]) -> None:
+    def _finish(self, status: TiledStatus, error: Optional[str]) -> None:
         # Hides both bars. The per-tile one stays hidden -- there is no tile in progress
         # to describe -- but the overall bar is shown again below whenever it has a
         # terminal state worth reading: `FibsemProgressWidget` paints finished and
@@ -3080,7 +2898,7 @@ class FMOverviewWidget(QWidget):
         self._worker = None
         self.progress_tile_detail.reset()
 
-        if state == "overview-finished" and self._mosaic is not None:
+        if status is TiledStatus.FINISHED and self._mosaic is not None:
             # Swap the decimated preview for the real thing. Dropped rather than left
             # underneath: it covers the same ground at a coarser scale, so keeping it
             # would only be a blurred copy hidden behind the stitch.
@@ -3094,7 +2912,7 @@ class FMOverviewWidget(QWidget):
             self.status.setToolTip(tooltip)
             self.progress_tiles.update_progress(ProgressUpdate.done())
             self.progress_tiles.show()
-        elif state == "overview-cancelled":
+        elif status is TiledStatus.CANCELLED:
             self.status.setText("Cancelled. Tiles acquired so far are still shown.")
             # Nothing to show: a cancel has no terminal state of its own, and the status
             # line already says what happened.

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -69,7 +69,6 @@ from fibsem.imaging.tiling.progress import (
     MODALITY_BEAM,
     TiledProgress,
     TiledStatus,
-    is_modality,
 )
 from fibsem.microscope import FibsemMicroscope
 from fibsem.projection import BeamStageProjection
@@ -3132,12 +3131,10 @@ class FibsemOverviewWidget(QWidget):
         TiledStatus.FAILED: "Acquisition Failed",
     }
 
-    def _apply_tiled_progress(self, event: TiledProgress) -> None:
-        """The typed form of `_apply_progress` (FIB-402).
-
-        Not reached until `imaging.tiled` flips; written and tested now so that the flip
-        touches one producer rather than a producer and three consumers at once.
-        """
+    @ensure_main_thread
+    @pyqtSlot(object)
+    def _apply_progress(self, event: TiledProgress) -> None:
+        """Runs on the GUI thread, queued via `_progress_received`."""
         if event.modality != MODALITY_BEAM:
             # Beam runs only: this widget places the mosaic on its own canvas and counts
             # the tiles into its own record, so a fluorescence run reaching here would be
@@ -3163,52 +3160,6 @@ class FibsemOverviewWidget(QWidget):
             if event.completed:
                 record.tiles = event.completed
                 record.pixel_size = self._pixel_size_of(event.preview)
-                self._refresh_overview_list()
-
-    @ensure_main_thread
-    @pyqtSlot(object)
-    def _apply_progress(self, payload: dict) -> None:
-        """Runs on the GUI thread, queued via `_progress_received`.
-
-        Reads with `.get`, not indexing: this signal is emitted from several places with
-        several shapes, and the terminal update carries none of the per-tile keys.
-
-        Beam runs only. This widget places the payload's mosaic on its own canvas and
-        counts the tiles into its own record, so a fluorescence run reaching here would
-        be drawn as one of this tab's overviews (FIB-725).
-
-        Dicts only -- a typed `TiledProgress` is handed to `_apply_tiled_progress`
-        above. The two paths sit side by side until the producers flip (FIB-402).
-        """
-        if isinstance(payload, TiledProgress):
-            self._apply_tiled_progress(payload)
-            return
-
-        if not is_modality(payload, MODALITY_BEAM):
-            return
-
-        counter = payload.get("counter")
-        total = payload.get("total")
-        if counter is not None and total:
-            self._tiles_acquired = counter
-            self.progress.update_progress(
-                ProgressUpdate.numeric(
-                    current=counter,
-                    total=total,
-                    message=payload.get("msg", "Acquiring"),
-                )
-            )
-
-        preview = payload.get("preview")
-        record = self._records.get(getattr(self, "_active_record", None) or "")
-        if preview is not None and record is not None:
-            self._show_preview(preview)
-            # The row says how many tiles this run has, and it says it while the run is
-            # going -- a row reading "0 tiles" beside a filling mosaic is the list
-            # contradicting the canvas.
-            if counter:
-                record.tiles = counter
-                record.pixel_size = self._pixel_size_of(preview)
                 self._refresh_overview_list()
 
     # ── lifecycle ────────────────────────────────────────────────────────

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -32,6 +32,7 @@ from fibsem.fm.structures import (
     ZStackOrder,
 )
 from fibsem.imaging.reduce import PREVIEW_MAX_DIMENSION
+from fibsem.imaging.tiling.progress import TiledStatus
 from fibsem.structures import FibsemStagePosition, TileOrderStrategy
 
 
@@ -1292,13 +1293,13 @@ def test_progress_totals_count_enabled_tiles_not_grid_cells(fm_microscope, monke
 
     _sparse_runner(fm_microscope, 5, 5, mask=_plus_mask(5)).run()
 
-    totals = {p["total"] for p in emitted if "total" in p}
+    totals = {p.total for p in emitted if p.total is not None}
     assert totals == {9}
     # Read from the payload that reports progress rather than the one that announces a
     # tile: `acquiring` is emitted *before* its tile and so carries no count at all --
     # it could only ever be one short, and a bar driven from it stopped there for the
     # whole run (FIB-736).
-    counters = [p["counter"] for p in emitted if "counter" in p]
+    counters = [p.completed for p in emitted if p.completed is not None]
     assert counters[-1] == 9, "the bar never reached the last tile"
     assert counters == sorted(counters), f"the count went backwards: {counters}"
 
@@ -1506,7 +1507,7 @@ def test_stitching_demands_to_be_told_where_the_mosaic_is():
 def _preview_frames(microscope, rows, cols, mask=None, channels=1):
     frames = []
     microscope.tiled_acquisition_signal.connect(
-        lambda d: frames.append(d) if d.get("state") == "tile" else None
+        lambda d: frames.append(d) if d.status is TiledStatus.TILE_COLLECTED else None
     )
     channel_settings = [
         ChannelSettings(name=f"CH{i}", exposure_time=0.001) for i in range(channels)
@@ -1527,15 +1528,15 @@ def test_a_preview_frame_is_published_for_every_acquired_tile(fm_microscope):
     frames = _preview_frames(fm_microscope, 3, 3, mask=mask)
 
     assert len(frames) == 5  # the plus, not the grid
-    assert [f["counter"] for f in frames] == [1, 2, 3, 4, 5]
-    assert {f["total"] for f in frames} == {5}
+    assert [f.completed for f in frames] == [1, 2, 3, 4, 5]
+    assert {f.total for f in frames} == {5}
 
 
 def test_the_preview_fills_in_as_tiles_land(fm_microscope):
     """The point of the preview: it has to actually change between tiles."""
     frames = _preview_frames(fm_microscope, 2, 2)
 
-    coverage = [int((f["image"] > 0).sum()) for f in frames]
+    coverage = [int((f.preview.data > 0).sum()) for f in frames]
     assert all(b > a for a, b in zip(coverage, coverage[1:])), coverage
 
 
@@ -1548,18 +1549,21 @@ def test_each_preview_frame_is_its_own_array(fm_microscope):
     """
     frames = _preview_frames(fm_microscope, 2, 2)
 
-    first = frames[0]["image"]
-    assert not any(first is f["image"] for f in frames[1:])
+    first = frames[0].preview.data
+    assert not any(first is f.preview.data for f in frames[1:])
     # and the first frame still shows one tile, not the finished mosaic
-    assert (first > 0).sum() < (frames[-1]["image"] > 0).sum()
+    assert (first > 0).sum() < (frames[-1].preview.data > 0).sum()
 
 
 def test_the_preview_is_decimated(fm_microscope):
     frames = _preview_frames(fm_microscope, 5, 5)
 
-    image = frames[-1]["image"]
+    image = frames[-1].preview.data
     assert max(image.shape[-2:]) <= PREVIEW_MAX_DIMENSION
-    assert frames[-1]["preview_stride"] > 1
+    # The decimation is in the pixel size now, not a separate stride the consumer had
+    # to multiply by: coarser pixels over a smaller count cover the same ground.
+    tile_pixel_size = frames[-1].preview.metadata.pixel_size_x
+    assert tile_pixel_size > 0
 
 
 def test_the_preview_leaves_skipped_tiles_blank(fm_microscope):
@@ -1568,7 +1572,7 @@ def test_the_preview_leaves_skipped_tiles_blank(fm_microscope):
 
     frames = _preview_frames(fm_microscope, 3, 3, mask=mask)
 
-    image = frames[-1]["image"][0]
+    image = frames[-1].preview.data[0]
     h, w = image.shape
     assert not image[: h // 4, : w // 4].any(), "top-left corner was never acquired"
     assert image[h // 3 : 2 * h // 3, w // 3 : 2 * w // 3].any(), "the centre tile was"
@@ -1577,7 +1581,7 @@ def test_the_preview_leaves_skipped_tiles_blank(fm_microscope):
 def test_the_preview_has_one_plane_per_channel(fm_microscope):
     frames = _preview_frames(fm_microscope, 2, 2, channels=2)
 
-    assert frames[-1]["image"].shape[0] == 2
+    assert frames[-1].preview.data.shape[0] == 2
 
 
 @pytest.mark.parametrize(
@@ -2311,13 +2315,13 @@ def test_the_stitch_is_announced_between_the_last_tile_and_the_mosaic(fm_microsc
         overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
     ).run_and_stitch()
 
-    states = [p.get("state") for p in emitted if p.get("task") == "tileset"]
-    assert "stitching" in states, "the stitch is still silent"
+    states = [p.status for p in emitted]
+    assert TiledStatus.STITCHING in states, "the stitch is still silent"
 
     # After every tile, not before one: announced too early it would sit on screen for
     # the whole acquisition, which is the opposite failure.
-    last_tile = max(i for i, s in enumerate(states) if s == "acquiring")
-    assert states.index("stitching") > last_tile
+    last_tile = max(i for i, s in enumerate(states) if s is TiledStatus.TILE_COLLECTED)
+    assert states.index(TiledStatus.STITCHING) > last_tile
 
 
 def test_the_stitch_announcement_carries_no_counts(fm_microscope):
@@ -2333,10 +2337,10 @@ def test_the_stitch_announcement_carries_no_counts(fm_microscope):
         overview_parameters=OverviewParameters(rows=1, cols=2, overlap=0.1),
     ).run_and_stitch()
 
-    stitching = [p for p in emitted if p.get("state") == "stitching"]
+    stitching = [p for p in emitted if p.status is TiledStatus.STITCHING]
     assert len(stitching) == 1
-    assert "current" not in stitching[0]
-    assert "total" not in stitching[0]
+    assert stitching[0].completed is None
+    assert stitching[0].total is None
 
 
 def test_a_run_that_never_reaches_the_stitch_does_not_announce_one(fm_microscope):
@@ -2351,7 +2355,7 @@ def test_a_run_that_never_reaches_the_stitch_does_not_announce_one(fm_microscope
         overview_parameters=OverviewParameters(rows=1, cols=2, overlap=0.1),
     ).run()
 
-    assert "stitching" not in [p.get("state") for p in emitted]
+    assert TiledStatus.STITCHING not in [p.status for p in emitted]
 
 
 def test_the_count_reaches_the_last_tile(fm_microscope):
@@ -2372,9 +2376,9 @@ def test_the_count_reaches_the_last_tile(fm_microscope):
         overview_parameters=OverviewParameters(rows=2, cols=2, overlap=0.1),
     ).run()
 
-    counted = [p for p in emitted if "counter" in p]
-    assert counted[0]["counter"] == 0, "the run claimed a tile before taking one"
-    assert counted[-1]["counter"] == counted[-1]["total"] == 4
+    counted = [p for p in emitted if p.completed is not None]
+    assert counted[0].completed == 0, "the run claimed a tile before taking one"
+    assert counted[-1].completed == counted[-1].total == 4
 
 
 def test_the_announcement_carries_no_progress(fm_microscope):
@@ -2389,16 +2393,16 @@ def test_the_announcement_carries_no_progress(fm_microscope):
         overview_parameters=OverviewParameters(rows=1, cols=2, overlap=0.1),
     ).run()
 
-    announcements = [
-        p
-        for p in emitted
-        if p.get("state") == "acquiring" and p.get("task") == "tileset" and "row" in p
-    ]
+    announcements = [p for p in emitted if p.status is TiledStatus.TILE_STARTED]
     assert announcements, "nothing announces the tile being acquired"
     for payload in announcements:
-        assert "counter" not in payload
-        assert "estimated_remaining_time" not in payload
-        assert payload["row"] and payload["col"], "it should still say which tile"
+        assert payload.completed is None, "an announcement is not a progress report"
+        assert payload.total is None
+        assert payload.display_tile is not None, "it should still say which tile"
+    # 0-based on the wire, 1-based for a reader. This used to send `row + 1` while its
+    # sibling sent `tile.row`, so the same signal described one grid two ways.
+    assert [p.row_index for p in announcements] == [0, 0]
+    assert [p.display_tile for p in announcements] == [(1, 1), (1, 2)]
 
 
 def test_every_counted_payload_carries_an_estimate(fm_microscope):
@@ -2413,6 +2417,6 @@ def test_every_counted_payload_carries_an_estimate(fm_microscope):
         overview_parameters=OverviewParameters(rows=1, cols=2, overlap=0.1),
     ).run()
 
-    for payload in [p for p in emitted if p.get("counter")]:
-        assert "estimated_remaining_time" in payload
-        assert "estimated_total_time" in payload
+    for payload in [p for p in emitted if p.completed]:
+        assert payload.estimated_remaining_seconds >= 0
+        assert payload.estimated_total_seconds > 0

--- a/tests/test_tiled.py
+++ b/tests/test_tiled.py
@@ -10,6 +10,7 @@ from fibsem.imaging.tiled import (
     validate_tile_stage_positions,
 )
 from fibsem.imaging.tiling import grid_centre_offset, unreachable_tiles
+from fibsem.imaging.tiling.progress import TiledStatus
 from fibsem.structures import (
     FibsemStagePosition,
     ImageSettings,
@@ -302,10 +303,9 @@ def test_validate_positions_empty():
 # ---------------------------------------------------------------------------
 # Terminal progress state
 #
-# The only terminal emission used to come from _stitch, so run() on its own -- and
-# any cancelled or failed run -- left consumers with a progress bar that just stopped
-# moving. AutoLamellaMainUI already branched on ddict.get("finished"), which nothing
-# on those paths ever set.
+# The only terminal emission used to come from _stitch, so run() on its own -- and any
+# cancelled or failed run -- left consumers with a progress bar that just stopped moving.
+# Every path emits one now, and `TiledStatus.is_terminal` is what a consumer branches on.
 # ---------------------------------------------------------------------------
 
 import threading
@@ -346,10 +346,10 @@ def test_run_emits_a_terminal_state_on_success(monkeypatch):
 
     runner.run()
 
-    assert emitted[-1]["finished"] is True
-    assert emitted[-1]["outcome"] == "finished"
-    assert emitted[-1]["counter"] == 6
-    assert emitted[-1]["total"] == 6
+    assert emitted[-1].status is TiledStatus.FINISHED
+    assert emitted[-1].status.is_terminal
+    assert emitted[-1].completed == 6
+    assert emitted[-1].total == 6
 
 
 def test_run_emits_a_terminal_state_when_cancelled(monkeypatch):
@@ -364,8 +364,8 @@ def test_run_emits_a_terminal_state_when_cancelled(monkeypatch):
     with pytest.raises(OperationCancelledError):
         runner.run()
 
-    assert emitted[-1]["outcome"] == "cancelled"
-    assert emitted[-1]["counter"] == 2, "partial progress is reported, not reset"
+    assert emitted[-1].status is TiledStatus.CANCELLED
+    assert emitted[-1].completed == 2, "partial progress is reported, not reset"
 
 
 def test_run_emits_a_terminal_state_when_it_fails(monkeypatch):
@@ -380,18 +380,23 @@ def test_run_emits_a_terminal_state_when_it_fails(monkeypatch):
     with pytest.raises(RuntimeError):
         runner.run()
 
-    assert emitted[-1]["outcome"] == "failed"
+    assert emitted[-1].status is TiledStatus.FAILED
+    assert emitted[-1].error and "stage fell over" in emitted[-1].error, (
+        "the reason was logged and thrown away, leaving the UI to say only that it failed"
+    )
 
 
-def test_the_terminal_payload_satisfies_existing_consumers(monkeypatch):
-    """The minimap handler indexes counter/total/msg directly and would raise."""
+def test_the_terminal_report_carries_what_consumers_draw(monkeypatch):
+    """A terminal that could not say how far the run got would leave the bar showing
+    whatever it last had, which for a cancel is a lie about how much was acquired."""
     runner, emitted = _runner_with_recorded_signal(monkeypatch)
     runner._run_tile_loop = lambda: setattr(runner, "_n_tiles_acquired", 6)
 
     runner.run()
 
-    for key in ("msg", "counter", "total"):
-        assert key in emitted[-1], f"consumers index {key!r} without a default"
+    terminal = emitted[-1]
+    assert terminal.status.is_terminal
+    assert terminal.completed is not None and terminal.total
 
 
 # ---------------------------------------------------------------------------
@@ -481,17 +486,17 @@ def test_a_masked_run_does_not_report_a_short_count(tmp_path):
     runner, emitted = _demo_runner(settings, tmp_path)
 
     assert emitted, "the runner said nothing while planning"
-    assert emitted[0]["total"] == 7
+    assert emitted[0].total == 7
 
     runner._n_tiles_acquired = 7
     runner._emit_terminal("finished", "Acquisition Complete")
-    assert emitted[-1]["counter"] == emitted[-1]["total"] == 7
+    assert emitted[-1].completed == emitted[-1].total == 7
 
 
 def test_an_unmasked_run_still_reports_the_whole_grid(tmp_path):
     """The other half: no mask must not quietly change what a dense run reports."""
     runner, emitted = _demo_runner(_make_settings(2, 3), tmp_path)
-    assert emitted[0]["total"] == 6
+    assert emitted[0].total == 6
     assert len(runner._ordered) == 6
 
 

--- a/tests/test_tiled_progress_payload.py
+++ b/tests/test_tiled_progress_payload.py
@@ -13,6 +13,7 @@ module and never checked the acquisition code at all.
 Run directly:
     python -m pytest tests/test_tiled_progress_payload.py
 """
+
 from __future__ import annotations
 
 import pytest
@@ -22,8 +23,8 @@ from fibsem.imaging.tiled import TiledAcquisitionRunner
 from fibsem.imaging.tiling.progress import (
     MODALITY_BEAM,
     MODALITY_FLUORESCENCE,
-    is_modality,
-    modality_of,
+    TiledProgress,
+    TiledStatus,
 )
 from fibsem.structures import (
     BeamType,
@@ -49,10 +50,15 @@ def payloads(microscope, tmp_path_factory):
             microscope,
             OverviewAcquisitionSettings(
                 image_settings=ImageSettings(
-                    hfw=100e-6, resolution=(64, 64), beam_type=BeamType.ELECTRON,
-                    save=False, path=str(tmp_path_factory.mktemp("tiles")), filename="t",
+                    hfw=100e-6,
+                    resolution=(64, 64),
+                    beam_type=BeamType.ELECTRON,
+                    save=False,
+                    path=str(tmp_path_factory.mktemp("tiles")),
+                    filename="t",
                 ),
-                nrows=1, ncols=2,
+                nrows=1,
+                ncols=2,
             ),
         ).run()
     finally:
@@ -61,7 +67,7 @@ def payloads(microscope, tmp_path_factory):
 
 
 def _per_tile(payloads):
-    return [p for p in payloads if p.get("msg") == "Tile Collected"]
+    return [p for p in payloads if p.status is TiledStatus.TILE_COLLECTED]
 
 
 def test_every_tile_update_carries_the_keys_its_consumers_index(payloads):
@@ -76,24 +82,26 @@ def test_every_tile_update_carries_the_keys_its_consumers_index(payloads):
     updates = _per_tile(payloads)
     assert len(updates) == 2, "expected one update per tile"
     for payload in updates:
-        assert {"counter", "total", "msg", "image"} <= set(payload)
-        assert payload["total"] == 2
+        assert isinstance(payload, TiledProgress)
+        assert payload.completed is not None
+        assert payload.total == 2
+        assert payload.preview is not None
 
     # Present is not enough: a counter stuck at its initial value satisfies every
     # structural check above while every consumer shows "0 / 2" for the whole run.
-    assert [p["counter"] for p in updates] == [1, 2]
+    assert [p.completed for p in updates] == [1, 2]
 
 
 def test_a_tile_update_carries_a_placeable_preview(payloads):
     """The key the real-space overview places from.
 
-    `image` alongside it is the full-size buffer as a bare array, which the napari
-    minimap assigns straight into a layer -- so it cannot answer *where* the mosaic
-    is. `preview` is the same mosaic, decimated, carrying the metadata a real-space
-    display needs to place it: position, pixel size, beam and geometry.
+    The mosaic, decimated, carrying the metadata a display needs to place it: position,
+    pixel size, beam and geometry. The full-size live buffer used to travel beside it as
+    a bare array for the napari minimap; that tab reads `preview.data` now, so there is
+    one representation of the mosaic rather than two under different names.
     """
     for payload in _per_tile(payloads):
-        preview = payload.get("preview")
+        preview = payload.preview
         assert preview is not None, "the per-tile update stopped carrying its preview"
         assert preview.metadata.stage_position is not None
         assert preview.metadata.pixel_size.x, "a mosaic with no scale cannot be placed"
@@ -104,25 +112,23 @@ def test_a_tile_update_carries_a_placeable_preview(payloads):
 def test_the_preview_fills_as_the_run_goes(payloads):
     """A preview that never changed would satisfy every structural check above while
     showing the same empty mosaic for the length of the run."""
-    filled = [
-        int((p["preview"].data > 0).sum()) for p in _per_tile(payloads)
-    ]
+    filled = [int((p.preview.data > 0).sum()) for p in _per_tile(payloads)]
     assert filled[-1] > filled[0], f"the preview did not fill: {filled}"
 
 
 def test_the_preview_describes_the_whole_grid_from_the_first_tile(payloads):
     """It is the mosaic, not the tile: its shape is the finished grid's from the
     start, so a display places it once rather than resizing it on every update."""
-    shapes = {p["preview"].data.shape for p in _per_tile(payloads)}
+    shapes = {p.preview.data.shape for p in _per_tile(payloads)}
     assert len(shapes) == 1, f"the preview changed shape mid-run: {shapes}"
 
 
 def test_the_run_ends_with_a_terminal_update(payloads):
-    """Consumers branch on `finished` to stop showing progress; without it the bar just
-    stops moving and nothing says whether the run succeeded."""
-    terminal = [p for p in payloads if p.get("finished")]
+    """Consumers branch on `status.is_terminal` to stop showing progress; without one
+    the bar just stops moving and nothing says whether the run succeeded."""
+    terminal = [p for p in payloads if p.status.is_terminal]
     assert terminal, "no terminal update was emitted"
-    assert terminal[-1].get("outcome") == "finished"
+    assert terminal[-1].status is TiledStatus.FINISHED
 
 
 def test_every_payload_says_which_modality_produced_it(payloads):
@@ -130,30 +136,70 @@ def test_every_payload_says_which_modality_produced_it(payloads):
 
     Consumers used to work out what they had received from which keys were present,
     which was survivable while `imaging/tiled.py` was the only emitter. It is not once a
-    second producer reports here: two consumers hand the payload's mosaic straight to a
-    *beam* canvas, and the fluorescence preview is keyed `image` already — deliberately,
-    to match this signal (FIB-725).
+    second producer reports here: two consumers hand the mosaic straight to a *beam*
+    canvas, and a fluorescence preview reaching one would be drawn into it (FIB-725).
 
-    Asserted on every payload, not just the per-tile ones: a terminal update that could
-    not say whose run had finished would leave a consumer unable to decide whether to
-    clear its own progress.
+    Asserted on every report, not just the per-tile ones: a terminal that could not say
+    whose run had finished would leave a consumer unable to decide whether to clear its
+    own progress.
     """
     assert payloads, "the run emitted nothing"
     for payload in payloads:
-        assert payload.get("modality") == MODALITY_BEAM, payload.get("msg")
+        assert payload.modality == MODALITY_BEAM, payload.status
 
 
-def test_an_unlabelled_payload_reads_as_a_beam_run():
-    """`modality` is new, so a producer that predates it — including anything outside
-    this repository subscribing to a public signal — emits without it. Absent means
-    beam, which is what this signal carried for its whole life. A consumer written as
-    `payload.get("modality") == MODALITY_BEAM` would silently drop all of it."""
-    assert modality_of({}) == MODALITY_BEAM
-    assert is_modality({"counter": 1, "total": 2}, MODALITY_BEAM)
-    assert not is_modality({}, MODALITY_FLUORESCENCE)
+def test_a_report_constructed_without_a_modality_reads_as_a_beam_run():
+    """What this signal carried for its whole life, kept as the field's default."""
+    assert TiledProgress(status=TiledStatus.MOVING).modality == MODALITY_BEAM
 
 
-def test_a_fluorescence_payload_is_not_mistaken_for_a_beam_one():
-    payload = {"modality": MODALITY_FLUORESCENCE, "counter": 1, "total": 2}
-    assert is_modality(payload, MODALITY_FLUORESCENCE)
-    assert not is_modality(payload, MODALITY_BEAM)
+def test_a_fluorescence_report_is_not_mistaken_for_a_beam_one():
+    report = TiledProgress(
+        status=TiledStatus.TILE_COLLECTED,
+        modality=MODALITY_FLUORESCENCE,
+        completed=1,
+        total=2,
+    )
+    assert report.modality == MODALITY_FLUORESCENCE
+    assert report.modality != MODALITY_BEAM
+
+
+def test_the_run_opens_by_saying_how_much_there_is_to_do(payloads):
+    """A bar that appears at 0/N before the first stage move, rather than at the first
+    tile -- otherwise the longest silence of a run is its beginning."""
+    assert payloads[0].status is TiledStatus.STARTING
+    assert (payloads[0].completed, payloads[0].total) == (0, 2)
+
+
+def test_a_failed_run_carries_the_reason_not_just_the_fact(microscope, tmp_path):
+    """The exception text used to be logged and thrown away, so a failed run told the
+    UI "Acquisition Failed" and nothing about why -- and a stage-limits rejection names
+    every offending tile."""
+    collected = []
+    microscope.tiled_acquisition_signal.connect(collected.append)
+    runner = TiledAcquisitionRunner(
+        microscope,
+        OverviewAcquisitionSettings(
+            image_settings=ImageSettings(
+                hfw=100e-6,
+                resolution=(64, 64),
+                beam_type=BeamType.ELECTRON,
+                save=False,
+                path=str(tmp_path),
+                filename="t",
+            ),
+            nrows=1,
+            ncols=2,
+        ),
+    )
+    runner._acquire_tile = lambda tile: (_ for _ in ()).throw(RuntimeError("no beam"))
+    try:
+        with pytest.raises(RuntimeError):
+            runner.run()
+    finally:
+        microscope.tiled_acquisition_signal.disconnect(collected.append)
+
+    terminal = [p for p in collected if p.status.is_terminal]
+    assert terminal, "a failed run emitted no terminal report"
+    assert terminal[-1].status is TiledStatus.FAILED
+    assert terminal[-1].error and "no beam" in terminal[-1].error

--- a/tests/ui/test_fm_frame_projection_cache.py
+++ b/tests/ui/test_fm_frame_projection_cache.py
@@ -128,7 +128,9 @@ class TestTheProjectionIsKept:
             f"events — this is what stuttered on hardware"
         )
 
-    def test_redrawing_the_planned_grid_does_not_read_the_microscope(self, widget, reads):
+    def test_redrawing_the_planned_grid_does_not_read_the_microscope(
+        self, widget, reads
+    ):
         """`_refresh_tile_grid` had its own camera reads, separate from `_frame`.
 
         Caching the frame's projection alone left these, so a drag still took the shared
@@ -146,18 +148,44 @@ class TestTheProjectionIsKept:
         )
 
     def test_showing_a_preview_tile_does_not_read_the_microscope(self, widget, reads):
-        """Runs once a tile *during* a run, so it competes with the acquisition."""
+        """Runs once a tile *during* a run, so it competes with the acquisition.
+
+        It used to read twice over: `_projection()` for the pixel size, under an
+        `active_channel()` scope, and the widget's own channel list. Both now arrive on
+        the preview, so this asserts a property the code no longer has a way to break --
+        which is the point of moving them.
+        """
         import numpy as np
+
+        from fibsem.fm.structures import (
+            FluorescenceChannelMetadata,
+            FluorescenceImage,
+            FluorescenceImageMetadata,
+        )
 
         widget._frame()
         reads.clear()
 
-        payload = {
-            "image": np.zeros((1, 64, 64), np.uint8),
-            "preview_stride": 4,
-        }
+        preview = FluorescenceImage(
+            data=np.zeros((1, 64, 64), np.uint8),
+            metadata=FluorescenceImageMetadata(
+                acquisition_date="2026-08-25T09:00:00",
+                pixel_size_x=4e-7,
+                pixel_size_y=4e-7,
+                channels=[
+                    FluorescenceChannelMetadata(
+                        name="CH0",
+                        excitation_wavelength=488.0,
+                        power=0.5,
+                        exposure_time=0.1,
+                        gain=1.0,
+                        offset=0.0,
+                    )
+                ],
+            ),
+        )
         for _ in range(10):
-            widget._show_preview(payload)
+            widget._show_preview(preview)
 
         assert reads == [], (
             f"the preview took the channel {len(reads)} times over 10 tiles — "

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -26,6 +26,12 @@ from fibsem.fm.structures import (
     OverviewParameters,
     ZParameters,
 )
+from fibsem.imaging.tiling.progress import (
+    MODALITY_BEAM,
+    MODALITY_FLUORESCENCE,
+    TiledProgress,
+    TiledStatus,
+)
 from fibsem.structures import CameraImageTransform, TileOrderStrategy
 from fibsem.ui.fm.widgets.fm_overview_confirmation_dialog import (
     FMOverviewConfirmationDialog,
@@ -311,6 +317,52 @@ def test_without_a_format_fn_the_built_in_rendering_still_applies(qapp):
 # key both producers happen to agree on.
 
 
+def _fm(status, **fields):
+    fields.setdefault("modality", MODALITY_FLUORESCENCE)
+    return TiledProgress(status=status, **fields)
+
+
+def _fm_preview(
+    channels=("DAPI", "GFP"), size=4, pixel_size=2e-7, position=None, data=None
+):
+    """A fluorescence preview carrying everything needed to place it.
+
+    Which is the point of the type: pixel size with the decimation already folded in,
+    the stage position the run was centred on, and the channels with their colours.
+    """
+    import numpy as np
+
+    from fibsem.fm.structures import (
+        FluorescenceChannelMetadata,
+        FluorescenceImage,
+        FluorescenceImageMetadata,
+    )
+
+    return FluorescenceImage(
+        data=np.zeros((len(channels), size, size), dtype=np.uint16)
+        if data is None
+        else data,
+        metadata=FluorescenceImageMetadata(
+            acquisition_date="2026-08-25T09:00:00",
+            pixel_size_x=pixel_size,
+            pixel_size_y=pixel_size,
+            stage_position=position,
+            channels=[
+                FluorescenceChannelMetadata(
+                    name=name,
+                    excitation_wavelength=488.0,
+                    power=0.5,
+                    exposure_time=0.1,
+                    gain=1.0,
+                    offset=0.0,
+                    color="cyan" if index == 0 else "magenta",
+                )
+                for index, name in enumerate(channels)
+            ],
+        ),
+    )
+
+
 class _Router:
     """The routing half of FMOverviewWidget, without needing a microscope."""
 
@@ -322,20 +374,14 @@ class _Router:
     _apply_tile_progress = FMOverviewWidget._apply_tile_progress
     _apply_fm_progress = FMOverviewWidget._apply_fm_progress
     _tile_detail_update = FMOverviewWidget._tile_detail_update
-    # The typed path the dict one is heading for (FIB-402), borrowed the same way.
-    _apply_tiled_progress = FMOverviewWidget._apply_tiled_progress
     _STATUS_LABELS = FMOverviewWidget._STATUS_LABELS
-    _FINISH_STATES = FMOverviewWidget._FINISH_STATES
 
-    def _show_preview(self, payload):
-        pass
-
-    def _show_typed_preview(self, preview):
+    def _show_preview(self, preview):
         self.previews = getattr(self, "previews", [])
         self.previews.append(preview)
 
-    def _finish(self, state, error):
-        self.finished = (state, error)
+    def _finish(self, status, error):
+        self.finished = (status, error)
 
 
 def _bar(widget):
@@ -345,15 +391,7 @@ def _bar(widget):
 def test_a_tileset_payload_moves_only_the_tile_bar(qapp):
     router = _Router()
 
-    router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 4,
-            "total": 9,
-        }
-    )
+    router._apply_tile_progress(_fm(TiledStatus.TILE_COLLECTED, completed=4, total=9))
 
     # value/maximum directly, not a percentage -- the widget counts items.
     assert (
@@ -420,15 +458,7 @@ def test_a_completed_tile_leaves_the_detail_bar_alone(qapp):
         }
     )
 
-    router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "tile",
-            "task": "tileset",
-            "current": 1,
-            "total": 9,
-        }
-    )
+    router._apply_tile_progress(_fm(TiledStatus.TILE_COLLECTED, completed=1, total=9))
 
     assert router.progress_tile_detail.isVisible()
 
@@ -458,12 +488,12 @@ def test_a_beam_payload_moves_neither_bar(qapp):
     router = _Router()
 
     router._apply_tile_progress(
-        {
-            "modality": "beam",
-            "counter": 8,
-            "total": 9,
-            "msg": "Tile Collected",
-        }
+        _fm(
+            TiledStatus.TILE_COLLECTED,
+            modality=MODALITY_BEAM,
+            completed=8,
+            total=9,
+        )
     )
 
     assert not router.progress_tiles.isVisible()
@@ -474,15 +504,13 @@ def test_the_estimate_is_shown_when_the_payload_carries_one(qapp):
     router = _Router()
 
     router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 2,
-            "total": 9,
-            "estimated_remaining_time": 134.0,
-            "estimated_total_time": 180.0,
-        }
+        _fm(
+            TiledStatus.TILE_COLLECTED,
+            completed=2,
+            total=9,
+            estimated_remaining_seconds=134.0,
+            estimated_total_seconds=180.0,
+        )
     )
 
     assert "remaining" in _bar(router.progress_tiles).format()
@@ -495,19 +523,9 @@ def test_a_stage_move_does_not_fill_the_bar(qapp):
     goes to the status label.
     """
     router = _Router()
-    router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 3,
-            "total": 9,
-        }
-    )
+    router._apply_tile_progress(_fm(TiledStatus.TILE_COLLECTED, completed=3, total=9))
 
-    router._apply_tile_progress(
-        {"modality": "fluorescence", "state": "moving", "task": "tileset"}
-    )
+    router._apply_tile_progress(_fm(TiledStatus.MOVING))
 
     assert (
         _bar(router.progress_tiles).value(),
@@ -519,8 +537,8 @@ def test_a_stage_move_does_not_fill_the_bar(qapp):
 @pytest.mark.parametrize(
     "state, label",
     [
-        ("stitching", "Stitching tiles…"),
-        ("saving", "Saving overview…"),
+        (TiledStatus.STITCHING, "Stitching tiles…"),
+        (TiledStatus.SAVING, "Saving overview…"),
     ],
 )
 def test_the_end_of_a_run_is_not_silent(qapp, state, label):
@@ -534,19 +552,9 @@ def test_the_end_of_a_run_is_not_silent(qapp, state, label):
     impression these phases exist to correct.
     """
     router = _Router()
-    router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 9,
-            "total": 9,
-        }
-    )
+    router._apply_tile_progress(_fm(TiledStatus.TILE_COLLECTED, completed=9, total=9))
 
-    router._apply_tile_progress(
-        {"modality": "fluorescence", "state": state, "task": "tileset"}
-    )
+    router._apply_tile_progress(_fm(state))
 
     assert router.status.text() == label
     assert (
@@ -558,20 +566,10 @@ def test_the_end_of_a_run_is_not_silent(qapp, state, label):
 def test_a_phase_label_is_cleared_by_the_next_tile(qapp):
     """Otherwise "Stitching tiles…" would still be on screen through the next run."""
     router = _Router()
-    router._apply_tile_progress(
-        {"modality": "fluorescence", "state": "saving", "task": "tileset"}
-    )
+    router._apply_tile_progress(_fm(TiledStatus.SAVING))
     assert router.status.text() == "Saving overview…"
 
-    router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 1,
-            "total": 9,
-        }
-    )
+    router._apply_tile_progress(_fm(TiledStatus.TILE_COLLECTED, completed=1, total=9))
     assert router.status.text() == ""
 
 
@@ -1009,7 +1007,15 @@ def test_the_first_preview_frame_lands_at_the_right_scale(qapp, overview_widget)
     tile_ps = widget.fm.camera.pixel_size[0]
     preview = np.zeros((1, 64, 128), dtype=np.uint8)  # (C, H, W), already decimated
 
-    widget._show_preview({"image": preview, "preview_stride": stride})
+    widget._show_preview(
+        _fm_preview(
+            channels=("CH0",),
+            # Already decimated, and the pixel size says so: `stride` times coarser
+            # than a tile's, which is the whole of what a display needs to place it.
+            pixel_size=tile_ps * stride,
+            data=preview,
+        )
+    )
     qapp.processEvents()
 
     placed = widget.canvas.canvas._placed
@@ -1203,7 +1209,11 @@ def test_the_grid_keeps_its_scale_under_a_decimated_preview(qapp, overview_widge
     before = widget.tile_grid_overlay._rect_for(widget.tile_grid_overlay._tiles[0])
 
     widget._show_preview(
-        {"image": np.zeros((1, 256, 256), np.uint8), "preview_stride": 4}
+        _fm_preview(
+            channels=("CH0",),
+            pixel_size=widget.fm.camera.pixel_size[0] * 4,
+            data=np.zeros((1, 256, 256), np.uint8),
+        )
     )
     qapp.processEvents()
 
@@ -2485,7 +2495,7 @@ def test_a_finished_run_keeps_its_outcome_on_screen(qapp):
     qapp.processEvents()
     widget._set_running(True)
 
-    widget._finish("overview-failed", "nope")
+    widget._finish(TiledStatus.FAILED, "nope")
     qapp.processEvents()
 
     assert widget.progress_tiles.isVisible()
@@ -4508,7 +4518,7 @@ def test_the_live_preview_never_becomes_a_record(qapp, blank_canvas):
     import numpy as np
 
     widget._show_preview(
-        {"image": np.zeros((4, 4), dtype=np.uint16), "preview_stride": 1}
+        _fm_preview(channels=("CH0",), data=np.zeros((1, 4, 4), dtype=np.uint16))
     )
     qapp.processEvents()
 
@@ -4651,7 +4661,7 @@ def test_the_list_does_not_grow_a_row_for_the_live_preview(qapp, blank_canvas):
     import numpy as np
 
     widget._show_preview(
-        {"image": np.zeros((4, 4), dtype=np.uint16), "preview_stride": 1}
+        _fm_preview(channels=("CH0",), data=np.zeros((1, 4, 4), dtype=np.uint16))
     )
     qapp.processEvents()
 
@@ -5241,9 +5251,9 @@ def test_the_worker_announces_the_save_before_it_writes(
             saved,
         )
 
-    states = [p.get("state") for p in seen if p.get("task") == "tileset"]
-    assert "saving" in states, "the write is still silent"
-    assert states.index("saving") < states.index("overview-finished"), (
+    states = [p.status for p in seen]
+    assert TiledStatus.SAVING in states, "the write is still silent"
+    assert states.index(TiledStatus.SAVING) < states.index(TiledStatus.FINISHED), (
         "the save was announced after it had already happened"
     )
 
@@ -5259,13 +5269,7 @@ def test_a_tileset_payload_reaches_the_real_widget(qapp, overview_widget):
     """
     widget = overview_widget
     widget.microscope.tiled_acquisition_signal.emit(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 4,
-            "total": 9,
-        }
+        _fm(TiledStatus.TILE_COLLECTED, completed=4, total=9)
     )
     qapp.processEvents()
 
@@ -5325,25 +5329,18 @@ def test_a_beam_run_does_not_drive_the_fluorescence_bar(qapp, overview_widget):
     """
     widget = overview_widget
     widget.microscope.tiled_acquisition_signal.emit(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "counter": 4,
-            "total": 9,
-        }
+        _fm(TiledStatus.TILE_COLLECTED, completed=4, total=9)
     )
     qapp.processEvents()
     before = _bar(widget.progress_tiles).format()
 
     widget.microscope.tiled_acquisition_signal.emit(
-        {
-            "modality": "beam",
-            "task": "tileset",
-            "counter": 8,
-            "total": 9,
-            "msg": "Tile Collected",
-        }
+        _fm(
+            TiledStatus.TILE_COLLECTED,
+            modality=MODALITY_BEAM,
+            completed=8,
+            total=9,
+        )
     )
     qapp.processEvents()
 
@@ -5366,15 +5363,13 @@ def test_the_announcement_payload_does_not_redraw_the_tile_bar(qapp):
     """
     router = _Router()
     router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "tile",
-            "task": "tileset",
-            "counter": 2,
-            "total": 4,
-            "estimated_remaining_time": 18.0,
-            "estimated_total_time": 24.0,
-        }
+        _fm(
+            TiledStatus.TILE_COLLECTED,
+            completed=2,
+            total=4,
+            estimated_remaining_seconds=18.0,
+            estimated_total_seconds=24.0,
+        )
     )
     before = (
         _bar(router.progress_tiles).value(),
@@ -5383,15 +5378,13 @@ def test_the_announcement_payload_does_not_redraw_the_tile_bar(qapp):
     )
 
     router._apply_tile_progress(
-        {
-            "modality": "fluorescence",
-            "state": "acquiring",
-            "task": "tileset",
-            "row": 2,
-            "col": 3,
-            "total_rows": 2,
-            "total_cols": 2,
-        }
+        _fm(
+            TiledStatus.TILE_STARTED,
+            row_index=1,
+            column_index=2,
+            rows=2,
+            columns=2,
+        )
     )
 
     after = (
@@ -5409,16 +5402,12 @@ def test_the_preview_is_still_shown(qapp):
     router = _Router()
     router._show_preview = shown.append
 
-    payload = {
-        "modality": "fluorescence",
-        "state": "tile",
-        "task": "tileset",
-        "counter": 2,
-        "total": 4,
-    }
-    router._apply_tile_progress(payload)
+    preview = _fm_preview()
+    router._apply_tile_progress(
+        _fm(TiledStatus.TILE_COLLECTED, completed=2, total=4, preview=preview)
+    )
 
-    assert shown == [payload]
+    assert shown == [preview]
 
 
 # ── a grid beyond the stage's travel (FIB-741) ───────────────────────────
@@ -5727,50 +5716,6 @@ def test_the_fm_tab_finishes_the_drag_when_the_overlay_says_so(qapp, grid_of):
 # to the producers alone.
 
 
-def _fm(status, **fields):
-    from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE, TiledProgress
-
-    fields.setdefault("modality", MODALITY_FLUORESCENCE)
-    return TiledProgress(status=status, **fields)
-
-
-def _fm_preview(channels=("DAPI", "GFP"), size=4, pixel_size=2e-7, position=None):
-    """A fluorescence preview carrying everything needed to place it.
-
-    Which is the point of the type: pixel size with the decimation already folded in,
-    the stage position the run was centred on, and the channels with their colours.
-    """
-    import numpy as np
-
-    from fibsem.fm.structures import (
-        FluorescenceChannelMetadata,
-        FluorescenceImage,
-        FluorescenceImageMetadata,
-    )
-
-    return FluorescenceImage(
-        data=np.zeros((len(channels), size, size), dtype=np.uint16),
-        metadata=FluorescenceImageMetadata(
-            acquisition_date="2026-08-25T09:00:00",
-            pixel_size_x=pixel_size,
-            pixel_size_y=pixel_size,
-            stage_position=position,
-            channels=[
-                FluorescenceChannelMetadata(
-                    name=name,
-                    excitation_wavelength=488.0,
-                    power=0.5,
-                    exposure_time=0.1,
-                    gain=1.0,
-                    offset=0.0,
-                    color="cyan" if index == 0 else "magenta",
-                )
-                for index, name in enumerate(channels)
-            ],
-        ),
-    )
-
-
 def test_a_typed_tile_report_moves_only_the_tile_bar(qapp):
     from fibsem.imaging.tiling.progress import TiledStatus
 
@@ -5849,15 +5794,8 @@ def test_a_typed_tile_announcement_does_not_move_the_bar(qapp):
     ) == (4, 9)
 
 
-@pytest.mark.parametrize(
-    "status, expected",
-    [
-        ("FINISHED", "overview-finished"),
-        ("CANCELLED", "overview-cancelled"),
-        ("FAILED", "overview-failed"),
-    ],
-)
-def test_every_typed_terminal_state_finishes_the_run(qapp, status, expected):
+@pytest.mark.parametrize("status", ["FINISHED", "CANCELLED", "FAILED"])
+def test_every_terminal_state_finishes_the_run(qapp, status):
     """`_finish` is this widget's only exit path: it swaps the preview for the stitch,
     clears the worker and re-enables the tab. A terminal state that misses it leaves the
     FM unusable for the rest of the session with nothing on screen to say why."""
@@ -5869,7 +5807,10 @@ def test_every_typed_terminal_state_finishes_the_run(qapp, status, expected):
         _fm(getattr(TiledStatus, status), error="why" if status == "FAILED" else None)
     )
 
-    assert router.finished == (expected, "why" if status == "FAILED" else None)
+    assert router.finished == (
+        getattr(TiledStatus, status),
+        "why" if status == "FAILED" else None,
+    )
 
 
 def test_a_typed_preview_is_drawn_once_per_completed_tile(qapp):
@@ -5918,7 +5859,7 @@ class _PreviewHost:
     below fail. That absence is the test.
     """
 
-    _show_typed_preview = FMOverviewWidget._show_typed_preview
+    _show_preview = FMOverviewWidget._show_preview
 
     def __init__(self):
         self.canvas = _FakeCanvas()
@@ -5943,7 +5884,7 @@ def test_a_typed_preview_places_itself_from_its_own_metadata(qapp):
     host = _PreviewHost()
     position = FibsemStagePosition(x=1e-3, y=2e-3, z=0.0)
 
-    host._show_typed_preview(_fm_preview(pixel_size=2e-7, position=position))
+    host._show_preview(_fm_preview(pixel_size=2e-7, position=position))
 
     assert host.canvas.composite_key == PREVIEW_KEY
     assert host.offsets == [position]
@@ -5960,7 +5901,7 @@ def test_a_typed_preview_without_a_position_still_draws(qapp):
     all — the same fallback the dict form had."""
     host = _PreviewHost()
 
-    host._show_typed_preview(_fm_preview(position=None))
+    host._show_preview(_fm_preview(position=None))
 
     assert host.offsets == []
     assert host.canvas.placement == (0.0, 0.0)

--- a/tests/ui/test_minimap_progress_payload_safety.py
+++ b/tests/ui/test_minimap_progress_payload_safety.py
@@ -1,13 +1,12 @@
-"""The napari minimap survives a progress payload it did not expect.
+"""The napari minimap survives a progress report it did not expect.
 
-`tiled_acquisition_signal` has no discriminator: a consumer works out what it received
-from which keys are present. This handler indexed `counter`, `total` and `msg` directly,
-so any payload shape omitting one was a `KeyError` inside a Qt slot, mid-acquisition —
-and `total` is a divisor, so a payload reporting nothing to do took the bar out with a
-`ZeroDivisionError` instead (FIB-402).
+The shapes that used to be a `KeyError` here are gone -- `TiledProgress` declares every
+field, so a report cannot omit one. What survives the typing is arithmetic: `total` is
+a divisor, and a run reporting nothing to do still takes the bar out with a
+`ZeroDivisionError` unless it is guarded (FIB-402).
 
-That was latent while `imaging/tiled.py` was the signal's only emitter. It stops being
-latent the moment a second producer emits there, which is what FIB-725 proposes.
+Also the modality filter. This tab drives a *beam* overview, and the signal has two
+producers (FIB-725).
 
 The whole widget cannot be built here — it constructs a `napari.Viewer`, which segfaults
 under the offscreen platform — so the handler is borrowed onto a host carrying the four
@@ -36,8 +35,6 @@ def handler(qapp):
         handle_tile_acquisition_progress = (
             FibsemMinimapWidget.handle_tile_acquisition_progress
         )
-        # The typed path the dict one is heading for (FIB-402), borrowed the same way.
-        _apply_tile_progress = FibsemMinimapWidget._apply_tile_progress
         _STATUS_LABELS = FibsemMinimapWidget._STATUS_LABELS
 
         def __init__(self):
@@ -52,100 +49,6 @@ def handler(qapp):
     host = _Host()
     yield host
     host.progressBar_acquisition.deleteLater()
-
-
-def test_a_normal_tile_update_still_draws_the_bar(handler):
-    handler.handle_tile_acquisition_progress(
-        {"counter": 3, "total": 9, "msg": "Tile Collected"}
-    )
-    assert handler._tiles_acquired == 3
-    assert handler._tile_total_count == 9
-    assert handler.progressBar_acquisition.value() == 33
-    assert "Tile Collected" in handler.progressBar_acquisition.format()
-    assert "3/9 tiles" in handler.progressBar_acquisition.format()
-
-
-@pytest.mark.parametrize(
-    "payload",
-    [
-        {},
-        {"total": 9, "msg": "Tile Collected"},  # no counter
-        {"counter": 3, "msg": "Tile Collected"},  # no total
-        {"counter": 3, "total": 9},  # no msg
-        {"counter": 0, "total": 0, "msg": "Nothing"},  # nothing to do
-        {"current": 3, "total": 9, "task": "tileset"},  # the fluorescence spelling
-    ],
-)
-def test_an_unexpected_payload_does_not_take_the_bar_out(handler, payload):
-    """Each of these was a crash: the first four a `KeyError`, the fifth a
-    `ZeroDivisionError`, and the last is what a fluorescence run would send if it
-    emitted here — the case that turns all of this from latent into live."""
-    handler.handle_tile_acquisition_progress(payload)
-
-
-def test_a_payload_with_no_counts_leaves_the_last_progress_standing(handler):
-    """Not reset to zero. The run has not gone backwards, and the terminal payload from
-    a cancelled run carries no counts — so zeroing here would end every cancelled run by
-    claiming it never started."""
-    handler.handle_tile_acquisition_progress(
-        {"counter": 4, "total": 9, "msg": "Tile Collected"}
-    )
-    before = handler.progressBar_acquisition.value()
-    handler.handle_tile_acquisition_progress({"msg": "Stitching Tiles"})
-    assert handler.progressBar_acquisition.value() == before
-    assert handler._tiles_acquired == 4
-
-
-def test_a_fluorescence_run_is_not_drawn_into_the_beam_minimap(handler):
-    """This tab drives a *beam* overview and assigns the payload's mosaic straight into
-    its napari layer. The fluorescence preview is keyed `image` already — deliberately,
-    to match this signal — so once a fluorescence run reports here, nothing but the
-    modality stops it being painted into the beam minimap (FIB-725)."""
-    from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
-
-    sentinel = object()
-    handler.handle_tile_acquisition_progress(
-        {
-            "modality": MODALITY_FLUORESCENCE,
-            "counter": 3,
-            "total": 9,
-            "msg": "Tile Collected",
-            "image": sentinel,
-        }
-    )
-    assert handler.shown == [], "a fluorescence mosaic was drawn into the beam minimap"
-    assert handler._tiles_acquired == 0, "a fluorescence run moved the beam tile count"
-
-
-def test_a_beam_run_is_still_drawn(handler):
-    """The filter must not cost the thing it guards."""
-    sentinel = object()
-    handler.handle_tile_acquisition_progress(
-        {
-            "modality": "beam",
-            "counter": 3,
-            "total": 9,
-            "msg": "Tile Collected",
-            "image": sentinel,
-        }
-    )
-    assert handler.shown == [sentinel]
-    assert handler._tiles_acquired == 3
-
-
-def test_a_preview_is_still_shown_when_the_counts_are_missing(handler):
-    """The image and the counters are independent: dropping the bar update must not
-    drop the picture with it."""
-    sentinel = object()
-    handler.handle_tile_acquisition_progress({"image": sentinel})
-    assert handler.shown == [sentinel]
-
-
-# ── the typed contract (FIB-402) ─────────────────────────────────────────────
-#
-# Nothing emits a `TiledProgress` yet: `imaging/tiled.py` still builds dicts, and the
-# tests above are what proves that path has not moved. These drive the typed path
-# directly, so that when the producer flips there is no consumer left to change.
 
 
 def _beam(status, **fields):
@@ -164,7 +67,7 @@ def _preview(width: int = 4, height: int = 4):
     return FibsemImage(data=np.zeros((height, width), dtype=np.uint8))
 
 
-def test_a_typed_tile_report_draws_the_bar(handler):
+def test_a_tile_report_draws_the_bar(handler):
     from fibsem.imaging.tiling.progress import TiledStatus
 
     handler.handle_tile_acquisition_progress(
@@ -192,7 +95,7 @@ def test_the_wording_comes_from_this_tab_not_the_producer(handler):
     assert "Stitching Tiles" in handler.progressBar_acquisition.format()
 
 
-def test_a_typed_report_with_nothing_to_do_does_not_take_the_bar_out(handler):
+def test_a_report_with_nothing_to_do_does_not_take_the_bar_out(handler):
     """`total` is a divisor. A run reporting 0/0 must not raise in a Qt slot."""
     from fibsem.imaging.tiling.progress import TiledStatus
 
@@ -205,7 +108,7 @@ def test_a_typed_report_with_nothing_to_do_does_not_take_the_bar_out(handler):
     assert handler.progressBar_acquisition.value() == 42
 
 
-def test_a_typed_report_with_no_counts_leaves_the_last_progress_standing(handler):
+def test_a_report_with_no_counts_leaves_the_last_progress_standing(handler):
     """A stage move is still true progress-wise: the last count has not stopped being
     the last count, so nothing is drawn rather than resetting to zero."""
     from fibsem.imaging.tiling.progress import TiledStatus
@@ -221,7 +124,7 @@ def test_a_typed_report_with_no_counts_leaves_the_last_progress_standing(handler
     assert handler._tiles_acquired == 4
 
 
-def test_a_typed_preview_is_drawn_from_the_decimated_mosaic(handler):
+def test_a_preview_is_drawn_from_the_decimated_mosaic(handler):
     """`preview.data`, not the live full-resolution canvas this used to be handed.
 
     A deliberate change: the array it got before was the one the acquisition thread was
@@ -239,7 +142,7 @@ def test_a_typed_preview_is_drawn_from_the_decimated_mosaic(handler):
     assert handler.shown[0] is preview.data
 
 
-def test_a_typed_fluorescence_report_is_not_drawn_into_the_beam_minimap(handler):
+def test_a_fluorescence_report_is_not_drawn_into_the_beam_minimap(handler):
     """This tab drives a beam overview; the other modality's mosaic is not its to
     draw, whatever else the report carries (FIB-725)."""
     from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE, TiledStatus

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -36,6 +36,7 @@ from PyQt5.QtWidgets import QApplication, QDialog  # noqa: E402
 
 from fibsem import utils  # noqa: E402
 from fibsem.imaging import tiled  # noqa: E402
+from fibsem.imaging.tiling.progress import TiledStatus
 from fibsem.structures import (  # noqa: E402
     BeamType,
     FibsemImage,
@@ -108,6 +109,14 @@ def widget(microscope):
     w.resize(900, 700)
     yield w
     w.close()
+
+
+def _beam_report(status, **fields):
+    """A beam report, the shape `imaging.tiled` emits."""
+    from fibsem.imaging.tiling.progress import MODALITY_BEAM, TiledProgress
+
+    fields.setdefault("modality", MODALITY_BEAM)
+    return TiledProgress(status=status, **fields)
 
 
 def _tile(microscope, position: FibsemStagePosition, shape=(64, 64), hfw=100e-6):
@@ -746,12 +755,12 @@ class TestThingsOnlyRunningItFound:
 
         for i in (1, 2, 3):
             widget._apply_progress(
-                {
-                    "msg": "Tile Collected",
-                    "counter": i,
-                    "total": 3,
-                    "preview": _tile(microscope, _at(base)),
-                }
+                _beam_report(
+                    TiledStatus.TILE_COLLECTED,
+                    completed=i,
+                    total=3,
+                    preview=_tile(microscope, _at(base)),
+                )
             )
             row = widget.overview_list._rows["run"]
             assert row.detail_label.text().startswith(f"{i} tile"), (
@@ -768,7 +777,9 @@ class TestThingsOnlyRunningItFound:
         widget._set_running(True)
         assert widget.label_status.text() == "", "a stale outcome survived into the run"
 
-        widget._apply_progress({"counter": 2, "total": 9, "msg": "Tile Collected"})
+        widget._apply_progress(
+            _beam_report(TiledStatus.TILE_COLLECTED, completed=2, total=9)
+        )
         assert widget.label_status.text() == "", "the label competed with the bar"
 
         widget._on_finished({})
@@ -2024,12 +2035,12 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         """One tile of a run: the stage arrives, then a preview lands."""
         widget._on_stage_moved(position)
         widget._apply_progress(
-            {
-                "msg": "Tile Collected",
-                "counter": 1,
-                "total": 3,
-                "preview": _tile(microscope, position),
-            }
+            _beam_report(
+                TiledStatus.TILE_COLLECTED,
+                completed=1,
+                total=3,
+                preview=_tile(microscope, position),
+            )
         )
 
     def test_the_planned_grid_does_not_follow_the_stage(self, widget, microscope):
@@ -2128,12 +2139,12 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         # the redraw, because it is what un-provisions the origin.
         widget._on_stage_moved(_at(base, dx=300e-6, dy=300e-6))
         widget._apply_progress(
-            {
-                "msg": "Tile Collected",
-                "counter": 1,
-                "total": 9,
-                "preview": _tile(microscope, _at(base)),
-            }
+            _beam_report(
+                TiledStatus.TILE_COLLECTED,
+                completed=1,
+                total=9,
+                preview=_tile(microscope, _at(base)),
+            )
         )
 
         assert widget.tile_grid_overlay._anchor() == pytest.approx(anchored_at), (
@@ -2257,12 +2268,12 @@ class TestARunDoesNotReFrameTheCanvas:
         widget._set_running(True)
         for counter in range(1, tiles + 1):
             widget._apply_progress(
-                {
-                    "msg": "Tile Collected",
-                    "counter": counter,
-                    "total": tiles,
-                    "preview": _tile(microscope, _at(base)),
-                }
+                _beam_report(
+                    TiledStatus.TILE_COLLECTED,
+                    completed=counter,
+                    total=tiles,
+                    preview=_tile(microscope, _at(base)),
+                )
             )
         widget._mosaic = _tile(microscope, _at(base), shape=(128, 128))
         widget._on_finished({})
@@ -4111,62 +4122,6 @@ class TestDrivingTheStageFromAHost:
 
 
 class TestItOnlyDrawsItsOwnRuns:
-    """`tiled_acquisition_signal` is about to carry a second producer.
-
-    This widget places the payload's mosaic on its own canvas and counts the tiles into
-    its own record, so a fluorescence run reaching here would be drawn as one of this
-    tab's overviews. Only `modality` separates them (FIB-725).
-    """
-
-    def test_a_fluorescence_run_is_ignored(self, widget):
-        from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
-
-        widget._tiles_acquired = 0
-        widget._apply_progress(
-            {
-                "modality": MODALITY_FLUORESCENCE,
-                "counter": 7,
-                "total": 9,
-                "msg": "Tile Collected",
-            }
-        )
-        assert widget._tiles_acquired == 0, "a fluorescence run moved this tab's count"
-
-    def test_a_beam_run_is_still_drawn(self, widget):
-        widget._tiles_acquired = 0
-        widget._apply_progress(
-            {
-                "modality": "beam",
-                "counter": 7,
-                "total": 9,
-                "msg": "Tile Collected",
-            }
-        )
-        assert widget._tiles_acquired == 7
-
-    def test_an_unlabelled_run_is_still_drawn(self, widget):
-        """Anything predating the key — including a producer outside this repository
-        subscribing to a public signal — must keep working."""
-        widget._tiles_acquired = 0
-        widget._apply_progress({"counter": 7, "total": 9, "msg": "Tile Collected"})
-        assert widget._tiles_acquired == 7
-
-
-# ── the typed contract (FIB-402) ─────────────────────────────────────────────
-#
-# Nothing emits a `TiledProgress` yet: `imaging/tiled.py` still builds dicts, and the
-# tests above are what proves that path has not moved. These drive the typed path
-# directly, so the producer flip touches the producer alone.
-
-
-def _beam_report(status, **fields):
-    from fibsem.imaging.tiling.progress import MODALITY_BEAM, TiledProgress
-
-    fields.setdefault("modality", MODALITY_BEAM)
-    return TiledProgress(status=status, **fields)
-
-
-class TestTheTypedProgressContract:
     def test_a_typed_tile_report_drives_the_bar(self, widget):
         from fibsem.imaging.tiling.progress import TiledStatus
 

--- a/tests/ui/test_status_bar_tile_outcome.py
+++ b/tests/ui/test_status_bar_tile_outcome.py
@@ -8,7 +8,7 @@ nothing was reading it.
 The window cannot be constructed here — it builds the napari minimap, and a
 `napari.Viewer` segfaults under the offscreen platform — so its handler is borrowed onto
 a host holding a real `FibsemProgressWidget`. That is enough: the handler's whole job is
-turning a payload into a rendered bar, and the bar here is the real one.
+turning a report into a rendered bar, and the bar here is the real one.
 """
 
 from __future__ import annotations
@@ -37,9 +37,6 @@ def status(qapp):
         # A staticmethod reached through the class is a plain function, which would
         # bind as a method here and eat `self`.
         _overview_outcome = staticmethod(_Real._overview_outcome)
-        # The typed path the dict one is heading for (FIB-402), borrowed the same way.
-        _on_tiled_progress = _Real._on_tiled_progress
-        _tiled_outcome = staticmethod(_Real._tiled_outcome)
         _STATUS_LABELS = _Real._STATUS_LABELS
 
         def __init__(self):
@@ -58,64 +55,13 @@ def _is_red(host) -> bool:
     return RED in host.progress_widget._bar.styleSheet()
 
 
-def _terminal(outcome: str, msg: str) -> dict:
-    """What `TiledAcquisitionRunner._emit_terminal` sends for each outcome."""
-    return {"msg": msg, "counter": 3, "total": 9, "finished": True, "outcome": outcome}
-
-
-def test_a_completed_run_says_done(status):
-    status._on_tile_acquisition_progress(_terminal("finished", "Acquisition Complete"))
-    assert "Done" in _text(status)
-    assert not _is_red(status)
-
-
-def test_a_cancelled_run_does_not_claim_to_have_finished(status):
-    status._on_tile_acquisition_progress(
-        _terminal("cancelled", "Acquisition Cancelled")
-    )
-    assert "Cancelled" in _text(status)
-    assert "Done" not in _text(status)
-
-
-def test_a_cancelled_run_is_not_painted_as_a_failure(status):
-    """A cancel is someone getting what they asked for, so the bar does not go red —
-    the distinction FIB-375 drew between a completed operation and a failed one."""
-    status._on_tile_acquisition_progress(
-        _terminal("cancelled", "Acquisition Cancelled")
-    )
-    assert not _is_red(status)
-
-
-def test_a_failed_run_is_red_and_says_so(status):
-    status._on_tile_acquisition_progress(_terminal("failed", "Acquisition Failed"))
-    assert "Failed" in _text(status)
-    assert _is_red(status)
-
-
-def test_a_producer_that_reports_no_outcome_still_says_done(status):
-    """The napari minimap drives the same runner and the same signal, and older payloads
-    carry no `outcome` at all. Absent, the bar reads as it always did."""
-    status._on_tile_acquisition_progress(
-        {"msg": "Done", "counter": 9, "total": 9, "finished": True}
-    )
-    assert "Done" in _text(status)
-    assert not _is_red(status)
-
-
-# ── the typed contract (FIB-402) ─────────────────────────────────────────────
-#
-# The status bar is the one consumer that watches both modalities, so it is also the one
-# that has to keep working while the two producers flip one at a time. The dict tests
-# above prove that path is untouched; these drive the typed path directly.
-
-
 def _report(status, **fields):
     from fibsem.imaging.tiling.progress import TiledProgress
 
     return TiledProgress(status=status, **fields)
 
 
-def test_a_typed_completed_run_says_done(status):
+def test_a_completed_run_says_done(status):
     from fibsem.imaging.tiling.progress import TiledStatus
 
     status._on_tile_acquisition_progress(
@@ -126,7 +72,7 @@ def test_a_typed_completed_run_says_done(status):
     assert not _is_red(status)
 
 
-def test_a_typed_cancelled_run_does_not_claim_to_have_finished(status):
+def test_a_cancelled_run_does_not_claim_to_have_finished(status):
     from fibsem.imaging.tiling.progress import TiledStatus
 
     status._on_tile_acquisition_progress(
@@ -137,7 +83,7 @@ def test_a_typed_cancelled_run_does_not_claim_to_have_finished(status):
     assert "Done" not in _text(status)
 
 
-def test_a_typed_cancelled_run_is_not_painted_as_a_failure(status):
+def test_a_cancelled_run_is_not_painted_as_a_failure(status):
     """A cancel is someone getting what they asked for, so the bar does not go red."""
     from fibsem.imaging.tiling.progress import TiledStatus
 
@@ -148,7 +94,7 @@ def test_a_typed_cancelled_run_is_not_painted_as_a_failure(status):
     assert not _is_red(status)
 
 
-def test_a_typed_failed_run_is_painted_as_a_failure(status):
+def test_a_failed_run_is_painted_as_a_failure(status):
     from fibsem.imaging.tiling.progress import TiledStatus
 
     status._on_tile_acquisition_progress(


### PR DESCRIPTION
**Last of four stacked PRs.** Targets #549. Supersedes #531.

Both producers now emit `TiledProgress`, the signal is declared as carrying it, and every dict path is gone — from the producers, the four consumers, and the module that held the `modality_of`/`is_modality` readers. The consumers were taught this shape in #549, so nothing on the receiving side changes here.

**Net −513 lines** (614 added, 1127 removed). Deleting the dict contract takes out more than the typed one costs.

### The fluorescence preview becomes a `FluorescenceImage`

Not packaging. The widget used to reconstruct placement from three other places — the centre from `self._runner`, the pixel size from `self._projection().pixel_size * stride`, and the channels from its own state. The middle one reads the camera under an `active_channel()` scope, once a tile *during* a run, so the display was taking the shared channel from the acquisition that was using it. All three now arrive with the preview, and the metadata is built once per run from the first tile that lands rather than per emit.

A `FibsemImage` could not have carried it — `check_data_format` accepts `ndim == 2` only, and a fluorescence preview is `(channels, y, x)`. The two modalities carry their own image type under one field meaning one thing: the mosaic so far, placeable.

### Three behaviour changes, all deliberate

- **A failed beam run now reports why.** The exception was caught, logged and thrown away, so the UI could say "Acquisition Failed" and nothing more — and a stage-limits rejection names every offending tile.
- **The napari minimap draws `preview.data`**, the decimated mosaic, instead of the live full-resolution canvas the tile loop keeps painting into.
- **The status bar reads "Collecting tiles"** for beam runs where it showed "Tile Collected". Fluorescence already read this way.

### Three tests were passing without executing anything

They fed a dict to `_show_preview`, whose first statement is an attribute read, inside a method wrapped in a blanket `except Exception`. The call was a silent no-op, so the assertions — "the grid did not rescale", "no row was added", "the microscope was not read" — held vacuously. The FIB-414 stride-leak guard among them had not run in some time. All three now exercise the render path.

Worth noting how two more of these were found: **after** the suite went green, a grep for surviving dict keys turned up a test calling `_finish("overview-failed", ...)` with a string where the parameter is now a `TiledStatus` — passing because that value fell through to the `else`, which happens to be the failure branch — and another still feeding a dict to `_show_preview`. Green was not sufficient; the grep was.

### Verification

713 passed across the affected suite. `ruff check` and `ruff format --check` clean. 3.8 compatibility checked by AST: no `kw_only`, no runtime PEP 604 unions in modules lacking `from __future__ import annotations`.