### PR TITLE
[refactor] Flip the fluorescence progress producers to the typed contract (FIB-401)

### DIFF
--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -12,6 +12,10 @@ from fibsem import utils
 from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
 from fibsem.fm.calibration import run_coarse_fine_autofocus
 from fibsem.fm.microscope import FluorescenceMicroscope
+from fibsem.fm.progress import (
+    FluorescenceAcquisitionProgress,
+    FluorescenceAcquisitionStatus,
+)
 from fibsem.fm.structures import (
     AutoFocusMode,
     AutoFocusSettings,
@@ -62,13 +66,12 @@ def acquire_channels(
         # multi-channel acquisition was silent, so anything watching progress within a
         # tile had nothing to show unless a z-stack happened to be enabled.
         microscope.acquisition_progress_signal.emit(
-            {
-                "state": "acquiring",
-                "operation": "channels",
-                "channel": channel.name,
-                "channel_index": i + 1,
-                "total_channels": len(channel_settings),
-            }
+            FluorescenceAcquisitionProgress(
+                status=FluorescenceAcquisitionStatus.ACQUIRING_CHANNELS,
+                channel=channel.name,
+                channel_index=i + 1,
+                total_channels=len(channel_settings),
+            )
         )
 
         # Check for cancellation before each channel
@@ -117,15 +120,14 @@ def acquire_z_stack(
                 ch_images: List[FluorescenceImage] = []
                 for i, ch in enumerate(channel_settings):
                     microscope.acquisition_progress_signal.emit(
-                        {
-                            "state": "acquiring",
-                            "operation": "z-stack",
-                            "channel": ch.name,
-                            "channel_index": i + 1,
-                            "total_channels": len(channel_settings),
-                            "zlevel": j + 1,
-                            "total_zlevels": len(z_positions),
-                        }
+                        FluorescenceAcquisitionProgress(
+                            status=FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+                            channel=ch.name,
+                            channel_index=i + 1,
+                            total_channels=len(channel_settings),
+                            zlevel=j + 1,
+                            total_zlevels=len(z_positions),
+                        )
                     )
                     if stop_event and stop_event.is_set():
                         logging.info(
@@ -153,15 +155,14 @@ def acquire_z_stack(
                 ch_images = []
                 for j, z in enumerate(z_positions):
                     microscope.acquisition_progress_signal.emit(
-                        {
-                            "state": "acquiring",
-                            "operation": "z-stack",
-                            "channel": ch.name,
-                            "channel_index": i + 1,
-                            "total_channels": len(channel_settings),
-                            "zlevel": j + 1,
-                            "total_zlevels": len(z_positions),
-                        }
+                        FluorescenceAcquisitionProgress(
+                            status=FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+                            channel=ch.name,
+                            channel_index=i + 1,
+                            total_channels=len(channel_settings),
+                            zlevel=j + 1,
+                            total_zlevels=len(z_positions),
+                        )
                     )
                     if stop_event and stop_event.is_set():
                         logging.info("Z-stack acquisition cancelled during z-stack")
@@ -223,7 +224,9 @@ def acquire_image(
         except Exception as e:
             logging.error(f"Failed to save image to {filename}: {e}")
 
-    microscope.acquisition_progress_signal.emit({"state": "finished"})
+    microscope.acquisition_progress_signal.emit(
+        FluorescenceAcquisitionProgress(status=FluorescenceAcquisitionStatus.FINISHED)
+    )
 
     return image
 

--- a/fibsem/fm/calibration/__init__.py
+++ b/fibsem/fm/calibration/__init__.py
@@ -35,6 +35,10 @@ from fibsem.autofunctions.stacking import (
     create_pixel_based_focus_stack,
     pixel_based_focus_selection,
 )
+from fibsem.fm.progress import (
+    FluorescenceAcquisitionProgress,
+    FluorescenceAcquisitionStatus,
+)
 from fibsem.fm.structures import AutoFocusSettings, ZParameters
 from fibsem.structures import FibsemRectangle
 
@@ -140,7 +144,6 @@ def run_autofocus(
         if channel_settings is not None:
             microscope.set_channel(channel_settings=channel_settings)
 
-        microscope.acquisition_progress_signal.emit({"state": "autofocus"})
         logging.info(
             f"Starting autofocus: {len(z_positions)} positions, method='{method}'"
         )
@@ -154,21 +157,26 @@ def run_autofocus(
                 microscope.objective.move_absolute(initial_z)
                 return None
 
-            # Same payload shape the z-stack and channel loops emit, so a viewer that
+            # The same shape the z-stack and channel loops emit, so a viewer that
             # renders within-tile progress renders this too. Without it the bars froze for
             # the whole sweep -- which on per-tile autofocus is most of the run.
+            #
+            # Emitted at the top of the loop, before the objective move and the exposure,
+            # so it lands microseconds after the sweep begins. That is what made a
+            # separate sweep-start announcement redundant: it set "Running Autofocus…"
+            # and reset the bar, and this overwrote both almost immediately with
+            # something strictly better, having named the channel and the step.
             microscope.acquisition_progress_signal.emit(
-                {
-                    "state": "acquiring",
-                    "operation": "autofocus",
-                    "channel": channel_settings.name
+                FluorescenceAcquisitionProgress(
+                    status=FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
+                    channel=channel_settings.name
                     if channel_settings is not None
                     else "",
-                    "zlevel": i + 1,
-                    "total_zlevels": len(z_positions),
-                    "pass_index": pass_index,
-                    "total_passes": total_passes,
-                }
+                    zlevel=i + 1,
+                    total_zlevels=len(z_positions),
+                    pass_index=pass_index,
+                    total_passes=total_passes,
+                )
             )
 
             microscope.objective.move_absolute(z_pos)

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -12,6 +12,7 @@ import numpy as np
 from psygnal import Signal
 
 from fibsem._timing import sim_sleep
+from fibsem.fm.progress import FluorescenceAcquisitionProgress
 from fibsem.fm.structures import (
     CameraImageTransform,
     ChannelSettings,
@@ -697,7 +698,7 @@ class FluorescenceMicroscope(ABC):
     # What a *task* is doing belongs on the task's own signals (`step_update_signal`,
     # `workflow_update_signal`), and tile progress belongs on `tiled_acquisition_signal`
     # (FIB-725). This signal is the acquisition functions', and nothing else's.
-    acquisition_progress_signal = Signal(dict)
+    acquisition_progress_signal = Signal(FluorescenceAcquisitionProgress)
     # Raised when something starts or stops driving the FM, so a widget that did not
     # start it can grey its controls out. Emitted from whichever thread set the flag --
     # connect with `@ensure_main_thread` if the slot touches widgets.

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -2719,19 +2719,18 @@ class FMOverviewWidget(QWidget):
         FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
     )
 
-    def _apply_typed_fm_progress(self, report: FluorescenceAcquisitionProgress) -> None:
-        """The typed form of `_apply_fm_progress` (FIB-401).
+    def _apply_fm_progress(self, report: FluorescenceAcquisitionProgress) -> None:
+        """The tile currently being taken, on the detail bar.
 
-        Not reached until the fluorescence producers flip; written and tested now so the
-        flip is a change to the producers alone.
+        Runs on the GUI thread, queued via `_fm_progress_received`. The detector's
+        signal reports whatever it is doing, tileset or not, so the states this bar can
+        render are named rather than assumed.
         """
         if report.status in self._DETAIL_STATUSES:
-            self.progress_tile_detail.update_progress(
-                self._typed_tile_detail_update(report)
-            )
+            self.progress_tile_detail.update_progress(self._tile_detail_update(report))
 
     @staticmethod
-    def _typed_tile_detail_update(
+    def _tile_detail_update(
         report: FluorescenceAcquisitionProgress,
     ) -> ProgressUpdate:
         """Progress within the tile currently being acquired.
@@ -2770,26 +2769,9 @@ class FMOverviewWidget(QWidget):
             message=f"{channel} channels",
         )
 
-    def _apply_fm_progress(self, payload: dict) -> None:
-        """The tile currently being taken, on the detail bar.
-
-        Runs on the GUI thread, queued via `_fm_progress_received`. The detector's
-        progress signal reports whatever it is doing, tileset or not, so the tasks this
-        bar can render are named rather than assumed.
-
-        Dicts only -- a typed report goes to `_apply_typed_fm_progress` above. The two
-        sit side by side until the producers flip (FIB-401).
-        """
-        if isinstance(payload, FluorescenceAcquisitionProgress):
-            self._apply_typed_fm_progress(payload)
-            return
-
-        if payload.get("operation") in ("z-stack", "channels", "autofocus"):
-            self.progress_tile_detail.update_progress(self._tile_detail_update(payload))
-
-    # This widget's words for the states a fluorescence run passes through. The states
-    # with nothing worth saying are absent on purpose: `.get` returning None is what
-    # clears the label rather than leaving a stale one up.
+    # This widget's words for the states a fluorescence *tileset* run passes through.
+    # The states with nothing worth saying are absent on purpose: `.get` returning None
+    # is what clears the label rather than leaving a stale one up.
     _STATUS_LABELS = {
         TiledStatus.MOVING: "Moving stage…",
         TiledStatus.STITCHING: "Stitching tiles…",
@@ -2859,37 +2841,6 @@ class FMOverviewWidget(QWidget):
                     current=event.completed, total=event.total, message=message
                 )
             )
-
-    def _tile_detail_update(self, payload: dict) -> ProgressUpdate:
-        """Progress within the tile currently being acquired.
-
-        A z-stack counts planes and a plain multi-channel acquisition counts channels,
-        so the same bar reads sensibly either way rather than sitting empty whenever
-        z-stacking happens to be off.
-        """
-        channel = payload.get("channel", "")
-        zlevel, total_z = payload.get("zlevel"), payload.get("total_zlevels")
-        if zlevel and total_z:
-            if payload.get("operation") == "autofocus":
-                # Say which pass, so a coarse sweep followed by a fine one does not
-                # look like the same bar inexplicably starting over.
-                total_passes = payload.get("total_passes", 1)
-                which = (
-                    f" {payload.get('pass_index', 1)}/{total_passes}"
-                    if total_passes > 1
-                    else ""
-                )
-                return ProgressUpdate.numeric(
-                    current=zlevel, total=total_z, message=f"{channel} focus{which}"
-                )
-            return ProgressUpdate.numeric(
-                current=zlevel, total=total_z, message=f"{channel} z-stack"
-            )
-        index = payload.get("channel_index", 1)
-        total = payload.get("total_channels", 1)
-        return ProgressUpdate.numeric(
-            current=index, total=total, message=f"{channel} channels"
-        )
 
     def _show_preview(self, preview: FluorescenceImage) -> None:
         """Paint the mosaic-so-far onto the canvas.

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -516,11 +516,12 @@ class FMControlWidget(QWidget):
         self._update_acquisition_button_states()
 
     @ensure_main_thread
-    def _apply_typed_progress(self, report: "FluorescenceAcquisitionProgress") -> None:
-        """The typed form of `_on_acquisition_progress` (FIB-401).
+    def _on_acquisition_progress(
+        self, report: "FluorescenceAcquisitionProgress"
+    ) -> None:
+        """Update progress bars on acquisition signal.
 
-        Not reached until the producers flip. Two branches the dict form carried are
-        absent rather than ported:
+        Two branches the dict form carried are absent rather than ported:
 
         * `state == "moving"` -- nothing has emitted a stage move on this signal since
           the workflow emits were deleted in step 1 of this issue. The two remaining
@@ -579,84 +580,6 @@ class FMControlWidget(QWidget):
                 label = f"Focus {report.zlevel}/{report.total_zlevels}{which}"
             else:
                 label = f"Z-level {report.zlevel}/{report.total_zlevels}"
-            self.progressBar_current_acquisition.setFormat(label)
-
-    def _on_acquisition_progress(self, progress: dict):
-        """Update progress bars on acquisition signal.
-
-        Dicts only -- a typed report goes to `_apply_typed_progress` above. The two sit
-        side by side until the producers flip (FIB-401).
-        """
-        from fibsem.fm.progress import FluorescenceAcquisitionProgress
-
-        if isinstance(progress, FluorescenceAcquisitionProgress):
-            self._apply_typed_progress(progress)
-            return
-
-        # Show progress bar when acquisition progress is updated
-        if not self.progressBar_current_acquisition.isVisible():
-            self.progressBar_current_acquisition.show()
-        if not self.progressText.isVisible():
-            self.progressText.show()
-
-        progress_zlevels = progress.get("zlevel", None)
-        progress_total_zlevels = progress.get("total_zlevels", None)
-        channel_name = progress.get("channel", None)
-        progress_state = progress.get("state", None)
-        progress_operation = progress.get("operation", None)
-
-        if progress_state == "moving":
-            self.progressText.setText("Moving stage...")
-            self.progressBar_current_acquisition.setValue(0)
-            self.progressBar_current_acquisition.setFormat("")
-
-        if progress_state == "autofocus":
-            self.progressText.setText("Running Autofocus...")
-            self.progressBar_current_acquisition.setValue(0)
-            self.progressBar_current_acquisition.setFormat("")
-
-        if progress_state == "finished":
-            self.progressBar_current_acquisition.hide()
-            self.progressText.setText("Acquisition complete.")
-            self.progressText.hide()
-            return
-
-        # set progress message
-        if progress_operation == "autofocus":
-            # Handled before the channel branch, not inside it: a sweep with no channel
-            # reports an empty name, which used to render "Acquiring  (1/1)..." and now
-            # would leave the previous message sitting there instead.
-            self.progressText.setText(
-                f"Focusing on {channel_name}..." if channel_name else "Focusing..."
-            )
-        elif channel_name:
-            channel_index = progress.get("channel_index", 1)
-            total_channels = progress.get("total_channels", 1)
-            msg = f"Acquiring {channel_name} ({channel_index}/{total_channels})..."
-            self.progressText.setText(msg)
-
-        # set individual image acquisition progress bar
-        if progress_zlevels and progress_total_zlevels:
-            percentage_zlevel = (
-                int((progress_zlevels / progress_total_zlevels) * 100)
-                if progress_total_zlevels > 0
-                else 0
-            )
-            self.progressBar_current_acquisition.setValue(percentage_zlevel)
-            if progress_operation == "autofocus":
-                # A focus sweep steps the objective through a search range. Calling
-                # those positions "Z-level" names the z-stack, which is not running --
-                # and says which pass, so a coarse sweep followed by a fine one does
-                # not look like the same bar inexplicably starting over.
-                total_passes = progress.get("total_passes", 1)
-                which = (
-                    f" · pass {progress.get('pass_index', 1)}/{total_passes}"
-                    if total_passes > 1
-                    else ""
-                )
-                label = f"Focus {progress_zlevels}/{progress_total_zlevels}{which}"
-            else:
-                label = f"Z-level {progress_zlevels}/{progress_total_zlevels}"
             self.progressBar_current_acquisition.setFormat(label)
 
     @ensure_main_thread

--- a/tests/fm/test_acquisition.py
+++ b/tests/fm/test_acquisition.py
@@ -20,6 +20,7 @@ from fibsem.fm.acquisition import (
     calculate_grid_overlap,
     stitch_tileset,
 )
+from fibsem.fm.progress import FluorescenceAcquisitionStatus
 from fibsem.fm.structures import (
     AutoFocusMode,
     AutoFocusSettings,
@@ -1619,7 +1620,11 @@ def _autofocus_payloads(microscope, monkeypatch, mode):
     _record_tile_positions(microscope, monkeypatch)
     seen = []
     microscope.fm.acquisition_progress_signal.connect(
-        lambda d: seen.append(d) if d.get("operation") == "autofocus" else None
+        lambda d: (
+            seen.append(d)
+            if d.status is FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS
+            else None
+        )
     )
     acquisition.FMTiledAcquisitionRunner(
         microscope=microscope,
@@ -1640,9 +1645,7 @@ def test_focusing_once_runs_every_enabled_pass(fm_microscope, monkeypatch):
     """
     seen = _autofocus_payloads(fm_microscope, monkeypatch, AutoFocusMode.ONCE)
 
-    passes = sorted(
-        {(d["pass_index"], d["total_passes"], d["total_zlevels"]) for d in seen}
-    )
+    passes = sorted({(d.pass_index, d.total_passes, d.total_zlevels) for d in seen})
     assert passes == [(1, 2, 5), (2, 2, 7)]
 
 
@@ -1650,9 +1653,9 @@ def test_per_tile_focusing_runs_only_the_narrowest_pass(fm_microscope, monkeypat
     """It refines an already-good position; a wide sweep at every tile would dominate."""
     seen = _autofocus_payloads(fm_microscope, monkeypatch, AutoFocusMode.EACH_TILE)
 
-    assert sorted({(d["pass_index"], d["total_passes"]) for d in seen}) == [(1, 1)]
-    assert {d["total_zlevels"] for d in seen} == {7}  # the fine pass
-    assert len([d for d in seen if d["zlevel"] == 1]) == 4  # once per tile
+    assert sorted({(d.pass_index, d.total_passes) for d in seen}) == [(1, 1)]
+    assert {d.total_zlevels for d in seen} == {7}  # the fine pass
+    assert len([d for d in seen if d.zlevel == 1]) == 4  # once per tile
 
 
 def test_the_sweep_reports_progress_per_position(fm_microscope, monkeypatch):
@@ -1660,8 +1663,8 @@ def test_the_sweep_reports_progress_per_position(fm_microscope, monkeypatch):
     focusing is most of the run."""
     seen = _autofocus_payloads(fm_microscope, monkeypatch, AutoFocusMode.ONCE)
 
-    assert [d["zlevel"] for d in seen if d["pass_index"] == 1] == [1, 2, 3, 4, 5]
-    assert all(d["channel"] == "DAPI" for d in seen)
+    assert [d.zlevel for d in seen if d.pass_index == 1] == [1, 2, 3, 4, 5]
+    assert all(d.channel == "DAPI" for d in seen)
 
 
 def test_a_cancelled_sweep_does_not_start_the_next_pass(fm_microscope, monkeypatch):
@@ -1671,7 +1674,11 @@ def test_a_cancelled_sweep_does_not_start_the_next_pass(fm_microscope, monkeypat
     # Still the detector's signal: an autofocus sweep is work *inside* a tile, which is
     # the scale that stayed there when the tileset moved to `tiled_acquisition_signal`.
     fm_microscope.fm.acquisition_progress_signal.connect(
-        lambda d: seen.append(d) if d.get("operation") == "autofocus" else None
+        lambda d: (
+            seen.append(d)
+            if d.status is FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS
+            else None
+        )
     )
 
     def cancel_during_the_first_pass(*args, **kwargs):
@@ -1691,7 +1698,7 @@ def test_a_cancelled_sweep_does_not_start_the_next_pass(fm_microscope, monkeypat
             stop_event=stop_event,
         ).run()
 
-    assert {d["pass_index"] for d in seen} == {1}, "the second pass must not start"
+    assert {d.pass_index for d in seen} == {1}, "the second pass must not start"
 
 
 # ── acquiring somewhere other than under the stage ───────────────────────

--- a/tests/ui/test_fm_control_widget_progress.py
+++ b/tests/ui/test_fm_control_widget_progress.py
@@ -35,7 +35,7 @@ class _Host:
     host carrying real ones.
     """
 
-    _apply_typed_progress = FMControlWidget._apply_typed_progress
+    _on_acquisition_progress = FMControlWidget._on_acquisition_progress
 
     def __init__(self):
         from PyQt5.QtWidgets import QLabel, QProgressBar
@@ -58,7 +58,7 @@ def _report(status, **fields):
 
 class TestAChannelAcquisition:
     def test_it_names_the_channel_and_counts_them(self, host):
-        host._apply_typed_progress(
+        host._on_acquisition_progress(
             _report(
                 FluorescenceAcquisitionStatus.ACQUIRING_CHANNELS,
                 channel="GFP",
@@ -72,7 +72,7 @@ class TestAChannelAcquisition:
 
 class TestAZStack:
     def test_the_bar_counts_planes(self, host):
-        host._apply_typed_progress(
+        host._on_acquisition_progress(
             _report(
                 FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
                 channel="DAPI",
@@ -91,7 +91,7 @@ class TestAFocusSweep:
     def test_it_is_not_labelled_as_a_z_stack(self, host):
         """A sweep steps the objective through a search range. Calling those positions
         "Z-level" names the z-stack, which is not running."""
-        host._apply_typed_progress(
+        host._on_acquisition_progress(
             _report(
                 FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
                 channel="DAPI",
@@ -107,7 +107,7 @@ class TestAFocusSweep:
     def test_a_multi_pass_sweep_says_which_pass(self, host):
         """Otherwise a coarse sweep followed by a fine one looks like the same bar
         inexplicably starting over."""
-        host._apply_typed_progress(
+        host._on_acquisition_progress(
             _report(
                 FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
                 channel="DAPI",
@@ -122,7 +122,7 @@ class TestAFocusSweep:
 
     def test_a_single_pass_sweep_does_not(self, host):
         """ "pass 1/1" is noise on the common case."""
-        host._apply_typed_progress(
+        host._on_acquisition_progress(
             _report(
                 FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
                 channel="DAPI",
@@ -141,7 +141,7 @@ class TestAFocusSweep:
         "Acquiring  (1/1)..." or leaving the previous message sitting there."""
         host.progressText.setText("Acquiring DAPI (1/2)...")
 
-        host._apply_typed_progress(
+        host._on_acquisition_progress(
             _report(
                 FluorescenceAcquisitionStatus.ACQUIRING_AUTOFOCUS,
                 channel="",
@@ -158,14 +158,14 @@ class TestTheEndOfAnAcquisition:
         host.progressBar_current_acquisition.show()
         host.progressText.show()
 
-        host._apply_typed_progress(_report(FluorescenceAcquisitionStatus.FINISHED))
+        host._on_acquisition_progress(_report(FluorescenceAcquisitionStatus.FINISHED))
 
         assert not host.progressBar_current_acquisition.isVisible()
         assert not host.progressText.isVisible()
 
     def test_finished_returns_before_drawing_a_count(self, host):
         """It carries none, so anything drawn from it would be drawn from defaults."""
-        host._apply_typed_progress(
+        host._on_acquisition_progress(
             _report(
                 FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
                 zlevel=2,
@@ -174,6 +174,6 @@ class TestTheEndOfAnAcquisition:
         )
         before = host.progressBar_current_acquisition.format()
 
-        host._apply_typed_progress(_report(FluorescenceAcquisitionStatus.FINISHED))
+        host._on_acquisition_progress(_report(FluorescenceAcquisitionStatus.FINISHED))
 
         assert host.progressBar_current_acquisition.format() == before

--- a/tests/ui/test_fm_control_widget_teardown.py
+++ b/tests/ui/test_fm_control_widget_teardown.py
@@ -22,20 +22,23 @@ pytest.importorskip("PyQt5")
 from PyQt5 import sip
 from PyQt5.QtWidgets import QApplication
 
+from fibsem.fm.progress import (  # noqa: E402
+    FluorescenceAcquisitionProgress,
+    FluorescenceAcquisitionStatus,
+)
 from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget, _DemoHost
 
-# A payload an emitter actually produces: the within-tile z-stack progress from
+# A report an emitter actually produces: the within-tile z-stack progress from
 # `acquire_z_stack`. It reaches the bar and the label, which is what these tests need
 # a live slot to touch.
-PROGRESS = {
-    "state": "acquiring",
-    "operation": "z-stack",
-    "channel": "DAPI",
-    "channel_index": 1,
-    "total_channels": 1,
-    "zlevel": 1,
-    "total_zlevels": 3,
-}
+PROGRESS = FluorescenceAcquisitionProgress(
+    status=FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+    channel="DAPI",
+    channel_index=1,
+    total_channels=1,
+    zlevel=1,
+    total_zlevels=3,
+)
 
 
 @pytest.fixture(scope="module")

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -20,6 +20,10 @@ pytest.importorskip("PyQt5")
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtWidgets import QApplication, QLabel
 
+from fibsem.fm.progress import (
+    FluorescenceAcquisitionProgress,
+    FluorescenceAcquisitionStatus,
+)
 from fibsem.fm.structures import (
     AutoFocusMode,
     ChannelSettings,
@@ -363,6 +367,11 @@ def _fm_preview(
     )
 
 
+def _fm_report(status, **fields):
+    """A report on the detector's own signal -- the *within-tile* scale."""
+    return FluorescenceAcquisitionProgress(status=status, **fields)
+
+
 class _Router:
     """The routing half of FMOverviewWidget, without needing a microscope."""
 
@@ -373,11 +382,8 @@ class _Router:
 
     _apply_tile_progress = FMOverviewWidget._apply_tile_progress
     _apply_fm_progress = FMOverviewWidget._apply_fm_progress
-    # The typed path the dict one is heading for (FIB-401), borrowed the same way.
-    _apply_typed_fm_progress = FMOverviewWidget._apply_typed_fm_progress
-    _typed_tile_detail_update = staticmethod(FMOverviewWidget._typed_tile_detail_update)
+    _tile_detail_update = staticmethod(FMOverviewWidget._tile_detail_update)
     _DETAIL_STATUSES = FMOverviewWidget._DETAIL_STATUSES
-    _tile_detail_update = FMOverviewWidget._tile_detail_update
     _STATUS_LABELS = FMOverviewWidget._STATUS_LABELS
 
     def _show_preview(self, preview):
@@ -409,13 +415,12 @@ def test_a_zstack_payload_moves_only_the_detail_bar(qapp):
     router = _Router()
 
     router._apply_fm_progress(
-        {
-            "state": "acquiring",
-            "operation": "z-stack",
-            "channel": "GFP",
-            "zlevel": 7,
-            "total_zlevels": 21,
-        }
+        _fm_report(
+            FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+            channel="GFP",
+            zlevel=7,
+            total_zlevels=21,
+        )
     )
 
     assert "z-stack" in _bar(router.progress_tile_detail).format()
@@ -431,13 +436,12 @@ def test_a_channels_payload_drives_the_detail_bar_too(qapp):
     router = _Router()
 
     router._apply_fm_progress(
-        {
-            "state": "acquiring",
-            "operation": "channels",
-            "channel": "RFP",
-            "channel_index": 2,
-            "total_channels": 3,
-        }
+        _fm_report(
+            FluorescenceAcquisitionStatus.ACQUIRING_CHANNELS,
+            channel="RFP",
+            channel_index=2,
+            total_channels=3,
+        )
     )
 
     assert "RFP" in _bar(router.progress_tile_detail).format()
@@ -453,13 +457,12 @@ def test_a_completed_tile_leaves_the_detail_bar_alone(qapp):
     anyway, so the stale count is never seen."""
     router = _Router()
     router._apply_fm_progress(
-        {
-            "state": "acquiring",
-            "operation": "z-stack",
-            "channel": "GFP",
-            "zlevel": 21,
-            "total_zlevels": 21,
-        }
+        _fm_report(
+            FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+            channel="GFP",
+            zlevel=21,
+            total_zlevels=21,
+        )
     )
 
     router._apply_tile_progress(_fm(TiledStatus.TILE_COLLECTED, completed=1, total=9))
@@ -467,18 +470,20 @@ def test_a_completed_tile_leaves_the_detail_bar_alone(qapp):
     assert router.progress_tile_detail.isVisible()
 
 
-def test_an_unknown_task_moves_nothing(qapp):
+def test_a_state_this_bar_cannot_render_moves_nothing(qapp):
     """The detector reports whatever it is doing, tileset or not.
 
-    A workflow task driving the FM while this tab is open emits its own task name, and
-    `finished` arrives with no task at all. Neither describes the tile being taken.
+    `FINISHED` describes the acquisition ending rather than progress within it, so it is
+    dropped rather than drawn as a bar with nothing in it. The free-form task names that
+    used to arrive here are gone -- step 1 of FIB-401 deleted the workflow emits -- so a
+    closed enum is now the whole vocabulary and there is no "unknown task" left to test.
     """
     router = _Router()
 
-    router._apply_fm_progress({"state": "acquiring", "operation": "something-else"})
-    router._apply_fm_progress({"state": "finished"})
+    router._apply_fm_progress(_fm_report(FluorescenceAcquisitionStatus.FINISHED))
 
     assert not router.progress_tiles.isVisible()
+    assert not router.progress_tile_detail.isVisible()
     assert not router.progress_tile_detail.isVisible()
 
 
@@ -5299,13 +5304,12 @@ def test_an_fm_payload_reaches_the_real_widget(qapp, overview_widget):
     """
     widget = overview_widget
     widget.fm.acquisition_progress_signal.emit(
-        {
-            "state": "acquiring",
-            "operation": "z-stack",
-            "channel": "GFP",
-            "zlevel": 7,
-            "total_zlevels": 21,
-        }
+        _fm_report(
+            FluorescenceAcquisitionStatus.ACQUIRING_ZSTACK,
+            channel="GFP",
+            zlevel=7,
+            total_zlevels=21,
+        )
     )
     qapp.processEvents()
 
@@ -5926,12 +5930,6 @@ def test_a_typed_preview_without_a_position_still_draws(qapp):
 # The detector's own signal, which drives the *within-tile* bar -- a different scale from
 # the tileset progress above, and a different signal. Nothing emits a typed report yet;
 # the dict tests above are what proves that path has not moved.
-
-
-def _fm_report(status, **fields):
-    from fibsem.fm.progress import FluorescenceAcquisitionProgress
-
-    return FluorescenceAcquisitionProgress(status=status, **fields)
 
 
 def test_a_typed_zstack_report_counts_planes_on_the_detail_bar(qapp):


### PR DESCRIPTION
**Last of three.** Targets #555. Completes FIB-401 step 4.

Both producers emit `FluorescenceAcquisitionProgress`, the signal is declared as carrying it, and every dict path is gone.

### Deletes the autofocus sweep-start announcement

`run_autofocus` emitted `{"state": "autofocus"}` before its loop *and* a per-step report inside it, so autofocus signalled itself two ways at once — the issue's **defect 1**. Fixed by deletion rather than by typing both spellings, because sweep-start was already redundant:

```python
microscope.acquisition_progress_signal.emit({"state": "autofocus"})   # sweep start
logging.info(...)
initial_z = microscope.objective.position
for i, z_pos in enumerate(z_positions):
    ...
    microscope.acquisition_progress_signal.emit({... "zlevel": i + 1 ...})   # ← before the work
    microscope.objective.move_absolute(z_pos)
    image = microscope.acquire_image()
```

The per-step emit is at the **top** of the loop, before the objective move and the exposure — so it lands microseconds later and strictly dominates. Sweep-start set "Running Autofocus…" and reset the bar; the per-step report sets a value, a format, and names the channel and the step. Its label was never really seen.

Same call as steps 1 and 2: delete the redundant emit rather than accommodate it.

**The one behaviour change**: a sweep with zero positions now signals nothing rather than "Running Autofocus…" forever. Unreachable in practice for an unrelated reason — `zmin > zmax` is the only way to produce one, and `np.argmax` on the empty iteration list raises before the sweep could report anything either way. Worth noting `ZParameters` does not validate `zmin < zmax`; that's a separate gap.

### Verification

**1284 passed** across both the FIB-401 and FIB-402 affected suites. `ruff check` / `ruff format --check` clean. 3.8 compatibility checked by AST across all 24 changed files: no `kw_only`, no runtime PEP 604, no builtin generics outside deferred annotations.