### PR TITLE
[refactor] Teach the fluorescence progress consumers the typed contract (FIB-401)

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -31,6 +31,10 @@ from superqt import ensure_main_thread
 
 from fibsem import constants
 from fibsem.fm.acquisition import FMTiledAcquisitionRunner, OverviewDestination
+from fibsem.fm.progress import (
+    FluorescenceAcquisitionProgress,
+    FluorescenceAcquisitionStatus,
+)
 from fibsem.fm.structures import (
     AutoFocusMode,
     AutoFocusSettings,
@@ -224,7 +228,10 @@ class FMOverviewWidget(QWidget):
     # producers flip (FIB-402). Both marshal to `PyQt_PyObject`, so this changes nothing
     # at the Qt level -- it stops the declaration lying.
     _tile_progress_received = pyqtSignal(object)
-    _fm_progress_received = pyqtSignal(dict)
+    # `object`, not `dict`: carries a dict today and a typed report once the producers
+    # flip (FIB-401). Both marshal to `PyQt_PyObject`, so this changes nothing at the Qt
+    # level -- it stops the declaration lying.
+    _fm_progress_received = pyqtSignal(object)
     # Same hop for stage moves: `stage_position_changed` is a psygnal, so it fires
     # on whichever thread moved the stage -- a worker, during an acquisition.
     _stage_moved = pyqtSignal(object)
@@ -2703,16 +2710,80 @@ class FMOverviewWidget(QWidget):
         """Called by psygnal, on whichever thread emitted. Touches no widgets."""
         self._fm_progress_received.emit(payload)
 
+    # The states this bar can render. `FINISHED` is deliberately absent: it describes
+    # the acquisition ending rather than progress within it, and drawing it here would
+    # be a bar with nothing in it.
+    _DETAIL_STATUSES = (
+        FluorescenceAcquisitionStatus.ACQUIRING_CHANNELS,
+        FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+        FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
+    )
+
+    def _apply_typed_fm_progress(self, report: FluorescenceAcquisitionProgress) -> None:
+        """The typed form of `_apply_fm_progress` (FIB-401).
+
+        Not reached until the fluorescence producers flip; written and tested now so the
+        flip is a change to the producers alone.
+        """
+        if report.status in self._DETAIL_STATUSES:
+            self.progress_tile_detail.update_progress(
+                self._typed_tile_detail_update(report)
+            )
+
+    @staticmethod
+    def _typed_tile_detail_update(
+        report: FluorescenceAcquisitionProgress,
+    ) -> ProgressUpdate:
+        """Progress within the tile currently being acquired.
+
+        A z-stack counts planes and a plain multi-channel acquisition counts channels,
+        so the same bar reads sensibly either way rather than sitting empty whenever
+        z-stacking happens to be off.
+
+        The z branch is taken by *two* statuses, which is the whole reason this contract
+        is one record rather than a type per acquisition routine.
+        """
+        channel = report.channel or ""
+        if report.zlevel and report.total_zlevels:
+            if report.status is FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS:
+                # Say which pass, so a coarse sweep followed by a fine one does not
+                # look like the same bar inexplicably starting over.
+                total_passes = report.total_passes or 1
+                which = (
+                    f" {report.pass_index or 1}/{total_passes}"
+                    if total_passes > 1
+                    else ""
+                )
+                return ProgressUpdate.numeric(
+                    current=report.zlevel,
+                    total=report.total_zlevels,
+                    message=f"{channel} focus{which}",
+                )
+            return ProgressUpdate.numeric(
+                current=report.zlevel,
+                total=report.total_zlevels,
+                message=f"{channel} z-stack",
+            )
+        return ProgressUpdate.numeric(
+            current=report.channel_index or 1,
+            total=report.total_channels or 1,
+            message=f"{channel} channels",
+        )
+
     def _apply_fm_progress(self, payload: dict) -> None:
         """The tile currently being taken, on the detail bar.
 
         Runs on the GUI thread, queued via `_fm_progress_received`. The detector's
         progress signal reports whatever it is doing, tileset or not, so the tasks this
-        bar can render are named rather than assumed: everything else on it -- a
-        workflow task announcing a stage move, a `finished` with no task -- describes
-        something this widget is not showing, and is dropped rather than rendered as a
-        bar with nothing in it.
+        bar can render are named rather than assumed.
+
+        Dicts only -- a typed report goes to `_apply_typed_fm_progress` above. The two
+        sit side by side until the producers flip (FIB-401).
         """
+        if isinstance(payload, FluorescenceAcquisitionProgress):
+            self._apply_typed_fm_progress(payload)
+            return
+
         if payload.get("operation") in ("z-stack", "channels", "autofocus"):
             self.progress_tile_detail.update_progress(self._tile_detail_update(payload))
 

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -516,8 +516,82 @@ class FMControlWidget(QWidget):
         self._update_acquisition_button_states()
 
     @ensure_main_thread
+    def _apply_typed_progress(self, report: "FluorescenceAcquisitionProgress") -> None:
+        """The typed form of `_on_acquisition_progress` (FIB-401).
+
+        Not reached until the producers flip. Two branches the dict form carried are
+        absent rather than ported:
+
+        * `state == "moving"` -- nothing has emitted a stage move on this signal since
+          the workflow emits were deleted in step 1 of this issue. The two remaining
+          `state: "moving"` sites in `fm/acquisition.py` belong to the tileset runner
+          and go to `tiled_acquisition_signal`.
+        * `state == "autofocus"` -- the sweep-start announcement, deleted in this stack.
+          It set "Running Autofocus…" and reset the bar, and the per-step report that
+          arrives microseconds later overwrote both with something strictly better,
+          having named the channel and the step.
+        """
+        from fibsem.fm.progress import FluorescenceAcquisitionStatus
+
+        if not self.progressBar_current_acquisition.isVisible():
+            self.progressBar_current_acquisition.show()
+        if not self.progressText.isVisible():
+            self.progressText.show()
+
+        if report.status is FluorescenceAcquisitionStatus.FINISHED:
+            self.progressBar_current_acquisition.hide()
+            self.progressText.setText("Acquisition complete.")
+            self.progressText.hide()
+            return
+
+        channel = report.channel
+        is_autofocus = (
+            report.status is FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS
+        )
+
+        if is_autofocus:
+            # Handled before the channel branch, not inside it: a sweep with no channel
+            # reports an empty name, which used to render "Acquiring  (1/1)..." and now
+            # would leave the previous message sitting there instead.
+            self.progressText.setText(
+                f"Focusing on {channel}..." if channel else "Focusing..."
+            )
+        elif channel:
+            index = report.channel_index or 1
+            total = report.total_channels or 1
+            self.progressText.setText(f"Acquiring {channel} ({index}/{total})...")
+
+        if report.zlevel and report.total_zlevels:
+            self.progressBar_current_acquisition.setValue(
+                int((report.zlevel / report.total_zlevels) * 100)
+            )
+            if is_autofocus:
+                # A focus sweep steps the objective through a search range. Calling
+                # those positions "Z-level" names the z-stack, which is not running --
+                # and says which pass, so a coarse sweep followed by a fine one does
+                # not look like the same bar inexplicably starting over.
+                total_passes = report.total_passes or 1
+                which = (
+                    f" · pass {report.pass_index or 1}/{total_passes}"
+                    if total_passes > 1
+                    else ""
+                )
+                label = f"Focus {report.zlevel}/{report.total_zlevels}{which}"
+            else:
+                label = f"Z-level {report.zlevel}/{report.total_zlevels}"
+            self.progressBar_current_acquisition.setFormat(label)
+
     def _on_acquisition_progress(self, progress: dict):
-        """Update progress bars on acquisition signal"""
+        """Update progress bars on acquisition signal.
+
+        Dicts only -- a typed report goes to `_apply_typed_progress` above. The two sit
+        side by side until the producers flip (FIB-401).
+        """
+        from fibsem.fm.progress import FluorescenceAcquisitionProgress
+
+        if isinstance(progress, FluorescenceAcquisitionProgress):
+            self._apply_typed_progress(progress)
+            return
 
         # Show progress bar when acquisition progress is updated
         if not self.progressBar_current_acquisition.isVisible():

--- a/tests/ui/test_fm_control_widget_progress.py
+++ b/tests/ui/test_fm_control_widget_progress.py
@@ -1,0 +1,179 @@
+"""What `FMControlWidget` renders for each fluorescence progress report (FIB-401).
+
+This decode path has never had a test. Its only existing test file covers teardown, and
+nothing in `tests/` asserted a rendered label from it -- every check during steps 1 and 2
+of this issue was a scratch harness. Typing the payload is the moment to fix that, since
+the branch structure is now legible enough to enumerate.
+
+Deliberately about the *rendered text*, not about which branch ran. The bugs this path
+has actually had were all wording ones -- a sweep with no channel rendering
+"Acquiring  (1/1)...", a focus sweep labelling its objective positions "Z-level", a
+second pass looking like the first bar starting over -- and none of them would have been
+caught by asserting on control flow.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.fm.progress import (  # noqa: E402
+    FluorescenceAcquisitionProgress,
+    FluorescenceAcquisitionStatus,
+)
+from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget  # noqa: E402
+
+
+class _Host:
+    """Only the three widgets the decode path touches.
+
+    The whole `FMControlWidget` needs a microscope and builds a canvas; the decode is a
+    method that reads a report and writes to a label and a bar, so it is borrowed onto a
+    host carrying real ones.
+    """
+
+    _apply_typed_progress = FMControlWidget._apply_typed_progress
+
+    def __init__(self):
+        from PyQt5.QtWidgets import QLabel, QProgressBar
+
+        self.progressBar_current_acquisition = QProgressBar()
+        self.progressText = QLabel()
+
+
+@pytest.fixture
+def host(qapp):
+    h = _Host()
+    yield h
+    h.progressBar_current_acquisition.deleteLater()
+    h.progressText.deleteLater()
+
+
+def _report(status, **fields):
+    return FluorescenceAcquisitionProgress(status=status, **fields)
+
+
+class TestAChannelAcquisition:
+    def test_it_names_the_channel_and_counts_them(self, host):
+        host._apply_typed_progress(
+            _report(
+                FluorescenceAcquisitionStatus.ACQUIRING_CHANNELS,
+                channel="GFP",
+                channel_index=2,
+                total_channels=3,
+            )
+        )
+
+        assert host.progressText.text() == "Acquiring GFP (2/3)..."
+
+
+class TestAZStack:
+    def test_the_bar_counts_planes(self, host):
+        host._apply_typed_progress(
+            _report(
+                FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+                channel="DAPI",
+                channel_index=1,
+                total_channels=1,
+                zlevel=3,
+                total_zlevels=7,
+            )
+        )
+
+        assert host.progressBar_current_acquisition.format() == "Z-level 3/7"
+        assert host.progressBar_current_acquisition.value() == int(3 / 7 * 100)
+
+
+class TestAFocusSweep:
+    def test_it_is_not_labelled_as_a_z_stack(self, host):
+        """A sweep steps the objective through a search range. Calling those positions
+        "Z-level" names the z-stack, which is not running."""
+        host._apply_typed_progress(
+            _report(
+                FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
+                channel="DAPI",
+                zlevel=3,
+                total_zlevels=7,
+            )
+        )
+
+        assert host.progressBar_current_acquisition.format() == "Focus 3/7"
+        assert "Z-level" not in host.progressBar_current_acquisition.format()
+        assert host.progressText.text() == "Focusing on DAPI..."
+
+    def test_a_multi_pass_sweep_says_which_pass(self, host):
+        """Otherwise a coarse sweep followed by a fine one looks like the same bar
+        inexplicably starting over."""
+        host._apply_typed_progress(
+            _report(
+                FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
+                channel="DAPI",
+                zlevel=3,
+                total_zlevels=7,
+                pass_index=2,
+                total_passes=2,
+            )
+        )
+
+        assert host.progressBar_current_acquisition.format() == "Focus 3/7 · pass 2/2"
+
+    def test_a_single_pass_sweep_does_not(self, host):
+        """ "pass 1/1" is noise on the common case."""
+        host._apply_typed_progress(
+            _report(
+                FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
+                channel="DAPI",
+                zlevel=3,
+                total_zlevels=7,
+                pass_index=1,
+                total_passes=1,
+            )
+        )
+
+        assert host.progressBar_current_acquisition.format() == "Focus 3/7"
+
+    def test_a_sweep_with_no_channel_does_not_render_an_empty_name(self, host):
+        """The regression this branch ordering exists for: handled before the channel
+        branch, a nameless sweep says "Focusing..." rather than rendering
+        "Acquiring  (1/1)..." or leaving the previous message sitting there."""
+        host.progressText.setText("Acquiring DAPI (1/2)...")
+
+        host._apply_typed_progress(
+            _report(
+                FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
+                channel="",
+                zlevel=1,
+                total_zlevels=5,
+            )
+        )
+
+        assert host.progressText.text() == "Focusing..."
+
+
+class TestTheEndOfAnAcquisition:
+    def test_finished_hides_the_bar(self, host):
+        host.progressBar_current_acquisition.show()
+        host.progressText.show()
+
+        host._apply_typed_progress(_report(FluorescenceAcquisitionStatus.FINISHED))
+
+        assert not host.progressBar_current_acquisition.isVisible()
+        assert not host.progressText.isVisible()
+
+    def test_finished_returns_before_drawing_a_count(self, host):
+        """It carries none, so anything drawn from it would be drawn from defaults."""
+        host._apply_typed_progress(
+            _report(
+                FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+                zlevel=2,
+                total_zlevels=4,
+            )
+        )
+        before = host.progressBar_current_acquisition.format()
+
+        host._apply_typed_progress(_report(FluorescenceAcquisitionStatus.FINISHED))
+
+        assert host.progressBar_current_acquisition.format() == before

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -373,6 +373,10 @@ class _Router:
 
     _apply_tile_progress = FMOverviewWidget._apply_tile_progress
     _apply_fm_progress = FMOverviewWidget._apply_fm_progress
+    # The typed path the dict one is heading for (FIB-401), borrowed the same way.
+    _apply_typed_fm_progress = FMOverviewWidget._apply_typed_fm_progress
+    _typed_tile_detail_update = staticmethod(FMOverviewWidget._typed_tile_detail_update)
+    _DETAIL_STATUSES = FMOverviewWidget._DETAIL_STATUSES
     _tile_detail_update = FMOverviewWidget._tile_detail_update
     _STATUS_LABELS = FMOverviewWidget._STATUS_LABELS
 
@@ -5915,3 +5919,106 @@ def test_a_typed_preview_without_a_position_still_draws(qapp):
     assert host.offsets == []
     assert host.canvas.placement == (0.0, 0.0)
     assert host.canvas.channels is not None
+
+
+# ── the typed fluorescence progress contract (FIB-401) ───────────────────────
+#
+# The detector's own signal, which drives the *within-tile* bar -- a different scale from
+# the tileset progress above, and a different signal. Nothing emits a typed report yet;
+# the dict tests above are what proves that path has not moved.
+
+
+def _fm_report(status, **fields):
+    from fibsem.fm.progress import FluorescenceAcquisitionProgress
+
+    return FluorescenceAcquisitionProgress(status=status, **fields)
+
+
+def test_a_typed_zstack_report_counts_planes_on_the_detail_bar(qapp):
+    from fibsem.fm.progress import FluorescenceAcquisitionStatus
+
+    router = _Router()
+
+    router._apply_fm_progress(
+        _fm_report(
+            FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+            channel="DAPI",
+            zlevel=3,
+            total_zlevels=7,
+        )
+    )
+
+    assert (
+        _bar(router.progress_tile_detail).value(),
+        _bar(router.progress_tile_detail).maximum(),
+    ) == (3, 7)
+
+
+def test_a_typed_channel_report_counts_channels_instead(qapp):
+    """The same bar reads sensibly either way, rather than sitting empty whenever
+    z-stacking happens to be off."""
+    from fibsem.fm.progress import FluorescenceAcquisitionStatus
+
+    router = _Router()
+
+    router._apply_fm_progress(
+        _fm_report(
+            FluorescenceAcquisitionStatus.ACQUIRING_CHANNELS,
+            channel="GFP",
+            channel_index=2,
+            total_channels=3,
+        )
+    )
+
+    assert (
+        _bar(router.progress_tile_detail).value(),
+        _bar(router.progress_tile_detail).maximum(),
+    ) == (2, 3)
+
+
+def test_a_typed_focus_sweep_is_labelled_as_focus_not_a_z_stack(qapp):
+    """Both statuses carry a z count and take the same branch -- which is exactly why
+    the contract is one record rather than a type per acquisition routine. What
+    separates them here is the wording."""
+    from fibsem.fm.progress import FluorescenceAcquisitionStatus
+
+    router = _Router()
+
+    router._apply_fm_progress(
+        _fm_report(
+            FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
+            channel="DAPI",
+            zlevel=3,
+            total_zlevels=7,
+            pass_index=2,
+            total_passes=2,
+        )
+    )
+
+    text = _bar(router.progress_tile_detail).format()
+    assert "focus" in text and "z-stack" not in text
+    assert "2/2" in text, "a multi-pass sweep should say which pass"
+
+
+def test_a_typed_finished_report_does_not_draw_the_detail_bar(qapp):
+    """It describes the acquisition ending rather than progress within it, so drawing it
+    would be a bar with nothing in it."""
+    from fibsem.fm.progress import FluorescenceAcquisitionStatus
+
+    router = _Router()
+    router._apply_fm_progress(
+        _fm_report(
+            FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK, zlevel=2, total_zlevels=4
+        )
+    )
+    before = (
+        _bar(router.progress_tile_detail).value(),
+        _bar(router.progress_tile_detail).maximum(),
+    )
+
+    router._apply_fm_progress(_fm_report(FluorescenceAcquisitionStatus.FINISHED))
+
+    assert (
+        _bar(router.progress_tile_detail).value(),
+        _bar(router.progress_tile_detail).maximum(),
+    ) == before


### PR DESCRIPTION
**Second of three.** Targets #554.

Both consumers gain a typed path beside their dict path. The producers are untouched and still emit dicts, so **the dict path is the one that runs** and every pre-existing test still exercises it. When the producers flip there is no consumer left to change.

### Two branches are absent rather than ported

Neither is reachable:

- **`state == "moving"`** in `FMControlWidget` — step 1 of this issue deleted every stage-move emit on this signal. The two `state: "moving"` sites left in `fm/acquisition.py` belong to the *tileset runner* and go to `tiled_acquisition_signal`.
- **`state == "autofocus"`**, the sweep-start announcement — deleted in the next PR, with the reasoning there.

### The decode coverage this path has never had

`FMControlWidget._on_acquisition_progress` had one test file covering teardown and **nothing asserting a rendered label** — every check during steps 1 and 2 was a scratch harness. This adds 8 tests.

They assert the rendered *text*, not which branch ran, because every bug this path has actually had was a wording one:

- a sweep with no channel rendering `"Acquiring  (1/1)..."`
- a focus sweep labelling its objective positions `"Z-level"` when no stack is running
- a second pass looking like the first bar starting over

None would have been caught by asserting on control flow.

Also widens `_fm_progress_received` from `pyqtSignal(dict)` to `pyqtSignal(object)`. Both marshal to `PyQt_PyObject`, so nothing changes at the Qt level; it stops the declaration lying.

### Verification

290 passed across the FM suites, including every pre-existing dict test unchanged.