### PR TITLE
Remove the guided setup feature flag

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -903,12 +903,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self._preferences.features.scripts_enabled
             or self.script_menu_controller.runner.is_running
         )
-        # Tools -> Guided Setup, and the offer for it on the connection tab. Both go
-        # together: hiding one and leaving the other would mean a fresh install is
-        # invited to run something the menu says does not exist.
-        self.action_guided_setup.setVisible(
-            self._preferences.features.guided_setup_enabled
-        )
         # getattr because this also runs from the preferences dialog, and the tab it
         # reaches into is built by AutoLamellaUI rather than here.
         system_widget = getattr(self.autolamella_ui, "system_widget", None)

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -409,16 +409,6 @@ class FeatureFlags:
     # goes, and the geometry it rests on is only checkable against real data
     # (FIB-597). Staging, like the flag above -- deleted when it ships, not kept.
     sparse_fm_selection: bool = False
-    # The first-run guided setup: the callout on the connection tab, and Tools ->
-    # Guided Setup (FIB-740). A staging flag, like the two above, and it goes the same
-    # way -- deleted once the wizard is the route a new install takes, not kept as a
-    # preference.
-    #
-    # Off by default for a reason specific to this one: it is *offered* on first run,
-    # to someone who has no way to judge whether it is trustworthy yet, and it writes
-    # a configuration file plus two registry entries. Until it has had bench time on
-    # real instruments, that offer should be made deliberately rather than by default.
-    guided_setup_enabled: bool = False
 
 
 @dataclass

--- a/fibsem/ui/FibsemSystemSetupWidget.py
+++ b/fibsem/ui/FibsemSystemSetupWidget.py
@@ -164,11 +164,12 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
         return frame
 
     def refresh_first_run_offer(self, preferences=None) -> None:
-        """Show the offer when the flag is on, nothing is configured, and it stands.
+        """Show the offer when nothing is configured yet and it has not been dismissed.
 
-        Three separate conditions on purpose. Folding the first two together is what
-        broke this the first time: the flag lived in the file whose absence meant
-        "fresh install", so turning the flag on suppressed the offer it enabled.
+        Two separate conditions on purpose. Folding them together is what broke this
+        the first time: dismissal used to be inferred from the same file whose
+        absence meant "fresh install", which made recording a dismissal look like an
+        undo of it.
 
         Takes the whole preferences object rather than a bool, so AutoLamella's
         `_apply_preferences` can pass the one it already holds. None reads them, for
@@ -177,8 +178,7 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
         if preferences is None:
             preferences = cfg.load_user_preferences()
         self._frame_first_run.setVisible(
-            preferences.features.guided_setup_enabled
-            and not preferences.display.guided_setup_dismissed
+            not preferences.display.guided_setup_dismissed
             and guided_setup.is_first_run()
         )
 

--- a/fibsem/ui/widgets/connection_dialog.py
+++ b/fibsem/ui/widgets/connection_dialog.py
@@ -207,17 +207,16 @@ class ConnectionDialog(QDialog):
         return frame
 
     def refresh_first_run_offer(self, preferences=None) -> None:
-        """Show the offer when the flag is on, nothing is configured, and it stands.
+        """Show the offer when nothing is configured yet and it has not been dismissed.
 
