### PR TITLE
[feat] Spot burn preset selection for preset-driven backends (TESCAN)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -56,10 +56,15 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
         default_factory=list,
         metadata=field_meta(tooltip="Spot burn positions in normalised image coordinates (0-1)"),
     )
+    # beam preset for preset-driven backends (TESCAN); None means the backend default.
+    # Chosen in the spot burn tab's preset combo, not the generic parameter form.
+    preset: Optional[str] = None
 
     @property
     def parameters(self) -> tuple[str, ...]:
-        return tuple(p for p in super().parameters if p != "coordinates")
+        # coordinates are edited on the canvas, the preset in the spot burn tab's
+        # combo -- neither belongs in the generic parameter form
+        return tuple(p for p in super().parameters if p not in ("coordinates", "preset"))
 
     @property
     def opens_with_reference_alignment(self) -> bool:
@@ -91,6 +96,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
             "milling_current": self.milling_current,
             "exposure_time": self.exposure_time,
             "autofocus": self.autofocus,
+            "preset": self.preset,
         }
         ddict["milling"] = {k: v.to_dict() for k, v in self.milling.items()}
         if self.reference_imaging is not None:
@@ -111,22 +117,25 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
             milling_current=float(params.get("milling_current", 60.0e-12)),
             exposure_time=int(float(params.get("exposure_time", 10))),
             autofocus=bool(params.get("autofocus", False)),
+            preset=params.get("preset", None),
             coordinates=coordinates,
         )
 
     def to_settings(self) -> SpotBurnSettings:
-        """The run payload (coordinates + current + exposure) for this task."""
+        """The run payload (coordinates + conditions + exposure) for this task."""
         return SpotBurnSettings(
             coordinates=list(self.coordinates),
             milling_current=self.milling_current,
             exposure_time=float(self.exposure_time),
+            preset=self.preset,
         )
 
     def apply_settings(self, settings: SpotBurnSettings) -> None:
-        """Apply a run payload back onto this task config (coordinates + current + exposure)."""
+        """Apply a run payload back onto this task config (coordinates + conditions + exposure)."""
         self.coordinates = list(settings.coordinates)
         self.milling_current = settings.milling_current
         self.exposure_time = settings.exposure_time
+        self.preset = settings.preset
 
 
 class SpotBurnFiducialTask(AutoLamellaTask):

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -1,4 +1,3 @@
-
 ######## SPOT BURN FIDUCIAL TASK DEFINITIONS ########
 from __future__ import annotations
 
@@ -26,35 +25,30 @@ from fibsem.structures import BeamType, Point, field_meta
 @dataclass
 class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the SpotBurnFiducialTask."""
+
     task_type: ClassVar[str] = "SPOT_BURN_FIDUCIAL"
     display_name: ClassVar[str] = "Spot Burn Fiducial"
     milling_current: float = field(
         default=60.0e-12,  # in Amperes
-        metadata=field_meta(
-            tooltip='Milling current in Amperes',
-            unit='A',
-            scale=1e12
-        )
+        metadata=field_meta(tooltip="Milling current in Amperes", unit="A", scale=1e12),
     )
     exposure_time: int = field(
         default=10,
-        metadata=field_meta(
-            tooltip='Exposure time in seconds',
-            unit='s',
-            scale=1
-        )
+        metadata=field_meta(tooltip="Exposure time in seconds", unit="s", scale=1),
     )
     autofocus: bool = field(
         default=False,
         metadata=field_meta(
             tooltip="Run a FIB autofocus before acquiring the reference image, so the "
-                    "points are placed on (and burned into) a focused image",
+            "points are placed on (and burned into) a focused image",
             label="Autofocus",
         ),
     )
     coordinates: list[Point] = field(
         default_factory=list,
-        metadata=field_meta(tooltip="Spot burn positions in normalised image coordinates (0-1)"),
+        metadata=field_meta(
+            tooltip="Spot burn positions in normalised image coordinates (0-1)"
+        ),
     )
     # beam preset for preset-driven backends (TESCAN); None means the backend default.
     # Chosen in the spot burn tab's preset combo, not the generic parameter form.
@@ -64,7 +58,9 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
     def parameters(self) -> tuple[str, ...]:
         # coordinates are edited on the canvas, the preset in the spot burn tab's
         # combo -- neither belongs in the generic parameter form
-        return tuple(p for p in super().parameters if p not in ("coordinates", "preset"))
+        return tuple(
+            p for p in super().parameters if p not in ("coordinates", "preset")
+        )
 
     @property
     def opens_with_reference_alignment(self) -> bool:
@@ -83,7 +79,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
         Each point costs its exposure plus a blank/park/unblank cycle.
         """
         total = super().estimated_duration
-        total += 2 * timing.BEAM_CURRENT_CHANGE_S     # into the burn current and back
+        total += 2 * timing.BEAM_CURRENT_CHANGE_S  # into the burn current and back
         total += len(self.coordinates) * (
             self.exposure_time + timing.SPOT_BURN_POINT_OVERHEAD_S
         )
@@ -105,7 +101,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
         return ddict
 
     @classmethod
