### PR TITLE
[feat] Tescan coincidence correction from the SEM view (move_coincident_from_sem)

### DIFF
--- a/fibsem/imaging/tiling/reprojection.py
+++ b/fibsem/imaging/tiling/reprojection.py
@@ -490,6 +490,57 @@ def y_corrected_stage_movement_tescan_from_geometry(
     return float(y_move), float(z_move)
 
 
+def coincident_from_sem_stage_movement_tescan_from_geometry(
+    geometry: FibsemHardwareGeometry,
+    stage_position: FibsemStagePosition,
+    dy: float,
+) -> Tuple[float, float]:
+    """Tescan coincidence correction from the SEM view — the single source of the math.
+
+    The SEM-view mirror of ``vertical_move``: slide the sample along the FIB line
+    of sight, which is invisible in the FIB image, until the offset seen in the
+    SEM closes. A feature already positioned in the FIB view therefore lands on
+    both beam axes at once — at the coincidence point. Both gestures move the
+    sample by dy/sin(angle between the two axes), symmetric in the two
+    directions.
+
+    The FIB axis is chamber-fixed, so the sample plane — and with it the shuttle
+    pre-tilt — cancels out of this move entirely; only the stage tilt (the
+    y-axis rides the tilt module) and the column tilts appear:
+
+        y_move = dy * sin(fib) / (cos(tilt) * sin(fib - sem))
+        z_move = dy * cos(fib - tilt) / (cos(tilt) * sin(fib - sem))
+
+    which for a vertical SEM column (sem = 0) reduces to y = dy/cos(tilt),
+    z = dy*(tan(tilt) + cot(fib)). See
+    https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414
+    for the derivation, the figures, and how the signs are pinned by the two
+    hardware-verified moves.
+
+    Args:
+        geometry: fixed instrument geometry (only the column tilts are used —
+            the pre-tilt and rotation references drop out of this move).
+        stage_position: stage pose (tilt t, radians).
+        dy: offset along the image y-axis in the SEM view, in metres.
+
+    Returns:
+        (y_move, z_move) in metres — before the stage-axis inversion the caller
+        applies (``y_stage = -y_move``, z unchanged), the same convention as
+        :func:`y_corrected_stage_movement_tescan_from_geometry`.
+    """
+    stage_tilt = stage_position.t if stage_position.t is not None else 0.0
+    sem_column_tilt = np.deg2rad(geometry.column_tilt)
+    fib_column_tilt = np.deg2rad(geometry.fib_column_tilt)
+
+    # distance along the FIB axis that closes a SEM-view offset of dy: one
+    # beam axis, seen from the other, is foreshortened by sin(angle between them)
+    axis_move = dy / np.sin(fib_column_tilt - sem_column_tilt)
+
+    y_move = axis_move * np.sin(fib_column_tilt) / np.cos(stage_tilt)
+    z_move = axis_move * np.cos(fib_column_tilt - stage_tilt) / np.cos(stage_tilt)
+    return float(y_move), float(z_move)
+
+
 def inverse_y_corrected_stage_movement_tescan_from_geometry(
     geometry: FibsemHardwareGeometry,
     stage_position: FibsemStagePosition,

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -834,6 +834,62 @@ class TescanMicroscope(FibsemMicroscope):
         logging.info(f"vertical movement: {z_move}")
         self.move_stage_relative(z_move)
 
+    def move_coincident_from_sem(self, dx: float, dy: float) -> FibsemStagePosition:
+        """Correct the coincidence point from the SEM view.
+
+        The SEM-view mirror of vertical_move: the stage slides along the FIB
+        line of sight, which is invisible in the FIB image, until the clicked
+        feature is centred in the SEM. A feature already positioned in the FIB
+        view (e.g. just milled, or just corrected with vertical_move) therefore
+        lands on both beam axes at once -- at the coincidence point. The math
+        lives in reprojection.py (single source); the sample plane, and with it
+        the shuttle pre-tilt, cancels out of this move, so only the stage tilt
+        and the column tilts appear. See
+        https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414
+        for the derivation and figures.
+
+        TODO(hardware-verify): acceptance test -- Alt-double-click a feature in
+        the SEM view: it must land centred in the SEM image and must NOT move at
+        all in the FIB image (any FIB-image jump means a sign or term error).
+        Small focus shifts in both views are inherent to the move.
+
+        Args:
+            dx (float): distance along the image x-axis (SEM view), in metres.
+            dy (float): distance along the image y-axis (SEM view), in metres.
+        """
+        from fibsem.imaging.tiling.reprojection import (
+            coincident_from_sem_stage_movement_tescan_from_geometry,
+        )
+
+        # adjust for scan rotation (radians, codebase convention)
+        scan_rotation = self.get_scan_rotation(BeamType.ELECTRON)
+        if np.isclose(scan_rotation, np.pi):
+            dx *= -1.0
+            dy *= -1.0
+
+        y_move, z_move = coincident_from_sem_stage_movement_tescan_from_geometry(
+            geometry=self.hardware_geometry(),
+            stage_position=self.get_stage_position(),
+            dy=dy,
+        )
+
+        # same empirical x/y stage-axis inversion as stable_move (see there);
+        # z is commanded as computed (+z is down).
+        stage_position = FibsemStagePosition(x=-dx, y=-y_move, z=z_move, r=0, t=0)
+        logging.info(f"coincident move from SEM: {stage_position}")
+        self.move_stage_relative(stage_position)
+
+        logging.debug(
+            {
+                "msg": "move_coincident_from_sem",
+                "dx": dx,
+                "dy": dy,
+                "scan_rotation": scan_rotation,
+                "position": stage_position.to_dict(),
+            }
+        )
+        return self.get_stage_position()
+
     def _y_corrected_stage_movement(
         self,
         expected_y: float,

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -584,8 +584,8 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         )
 
         # refuse rather than silently fall through to stable_move below: on backends
-        # without move_coincident_from_sem (e.g. TESCAN) the operator would ask to
-        # restore coincidence and get a sample-plane move instead
+        # without move_coincident_from_sem (e.g. the simulator) the operator would
+        # ask to restore coincidence and get a sample-plane move instead
         if (
             beam_type is BeamType.ELECTRON
             and vertical_move

--- a/tests/test_tescan_movement.py
+++ b/tests/test_tescan_movement.py
@@ -472,3 +472,106 @@ def test_reprojection_round_trip_scan_rotation_180(beam_type):
 
     assert dx_recovered == pytest.approx(dx)
     assert dy_recovered == pytest.approx(dy)
+
+
+# ---------------------------------------------------------------------------
+# move_coincident_from_sem: slide along the FIB axis, so the FIB image is
+# untouched while the SEM offset closes
+# ---------------------------------------------------------------------------
+
+
+def test_tescan_has_move_coincident_from_sem():
+    """The movement widget's SEM-vertical gate and the alignment STAGE_VERTICAL
+    path both dispatch on hasattr; adding the method is what lights them up."""
+    assert hasattr(TescanMicroscope, "move_coincident_from_sem")
+
+
+def test_coincident_from_sem_explicit_values_flat():
+    """At zero tilt: y = dy, z = dy*cot(55) -- NOT a plain lateral move even flat."""
+    m = make_microscope(pretilt_deg=40.0, stage_position=stage_at(0.0))
+    dy = 10e-6
+
+    m.move_coincident_from_sem(dx=0.0, dy=dy)
+
+    (move,) = m._recorded_moves
+    assert move.y == pytest.approx(-10.00e-6, abs=0.01e-6)  # inverted, like stable_move
+    assert move.z == pytest.approx(7.00e-6, abs=0.01e-6)  # dy/tan(55 deg), +z down
+
+
+def test_coincident_from_sem_logged_milling_pose_regression():
+    """Pinned at the 2026-07-22 session's milling pose (stage tilt 20 deg).
+
+    tan(t) + cot(55) == 1/cos(t) exactly at t = 2*55 - 90 = 20 deg, so the y and
+    z commands come out equal at this pose -- not a typo.
+    """
+    m = make_microscope(pretilt_deg=40.0, stage_position=stage_at(20.0))
+    dy = 33.3e-6
+
+    m.move_coincident_from_sem(dx=0.0, dy=dy)
+
+    (move,) = m._recorded_moves
+    assert move.y == pytest.approx(-35.44e-6, abs=0.01e-6)
+    assert move.z == pytest.approx(35.44e-6, abs=0.01e-6)
+
+
+@pytest.mark.parametrize("tilt_deg", [0.0, 20.0, 60.0])
+def test_coincident_from_sem_is_pretilt_independent(tilt_deg):
+    """The FIB axis is chamber-fixed, so the sample plane (and the pre-tilt)
+    cancels out of this move entirely -- unlike stable_move."""
+    dy = 12e-6
+    moves = []
+    for pretilt_deg in (0.0, 40.0):
+        m = make_microscope(pretilt_deg=pretilt_deg, stage_position=stage_at(tilt_deg))
+        m.move_coincident_from_sem(dx=0.0, dy=dy)
+        moves.append(m._recorded_moves[0])
+
+    assert moves[0].y == pytest.approx(moves[1].y)
+    assert moves[0].z == pytest.approx(moves[1].z)
+
+
+@pytest.mark.parametrize("pretilt_deg", [0.0, 40.0])
+@pytest.mark.parametrize("tilt_deg", [0.0, 20.0, 60.0])
+def test_coincident_move_is_invisible_in_fib_view(tilt_deg, pretilt_deg):
+    """The defining property, tested as such: reconstruct the chamber displacement
+    from the commanded move (y rides the tilt, z is chamber-vertical with +z down)
+    and read it through each view's image-y direction e_y(eta) = (cos eta, sin eta).
+    The FIB must read zero (the move is along its line of sight); the SEM must
+    read exactly dy (the offset closes). Either term of the formula reversed
+    fails one of the two assertions."""
+    dy = 12e-6
+    m = make_microscope(pretilt_deg=pretilt_deg, stage_position=stage_at(tilt_deg))
+
+    m.move_coincident_from_sem(dx=0.0, dy=dy)
+
+    (move,) = m._recorded_moves
+    tilt = np.deg2rad(tilt_deg)
+    y_move = -move.y  # undo the stage-axis inversion
+    chamber_h = y_move * np.cos(tilt)
+    chamber_v = y_move * np.sin(tilt) - move.z
+
+    fib_reading = chamber_h * np.cos(FIB_COLUMN_TILT) + chamber_v * np.sin(
+        FIB_COLUMN_TILT
+    )
+    sem_reading = chamber_h  # SEM column is vertical (column_tilt 0)
+
+    assert fib_reading == pytest.approx(0.0, abs=1e-12)
+    assert sem_reading == pytest.approx(dy)
+
+
+def test_coincident_from_sem_scan_rotation_180_flips_all_axes():
+    """At 180 deg scan rotation dx and dy flip on the way in, so every commanded
+    axis (x, y, and the z that follows dy) changes sign."""
+    dx, dy = 2e-6, 10e-6
+    m0 = make_microscope(pretilt_deg=40.0, stage_position=stage_at(20.0))
+    m180 = make_microscope(
+        pretilt_deg=40.0, stage_position=stage_at(20.0), scan_rotation_deg=180.0
+    )
+
+    m0.move_coincident_from_sem(dx=dx, dy=dy)
+    m180.move_coincident_from_sem(dx=dx, dy=dy)
+
+    (move0,) = m0._recorded_moves
+    (move180,) = m180._recorded_moves
+    assert move180.x == pytest.approx(-move0.x)
+    assert move180.y == pytest.approx(-move0.y)
+    assert move180.z == pytest.approx(-move0.z)


### PR DESCRIPTION
## What

Adds `TescanMicroscope.move_coincident_from_sem` — the SEM-view mirror of `vertical_move`. The stage slides along the FIB line of sight, which is invisible in the FIB image, until the clicked feature is centred in the SEM. A feature already positioned in the FIB view (e.g. just milled, or just corrected with `vertical_move`) lands on both beam axes at once: at the coincidence point.

Because the FIB axis is chamber-fixed, the sample plane — and with it the shuttle pre-tilt — cancels out of the move entirely. Only the stage tilt and the column tilts appear:

```
y_move = dy · sin(fib) / (cos(t) · sin(fib − sem))     # = dy/cos(t) for a vertical SEM column
z_move = dy · cos(fib − t) / (cos(t) · sin(fib − sem)) # = dy·(tan(t) + cot(55°))
```

Both duals move the sample by `dy/sin(55°)` — the sine of the angle between the two beam axes, symmetric in the two directions. Unlike the stable move there is no grazing-angle blow-up: the SEM has no perspective on horizontal motion.

Full derivation, figures, and the sign chain: [Tescan sample-plane stage movement — derivation](https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414) (new section at the bottom).

## Changes

- `fibsem/imaging/tiling/reprojection.py` — `coincident_from_sem_stage_movement_tescan_from_geometry`, next to the stable-move core, same conventions (math-frame result; caller applies the empirical −x/−y inversion; +z down).
- `fibsem/microscopes/tescan.py` — `move_coincident_from_sem(dx, dy)`: SEM scan-rotation flip, delegate to the shared math, command with the same inversion as `stable_move`, forensic debug log.
- `fibsem/ui/FibsemMovementWidget.py` — comment-only: the SEM-vertical gate's example backend is now the simulator, not TESCAN.
- `tests/test_tescan_movement.py` — 13 new cases.

Adding the method flips two existing `hasattr` gates with no code changes there:
- the movement widget's Alt-double-click in the SEM view now dispatches instead of toasting "use the FIB view";
- the alignment `STAGE_VERTICAL` path from an ELECTRON image stops falling through to `vertical_move` (a pure z command computed from a lateral offset — wrong on any backend).

## Verification

- 369 tests green across `test_tescan_movement.py`, `test_beam_stage_projection.py`, `test_movement_widget_vertical_gate.py`; ruff check + format clean.
- The new tests pin the flat pose (y = dy, z = dy·cot 55°) and the logged milling pose (t = 20°: y and z both 35.44 µm for dy = 33.3 µm — equal because `tan t + cot η = 1/cos t` exactly at t = 2η − 90°) in microns, and encode the defining property directly: the commanded chamber displacement must read **zero** through the FIB view's image axis and **exactly dy** through the SEM's.
- Mutation check: reversing either term (z angle-sum flip; y `1/cos`→`·cos`) fails 5 tests each; both restored.

## Hardware acceptance test (marked TODO(hardware-verify) in code)

Alt-double-click a feature visible in both views, in the **SEM** view:
1. it lands centred in the SEM image;
2. it must **not move at all in the FIB image** — any FIB-image jump means a sign/term error;
3. small focus shifts in both views are inherent (height changes ≈ 0.70·dy, FIB beam-distance ≈ 1.22·dy).

A flat-stage (t = 0) check is a good low-risk first test — the move is not plain lateral even flat (z = 0.70·dy).

Depends on the corrected stable-move geometry already on this branch; if tonight's checklist flips a sign there, this move inherits the fix through the shared conventions.