-        The same three conditions the Connection tab applied, and separate for the
-        same reason: the flag lives in the file whose absence means "fresh install",
-        so folding the first two together suppresses the offer it enables.
+        The same two conditions the Connection tab applied, and separate for the
+        same reason: dismissal must not be inferred from the file whose absence
+        means "fresh install".
         """
         if preferences is None:
             preferences = cfg.load_user_preferences()
         self.first_run_frame.setVisible(
-            preferences.features.guided_setup_enabled
-            and not preferences.display.guided_setup_dismissed
+            not preferences.display.guided_setup_dismissed
             and guided_setup.is_first_run()
         )
 

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -73,14 +73,6 @@ _TIP_OVERVIEW_CANVAS = (
     "Tiles are placed where they were acquired rather than stitched first. Still being "
     "finished, and it drives the same microscope as the Overview tab it will replace."
 )
-_LBL_GUIDED_SETUP = "Enable Guided Setup"
-_TIP_GUIDED_SETUP = (
-    "Offer a guided walkthrough on the Connection tab of a fresh install that "
-    "configures fibsemOS to work with your microscope, and add Tools > Guided Setup. "
-    "It writes a new configuration file rather than "
-    "editing the one you are using, so it is non-destructive — but it is still being "
-    "finished, and it has not had bench time on every instrument."
-)
 _LBL_CONNECTION_CHIP = "Enable Connection Chip"
 _TIP_CONNECTION_CHIP = (
     "Show the connected instrument in the tab bar, beside the experiment, and add "
@@ -195,8 +187,6 @@ class PreferencesDialog(QDialog):
         self._chk_overview_canvas.setToolTip(_TIP_OVERVIEW_CANVAS)
         self._chk_sparse_fm = QCheckBox()
         self._chk_sparse_fm.setToolTip(_TIP_SPARSE_FM)
-        self._chk_guided_setup = QCheckBox()
-        self._chk_guided_setup.setToolTip(_TIP_GUIDED_SETUP)
         self._chk_connection_chip = QCheckBox()
         self._chk_connection_chip.setToolTip(_TIP_CONNECTION_CHIP)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
@@ -205,7 +195,6 @@ class PreferencesDialog(QDialog):
         features_form.addRow(_LBL_SCRIPTS, self._chk_scripts)
         features_form.addRow(_LBL_OVERVIEW_CANVAS, self._chk_overview_canvas)
         features_form.addRow(_LBL_SPARSE_FM, self._chk_sparse_fm)
-        features_form.addRow(_LBL_GUIDED_SETUP, self._chk_guided_setup)
         features_form.addRow(_LBL_CONNECTION_CHIP, self._chk_connection_chip)
         self._stack.addWidget(features_page)
 
@@ -280,7 +269,6 @@ class PreferencesDialog(QDialog):
         self._chk_scripts.setChecked(f.scripts_enabled)
         self._chk_overview_canvas.setChecked(f.overview_canvas_tab)
         self._chk_sparse_fm.setChecked(f.sparse_fm_selection)
-        self._chk_guided_setup.setChecked(f.guided_setup_enabled)
         self._chk_connection_chip.setChecked(f.connection_chip)
 
         e = prefs.experiment
@@ -355,7 +343,6 @@ class PreferencesDialog(QDialog):
                 overview_canvas_tab=self._chk_overview_canvas.isChecked(),
                 connection_chip=self._chk_connection_chip.isChecked(),
                 sparse_fm_selection=self._chk_sparse_fm.isChecked(),
-                guided_setup_enabled=self._chk_guided_setup.isChecked(),
             ),
             movement=MovementPreferences(
                 acquire_sem_after_stage_movement=self._chk_acquire_sem.isChecked(),

--- a/tests/test_guided_setup.py
+++ b/tests/test_guided_setup.py
@@ -544,16 +544,15 @@ def test_first_run_is_the_absence_of_a_registered_configuration(isolated_registr
 def test_writing_preferences_does_not_end_the_first_run(isolated_registry):
     """The regression test for the defect that made the offer unreachable.
 