-    def from_dict(cls, ddict: dict) -> 'SpotBurnFiducialTaskConfig':
+    def from_dict(cls, ddict: dict) -> "SpotBurnFiducialTaskConfig":
         cfg = AutoLamellaTaskConfig.from_dict(ddict)
         params = ddict.get("parameters", {})
         coordinates = [Point.from_dict(pt) for pt in ddict.get("coordinates", [])]
@@ -140,6 +136,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
 
 class SpotBurnFiducialTask(AutoLamellaTask):
     """Task to mill spot fiducial markers for correlation."""
+
     config: SpotBurnFiducialTaskConfig
     config_cls: ClassVar[Type[SpotBurnFiducialTaskConfig]] = SpotBurnFiducialTaskConfig
 
@@ -189,10 +186,12 @@ class SpotBurnFiducialTask(AutoLamellaTask):
                 )
                 return
             # burn the stored coordinates directly (progress via the microscope signal)
-            run_spot_burn(microscope=self.microscope,
-                          settings=self.config.to_settings(),
-                          beam_type=BeamType.ION,
-                          stop_event=self._stop_event)
+            run_spot_burn(
+                microscope=self.microscope,
+                settings=self.config.to_settings(),
+                beam_type=BeamType.ION,
+                stop_event=self._stop_event,
+            )
             return
 
         # supervised path: task-orchestrated run/wait/re-prompt loop (mirrors milling).
@@ -211,7 +210,9 @@ class SpotBurnFiducialTask(AutoLamellaTask):
         # before continuing so the workflow can't advance mid-burn.
         spot_burn_widget = self.parent_ui.spot_burn_widget
         msg = f"Place points and run the spot burn for {self.lamella.name}. Press Continue when finished."
-        response = ask_user(self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True)
+        response = ask_user(
+            self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True
+        )
         while response:
             self.update_status_ui("Running Spot Burn...")
             spot_burn_widget.start_spot_burn_signal.emit()
@@ -229,7 +230,13 @@ class SpotBurnFiducialTask(AutoLamellaTask):
                 # a threading.Event, so it is safe to call from the task thread.
                 spot_burn_widget.cancel_spot_burn()
                 raise
-            response = ask_user(self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True)
+            response = ask_user(
+                self.parent_ui,
+                msg=msg,
+                pos="Run Spot Burn",
+                neg="Continue",
+                spot_burn=True,
+            )
 
         # store the user's settings (coordinates + current/exposure) back to the config
         self.config.apply_settings(spot_burn_widget.get_settings())

--- a/fibsem/imaging/spot.py
+++ b/fibsem/imaging/spot.py
@@ -26,7 +26,7 @@ class SpotBurnSettings:
 
     coordinates: List[Point] = field(default_factory=list)
     milling_current: float = 60e-12  # amperes
-    exposure_time: float = 10.0      # seconds
+    exposure_time: float = 10.0  # seconds
     # beam preset for preset-driven backends (TESCAN); None means the backend's
     # default. milling_current is ignored wherever a preset drives the beam.
     preset: Optional[str] = None
@@ -49,10 +49,12 @@ class SpotBurnSettings:
         )
 
 
-def run_spot_burn(microscope: FibsemMicroscope,
-                  settings: SpotBurnSettings,
-                  beam_type: BeamType = BeamType.ION,
-                  stop_event: Optional[threading.Event] = None) -> None:
+def run_spot_burn(
+    microscope: FibsemMicroscope,
+    settings: SpotBurnSettings,
+    beam_type: BeamType = BeamType.ION,
+    stop_event: Optional[threading.Event] = None,
+) -> None:
     """Run a spot burn job on the microscope. Exposes the coordinates in *settings* for
     the exposure time at the milling current it specifies.
 

--- a/fibsem/imaging/spot.py
+++ b/fibsem/imaging/spot.py
@@ -27,12 +27,16 @@ class SpotBurnSettings:
     coordinates: List[Point] = field(default_factory=list)
     milling_current: float = 60e-12  # amperes
     exposure_time: float = 10.0      # seconds
+    # beam preset for preset-driven backends (TESCAN); None means the backend's
+    # default. milling_current is ignored wherever a preset drives the beam.
+    preset: Optional[str] = None
 
     def to_dict(self) -> dict:
         return {
             "coordinates": [pt.to_dict() for pt in self.coordinates],
             "milling_current": self.milling_current,
             "exposure_time": self.exposure_time,
+            "preset": self.preset,
         }
 
     @classmethod
@@ -41,6 +45,7 @@ class SpotBurnSettings:
             coordinates=[Point.from_dict(pt) for pt in ddict.get("coordinates", [])],
             milling_current=ddict.get("milling_current", 60e-12),
             exposure_time=ddict.get("exposure_time", 10.0),
+            preset=ddict.get("preset", None),
         )
 
 

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -1564,11 +1564,12 @@ class TescanMicroscope(FibsemMicroscope):
         exposure_time: float,
         hfw: float,
         resolution: Tuple[int, int],
+        preset: str,
     ) -> "Automation.DrawBeam.Layer":
         """Build a DrawBeam layer holding one timed dot per coordinate.
 
