### PR TITLE
[feat] FibsemMillingSettings.preset defaults to None; TESCAN hard-errors on a missing preset

### DIFF
--- a/fibsem/config/tescan-configuration.yaml
+++ b/fibsem/config/tescan-configuration.yaml
@@ -59,4 +59,4 @@ milling:
     rate:                       1.3e-08                     # the cryo ion etching rate         (TESCAN)          [m3/A/s]  [USER]
     spacing:                    0.005                       # the cryo exposition mesh spacing  (TESCAN)      [dimensionless][USER]
     spot_size:                  1.0e-06                     # the cryo milling spot size        (TESCAN)            [metres][USER]
-    preset:                     "30 keV; 20 nA"             # the default milling preset        (TESCAN)                    [USER]
+    preset:                     "30 keV; 1nA"               # the default milling preset        (TESCAN)                    [USER]

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -1273,6 +1273,15 @@ class TescanMicroscope(FibsemMicroscope):
         if mill_settings.milling_channel is not BeamType.ION:
             raise ValueError("Only FIB milling is currently supported.")
 
+        # fail before touching the hardware: TESCAN milling is preset-driven, so a
+        # stage without a preset has no beam conditions -- inheriting whatever
+        # preset happens to be active would be silent condition-dependence
+        if mill_settings.preset is None:
+            raise ValueError(
+                "The milling stage has no preset. TESCAN milling is preset-driven: "
+                "choose a preset in the milling settings before milling."
+            )
+
         self._prepare_beam(mill_settings.milling_channel)
 
         self.clear_patterns()

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -1273,13 +1273,21 @@ class TescanMicroscope(FibsemMicroscope):
         if mill_settings.milling_channel is not BeamType.ION:
             raise ValueError("Only FIB milling is currently supported.")
 
-        # fail before touching the hardware: TESCAN milling is preset-driven, so a
-        # stage without a preset has no beam conditions -- inheriting whatever
-        # preset happens to be active would be silent condition-dependence
-        if mill_settings.preset is None:
+        # TESCAN milling is preset-driven, so a stage without a preset has no beam
+        # conditions. Resolve stage preset -> system-config default -> hard error
+        # (before touching the hardware): stock protocols carry no preset, so they
+        # mill at the preset the site chose in its machine config, while inheriting
+        # whatever preset happens to be active would be silent condition-dependence.
+        preset = mill_settings.preset or self.system.milling.preset
+        if preset is None:
             raise ValueError(
-                "The milling stage has no preset. TESCAN milling is preset-driven: "
-                "choose a preset in the milling settings before milling."
+                "The milling stage has no preset and the system configuration "
+                "defines no default milling preset. TESCAN milling is "
+                "preset-driven: choose a preset in the milling settings."
+            )
+        if mill_settings.preset is None:
+            logging.info(
+                f"Milling stage has no preset; using the system default {preset!r}."
             )
 
         self._prepare_beam(mill_settings.milling_channel)
@@ -1299,7 +1307,7 @@ class TescanMicroscope(FibsemMicroscope):
             )
 
         self.set(
-            "preset", mill_settings.preset, BeamType.ION
+            "preset", preset, BeamType.ION
         )  # QUERY: do we need to set this here as it is also set in IEtching?
 
         layer_settings = IEtching(
@@ -1310,7 +1318,7 @@ class TescanMicroscope(FibsemMicroscope):
             rate=mill_settings.rate,
             dwellTime=mill_settings.dwell_time,
             parallel=bool(mill_settings.patterning_mode == "Parallel"),
-            preset=mill_settings.preset,
+            preset=preset,
             spacing=mill_settings.spacing,
         )
 