-    The feature flag that gates the offer lives in the preferences file. When that
-    file's absence *was* the first-run signal, turning the flag on created it and the
-    offer could never appear -- through the dialog or by hand, every route to enabling
-    it also suppressed it. Any signal a preference write can extinguish is the wrong
+    When dismissal *was* inferred from the preferences file's absence, any write to
+    that file -- for any preference, guided setup or otherwise -- looked the same as
+    dismissing the offer. Any signal a preference write can extinguish is the wrong
     signal for "nothing has been configured yet".
     """
     assert wizard.is_first_run()
 
     preferences = cfg.load_user_preferences()
-    preferences.features.guided_setup_enabled = True
+    preferences.display.sound_enabled = True
     cfg.save_user_preferences(preferences)
 
     assert os.path.exists(cfg.USER_PREFERENCES_PATH)

--- a/tests/ui/test_connection_tab_removal.py
+++ b/tests/ui/test_connection_tab_removal.py
@@ -78,7 +78,6 @@ def test_the_tab_is_gone_with_the_flag_on(qapp, prefs):
 
 def test_the_offer_shows_on_a_fresh_install(qapp, prefs, monkeypatch):
     monkeypatch.setattr(guided_setup, "is_first_run", lambda: True)
-    prefs.features.guided_setup_enabled = True
     prefs.display.guided_setup_dismissed = False
 
     dialog = ConnectionDialog()
@@ -90,24 +89,20 @@ def test_the_offer_shows_on_a_fresh_install(qapp, prefs, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "flag, dismissed, first_run",
+    "dismissed, first_run",
     [
-        (False, False, True),  # the feature is off
-        (True, True, True),  # already declined
-        (True, False, False),  # something is configured already
+        (True, True),  # already declined
+        (False, False),  # something is configured already
     ],
 )
-def test_the_offer_stays_away_otherwise(
-    qapp, prefs, monkeypatch, flag, dismissed, first_run
-):
-    """Three separate conditions, as the tab applied them.
+def test_the_offer_stays_away_otherwise(qapp, prefs, monkeypatch, dismissed, first_run):
+    """Two separate conditions, as the tab applied them.
 
-    Folding the first two together is what broke this the first time: the flag
-    lives in the file whose absence means "fresh install", so turning the flag on
-    suppressed the offer it enables.
+    Folding them together is what broke this the first time: dismissal used to be
+    inferred from the file whose absence means "fresh install", which made a write
+    that recorded a dismissal look like the same thing as undoing it.
     """
     monkeypatch.setattr(guided_setup, "is_first_run", lambda: first_run)
-    prefs.features.guided_setup_enabled = flag
     prefs.display.guided_setup_dismissed = dismissed
 
     dialog = ConnectionDialog()