-        The layer runs at SPOT_BURN_PRESET; the remaining IEtching fields are mandatory, so
-        they come from the configured milling defaults.
+        The layer runs at the given preset; the remaining IEtching fields are mandatory,
+        so they come from the configured milling defaults.
         """
         defaults = FibsemMillingSettings()
         layer_settings = IEtching(
@@ -1579,7 +1580,7 @@ class TescanMicroscope(FibsemMicroscope):
             rate=defaults.rate,
             dwellTime=defaults.dwell_time,
             parallel=False,
-            preset=SPOT_BURN_PRESET,
+            preset=preset,
             spacing=defaults.spacing,
         )
         with self._connection_lock:
@@ -1625,8 +1626,9 @@ class TescanMicroscope(FibsemMicroscope):
 
         Args:
             settings: coordinates to burn (normalised image coordinates, 0-1) and the
-                exposure time per point. ``settings.milling_current`` is ignored on
-                TESCAN; the beam conditions come from SPOT_BURN_PRESET.
+                exposure time per point. Beam conditions come from ``settings.preset``,
+                falling back to SPOT_BURN_PRESET when unset;
+                ``settings.milling_current`` is ignored on TESCAN.
             beam_type: must be BeamType.ION.
             stop_event: set to cancel the exposition.
         """
@@ -1639,10 +1641,11 @@ class TescanMicroscope(FibsemMicroscope):
         if exposure_time <= 0:
             raise ValueError(f"exposure_time must be positive, got {exposure_time}.")
 
+        preset = settings.preset or SPOT_BURN_PRESET
         if settings.milling_current is not None:
             logging.info(
                 f"Spot burn milling_current is ignored on TESCAN; using preset "
-                f"{SPOT_BURN_PRESET!r}. (requested: {settings.milling_current})"
+                f"{preset!r}. (requested: {settings.milling_current})"
             )
 
         # drop points outside the image bounds, matching the shared implementation
@@ -1670,6 +1673,7 @@ class TescanMicroscope(FibsemMicroscope):
             exposure_time=exposure_time,
             hfw=hfw,
             resolution=resolution,
+            preset=preset,
         )
 
         total_points = len(coordinates)

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -85,7 +85,9 @@ class FibsemSpotBurnWidget(QWidget):
 
         # coordinate editor (shared canvas overlay + list)
         self.coord_editor = SpotBurnCoordinatesWidget(
-            controller=self._view_controller(), beam=BeamType.ION, parent=self,
+            controller=self._view_controller(),
+            beam=BeamType.ION,
+            parent=self,
         )
         layout.addWidget(self.coord_editor)
 
@@ -113,11 +115,17 @@ class FibsemSpotBurnWidget(QWidget):
             )
             closest = min(beam_currents, key=lambda x: abs(x - DEFAULT_BEAM_CURRENT))
             self.comboBox_beam_current = ValueComboBox(
-                items=beam_currents, value=closest, unit="A", decimals=1,
+                items=beam_currents,
+                value=closest,
+                unit="A",
+                decimals=1,
             )
             form.addRow("Beam Current", self.comboBox_beam_current)
         self.doubleSpinBox_exposure_time = ValueSpinBox(
-            suffix="s", minimum=0.1, maximum=60, decimals=3,
+            suffix="s",
+            minimum=0.1,
+            maximum=60,
+            decimals=3,
         )
         self.doubleSpinBox_exposure_time.setValue(10)
         form.addRow("Exposure Time", self.doubleSpinBox_exposure_time)
@@ -158,7 +166,9 @@ class FibsemSpotBurnWidget(QWidget):
 
         # run button
         self.pushButton_run_spot_burn.clicked.connect(self.run_spot_burn_worker)
-        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.pushButton_run_spot_burn.setStyleSheet(
+            stylesheets.PRIMARY_BUTTON_STYLESHEET
+        )
         self.pushButton_run_spot_burn.setEnabled(False)
 
         # the workflow task drives the burn via start_spot_burn_signal (mirrors milling).
@@ -166,7 +176,8 @@ class FibsemSpotBurnWidget(QWidget):
         # so the burn is then either in progress (is_burning=True) or was refused (no
         # in-bounds points), in which case the task re-prompts.
         self.start_spot_burn_signal.connect(
-            self.run_spot_burn_worker, Qt.BlockingQueuedConnection  # type: ignore
+            self.run_spot_burn_worker,
+            Qt.BlockingQueuedConnection,  # type: ignore
         )
 
         # coordinate signal
