### PR TITLE
[feat] Milling time estimates use the dose model on preset-driven backends (TESCAN)

### DIFF
--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -54,6 +54,7 @@ except Exception as e:
     logging.debug(f"Automation (TESCAN) not installed. {e}")
 
 from fibsem.imaging.spot import SpotBurnSettings
+from fibsem.milling.base import set_preset_driven_estimation
 from fibsem.structures import (  # noqa
     ACTIVE_MILLING_STATES,
     BeamSettings,
@@ -333,6 +334,12 @@ class TescanMicroscope(FibsemMicroscope):
             BeamType.ION: BeamSettings(BeamType.ION),
         }
 
+        # TESCAN milling is preset-driven, so milling time estimates must come from
+        # the dose model (stage rate x preset current), not the legacy current-keyed
+        # table. Registered here because the planning stack estimates without a
+        # microscope in scope; disconnect() hands the legacy model back.
+        set_preset_driven_estimation(True)
+
         # logging
         logging.debug(
             {
@@ -346,6 +353,8 @@ class TescanMicroscope(FibsemMicroscope):
             self.connection.Disconnect()
         del self.connection
         self.connection = None
+        # hand milling time estimation back to the legacy model (see __init__)
+        set_preset_driven_estimation(False)
 
     def connect_to_microscope(
         self,

--- a/fibsem/milling/__init__.py
+++ b/fibsem/milling/__init__.py
@@ -4,10 +4,12 @@ from fibsem.milling.base import (
     MillingStrategy,
     MillingStrategyConfig,
     estimate_milling_time,
+    estimate_stage_milling_time,
     estimate_total_milling_time,
     get_milling_stages,
     get_protocol_from_stages,
     get_strategy,
+    set_preset_driven_estimation,
 )
 from fibsem.milling.core import (
     setup_milling,

--- a/fibsem/milling/base.py
+++ b/fibsem/milling/base.py
@@ -1,3 +1,4 @@
+import re
 import threading
 from abc import ABC, abstractmethod
 from copy import deepcopy
@@ -204,7 +205,7 @@ class FibsemMillingStage:
 
     @property
     def estimated_time(self) -> float:
-        return estimate_milling_time(self.pattern, self.milling.milling_current)
+        return estimate_stage_milling_time(self)
 
     def run(
         self, microscope: FibsemMicroscope, asynch: bool = False, parent_ui=None
@@ -300,6 +301,88 @@ def get_protocol_from_stages(
     return deepcopy([stage.to_dict() for stage in stages])
 
 
+# Whether estimated_time uses the preset-driven dose model (TESCAN) instead of the
+# legacy sputter-rate table. The planning stack (task ETAs, confirmation dialogs)
+# reaches estimates through the FibsemMillingStage.estimated_time property, which
+# has no microscope in scope — so the connected backend registers its model here.
+# Only the TESCAN driver flips this (construction: True, disconnect: False); every
+# other backend keeps the legacy table by never touching it. Keying off the stage's
+# own fields instead would not work: FibsemMillingSettings.preset defaults to a
+# real-looking string on every backend.
+_PRESET_DRIVEN_ESTIMATION = False
+
+
+def set_preset_driven_estimation(enabled: bool) -> None:
+    """Register whether the connected backend's milling is preset-driven (TESCAN)."""
+    global _PRESET_DRIVEN_ESTIMATION
+    _PRESET_DRIVEN_ESTIMATION = bool(enabled)
+
+
+# A current token inside a free-form TESCAN preset name, e.g. "30 keV; 100 pA" or
+# "30 keV; 2nA; my cool preset". Only prefixed units (pA/nA/uA/µA): a bare "A" in an
+# arbitrary name (e.g. "slot 2A") is far more likely noise than a beam current.
+_PRESET_CURRENT_RE = re.compile(r"(\d+(?:\.\d+)?)\s*([pnuµ])A(?![a-zA-Z])")
+_SI_CURRENT_PREFIX = {"p": 1e-12, "n": 1e-9, "u": 1e-6, "µ": 1e-6}
+
+
+def parse_current_from_preset(preset: Optional[str]) -> Optional[float]:
+    """Parse the beam current (in A) out of a TESCAN preset name, or None.
+
+    Preset names are free-form on the instrument, but conventionally embed the
+    beam conditions ("30 keV; 100 pA"). The first current-looking token wins.
+    """
+    if not preset:
+        return None
+    match = _PRESET_CURRENT_RE.search(preset)
+    if match is None:
+        return None
+    return float(match.group(1)) * _SI_CURRENT_PREFIX[match.group(2)]
+
+
+def _estimate_preset_driven_milling_time(
+    stage: "FibsemMillingStage",
+) -> Optional[float]:
+    """Dose-model estimate t = volume / (rate × current) for a preset-driven stage.
+
+    The same inputs DrawBeam computes the real exposure from: the stage's own
+    (per-material) etch rate and the current embedded in the preset name — the
+    legacy sputter-rate table is a silicon calibration keyed on a current field
+    the preset-driven backend ignores. Returns None (caller falls back to the
+    legacy model) when the preset carries no parseable current or the rate is
+    unusable.
+    """
+    pattern_time = getattr(stage.pattern, "time", 0)
+    if pattern_time:
+        return pattern_time
+
+    current = parse_current_from_preset(stage.milling.preset)
+    rate = stage.milling.rate  # m³/A/s
+    if current is None or current <= 0 or not rate or rate <= 0:
+        return None
+
+    volume = stage.pattern.volume  # m³
+    if (
+        hasattr(stage.pattern, "cross_section")
+        and stage.pattern.cross_section is CrossSectionPattern.CleaningCrossSection
+    ):
+        volume *= 0.66  # ccs is approx 2/3 of the volume of a rectangle
+    return volume / (rate * current)
+
+
+def estimate_stage_milling_time(stage: "FibsemMillingStage") -> float:
+    """Estimated milling time for one stage, per the registered estimation model.
+
+    Preset-driven backends (TESCAN, registered via set_preset_driven_estimation)
+    get the dose model; everywhere else — and any preset the model cannot read —
+    falls through to the legacy sputter-rate table, unchanged.
+    """
+    if _PRESET_DRIVEN_ESTIMATION:
+        estimate = _estimate_preset_driven_milling_time(stage)
+        if estimate is not None:
+            return estimate
+    return estimate_milling_time(stage.pattern, stage.milling.milling_current)
+
+
 def estimate_milling_time(pattern: BasePattern, milling_current: float) -> float:
     """Estimate the milling time for a given pattern and milling current.
     The time is calculated as the volume of the pattern divided by the sputter rate at the given current.
@@ -341,9 +424,4 @@ def estimate_total_milling_time(stages: List[FibsemMillingStage]) -> float:
     """Estimate the total milling time for a list of milling stages"""
     if not isinstance(stages, list):
         stages = [stages]
-    return sum(
-        [
-            estimate_milling_time(stage.pattern, stage.milling.milling_current)
-            for stage in stages
-        ]
-    )
+    return sum([estimate_stage_milling_time(stage) for stage in stages])

--- a/tests/test_milling_time_estimates.py
+++ b/tests/test_milling_time_estimates.py
@@ -1,0 +1,207 @@
+"""Milling time estimation: the preset-driven dose model vs the legacy table.
+
+On preset-driven backends (TESCAN) the beam conditions come from the selected
+preset, so the legacy estimate — a silicon sputter-rate table keyed on the
+unused ``milling_current`` field — is wrong twice over (wrong current scale,
+wrong material). The dose model ``t = volume / (rate × current)`` uses the same
+inputs DrawBeam computes the real exposure from: the stage's own etch rate and
+the current parsed from the preset name.
+
+The model is registered process-wide by the TESCAN driver
+(``set_preset_driven_estimation``): the planning stack estimates through the
+``FibsemMillingStage.estimated_time`` property with no microscope in scope, so
+it cannot be a call-site parameter. The hard requirement locked in here is that
+nothing changes for any other backend: unregistered — the default — must be
+byte-identical to the legacy behaviour, and so must every preset the model
+cannot read.
+"""
+
+import threading
+
+import pytest
+
+from fibsem.milling.base import (
+    FibsemMillingStage,
+    estimate_milling_time,
+    estimate_stage_milling_time,
+    estimate_total_milling_time,
+    parse_current_from_preset,
+    set_preset_driven_estimation,
+)
+from fibsem.milling.patterning.patterns2 import RectanglePattern
+from fibsem.structures import CrossSectionPattern, FibsemMillingSettings
+
+RATE = 1.3e-8  # m3/A/s (the cryo-lamella default)
+PRESET_100PA = "30 keV; 100 pA"
+
+# 10 x 1 x 1 um rectangle = 1e-17 m3; t = 1e-17 / (1.3e-8 * 100e-12) = 7.6923 s
+DOSE_MODEL_SECONDS = pytest.approx(7.6923, abs=1e-3)
+
+
+@pytest.fixture(autouse=True)
+def _legacy_estimation_by_default():
+    """Reset the process-wide registration around every test (it is global state)."""
+    set_preset_driven_estimation(False)
+    yield
+    set_preset_driven_estimation(False)
+
+
+def make_stage(
+    preset: str = PRESET_100PA,
+    rate: float = RATE,
+    milling_current: float = 2.0e-9,
+    cross_section: CrossSectionPattern = CrossSectionPattern.Rectangle,
+    pattern_time: float = 0,
+) -> FibsemMillingStage:
+    pattern = RectanglePattern(width=10e-6, height=1e-6, depth=1e-6)
+    pattern.cross_section = cross_section
+    pattern.time = pattern_time
+    return FibsemMillingStage(
+        milling=FibsemMillingSettings(
+            preset=preset, rate=rate, milling_current=milling_current
+        ),
+        pattern=pattern,
+    )
+
+
+# ---------------------------------------------------------------------------
+# preset-name parsing (names are free-form on the instrument)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "preset, expected",
+    [
+        ("30 keV; 100 pA", 100e-12),
+        ("30 keV; 2nA", 2e-9),  # the FibsemMillingSettings default, no space
+        ("30 keV; 1 nA; my cool preset", 1e-9),
+        ("15 keV; 1.5 nA", 1.5e-9),
+        ("20 keV; 500 uA", 500e-6),
+        ("20 keV; 500 µA", 500e-6),
+    ],
+)
+def test_parse_current_from_preset(preset, expected):
+    assert parse_current_from_preset(preset) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "preset",
+    [
+        None,
+        "",
+        "my cool preset",  # no current token at all
+        "30 keV",  # voltage only
+        "slot 2A",  # bare "A" is noise, not a beam current
+        "2 mA range",  # unprefixed/mA deliberately rejected
+        "nAmeless",  # unit letters inside a word
+    ],
+)
+def test_parse_current_rejects_non_current_names(preset):
+    assert parse_current_from_preset(preset) is None
+
+
+def test_parse_current_takes_the_first_token():
+    assert parse_current_from_preset("100 pA (was 1 nA)") == pytest.approx(100e-12)
+
+
+# ---------------------------------------------------------------------------
+# the hard requirement: nothing changes unless the TESCAN model is registered
+# ---------------------------------------------------------------------------
+
+
+def test_unregistered_is_identical_to_the_legacy_estimate():
+    stage = make_stage()
+    assert estimate_stage_milling_time(stage) == estimate_milling_time(
+        stage.pattern, stage.milling.milling_current
+    )
+    assert stage.estimated_time == estimate_milling_time(
+        stage.pattern, stage.milling.milling_current
+    )
+    assert estimate_total_milling_time([stage, stage]) == pytest.approx(
+        2 * estimate_milling_time(stage.pattern, stage.milling.milling_current)
+    )
+
+
+def test_unreadable_preset_falls_back_to_legacy_even_when_registered():
+    set_preset_driven_estimation(True)
+    stage = make_stage(preset="my cool preset")
+    assert estimate_stage_milling_time(stage) == estimate_milling_time(
+        stage.pattern, stage.milling.milling_current
+    )
+
+
+def test_unusable_rate_falls_back_to_legacy_even_when_registered():
+    set_preset_driven_estimation(True)
+    stage = make_stage(rate=0.0)
+    assert estimate_stage_milling_time(stage) == estimate_milling_time(
+        stage.pattern, stage.milling.milling_current
+    )
+
+
+# ---------------------------------------------------------------------------
+# the dose model
+# ---------------------------------------------------------------------------
+
+
+def test_registered_uses_the_dose_model():
+    set_preset_driven_estimation(True)
+    stage = make_stage()
+    assert estimate_stage_milling_time(stage) == DOSE_MODEL_SECONDS
+    assert stage.estimated_time == DOSE_MODEL_SECONDS
+    assert estimate_total_milling_time([stage]) == DOSE_MODEL_SECONDS
+
+
+def test_dose_model_keeps_the_cleaning_cross_section_factor():
+    set_preset_driven_estimation(True)
+    stage = make_stage(cross_section=CrossSectionPattern.CleaningCrossSection)
+    assert estimate_stage_milling_time(stage) == pytest.approx(0.66 * 7.6923, abs=1e-3)
+
+
+def test_explicit_pattern_time_wins_in_both_models():
+    stage = make_stage(pattern_time=42.0)
+    assert estimate_stage_milling_time(stage) == 42.0
+    set_preset_driven_estimation(True)
+    assert estimate_stage_milling_time(stage) == 42.0
+
+
+def test_dose_model_ignores_the_dead_milling_current_field():
+    set_preset_driven_estimation(True)
+    a = make_stage(milling_current=20e-12)
+    b = make_stage(milling_current=120e-9)
+    assert estimate_stage_milling_time(a) == estimate_stage_milling_time(b)
+
+
+# ---------------------------------------------------------------------------
+# driver registration
+# ---------------------------------------------------------------------------
+
+
+def test_tescan_construction_registers_and_disconnect_unregisters(monkeypatch):
+    """TescanMicroscope.__init__ registers the model; disconnect() hands the
+    legacy model back (so a later non-TESCAN session estimates as before)."""
+    import os
+
+    import fibsem.config as cfg
+    from fibsem import utils
+    from fibsem.microscopes import tescan as tescan_module
+    from fibsem.microscopes.tescan import TescanMicroscope
+
+    stage = make_stage()
+    legacy = estimate_milling_time(stage.pattern, stage.milling.milling_current)
+
+    config_path = os.path.join(cfg.CONFIG_PATH, "tescan-configuration.yaml")
+    system = utils.load_microscope_configuration(config_path).system
+
+    # __init__ only guards on the SDK's availability, it does not use it
+    monkeypatch.setattr(tescan_module, "TESCAN_API_AVAILABLE", True)
+    microscope = TescanMicroscope(system_settings=system)
+    assert estimate_stage_milling_time(stage) == DOSE_MODEL_SECONDS
+
+    class FakeConnection:
+        def Disconnect(self):
+            pass
+
+    microscope.connection = FakeConnection()
+    microscope._connection_lock = threading.RLock()
+    microscope.disconnect()
+    assert estimate_stage_milling_time(stage) == legacy


### PR DESCRIPTION
## What

TESCAN milling ETAs were fiction, twice over:

1. The estimate is keyed on `stage.milling.milling_current` — a dead field on TESCAN (`setup_milling`: "unused, use preset instead"), typically nA-scale while the preset says 100 pA: **10–100× scale error**.
2. The `MILLING_SPUTTER_RATE` table is a **silicon** calibration (~0.3–0.5 µm³/nA/s), while the stage's own `rate` field — the one DrawBeam actually mills with — defaults to the cryo-lamella value (13 µm³/nA/s): a **~40× material error** on top.

New `estimate_stage_milling_time(stage)` picks per the registered estimation model:

- **Preset-driven (TESCAN):** dose model `t = volume / (rate × current)` — the same inputs DrawBeam computes the real exposure from. `rate` is the stage's per-material etch rate; the current is parsed from the free-form preset name (`"30 keV; 100 pA"`, `"30 keV; 2nA; my cool preset"`; prefixed units only — a bare `A` in an arbitrary name is noise). The 0.66 CleaningCrossSection factor and the explicit `pattern.time` override are kept.
- **Everywhere else — and any preset/rate the model cannot read:** the legacy table path, byte-identical to today. `estimate_milling_time` itself is untouched.

`FibsemMillingStage.estimated_time` and `estimate_total_milling_time` route through the new function, so the milling dialogs and the task-timeline ETAs pick it up.

## Why a process-wide registration, not a parameter

The planning stack (task ETAs, confirmation dialogs, `timing.py`) estimates through the `estimated_time` **property**, deliberately microscope-free — there is no call site to pass a manufacturer through. And keying off the stage's own fields cannot satisfy the Tescan-only requirement: `FibsemMillingSettings.preset` defaults to a real-looking string (`"30 keV; 2nA"`) on **every** backend, so preset-presence inference would silently switch ThermoFisher estimates. Instead the TESCAN driver registers the model (`__init__`: on, `disconnect`: off) via `set_preset_driven_estimation`; no other backend touches it.

## Verification

- 22 new tests in `tests/test_milling_time_estimates.py`: parser cases (incl. free-form names, no-space `2nA`, µ/u, first-token-wins, and the noise rejections `"slot 2A"` / `"nAmeless"`), the **identity requirement** (unregistered == legacy for `estimated_time`, `estimate_stage_milling_time`, `estimate_total_milling_time`), unreadable-preset and unusable-rate fallbacks while registered, the pinned dose value (10×1×1 µm at 13 µm³/nA/s @ 100 pA → 7.692 s), CCS factor, `pattern.time` override in both models, dead-current-field independence, and driver registration/unregistration (`TescanMicroscope.__init__` / `disconnect`, SDK-free).
- 127 tests green across the new file + `tests/milling/`; ruff check + format clean.

## Notes / follow-up

- Model accuracy: the dose model ignores raster overhead (dwell/spacing) — estimate-grade, same as before. DrawBeam can report its own expected time once a layer is loaded; logging that next to our number during real milling would validate the model (needs a live connection, so it can't power planning ETAs).
- Design agreed on the tracking issue (estimate order, Tescan-only constraint, parser tolerance for arbitrary preset names).