### PR TITLE
[docs] Clear TODO(hardware-verify) markers after the hardware session

### DIFF
--- a/fibsem/imaging/tiling/reprojection.py
+++ b/fibsem/imaging/tiling/reprojection.py
@@ -571,8 +571,8 @@ def inverse_y_corrected_stage_movement_tescan_from_geometry(
     Returns:
         float: expected_y input that would produce the given dy, dz movements.
     """
-    # undo the stage-axis inversion applied in stable_move (y_stage = -y_move)
-    # TODO(hardware-verify): keep in sync with the x/y inversion in TescanMicroscope.stable_move.
+    # undo the stage-axis inversion applied in stable_move (y_stage = -y_move);
+    # keep in sync with the x/y inversion in TescanMicroscope.stable_move
     dy = -dy
 
     stage_tilt, corrected_pretilt_angle, sample_inclination = _tescan_pose_angles(

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -691,8 +691,7 @@ class TescanMicroscope(FibsemMicroscope):
         # sample-plane move in the chamber frame
         yz_move = self._y_corrected_stage_movement(dy, beam_type)
 
-        # apply the same stage-axis inversion as stable_move
-        # TODO(hardware-verify): see stable_move for the x/y inversion and z sign.
+        # apply the same stage-axis inversion as stable_move (see there)
         new_position = deepcopy(base_position)
         if new_position.x is not None:
             new_position.x += -dx
@@ -775,11 +774,10 @@ class TescanMicroscope(FibsemMicroscope):
             beam_type=beam_type,
         )
 
-        # TODO(hardware-verify): the x/y inversion is preserved from the previous
-        # empirical implementation (tescan stage x/y appear inverted wrt image
-        # coordinates). It is applied after the trig so the z sign stays independent.
-        # Verify on hardware: a stable_move at non-zero sample inclination should
-        # keep the feature centered AND in focus (wrong z sign -> focus error).
+        # The x/y inversion is empirical (tescan stage x/y appear inverted wrt
+        # image coordinates); it is applied after the trig so the z sign stays
+        # independent. Verified on hardware 2026-08-26: stable moves at tilt
+        # centre the feature and hold focus, in both views.
         stage_position = FibsemStagePosition(x=-dx, y=-yz_move.y, z=yz_move.z, r=0, t=0)
         logging.info(f"moving stage ({beam_type.name}): {stage_position}")
         self.move_stage_relative(stage_position)
@@ -828,8 +826,8 @@ class TescanMicroscope(FibsemMicroscope):
         # Verified on hardware 2026-07-22: this move (negated z + the 1/sin(column_tilt)
         # perspective factor above) corrects coincidence from the FIB view. z is negated
         # because Tescan +z increases downward, see _y_corrected_stage_movement.
-        # TODO(hardware-verify): the x inversion still assumes it matches stable_move;
-        # dx is currently always passed as 0 by the only caller, so it is unexercised.
+        # The x inversion assumes it matches stable_move; dx is currently always
+        # passed as 0 by the only caller, so it remains unexercised.
         z_move = FibsemStagePosition(x=-dx, y=0, z=-dz, r=0, t=0)
         logging.info(f"vertical movement: {z_move}")
         self.move_stage_relative(z_move)
@@ -848,10 +846,10 @@ class TescanMicroscope(FibsemMicroscope):
         https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414
         for the derivation and figures.
 
-        TODO(hardware-verify): acceptance test -- Alt-double-click a feature in
-        the SEM view: it must land centred in the SEM image and must NOT move at
-        all in the FIB image (any FIB-image jump means a sign or term error).
-        Small focus shifts in both views are inherent to the move.
+        Verified on hardware 2026-08-26 (acceptance test: Alt-double-click a
+        feature in the SEM view lands it centred in the SEM image with no
+        movement in the FIB image). Small focus shifts in both views are
+        inherent to the move.
 
         Args:
             dx (float): distance along the image x-axis (SEM view), in metres.
@@ -909,10 +907,10 @@ class TescanMicroscope(FibsemMicroscope):
         https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414
         for the derivation, the sign chain, and the hardware evidence.
 
-        TODO(hardware-verify): the tilted-y model is corroborated (it reproduces the
-        observed 1.65x ion-view overshoot at the milling pose, which the previous
-        chamber-fixed model cannot produce at all) but awaits one confirming stable
-        move at tilt: the feature must land centred AND stay in focus, in both views.
+        Verified on hardware 2026-08-26: stable moves at tilt centre the feature
+        and hold focus, in both views. (The model was derived from the 2026-07-22
+        session log, whose observed 1.65x ion-view overshoot the previous
+        chamber-fixed model cannot produce at all.)
 
         Args:
             expected_y (float): distance along the image y-axis.

--- a/tests/test_tescan_movement.py
+++ b/tests/test_tescan_movement.py
@@ -16,9 +16,9 @@ all, so the observation refuted it). See
 https://linear.app/fibsemos/document/tescan-sample-plane-stage-movement-stable-move-derivation-ae56d0f2c414 for the derivation.
 
 These tests lock in the derived math and the internal sign contracts
-(stable_move <-> inverse round trips). The remaining hardware confirmation (a
-stable move at tilt must centre the feature AND hold focus, in both views) is
-flagged with TODO(hardware-verify) in code.
+(stable_move <-> inverse round trips). Hardware-confirmed 2026-08-26: stable
+moves at tilt centre the feature and hold focus in both views, and the
+coincident move from the SEM leaves the FIB image untouched.
 
 No hardware or Tescan SDK required: the microscope object is created without
 __init__ and the stage state is stubbed.


### PR DESCRIPTION
## What

The 2026-08-26 on-hardware session passed in full — stable moves at tilt centre the feature and hold focus in both views, and the coincident move from the SEM view leaves the FIB image untouched. This clears all six `TODO(hardware-verify)` markers accordingly.

**Comment/docstring changes only, no behaviour.** Pending-verification notes become verified statements (dated 2026-08-26); constraints that remain true are kept as plain notes:
- the empirical x/y stage-axis inversion (still empirical, now hardware-confirmed at tilt),
- the inverse↔forward keep-in-sync note in `reprojection.py`,
- `vertical_move`'s dx inversion remains unexercised (only caller passes 0).

## Verification

- `grep -rn "hardware-verify"` — no matches remain.
- 365 tests green across `test_tescan_movement.py` + `test_beam_stage_projection.py`; ruff check + format clean.