@@ -249,7 +260,9 @@ class FibsemSpotBurnWidget(QWidget):
         would fire ``_update_progress_bar`` on a deleted object.
         """
         try:
-            self.microscope.spot_burn_progress_signal.disconnect(self._update_progress_bar)
+            self.microscope.spot_burn_progress_signal.disconnect(
+                self._update_progress_bar
+            )
         except Exception:
             pass
 
@@ -305,7 +318,9 @@ class FibsemSpotBurnWidget(QWidget):
 
         self._feed_image_shape()
         # the editor only owns coordinates; current/exposure live on the form
-        self.coord_editor.set_settings(SpotBurnSettings(coordinates=list(settings.coordinates)))
+        self.coord_editor.set_settings(
+            SpotBurnSettings(coordinates=list(settings.coordinates))
+        )
         self._refresh_info()  # set_settings is programmatic (no settings_changed)
 
     def get_settings(self) -> SpotBurnSettings:
@@ -368,7 +383,9 @@ class FibsemSpotBurnWidget(QWidget):
         self.stop_event.clear()
         self._is_burning = True
         self.pushButton_run_spot_burn.setText("Cancel")
-        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.DANGER_BUTTON_STYLESHEET)
+        self.pushButton_run_spot_burn.setStyleSheet(
+            stylesheets.DANGER_BUTTON_STYLESHEET
+        )
         self.pushButton_run_spot_burn.clicked.disconnect()
         self.pushButton_run_spot_burn.clicked.connect(self.cancel_spot_burn)
         # in workflow mode the button is hidden when idle — show it as "Cancel" while burning
@@ -389,10 +406,12 @@ class FibsemSpotBurnWidget(QWidget):
         ``microscope.spot_burn_progress_signal``; completion is delivered on the GUI
         thread via the FunctionWorker's returned / errored signals, so a failure anywhere
         here — including the post-burn acquire — resets the UI via spot_burn_errored."""
-        run_spot_burn(microscope=self.microscope,
-                      settings=settings,
-                      beam_type=BeamType.ION,
-                      stop_event=self.stop_event)
+        run_spot_burn(
+            microscope=self.microscope,
+            settings=settings,
+            beam_type=BeamType.ION,
+            stop_event=self.stop_event,
+        )
         # acquire a post-burn fib image and push it to the view (off the GUI thread)
         image = self.microscope.acquire_image(beam_type=BeamType.ION)
         self.microscope.fib_acquisition_signal.emit(image)
@@ -403,7 +422,9 @@ class FibsemSpotBurnWidget(QWidget):
         # hide the "Done" bar after a moment, so it doesn't linger for the rest of the
         # session (mirrors the status bar). reset_if_finished leaves the widget alone if
         # another burn has already started rendering progress in the meantime.
-        QTimer.singleShot(HIDE_PROGRESS_DELAY_MS, self.progress_widget.reset_if_finished)
+        QTimer.singleShot(
+            HIDE_PROGRESS_DELAY_MS, self.progress_widget.reset_if_finished
+        )
 
     def spot_burn_errored(self, error) -> None:
         """Called when the spot burn fails.
@@ -412,7 +433,9 @@ class FibsemSpotBurnWidget(QWidget):
         still visible if the user was not watching when it happened.
         """
         logging.error(f"Spot burn failed: {error}")
-        self.microscope.spot_burn_progress_signal.emit({"finished": True, "error": True})
+        self.microscope.spot_burn_progress_signal.emit(
+            {"finished": True, "error": True}
+        )
         self._restore_idle_state()
 
     def _restore_idle_state(self) -> None:
@@ -422,7 +445,9 @@ class FibsemSpotBurnWidget(QWidget):
         self.pushButton_run_spot_burn.clicked.connect(self.run_spot_burn_worker)
         self.pushButton_run_spot_burn.setEnabled(True)
         self.pushButton_run_spot_burn.setText("Run Spot Burn")
-        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.pushButton_run_spot_burn.setStyleSheet(
+            stylesheets.PRIMARY_BUTTON_STYLESHEET
+        )
         # in workflow mode, hide the button again now the burn is done
         self._update_run_button_visibility()
 

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -5,6 +5,7 @@ import threading
 
 from PyQt5.QtCore import Qt, QTimer, pyqtSignal
 from PyQt5.QtWidgets import (
+    QComboBox,
     QFormLayout,
     QLabel,
     QPushButton,
@@ -13,6 +14,7 @@ from PyQt5.QtWidgets import (
 )
 from superqt import ensure_main_thread
 
+from fibsem import manufacturers
 from fibsem.imaging.spot import SpotBurnSettings, run_spot_burn
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType
@@ -87,18 +89,37 @@ class FibsemSpotBurnWidget(QWidget):
         )
         layout.addWidget(self.coord_editor)
 
