### PR TITLE
[ui] Give overview position markers enough ink to see on a bright image

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -436,7 +436,7 @@ class FMOverviewWidget(QWidget):
         # draws: the origin explains why everything sits where it does, this is what
         # you steer by. They coincide until the stage moves, then diverge.
         self.current_position_overlay = PointsOverlay(
-            color=CURRENT_POSITION_COLOUR, marker="+", size=13
+            color=CURRENT_POSITION_COLOUR, marker="+", size=15, edge_width=2.8
         )
         self.canvas.canvas.add_overlay(self.current_position_overlay)
 

--- a/fibsem/ui/tokens.py
+++ b/fibsem/ui/tokens.py
@@ -45,8 +45,8 @@ PRIMARY_ACCENT = "#3a6ea5"  # matches the quad-view selection border
 # on one and something else on the other is worse than either colour alone. They were
 # defined privately in the FM overview and would have been copied verbatim into the
 # second one, which is how two constants that must agree stop agreeing.
-CURRENT_POSITION_COLOUR = "#ffee58"   # where the stage is now
-SAVED_POSITION_COLOUR = "#26c6da"     # a marked position
+CURRENT_POSITION_COLOUR = "#ffee58"  # where the stage is now
+SAVED_POSITION_COLOUR = "#26c6da"  # a marked position
 SELECTED_POSITION_COLOUR = "#76ff03"  # the marked position under the selection
 
 # The sample holder, drawn under everything else on the same canvases. Here for the
@@ -55,8 +55,8 @@ SELECTED_POSITION_COLOUR = "#76ff03"  # the marked position under the selection
 # which are pure #ffff00 and #ff0000 -- the two most saturated colours available, and
 # the only things in the app that shout. Structural context should not out-shout a
 # position someone marked.
-SLOT_COLOUR = "#90a4ae"           # holder slots: context, so muted
-STAGE_LIMITS_COLOUR = "#ffca28"   # how far the stage can travel
+SLOT_COLOUR = "#90a4ae"  # holder slots: context, so muted
+STAGE_LIMITS_COLOUR = "#ffca28"  # how far the stage can travel
 GRID_BOUNDARY_COLOUR = "#ff5252"  # the edge of the specimen grid
 
 # ---------------------------------------------------------------------------
@@ -73,17 +73,17 @@ GRID_BOUNDARY_COLOUR = "#ff5252"  # the edge of the specimen grid
 #
 # So: prefer these when styling a new dialog, and do not add a third spelling
 # of a colour that is already here twice.
-SURFACE_COLOR = "#262930"       # dialog background
-PANEL_COLOR = "#1e2027"         # inset panels, table headers
-ROW_ALT_COLOR = "#2b2f38"       # alternating row tint, hover
-BORDER_COLOR = "#3d4251"        # panel and control borders
-TEXT_COLOR = "#d6d6d6"          # body text
-TEXT_STRONG_COLOR = "#f0f1f2"   # titles, emphasis
-TEXT_MUTED_COLOR = "#868e93"    # secondary text, disabled
-ACCENT_COLOR = "#50a6ff"        # links, selected state, informational chips
-OK_COLOR = "#4caf50"            # success
-WARN_COLOR = "#e0a030"          # loaded but inactive, degraded, needs attention
-ERROR_COLOR = "#d04040"         # failure
+SURFACE_COLOR = "#262930"  # dialog background
+PANEL_COLOR = "#1e2027"  # inset panels, table headers
+ROW_ALT_COLOR = "#2b2f38"  # alternating row tint, hover
+BORDER_COLOR = "#3d4251"  # panel and control borders
+TEXT_COLOR = "#d6d6d6"  # body text
+TEXT_STRONG_COLOR = "#f0f1f2"  # titles, emphasis
+TEXT_MUTED_COLOR = "#868e93"  # secondary text, disabled
+ACCENT_COLOR = "#50a6ff"  # links, selected state, informational chips
+OK_COLOR = "#4caf50"  # success
+WARN_COLOR = "#e0a030"  # loaded but inactive, degraded, needs attention
+ERROR_COLOR = "#d04040"  # failure
 
 # The disabled pair. Every semantic button sheet renders its :disabled state in
 # these two, and until now both were bare literals repeated across the file --
@@ -94,8 +94,8 @@ ERROR_COLOR = "#d04040"         # failure
 # NAPARI_STYLE use this value where ROW_ALT_COLOR is the token that means hover;
 # collapsing those is a real (if invisible) change, so they are left flagged in
 # place rather than folded in silently.
-DISABLED_BG_COLOR = "#2d313b"   # disabled control background
-DISABLED_TEXT_COLOR = "#6b6b6b" # disabled label and control text
+DISABLED_BG_COLOR = "#2d313b"  # disabled control background
+DISABLED_TEXT_COLOR = "#6b6b6b"  # disabled label and control text
 
 # ---------------------------------------------------------------------------
 # Neutral ramp