--- a/fibsem/milling/base.py
+++ b/fibsem/milling/base.py
@@ -307,8 +307,8 @@ def get_protocol_from_stages(
 # has no microscope in scope — so the connected backend registers its model here.
 # Only the TESCAN driver flips this (construction: True, disconnect: False); every
 # other backend keeps the legacy table by never touching it. Keying off the stage's
-# own fields instead would not work: FibsemMillingSettings.preset defaults to a
-# real-looking string on every backend.
+# own fields instead would not work: protocols saved before the preset default
+# became None carry a real-looking string ("30 keV; 2nA") on every backend.
 _PRESET_DRIVEN_ESTIMATION = False
 
 

--- a/fibsem/milling/patterning/plotting.py
+++ b/fibsem/milling/patterning/plotting.py
@@ -613,7 +613,7 @@ def draw_milling_patterns(
         extra_parts = []
         if show_current:
             extra_parts.append(format_value(stage.milling.milling_current, "A"))
-        if show_preset:
+        if show_preset and stage.milling.preset:
             extra_parts.append(stage.milling.preset)
         if show_depth:
             # Get depth from pattern

--- a/fibsem/milling/patterning/plotting.py
+++ b/fibsem/milling/patterning/plotting.py
@@ -67,7 +67,9 @@ OVERLAP_PROPERTIES = {
 
 
 def _rect_pattern_to_image_pixels(
-    pattern: Union[FibsemRectangleSettings, FibsemBitmapSettings], pixel_size: float, image_shape: Tuple[int, int]
+    pattern: Union[FibsemRectangleSettings, FibsemBitmapSettings],
+    pixel_size: float,
+    image_shape: Tuple[int, int],
 ) -> Tuple[float, float, float, float]:
     """Convert rectangle pattern to image pixel coordinates.
     Args:
@@ -92,6 +94,7 @@ def _rect_pattern_to_image_pixels(
     height = height / pixel_size
 
     return centre.x, centre.y, width, height
+
 
 def _circle_pattern_to_image_pixels(
     pattern: FibsemCircleSettings, pixel_size: float, image_shape: Tuple[int, int]
@@ -121,6 +124,7 @@ def _circle_pattern_to_image_pixels(
     inner_radius_px = max(0, (radius - thickness) / pixel_size) if thickness > 0 else 0
 
     return centre.x, centre.y, radius_px, inner_radius_px, start_angle, end_angle
+
 
 def _line_pattern_to_image_pixels(
     pattern: FibsemLineSettings, pixel_size: float, image_shape: Tuple[int, int]
@@ -152,6 +156,7 @@ def _line_pattern_to_image_pixels(
     )
 
     return start.x, start.y, end.x, end.y
+
 
 def _polygon_pattern_to_image_pixels(
     pattern: FibsemPolygonSettings, pixel_size: float, image_shape: Tuple[int, int]
@@ -237,7 +242,6 @@ def _add_circle_mpl(
 
     if shape.is_exclusion:
         colour = "black"
-
 
     if inner_radius_px > 0:
         # annulus/ring pattern
@@ -434,17 +438,16 @@ def _add_polygon_mpl(
     pixel_size = image.metadata.pixel_size.x
     image_shape = image.data.shape
     pixel_vertices = _polygon_pattern_to_image_pixels(shape, pixel_size, image_shape)
-    
 
     patch = mpatches.Polygon(
-            pixel_vertices,
-            closed=True,
-            linewidth=PROPERTIES["line_width"],
-            edgecolor=colour,
-            facecolor=colour,
-            alpha=PROPERTIES["opacity"],
-            zorder=zorder,
-        )
+        pixel_vertices,
+        closed=True,
+        linewidth=PROPERTIES["line_width"],
+        edgecolor=colour,
+        facecolor=colour,
+        alpha=PROPERTIES["opacity"],
+        zorder=zorder,
+    )
 
     ax.add_patch(patch)
 
@@ -474,15 +477,20 @@ def _add_overlaps_mpl(
     """
     if len(milling_stages) < 2:
         return None
-    
+
     overlap_patches = []
-    
+
     # Create masks for each pattern
     pattern_masks = []
     for stage in milling_stages:
-        stage_mask = create_pattern_mask(stage.pattern, image.data.shape, pixelsize=image.metadata.pixel_size.x, include_exclusions=False)
+        stage_mask = create_pattern_mask(
+            stage.pattern,
+            image.data.shape,
+            pixelsize=image.metadata.pixel_size.x,
+            include_exclusions=False,
+        )
         pattern_masks.append(stage_mask)
-    
+
     # Find overlaps between patterns
     for i in range(len(pattern_masks)):
         for j in range(i + 1, len(pattern_masks)):
@@ -491,10 +499,13 @@ def _add_overlaps_mpl(
                 # Create contour patches for overlap regions
                 try:
                     import skimage.measure
+
                     contours = skimage.measure.find_contours(overlap.astype(float), 0.5)
-                    
+
                     for contour in contours:
-                        if len(contour) > 3:  # Only create patches for significant overlaps
+                        if (
+                            len(contour) > 3
+                        ):  # Only create patches for significant overlaps
                             # Swap x,y coordinates for matplotlib (contour gives row,col)
                             contour_xy = contour[:, [1, 0]]
                             patch = mpatches.Polygon(
@@ -513,7 +524,7 @@ def _add_overlaps_mpl(
                     if len(overlap_coords[0]) > 0:
                         y_min, y_max = overlap_coords[0].min(), overlap_coords[0].max()
                         x_min, x_max = overlap_coords[1].min(), overlap_coords[1].max()
-                        
+
                         patch = mpatches.Rectangle(
                             (x_min, y_min),
                             x_max - x_min,
@@ -617,11 +628,11 @@ def draw_milling_patterns(
             extra_parts.append(stage.milling.preset)
         if show_depth:
             # Get depth from pattern
-            depth_m = getattr(pattern, 'depth', None)
+            depth_m = getattr(pattern, "depth", None)
             if depth_m is not None:
                 depth_um = depth_m * 1e6  # Convert from meters to microns
                 extra_parts.append(f"{depth_um:.1f}μm")
-        
+
         extra = ", ".join(extra_parts)
 
         # Get all shapes from the pattern
@@ -748,13 +759,16 @@ def draw_milling_patterns(
 
     return fig, ax
 
+
 # Plotting utilities for drawing pattern as numpy arrays
+
 
 @dataclass
 class DrawnPattern:
     pattern: np.ndarray
     position: Point
     is_exclusion: bool
+
 
 def _create_annulus_shape(width, height, inner_radius, outer_radius):
     # Create a grid of coordinates
@@ -763,10 +777,17 @@ def _create_annulus_shape(width, height, inner_radius, outer_radius):
     X, Y = np.meshgrid(x, y)
     distance = np.sqrt(X**2 + Y**2)
     # Generate the donut shape
-    donut = np.logical_and(distance <= outer_radius, distance >= inner_radius).astype(int)
+    donut = np.logical_and(distance <= outer_radius, distance >= inner_radius).astype(
+        int
+    )
     return donut
 
-def draw_annulus_shape(pattern_settings: FibsemCircleSettings, image_shape: Tuple[int, int], pixelsize: float) -> DrawnPattern:
+
+def draw_annulus_shape(
+    pattern_settings: FibsemCircleSettings,
+    image_shape: Tuple[int, int],
+    pixelsize: float,
+) -> DrawnPattern:
     """Convert an annulus pattern to a np array. Note: annulus can only be plotted as image
     Args:
         pattern_settings: FibsemCircleSettings: Annulus pattern settings.
@@ -775,7 +796,7 @@ def draw_annulus_shape(pattern_settings: FibsemCircleSettings, image_shape: Tupl
     Returns:
         DrawnPattern: Annulus shape in image.
     """
-    
+
     # image parameters (centre, pixel size)
     icy, icx = get_image_pixel_centre(image_shape)
     pixelsize_x, pixelsize_y = pixelsize, pixelsize
@@ -786,15 +807,15 @@ def draw_annulus_shape(pattern_settings: FibsemCircleSettings, image_shape: Tupl
     center_x = pattern_settings.centre_x
     center_y = pattern_settings.centre_y
 
-    radius_px = radius / pixelsize_x # isotropic
+    radius_px = radius / pixelsize_x  # isotropic
     shape = int(2 * radius_px)
-    inner_radius_ratio = 0 # full circle
+    inner_radius_ratio = 0  # full circle
     if not np.isclose(thickness, 0):
-        inner_radius_ratio = (radius - thickness)/radius
-   
-    annulus_shape = _create_annulus_shape(width=shape, height=shape, 
-                                          inner_radius=inner_radius_ratio, 
-                                          outer_radius=1)
+        inner_radius_ratio = (radius - thickness) / radius
+
+    annulus_shape = _create_annulus_shape(
+        width=shape, height=shape, inner_radius=inner_radius_ratio, outer_radius=1
+    )
 
     # get pattern centre in image coordinates
     pattern_centre_x = int(icx + center_x / pixelsize_x)
@@ -802,9 +823,16 @@ def draw_annulus_shape(pattern_settings: FibsemCircleSettings, image_shape: Tupl
 
     pos = Point(x=pattern_centre_x, y=pattern_centre_y)
 
-    return DrawnPattern(pattern=annulus_shape, position=pos, is_exclusion=pattern_settings.is_exclusion)
+    return DrawnPattern(
+        pattern=annulus_shape, position=pos, is_exclusion=pattern_settings.is_exclusion
+    )
 
-def draw_rectangle_shape(pattern_settings: FibsemRectangleSettings, image_shape: Tuple[int, int], pixelsize: float) -> DrawnPattern:
+
+def draw_rectangle_shape(
+    pattern_settings: FibsemRectangleSettings,
+    image_shape: Tuple[int, int],
+    pixelsize: float,
+) -> DrawnPattern:
     """Convert a rectangle pattern to a np array with rotation support.
     Args:
         pattern_settings: FibsemRectangleSettings: Rectangle pattern settings.
@@ -839,17 +867,19 @@ def draw_rectangle_shape(pattern_settings: FibsemRectangleSettings, image_shape:
     if not np.isclose(rotation, 0):
         # Convert radians to degrees for scipy
         rotation_degrees = np.degrees(rotation)
-        
+
         # Rotate the shape, reshape=True to accommodate the rotated rectangle
         shape = rotate(shape, rotation_degrees, reshape=True, order=1, prefilter=False)
-        
+
         # Convert back to binary (rotation may introduce intermediate values)
         shape = (shape > 0.5).astype(float)
 
     # get pattern centre in image coordinates
     pos = Point(x=cx, y=cy)
 
-    return DrawnPattern(pattern=shape, position=pos, is_exclusion=pattern_settings.is_exclusion)
+    return DrawnPattern(
+        pattern=shape, position=pos, is_exclusion=pattern_settings.is_exclusion
+    )
 
 
 def draw_bitmap_shape(
@@ -933,7 +963,11 @@ def draw_line_shape(
     return DrawnPattern(pattern=shape, position=pos, is_exclusion=False)
 
 
-def draw_polygon_shape(pattern_settings: FibsemPolygonSettings, image_shape: Tuple[int, int], pixelsize: float) -> DrawnPattern:
+def draw_polygon_shape(
+    pattern_settings: FibsemPolygonSettings,
+    image_shape: Tuple[int, int],
+    pixelsize: float,
+) -> DrawnPattern:
     """Convert a polygon pattern to a np array.
     Args:
         pattern_settings: FibsemPolygonSettings: Polygon pattern settings.
@@ -953,42 +987,47 @@ def draw_polygon_shape(pattern_settings: FibsemPolygonSettings, image_shape: Tup
     for vertex in pattern_settings.vertices:
         # position in metres from image centre
         pmx, pmy = vertex[0] / pixelsize_x, vertex[1] / pixelsize_y
-        
+
         # convert to image coordinates
         px = icx + pmx
         py = icy - pmy
-        
+
         vertices_px.append((px, py))
-    
+
     vertices_px = np.array(vertices_px)
-    
+
     # Find bounding box of polygon
     min_x, min_y = np.floor(vertices_px.min(axis=0)).astype(int)
     max_x, max_y = np.ceil(vertices_px.max(axis=0)).astype(int)
-    
+
     # Create shape array with some padding
     padding = 2
     shape_width = max_x - min_x + 2 * padding
     shape_height = max_y - min_y + 2 * padding
-    
+
     # Offset vertices to shape coordinates
     vertices_shape = vertices_px - [min_x - padding, min_y - padding]
-    
+
     # Create the polygon mask
     shape = np.zeros((shape_height, shape_width), dtype=float)
-    
+
     # Use skimage.draw.polygon to fill the polygon
     rr, cc = polygon(vertices_shape[:, 1], vertices_shape[:, 0], shape.shape)
     shape[rr, cc] = 1.0
-    
+
     # Calculate center position
     center_x = (min_x + max_x) // 2
     center_y = (min_y + max_y) // 2
     pos = Point(x=center_x, y=center_y)
 
-    return DrawnPattern(pattern=shape, position=pos, is_exclusion=pattern_settings.is_exclusion)
+    return DrawnPattern(
+        pattern=shape, position=pos, is_exclusion=pattern_settings.is_exclusion
+    )
 
-def draw_pattern_shape(ps: FibsemPatternSettings, image_shape: Tuple[int, int], pixelsize: float) -> DrawnPattern:
+
+def draw_pattern_shape(
+    ps: FibsemPatternSettings, image_shape: Tuple[int, int], pixelsize: float
+) -> DrawnPattern:
     if isinstance(ps, FibsemCircleSettings):
         return draw_annulus_shape(ps, image_shape, pixelsize)
     elif isinstance(ps, FibsemRectangleSettings):
@@ -1002,12 +1041,12 @@ def draw_pattern_shape(ps: FibsemPatternSettings, image_shape: Tuple[int, int], 
     else:
         raise ValueError(f"Unsupported shape type {type(ps)}")
 
-def draw_pattern_in_image(image: np.ndarray, 
-                          drawn_pattern: DrawnPattern) -> np.ndarray:
+
+def draw_pattern_in_image(image: np.ndarray, drawn_pattern: DrawnPattern) -> np.ndarray:
 
     pattern = drawn_pattern.pattern
     pos = drawn_pattern.position
-    
+
     # place the annulus shape in the image
     w = pattern.shape[1] // 2
     h = pattern.shape[0] // 2
@@ -1016,18 +1055,21 @@ def draw_pattern_in_image(image: np.ndarray,
     xmin, xmax = pos.x - w, pos.x + w
     ymin, ymax = pos.y - h, pos.y + h
     zero_image = np.zeros_like(image)
-    zero_image[ymin:ymax, xmin:xmax] = pattern[:2*h, :2*w].astype(bool)
+    zero_image[ymin:ymax, xmin:xmax] = pattern[: 2 * h, : 2 * w].astype(bool)
 
     # if the pattern is an exclusion, set the image to zero
     if drawn_pattern.is_exclusion:
         image[zero_image == 1] = 0
     else:
         # add the annulus shape to the image, clip to 1
-        image = np.clip(image+zero_image, 0, 1)
+        image = np.clip(image + zero_image, 0, 1)
 
     return image
 
-def compose_pattern_image(image: np.ndarray, drawn_patterns: List[DrawnPattern]) -> np.ndarray:
+
+def compose_pattern_image(
+    image: np.ndarray, drawn_patterns: List[DrawnPattern]
+) -> np.ndarray:
     """Create an image with annulus shapes."""
     # create an empty image
     pattern_image = np.zeros_like(image)
@@ -1044,27 +1086,29 @@ def compose_pattern_image(image: np.ndarray, drawn_patterns: List[DrawnPattern])
 
 def simple_example(stages: List[FibsemMillingStage], image: FibsemImage) -> plt.Figure:
     """Simple demonstration of masks and bounding boxes."""
-    
+
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
-    
+
     # Plot 1: Show masks
-    ax1.imshow(image.data, cmap='gray', alpha=0.7)
+    ax1.imshow(image.data, cmap="gray", alpha=0.7)
     ax1.set_title("Pattern Masks")
-    
+
     for i, stage in enumerate(stages):
         # Create mask
-        mask = create_pattern_mask(stage.pattern, image.data.shape, pixelsize=image.metadata.pixel_size.x)
+        mask = create_pattern_mask(
+            stage.pattern, image.data.shape, pixelsize=image.metadata.pixel_size.x
+        )
 
         # Show mask as colored overlay
         masked = np.ma.masked_where(~mask, mask)
-        ax1.imshow(masked, alpha=0.6, cmap='gray', vmin=0, vmax=10)
+        ax1.imshow(masked, alpha=0.6, cmap="gray", vmin=0, vmax=10)
 
         print(f"{stage.name}: {np.sum(mask)} pixels")
-    
+
     # Plot 2: Show bounding boxes
-    ax2.imshow(image.data, cmap='gray')
+    ax2.imshow(image.data, cmap="gray")
     ax2.set_title("Bounding Boxes")
-    
+
     for i, stage in enumerate(stages):
         # Get bounding box
         x_min, y_min, x_max, y_max = get_pattern_bounding_box(stage.pattern, image)
@@ -1072,24 +1116,39 @@ def simple_example(stages: List[FibsemMillingStage], image: FibsemImage) -> plt.
         if (x_min, y_min, x_max, y_max) != (0, 0, 0, 0):
             # Draw bounding box using COLOURS from plotting.py
             bbox = mpatches.Rectangle(
-                (x_min, y_min), x_max - x_min, y_max - y_min,
-                linewidth=2, edgecolor=COLOURS[i % len(COLOURS)], facecolor='none'
+                (x_min, y_min),
+                x_max - x_min,
+                y_max - y_min,
+                linewidth=2,
+                edgecolor=COLOURS[i % len(COLOURS)],
+                facecolor="none",
             )
             ax2.add_patch(bbox)
-            ax2.text(x_min, y_min-5, stage.name, color=COLOURS[i % len(COLOURS)], fontsize=9)
+            ax2.text(
+                x_min,
+                y_min - 5,
+                stage.name,
+                color=COLOURS[i % len(COLOURS)],
+                fontsize=9,
+            )
 
     # Add combined bounding box
     patterns = [stage.pattern for stage in stages]
     x_min, y_min, x_max, y_max = get_patterns_bounding_box(patterns, image)
     if (x_min, y_min, x_max, y_max) != (0, 0, 0, 0):
         combined_bbox = mpatches.Rectangle(
-            (x_min, y_min), x_max - x_min, y_max - y_min,
-            linewidth=3, edgecolor='black', facecolor='none', linestyle='--'
+            (x_min, y_min),
+            x_max - x_min,
+            y_max - y_min,
+            linewidth=3,
+            edgecolor="black",
+            facecolor="none",
+            linestyle="--",
         )
         ax2.add_patch(combined_bbox)
-        ax2.text(x_min, y_max+10, 'Combined', color='black', fontweight='bold')
-    
+        ax2.text(x_min, y_max + 10, "Combined", color="black", fontweight="bold")
+
     plt.tight_layout()
     plt.show()
-    
+
     return fig

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2124,6 +2124,12 @@ class SystemSettings:
     gis: GISSystemSettings
     info: SystemInfo
     sim: Dict[str, Union[str, bool]] = field(default_factory=dict)
+    # Per-system milling defaults from the machine config's `milling:` block (e.g.
+    # the site's default TESCAN milling preset). A read-only convenience copy so
+    # the drivers -- which only receive SystemSettings -- can reach it; the block's
+    # canonical home stays MicroscopeSettings.milling, so to_dict deliberately does
+    # not emit it (MicroscopeSettings.to_dict would otherwise carry it twice).
+    milling: FibsemMillingSettings = field(default_factory=FibsemMillingSettings)
 
     def to_dict(self):
         return {
@@ -2151,6 +2157,9 @@ class SystemSettings:
             gis=GISSystemSettings.from_dict(settings["gis"]),
             info=SystemInfo.from_dict(settings["info"]),
             sim=settings.get("sim", {}),
+            milling=FibsemMillingSettings.from_dict(settings["milling"])
+            if settings.get("milling")
+            else FibsemMillingSettings(),
         )
 
 

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -1684,8 +1684,13 @@ class FibsemMillingSettings:
             "tooltip": "The horizontal field width used for milling. Patterns must fit within this field of view.",
         },
     )
-    preset: str = field(
-        default="30 keV; 2nA",
+    # None means "not set": every non-preset-driven backend (ThermoFisher, the
+    # simulator) leaves it None, and a TESCAN stage without one is a hard error at
+    # setup_milling rather than a silent default. NOTE: protocols saved before this
+    # default carry the old "30 keV; 2nA" string explicitly, on every backend, so
+    # a set preset does NOT imply TESCAN.
+    preset: Optional[str] = field(
+        default=None,
         metadata={
             "label": "Preset",
             "type": str,

--- a/fibsem/ui/widgets/form_builder.py
+++ b/fibsem/ui/widgets/form_builder.py
@@ -74,6 +74,7 @@ class FormDefaults:
     step: Optional[float] = None
     decimals: Optional[int] = None
 
+
 # A point is an offset from the image centre, so it is signed by definition and
 # must never inherit a floor of zero. The pattern form carried this same pair as
 # a literal default before the row was generalised.
@@ -135,7 +136,7 @@ def effective_scale(metadata: dict) -> Optional[float]:
     """
     base = metadata.get("scale")
     dims = metadata.get("dimensions")
-    return (base ** dims) if (base and dims) else base
+    return (base**dims) if (base and dims) else base
 
 
 def display_suffix(metadata: dict) -> str:
@@ -175,7 +176,9 @@ def _combo(items: Sequence[Any], value: Any, metadata: dict) -> Control:
     )
 
 
-def _point(value: Point, metadata: dict, fallback: Optional[Tuple[float, float]]) -> Control:
+def _point(
+    value: Point, metadata: dict, fallback: Optional[Tuple[float, float]]
+) -> Control:
     """Two spinboxes for a Point-typed field.
 
     Dispatched on the declared `type`, not on the field being called "point", so
@@ -288,7 +291,9 @@ def _scalar_list(value: Any, annotation: Any) -> Control:
     item_type = item_types[0] if item_types else str
     control = QLineEdit()
     control.setPlaceholderText("Enter comma-separated values")
-    control.setText(", ".join(str(v) for v in value) if isinstance(value, list) else str(value))
+    control.setText(
+        ", ".join(str(v) for v in value) if isinstance(value, list) else str(value)
+    )
 
     def read() -> List[Any]:
         text = control.text().strip()
@@ -346,7 +351,9 @@ def build_control(
     kind = type_ if type_ is not None else annotation
 
     if items == "dynamic":
-        resolved = dynamic_items(metadata["microscope_parameter"]) if dynamic_items else None
+        resolved = (
+            dynamic_items(metadata["microscope_parameter"]) if dynamic_items else None
+        )
         if not resolved:
             # keep the stored value selectable without a resolver; a None value
             # (field not set) means an empty combo, not a literal "None" entry
@@ -409,7 +416,9 @@ def build_control(
         control.setValue(int(round(value * scale)))
         return Control(
             widget=control,
-            read=lambda: int(round(control.value() / scale)) if scale else control.value(),
+            read=lambda: (
+                int(round(control.value() / scale)) if scale else control.value()
+            ),
             write=lambda new: control.setValue(int(round(new * scale))),
             signals=(control.valueChanged,),
         )
@@ -422,7 +431,9 @@ def build_control(
             minimum,
             maximum,
             metadata.get("step") if metadata.get("step") is not None else defaults.step,
-            metadata.get("decimals") if metadata.get("decimals") is not None else defaults.decimals,
+            metadata.get("decimals")
+            if metadata.get("decimals") is not None
+            else defaults.decimals,
         )
         control.setValue(value * scale)
         return Control(
@@ -445,7 +456,9 @@ def build_control(
     if annotation is None:
         # A milling form, which has no annotation to fall back on: nothing here
         # can render this, and there is no value in showing it disabled.
-        logging.warning("No control for field of type %r (value %r)", type_, type(value))
+        logging.warning(
+            "No control for field of type %r (value %r)", type_, type(value)
+        )
         return None
 
     # Debug, not warning: the form says this itself, visibly and in the right

--- a/fibsem/ui/widgets/form_builder.py
+++ b/fibsem/ui/widgets/form_builder.py
@@ -347,7 +347,11 @@ def build_control(
 
     if items == "dynamic":
         resolved = dynamic_items(metadata["microscope_parameter"]) if dynamic_items else None
-        return _combo(resolved if resolved else [value], value, metadata)
+        if not resolved:
+            # keep the stored value selectable without a resolver; a None value
+            # (field not set) means an empty combo, not a literal "None" entry
+            resolved = [value] if value is not None else []
+        return _combo(resolved, value, metadata)
 
     if items:
         return _combo(items, value, metadata)

--- a/fibsem/ui/widgets/milling_stage_list_widget.py
+++ b/fibsem/ui/widgets/milling_stage_list_widget.py
@@ -106,10 +106,10 @@ class _DraggableStageList(QListWidget):
 
 
 class MillingStageRowWidget(QWidget):
-    enabled_changed = pyqtSignal(object, bool)   # FibsemMillingStage, enabled
-    remove_clicked = pyqtSignal(object)          # FibsemMillingStage
-    row_clicked = pyqtSignal(object)             # FibsemMillingStage
-    stage_changed = pyqtSignal(object)           # FibsemMillingStage after inline mutation
+    enabled_changed = pyqtSignal(object, bool)  # FibsemMillingStage, enabled
+    remove_clicked = pyqtSignal(object)  # FibsemMillingStage
+    row_clicked = pyqtSignal(object)  # FibsemMillingStage
+    stage_changed = pyqtSignal(object)  # FibsemMillingStage after inline mutation
 
     def __init__(
         self,
@@ -155,7 +155,9 @@ class MillingStageRowWidget(QWidget):
         self.pattern_combo.setToolTip("Pattern type")
         _add_flex_column(layout, self.pattern_combo, _COL_PATTERN)
 
-        self.depth_spin = ValueSpinBox(suffix="µm", minimum=0.01, maximum=1000.0, step=0.1, decimals=1)
+        self.depth_spin = ValueSpinBox(
+            suffix="µm", minimum=0.01, maximum=1000.0, step=0.1, decimals=1
+        )
         self.depth_spin.setToolTip("Depth (µm)")
         # keep the column slot when hidden (patterns without depth) so rows stay aligned
         depth_sp = self.depth_spin.sizePolicy()
@@ -166,7 +168,11 @@ class MillingStageRowWidget(QWidget):
         # Current and Preset share one column: Tescan mills by preset (milling_current is
         # a no-op on that backend), every other backend mills by current. Exactly one is
         # ever visible, so the column boundaries still line up with the header.
-        _current_items = self._current_values if self._current_values else [stage.milling.milling_current]
+        _current_items = (
+            self._current_values
+            if self._current_values
+            else [stage.milling.milling_current]
+        )
         self.current_combo = ValueComboBox(items=_current_items, unit="A")
         self.current_combo.setToolTip("Milling current")
         _add_flex_column(layout, self.current_combo, _COL_CURRENT)
@@ -211,8 +217,14 @@ class MillingStageRowWidget(QWidget):
         )
         self.btn_remove.clicked.connect(lambda: self.remove_clicked.emit(self.stage))
 
-        for w in (self.name_edit, self.pattern_combo, self.depth_spin,
-                  self.current_combo, self.preset_combo, self.strategy_combo):
+        for w in (
+            self.name_edit,
+            self.pattern_combo,
+            self.depth_spin,
+            self.current_combo,
+            self.preset_combo,
+            self.strategy_combo,
+        ):
             w.installEventFilter(self)
 
         self._connect_signals()
@@ -235,12 +247,21 @@ class MillingStageRowWidget(QWidget):
     # ------------------------------------------------------------------
 
     def _block_controls(self, block: bool) -> None:
-        for w in (self.name_edit, self.pattern_combo, self.depth_spin,
-                  self.current_combo, self.preset_combo, self.strategy_combo):
+        for w in (
+            self.name_edit,
+            self.pattern_combo,
+            self.depth_spin,
+            self.current_combo,
+            self.preset_combo,
+            self.strategy_combo,
+        ):
             w.blockSignals(block)
 
     def _update_depth_visibility(self) -> None:
-        has_depth = hasattr(self.stage.pattern, "depth") and self.stage.pattern.depth is not None
+        has_depth = (
+            hasattr(self.stage.pattern, "depth")
+            and self.stage.pattern.depth is not None
+        )
         self.depth_spin.setVisible(has_depth)
         self.depth_spin.setEnabled(has_depth)
 
@@ -387,7 +408,9 @@ class _MillingStageListHeader(QWidget):
             if label_text == "Pattern":
                 self.lbl_pattern = lbl  # toggled with the pattern column (eye button)
             if label_text == "Current":
-                self.lbl_current = lbl  # retitled "Preset" on backends that mill by preset
+                self.lbl_current = (
+                    lbl  # retitled "Preset" on backends that mill by preset
+                )
 
         # trailing spacer matches the row's color+remove+drag vs the header's eye+add,
         # so the strategy column's right edge lines up with the rows
@@ -425,13 +448,15 @@ class _MillingStageListHeader(QWidget):
 class MillingStageListWidget(QWidget):
     """Multi-column list widget for FibsemMillingStage objects."""
 
-    stage_selected = pyqtSignal(object)    # FibsemMillingStage
-    stage_added = pyqtSignal(object)       # FibsemMillingStage (new stage, distinct from selection)
-    stage_removed = pyqtSignal(object)     # FibsemMillingStage
-    stage_changed = pyqtSignal(object)     # FibsemMillingStage (inline field edit)
-    enabled_changed = pyqtSignal(list)     # List[FibsemMillingStage] (enabled only)
-    order_changed = pyqtSignal(list)       # List[FibsemMillingStage] in new order
-    eye_toggled = pyqtSignal(bool)         # True = patterns visible
+    stage_selected = pyqtSignal(object)  # FibsemMillingStage
+    stage_added = pyqtSignal(
+        object
+    )  # FibsemMillingStage (new stage, distinct from selection)
+    stage_removed = pyqtSignal(object)  # FibsemMillingStage
+    stage_changed = pyqtSignal(object)  # FibsemMillingStage (inline field edit)
+    enabled_changed = pyqtSignal(list)  # List[FibsemMillingStage] (enabled only)
+    order_changed = pyqtSignal(list)  # List[FibsemMillingStage] in new order
+    eye_toggled = pyqtSignal(bool)  # True = patterns visible
 
     def __init__(
         self,
@@ -478,12 +503,16 @@ class MillingStageListWidget(QWidget):
         layout.addWidget(self._list)
 
         self._empty_label = QLabel("No milling stages. Click + to add one.")
-        self._empty_label.setStyleSheet(f"color: {NEUTRAL_700}; font-style: italic; padding: 12px;")
+        self._empty_label.setStyleSheet(
+            f"color: {NEUTRAL_700}; font-style: italic; padding: 12px;"
+        )
         self._empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self._empty_label)
 
         self._status_label = QLabel("")
-        self._status_label.setStyleSheet(f"color: {ORANGE_COLOR}; font-style: italic; padding: 2px 12px;")
+        self._status_label.setStyleSheet(
+            f"color: {ORANGE_COLOR}; font-style: italic; padding: 2px 12px;"
+        )
         self._status_label.setAlignment(Qt.AlignmentFlag.AlignLeft)
         self._status_label.setVisible(False)
         layout.addWidget(self._status_label)
@@ -517,7 +546,8 @@ class MillingStageListWidget(QWidget):
         index = self._list.count()
         stage.enabled = enabled
         row = MillingStageRowWidget(
-            stage, index=index,
+            stage,
+            index=index,
             pattern_names=self._pattern_names,
             strategy_names=self._strategy_names,
             current_values=self._current_values,
@@ -649,7 +679,11 @@ class MillingStageListWidget(QWidget):
         row.stage_changed.connect(self._on_row_stage_changed, type=Qt.QueuedConnection)
 
     def _is_name_available(self, name: str, row: MillingStageRowWidget) -> bool:
-        existing = {self._row(i).stage.name for i in range(self._list.count()) if self._row(i) is not row}
+        existing = {
+            self._row(i).stage.name
+            for i in range(self._list.count())
+            if self._row(i) is not row
+        }
         return name not in existing
 
     def _show_name_error(self, name: str) -> None:
@@ -677,7 +711,8 @@ class MillingStageListWidget(QWidget):
                 continue
             enabled = stage.enabled
             row = MillingStageRowWidget(
-                stage, index=i,
+                stage,
+                index=i,
                 pattern_names=self._pattern_names,
                 strategy_names=self._strategy_names,
                 current_values=self._current_values,

--- a/fibsem/ui/widgets/milling_stage_list_widget.py
+++ b/fibsem/ui/widgets/milling_stage_list_widget.py
@@ -171,7 +171,12 @@ class MillingStageRowWidget(QWidget):
         self.current_combo.setToolTip("Milling current")
         _add_flex_column(layout, self.current_combo, _COL_CURRENT)
 
-        _preset_items = self._preset_values if self._preset_values else [stage.milling.preset]
+        # preset may be None (not set): an empty combo, not a literal "None" entry
+        _preset_items = (
+            self._preset_values
+            if self._preset_values
+            else ([stage.milling.preset] if stage.milling.preset else [])
+        )
         self.preset_combo = ValueComboBox(items=_preset_items)
         self.preset_combo.setToolTip("Milling preset")
         _add_flex_column(layout, self.preset_combo, _COL_CURRENT)

--- a/tests/milling/test_base.py
+++ b/tests/milling/test_base.py
@@ -58,7 +58,6 @@ def test_milling_stage():
     }
     new_milling_stage = FibsemMillingStage.from_dict(dict_repr)
 
-
     assert new_milling_stage.name == "Test Stage"
     assert new_milling_stage.num == 1
     assert isinstance(new_milling_stage.milling, FibsemMillingSettings)
@@ -66,6 +65,7 @@ def test_milling_stage():
     assert isinstance(new_milling_stage.strategy, MillingStrategy)
     assert isinstance(new_milling_stage.alignment, MillingAlignment)
     assert new_milling_stage.imaging.path is None
+
 
 def test_get_strategy():
     # Test with default strategy

--- a/tests/milling/test_base.py
+++ b/tests/milling/test_base.py
@@ -83,3 +83,16 @@ def test_get_strategy():
     strategy = get_strategy(name="NonExistentStrategy")
     assert isinstance(strategy, MillingStrategy)
     assert strategy.name == DEFAULT_STRATEGY.name
+
+
+def test_preset_defaults_to_none_and_round_trips():
+    """None means "not set" -- non-preset-driven backends never fill it in. Protocols
+    saved before the default changed carry the old string explicitly on every
+    backend, and keep it on load (so a set preset does NOT imply TESCAN)."""
+    settings = FibsemMillingSettings()
+    assert settings.preset is None
+    assert FibsemMillingSettings.from_dict(settings.to_dict()).preset is None
+
+    old_protocol = settings.to_dict()
+    old_protocol["preset"] = "30 keV; 2nA"
+    assert FibsemMillingSettings.from_dict(old_protocol).preset == "30 keV; 2nA"

--- a/tests/test_milling_time_estimates.py
+++ b/tests/test_milling_time_estimates.py
@@ -73,7 +73,7 @@ def make_stage(
     "preset, expected",
     [
         ("30 keV; 100 pA", 100e-12),
-        ("30 keV; 2nA", 2e-9),  # the FibsemMillingSettings default, no space
+        ("30 keV; 2nA", 2e-9),  # the old field default; vendor style without a space
         ("30 keV; 1 nA; my cool preset", 1e-9),
         ("15 keV; 1.5 nA", 1.5e-9),
         ("20 keV; 500 uA", 500e-6),

--- a/tests/test_tescan_milling_lifecycle.py
+++ b/tests/test_tescan_milling_lifecycle.py
@@ -8,14 +8,19 @@ No hardware or Tescan SDK required: the microscope object is created without __i
 connection is stubbed, and the SDK names the driver imports are monkeypatched in.
 """
 
+import os
 import threading
 from typing import List, Optional
 
 import pytest
 
+import fibsem.config as cfg
+from fibsem import utils
 from fibsem.microscopes import tescan as tescan_module
 from fibsem.microscopes.tescan import TescanMicroscope
 from fibsem.structures import BeamType, FibsemMillingSettings
+
+TESCAN_CONFIG_PATH = os.path.join(cfg.CONFIG_PATH, "tescan-configuration.yaml")
 
 
 class FakeDrawBeam:
@@ -38,17 +43,28 @@ class FakeConnection:
         self.DrawBeam = FakeDrawBeam(unload_error)
 
 
-def make_microscope(monkeypatch, current_preset="30 keV; 20 pA", unload_error=None):
+def make_microscope(
+    monkeypatch,
+    current_preset="30 keV; 20 pA",
+    unload_error=None,
+    system_default_preset: Optional[str] = "30 keV; 1nA",
+):
     """Create a TescanMicroscope with the SDK and connection stubbed out.
 
     finish_milling restores the preset through the base set_preset() -> set("preset"),
     so preset changes are captured in state["set_calls"] rather than a raw SDK call.
     state["fail_preset"] arms a failure on the next set("preset") to simulate the restore
     step raising while leaving setup's own preset set intact.
+
+    ``system_default_preset`` is the machine config's default milling preset, which
+    setup_milling falls back to for a stage without one; None models a config that
+    defines no default.
     """
     microscope = object.__new__(TescanMicroscope)
     microscope._connection_lock = threading.RLock()
     microscope.connection = FakeConnection(unload_error)
+    microscope.system = utils.load_microscope_configuration(TESCAN_CONFIG_PATH).system
+    microscope.system.milling.preset = system_default_preset
     microscope.milling_channel = BeamType.ION
     microscope._preset_before_milling = None
     microscope._prepare_beam = lambda beam_type: None
@@ -228,14 +244,34 @@ def test_setup_milling_rejects_electron_channel(monkeypatch):
         m.setup_milling(FibsemMillingSettings(milling_channel=BeamType.ELECTRON))
 
 
-def test_setup_milling_refuses_a_stage_without_a_preset(monkeypatch):
+def test_setup_milling_refuses_when_no_preset_anywhere(monkeypatch):
     """TESCAN milling is preset-driven: a stage with preset=None (the field default)
-    is a hard error before anything reaches the hardware -- inheriting whatever
-    preset is active would be silent condition-dependence."""
-    m = make_microscope(monkeypatch)
+    on a system whose config defines no default either is a hard error before
+    anything reaches the hardware -- inheriting whatever preset is active would be
+    silent condition-dependence."""
+    m = make_microscope(monkeypatch, system_default_preset=None)
 
     with pytest.raises(ValueError, match="preset"):
         m.setup_milling(FibsemMillingSettings(preset=None))
 
     assert m.connection.DrawBeam.calls == []
     assert m._test_state["set_calls"] == []
+
+
+def test_setup_milling_falls_back_to_the_system_default_preset(monkeypatch):
+    """A stage without a preset (stock protocols carry none) mills at the machine
+    config's default milling preset, so default protocols work out of the box."""
+    m = make_microscope(monkeypatch, system_default_preset="30 keV; 1nA")
+
+    m.setup_milling(FibsemMillingSettings(preset=None))
+
+    assert ("preset", "30 keV; 1nA") in m._test_state["set_calls"]
+
+
+def test_setup_milling_stage_preset_wins_over_the_system_default(monkeypatch):
+    m = make_microscope(monkeypatch, system_default_preset="30 keV; 1nA")
+
+    m.setup_milling(FibsemMillingSettings(preset="30 keV; 100 pA"))
+
+    assert ("preset", "30 keV; 100 pA") in m._test_state["set_calls"]
+    assert ("preset", "30 keV; 1nA") not in m._test_state["set_calls"]

--- a/tests/test_tescan_milling_lifecycle.py
+++ b/tests/test_tescan_milling_lifecycle.py
@@ -226,3 +226,16 @@ def test_setup_milling_rejects_electron_channel(monkeypatch):
     m = make_microscope(monkeypatch)
     with pytest.raises(ValueError, match="FIB milling"):
         m.setup_milling(FibsemMillingSettings(milling_channel=BeamType.ELECTRON))
+
+
+def test_setup_milling_refuses_a_stage_without_a_preset(monkeypatch):
+    """TESCAN milling is preset-driven: a stage with preset=None (the field default)
+    is a hard error before anything reaches the hardware -- inheriting whatever
+    preset is active would be silent condition-dependence."""
+    m = make_microscope(monkeypatch)
+
+    with pytest.raises(ValueError, match="preset"):
+        m.setup_milling(FibsemMillingSettings(preset=None))
+
+    assert m.connection.DrawBeam.calls == []
+    assert m._test_state["set_calls"] == []


### PR DESCRIPTION
**Stacked on #561** (it updates the estimation-model comment that PR adds) — GitHub will retarget to main when #561 merges. Stacked PRs get no CI here; local gate: 322 tests green across `tests/milling`, the tescan lifecycle/spot-burn/estimate suites, the form-builder and stage-list widget suites; ruff check + format clean.

## What

`preset` now means what it says: **None = not set** (ThermoFisher, simulator — no more fake-looking `"30 keV; 2nA"` on every stage), **string = chosen**. On TESCAN, `setup_milling` raises a clear `ValueError` **before touching the hardware** when a stage has no preset — inheriting whatever preset happens to be active would be silent condition-dependence.

## What it does NOT do

It does not make preset-presence imply TESCAN retroactively: `to_dict` always wrote the preset, so protocols saved before this change carry the old default string explicitly, on every backend. That is why the estimation-model switch in #561 stays a driver registration rather than preset inference — the comment there is updated to say so. Old protocols on either backend load unchanged (covered by tests).

## None-safety in the readers

- stage-list preset combo and the form builder's `items: "dynamic"` combo render an **empty** combo for an unset preset, not a literal "None" entry
- the pattern-plot label skips an unset preset
- everything else already tolerated None (`ValueComboBox.set_value(None)` is a no-op on string combos; the estimate parser returns None)

## Tests

- default is None; None and string presets round-trip; an old protocol dict with the explicit string loads unchanged
- `setup_milling` with `preset=None` raises and nothing reaches the fake connection (no layer, no set calls)
- second commit is a whole-file format pass on the four pre-format-dirty files, proved AST-identical

## Update: system-config fallback (out-of-the-box behaviour)

Review question: do stock protocols still work on TESCAN? They carry **no** preset keys, so under the original hard error they would have refused to mill. `setup_milling` now resolves **stage preset → machine config's default milling preset → hard error**, with an info log when the fallback fires. The config's `milling: preset` field ([USER]-marked) existed but was consumed nowhere — the drivers only receive `SystemSettings`, so that now carries a read-only copy of the config milling block (deliberately not emitted by `to_dict`; the canonical home stays `MicroscopeSettings.milling`). The shipped tescan config default is set to `"30 keV; 1nA"`.

Net behaviour:
- existing app-saved protocols: unchanged (they carry presets explicitly)
- stock/hand-written protocols without presets: mill at the site's configured default, logged
- no stage preset **and** no config default: hard error before touching hardware

New tests: fallback fires, stage preset wins over the default, refusal only when neither is set.