-        # beam current + exposure
-        beam_currents = self.microscope.get_available_values("current", BeamType.ION)
-        closest = min(beam_currents, key=lambda x: abs(x - DEFAULT_BEAM_CURRENT))
-        self.comboBox_beam_current = ValueComboBox(
-            items=beam_currents, value=closest, unit="A", decimals=1,
-        )
+        # beam conditions + exposure. On preset-driven backends (TESCAN) the burn
+        # conditions are an ION preset, so the current combo would be a lie -- the
+        # driver ignores milling_current there. The preset list comes from the cached
+        # getter: building a tab must not query the microscope.
+        presets = []
+        if manufacturers.is_tescan(self.microscope.manufacturer):
+            presets = self.microscope.get_available_values_cached(
+                "preset", BeamType.ION
+            )
+        self._use_presets = bool(presets)
+
+        form = QFormLayout()
+        if self._use_presets:
+            self.comboBox_beam_current = None
+            self.comboBox_preset = QComboBox()
+            self.comboBox_preset.addItems([str(p) for p in presets])
+            form.addRow("Preset", self.comboBox_preset)
+        else:
+            self.comboBox_preset = None
+            beam_currents = self.microscope.get_available_values_cached(
+                "current", BeamType.ION
+            )
+            closest = min(beam_currents, key=lambda x: abs(x - DEFAULT_BEAM_CURRENT))
+            self.comboBox_beam_current = ValueComboBox(
+                items=beam_currents, value=closest, unit="A", decimals=1,
+            )
+            form.addRow("Beam Current", self.comboBox_beam_current)
         self.doubleSpinBox_exposure_time = ValueSpinBox(
             suffix="s", minimum=0.1, maximum=60, decimals=3,
         )
         self.doubleSpinBox_exposure_time.setValue(10)
-        form = QFormLayout()
-        form.addRow("Beam Current", self.comboBox_beam_current)
         form.addRow("Exposure Time", self.doubleSpinBox_exposure_time)
         layout.addLayout(form)
 
@@ -129,7 +150,10 @@ class FibsemSpotBurnWidget(QWidget):
         layout.addStretch()
 
     def _setup_connections(self) -> None:
-        self.comboBox_beam_current.currentIndexChanged.connect(self._refresh_info)
+        conditions_combo = (
+            self.comboBox_preset if self._use_presets else self.comboBox_beam_current
+        )
+        conditions_combo.currentIndexChanged.connect(self._refresh_info)
         self.doubleSpinBox_exposure_time.valueChanged.connect(self._refresh_info)
 
         # run button
@@ -260,15 +284,23 @@ class FibsemSpotBurnWidget(QWidget):
     # ------------------------------------------------------------------
 
     def set_settings(self, settings: SpotBurnSettings) -> None:
-        """Apply a settings payload (current / exposure / coordinates)."""
-        # keep an off-grid (protocol) current exactly selectable so an untouched value
-        # round-trips losslessly — otherwise the closest-match snap would rewrite the config
-        if self.comboBox_beam_current.findData(settings.milling_current) == -1:
-            self.comboBox_beam_current.addItem(
-                format_value(settings.milling_current, unit="A", precision=1),
-                settings.milling_current,
-            )
-        self.comboBox_beam_current.set_value(settings.milling_current)
+        """Apply a settings payload (conditions / exposure / coordinates)."""
+        if self._use_presets:
+            # keep an off-list (protocol) preset exactly selectable so an untouched
+            # value round-trips losslessly
+            if settings.preset:
+                if self.comboBox_preset.findText(settings.preset) == -1:
+                    self.comboBox_preset.addItem(settings.preset)
+                self.comboBox_preset.setCurrentText(settings.preset)
+        else:
+            # keep an off-grid (protocol) current exactly selectable so an untouched value
+            # round-trips losslessly — otherwise the closest-match snap would rewrite the config
+            if self.comboBox_beam_current.findData(settings.milling_current) == -1:
+                self.comboBox_beam_current.addItem(
+                    format_value(settings.milling_current, unit="A", precision=1),
+                    settings.milling_current,
+                )
+            self.comboBox_beam_current.set_value(settings.milling_current)
         self.doubleSpinBox_exposure_time.setValue(settings.exposure_time)
 
         self._feed_image_shape()
@@ -277,11 +309,16 @@ class FibsemSpotBurnWidget(QWidget):
         self._refresh_info()  # set_settings is programmatic (no settings_changed)
 
     def get_settings(self) -> SpotBurnSettings:
-        """The run payload — coordinates from the editor, current/exposure from the form."""
+        """The run payload — coordinates from the editor, conditions/exposure from the form."""
         return SpotBurnSettings(
             coordinates=self.get_coordinates(),
-            milling_current=self.comboBox_beam_current.value(),
+            milling_current=(
+                DEFAULT_BEAM_CURRENT
+                if self._use_presets
+                else self.comboBox_beam_current.value()
+            ),
             exposure_time=self.doubleSpinBox_exposure_time.value(),
+            preset=self.comboBox_preset.currentText() if self._use_presets else None,
         )
 
     def get_coordinates(self) -> list:
@@ -318,9 +355,14 @@ class FibsemSpotBurnWidget(QWidget):
             )
             return
 
+        conditions = (
+            f"Preset: {settings.preset!r}"
+            if settings.preset
+            else f"Beam current: {settings.milling_current} A"
+        )
         logging.info(
             f"Running spot burn with {len(settings.coordinates)} points. "
-            f"Beam current: {settings.milling_current} A, exposure time: {settings.exposure_time} s"
+            f"{conditions}, exposure time: {settings.exposure_time} s"
         )
 
         self.stop_event.clear()

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -404,3 +404,27 @@ def test_exposure_time_spinbox_has_seconds_suffix(qapp):
     widget = AutoLamellaTaskParametersConfigWidget(cfg)
 
     assert _control_widget(widget, "exposure_time").suffix() == " s"