--- a/fibsem/ui/tokens.py
+++ b/fibsem/ui/tokens.py
@@ -46,7 +46,11 @@ PRIMARY_ACCENT = "#3a6ea5"  # matches the quad-view selection border
 # defined privately in the FM overview and would have been copied verbatim into the
 # second one, which is how two constants that must agree stop agreeing.
 CURRENT_POSITION_COLOUR = "#ffee58"  # where the stage is now
-SAVED_POSITION_COLOUR = "#26c6da"  # a marked position
+# Cyan A400, not Cyan 400: an accent, matching SELECTED's Light Green A400 below,
+# and the value already used for points drawn over image data elsewhere (the
+# correlation overlay's FM points, the tile-grid colour picker). The 400-series
+# value it replaced was muted enough to disappear into a bright overview.
+SAVED_POSITION_COLOUR = "#00e5ff"  # a marked position
 SELECTED_POSITION_COLOUR = "#76ff03"  # the marked position under the selection
 
 # The sample holder, drawn under everything else on the same canvases. Here for the

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -31,12 +31,14 @@ class PointsOverlay(CanvasOverlay):
         marker: str = "o",
         size: int = 8,
         label_prefix: str = "",
+        edge_width: Optional[float] = None,
     ):
         self._points = list(points)
         self._color = color
         self._marker = marker
         self._size = size
         self._label_prefix = label_prefix
+        self._edge_width = edge_width
         self._labels: Optional[List[str]] = None
         self._ax = None
         self._canvas = None
@@ -94,12 +96,20 @@ class PointsOverlay(CanvasOverlay):
         legible against a bright image.
 
         Same rule as `PointOverlay._marker_edge` below, which had it right.
+
+        `edge_width` overrides the width for one overlay. For an unfilled marker that
+        is the stroke thickness of the glyph itself, so it is the only way to give a
+        bare crosshair more ink -- which the current-stage marker needs and its
+        neighbours do not: it carries no field-of-view box and no label (it is passed
+        an empty one), deliberately, so that driving to a lamella does not double that
+        lamella's box. The glyph is all it has. Left as None everywhere else so this
+        stays a property of that one marker rather than of every point on the canvas.
         """
         from matplotlib.lines import Line2D
 
         if self._marker in Line2D.filled_markers:
-            return "white", 0.8
-        return self._color, 2.0
+            return "white", self._edge_width or 0.8
+        return self._color, self._edge_width or 2.0
 
     def _draw(self):
         if self._ax is None:
@@ -158,12 +168,32 @@ class PointsOverlay(CanvasOverlay):
         self._artists.append(ann)
 
 
-# How the field-of-view box is drawn. Deliberately light: the box is context for the
-# marker, not the subject. At full weight its edge competes with the magenta lattice
-# behind it -- gridbars on the beam tab, the planned tile grid on either -- and the box
-# reads as part of that grid rather than as one position.
-FOV_BOX_LINEWIDTH = 0.6
-FOV_LABEL_FONTSIZE = 6.5
+# How the field-of-view box is drawn. Light, because the box is context for the
+# marker rather than the subject -- but not as light as it was.
+#
+# These were 0.6 and 6.5, and reported from a session as hard to see on bright
+# FIB/SEM overviews. Not a contrast problem: nothing here sets an alpha, and a
+# saturated colour separates from greyscale image data by hue at any brightness.
+# There was simply too little of it. At 0.6 this was the thinnest line on the canvas
+# by some way, against 1.0-2.5 for every sibling overlay (alignment 2.5, pattern 1.5,
+# milling 1.0), and the label was the smallest text on it.
+#
+# The original 0.6 had a reason, which is why this is not a straight increase: at
+# full weight the edge was expected to compete with the magenta lattice behind it --
+# gridbars on the beam tab, the planned tile grid on either -- and read as part of
+# that grid rather than as one position. Re-checked at 1.2 against that lattice and
+# it does not happen. What separates the two is hue, not weight: the box is cyan and
+# the lattice is magenta, about as far apart as the wheel allows. 1.2 also matches
+# the lattice's own 1.0, so the box reads as a peer of the grid rather than as a
+# hairline drawn on top of it. Anything that narrows that hue gap -- recolouring
+# either the box or the tile grid -- brings the original concern back, so re-check
+# then rather than assuming this settled it.
+#
+# An outline was tried before reaching for weight, and looked worse: a halo wider
+# than the line it surrounds reads as a botched double border rather than a haloed
+# line. More ink, not more halo.
+FOV_BOX_LINEWIDTH = 1.2
+FOV_LABEL_FONTSIZE = 7.5
 
 
 class FieldOfViewOverlay(PointsOverlay):

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -596,7 +596,11 @@ class PointOverlay(QObject):
         if not self._points or not self._legend_label:
             return [], []
         handle = Line2D(
-            [], [], linestyle="None", marker=self._marker, markersize=9,
+            [],
+            [],
+            linestyle="None",
+            marker=self._marker,
+            markersize=9,
             color=self._color,
             markeredgewidth=(self._edge_width if self._edge_width is not None else 2.0),
             label=self._legend_label,
@@ -665,6 +669,7 @@ class PointOverlay(QObject):
         adds a fixed bump, so backward-compatible defaults are preserved when unset.
         """
         from matplotlib.lines import Line2D