@@ -120,7 +115,6 @@ def test_the_offer_stays_away_otherwise(
 
 def test_declining_the_offer_records_it(qapp, prefs, monkeypatch):
     monkeypatch.setattr(guided_setup, "is_first_run", lambda: True)
-    prefs.features.guided_setup_enabled = True
     recorded = []
     monkeypatch.setattr(
         guided_setup, "dismiss_first_run", lambda: recorded.append(True)
@@ -140,7 +134,6 @@ def test_declining_the_offer_records_it(qapp, prefs, monkeypatch):
 def test_finishing_the_wizard_selects_what_it_wrote(qapp, prefs, monkeypatch):
     """Otherwise the dialog still points at whatever was selected before it ran."""
     monkeypatch.setattr(guided_setup, "is_first_run", lambda: True)
-    prefs.features.guided_setup_enabled = True
 
     dialog = ConnectionDialog()
     try:

--- a/tests/ui/test_guided_setup_dialog.py
+++ b/tests/ui/test_guided_setup_dialog.py
@@ -805,30 +805,15 @@ def test_a_save_that_fails_leaves_the_dialog_open(dialog, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _enable_flag(enabled: bool = True) -> None:
-    """Write the feature flag, as the preferences dialog would."""
-    preferences = cfg.load_user_preferences()
-    preferences.features.guided_setup_enabled = enabled
-    cfg.save_user_preferences(preferences)
-
-
 @pytest.fixture
 def connection_tab(qapp, isolated_state, monkeypatch):
-    """The connection tab with the flag on, since that is what most of these test.
-
-    Nothing is faked here any more. Enabling the flag writes the preferences file, and
-    that is now simply not the first-run signal -- which is the whole point of the fix.
-    The previous version of this fixture wrote the flag, deleted the file and
-    monkeypatched the reader to keep both true at once; that it had to invent a state
-    the disk cannot hold was the defect, showing up in the harness.
-    """
+    """The connection tab on a fresh install, since that is what most of these test."""
     pytest.importorskip("napari")
     from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
 
     monkeypatch.setattr(
         "fibsem.ui.notification_service.show_toast", lambda *a, **k: None
     )
-    _enable_flag(True)
     widget = FibsemSystemSetupWidget()
     yield widget
     widget.deleteLater()
@@ -838,14 +823,14 @@ def test_the_offer_appears_on_a_fresh_install(connection_tab):
     assert not connection_tab._frame_first_run.isHidden()
 
 
-def test_turning_the_flag_on_does_not_suppress_the_offer(
+def test_writing_preferences_does_not_suppress_the_offer(
     qapp, isolated_state, monkeypatch
 ):
     """The defect this whole arrangement exists to prevent, at the widget.
 
-    The flag lives in the preferences file. When that file's absence was the first-run
-    signal, every route to enabling the flag -- the dialog, or writing the file by
-    hand -- also ended the first run, so the callout could not be reached at all.
+    Dismissal used to be inferred from the preferences file's absence, so any write to
+    that file -- for any preference -- also ended the first run, and the callout could
+    not be reached at all.
     """
     pytest.importorskip("napari")
     from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
@@ -853,7 +838,9 @@ def test_turning_the_flag_on_does_not_suppress_the_offer(
     monkeypatch.setattr(
         "fibsem.ui.notification_service.show_toast", lambda *a, **k: None
     )
-    _enable_flag(True)  # writes user-preferences.yaml, exactly as the dialog does
+    preferences = cfg.load_user_preferences()
+    preferences.display.sound_enabled = True
+    cfg.save_user_preferences(preferences)
     assert os.path.exists(cfg.USER_PREFERENCES_PATH)
 
     widget = FibsemSystemSetupWidget()
@@ -863,38 +850,7 @@ def test_turning_the_flag_on_does_not_suppress_the_offer(
         widget.deleteLater()
 
 
-def test_the_offer_is_behind_the_feature_flag(qapp, isolated_state, monkeypatch):
-    """A fresh install with the flag off is offered nothing.
-
-    The wizard writes a configuration file and two registry entries, and it is offered
-    to someone with no way yet to judge whether it is trustworthy. Until it has bench
-    time that offer is opt-in.
-    """
-    pytest.importorskip("napari")
-    from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
-
-    monkeypatch.setattr(
-        "fibsem.ui.notification_service.show_toast", lambda *a, **k: None
-    )
-    assert wizard.is_first_run()  # the offer has something to appear for
-    widget = FibsemSystemSetupWidget()
-    try:
-        assert widget._frame_first_run.isHidden()
-        # And it appears the moment the flag is turned on, without a restart.
-        preferences = cfg.load_user_preferences()
-        preferences.features.guided_setup_enabled = True
-        widget.refresh_first_run_offer(preferences)
-        assert not widget._frame_first_run.isHidden()
-        preferences.features.guided_setup_enabled = False
-        widget.refresh_first_run_offer(preferences)
-        assert widget._frame_first_run.isHidden()
-    finally:
-        widget.deleteLater()
-
-
-def test_a_dismissed_offer_stays_dismissed_with_the_flag_on(
-    qapp, isolated_state, monkeypatch
-):
+def test_a_dismissed_offer_stays_dismissed(qapp, isolated_state, monkeypatch):
     """Dismissal is its own answer, not a side effect of anything else."""
     pytest.importorskip("napari")
     from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
@@ -902,7 +858,6 @@ def test_a_dismissed_offer_stays_dismissed_with_the_flag_on(
     monkeypatch.setattr(
         "fibsem.ui.notification_service.show_toast", lambda *a, **k: None
     )
-    _enable_flag(True)
     wizard.dismiss_first_run()
 
     widget = FibsemSystemSetupWidget()
@@ -937,7 +892,6 @@ def test_the_offer_is_absent_once_a_configuration_is_registered(
     pytest.importorskip("napari")
     from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
 
-    _enable_flag(True)
     cfg.register_configuration(
         path=cfg.MICROSCOPE_CONFIGURATION_PATH, configuration_name="Bay 2"
     )


### PR DESCRIPTION
## Summary
- Removes `features.guided_setup_enabled` (FeatureFlags), which staged the guided setup wizard (FIB-740) behind an off-by-default flag
- The first-run offer callout (Connection tab + connection dialog) now shows based only on "nothing configured yet" and "not dismissed"
- Tools > Guided Setup is now always visible
- Drops the checkbox from the Preferences dialog

## Test plan
- [x] `pytest tests/test_guided_setup.py tests/ui/test_guided_setup_dialog.py tests/ui/test_connection_tab_removal.py` — 117 passed
- [x] `pytest tests/test_manufacturers.py tests/ui/test_connection_dialog.py tests/ui/test_system_setup_widget.py tests/ui/test_preferences_dialog.py tests/ui/test_configuration_import.py tests/ui/test_scripts_feature_flag.py` — 97 passed
- [x] `ruff check` on all changed files