+
+
+def test_preset_round_trips_and_defaults_to_none():
+    """The burn preset survives save/load and to_settings; protocols written before
+    the field existed load as None (backend default)."""
+    cfg = SpotBurnFiducialTaskConfig(
+        task_name="Spot Burn Fiducial", preset="30 keV; 1 nA; my cool preset"
+    )
+
+    loaded = SpotBurnFiducialTaskConfig.from_dict(cfg.to_dict())
+    assert loaded.preset == "30 keV; 1 nA; my cool preset"
+    assert loaded.to_settings().preset == "30 keV; 1 nA; my cool preset"
+
+    d = cfg.to_dict()
+    del d["parameters"]["preset"]  # pre-preset protocol
+    assert SpotBurnFiducialTaskConfig.from_dict(d).preset is None
+
+
+def test_preset_stays_out_of_the_generic_parameter_form():
+    """The preset is chosen in the spot burn tab's combo (like coordinates on the
+    canvas) -- the generic parameter form must not render it as a free-text field."""
+    cfg = SpotBurnFiducialTaskConfig(task_name="Spot Burn Fiducial")
+    assert "preset" not in cfg.parameters
+    assert "coordinates" not in cfg.parameters

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -70,16 +70,17 @@ def _burned_points(mic: MagicMock) -> list:
 def test_run_spot_burn_filters_out_of_bounds_coordinates(mock_microscope):
     """Coordinates outside the 0-1 image bounds are skipped, not sent to set_spot."""
     coords = [
-        Point(0.5, 0.5),   # valid
-        Point(0.9, 0.2),   # valid
+        Point(0.5, 0.5),  # valid
+        Point(0.9, 0.2),  # valid
         Point(1.02, 0.5),  # x > 1
         Point(-0.1, 0.3),  # x < 0
-        Point(0.5, 1.5),   # y > 1
+        Point(0.5, 1.5),  # y > 1
     ]
     FibsemMicroscope.run_spot_burn(
         mock_microscope,
-        settings=SpotBurnSettings(coordinates=coords, exposure_time=1.0,
-                                  milling_current=30e-12),
+        settings=SpotBurnSettings(
+            coordinates=coords, exposure_time=1.0, milling_current=30e-12
+        ),
         beam_type=BeamType.ION,
     )
     assert _burned_points(mock_microscope) == [Point(0.5, 0.5), Point(0.9, 0.2)]
@@ -90,8 +91,9 @@ def test_run_spot_burn_keeps_boundary_coordinates(mock_microscope):
     coords = [Point(0.0, 0.0), Point(1.0, 1.0)]
     FibsemMicroscope.run_spot_burn(
         mock_microscope,
-        settings=SpotBurnSettings(coordinates=coords, exposure_time=1.0,
-                                  milling_current=30e-12),
+        settings=SpotBurnSettings(
+            coordinates=coords, exposure_time=1.0, milling_current=30e-12
+        ),
     )
     assert _burned_points(mock_microscope) == coords
 
@@ -100,8 +102,9 @@ def test_run_spot_burn_empty_coordinates_does_not_burn(mock_microscope):
     """No coordinates -> no spot exposures, but the beam state is still restored."""
     FibsemMicroscope.run_spot_burn(
         mock_microscope,
-        settings=SpotBurnSettings(coordinates=[], exposure_time=1.0,
-                                  milling_current=30e-12),
+        settings=SpotBurnSettings(
+            coordinates=[], exposure_time=1.0, milling_current=30e-12
+        ),
     )
     mock_microscope.set_spot_scanning_mode.assert_not_called()
     mock_microscope.set_full_frame_scanning_mode.assert_called_once()
@@ -114,8 +117,9 @@ def test_run_spot_burn_coerces_string_parameters(mock_microscope):
     """String milling_current/exposure_time (from the editor QLineEdit bug) don't crash."""
     FibsemMicroscope.run_spot_burn(
         mock_microscope,
-        settings=SpotBurnSettings(coordinates=[Point(0.5, 0.5)], exposure_time="2",
-                                  milling_current="3e-11"),
+        settings=SpotBurnSettings(
+            coordinates=[Point(0.5, 0.5)], exposure_time="2", milling_current="3e-11"
+        ),
         beam_type=BeamType.ION,
     )
     # the milling current is applied as a real float, not the string "3e-11"
@@ -131,8 +135,9 @@ def test_run_spot_burn_restores_full_frame_and_imaging_current(mock_microscope):
     """After burning, scanning returns to full frame and the imaging current is restored."""
     FibsemMicroscope.run_spot_burn(
         mock_microscope,
-        settings=SpotBurnSettings(coordinates=[Point(0.5, 0.5)], exposure_time=1.0,
-                                  milling_current=30e-12),
+        settings=SpotBurnSettings(
+            coordinates=[Point(0.5, 0.5)], exposure_time=1.0, milling_current=30e-12
+        ),
     )
     mock_microscope.set_full_frame_scanning_mode.assert_called_once()
     last_current = mock_microscope.set_beam_current.call_args_list[-1].kwargs["current"]