+
         if self._point_marker(idx) in Line2D.filled_markers:
             base = self._edge_width if self._edge_width is not None else 0.8
             return "white", (base + 1.2 if selected else base)

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -666,7 +666,7 @@ class FibsemOverviewWidget(QWidget):
         # the origin explains why everything sits where it does, this is what you steer
         # by. They coincide until the stage moves, then diverge.
         self.current_position_overlay = PointsOverlay(
-            color=CURRENT_POSITION_COLOUR, marker="+", size=13
+            color=CURRENT_POSITION_COLOUR, marker="+", size=15, edge_width=2.8
         )
         self.canvas.add_overlay(self.current_position_overlay)
 


### PR DESCRIPTION
Reported from a session: the cyan saved-position markers on the FIB/SEM overview tab are hard to see on bright images. *"Are they dulled? Should we brighten them or add an outline?"*

**Neither.** They are not dulled — nothing in the overlay sets an alpha. And brightening makes it strictly worse: contrast against a bright field *falls* as luminance rises, so pure cyan scores 1.05:1 against `#e0e0e0` where the current colour manages 1.56.

## The diagnosis took two attempts, and the first was wrong

I first read this as a contrast problem and added a `patheffects` halo. It looked bad, and the reasoning behind it was wrong twice over:

* **Wrong model.** WCAG contrast is a text-legibility metric and it is luminance-only. These are *saturated marks on greyscale imagery* — grey has zero chroma, so a cyan line separates from it by hue at almost any brightness.
* **Wrong fix.** A halo wider than the hairline it surrounds reads as a botched double border, not a haloed line.

The measurement that actually mattered: **the field-of-view box was 0.6, the thinnest line on the canvas by some way**, against 1.0–2.5 for every sibling overlay (`alignment_overlay` 2.5, `pattern_overlay` 1.5, `milling_overlay` 1.0). Paired with the smallest text on the canvas. There was simply too little of it. More ink, not more halo.

## What changes

| | from | to |
| -- | -- | -- |
| `FOV_BOX_LINEWIDTH` | 0.6 | **1.2** |
| `FOV_LABEL_FONTSIZE` | 6.5 | **7.5** |
| `SAVED_POSITION_COLOUR` | `#26c6da` | **`#00e5ff`** |
| current-stage marker | size 13 | **size 15, `edge_width=2.8`** |

The colour is not a new invention. Cyan A400 is what this codebase already uses for points drawn over image data — the correlation overlay's FM points, the tile-grid colour picker — and it matches `SELECTED`'s Light Green A400 rather than sitting a series below it. Both overview tabs consume the token, so they stay in step.

## The 0.6 was deliberate, and I checked before overriding it

The comment above that constant expected a heavier edge to compete with the magenta tile-grid lattice and read as part of that grid. Re-rendered at 1.2 against the lattice: **it does not happen.** What separates them is hue, not weight — the box is cyan and the lattice is magenta, about as far apart as the wheel allows — and 1.2 matches the lattice's own 1.0, so the box reads as a peer of the grid rather than a hairline drawn over it.

That reasoning is now recorded next to the constants, including the condition that would bring the original concern back: anything that narrows the hue gap, such as recolouring either the box or the tile grid.

## The current-stage marker needed separate handling

It is a bare crosshair — no field-of-view box, and passed an empty label — deliberately, so that driving to a lamella does not double that lamella's box. So it gained nothing from the box and label changes above; the glyph is all it has.

`PointsOverlay` now takes an optional `edge_width`, which for an unfilled marker is the stroke thickness of the glyph itself, and the two current-position sites pass 2.8. **Left as `None` everywhere else**, so every other point on every canvas is byte-identical — verified: `+`/`x` still resolve to `(colour, 2.0)` and `o`/`s` to `("white", 0.8)`.

**Yellow stays**, by choice. It measures worst of the candidates on a bright field — 1.11:1 against `#e0e0e0`, where magenta is 2.38 and pink 3.17 — and it shares a hue family with `STAGE_LIMITS_COLOUR` at ΔRGB 60. But rendered together, the two differ in shape, weight and position on the canvas and do not actually compete, and the extra ink covers most of the gap. Recorded here because the numbers say the bright-field weakness is real and unfixed; if it still bothers anyone at the microscope, magenta `#ff00ff` is the only genuinely unoccupied region of this canvas's palette (ΔRGB 191 from its nearest neighbour, against 60–70 for every orange).

## Commits

Split so the review is not whitespace: `tokens.py` needed a whole-file reformat for the format-on-touch check — 34 lines of collapsed comment alignment against 6 lines of substance. The format commit is verified inert (identical parse tree, no token value altered); the change sits on top of it.

**554 tests** pass across the point-overlay, overview, FM-overview, correlation and detection suites.
