### PR TITLE
[refactor] Declare a typed contract for fluorescence acquisition progress (FIB-401)

### DIFF
--- a/fibsem/fm/progress.py
+++ b/fibsem/fm/progress.py
@@ -1,0 +1,115 @@
+"""What a fluorescence acquisition says about itself while it runs.
+
+`FluorescenceMicroscope.acquisition_progress_signal` used to carry a bare dict with no
+declared shape, so every consumer worked out what it had received from which keys
+happened to be present -- and a key an emitter forgot was indistinguishable from one
+legitimately absent.
+
+This signal is **fluorescence only**, by construction rather than by convention: it is
+declared on `FluorescenceMicroscope`, every subscriber reaches it as
+`microscope.fm.acquisition_progress_signal`, and every emit site is in `fibsem/fm`. That
+is why nothing here carries a modality, unlike `imaging.tiling.progress.TiledProgress` --
+that signal hangs off `FibsemMicroscope` and genuinely has two producers, so it needs a
+field to tell them apart. This one can only ever have one.
+
+The types are named for the modality anyway, because `acquisition_progress_signal` is
+*also* the name of an unrelated `pyqtSignal` on `FibsemImageSettingsWidget` carrying the
+beam side's `{"msg"} / {"finished"}`. The two are distinguishable only by whether you
+reach them through `.fm.` or `.image_widget.`, which is a poor thing to rely on when
+reading a call site.
+
+# One flat record, not a union
+
+The same reasoning as `TiledProgress`, and it applies harder here. A union keyed on the
+acquisition routine looks natural and does not match how either consumer branches: both
+ask first *is there a z count?* --
+
+    if zlevel and total_zlevels:
+
+-- and **both the z-stack and the autofocus sweep carry one**. A `ZStackProgress` type
+would miss autofocus, so the check becomes `isinstance(e, (ZStackProgress,
+AutofocusProgress))`: the multi-class tuple whose failure mode is silent, since an
+omitted class is a bar that stops moving rather than an error. The union would cut
+across the axis the consumers actually use.
+
+What is left after that is presence checks on optional fields, which is what this is.
+
+# One status, not `state` plus `operation`
+
+Those two fields were separate axes with only four live combinations between them, and
+the overlap is what made autofocus signal itself two different ways -- a `state:
+"autofocus"` at sweep start and an `operation: "autofocus"` per step, both live at once.
+A single closed enum makes that unrepresentable.
+
+`zlevel` and `channel_index` are 1-based on the wire, unlike the tile indices on
+`TiledProgress`. They are counts of work done, not indices into anything -- nothing
+subscripts by them -- so the number a reader sees is the number the producer sends, and
+there is no offset to apply anywhere.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+__all__ = [
+    "FluorescenceAcquisitionStatus",
+    "FluorescenceAcquisitionProgress",
+]
+
+
+class FluorescenceAcquisitionStatus(str, Enum):
+    """What a fluorescence acquisition is doing.
+
+    Four members for what used to be a `state` field crossed with an `operation` field.
+    The three `ACQUIRING_*` members differ in *what is being counted*, which is the only
+    thing a consumer needs them for: channels, z planes, or focus steps.
+
+    A `str` mixin so a member compares equal to its own value. These are persisted
+    nowhere, but they reach log lines, and `"acquiring-zstack"` reads better than
+    `FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK`.
+    """
+
+    # A plain multi-channel acquisition, counting channels.
+    ACQUIRING_CHANNELS = "acquiring-channels"
+    # A z-stack, counting planes within the channel named on the report.
+    ACQUIRING_ZSTACK = "acquiring-zstack"
+    # A focus sweep, counting objective positions. Distinct from `ACQUIRING_ZSTACK`
+    # because a sweep steps the objective through a search range rather than acquiring a
+    # stack, and calling its positions "Z-level" names something that is not running.
+    ACQUIRING_AUTOFOCUS = "acquiring-autofocus"
+    # The acquisition is over. Carries no counts: there is nothing left to count.
+    FINISHED = "finished"
+
+
+@dataclass(frozen=True)
+class FluorescenceAcquisitionProgress:
+    """One report from a fluorescence acquisition.
+
+    Most fields are absent on most reports. `status` is the only one every report
+    carries, and the only required field -- which is also what keeps this constructible
+    on Python 3.8, where `kw_only` does not exist and required fields must come first.
+
+    Equality is left generated, unlike `TiledProgress`. Nothing on this signal carries a
+    numpy array, so there is no field whose `__eq__` returns an array and blows up the
+    comparison -- which makes these usable in `assert emitted == [...]` and in a set.
+    """
+
+    status: FluorescenceAcquisitionStatus
+    # Which channel this report is about. Absent on `FINISHED`, and empty rather than
+    # absent on a focus sweep run without channel settings.
+    channel: Optional[str] = None
+    # Channels done and to do. Only a plain multi-channel acquisition counts these; a
+    # z-stack reports them too, but its bar counts planes instead.
+    channel_index: Optional[int] = None
+    total_channels: Optional[int] = None
+    # Planes, or focus-sweep positions, done and to do. Carried by both
+    # `ACQUIRING_ZSTACK` and `ACQUIRING_AUTOFOCUS` -- which is exactly why a type per
+    # acquisition routine would not have worked.
+    zlevel: Optional[int] = None
+    total_zlevels: Optional[int] = None
+    # Which pass of a multi-pass focus sweep. Without it a coarse sweep followed by a
+    # fine one looks like one bar inexplicably starting over.
+    pass_index: Optional[int] = None
+    total_passes: Optional[int] = None

--- a/tests/fm/test_progress.py
+++ b/tests/fm/test_progress.py
@@ -1,0 +1,161 @@
+"""The typed contract carried by ``acquisition_progress_signal`` (FIB-401).
+
+Nothing emits or reads a ``FluorescenceAcquisitionProgress`` yet -- the producers still
+build dicts and the consumers still read them. What is worth pinning before either moves
+is the shape, and specifically the two decisions that are easy to quietly undo later:
+that the three acquiring states are distinct, and that a z count can arrive under two of
+them.
+"""
+
+import dataclasses
+
+import pytest
+
+from fibsem.fm.progress import (
+    FluorescenceAcquisitionProgress,
+    FluorescenceAcquisitionStatus,
+)
+
+
+class TestTheStatusVocabulary:
+    def test_the_three_acquiring_states_are_distinct(self):
+        """They differ in what is being counted, which is the only thing consumers use
+        them for: channels, z planes, or focus steps."""
+        acquiring = {
+            FluorescenceAcquisitionStatus.ACQUIRING_CHANNELS,
+            FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+            FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
+        }
+        assert len(acquiring) == 3
+        assert FluorescenceAcquisitionStatus.FINISHED not in acquiring
+
+    def test_a_focus_sweep_is_not_a_z_stack(self):
+        """A sweep steps the objective through a search range; a stack acquires planes.
+        Labelling sweep positions "Z-level" names something that is not running, which
+        is the distinction this pair exists to keep."""
+        assert (
+            FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS
+            is not FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK
+        )
+
+    def test_autofocus_has_exactly_one_spelling(self):
+        """It used to have two live at once -- a `state: "autofocus"` at sweep start and
+        an `operation: "autofocus"` per step -- and briefly a third, `"autofocusing"`,
+        that no consumer decoded. A single closed enum makes that unrepresentable."""
+        autofocus = [s for s in FluorescenceAcquisitionStatus if "autofocus" in s.value]
+        assert autofocus == [FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS]
+
+    def test_a_member_compares_equal_to_its_own_value(self):
+        assert FluorescenceAcquisitionStatus.FINISHED == "finished"
+
+
+class TestTheReportShape:
+    def test_status_is_the_only_thing_every_report_carries(self):
+        """Everything else is absent on some report, so everything else has a default.
+
+        Also what keeps this constructible on Python 3.8: `kw_only` does not exist
+        there, so exactly one required field, and it has to be first.
+        """
+        report = FluorescenceAcquisitionProgress(
+            status=FluorescenceAcquisitionStatus.FINISHED
+        )
+
+        assert report.status is FluorescenceAcquisitionStatus.FINISHED
+        assert report.channel is None
+        assert report.zlevel is None and report.total_zlevels is None
+
+        required = [
+            f.name
+            for f in dataclasses.fields(FluorescenceAcquisitionProgress)
+            if f.default is dataclasses.MISSING
+            and f.default_factory is dataclasses.MISSING
+        ]
+        assert required == ["status"]
+
+    def test_a_report_cannot_be_written_to(self):
+        report = FluorescenceAcquisitionProgress(
+            status=FluorescenceAcquisitionStatus.FINISHED
+        )
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            report.status = FluorescenceAcquisitionStatus.ACQUIRING_CHANNELS
+
+    def test_two_equal_reports_compare_equal(self):
+        """Equality is left generated here, unlike `TiledProgress`, which had to set
+        `eq=False` because a preview image compares its numpy data elementwise and
+        raises. Nothing on this signal carries an array, so `==` is usable -- which is
+        what lets a producer test assert on a whole list of emitted reports.
+        """
+
+        def report():
+            return FluorescenceAcquisitionProgress(
+                status=FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+                channel="DAPI",
+                zlevel=3,
+                total_zlevels=7,
+            )
+
+        assert report() == report()
+        assert len({report(), report()}) == 1
+        assert report() != FluorescenceAcquisitionProgress(
+            status=FluorescenceAcquisitionStatus.FINISHED
+        )
+
+
+class TestWhatTheConsumersActuallyBranchOn:
+    """The reason this is one flat record rather than a type per acquisition routine.
+
+    Both consumers ask *is there a z count?* before anything else, and the answer is yes
+    for two different routines. A type per routine would force
+    `isinstance(e, (ZStackProgress, AutofocusProgress))` at that branch -- a multi-class
+    tuple whose failure mode is silent, because an omitted class is a bar that stops
+    moving rather than an error.
+    """
+
+    def test_a_z_count_arrives_under_two_different_statuses(self):
+        stack = FluorescenceAcquisitionProgress(
+            status=FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+            channel="DAPI",
+            zlevel=3,
+            total_zlevels=7,
+        )
+        sweep = FluorescenceAcquisitionProgress(
+            status=FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
+            channel="DAPI",
+            zlevel=3,
+            total_zlevels=7,
+            pass_index=2,
+            total_passes=2,
+        )
+
+        assert stack.status is not sweep.status
+        for report in (stack, sweep):
+            assert report.zlevel and report.total_zlevels, (
+                "both routines count z; a type per routine would split this branch"
+            )
+
+    def test_a_channel_acquisition_carries_no_z_count(self):
+        """Which is what sends it down the other branch, to count channels instead."""
+        report = FluorescenceAcquisitionProgress(
+            status=FluorescenceAcquisitionStatus.ACQUIRING_CHANNELS,
+            channel="GFP",
+            channel_index=2,
+            total_channels=3,
+        )
+
+        assert not (report.zlevel and report.total_zlevels)
+        assert (report.channel_index, report.total_channels) == (2, 3)
+
+    def test_counts_are_one_based_on_the_wire(self):
+        """Counts of work done, not indices into anything -- nothing subscripts by them.
+        So the number a reader sees is the number the producer sends, and unlike the
+        tile indices on `TiledProgress` there is no offset to apply anywhere.
+        """
+        first = FluorescenceAcquisitionProgress(
+            status=FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+            zlevel=1,
+            total_zlevels=7,
+        )
+
+        assert first.zlevel == 1, "the first plane reads as 1 of 7, never 0 of 7"
+        assert f"{first.zlevel}/{first.total_zlevels}" == "1/7"


### PR DESCRIPTION
**First of three stacked PRs** for FIB-401. Stacked on top of the FIB-402 stack (#550) because both touch `fm/acquisition.py` and `fm_overview_widget.py`; GitHub retargets automatically as those merge.

Steps 1 and 2 of FIB-401 are already merged (#521, #526). This is step 3's contract. Nothing imports it yet.

### One flat record — overturning what the issue proposes

FIB-401 argues for a tagged union of small dataclasses, "**not** one flat dataclass — a flat one needs ~15 optional fields". Two reasons that doesn't survive contact with the code:

**The field count is wrong.** The real union across all live emit sites is **9**, and **7** once `state` and `operation` collapse. That estimate predates steps 1–2 deleting the multi-position variant and the six workflow emits.

**The union cuts across the axis the consumers use.** Both branch first on *is there a z count?* —

```python
if zlevel and total_zlevels:
```

— and **both the z-stack and the autofocus sweep carry one**. A `ZStackProgress` type would miss autofocus, so the check becomes `isinstance(e, (ZStackProgress, AutofocusProgress))`: the multi-class tuple whose failure mode is silent, because an omitted class is a bar that stops moving rather than an error.

### One status, not `state` × `operation`

Two axes with four live combinations between them, and the overlap is what let autofocus signal itself two ways at once — a `state: "autofocus"` at sweep start and an `operation: "autofocus"` per step. One closed enum makes that unrepresentable, resolving the issue's **defect 1** by construction.

### Named for the modality, though the signal isn't

`acquisition_progress_signal` is *also* the name of an unrelated `pyqtSignal` on `FibsemImageSettingsWidget` carrying the beam side's `{"msg"}`/`{"finished"}`. The two are distinguishable only by whether a call site reaches them through `.fm.` or `.image_widget.`. No modality *field*, unlike `TiledProgress` — this signal is declared on `FluorescenceMicroscope` and can only ever have one producer.

Equality is left generated, also unlike `TiledProgress`: nothing here carries a numpy array, so `==` is usable and a producer test can assert on a whole list of reports.

### Verification

10 tests. `ruff check` / `ruff format --check` clean. No `kw_only`, no runtime PEP 604 — checked by AST across the stack.