@@ -146,8 +151,11 @@ def test_run_spot_burn_emits_progress_via_microscope(mock_microscope):
     """Progress is reported through microscope.spot_burn_progress_signal (both run paths)."""
     FibsemMicroscope.run_spot_burn(
         mock_microscope,
-        settings=SpotBurnSettings(coordinates=[Point(0.5, 0.5), Point(0.6, 0.6)],
-                                  exposure_time=1.0, milling_current=30e-12),
+        settings=SpotBurnSettings(
+            coordinates=[Point(0.5, 0.5), Point(0.6, 0.6)],
+            exposure_time=1.0,
+            milling_current=30e-12,
+        ),
     )
     emitted = [
         c.args[0] for c in mock_microscope.spot_burn_progress_signal.emit.call_args_list
@@ -162,10 +170,15 @@ def test_run_spot_burn_emits_progress_via_microscope(mock_microscope):
 def test_run_spot_burn_module_function_delegates_to_the_microscope(mock_microscope):
     """The module entry point dispatches polymorphically (FIB-297): the default
     implementation parks the beam per point, TESCAN overrides with DrawBeam dots."""
-    settings = SpotBurnSettings(coordinates=[Point(0.5, 0.5)], exposure_time=1.0,
-                                milling_current=30e-12)
-    run_spot_burn(microscope=mock_microscope, settings=settings,
-                  beam_type=BeamType.ION, stop_event=None)
+    settings = SpotBurnSettings(
+        coordinates=[Point(0.5, 0.5)], exposure_time=1.0, milling_current=30e-12
+    )
+    run_spot_burn(
+        microscope=mock_microscope,
+        settings=settings,
+        beam_type=BeamType.ION,
+        stop_event=None,
+    )
     mock_microscope.run_spot_burn.assert_called_once_with(
         settings=settings, beam_type=BeamType.ION, stop_event=None
     )
@@ -177,8 +190,12 @@ def test_build_spot_burn_progress_update_mapping():
     from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
 
     running = build_spot_burn_progress_update(
-        {"current_point": 1, "total_points": 3,
-         "total_remaining_time": 20.0, "total_estimated_time": 30.0}
+        {
+            "current_point": 1,
+            "total_points": 3,
+            "total_remaining_time": 20.0,
+            "total_estimated_time": 30.0,
+        }
     )
     assert (running.current, running.total) == (1, 3)
     assert running.remaining_seconds == 20.0
@@ -265,7 +282,9 @@ def _make_supervised_spot_burn_task(monkeypatch, tmp_path, ask_user_responses):
     widget.get_settings.return_value = SpotBurnSettings(
         coordinates=[Point(0.5, 0.5)], exposure_time=1.0, milling_current=1e-9
     )
-    parent_ui = MagicMock()  # truthy experiment.task_protocol.get_supervision -> supervised
+    parent_ui = (
+        MagicMock()
+    )  # truthy experiment.task_protocol.get_supervision -> supervised
     parent_ui.spot_burn_widget = widget
 
     responses = iter(ask_user_responses)

--- a/tests/test_spot_burn_widget_preset.py
+++ b/tests/test_spot_burn_widget_preset.py
@@ -1,0 +1,111 @@
+"""The spot burn widget's beam-conditions control is backend-dependent.
+
+Preset-driven backends (TESCAN) get a Preset combo — the driver ignores
+``milling_current`` there, so a current combo would be a lie — while every other
+backend keeps the Beam Current combo. Values come from the cached
+available-values getter: building the tab must not query the microscope, so the
+tests seed the cache and stub nothing else.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python tests/test_spot_burn_widget_preset.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5.QtWidgets import QApplication, QWidget
+
+from fibsem.imaging.spot import SpotBurnSettings
+from fibsem.microscopes.simulator import DemoMicroscope
+from fibsem.microscopes.tescan import TescanMicroscope
+from fibsem.ui.FibsemSpotBurnWidget import DEFAULT_BEAM_CURRENT, FibsemSpotBurnWidget
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+PRESETS = ["30 keV; 100 pA", "30 keV; 1 nA; my cool preset"]
+CURRENTS = [20e-12, 60e-12, 1e-9]
+
+
+def make_tescan_microscope() -> TescanMicroscope:
+    """A TescanMicroscope without the SDK, with the preset cache pre-seeded.
+
+    Seeding ``_available_values_cache`` (the store behind
+    ``get_available_values_cached``) is the point: the widget must read the
+    cache, never the SDK — an uncached call would hit ``connection`` and fail.
+    """
+    microscope = object.__new__(TescanMicroscope)
+    microscope._available_values_cache = {"preset_ION": list(PRESETS)}
+    return microscope
+
+
+def make_demo_microscope() -> DemoMicroscope:
+    """A DemoMicroscope (non-Tescan) with the current cache pre-seeded."""
+    microscope = object.__new__(DemoMicroscope)
+    microscope._available_values_cache = {"current_ION": list(CURRENTS)}
+    return microscope
+
+
+def make_widget(microscope) -> FibsemSpotBurnWidget:
+    host = QWidget()
+    host.microscope = microscope
+    widget = FibsemSpotBurnWidget(parent=host)
+    widget._host = host  # keep the parent alive for the widget's lifetime
+    return widget
+
+
+def test_tescan_gets_a_preset_combo():
+    widget = make_widget(make_tescan_microscope())
+
+    assert widget._use_presets
+    assert widget.comboBox_beam_current is None
+    items = [
+        widget.comboBox_preset.itemText(i)
+        for i in range(widget.comboBox_preset.count())
+    ]
+    assert items == PRESETS
+
+    settings = widget.get_settings()
+    assert settings.preset == PRESETS[0]
+    # milling_current is carried but ignored by the preset-driven driver
+    assert settings.milling_current == DEFAULT_BEAM_CURRENT
+
+
+def test_non_tescan_keeps_the_current_combo():
+    widget = make_widget(make_demo_microscope())
+
+    assert not widget._use_presets
+    assert widget.comboBox_preset is None
+
+    settings = widget.get_settings()
+    assert settings.preset is None
+    assert settings.milling_current == 60e-12  # closest to the default
+
+
+def test_off_list_preset_round_trips_losslessly():
+    """A protocol preset not in the machine's list stays exactly selectable, so an
+    untouched value is not rewritten on save (mirrors the off-grid current rule)."""
+    widget = make_widget(make_tescan_microscope())
+
+    widget.set_settings(SpotBurnSettings(preset="20 keV; 40 pA; custom"))
+
+    assert widget.get_settings().preset == "20 keV; 40 pA; custom"
+
+
+def test_listed_preset_selection_round_trips():
+    widget = make_widget(make_tescan_microscope())
+
+    widget.set_settings(SpotBurnSettings(preset=PRESETS[1]))
+
+    assert widget.comboBox_preset.count() == len(PRESETS)  # no duplicate added
+    assert widget.get_settings().preset == PRESETS[1]
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+            print(f"{name} passed")

--- a/tests/test_tescan_spot_burn.py
+++ b/tests/test_tescan_spot_burn.py
@@ -272,6 +272,23 @@ def test_layer_settings_use_the_spot_burn_preset_and_configured_defaults(monkeyp
     assert layer_settings["parallel"] is False
 
 
+def test_settings_preset_overrides_the_default(monkeypatch):
+    """A preset on the settings payload (chosen in the GUI / protocol) wins over
+    SPOT_BURN_PRESET. Preset names are free-form on the instrument."""
+    m = make_microscope(monkeypatch)
+
+    m.run_spot_burn(
+        SpotBurnSettings(
+            coordinates=[Point(0.5, 0.5)],
+            exposure_time=1.0,
+            preset="30 keV; 1 nA; my cool preset",
+        )
+    )
+
+    layer_settings = m.connection.DrawBeam.layers[0].settings
+    assert layer_settings["preset"] == "30 keV; 1 nA; my cool preset"
+
+
 # --------------------------------------------------------------------------
 # cancellation
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What

On TESCAN the spot burn conditions were a lie: the widget offered a Beam Current combo (fed from a hardcoded fake current list) that `run_spot_burn` then ignored in favour of a hardcoded module constant (`SPOT_BURN_PRESET = "30 keV; 100 pA"`). The preset is now a real, user-visible setting.

- `SpotBurnSettings` gains an optional `preset` (serialized; `None` = backend default; `milling_current` stays ignored wherever a preset drives the beam).
- `TescanMicroscope.run_spot_burn` burns at `settings.preset`, falling back to `SPOT_BURN_PRESET` when unset. `_create_spot_burn_layer` takes the preset as a parameter.
- The spot burn tab shows a **Preset** combo on TESCAN — fed from `get_available_values_cached` (building a tab must not query the microscope; the Beam Current path now uses the cached getter too) — and keeps the Beam Current combo on every other backend. Off-list protocol presets stay exactly selectable so an untouched value round-trips losslessly (mirrors the off-grid current rule).
- The workflow task config carries the preset. It is deliberately excluded from the generic parameter form (like `coordinates`): it's chosen in the spot burn tab's combo, not as free text. Pre-preset protocols load as `None`.

Preset names are free-form on the instrument (e.g. "30 keV; 100 pA; my cool preset"), so nothing parses them here.

## Verification

- 61 tests green across `test_tescan_spot_burn.py` (new: settings preset reaches the DrawBeam layer), `tests/autolamella/test_spot_burn.py` (new: preset round-trips, pre-preset protocols default to None, preset stays out of the parameter form), the new `tests/test_spot_burn_widget_preset.py` (Tescan gets the preset combo from the seeded cache, non-Tescan keeps the current combo, off-list presets round-trip), and the coordinates-widget suite.
- ruff check clean; the four pre-format-dirty files got a separate whole-file format commit, proved AST-identical (docstring trailing whitespace normalised).

## Notes

- Second commit is format-only.
- Not yet exercised on hardware; the preset reaches the same IEtching field the hardware-verified default did, so risk is confined to the plumbing covered by tests.