### PR TITLE
[fix] Consistent Move/Update position button order across every list

### DIFF
--- a/fibsem/applications/autolamella/ui/lamella_card_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_card_widget.py
@@ -38,7 +38,7 @@ from fibsem.ui.tokens import (
 from fibsem.ui.widgets.custom_widgets import ElidedLabel
 
 _CARD_WIDTH = 300
-_THUMB_PADDING = 6        # inset from card edges so rounded corners stay visible
+_THUMB_PADDING = 6  # inset from card edges so rounded corners stay visible
 # 3:2, matching the 1536x1024 frames the microscope acquires, so the thumbnail
 # scales rather than crops -- _thumbnail_image expands to fill. Kept small: at this
 # size it is a scanning cue ("which of these looks milled"), and every pixel of
@@ -146,7 +146,8 @@ def _thumbnail_image(lamella: Lamella, w: int, h: int) -> QImage:
         return image
 
     image = _arr_to_qimage(lamella.get_thumbnail()).scaled(
-        w, h,
+        w,
+        h,
         Qt.AspectRatioMode.KeepAspectRatioByExpanding,
         Qt.TransformationMode.SmoothTransformation,
     )
@@ -159,11 +160,11 @@ def _thumbnail_image(lamella: Lamella, w: int, h: int) -> QImage:
 class LamellaCardWidget(QWidget):
     """Modern card-style widget for a single Lamella."""
 
-    clicked = pyqtSignal(object)                    # Lamella
-    defect_changed = pyqtSignal(object)             # Lamella
-    move_to_requested = pyqtSignal(object)          # Lamella
+    clicked = pyqtSignal(object)  # Lamella
+    defect_changed = pyqtSignal(object)  # Lamella
+    move_to_requested = pyqtSignal(object)  # Lamella
     update_position_requested = pyqtSignal(object)  # Lamella
-    remove_requested = pyqtSignal(object)           # Lamella
+    remove_requested = pyqtSignal(object)  # Lamella
 
     def __init__(
         self,
@@ -198,7 +199,9 @@ class LamellaCardWidget(QWidget):
         # ── thumbnail ───────────────────────────────────────────────────
         self._thumb_label = QLabel()
         self._thumb_label.setAlignment(Qt.AlignCenter)
-        self._thumb_label.setStyleSheet(f"background: {NEUTRAL_900}; border-radius: 4px;")
+        self._thumb_label.setStyleSheet(
+            f"background: {NEUTRAL_900}; border-radius: 4px;"
+        )
 
         self._name_label = QLabel()
         self._name_label.setStyleSheet(
@@ -207,23 +210,34 @@ class LamellaCardWidget(QWidget):
 
         self._btn_actions = QToolButton()
         self._btn_actions.setFixedSize(_BTN_SIZE, _BTN_SIZE)
-        self._btn_actions.setStyleSheet(_BTN_STYLE + " QToolButton::menu-indicator { image: none; }")
-        self._btn_actions.setIcon(fibsem_icon("mdi:dots-horizontal", color=stylesheets.GRAY_ICON_COLOR))
+        self._btn_actions.setStyleSheet(
+            _BTN_STYLE + " QToolButton::menu-indicator { image: none; }"
+        )
+        self._btn_actions.setIcon(
+            fibsem_icon("mdi:dots-horizontal", color=stylesheets.GRAY_ICON_COLOR)
+        )
         self._btn_actions.setToolTip("Actions")
         self._btn_actions.setPopupMode(QToolButton.InstantPopup)
         _actions_menu = QMenu(self)
         self._action_move = _actions_menu.addAction(
-            fibsem_icon(ICON_MOVE_TO_POSITION, color=stylesheets.GRAY_ICON_COLOR), "Move to Position"
+            fibsem_icon(ICON_MOVE_TO_POSITION, color=stylesheets.GRAY_ICON_COLOR),
+            "Move to Position",
         )
         self._action_update = _actions_menu.addAction(
-            fibsem_icon(ICON_UPDATE_POSITION, color=stylesheets.GRAY_ICON_COLOR), "Update Position"
+            fibsem_icon(ICON_UPDATE_POSITION, color=stylesheets.GRAY_ICON_COLOR),
+            "Update Position",
         )
         self._action_remove = _actions_menu.addAction(
-            fibsem_icon("mdi:trash-can-outline", color=stylesheets.GRAY_ICON_COLOR), "Remove"
+            fibsem_icon("mdi:trash-can-outline", color=stylesheets.GRAY_ICON_COLOR),
+            "Remove",
         )
         self._btn_actions.setMenu(_actions_menu)
-        self._action_move.triggered.connect(lambda: self.move_to_requested.emit(self.lamella))
-        self._action_update.triggered.connect(lambda: self.update_position_requested.emit(self.lamella))
+        self._action_move.triggered.connect(
+            lambda: self.move_to_requested.emit(self.lamella)
+        )
+        self._action_update.triggered.connect(
+            lambda: self.update_position_requested.emit(self.lamella)
+        )
         self._action_remove.triggered.connect(self._on_remove_clicked)
 
         self._btn_defect = QToolButton()
@@ -260,8 +274,8 @@ class LamellaCardWidget(QWidget):
         # fatal. Delete these once FIB-604 lands a trigger that fires after the write.
         # lamella.task_state.events.name.connect(self.refresh)    # DISABLED: FIB-604
         # lamella.task_state.events.status.connect(self.refresh)  # DISABLED: FIB-604
-        lamella.events.defect.connect(self.refresh)             # type: ignore[union-attr]
-        lamella.events.description.connect(self.refresh)        # type: ignore[union-attr]
+        lamella.events.defect.connect(self.refresh)  # type: ignore[union-attr]
+        lamella.events.description.connect(self.refresh)  # type: ignore[union-attr]
 
         self.refresh()
 
@@ -288,8 +302,13 @@ class LamellaCardWidget(QWidget):
         if self._content is not None:
             # Re-parent the shared children out first, or deleting their container
             # takes them with it.
-            for widget in (self._thumb_label, self._name_label,
-                           self._status_label, self._btn_defect, self._btn_actions):
+            for widget in (
+                self._thumb_label,
+                self._name_label,
+                self._status_label,
+                self._btn_defect,
+                self._btn_actions,
+            ):
                 widget.setParent(None)
             self._frame_layout.removeWidget(self._content)
             self._content.deleteLater()
@@ -308,8 +327,12 @@ class LamellaCardWidget(QWidget):
         # says "visible once the parent is".
         self._content.show()
 
-        for widget in (self._name_label, self._status_label,
-                       self._btn_defect, self._btn_actions):
+        for widget in (
+            self._name_label,
+            self._status_label,
+            self._btn_defect,
+            self._btn_actions,
+        ):
             widget.show()
         # The compact arrangement leaves the thumbnail out of the layout entirely;
         # showing an unparented widget would pop it up as its own top-level window.
@@ -332,7 +355,9 @@ class LamellaCardWidget(QWidget):
 
         content = QWidget()
         row = QHBoxLayout(content)
-        row.setContentsMargins(_THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING)
+        row.setContentsMargins(
+            _THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING
+        )
         row.setSpacing(6)
         row.addWidget(self._thumb_label)
 
@@ -437,9 +462,7 @@ class LamellaCardWidget(QWidget):
         super().mousePressEvent(event)
 
     def set_selected(self, selected: bool) -> None:
-        self._card.setStyleSheet(
-            _CARD_SELECTED_STYLE if selected else _CARD_STYLE
-        )
+        self._card.setStyleSheet(_CARD_SELECTED_STYLE if selected else _CARD_STYLE)
 
     def _on_remove_clicked(self) -> None:
         reply = QMessageBox.question(
@@ -458,15 +481,17 @@ class LamellaCardWidget(QWidget):
             fibsem_icon("mdi:check-circle", color=stylesheets.GREEN_COLOR), "No defect"
         )
         action_rework = menu.addAction(
-            fibsem_icon("mdi:refresh-circle", color=stylesheets.DEFECT_ORANGE_COLOR), "Rework required"
+            fibsem_icon("mdi:refresh-circle", color=stylesheets.DEFECT_ORANGE_COLOR),
+            "Rework required",
         )
         action_failure = menu.addAction(
-            fibsem_icon("mdi:close-circle", color=stylesheets.DEFECT_RED_COLOR), "Failure"
+            fibsem_icon("mdi:close-circle", color=stylesheets.DEFECT_RED_COLOR),
+            "Failure",
         )
 
-        chosen = menu.exec_(self._btn_defect.mapToGlobal(
-            self._btn_defect.rect().bottomLeft()
-        ))
+        chosen = menu.exec_(
+            self._btn_defect.mapToGlobal(self._btn_defect.rect().bottomLeft())
+        )
 
         if chosen == action_none:
             self.lamella.defect = DefectState(state=DefectType.NONE)
@@ -487,11 +512,11 @@ _N_COLS = 4
 class LamellaCardContainer(QWidget):
     """Grid container that displays LamellaCardWidget in 4 columns."""
 
-    lamella_selected = pyqtSignal(object)           # Lamella | None
-    defect_changed = pyqtSignal(object)             # Lamella
-    move_to_requested = pyqtSignal(object)          # Lamella
+    lamella_selected = pyqtSignal(object)  # Lamella | None
+    defect_changed = pyqtSignal(object)  # Lamella
+    move_to_requested = pyqtSignal(object)  # Lamella
     update_position_requested = pyqtSignal(object)  # Lamella
-    remove_requested = pyqtSignal(object)           # Lamella
+    remove_requested = pyqtSignal(object)  # Lamella
 
     def __init__(
         self,
@@ -500,7 +525,7 @@ class LamellaCardContainer(QWidget):
         mode: str = MODE_COZY,
     ) -> None:
         super().__init__(parent)
-        self._cards: Dict[str, LamellaCardWidget] = {}   # lamella.id → card
+        self._cards: Dict[str, LamellaCardWidget] = {}  # lamella.id → card
         self._selected_id: Optional[str] = None
         self._n_cols: int = max(1, columns)
         self._mode: str = mode if mode in CARD_MODES else MODE_COZY

--- a/fibsem/applications/autolamella/ui/lamella_card_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_card_widget.py
@@ -27,7 +27,7 @@ from fibsem.applications.autolamella.ui.lamella_list_widget import (
 )
 from fibsem.config import CARD_MODES, MODE_COMPACT, MODE_COZY, MODE_STANDARD
 from fibsem.ui import stylesheets
-from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.icon import ICON_MOVE_TO_POSITION, ICON_UPDATE_POSITION, fibsem_icon
 from fibsem.ui.tokens import (
     NEUTRAL_200,
     NEUTRAL_550,
@@ -213,10 +213,10 @@ class LamellaCardWidget(QWidget):
         self._btn_actions.setPopupMode(QToolButton.InstantPopup)
         _actions_menu = QMenu(self)
         self._action_move = _actions_menu.addAction(
-            fibsem_icon("mdi:crosshairs-gps", color=stylesheets.GRAY_ICON_COLOR), "Move to Position"
+            fibsem_icon(ICON_MOVE_TO_POSITION, color=stylesheets.GRAY_ICON_COLOR), "Move to Position"
         )
         self._action_update = _actions_menu.addAction(
-            fibsem_icon("mdi:map-marker-check", color=stylesheets.GRAY_ICON_COLOR), "Update Position"
+            fibsem_icon(ICON_UPDATE_POSITION, color=stylesheets.GRAY_ICON_COLOR), "Update Position"
         )
         self._action_remove = _actions_menu.addAction(
             fibsem_icon("mdi:trash-can-outline", color=stylesheets.GRAY_ICON_COLOR), "Remove"

--- a/fibsem/applications/autolamella/ui/lamella_name_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_name_list_widget.py
@@ -125,14 +125,6 @@ class _LamellaRow(QWidget):
         self.btn_move_to.setVisible(False)
         layout.addWidget(self.btn_move_to)
 
-        self.btn_edit = QToolButton()
-        self.btn_edit.setIcon(fibsem_icon("mdi:pencil", color=stylesheets.GRAY_ICON_COLOR))
-        self.btn_edit.setToolTip("Edit Lamella")
-        self.btn_edit.setFixedSize(_LAMELLA_BTN_SIZE)
-        self.btn_edit.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
-        self.btn_edit.setVisible(False)
-        layout.addWidget(self.btn_edit)
-
         self.btn_update = QToolButton()
         self.btn_update.setIcon(fibsem_icon(ICON_UPDATE_POSITION, color=stylesheets.GRAY_ICON_COLOR))
         self.btn_update.setToolTip("Update Position")
@@ -140,6 +132,14 @@ class _LamellaRow(QWidget):
         self.btn_update.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
         self.btn_update.setVisible(False)
         layout.addWidget(self.btn_update)
+
+        self.btn_edit = QToolButton()
+        self.btn_edit.setIcon(fibsem_icon("mdi:pencil", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_edit.setToolTip("Edit Lamella")
+        self.btn_edit.setFixedSize(_LAMELLA_BTN_SIZE)
+        self.btn_edit.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
+        self.btn_edit.setVisible(False)
+        layout.addWidget(self.btn_edit)
 
         self.btn_move_to.clicked.connect(lambda: self.move_to_clicked.emit(self.lamella))
         self.btn_edit.clicked.connect(lambda: self.edit_clicked.emit(self.lamella))

--- a/fibsem/applications/autolamella/ui/lamella_name_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_name_list_widget.py
@@ -16,6 +16,7 @@ there yet: three of its consumers (the minimap, the coincidence viewer and the s
 burn widget) live in ``fibsem/ui/``, so moving it now would create three new
 generic-to-application imports rather than removing any. That move is FIB-559.
 """
+
 from __future__ import annotations
 
 from typing import Any, List, Optional
@@ -75,7 +76,11 @@ def _lamella_defect_icon(lamella) -> tuple[str, str, str]:
         return "mdi:check-circle", stylesheets.GREEN_COLOR, "No defect"
     if defect.state == DefectType.REWORK:
         desc = f": {defect.description}" if defect.description else ""
-        return "mdi:refresh-circle", stylesheets.DEFECT_ORANGE_COLOR, f"Rework required{desc}"
+        return (
+            "mdi:refresh-circle",
+            stylesheets.DEFECT_ORANGE_COLOR,
+            f"Rework required{desc}",
+        )
     if defect.state == DefectType.FAILURE:
         desc = f": {defect.description}" if defect.description else ""
         return "mdi:close-circle", stylesheets.DEFECT_RED_COLOR, f"Failure{desc}"
@@ -118,7 +123,9 @@ class _LamellaRow(QWidget):
 
         # Direct action buttons (replaces "…" dropdown)
         self.btn_move_to = QToolButton()
-        self.btn_move_to.setIcon(fibsem_icon(ICON_MOVE_TO_POSITION, color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_move_to.setIcon(
+            fibsem_icon(ICON_MOVE_TO_POSITION, color=stylesheets.GRAY_ICON_COLOR)
+        )
         self.btn_move_to.setToolTip("Move to Position")
         self.btn_move_to.setFixedSize(_LAMELLA_BTN_SIZE)
         self.btn_move_to.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
@@ -126,7 +133,9 @@ class _LamellaRow(QWidget):
         layout.addWidget(self.btn_move_to)
 
         self.btn_update = QToolButton()
-        self.btn_update.setIcon(fibsem_icon(ICON_UPDATE_POSITION, color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_update.setIcon(
+            fibsem_icon(ICON_UPDATE_POSITION, color=stylesheets.GRAY_ICON_COLOR)
+        )
         self.btn_update.setToolTip("Update Position")
         self.btn_update.setFixedSize(_LAMELLA_BTN_SIZE)
         self.btn_update.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
@@ -134,20 +143,26 @@ class _LamellaRow(QWidget):
         layout.addWidget(self.btn_update)
 
         self.btn_edit = QToolButton()
-        self.btn_edit.setIcon(fibsem_icon("mdi:pencil", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_edit.setIcon(
+            fibsem_icon("mdi:pencil", color=stylesheets.GRAY_ICON_COLOR)
+        )
         self.btn_edit.setToolTip("Edit Lamella")
         self.btn_edit.setFixedSize(_LAMELLA_BTN_SIZE)
         self.btn_edit.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
         self.btn_edit.setVisible(False)
         layout.addWidget(self.btn_edit)
 
-        self.btn_move_to.clicked.connect(lambda: self.move_to_clicked.emit(self.lamella))
+        self.btn_move_to.clicked.connect(
+            lambda: self.move_to_clicked.emit(self.lamella)
+        )
         self.btn_edit.clicked.connect(lambda: self.edit_clicked.emit(self.lamella))
         self.btn_update.clicked.connect(lambda: self.update_clicked.emit(self.lamella))
 
         # Remove button
         self.btn_remove = QToolButton()
-        self.btn_remove.setIcon(fibsem_icon("mdi:trash-can-outline", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_remove.setIcon(
+            fibsem_icon("mdi:trash-can-outline", color=stylesheets.GRAY_ICON_COLOR)
+        )
         self.btn_remove.setToolTip("Remove")
         self.btn_remove.setFixedSize(_LAMELLA_BTN_SIZE)
         self.btn_remove.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
@@ -190,12 +205,16 @@ class _LamellaRow(QWidget):
             fibsem_icon("mdi:check-circle", color=stylesheets.GREEN_COLOR), "No defect"
         )
         action_rework = menu.addAction(
-            fibsem_icon("mdi:refresh-circle", color=stylesheets.DEFECT_ORANGE_COLOR), "Rework required"
+            fibsem_icon("mdi:refresh-circle", color=stylesheets.DEFECT_ORANGE_COLOR),
+            "Rework required",
         )
         action_failure = menu.addAction(
-            fibsem_icon("mdi:close-circle", color=stylesheets.DEFECT_RED_COLOR), "Failure"
+            fibsem_icon("mdi:close-circle", color=stylesheets.DEFECT_RED_COLOR),
+            "Failure",
         )
-        chosen = menu.exec_(self.btn_defect.mapToGlobal(self.btn_defect.rect().bottomLeft()))
+        chosen = menu.exec_(
+            self.btn_defect.mapToGlobal(self.btn_defect.rect().bottomLeft())
+        )
         if chosen == action_none:
             self.lamella.defect = DefectState(state=DefectType.NONE)
         elif chosen == action_rework:
@@ -209,8 +228,11 @@ class _LamellaRow(QWidget):
 
     def _on_remove_clicked(self) -> None:
         reply = QMessageBox.question(
-            self, "Remove Lamella", f"Remove <b>{self.lamella.name}</b>?",
-            QMessageBox.Yes | QMessageBox.No, QMessageBox.No,
+            self,
+            "Remove Lamella",
+            f"Remove <b>{self.lamella.name}</b>?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
         )
         if reply == QMessageBox.Yes:
             self.remove_clicked.emit(self.lamella)
@@ -277,7 +299,9 @@ class LamellaNameListWidget(QWidget):
         lbl_status = QLabel("Status")
         lbl_status.setStyleSheet("font-weight: bold; background: transparent;")
         header_layout.addWidget(lbl_status, stretch=1)
-        self.btn_add = IconToolButton(icon="mdi:plus", tooltip="Add", size=_LAMELLA_BTN_SIZE.width())
+        self.btn_add = IconToolButton(
+            icon="mdi:plus", tooltip="Add", size=_LAMELLA_BTN_SIZE.width()
+        )
         self.btn_add.setVisible(False)
         self.btn_add.clicked.connect(self.add_requested.emit)
         header_layout.addWidget(self.btn_add)

--- a/fibsem/applications/autolamella/ui/lamella_pose_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_pose_list_widget.py
@@ -16,6 +16,7 @@ from PyQt5.QtWidgets import (
 
 from fibsem.applications.autolamella.structures import Lamella
 from fibsem.ui import stylesheets
+from fibsem.ui.icon import ICON_MOVE_TO_POSITION, ICON_UPDATE_POSITION
 from fibsem.ui.tokens import (
     CANVAS_BG,
     NEUTRAL_550,
@@ -55,19 +56,19 @@ class LamellaPoseRowWidget(QWidget):
         self.position_label.setStyleSheet(f"background: transparent; color: {NEUTRAL_550};")
         layout.addWidget(self.position_label, 1)
 
-        self.btn_update = IconToolButton(
-            icon="mdi:map-marker-check",
-            tooltip="Update Position",
-            size=_BTN_SIZE.width(),
-        )
-        layout.addWidget(self.btn_update)
-
         self.btn_move_to = IconToolButton(
-            icon="mdi:crosshairs-gps",
+            icon=ICON_MOVE_TO_POSITION,
             tooltip="Move to Position",
             size=_BTN_SIZE.width(),
         )
         layout.addWidget(self.btn_move_to)
+
+        self.btn_update = IconToolButton(
+            icon=ICON_UPDATE_POSITION,
+            tooltip="Update Position",
+            size=_BTN_SIZE.width(),
+        )
+        layout.addWidget(self.btn_update)
 
         self.btn_update.clicked.connect(lambda: self.update_clicked.emit(self.pose_name))
         self.btn_move_to.clicked.connect(lambda: self.move_to_clicked.emit(self.pose_name))

--- a/fibsem/applications/autolamella/ui/lamella_pose_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_pose_list_widget.py
@@ -35,10 +35,12 @@ _POSE_ORDER = ["MILLING", "FLUORESCENCE"]
 class LamellaPoseRowWidget(QWidget):
     """A single pose row: name, pretty position, update and move-to buttons."""
 
-    update_clicked = pyqtSignal(str)   # pose name
+    update_clicked = pyqtSignal(str)  # pose name
     move_to_clicked = pyqtSignal(str)  # pose name
 
-    def __init__(self, pose_name: str, pretty: str, parent: Optional[QWidget] = None) -> None:
+    def __init__(
+        self, pose_name: str, pretty: str, parent: Optional[QWidget] = None
+    ) -> None:
         super().__init__(parent)
         self.pose_name = pose_name
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
@@ -53,7 +55,9 @@ class LamellaPoseRowWidget(QWidget):
         layout.addWidget(self.name_label)
 
         self.position_label = QLabel(pretty)
-        self.position_label.setStyleSheet(f"background: transparent; color: {NEUTRAL_550};")
+        self.position_label.setStyleSheet(
+            f"background: transparent; color: {NEUTRAL_550};"
+        )
         layout.addWidget(self.position_label, 1)
 
         self.btn_move_to = IconToolButton(
@@ -70,8 +74,12 @@ class LamellaPoseRowWidget(QWidget):
         )
         layout.addWidget(self.btn_update)
 
-        self.btn_update.clicked.connect(lambda: self.update_clicked.emit(self.pose_name))
-        self.btn_move_to.clicked.connect(lambda: self.move_to_clicked.emit(self.pose_name))
+        self.btn_update.clicked.connect(
+            lambda: self.update_clicked.emit(self.pose_name)
+        )
+        self.btn_move_to.clicked.connect(
+            lambda: self.move_to_clicked.emit(self.pose_name)
+        )
 
     def set_pretty(self, pretty: str) -> None:
         self.position_label.setText(pretty)
@@ -109,7 +117,7 @@ class LamellaPoseListWidget(QWidget):
     with the pose name when the row buttons are clicked.
     """
 
-    update_requested = pyqtSignal(str)   # pose name
+    update_requested = pyqtSignal(str)  # pose name
     move_to_requested = pyqtSignal(str)  # pose name
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
@@ -170,11 +178,13 @@ class LamellaPoseListWidget(QWidget):
     @staticmethod
     def _sorted_pose_names(poses) -> list:
         """Order poses by _POSE_ORDER first; remaining keep insertion order after."""
+
         def key(name: str):
             try:
                 return (0, _POSE_ORDER.index(name))
             except ValueError:
                 return (1, 0)
+
         return sorted(poses.keys(), key=key)
 
     @staticmethod

--- a/fibsem/ui/widgets/sample_holder_widget.py
+++ b/fibsem/ui/widgets/sample_holder_widget.py
@@ -18,7 +18,7 @@ from PyQt5.QtWidgets import (
 
 from fibsem.microscopes._stage import GridSlot, SampleGrid, SampleHolder
 from fibsem.ui import stylesheets
-from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.icon import ICON_MOVE_TO_POSITION, ICON_UPDATE_POSITION, fibsem_icon
 from fibsem.ui.tokens import (
     CANVAS_BG,
     NEUTRAL_500,
@@ -79,25 +79,25 @@ class _GridSlotRowWidget(QWidget):
 
         _show_move = has_microscope and show_move
 
-        self.btn_capture = QToolButton()
-        self.btn_capture.setFixedSize(_ACTIONS_BTN_SIZE, _ACTIONS_BTN_SIZE)
-        self.btn_capture.setStyleSheet(_BTN_STYLE)
-        self.btn_capture.setIcon(fibsem_icon("mdi:map-marker-plus", color=stylesheets.GRAY_ICON_COLOR))
-        self.btn_capture.setToolTip("Update Position")
-        self.btn_capture.setVisible(_show_move)
-        self.btn_capture.clicked.connect(lambda: self.capture_clicked.emit(self.slot))
-        self.btn_capture.installEventFilter(self)
-        layout.addWidget(self.btn_capture)
-
         self.btn_move = QToolButton()
         self.btn_move.setFixedSize(_ACTIONS_BTN_SIZE, _ACTIONS_BTN_SIZE)
         self.btn_move.setStyleSheet(_BTN_STYLE)
-        self.btn_move.setIcon(fibsem_icon("mdi:crosshairs-gps", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_move.setIcon(fibsem_icon(ICON_MOVE_TO_POSITION, color=stylesheets.GRAY_ICON_COLOR))
         self.btn_move.setToolTip("Move to Position")
         self.btn_move.setVisible(_show_move)
         self.btn_move.clicked.connect(lambda: self.move_clicked.emit(self.slot))
         self.btn_move.installEventFilter(self)
         layout.addWidget(self.btn_move)
+
+        self.btn_capture = QToolButton()
+        self.btn_capture.setFixedSize(_ACTIONS_BTN_SIZE, _ACTIONS_BTN_SIZE)
+        self.btn_capture.setStyleSheet(_BTN_STYLE)
+        self.btn_capture.setIcon(fibsem_icon(ICON_UPDATE_POSITION, color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_capture.setToolTip("Update Position")
+        self.btn_capture.setVisible(_show_move)
+        self.btn_capture.clicked.connect(lambda: self.capture_clicked.emit(self.slot))
+        self.btn_capture.installEventFilter(self)
+        layout.addWidget(self.btn_capture)
 
         # Clear button — always visible, enabled only when a grid is loaded
         self.btn_clear = QToolButton()

--- a/fibsem/ui/widgets/sample_holder_widget.py
+++ b/fibsem/ui/widgets/sample_holder_widget.py
@@ -48,10 +48,10 @@ _LOADED_STYLE = "background: transparent;"
 
 
 class _GridSlotRowWidget(QWidget):
-    move_clicked = pyqtSignal(object)    # GridSlot
-    capture_clicked = pyqtSignal(object) # GridSlot
-    clear_clicked = pyqtSignal(object)   # GridSlot
-    row_clicked = pyqtSignal(object)     # GridSlot
+    move_clicked = pyqtSignal(object)  # GridSlot
+    capture_clicked = pyqtSignal(object)  # GridSlot
+    clear_clicked = pyqtSignal(object)  # GridSlot
+    row_clicked = pyqtSignal(object)  # GridSlot
 
     def __init__(
         self,
@@ -82,7 +82,9 @@ class _GridSlotRowWidget(QWidget):
         self.btn_move = QToolButton()
         self.btn_move.setFixedSize(_ACTIONS_BTN_SIZE, _ACTIONS_BTN_SIZE)
         self.btn_move.setStyleSheet(_BTN_STYLE)
-        self.btn_move.setIcon(fibsem_icon(ICON_MOVE_TO_POSITION, color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_move.setIcon(
+            fibsem_icon(ICON_MOVE_TO_POSITION, color=stylesheets.GRAY_ICON_COLOR)
+        )
         self.btn_move.setToolTip("Move to Position")
         self.btn_move.setVisible(_show_move)
         self.btn_move.clicked.connect(lambda: self.move_clicked.emit(self.slot))
@@ -92,7 +94,9 @@ class _GridSlotRowWidget(QWidget):
         self.btn_capture = QToolButton()
         self.btn_capture.setFixedSize(_ACTIONS_BTN_SIZE, _ACTIONS_BTN_SIZE)
         self.btn_capture.setStyleSheet(_BTN_STYLE)
-        self.btn_capture.setIcon(fibsem_icon(ICON_UPDATE_POSITION, color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_capture.setIcon(
+            fibsem_icon(ICON_UPDATE_POSITION, color=stylesheets.GRAY_ICON_COLOR)
+        )
         self.btn_capture.setToolTip("Update Position")
         self.btn_capture.setVisible(_show_move)
         self.btn_capture.clicked.connect(lambda: self.capture_clicked.emit(self.slot))
@@ -483,6 +487,7 @@ class SampleHolderWidget(QWidget):
         if holder is None:
             return
         from fibsem import config as cfg
+
         try:
             holder.save(cfg.SAMPLE_HOLDER_CONFIGURATION_PATH)
         except Exception as e:

--- a/fibsem/ui/widgets/saved_position_widget.py
+++ b/fibsem/ui/widgets/saved_position_widget.py
@@ -23,6 +23,7 @@ from PyQt5.QtWidgets import (
 from fibsem import config as cfg
 from fibsem.structures import FibsemStagePosition
 from fibsem.ui import stylesheets
+from fibsem.ui.icon import ICON_MOVE_TO_POSITION, ICON_UPDATE_POSITION
 from fibsem.ui.tokens import (
     CANVAS_BG,
 )
@@ -71,15 +72,15 @@ class SavedPositionRowWidget(QWidget):
         layout.addWidget(self.position_label, 1)
 
         self.btn_move = IconToolButton(
-            icon="mdi:crosshairs-gps",
-            tooltip="Move to position",
+            icon=ICON_MOVE_TO_POSITION,
+            tooltip="Move to Position",
             size=_BTN_SIZE.width(),
         )
         layout.addWidget(self.btn_move)
 
         self.btn_update = IconToolButton(
-            icon="mdi:map-marker-check",
-            tooltip="Update to current position",
+            icon=ICON_UPDATE_POSITION,
+            tooltip="Update Position",
             size=_BTN_SIZE.width(),
         )
         layout.addWidget(self.btn_update)

--- a/fibsem/ui/widgets/saved_position_widget.py
+++ b/fibsem/ui/widgets/saved_position_widget.py
@@ -44,10 +44,10 @@ _NAME_EDIT_STYLE = (
 
 class SavedPositionRowWidget(QWidget):
     name_changed = pyqtSignal(object, str)  # (FibsemStagePosition, name)
-    move_to_clicked = pyqtSignal(object)    # FibsemStagePosition
-    update_clicked = pyqtSignal(object)     # FibsemStagePosition
-    remove_clicked = pyqtSignal(object)     # FibsemStagePosition
-    row_clicked = pyqtSignal(object)        # FibsemStagePosition
+    move_to_clicked = pyqtSignal(object)  # FibsemStagePosition
+    update_clicked = pyqtSignal(object)  # FibsemStagePosition
+    remove_clicked = pyqtSignal(object)  # FibsemStagePosition
+    row_clicked = pyqtSignal(object)  # FibsemStagePosition
 
     def __init__(self, position: FibsemStagePosition, parent: QWidget = None) -> None:
         super().__init__(parent)
@@ -68,7 +68,9 @@ class SavedPositionRowWidget(QWidget):
         layout.addWidget(self.name_edit)
 
         self.position_label = QLabel(self.position.pretty_string)
-        self.position_label.setStyleSheet("color: #888; font-size: 11px; background: transparent;")
+        self.position_label.setStyleSheet(
+            "color: #888; font-size: 11px; background: transparent;"
+        )
         layout.addWidget(self.position_label, 1)
 
         self.btn_move = IconToolButton(
@@ -155,7 +157,7 @@ class _SavedPositionListHeader(QWidget):
 
 class SavedPositionListWidget(QWidget):
     move_to_requested = pyqtSignal(object)  # FibsemStagePosition
-    positions_updated = pyqtSignal(list)    # List[FibsemStagePosition]
+    positions_updated = pyqtSignal(list)  # List[FibsemStagePosition]
     position_selected = pyqtSignal(object)  # FibsemStagePosition
 
     def __init__(self, microscope=None, parent: QWidget = None) -> None:


### PR DESCRIPTION
## Problem

User feedback on the Experiment tab:

> Could the Move to Position & Update Position buttons in the Microscope Tab be consistently oriented?

They were not. The same pair of icons appeared in a different order depending on which list you were looking at — most visibly in the Experiment tab, where the Selected Lamella pose rows put **Update** first while the lamella rows directly above them put **Move** first, so the two icon columns did not line up.

## Change

One order everywhere — **Move to Position → Update Position → (other actions) → destructive last**:

| Widget | Before | After |
|---|---|---|
| Saved positions (Movement) | Move, Update, Remove | unchanged |
| Sample holder slots | **Update, Move**, Clear | Move, Update, Clear |
| Lamella pose list | **Update, Move** | Move, Update |
| Lamella name list | Move, **Edit**, Update, Remove | Move, Update, Edit, Remove |
| Lamella card menu | Move, Update, Remove | unchanged |

Two smaller inconsistencies fixed along the way:

- the sample holder's Update button drew `mdi:map-marker-plus` while every other Update drew `mdi:map-marker-check` — same action, different icon.
- saved-position tooltips read "Move to position" / "Update to current position" instead of the title-case wording used everywhere else.

All five sites now reference `ICON_MOVE_TO_POSITION` / `ICON_UPDATE_POSITION` from `fibsem/ui/icon.py` rather than repeating the mdi strings, so the icons cannot drift apart again.

No behaviour change — only layout order, icon source and tooltip text.

## Verification

- Ran the app (Demo, quickload of a 3-lamella experiment) and captured the Experiment and Movement sub-tabs. The lamella rows and the pose rows below them now sit in the same two columns.
- Constructed each row widget offscreen and read back the tooltip order: all four give `Move to Position, Update Position, (Edit), Remove`.
- `tests/ui` — 255 selected tests pass (`-k "lamella or position or holder or pose"`).