### PR TITLE
[fix] Overview export: size the page to the image, and stop labels colliding

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -52,8 +52,6 @@ if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
 
 
-
-
 class AutoLamellaTaskStatus(Enum):
     NotStarted = auto()
     InProgress = auto()
@@ -61,7 +59,7 @@ class AutoLamellaTaskStatus(Enum):
     Failed = auto()
     Skipped = auto()
     Cancelled = auto()  # aborted by the user (Stop), distinct from a genuine Failure
-    Removed = auto()    # pulled from the queue by the user before it ran
+    Removed = auto()  # pulled from the queue by the user before it ran
 
 
 # AutoLamellaUser lived here: a richer user identity (role, preferences, is_default)
@@ -80,7 +78,9 @@ class AutoLamellaTaskState:
     task_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     task_type: str = ""
     lamella_id: str = ""
-    start_timestamp: float = field(default_factory=lambda: datetime.timestamp(datetime.now()))
+    start_timestamp: float = field(
+        default_factory=lambda: datetime.timestamp(datetime.now())
+    )
     end_timestamp: Optional[float] = None
     status: AutoLamellaTaskStatus = AutoLamellaTaskStatus.NotStarted
     status_message: str = ""
@@ -100,11 +100,15 @@ class AutoLamellaTaskState:
     def completed_at(self) -> str:
         if self.end_timestamp is None:
             return "in progress"
-        return datetime.fromtimestamp(self.end_timestamp).strftime(TIME_DISPLAY_AMPM_SHORT)
+        return datetime.fromtimestamp(self.end_timestamp).strftime(
+            TIME_DISPLAY_AMPM_SHORT
+        )
 
     @property
     def started_at(self) -> str:
-        return datetime.fromtimestamp(self.start_timestamp).strftime(TIME_DISPLAY_AMPM_SHORT)
+        return datetime.fromtimestamp(self.start_timestamp).strftime(
+            TIME_DISPLAY_AMPM_SHORT
+        )
 
     @property
     def duration(self) -> float:
@@ -123,7 +127,7 @@ class AutoLamellaTaskState:
         return ddict
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'AutoLamellaTaskState':
+    def from_dict(cls, data: dict) -> "AutoLamellaTaskState":
         """Create a task state from a dictionary."""
         if data is None:
             return cls()
@@ -139,21 +143,20 @@ class AutoLamellaTaskState:
 @dataclass
 class AutoLamellaTaskConfig(ABC):
     """Configuration for AutoLamella tasks."""
+
     task_type: ClassVar[str]
     display_name: ClassVar[str]
-    related_tasks: ClassVar[list[type['AutoLamellaTaskConfig']]] = []
-    task_name: str = "" # unique name for identifying in multi-task workflows
+    related_tasks: ClassVar[list[type["AutoLamellaTaskConfig"]]] = []
+    task_name: str = ""  # unique name for identifying in multi-task workflows
     milling: Dict[str, FibsemMillingTaskConfig] = field(default_factory=dict)
-    reference_imaging: ReferenceImageParameters = field(default_factory=ReferenceImageParameters)
+    reference_imaging: ReferenceImageParameters = field(
+        default_factory=ReferenceImageParameters
+    )
 
     @property
     def parameters(self) -> Tuple[str, ...]:
         core_params = [f.name for f in fields(AutoLamellaTaskConfig)]
-        return tuple(
-            f.name
-            for f in fields(self)
-            if f.name not in core_params
-        )
+        return tuple(f.name for f in fields(self) if f.name not in core_params)
 
     @property
     def field_metadata(self) -> Dict[str, Dict[str, Any]]:
@@ -181,7 +184,7 @@ class AutoLamellaTaskConfig(ABC):
         return ddict
 
     @classmethod
-    def from_dict(cls, ddict: Dict[str, Any]) -> 'AutoLamellaTaskConfig':
+    def from_dict(cls, ddict: Dict[str, Any]) -> "AutoLamellaTaskConfig":
         kwargs = {}
 
         for f in fields(cls):
@@ -189,7 +192,7 @@ class AutoLamellaTaskConfig(ABC):
                 kwargs[f.name] = ddict[f.name]
 
         # unroll the parameters dictionary
-        if "parameters" in ddict and ddict["parameters"] is not None:                
+        if "parameters" in ddict and ddict["parameters"] is not None:
             for key, value in ddict["parameters"].items():
                 if key in cls.__annotations__:
                     kwargs[key] = value
@@ -198,10 +201,13 @@ class AutoLamellaTaskConfig(ABC):
 
         if "milling" in ddict:
             kwargs["milling"] = {
-                k: FibsemMillingTaskConfig.from_dict(v) for k, v in ddict["milling"].items()
+                k: FibsemMillingTaskConfig.from_dict(v)
+                for k, v in ddict["milling"].items()
             }
         if "reference_imaging" in ddict:
-            kwargs["reference_imaging"] = ReferenceImageParameters.from_dict(ddict["reference_imaging"])
+            kwargs["reference_imaging"] = ReferenceImageParameters.from_dict(
+                ddict["reference_imaging"]
+            )
 
         return cls(**kwargs)
 
@@ -260,12 +266,12 @@ class AutoLamellaTaskConfig(ABC):
         for milling_task in self.milling.values():
             total += timing.milling_task_cost(milling_task)
         return total
-    
+
     @property
     def imaging(self) -> ImageSettings:
         """Get the imaging settings from the reference imaging parameters."""
         return self.reference_imaging.imaging
-    
+
     @imaging.setter
     def imaging(self, value: ImageSettings):
         """Set the imaging settings in the reference imaging parameters."""
@@ -275,7 +281,7 @@ class AutoLamellaTaskConfig(ABC):
 @evented
 @dataclass
 class AutoLamellaTaskDescription:
-    name: str # unique_name
+    name: str  # unique_name
     supervise: bool
     required: bool
     requires: List[str] = field(default_factory=list)
@@ -288,9 +294,11 @@ class AutoLamellaTaskDescription:
         return d
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaTaskDescription':
+    def from_dict(cls, data: Dict[str, Any]) -> "AutoLamellaTaskDescription":
         if data is None:
-            return cls(name="", task_type="", supervise=False, required=False, requires=[])
+            return cls(
+                name="", task_type="", supervise=False, required=False, requires=[]
+            )
         data = dict(data)
         sa = data.get("scheduled_at")
         if isinstance(sa, str):
@@ -311,8 +319,10 @@ class AutoLamellaWorkflowConfig:
         return ddict
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaWorkflowConfig':
-        data["tasks"] = [AutoLamellaTaskDescription.from_dict(task) for task in data.get("tasks", [])]
+    def from_dict(cls, data: Dict[str, Any]) -> "AutoLamellaWorkflowConfig":
+        data["tasks"] = [
+            AutoLamellaTaskDescription.from_dict(task) for task in data.get("tasks", [])
+        ]
         return cls(**data)
 
     @property
@@ -330,7 +340,9 @@ class AutoLamellaWorkflowConfig:
                 return task.requires
         return []
 
-    def get_completed_tasks(self, lamella: 'Lamella', with_timestamps: bool = False) -> List[str]:
+    def get_completed_tasks(
+        self, lamella: "Lamella", with_timestamps: bool = False
+    ) -> List[str]:
         """Get the list of completed tasks for a given lamella.
 
         Filtered on status for the same reason as Lamella.completed_tasks:
@@ -350,7 +362,7 @@ class AutoLamellaWorkflowConfig:
                 completed_tasks.append(txt)
         return completed_tasks
 
-    def get_remaining_tasks(self, lamella: 'Lamella') -> List[str]:
+    def get_remaining_tasks(self, lamella: "Lamella") -> List[str]:
         """Get the list of remaining tasks for a given lamella."""
         remaining_tasks = []
         completed_tasks = self.get_completed_tasks(lamella)
@@ -359,7 +371,7 @@ class AutoLamellaWorkflowConfig:
                 remaining_tasks.append(task)
         return remaining_tasks
 
-    def is_completed(self, lamella: 'Lamella') -> bool:
+    def is_completed(self, lamella: "Lamella") -> bool:
         """Check if all required tasks for the workflow are completed."""
         completed_tasks = self.get_completed_tasks(lamella)
         for task in self.required_tasks:
@@ -383,10 +395,11 @@ class AutoLamellaWorkflowConfig:
 
     def add_task(self, task: AutoLamellaTaskConfig) -> None:
         """Add a task to the workflow configuration."""
-        self.tasks.append(AutoLamellaTaskDescription(name=task.task_name, 
-                                                     supervise=True, 
-                                                     required=True, 
-                                                     requires=[]))
+        self.tasks.append(
+            AutoLamellaTaskDescription(
+                name=task.task_name, supervise=True, required=True, requires=[]
+            )
+        )
 
     @property
     def is_valid(self) -> bool:
@@ -403,7 +416,9 @@ class AutoLamellaWorkflowConfig:
                 if req not in task_names:
                     issues.append(f"Task '{task.name}' requires unknown task '{req}'.")
                 elif req not in task_names[:i]:
-                    issues.append(f"Task '{task.name}' requires '{req}' which comes after it in the workflow.")
+                    issues.append(
+                        f"Task '{task.name}' requires '{req}' which comes after it in the workflow."
+                    )
         return issues
 
 
@@ -416,7 +431,7 @@ class AutoLamellaWorkflowOptions:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaWorkflowOptions':
+    def from_dict(cls, data: Dict[str, Any]) -> "AutoLamellaWorkflowOptions":
         return cls(**data)
 
 
@@ -424,6 +439,7 @@ class AutoLamellaWorkflowOptions:
 @dataclass
 class LamellaDefaultConfig:
     """Initial state applied to every new Lamella created from this protocol."""
+
     use_petname: bool = True
     name_prefix: str = ""
     alignment_area: Optional[FibsemRectangle] = None
@@ -441,13 +457,15 @@ class LamellaDefaultConfig:
         return d
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'LamellaDefaultConfig':
+    def from_dict(cls, data: Dict[str, Any]) -> "LamellaDefaultConfig":
         aa = data.get("alignment_area")
         poi = data.get("poi")
         return cls(
             use_petname=data.get("use_petname", True),
             name_prefix=data.get("name_prefix", ""),
-            alignment_area=FibsemRectangle.from_dict(aa) if isinstance(aa, dict) else None,
+            alignment_area=FibsemRectangle.from_dict(aa)
+            if isinstance(aa, dict)
+            else None,
             poi=Point.from_dict(poi) if isinstance(poi, dict) else None,
         )
 
@@ -459,9 +477,15 @@ class AutoLamellaTaskProtocol:
     description: str = "Protocol for AutoLamella"
     version: str = "1.0"
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    task_config: EventedDict[str, AutoLamellaTaskConfig] = field(default_factory=lambda: EventedDict())   # unique_name: AutoLamellaTaskConfig
-    workflow_config: AutoLamellaWorkflowConfig = field(default_factory=AutoLamellaWorkflowConfig)
-    options: AutoLamellaWorkflowOptions = field(default_factory=AutoLamellaWorkflowOptions)
+    task_config: EventedDict[str, AutoLamellaTaskConfig] = field(
+        default_factory=lambda: EventedDict()
+    )  # unique_name: AutoLamellaTaskConfig
+    workflow_config: AutoLamellaWorkflowConfig = field(
+        default_factory=AutoLamellaWorkflowConfig
+    )
+    options: AutoLamellaWorkflowOptions = field(
+        default_factory=AutoLamellaWorkflowOptions
+    )
     lamella_defaults: LamellaDefaultConfig = field(default_factory=LamellaDefaultConfig)
     # Experiment-global correlation config (FIB-298): a user-step config, not an
     # automated task, so a peer field rather than an entry in task_config.
@@ -481,8 +505,9 @@ class AutoLamellaTaskProtocol:
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaTaskProtocol':
+    def from_dict(cls, data: Dict[str, Any]) -> "AutoLamellaTaskProtocol":
         from fibsem.applications.autolamella.workflows.tasks import load_task_config
+
         task_config = load_task_config(data.get("tasks", {}))
         workflow_config = AutoLamellaWorkflowConfig.from_dict(data.get("workflow", {}))
 
@@ -493,7 +518,9 @@ class AutoLamellaTaskProtocol:
             task_config=task_config,
             workflow_config=workflow_config,
             options=AutoLamellaWorkflowOptions.from_dict(data.get("options", {})),
-            lamella_defaults=LamellaDefaultConfig.from_dict(data.get("lamella_defaults", {})),
+            lamella_defaults=LamellaDefaultConfig.from_dict(
+                data.get("lamella_defaults", {})
+            ),
             # Missing on protocols saved before this field -> a default config.
             correlation=CorrelationConfig.from_dict(data.get("correlation")),
         )
@@ -502,26 +529,28 @@ class AutoLamellaTaskProtocol:
         return protocol
 
     @classmethod
-    def load(cls, filename: str) -> 'AutoLamellaTaskProtocol':
-        with open(filename, 'r') as file:
+    def load(cls, filename: str) -> "AutoLamellaTaskProtocol":
+        with open(filename, "r") as file:
             data = yaml.safe_load(file)
         return cls.from_dict(data)
 
     def save(self, filename: str) -> None:
         """Save the task protocol to a YAML file."""
-        with open(filename, 'w') as file:
-            yaml.safe_dump(self.to_dict(), 
-                           file,
-                           indent=4, 
-                           default_flow_style=False, 
-                           sort_keys=False)
+        with open(filename, "w") as file:
+            yaml.safe_dump(
+                self.to_dict(),
+                file,
+                indent=4,
+                default_flow_style=False,
+                sort_keys=False,
+            )
 
     def get_supervision(self, task_name: str) -> bool:
         """Check if a task requires supervision."""
         return self.workflow_config.get_supervision(task_name)
 
     @classmethod
-    def load_from_old_protocol(cls, path: Path) -> 'AutoLamellaTaskProtocol':
+    def load_from_old_protocol(cls, path: Path) -> "AutoLamellaTaskProtocol":
         """Convert an AutoLamellaProtocol to an AutoLamellaTaskProtocol.
         This involves mapping the milling configurations to the new task names.
         Used to converte old protocols to the new task-based protocol format."""
@@ -539,6 +568,7 @@ class AutoLamellaTaskProtocol:
             MillUndercutTaskConfig,
             SelectMillingPositionTaskConfig,
         )
+
         protocol = AutoLamellaProtocol.load(path)
 
         # we need to map the milling configurations to the new task names
@@ -549,9 +579,15 @@ class AutoLamellaTaskProtocol:
         # undercut -> Trench Milling / undercut
         # fiducial -> Setup Lamella / fiducial
         # mill_polishing -> Polishing
-        
-        if protocol.method not in [AutoLamellaMethod.ON_GRID, AutoLamellaMethod.TRENCH, AutoLamellaMethod.WAFFLE]:
-            raise ValueError(f"Protocol method {protocol.method} not supported for conversion to task protocol")
+
+        if protocol.method not in [
+            AutoLamellaMethod.ON_GRID,
+            AutoLamellaMethod.TRENCH,
+            AutoLamellaMethod.WAFFLE,
+        ]:
+            raise ValueError(
+                f"Protocol method {protocol.method} not supported for conversion to task protocol"
+            )
 
         ROUGH_MILLING_TASK_NAME = "Rough Milling"
         POLISHING_TASK_NAME = "Polishing"
@@ -566,22 +602,40 @@ class AutoLamellaTaskProtocol:
         if protocol.method in [AutoLamellaMethod.ON_GRID, AutoLamellaMethod.WAFFLE]:
             rough_milling_task = MillRoughTaskConfig(
                 task_name=ROUGH_MILLING_TASK_NAME,
-                milling={MILL_ROUGH_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[MILL_ROUGH_KEY], name="Rough Milling")},
+                milling={
+                    MILL_ROUGH_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[MILL_ROUGH_KEY], name="Rough Milling"
+                    )
+                },
             )
 
             if protocol.options.use_microexpansion:
-                rough_milling_task.milling[MILL_ROUGH_KEY].stages.extend(protocol.milling[MICROEXPANSION_KEY])
+                rough_milling_task.milling[MILL_ROUGH_KEY].stages.extend(
+                    protocol.milling[MICROEXPANSION_KEY]
+                )
             if protocol.options.use_notch:
-                rough_milling_task.milling[STRESS_RELIEF_KEY] = FibsemMillingTaskConfig.from_stages(protocol.milling[NOTCH_KEY], name="Notch")
+                rough_milling_task.milling[STRESS_RELIEF_KEY] = (
+                    FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[NOTCH_KEY], name="Notch"
+                    )
+                )
 
             polishing_milling_task = MillPolishingTaskConfig(
                 task_name=POLISHING_TASK_NAME,
-                milling={MILL_POLISHING_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[MILL_POLISHING_KEY], name="Polishing")},
+                milling={
+                    MILL_POLISHING_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[MILL_POLISHING_KEY], name="Polishing"
+                    )
+                },
             )
 
             mill_fiducial_task = MillFiducialTaskConfig(
                 task_name=MILL_FIDUCIAL_TASK_NAME,
-                milling={FIDUCIAL_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[FIDUCIAL_KEY], name="Fiducial")},
+                milling={
+                    FIDUCIAL_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[FIDUCIAL_KEY], name="Fiducial"
+                    )
+                },
             )
             setup_lamella_task = SelectMillingPositionTaskConfig(
                 task_name=SETUP_LAMELLA_POSITION_TASK_NAME,
@@ -595,57 +649,93 @@ class AutoLamellaTaskProtocol:
             task_config[SETUP_LAMELLA_POSITION_TASK_NAME] = setup_lamella_task
 
             workflow_config.tasks = [
-                AutoLamellaTaskDescription(name=SETUP_LAMELLA_POSITION_TASK_NAME, supervise=protocol.supervision[AutoLamellaStage.SetupLamella], required=True),
-                AutoLamellaTaskDescription(name=MILL_FIDUCIAL_TASK_NAME, supervise=protocol.supervision[AutoLamellaStage.SetupLamella], required=True),
-                AutoLamellaTaskDescription(name=ROUGH_MILLING_TASK_NAME, supervise=protocol.supervision[AutoLamellaStage.MillRough], required=True, requires=[MILL_FIDUCIAL_TASK_NAME]),
-                AutoLamellaTaskDescription(name=POLISHING_TASK_NAME, supervise=protocol.supervision[AutoLamellaStage.MillPolishing], required=True, requires=[ROUGH_MILLING_TASK_NAME]),
+                AutoLamellaTaskDescription(
+                    name=SETUP_LAMELLA_POSITION_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.SetupLamella],
+                    required=True,
+                ),
+                AutoLamellaTaskDescription(
+                    name=MILL_FIDUCIAL_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.SetupLamella],
+                    required=True,
+                ),
+                AutoLamellaTaskDescription(
+                    name=ROUGH_MILLING_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.MillRough],
+                    required=True,
+                    requires=[MILL_FIDUCIAL_TASK_NAME],
+                ),
+                AutoLamellaTaskDescription(
+                    name=POLISHING_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.MillPolishing],
+                    required=True,
+                    requires=[ROUGH_MILLING_TASK_NAME],
+                ),
             ]
-
 
         if protocol.method in [AutoLamellaMethod.TRENCH, AutoLamellaMethod.WAFFLE]:
             trench_milling_task = MillTrenchTaskConfig(
                 task_name=TRENCH_MILLING_TASK_NAME,
-                milling={TRENCH_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[TRENCH_KEY], name="Trench"),
+                milling={
+                    TRENCH_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[TRENCH_KEY], name="Trench"
+                    ),
                 },
                 orientation="FIB",
             )
             task_config[TRENCH_MILLING_TASK_NAME] = trench_milling_task
-            workflow_config.tasks.insert(0, AutoLamellaTaskDescription(name=TRENCH_MILLING_TASK_NAME,
-                                                                    supervise=protocol.supervision[AutoLamellaStage.MillTrench], 
-                                                                    required=True))
+            workflow_config.tasks.insert(
+                0,
+                AutoLamellaTaskDescription(
+                    name=TRENCH_MILLING_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.MillTrench],
+                    required=True,
+                ),
+            )
 
         if protocol.method is AutoLamellaMethod.WAFFLE:
-
             undercut_task = MillUndercutTaskConfig(
                 task_name=UNDERCUT_TASK_NAME,
-                milling={UNDERCUT_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[UNDERCUT_KEY], name="Undercut")},
+                milling={
+                    UNDERCUT_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[UNDERCUT_KEY], name="Undercut"
+                    )
+                },
                 orientation="SEM",
-
             )
             task_config[UNDERCUT_TASK_NAME] = undercut_task
-            workflow_config.tasks.insert(1, AutoLamellaTaskDescription(name=UNDERCUT_TASK_NAME,
-                                                                    supervise=protocol.supervision[AutoLamellaStage.MillUndercut], 
-                                                                    required=True, requires=[TRENCH_MILLING_TASK_NAME]))
-
+            workflow_config.tasks.insert(
+                1,
+                AutoLamellaTaskDescription(
+                    name=UNDERCUT_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.MillUndercut],
+                    required=True,
+                    requires=[TRENCH_MILLING_TASK_NAME],
+                ),
+            )
 
         options = AutoLamellaWorkflowOptions(
             turn_beams_off=protocol.options.turn_beams_off,
         )
 
         workflow_config.name = protocol.name
-        workflow_config.description = f"auto-converted protocol from {protocol.name} - {protocol.method.name}"
+        workflow_config.description = (
+            f"auto-converted protocol from {protocol.name} - {protocol.method.name}"
+        )
 
         task_protocol = AutoLamellaTaskProtocol(
             name=protocol.name,
             description=f"auto-converted protocol from {protocol.name} - {protocol.method.name}",
             task_config=task_config,
             workflow_config=workflow_config,
-            options=options
+            options=options,
         )
 
         return task_protocol
 
-    def get_task_config_by_type(self, task_type: Type['AutoLamellaTaskConfig']) -> EventedDict[str, AutoLamellaTaskConfig]:
+    def get_task_config_by_type(
+        self, task_type: Type["AutoLamellaTaskConfig"]
+    ) -> EventedDict[str, AutoLamellaTaskConfig]:
         """Get the task configuration by type."""
         task_configs = EventedDict()
         for k, v in self.task_config.items():
@@ -677,13 +767,17 @@ class DefectState:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'DefectState':
+    def from_dict(cls, data: dict) -> "DefectState":
         if not data:
             return cls()
         # Backwards compatibility: old format used has_defect / requires_rework bools
         if "has_defect" in data:
             if data.get("has_defect"):
-                state = DefectType.REWORK if data.get("requires_rework") else DefectType.FAILURE
+                state = (
+                    DefectType.REWORK
+                    if data.get("requires_rework")
+                    else DefectType.FAILURE
+                )
             else:
                 state = DefectType.NONE
             return cls(
@@ -726,6 +820,7 @@ _THUMBNAIL_MAX_EDGE = 512
 def _make_thumbnail_placeholder():
     import numpy as np
     from PIL import Image, ImageDraw, ImageFont
+
     img = Image.new("RGB", (256, 170), color=(30, 30, 30))
     draw = ImageDraw.Draw(img)
     text = "No Data"
@@ -746,17 +841,23 @@ _THUMBNAIL_PLACEHOLDER = None
 @dataclass
 class Lamella:
     path: Path
-    number: int                                                             # TODO: deprecate, use petname instead
+    number: int  # TODO: deprecate, use petname instead
     petname: str
-    alignment_area: FibsemRectangle = field(default_factory=lambda: FibsemRectangle.from_dict(DEFAULT_ALIGNMENT_AREA))
+    alignment_area: FibsemRectangle = field(
+        default_factory=lambda: FibsemRectangle.from_dict(DEFAULT_ALIGNMENT_AREA)
+    )
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    task_config: EventedDict[str, 'AutoLamellaTaskConfig'] = field(default_factory=lambda: EventedDict())
+    task_config: EventedDict[str, "AutoLamellaTaskConfig"] = field(
+        default_factory=lambda: EventedDict()
+    )
     poses: Dict[str, MicroscopeState] = field(default_factory=dict)
     task_state: AutoLamellaTaskState = field(default_factory=AutoLamellaTaskState)
-    task_history: List['AutoLamellaTaskState'] = field(default_factory=list)
+    task_history: List["AutoLamellaTaskState"] = field(default_factory=list)
     defect: DefectState = field(default_factory=DefectState)
     milling_angle: Optional[float] = None
-    poi: Point = field(default_factory=lambda: Point(0,0))  # point of interest within lamella area (milling coordinate system)
+    poi: Point = field(
+        default_factory=lambda: Point(0, 0)
+    )  # point of interest within lamella area (milling coordinate system)
     description: str = ""  # free-text note about the lamella
 
     def __post_init__(self):
@@ -823,7 +924,7 @@ class Lamella:
 
     @property
     def stage_position(self) -> FibsemStagePosition:
-        return self.milling_pose.stage_position # type: ignore
+        return self.milling_pose.stage_position  # type: ignore
 
     @stage_position.setter
     def stage_position(self, value: FibsemStagePosition):
@@ -849,7 +950,7 @@ class Lamella:
         ]
 
     @property
-    def last_completed_task(self) -> Optional['AutoLamellaTaskState']:
+    def last_completed_task(self) -> Optional["AutoLamellaTaskState"]:
         """Return the last completed task state.
 
         The last *completed* one, not the last recorded: a failure landing last
@@ -900,7 +1001,10 @@ class Lamella:
 
     @property
     def fluorescence_selected(self) -> bool:
-        return self.fluorescence_pose is not None and self.fluorescence_pose.objective_position is not None
+        return (
+            self.fluorescence_pose is not None
+            and self.fluorescence_pose.objective_position is not None
+        )
 
     def update_milling_angle(self, microscope: "FibsemMicroscope") -> None:
         """Recompute milling_angle from the milling-pose stage tilt.
@@ -909,14 +1013,20 @@ class Lamella:
         column-tilt configuration), so it is kept consistent with the stored milling pose.
         Leaves the existing value unchanged if the stage tilt/rotation is unavailable.
         """
-        if microscope is None or self.milling_pose is None or self.milling_pose.stage_position is None:
+        if (
+            microscope is None
+            or self.milling_pose is None
+            or self.milling_pose.stage_position is None
+        ):
             return
         try:
             self.milling_angle = microscope.get_current_milling_angle(
                 stage_position=self.milling_pose.stage_position
             )
         except ValueError:
-            logging.debug(f"Could not compute milling angle for {self.name}: stage tilt/rotation unavailable")
+            logging.debug(
+                f"Could not compute milling angle for {self.name}: stage tilt/rotation unavailable"
+            )
 
     def to_dict(self):
         return {
@@ -946,19 +1056,25 @@ class Lamella:
     @property
     def pretty_fm_name(self) -> str:
         """Generate a pretty name for the stage position."""
-        obj_pos = self.fluorescence_pose.objective_position if self.fluorescence_pose is not None else None
+        obj_pos = (
+            self.fluorescence_pose.objective_position
+            if self.fluorescence_pose is not None
+            else None
+        )
         objective_str = f"{obj_pos * 1e3:.3f}mm" if obj_pos is not None else "N/A"
         return f"{self.name} ({self.stage_position.x * 1e6:.1f}μm, {self.stage_position.y * 1e6:.1f}μm, {objective_str})"
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'Lamella':
+    def from_dict(cls, data: dict) -> "Lamella":
         # backwards compatibility
         alignment_area_ddict = data.get("alignment_area", DEFAULT_ALIGNMENT_AREA)
         alignment_area = FibsemRectangle.from_dict(alignment_area_ddict)
 
         from fibsem.applications.autolamella.workflows.tasks import load_task_config
 
-        poses = {k: MicroscopeState.from_dict(v) for k, v in data.get("poses", {}).items()}
+        poses = {
+            k: MicroscopeState.from_dict(v) for k, v in data.get("poses", {}).items()
+        }
         # backwards compat: migrate legacy top-level objective_position into fluorescence_pose
         legacy_obj_pos = data.get("objective_position", None)
         if legacy_obj_pos is not None and "FLUORESCENCE" in poses:
@@ -974,10 +1090,13 @@ class Lamella:
             poses=poses,
             task_config=load_task_config(data.get("task_config", {})),
             task_state=AutoLamellaTaskState.from_dict(data.get("task_state", {})),
-            task_history=[AutoLamellaTaskState.from_dict(task) for task in data.get("task_history", [])],
+            task_history=[
+                AutoLamellaTaskState.from_dict(task)
+                for task in data.get("task_history", [])
+            ],
             defect=DefectState.from_dict(data.get("defect", {})),
             milling_angle=data.get("milling_angle", None),
-            poi=Point.from_dict(data.get("poi", {"x":0,"y":0})),
+            poi=Point.from_dict(data.get("poi", {"x": 0, "y": 0})),
             description=data.get("description", ""),
         )
 
@@ -1005,6 +1124,7 @@ class Lamella:
         thumb_path = os.path.join(self.path, "thumbnail.png")
         import numpy as np
         from PIL import Image
+
         if not os.path.exists(thumb_path):
             if _THUMBNAIL_PLACEHOLDER is None:
                 _THUMBNAIL_PLACEHOLDER = _make_thumbnail_placeholder()
@@ -1044,6 +1164,7 @@ class Lamella:
 
         import numpy as np
         from PIL import Image
+
         data = image.filtered_data
         if data.ndim == 2:
             data = np.stack([data, data, data], axis=2)
@@ -1082,7 +1203,7 @@ class Lamella:
     #     return task_configs
 
     def sync_tasks_to_poi(self, point: Optional[Point] = None) -> list[str]:
-        """Sync the milling patterns to point of interest  """
+        """Sync the milling patterns to point of interest"""
 
         if point is None:
             point = self.poi
@@ -1107,6 +1228,7 @@ class Lamella:
             synced_tasks.append(task_name)
         return synced_tasks
 
+
 @evented
 @dataclass
 class Experiment:
@@ -1115,14 +1237,21 @@ class Experiment:
     path: Path
     positions: EventedList[Lamella] = field(default_factory=EventedList)
     landing_positions: List[FibsemStagePosition] = field(default_factory=list)
-    created_at: float = field(default_factory=lambda: datetime.timestamp(datetime.now()))
-    task_protocol: 'AutoLamellaTaskProtocol' = field(default_factory=lambda: AutoLamellaTaskProtocol())
+    created_at: float = field(
+        default_factory=lambda: datetime.timestamp(datetime.now())
+    )
+    task_protocol: "AutoLamellaTaskProtocol" = field(
+        default_factory=lambda: AutoLamellaTaskProtocol()
+    )
     metadata: Dict[str, Any] = field(default_factory=dict)
     session: Optional[SessionInfo] = None
 
-    def __init__(self, path: Path,
-                 name: str = cfg.EXPERIMENT_NAME,
-                 metadata: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(
+        self,
+        path: Path,
+        name: str = cfg.EXPERIMENT_NAME,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Create a new experiment.
 
         Args:
@@ -1138,7 +1267,7 @@ class Experiment:
         self.positions: EventedList[Lamella] = EventedList()
         self.landing_positions: List[FibsemStagePosition] = []
 
-        self.task_protocol: AutoLamellaTaskProtocol = None # must be set externally
+        self.task_protocol: AutoLamellaTaskProtocol = None  # must be set externally
         self.metadata: Dict[str, Any] = metadata if metadata is not None else {}
         # The instrument, operator and software that last worked on this. Filled in
         # by register_metadata, when a session adopts the experiment and there is a
@@ -1160,12 +1289,14 @@ class Experiment:
         }
 
         if include_protocol:
-            state_dict["protocol"] = self.task_protocol.to_dict() if self.task_protocol is not None else None
+            state_dict["protocol"] = (
+                self.task_protocol.to_dict() if self.task_protocol is not None else None
+            )
 
         return state_dict
 
     @classmethod
-    def from_dict(cls, ddict: dict) -> 'Experiment':
+    def from_dict(cls, ddict: dict) -> "Experiment":
 
         path = os.path.dirname(ddict["path"])
         name = ddict["name"]
@@ -1233,7 +1364,7 @@ class Experiment:
         """Set the organisation name in metadata."""
         self.metadata["organisation"] = value
 
-    def get_lamella_by_name(self, name: str) -> Optional['Lamella']:
+    def get_lamella_by_name(self, name: str) -> Optional["Lamella"]:
         """Return the Lamella with the given name, or None if not found."""
         return next((p for p in self.positions if p.name == name), None)
 
@@ -1253,7 +1384,7 @@ class Experiment:
         """
 
     @staticmethod
-    def load(fname: Path) -> 'Experiment':
+    def load(fname: Path) -> "Experiment":
         """Load an experiment from disk.
 
         Automatically attempts to load the task_protocol from protocol.yaml
@@ -1291,7 +1422,9 @@ class Experiment:
                 experiment.task_protocol = AutoLamellaTaskProtocol.load(protocol_path)
                 logging.info(f"Loaded task protocol from {protocol_path}")
             except Exception as e:
-                logging.warning(f"Failed to load task protocol from {protocol_path}: {e}")
+                logging.warning(
+                    f"Failed to load task protocol from {protocol_path}: {e}"
+                )
 
         return experiment
 
@@ -1350,7 +1483,9 @@ class Experiment:
                 # Preserve existing milling pattern positions
                 if existing_config is not None and new_config.milling:
                     for milling_name, new_milling_config in new_config.milling.items():
-                        existing_milling_config = existing_config.milling.get(milling_name)
+                        existing_milling_config = existing_config.milling.get(
+                            milling_name
+                        )
                         if existing_milling_config is None:
                             continue
 
@@ -1366,10 +1501,9 @@ class Experiment:
                             if existing_stage is None:
                                 continue
 
-                            if (
-                                type(existing_stage.pattern) is type(new_stage.pattern)
-                                and hasattr(existing_stage.pattern, "point")
-                            ):
+                            if type(existing_stage.pattern) is type(
+                                new_stage.pattern
+                            ) and hasattr(existing_stage.pattern, "point"):
                                 new_stage.pattern.point = deepcopy(
                                     existing_stage.pattern.point
                                 )
@@ -1383,7 +1517,11 @@ class Experiment:
             )
 
         # Update base protocol if requested (skip if source is already the base protocol)
-        if update_base_protocol and self.task_protocol is not None and source_lamella_name is not None:
+        if (
+            update_base_protocol
+            and self.task_protocol is not None
+            and source_lamella_name is not None
+        ):
             for task_name in task_names:
                 if task_name in source_task_config:
                     self.task_protocol.task_config[task_name] = deepcopy(
@@ -1416,13 +1554,20 @@ class Experiment:
 
         # check if lamella already exists
         if lamella in self.positions:
-            raise ValueError(f"Lamella {lamella.name} already exists in the experiment.")
+            raise ValueError(
+                f"Lamella {lamella.name} already exists in the experiment."
+            )
 
         self.positions.append(deepcopy(lamella))
         logging.info(f"Added lamella {lamella.name} to experiment {self.name}")
 
     @classmethod
-    def create(cls, path: Path, name: str = cfg.EXPERIMENT_NAME, metadata: Optional[Dict[str, Any]] = None) -> 'Experiment':
+    def create(
+        cls,
+        path: Path,
+        name: str = cfg.EXPERIMENT_NAME,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> "Experiment":
         """Create a new experiment with the given path and name. Also configures logging.
 
         Args:
@@ -1501,9 +1646,7 @@ class Experiment:
 
         # After _register_metadata, which sets `application` on the very SystemInfo
         # being snapshotted here.
-        self.session = SessionInfo.collect(
-            microscope, user=self._declared_user()
-        )
+        self.session = SessionInfo.collect(microscope, user=self._declared_user())
 
         # Written now rather than left to whatever saves next -- relying on someone
         # else's save is how FIB-490 lost every failed task. Only for an experiment
@@ -1543,13 +1686,15 @@ class Experiment:
         """Save the task protocol to disk in the experiment directory."""
         self.task_protocol.save(os.path.join(self.path, "protocol.yaml"))
 
-###### TASK REFACTORING ##########
+    ###### TASK REFACTORING ##########
 
-    def add_new_lamella(self,
-                        microscope_state: MicroscopeState,
-                        task_config: EventedDict[str, AutoLamellaTaskConfig],
-                        name: Optional[str] = None,
-                        fluorescence_pose: Optional[MicroscopeState] = None) -> None:
+    def add_new_lamella(
+        self,
+        microscope_state: MicroscopeState,
+        task_config: EventedDict[str, AutoLamellaTaskConfig],
+        name: Optional[str] = None,
+        fluorescence_pose: Optional[MicroscopeState] = None,
+    ) -> None:
         """Create a new lamella and add it to the experiment.
 
         Args:
@@ -1573,10 +1718,9 @@ class Experiment:
         path = Path(os.path.join(self.path, name))
 
         # create the lamella
-        lamella = Lamella(petname=name,
-                          path=path,
-                          number=number,
-                          task_config=deepcopy(task_config))
+        lamella = Lamella(
+            petname=name, path=path, number=number, task_config=deepcopy(task_config)
+        )
         if template.alignment_area is not None:
             lamella.alignment_area = deepcopy(template.alignment_area)
         if template.poi is not None:
@@ -1616,7 +1760,7 @@ class Experiment:
 
         df_task_history = pd.DataFrame(history)
         return df_task_history
-    
+
     def experiment_summary_dataframe(self) -> pd.DataFrame:
         """Create a summary dataframe of the experiment."""
         edict = []
@@ -1628,9 +1772,15 @@ class Experiment:
                 "experiment_id": self.id,
                 "lamella_name": p.name,
                 "lamella_id": p.id,
-                "last_completed": p.last_completed_task.completed if p.last_completed_task else None,
-                "last_completed_task": p.last_completed_task.name if p.last_completed_task else None,
-                "last_completed_at": p.last_completed_task.completed_at if p.last_completed_task else None,
+                "last_completed": p.last_completed_task.completed
+                if p.last_completed_task
+                else None,
+                "last_completed_task": p.last_completed_task.name
+                if p.last_completed_task
+                else None,
+                "last_completed_at": p.last_completed_task.completed_at
+                if p.last_completed_task
+                else None,
                 "is_completed": self.task_protocol.workflow_config.is_completed(p),
                 "is_failure": p.is_failure,
                 "milling_angle": p.milling_angle,
@@ -1640,9 +1790,9 @@ class Experiment:
         df = pd.DataFrame(edict)
 
         return df
-    
+
     def workflow_dataframe(self) -> pd.DataFrame:
-        """Create a dataframe with the workflow """
+        """Create a dataframe with the workflow"""
         wlist: List[Dict] = []
         for i, t in enumerate(self.task_protocol.workflow_config.tasks, 1):
             ddict = {

--- a/fibsem/applications/autolamella/tools/artifacts.py
+++ b/fibsem/applications/autolamella/tools/artifacts.py
@@ -113,9 +113,7 @@ def _task_record(task: "AutoLamellaTaskState") -> dict:
     }
 
 
-def _find_item(
-    experiment: "Experiment", context: "HookContext"
-) -> Optional["Lamella"]:
+def _find_item(experiment: "Experiment", context: "HookContext") -> Optional["Lamella"]:
     """Resolve the item a context names back to the lamella it refers to.
 
     By id first: the name is a petname a user can edit, the id is the stable key. The

--- a/fibsem/applications/autolamella/tools/reporting.py
+++ b/fibsem/applications/autolamella/tools/reporting.py
@@ -49,85 +49,96 @@ class PDFReportGenerator:
             rightMargin=72,
             leftMargin=72,
             topMargin=72,
-            bottomMargin=72
+            bottomMargin=72,
         )
         self.styles = getSampleStyleSheet()
         self.story = []
 
         # Create custom styles
-        self.styles.add(ParagraphStyle(
-            'CustomTitle',
-            parent=self.styles['Heading1'],
-            fontSize=24,
-            spaceAfter=30,
-            alignment=1  # Center alignment
-        ))
-        
-        self.styles.add(ParagraphStyle(
-            'Subtitle',
-            parent=self.styles['Normal'],
-            fontSize=14,
-            textColor=colors.grey,
-            alignment=1,
-            spaceAfter=20
-        ))
+        self.styles.add(
+            ParagraphStyle(
+                "CustomTitle",
+                parent=self.styles["Heading1"],
+                fontSize=24,
+                spaceAfter=30,
+                alignment=1,  # Center alignment
+            )
+        )
+
+        self.styles.add(
+            ParagraphStyle(
+                "Subtitle",
+                parent=self.styles["Normal"],
+                fontSize=14,
+                textColor=colors.grey,
+                alignment=1,
+                spaceAfter=20,
+            )
+        )
 
     def add_title(self, title: str, subtitle: Optional[str] = None):
         """Add a title and optional subtitle to the document"""
-        self.story.append(Paragraph(title, self.styles['CustomTitle']))
+        self.story.append(Paragraph(title, self.styles["CustomTitle"]))
         if subtitle:
-            self.story.append(Paragraph(subtitle, self.styles['Subtitle']))
+            self.story.append(Paragraph(subtitle, self.styles["Subtitle"]))
         self.story.append(Spacer(1, 20))
 
     def add_heading(self, text: str, level: int = 2):
         """Add a heading with specified level"""
-        style = self.styles[f'Heading{level}']
+        style = self.styles[f"Heading{level}"]
         self.story.append(Paragraph(text, style))
         self.story.append(Spacer(1, 12))
 
     def add_paragraph(self, text: str):
         """Add a paragraph of text"""
-        self.story.append(Paragraph(text, self.styles['Normal']))
+        self.story.append(Paragraph(text, self.styles["Normal"]))
         self.story.append(Spacer(1, 12))
 
     def add_page_break(self):
         """Add a page break"""
         self.story.append(PageBreak())
 
-    def add_image(self, path: str, width=6*inch, height=4*inch):
+    def add_image(self, path: str, width=6 * inch, height=4 * inch):
         """Add an image to the PDF"""
         img = Image(path, width=width, height=height)
         self.story.append(img)
         self.story.append(Spacer(1, 20))
 
-    def add_dataframe(self, df: pd.DataFrame, title: Optional[str] = None, includes_totals: bool = False):
+    def add_dataframe(
+        self,
+        df: pd.DataFrame,
+        title: Optional[str] = None,
+        includes_totals: bool = False,
+    ):
         """Add a pandas DataFrame as a table"""
         if title:
             self.add_heading(title, 3)
-        
+
         # Convert DataFrame to list of lists
         data = [df.columns.tolist()] + df.values.tolist()
-        
+
         # Create table style
-        style = TableStyle([
-            ('BACKGROUND', (0, 0), (-1, 0), colors.HexColor("#2F314F")),
-            ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
-            ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
-            ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-            ('FONTSIZE', (0, 0), (-1, 0), 8),
-            ('BOTTOMPADDING', (0, 0), (-1, 0), 12),
-            ('BACKGROUND', (0, 1), (-1, -1), colors.white),
-            ('TEXTCOLOR', (0, 1), (-1, -1), colors.black),
-            ('FONTNAME', (0, 1), (-1, -1), 'Helvetica'),
-            ('FONTSIZE', (0, 1), (-1, -1), 8),
-            ('GRID', (0, 0), (-1, -1), 1, colors.black),
-            ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.whitesmoke, colors.white])
-        ])
-        
+        style = TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#2F314F")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, 0), 8),
+                ("BOTTOMPADDING", (0, 0), (-1, 0), 12),
+                ("BACKGROUND", (0, 1), (-1, -1), colors.white),
+                ("TEXTCOLOR", (0, 1), (-1, -1), colors.black),
+                ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
+                ("FONTSIZE", (0, 1), (-1, -1), 8),
+                ("GRID", (0, 0), (-1, -1), 1, colors.black),
+                ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.whitesmoke, colors.white]),
+            ]
+        )
+
         if includes_totals:
-            style.add('BACKGROUND', (0, -1), (-1, -1), colors.HexColor('#E8E8E8'))
-            style.add('FONTNAME', (0, -1), (-1, -1), 'Helvetica-Bold')
-        
+            style.add("BACKGROUND", (0, -1), (-1, -1), colors.HexColor("#E8E8E8"))
+            style.add("FONTNAME", (0, -1), (-1, -1), "Helvetica-Bold")
+
         table = Table(data)
         table.setStyle(style)
         self.story.append(table)
@@ -139,20 +150,22 @@ class PDFReportGenerator:
         """
         if title:
             self.add_heading(title, 3)
-        
+
         # Create plot and save to bytes buffer
         fig = plot_function(*args, **kwargs)
         img_buffer = io.BytesIO()
-        fig.savefig(img_buffer, format='png', bbox_inches='tight', dpi=300)
+        fig.savefig(img_buffer, format="png", bbox_inches="tight", dpi=300)
         img_buffer.seek(0)
-        
+
         # Add plot to story
-        img = Image(img_buffer, width=6*inch, height=4*inch)
+        img = Image(img_buffer, width=6 * inch, height=4 * inch)
         self.story.append(img)
         self.story.append(Spacer(1, 20))
         plt.close(fig)
 
-    def add_mpl_figure(self, fig: Figure, width: float = 6*inch, height: float = 4*inch) -> None:
+    def add_mpl_figure(
+        self, fig: Figure, width: float = 6 * inch, height: float = 4 * inch
+    ) -> None:
         """Add a matplotlib figure to the PDF using in-memory buffer
 
         Args:
@@ -161,13 +174,15 @@ class PDFReportGenerator:
             height: Height in inches (default: 4 inches)
         """
         buf = io.BytesIO()
-        fig.savefig(buf, format='png', bbox_inches='tight', dpi=300)
+        fig.savefig(buf, format="png", bbox_inches="tight", dpi=300)
         buf.seek(0)
         plt.close(fig)
         self.story.append(Image(buf, width=width, height=height))
         self.story.append(Spacer(1, 20))
 
-    def add_plotly_figure(self, fig: 'go.Figure', title=None, width=6.5*inch, height=4*inch) -> None:
+    def add_plotly_figure(
+        self, fig: "go.Figure", title=None, width=6.5 * inch, height=4 * inch
+    ) -> None:
         """Add a Plotly figure to the PDF"""
         if title:
             self.add_heading(title, 3)
@@ -188,8 +203,6 @@ class PDFReportGenerator:
         self.doc.build(self.story)
 
 
-
-
 ###### NEW REPORTING FOR NEW TASK-WORKFLOW ######
 # The sections generate_report2 understands, in report order. Exported so callers
 # building a sections dict name them from here rather than by hand -- the report
@@ -206,13 +219,15 @@ REPORT_SECTIONS = (
 )
 
 
-def _add_lamella_section(pdf: PDFReportGenerator,
-                         lamella: Lamella,
-                         df_task_history: pd.DataFrame,
-                         df_milling: pd.DataFrame,
-                         include_workflow: bool = True,
-                         include_images: bool = True,
-                         include_milling: bool = True) -> None:
+def _add_lamella_section(
+    pdf: PDFReportGenerator,
+    lamella: Lamella,
+    df_task_history: pd.DataFrame,
+    df_milling: pd.DataFrame,
+    include_workflow: bool = True,
+    include_images: bool = True,
+    include_milling: bool = True,
+) -> None:
     """Add a complete lamella section to the report.
 
     Args:
@@ -231,27 +246,29 @@ def _add_lamella_section(pdf: PDFReportGenerator,
     if include_workflow:
         df = df_task_history[df_task_history["Lamella Name"] == lamella.name]
         if not df.empty:
-            pdf.add_dataframe(df, 'Workflow')
+            pdf.add_dataframe(df, "Workflow")
 
     # Workflow images
     if include_images:
         fig = plot_lamella_task_workflow_summary(lamella)
         if fig is not None:
-            pdf.add_mpl_figure(fig, width=6*inch, height=4*inch)
+            pdf.add_mpl_figure(fig, width=6 * inch, height=4 * inch)
 
     # Milling data and patterns
     if include_milling:
         df = df_milling[df_milling["Lamella Name"] == lamella.name]
         if not df.empty:
-            pdf.add_dataframe(df, 'Milling Data')
+            pdf.add_dataframe(df, "Milling Data")
 
         figs = plot_task_milling_summary(lamella)
         if figs:
             for fig in figs:
-                pdf.add_mpl_figure(fig, width=6*inch, height=4*inch)
+                pdf.add_mpl_figure(fig, width=6 * inch, height=4 * inch)
 
 
-def generate_report_data2(experiment: Experiment, encoding: str = "utf-8") -> Dict[str, any]:
+def generate_report_data2(
+    experiment: Experiment, encoding: str = "utf-8"
+) -> Dict[str, any]:
     """Generate report data from an experiment by parsing the logfile directly.
 
     Args:
@@ -284,10 +301,12 @@ def generate_report_data2(experiment: Experiment, encoding: str = "utf-8") -> Di
     return REPORT_DATA
 
 
-def generate_report2(experiment: Experiment,
-                    output_filename: str = "autolamella.pdf",
-                    sections: Optional[Dict[str, bool]] = None,
-                    encoding: str = "utf-8") -> None:
+def generate_report2(
+    experiment: Experiment,
+    output_filename: str = "autolamella.pdf",
+    sections: Optional[Dict[str, bool]] = None,
+    encoding: str = "utf-8",
+) -> None:
     """Generate a comprehensive AutoLamella experiment report.
 
     This function generates a PDF report from an experiment by parsing the logfile directly.
@@ -337,11 +356,15 @@ def generate_report2(experiment: Experiment,
     pdf = PDFReportGenerator(output_filename=output_filename)
 
     # Add content - Header and summary tables
-    pdf.add_title(f"AutoLamella Report: {report_data['experiment_name']}",
-                  f'Generated on {datetime.now().strftime(DATE_LONG)}')
-    pdf.add_paragraph('This report summarises the results of the AutoLamella experiment.')
-    pdf.add_dataframe(report_data["workflow_dataframe"], 'Workflow Summary')
-    pdf.add_dataframe(report_data["experiment_summary_dataframe"], 'Experiment Summary')
+    pdf.add_title(
+        f"AutoLamella Report: {report_data['experiment_name']}",
+        f"Generated on {datetime.now().strftime(DATE_LONG)}",
+    )
+    pdf.add_paragraph(
+        "This report summarises the results of the AutoLamella experiment."
+    )
+    pdf.add_dataframe(report_data["workflow_dataframe"], "Workflow Summary")
+    pdf.add_dataframe(report_data["experiment_summary_dataframe"], "Experiment Summary")
 
     # Overview image with positions
     if sections["overview"]:
@@ -353,7 +376,7 @@ def generate_report2(experiment: Experiment,
                 for filename in filenames:
                     image = FibsemImage.load(filename)
                     fig = generate_final_overview_image(exp=experiment, image=image)
-                    pdf.add_mpl_figure(fig, width=4.5*inch, height=4.5*inch)
+                    pdf.add_mpl_figure(fig, width=4.5 * inch, height=4.5 * inch)
         except Exception as e:
             logging.warning(f"Error generating overview image: {e}")
 
@@ -365,11 +388,16 @@ def generate_report2(experiment: Experiment,
 
     # Detection data
     if sections["detection"]:
-        if report_data["detection_dataframe"] is not None and not report_data["detection_dataframe"].empty:
+        if (
+            report_data["detection_dataframe"] is not None
+            and not report_data["detection_dataframe"].empty
+        ):
             pdf.add_page_break()
             pdf.add_heading("Detection Data")
             pdf.add_dataframe(report_data["detection_dataframe"])
-            pdf.add_dataframe(report_data["detection_summary_dataframe"], "Detection Summary")
+            pdf.add_dataframe(
+                report_data["detection_summary_dataframe"], "Detection Summary"
+            )
 
     # Per-lamella sections
     df_task_history = report_data["task_history_dataframe"]
@@ -383,20 +411,23 @@ def generate_report2(experiment: Experiment,
             df_milling=df_milling,
             include_workflow=sections["lamella_workflow"],
             include_images=sections["lamella_workflow_images"],
-            include_milling=sections["lamella_milling"]
+            include_milling=sections["lamella_milling"],
         )
 
     # Generate PDF
     pdf.generate()
 
-def plot_lamella_task_workflow_summary(p: Lamella,
-                         show_title: bool = False,
-                         show_scalebar: bool = True,
-                         figsize: Tuple[int, int] = (30, 5),
-                         target_size: int = 256,
-                         fontsize: int = 12,
-                         mode: str = "light",
-                         show: bool = False) -> Optional[Figure]:
+
+def plot_lamella_task_workflow_summary(
+    p: Lamella,
+    show_title: bool = False,
+    show_scalebar: bool = True,
+    figsize: Tuple[int, int] = (30, 5),
+    target_size: int = 256,
+    fontsize: int = 12,
+    mode: str = "light",
+    show: bool = False,
+) -> Optional[Figure]:
     """Plot the final images for each task of the lamella workflow.
 
     Creates a grid of images showing SEM and FIB views at different resolutions
@@ -426,7 +457,9 @@ def plot_lamella_task_workflow_summary(p: Lamella,
 
     task_filenames = {}
     for task_name in completed_tasks:
-        filenames = sorted(glob.glob(os.path.join(p.path, f"ref_{task_name}*_final_*res*.tif*")))
+        filenames = sorted(
+            glob.glob(os.path.join(p.path, f"ref_{task_name}*_final_*res*.tif*"))
+        )
         if len(filenames) == 0:
             continue
         task_filenames[task_name] = filenames
@@ -456,7 +489,6 @@ def plot_lamella_task_workflow_summary(p: Lamella,
     fig, axes = plt.subplots(nrows, ncols, figsize=(fig_width, fig_height))
 
     for i, task_name in enumerate(completed_tasks):
-
         if nrows == 1:
             ax = axes
         else:
@@ -466,7 +498,14 @@ def plot_lamella_task_workflow_summary(p: Lamella,
             ax = np.expand_dims(ax, axis=0)
 
         # Set y-axis label for this row (only on the leftmost subplot)
-        ax[0].set_ylabel(task_name, fontsize=fontsize, rotation=90, ha='center', va='center', color=text_color)
+        ax[0].set_ylabel(
+            task_name,
+            fontsize=fontsize,
+            rotation=90,
+            ha="center",
+            va="center",
+            color=text_color,
+        )
 
         filenames = task_filenames[task_name]
         try:
@@ -476,7 +515,9 @@ def plot_lamella_task_workflow_summary(p: Lamella,
                 # resize image, maintain aspect ratio
                 shape = img.data.shape
                 resize_shape = (int(shape[0] * (target_size / shape[1])), target_size)
-                arr = resize(img.data, resize_shape, preserve_range=True).astype(img.data.dtype)
+                arr = resize(img.data, resize_shape, preserve_range=True).astype(
+                    img.data.dtype
+                )
                 arr = median_filter(arr, size=3)
 
                 ax[j].imshow(arr, cmap="gray")
@@ -487,13 +528,15 @@ def plot_lamella_task_workflow_summary(p: Lamella,
 
                 # add scalebar
                 if show_scalebar:
-                    ax[j].add_artist(ScaleBar(
-                        dx=img.metadata.pixel_size.x * (shape[1] / target_size),
-                        color="black",
-                        box_color="white",
-                        box_alpha=0.5,
-                    location="lower right",
-                ))
+                    ax[j].add_artist(
+                        ScaleBar(
+                            dx=img.metadata.pixel_size.x * (shape[1] / target_size),
+                            color="black",
+                            box_color="white",
+                            box_alpha=0.5,
+                            location="lower right",
+                        )
+                    )
 
             if j < ncols - 1:
                 # fill remaining subplots with blank images
@@ -503,24 +546,35 @@ def plot_lamella_task_workflow_summary(p: Lamella,
                     ax[k].set_yticks([])
                     for spine in ax[k].spines.values():
                         spine.set_visible(False)
-                    ax[k].text(0.5, 0.5, "No Data", color="white", fontsize=fontsize,
-                               ha='center', va='center', transform=ax[k].transAxes)
+                    ax[k].text(
+                        0.5,
+                        0.5,
+                        "No Data",
+                        color="white",
+                        fontsize=fontsize,
+                        ha="center",
+                        va="center",
+                        transform=ax[k].transAxes,
+                    )
 
         except Exception as e:
             logging.error(f"Error plotting {p.name} - {task_name}: {e}")
             continue
 
     if show_title:
-        fig.suptitle(f"Lamella {p.name}", fontsize=int(fontsize * 1.5), color=text_color)
+        fig.suptitle(
+            f"Lamella {p.name}", fontsize=int(fontsize * 1.5), color=text_color
+        )
 
     # Minimize spacing between subplots
-    plt.subplots_adjust(left=0.05, right=0.95, top=0.95, bottom=0.05, wspace=0.02, hspace=0.02)
+    plt.subplots_adjust(
+        left=0.05, right=0.95, top=0.95, bottom=0.05, wspace=0.02, hspace=0.02
+    )
 
     if show:
         plt.show()
 
     return fig
-
 
 
 def plot_task_milling_summary(p: Lamella, show: bool = False) -> List[Figure]:
@@ -538,34 +592,39 @@ def plot_task_milling_summary(p: Lamella, show: bool = False) -> List[Figure]:
         Returns empty list if no milling tasks are found or images are missing.
     """
     figures = []
-     
-    for k, v in p.task_config.items():
 
+    for k, v in p.task_config.items():
         # check if the task was completed
         if k not in [t.name for t in p.task_history]:
             continue
 
         # check if the task has milling operations
         if v.milling:
-
-            filenames = sorted(glob.glob(os.path.join(p.path, f"ref_{k}_final_*_ib.tif")))
+            filenames = sorted(
+                glob.glob(os.path.join(p.path, f"ref_{k}_final_*_ib.tif"))
+            )
             if len(filenames) == 0:
-                logging.info(f"No final high-res ion beam image found for {p.name} - {k}")
+                logging.info(
+                    f"No final high-res ion beam image found for {p.name} - {k}"
+                )
                 continue
             image = FibsemImage.load(filenames[0])
             milling_stages = []
             for mtask in v.milling.values():
                 milling_stages.extend(mtask.stages)
 
-            fig, ax = plot_milling_patterns(image, milling_stages, title=f"Lamella {p.name} - {k}")
+            fig, ax = plot_milling_patterns(
+                image, milling_stages, title=f"Lamella {p.name} - {k}"
+            )
             figures.append(fig)
             if show:
                 plt.show()
     return figures
 
-def generate_final_overview_image(exp: Experiment,
-                                  image: FibsemImage,
-                                  state: str = "MILLING") -> Figure:
+
+def generate_final_overview_image(
+    exp: Experiment, image: FibsemImage, state: str = "MILLING"
+) -> Figure:
     """Generate an overview image with all the final lamellae positions marked.
 
     Creates a figure showing the overview image with colored markers indicating
@@ -589,11 +648,9 @@ def generate_final_overview_image(exp: Experiment,
         pos.name = p.name
         sem_positions.append(pos)
 
-    fig = plot_stage_positions_on_image(image, sem_positions,
-                                        show=False,
-                                        color="cyan",
-                                        show_scalebar=True,
-                                        figsize=None)
+    fig = plot_stage_positions_on_image(
+        image, sem_positions, show=False, color="cyan", show_scalebar=True, figsize=None
+    )
 
     # plot details
     fig.suptitle(f"Experiment: {exp.name}")
@@ -601,11 +658,12 @@ def generate_final_overview_image(exp: Experiment,
 
     return fig
 
-def save_final_overview_image(exp: Experiment, 
-                        image: FibsemImage, 
-                        output_path: str) -> Figure:
+
+def save_final_overview_image(
+    exp: Experiment, image: FibsemImage, output_path: str
+) -> Figure:
     """Save the final overview image with all the final lamellae positions.
-    Args: 
+    Args:
         exp (Experiment): The experiment to plot.
         image (FibsemImage): The overview image.
         output_path (str): The path to save the image to.

--- a/fibsem/applications/autolamella/ui/autolamella_overview_image_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_overview_image_widget.py
@@ -141,7 +141,7 @@ class OverviewImageWidget(QWidget):
     - Export the final image
     """
 
-    def __init__(self, parent: Optional['AutoLamellaUI'] = None):
+    def __init__(self, parent: Optional["AutoLamellaUI"] = None):
         """Initialize the overview image widget.
 
         Args:
@@ -149,8 +149,8 @@ class OverviewImageWidget(QWidget):
         """
         super().__init__(parent)
         self.parent_widget = parent
-        self.experiment: Optional['Experiment'] = None
-        self.overview_image: Optional['FibsemImage'] = None
+        self.experiment: Optional["Experiment"] = None
+        self.overview_image: Optional["FibsemImage"] = None
         self.current_figure: Optional[Figure] = None
         self.marker_color = QColor("cyan")
         self.stage_positions = []
@@ -182,7 +182,9 @@ class OverviewImageWidget(QWidget):
 
         # Marker color
         self.color_label = QLabel("●")
-        self.color_label.setStyleSheet(f"color: {self.marker_color.name()}; font-size: 20px;")
+        self.color_label.setStyleSheet(
+            f"color: {self.marker_color.name()}; font-size: 20px;"
+        )
         self.color_button = QPushButton("Choose Color")
         self.color_button.setStyleSheet(BUTTON_STYLESHEET)
         self.color_button.clicked.connect(self._on_color_button_clicked)
@@ -229,7 +231,9 @@ class OverviewImageWidget(QWidget):
         display_layout.addRow("Show Descriptions", self.show_descriptions_checkbox)
         display_layout.addRow("Show Scalebar", self.show_scalebar_checkbox)
 
-        display_group = TitledPanel("Display Options", content=display_content, collapsible=False)
+        display_group = TitledPanel(
+            "Display Options", content=display_content, collapsible=False
+        )
 
         # Connect signals to update preview on change
         self.text_size_spinbox.valueChanged.connect(self._on_preview_clicked)
@@ -238,7 +242,6 @@ class OverviewImageWidget(QWidget):
         self.show_descriptions_checkbox.stateChanged.connect(self._on_preview_clicked)
         self.show_scalebar_checkbox.stateChanged.connect(self._on_preview_clicked)
         self.title_textbox.editingFinished.connect(self._on_preview_clicked)
-
 
         # Preview canvas
         self.canvas = None
@@ -362,7 +365,12 @@ class OverviewImageWidget(QWidget):
         if self.canvas is None:
             return
 
-        for attr in ("_scroll_cid", "_pan_press_cid", "_pan_release_cid", "_pan_motion_cid"):
+        for attr in (
+            "_scroll_cid",
+            "_pan_press_cid",
+            "_pan_release_cid",
+            "_pan_motion_cid",
+        ):
             cid = getattr(self, attr)
             if cid is None:
                 continue
@@ -382,10 +390,18 @@ class OverviewImageWidget(QWidget):
         if self.canvas is None:
             return
 
-        self._scroll_cid = self.canvas.mpl_connect("scroll_event", self._on_canvas_scroll)
-        self._pan_press_cid = self.canvas.mpl_connect("button_press_event", self._on_canvas_press)
-        self._pan_release_cid = self.canvas.mpl_connect("button_release_event", self._on_canvas_release)
-        self._pan_motion_cid = self.canvas.mpl_connect("motion_notify_event", self._on_canvas_motion)
+        self._scroll_cid = self.canvas.mpl_connect(
+            "scroll_event", self._on_canvas_scroll
+        )
+        self._pan_press_cid = self.canvas.mpl_connect(
+            "button_press_event", self._on_canvas_press
+        )
+        self._pan_release_cid = self.canvas.mpl_connect(
+            "button_release_event", self._on_canvas_release
+        )
+        self._pan_motion_cid = self.canvas.mpl_connect(
+            "motion_notify_event", self._on_canvas_motion
+        )
 
     def _on_canvas_scroll(self, event):
         """Handle scroll-wheel events to zoom in/out."""
@@ -429,7 +445,12 @@ class OverviewImageWidget(QWidget):
 
     def _on_canvas_press(self, event):
         """Start a pan gesture when the left mouse button is pressed."""
-        if event.button != 1 or event.inaxes is None or event.xdata is None or event.ydata is None:
+        if (
+            event.button != 1
+            or event.inaxes is None
+            or event.xdata is None
+            or event.ydata is None
+        ):
             return
 
         self._pan_active = True
@@ -491,7 +512,7 @@ class OverviewImageWidget(QWidget):
 
         self.canvas.draw_idle()
 
-    def set_experiment(self, experiment: 'Experiment'):
+    def set_experiment(self, experiment: "Experiment"):
         """Set the experiment to use for generating overview images.
 
         Args:
@@ -499,11 +520,9 @@ class OverviewImageWidget(QWidget):
         """
         self.experiment = experiment
 
-
         if experiment is not None:
             self.info_label.setText(
-                f"Experiment: {experiment.name} | "
-                f"{len(experiment.positions)} lamellae"
+                f"Experiment: {experiment.name} | {len(experiment.positions)} lamellae"
             )
             self.title_textbox.setText(f"Experiment: {self.experiment.name}")
             self.title_textbox.setCursorPosition(0)
@@ -528,7 +547,7 @@ class OverviewImageWidget(QWidget):
             self,
             "Select Overview Image",
             start_dir,
-            "TIFF Files (*.tif *.tiff);;All Files (*.*)"
+            "TIFF Files (*.tif *.tiff);;All Files (*.*)",
         )
 
         if file_path:
@@ -550,11 +569,7 @@ class OverviewImageWidget(QWidget):
 
     def _on_color_button_clicked(self):
         """Handle color button click to select marker color."""
-        color = QColorDialog.getColor(
-            self.marker_color,
-            self,
-            "Select Marker Color"
-        )
+        color = QColorDialog.getColor(self.marker_color, self, "Select Marker Color")
 
         if color.isValid():
             self.marker_color = color
@@ -572,7 +587,6 @@ class OverviewImageWidget(QWidget):
             return
 
         try:
-
             # Get settings
             show_names = self.show_names_checkbox.isChecked()
             show_descriptions = self.show_descriptions_checkbox.isChecked()
@@ -582,7 +596,9 @@ class OverviewImageWidget(QWidget):
             markersize = self.markersize_spinbox.value()
 
             # lamella name -> free-text description, for the optional subtitle
-            descriptions = {lam.name: lam.description for lam in self.experiment.positions}
+            descriptions = {
+                lam.name: lam.description for lam in self.experiment.positions
+            }
 
             if not self.stage_positions:
                 self.info_label.setText("Warning: No positions found for MILLING state")
@@ -602,7 +618,7 @@ class OverviewImageWidget(QWidget):
                 show_names=show_names,
                 show_descriptions=show_descriptions,
                 descriptions=descriptions,
-                figsize=(15, 15)
+                figsize=(15, 15),
             )
 
             # Add title
@@ -621,6 +637,7 @@ class OverviewImageWidget(QWidget):
         except Exception as e:
             logging.error(f"Error generating preview: {e}")
             import traceback
+
             traceback.print_exc()
             self.info_label.setText(f"Error: {str(e)}")
             self._create_empty_canvas()
@@ -628,7 +645,9 @@ class OverviewImageWidget(QWidget):
     def _on_save_clicked(self):
         """Save the overview image by opening a save file dialog."""
         if self.current_figure is None:
-            self.info_label.setText("Error: No preview to save. Generate preview first.")
+            self.info_label.setText(
+                "Error: No preview to save. Generate preview first."
+            )
             return
 
         if self.overview_image is None or self.experiment is None:
@@ -640,10 +659,7 @@ class OverviewImageWidget(QWidget):
         start_filename = os.path.join(str(self.experiment.path), default_name)
 
         output_path, _ = QFileDialog.getSaveFileName(
-            self,
-            "Save Overview Image",
-            start_filename,
-            "PNG Files (*.png);;"
+            self, "Save Overview Image", start_filename, "PNG Files (*.png);;"
         )
 
         if not output_path:
@@ -657,7 +673,9 @@ class OverviewImageWidget(QWidget):
                 self._title_artist.set_color("black")
 
             # Save the current figure directly
-            self.current_figure.savefig(output_path, dpi=300, bbox_inches='tight', facecolor='white')
+            self.current_figure.savefig(
+                output_path, dpi=300, bbox_inches="tight", facecolor="white"
+            )
 
             logging.info(f"Saved overview image to: {output_path}")
             self.info_label.setText(f"Saved to: {output_path}")
@@ -665,6 +683,7 @@ class OverviewImageWidget(QWidget):
         except Exception as e:
             logging.error(f"Error saving image: {e}")
             import traceback
+
             traceback.print_exc()
             self.info_label.setText(f"Error saving: {str(e)}")
         finally:
@@ -672,8 +691,9 @@ class OverviewImageWidget(QWidget):
                 self._title_artist.set_color(original_title_color)
 
 
-def create_overview_image_widget(experiment: 'Experiment',
-                                  parent: Optional['AutoLamellaUI'] = None) -> QDialog:
+def create_overview_image_widget(
+    experiment: "Experiment", parent: Optional["AutoLamellaUI"] = None
+) -> QDialog:
     """Create and initialize an OverviewImageWidget wrapped in a dialog.
 
     Args:
@@ -699,6 +719,7 @@ def create_overview_image_widget(experiment: 'Experiment',
     dialog.setLayout(layout)
 
     return dialog
+
 
 # TODO: add more options for customization (scalebar size, font type, etc.)
 # - show only completed lamellae

--- a/fibsem/applications/autolamella/ui/autolamella_overview_image_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_overview_image_widget.py
@@ -21,6 +21,7 @@ from PyQt5.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QSizePolicy,
     QSpinBox,
     QVBoxLayout,
     QWidget,
@@ -163,7 +164,6 @@ class OverviewImageWidget(QWidget):
         self._pan_start = None
         self._pan_axes_limits = None
         self._initial_axes_limits = []
-        self._title_artist = None
 
         self.initUI()
 
@@ -270,9 +270,13 @@ class OverviewImageWidget(QWidget):
         self.save_button.setStyleSheet(BUTTON_STYLESHEET)
         self.save_button.clicked.connect(self._on_save_clicked)
 
+        # The preview takes the slack; the options column keeps its natural height at the
+        # top. Until the header stopped stretching (see TitledPanel) the column absorbed
+        # the spare space instead, which made the row look full while the canvas -- the
+        # thing anyone actually looks at -- was the part being squeezed.
         hlayout = QHBoxLayout()
-        hlayout.addWidget(self.canvas_container)
-        hlayout.addWidget(display_group)
+        hlayout.addWidget(self.canvas_container, stretch=1)
+        hlayout.addWidget(display_group, stretch=0, alignment=Qt.AlignmentFlag.AlignTop)
 
         # button layouts
         button_layout = QHBoxLayout()
@@ -288,7 +292,7 @@ class OverviewImageWidget(QWidget):
 
         # main layout
         main_layout = QVBoxLayout()
-        main_layout.addLayout(hlayout)
+        main_layout.addLayout(hlayout, stretch=1)
         main_layout.addLayout(button_layout)
         main_layout.addWidget(self.info_label)
 
@@ -308,6 +312,7 @@ class OverviewImageWidget(QWidget):
 
         self.canvas = FigureCanvas(self.figure)
         self.canvas.setMinimumSize(400, 300)
+        self.canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.canvas_layout.addWidget(self.canvas)
 
         # Add placeholder text
@@ -353,6 +358,11 @@ class OverviewImageWidget(QWidget):
 
         # Create new canvas with the figure
         self.canvas = FigureCanvas(self.figure)
+        # A FigureCanvas asks for exactly the figure's own size and will not grow past
+        # it on its own, so a preview replaced mid-session would otherwise shrink the
+        # row to whatever inches the renderer chose.
+        self.canvas.setMinimumSize(400, 300)
+        self.canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.canvas_layout.addWidget(self.canvas)
 
         # Draw the canvas
@@ -576,6 +586,40 @@ class OverviewImageWidget(QWidget):
             self.color_label.setStyleSheet(f"color: {color.name()}; font-size: 20px;")
             self._on_preview_clicked()
 
+    def _build_figure(self, title_color: str) -> Figure:
+        """Render the overview and its markers into a new figure.
+
+        The one place the figure is drawn, so the preview and the export cannot drift
+        apart in anything but the colour of the title -- which is the only thing that
+        legitimately differs between a dark canvas and a white page.
+        """
+        # lamella name -> free-text description, for the optional subtitle
+        descriptions = {lam.name: lam.description for lam in self.experiment.positions}
+
+        fig = plot_minimap(
+            self.overview_image,
+            self.stage_positions,
+            current_position=None,
+            grid_positions=None,
+            color=self.marker_color.name(),
+            fontsize=self.text_size_spinbox.value(),
+            markersize=self.markersize_spinbox.value(),
+            show_scalebar=self.show_scalebar_checkbox.isChecked(),
+            show_names=self.show_names_checkbox.isChecked(),
+            show_descriptions=self.show_descriptions_checkbox.isChecked(),
+            descriptions=descriptions,
+            # None sizes the figure to the overview's aspect. Only the starting point
+            # for the preview, whose figure is then resized to the canvas widget -- but
+            # it is what the export is built at, and there it decides everything.
+            figsize=None,
+        )
+
+        title_text = self.title_textbox.text().strip()
+        if title_text:
+            fig.suptitle(title_text, fontsize=14, color=title_color)
+        fig.tight_layout(rect=(0, 0, 1, 0.98))
+        return fig
+
     def _on_preview_clicked(self):
         """Generate and display preview of the overview image."""
         if self.experiment is None:
@@ -587,44 +631,12 @@ class OverviewImageWidget(QWidget):
             return
 
         try:
-            # Get settings
-            show_names = self.show_names_checkbox.isChecked()
-            show_descriptions = self.show_descriptions_checkbox.isChecked()
-            show_scalebar = self.show_scalebar_checkbox.isChecked()
-            color = self.marker_color.name()
-            fontsize = self.text_size_spinbox.value()
-            markersize = self.markersize_spinbox.value()
-
-            # lamella name -> free-text description, for the optional subtitle
-            descriptions = {
-                lam.name: lam.description for lam in self.experiment.positions
-            }
-
             if not self.stage_positions:
                 self.info_label.setText("Warning: No positions found for MILLING state")
                 self._create_empty_canvas()
                 return
 
-            # Generate figure
-            fig = plot_minimap(
-                self.overview_image,
-                self.stage_positions,
-                current_position=None,
-                grid_positions=None,
-                color=color,
-                fontsize=fontsize,
-                markersize=markersize,
-                show_scalebar=show_scalebar,
-                show_names=show_names,
-                show_descriptions=show_descriptions,
-                descriptions=descriptions,
-                figsize=(15, 15),
-            )
-
-            # Add title
-            title_text = self.title_textbox.text().strip()
-            self._title_artist = fig.suptitle(title_text, fontsize=14, color="white")
-            fig.tight_layout(rect=(0, 0, 1, 0.98))
+            fig = self._build_figure(title_color="white")
 
             # Store and display figure
             self.current_figure = fig
@@ -666,14 +678,23 @@ class OverviewImageWidget(QWidget):
             # User cancelled
             return
 
-        original_title_color = None
+        export_figure = None
         try:
-            if self._title_artist is not None:
-                original_title_color = self._title_artist.get_color()
-                self._title_artist.set_color("black")
-
-            # Save the current figure directly
-            self.current_figure.savefig(
+            # Rendered fresh rather than saved from the preview. The preview's figure is
+            # resized to the canvas *widget* the moment it is shown, so its shape is the
+            # dialog's, not the overview's -- and a wide overview in a tall widget leaves
+            # a band of empty paper between the title and the image that no amount of
+            # `bbox_inches="tight"` removes, because a bounding box is a rectangle and
+            # the gap is inside it. Measured on a 3:1 overview: the axes held 0.35 of the
+            # exported page.
+            #
+            # It also retires the trick this replaces, which recoloured the preview's
+            # title black, saved, and put it back. That worked only for callers who went
+            # through this method, and left the figure briefly in a state no reader
+            # expected.
+            export_figure = self._build_figure(title_color="black")
+            self._match_view_limits(source=self.current_figure, target=export_figure)
+            export_figure.savefig(
                 output_path, dpi=300, bbox_inches="tight", facecolor="white"
             )
 
@@ -687,8 +708,21 @@ class OverviewImageWidget(QWidget):
             traceback.print_exc()
             self.info_label.setText(f"Error saving: {str(e)}")
         finally:
-            if self._title_artist is not None and original_title_color is not None:
-                self._title_artist.set_color(original_title_color)
+            if export_figure is not None:
+                plt.close(export_figure)
+
+    @staticmethod
+    def _match_view_limits(source: Optional[Figure], target: Figure) -> None:
+        """Copy the panned/zoomed view from one figure's axes onto another's.
+
+        So that exporting after zooming into a corner of the grid exports that corner,
+        which is the whole reason the preview can be zoomed.
+        """
+        if source is None:
+            return
+        for src_ax, dst_ax in zip(source.axes, target.axes):
+            dst_ax.set_xlim(src_ax.get_xlim())
+            dst_ax.set_ylim(src_ax.get_ylim())
 
 
 def create_overview_image_widget(

--- a/fibsem/imaging/tiling/plotting.py
+++ b/fibsem/imaging/tiling/plotting.py
@@ -24,7 +24,16 @@ from fibsem.structures import (
     OverviewAcquisitionSettings,
 )
 
-POSITION_COLOURS = ["lime", "blue", "cyan", "magenta", "hotpink", "yellow", "orange", "red"]
+POSITION_COLOURS = [
+    "lime",
+    "blue",
+    "cyan",
+    "magenta",
+    "hotpink",
+    "yellow",
+    "orange",
+    "red",
+]
 
 
 def plot_tile_positions(
@@ -63,7 +72,7 @@ def plot_tile_positions(
         stage_positions=stage_positions,
         title=(
             f"{settings.tile_order.value.title()} — {settings.nrows}×{settings.ncols} tiles, "
-            f"{settings.overlap*100:.0f}% overlap"
+            f"{settings.overlap * 100:.0f}% overlap"
         ),
     )
 
@@ -119,31 +128,57 @@ def plot_tile_grid(
         if tile.enabled:
             continue
         cx, cy = centre(tile)
-        ax.add_patch(mpatches.FancyBboxPatch(
-            (cx - tile_fov_x / 2, cy - tile_fov_y / 2), tile_fov_x, tile_fov_y,
-            boxstyle="round,pad=0.01",
-            linewidth=1, edgecolor="#5a5f6e", facecolor="none", linestyle="--",
-        ))
+        ax.add_patch(
+            mpatches.FancyBboxPatch(
+                (cx - tile_fov_x / 2, cy - tile_fov_y / 2),
+                tile_fov_x,
+                tile_fov_y,
+                boxstyle="round,pad=0.01",
+                linewidth=1,
+                edgecolor="#5a5f6e",
+                facecolor="none",
+                linestyle="--",
+            )
+        )
         ax.text(cx, cy, "—", ha="center", va="center", fontsize=8, color="#5a5f6e")
 
     for order_idx, tile in enumerate(order):
         cx, cy = centre(tile)
         colour = POSITION_COLOURS[tile.row % len(POSITION_COLOURS)]
-        ax.add_patch(mpatches.FancyBboxPatch(
-            (cx - tile_fov_x / 2, cy - tile_fov_y / 2), tile_fov_x, tile_fov_y,
-            boxstyle="round,pad=0.01",
-            linewidth=1, edgecolor="white", facecolor=colour, alpha=0.4,
-        ))
-        ax.text(cx, cy, str(order_idx), ha="center", va="center",
-                fontsize=8, color="white", fontweight="bold")
+        ax.add_patch(
+            mpatches.FancyBboxPatch(
+                (cx - tile_fov_x / 2, cy - tile_fov_y / 2),
+                tile_fov_x,
+                tile_fov_y,
+                boxstyle="round,pad=0.01",
+                linewidth=1,
+                edgecolor="white",
+                facecolor=colour,
+                alpha=0.4,
+            )
+        )
+        ax.text(
+            cx,
+            cy,
+            str(order_idx),
+            ha="center",
+            va="center",
+            fontsize=8,
+            color="white",
+            fontweight="bold",
+        )
 
     # traversal path -- through the acquired tiles only, so a jump over a skipped
     # region is visible as a long arrow rather than hidden
     if len(order) > 1:
         pts = [centre(t) for t in order]
         for (x0, y0), (x1, y1) in zip(pts, pts[1:]):
-            ax.annotate("", xy=(x1, y1), xytext=(x0, y0),
-                        arrowprops=dict(arrowstyle="->", color="white", lw=1.0))
+            ax.annotate(
+                "",
+                xy=(x1, y1),
+                xytext=(x0, y0),
+                arrowprops=dict(arrowstyle="->", color="white", lw=1.0),
+            )
 
     # overlay actual projected stage positions (if provided)
     if stage_positions is not None and len(stage_positions) > 0 and order:
@@ -155,10 +190,22 @@ def plot_tile_grid(
         # of the projected path matches the grid it came from.
         ref = stage_positions[0]
         anchor_x, anchor_y = centre(order[0])
-        sxs = [anchor_x + (sp.x - ref.x) * constants.SI_TO_MICRO for sp in stage_positions]
-        sys_ = [anchor_y + (sp.y - ref.y) * constants.SI_TO_MICRO for sp in stage_positions]
+        sxs = [
+            anchor_x + (sp.x - ref.x) * constants.SI_TO_MICRO for sp in stage_positions
+        ]
+        sys_ = [
+            anchor_y + (sp.y - ref.y) * constants.SI_TO_MICRO for sp in stage_positions
+        ]
         ax.plot(sxs, sys_, linestyle=":", color="white", lw=0.8, alpha=0.6)
-        ax.plot(sxs, sys_, marker="x", color="white", ms=6, markeredgewidth=1.5, linestyle="none")
+        ax.plot(
+            sxs,
+            sys_,
+            marker="x",
+            color="white",
+            ms=6,
+            markeredgewidth=1.5,
+            linestyle="none",
+        )
 
     sym = constants.MICRON_SYMBOL
     ax.set_xlabel(f"X ({sym})")
@@ -176,15 +223,17 @@ def plot_tile_grid(
     fig.tight_layout()
     return fig
 
+
 def plot_stage_positions_on_image(
-        image: FibsemImage,
-        positions: List[FibsemStagePosition],
-        show: bool = False,
-        bound: bool = True,
-        color: Optional[str] = None,
-        show_scalebar: bool = False,
-        show_names: bool = True,
-        figsize: Optional[Tuple[int, int]] = (15, 15)) -> Figure:
+    image: FibsemImage,
+    positions: List[FibsemStagePosition],
+    show: bool = False,
+    bound: bool = True,
+    color: Optional[str] = None,
+    show_scalebar: bool = False,
+    show_names: bool = True,
+    figsize: Optional[Tuple[int, int]] = (15, 15),
+) -> Figure:
     """Plot stage positions reprojected on an image as matplotlib figure. Assumes image is flat to beam.
     Args:
         image: The image.
@@ -195,35 +244,41 @@ def plot_stage_positions_on_image(
     Returns:
         The matplotlib figure."""
     if image.metadata is None or image.metadata.microscope_state is None:
-        raise ValueError("Image metadata or microscope state is not set. Cannot reproject stage positions.")
+        raise ValueError(
+            "Image metadata or microscope state is not set. Cannot reproject stage positions."
+        )
 
-    # reproject stage positions onto image 
+    # reproject stage positions onto image
     points = reproject_stage_positions_onto_image2(image=image, positions=positions)
 
     # construct matplotlib figure
-    fig = plt.figure(figsize = figsize)
+    fig = plt.figure(figsize=figsize)
     plt.imshow(image.data, cmap="gray")
 
     for i, pt in enumerate(points):
-
         # if points outside image, don't plot
-        if bound and not is_inside_image_bounds((pt.y, pt.x), (image.data.shape[0], image.data.shape[1])):
+        if bound and not is_inside_image_bounds(
+            (pt.y, pt.x), (image.data.shape[0], image.data.shape[1])
+        ):
             continue
 
         if color is None:
-            c = POSITION_COLOURS[i%len(POSITION_COLOURS)]
+            c = POSITION_COLOURS[i % len(POSITION_COLOURS)]
         else:
             c = color
-        plt.plot(pt.x, pt.y, ms=20, c=c, marker="+", markeredgewidth=2, label=f"{pt.name}")
+        plt.plot(
+            pt.x, pt.y, ms=20, c=c, marker="+", markeredgewidth=2, label=f"{pt.name}"
+        )
 
         if show_names:
             # draw position name next to point
-            plt.text(pt.x, pt.y-50, pt.name, fontsize=14, color=c, alpha=0.75)
+            plt.text(pt.x, pt.y - 50, pt.name, fontsize=14, color=c, alpha=0.75)
 
     if show_scalebar:
         try:
             # add scalebar
             from matplotlib_scalebar.scalebar import ScaleBar
+
             scalebar = ScaleBar(
                 dx=image.metadata.pixel_size.x,
                 color="black",
@@ -241,23 +296,25 @@ def plot_stage_positions_on_image(
 
     return fig
 
+
 def plot_minimap(
-        image: FibsemImage,
-        positions: List[FibsemStagePosition],
-        current_position: Optional[FibsemStagePosition] = None,
-        grid_positions: Optional[List[FibsemStagePosition]] = None,
-        show: bool = False,
-        bound: bool = True,
-        color: str = "cyan",
-        show_scalebar: bool = False,
-        show_names: bool = True,
-        show_descriptions: bool = False,
-        descriptions: Optional[Dict[str, str]] = None,
-        show_grid_radius: bool = False,
-        fontsize: int = 12,
-        markersize: int = 20,
-        figsize: Optional[Tuple[int, int]] = (15, 15),
-        ax: Optional[plt.Axes] = None) -> Figure:
+    image: FibsemImage,
+    positions: List[FibsemStagePosition],
+    current_position: Optional[FibsemStagePosition] = None,
+    grid_positions: Optional[List[FibsemStagePosition]] = None,
+    show: bool = False,
+    bound: bool = True,
+    color: str = "cyan",
+    show_scalebar: bool = False,
+    show_names: bool = True,
+    show_descriptions: bool = False,
+    descriptions: Optional[Dict[str, str]] = None,
+    show_grid_radius: bool = False,
+    fontsize: int = 12,
+    markersize: int = 20,
+    figsize: Optional[Tuple[int, int]] = (15, 15),
+    ax: Optional[plt.Axes] = None,
+) -> Figure:
     """Plot stage positions reprojected on an image as matplotlib figure. Assumes image is flat to beam.
     Args:
         image: The image.
@@ -274,7 +331,9 @@ def plot_minimap(
     Returns:
         The matplotlib figure."""
     if image.metadata is None or image.metadata.microscope_state is None:
-        raise ValueError("Image metadata or microscope state is not set. Cannot reproject stage positions.")
+        raise ValueError(
+            "Image metadata or microscope state is not set. Cannot reproject stage positions."
+        )
 
     all_positions = list(positions)
     if current_position is not None:
@@ -289,16 +348,17 @@ def plot_minimap(
         fig = ax.figure
     ax.imshow(image.data, cmap="gray")
 
-    # reproject stage positions onto image 
+    # reproject stage positions onto image
     points = reproject_stage_positions_onto_image2(image=image, positions=all_positions)
 
     marker_entries: List[dict] = []
     for i, pt in enumerate(points):
-
         # if points outside image, don't plot
-        if bound and not is_inside_image_bounds((pt.y, pt.x), (image.data.shape[0], image.data.shape[1])):
+        if bound and not is_inside_image_bounds(
+            (pt.y, pt.x), (image.data.shape[0], image.data.shape[1])
+        ):
             continue
-        
+
         if pt.name is None:
             pt.name = f"Position {i:02d}"
 
@@ -319,8 +379,11 @@ def plot_minimap(
 
         # show grid radius
         if c == "red" and show_grid_radius:
-            r_pixels = 1000e-6 / image.metadata.pixel_size.x 
-            ax.add_artist(plt.Circle((pt.x, pt.y), radius=r_pixels, color=c, fill=False, linewidth=5)
+            r_pixels = 1000e-6 / image.metadata.pixel_size.x
+            ax.add_artist(
+                plt.Circle(
+                    (pt.x, pt.y), radius=r_pixels, color=c, fill=False, linewidth=5
+                )
             )
 
     if marker_entries:
@@ -331,7 +394,7 @@ def plot_minimap(
             scatter_array[:, 1],
             c=scatter_colors,
             marker="+",
-            s=markersize ** 2,
+            s=markersize**2,
             linewidths=2,
         )
 
@@ -365,6 +428,7 @@ def plot_minimap(
         try:
             # add scalebar
             from matplotlib_scalebar.scalebar import ScaleBar
+
             ax.add_artist(
                 ScaleBar(
                     dx=image.metadata.pixel_size.x,

--- a/fibsem/imaging/tiling/plotting.py
+++ b/fibsem/imaging/tiling/plotting.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from typing import Dict, List, Optional, Tuple
 
+import matplotlib.patheffects as path_effects
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.figure import Figure
@@ -34,6 +35,146 @@ POSITION_COLOURS = [
     "orange",
     "red",
 ]
+
+# Figure width in inches when the size is derived from the image. The height follows the
+# image's aspect, so a 3:1 overview gets a 3:1 figure.
+_AUTO_FIGURE_WIDTH_IN = 10.0
+
+# Clear space between a marker's edge and its label, in points.
+_LABEL_GAP_POINTS = 6.0
+
+# How near an edge a marker must be before its label is placed on the other side of it.
+# A fraction of the image rather than a pixel count, because overviews differ by orders
+# of magnitude in pixel size.
+_EDGE_FRACTION = 0.18
+
+
+def figsize_for_image(
+    image_shape: Tuple[int, ...], width_in: float = _AUTO_FIGURE_WIDTH_IN
+) -> Tuple[float, float]:
+    """A figure the same shape as the image, so the axes fills it.
+
+    A square figure holding a wide image spends the difference on blank paper, and
+    ``bbox_inches="tight"`` cannot reclaim it: the whitespace is inside the axes
+    rectangle, not around it. Measured on a real 3:1 overview drawn at ``figsize=(15,
+    15)``, the axes occupied 0.355 of the figure height -- so nearly two thirds of the
+    exported PNG was white.
+
+    Args:
+        image_shape: the image's ``.shape``; only the first two entries are read.
+        width_in: figure width in inches. The height is derived from it.
+    Returns:
+        ``(width, height)`` in inches, for ``figsize``.
+    """
+    height = float(image_shape[0]) if len(image_shape) > 0 else 0.0
+    width = float(image_shape[1]) if len(image_shape) > 1 else 0.0
+    if width <= 0 or height <= 0:
+        return (width_in, width_in)
+    # Clamped at both ends: an extreme mosaic would otherwise produce a figure feet wide
+    # and an inch tall, which has no room for a label, or the reverse.
+    aspect = min(max(height / width, 0.2), 5.0)
+    return (width_in, width_in * aspect)
+
+
+def _label_placement(
+    x: float,
+    y: float,
+    image_shape: Tuple[int, ...],
+    marker_half_points: float,
+) -> Tuple[Tuple[float, float], str, str]:
+    """Where a marker's label goes: an offset in points, plus how to align it.
+
+    Two things this fixes, both of which made labels unreadable on real overviews.
+
+    The offset is in **points**, derived from the marker's own size, rather than in image
+    pixels. A fixed pixel offset puts the label *inside* its marker at any real scale --
+    an overview pixel is tens of nanometres, so the old ``+10, -10`` was well within the
+    crosshair.
+
+    And the label is pushed away from whichever edge the marker is near, instead of being
+    clipped at it. ``clip_on`` truncates silently, so a name running off the right-hand
+    edge looked like a lamella that had simply been given a shorter name.
+    """
+    height = float(image_shape[0]) if len(image_shape) > 0 else 0.0
+    width = float(image_shape[1]) if len(image_shape) > 1 else 0.0
+    gap = marker_half_points + _LABEL_GAP_POINTS
+
+    if width > 0 and x > width * (1.0 - _EDGE_FRACTION):
+        dx, ha = -gap, "right"
+    else:
+        dx, ha = gap, "left"
+
+    # Screen terms, not data terms: an offset in points is measured in display space, so
+    # a positive dy is up the page whichever way the image's y-axis runs.
+    if height > 0 and y < height * _EDGE_FRACTION:
+        dy, va = -gap, "top"
+    else:
+        dy, va = gap, "bottom"
+
+    return (dx, dy), ha, va
+
+
+def _draw_position_label(
+    ax: plt.Axes,
+    x: float,
+    y: float,
+    label: str,
+    colour: str,
+    fontsize: float,
+    image_shape: Tuple[int, ...],
+    marker_half_points: float,
+    description: str = "",
+) -> None:
+    """Draw a marker's name, and its description beneath it if there is one.
+
+    The two are drawn as separate artists rather than one two-line string so the
+    description can be smaller, and they are stacked so that the block reads downwards
+    from the name wherever :func:`_label_placement` put it.
+    """
+    (dx, dy), ha, va = _label_placement(x, y, image_shape, marker_half_points)
+
+    # A halo, rather than the transparency it replaces. A single overview holds bright
+    # ice and black vacuum, and text at alpha 0.75 was hard to read on both.
+    halo = [path_effects.withStroke(linewidth=2.0, foreground="black", alpha=0.7)]
+
+    line_gap = fontsize + 2.0
+    sub_size = max(6.0, fontsize * 0.7)
+
+    # Above the marker, the name goes on top and the description sits between it and the
+    # marker; below the marker, the order is the other way up. Either way the name is the
+    # line further from the marker, so a column of markers reads name-first.
+    if description:
+        name_dy = dy + line_gap if va == "bottom" else dy
+        sub_dy = dy if va == "bottom" else dy - line_gap
+    else:
+        name_dy, sub_dy = dy, dy
+
+    ax.annotate(
+        label,
+        xy=(x, y),
+        xytext=(dx, name_dy),
+        textcoords="offset points",
+        fontsize=fontsize,
+        color=colour,
+        ha=ha,
+        va=va,
+        path_effects=halo,
+        annotation_clip=False,
+    )
+
+    if description:
+        ax.annotate(
+            description,
+            xy=(x, y),
+            xytext=(dx, sub_dy),
+            textcoords="offset points",
+            fontsize=sub_size,
+            color=colour,
+            ha=ha,
+            va=va,
+            path_effects=halo,
+            annotation_clip=False,
+        )
 
 
 def plot_tile_positions(
@@ -232,7 +373,7 @@ def plot_stage_positions_on_image(
     color: Optional[str] = None,
     show_scalebar: bool = False,
     show_names: bool = True,
-    figsize: Optional[Tuple[int, int]] = (15, 15),
+    figsize: Optional[Tuple[int, int]] = None,
 ) -> Figure:
     """Plot stage positions reprojected on an image as matplotlib figure. Assumes image is flat to beam.
     Args:
@@ -241,6 +382,8 @@ def plot_stage_positions_on_image(
         show: Whether to show the plot.
         bound: Whether to only plot points inside the image.
         color: The color of the points. (None -> default colour cycle)
+        figsize: Figure size in inches. None (the default) sizes the figure to the
+            image's aspect -- see :func:`figsize_for_image`.
     Returns:
         The matplotlib figure."""
     if image.metadata is None or image.metadata.microscope_state is None:
@@ -252,9 +395,14 @@ def plot_stage_positions_on_image(
     points = reproject_stage_positions_onto_image2(image=image, positions=positions)
 
     # construct matplotlib figure
+    if figsize is None:
+        figsize = figsize_for_image(image.data.shape)
     fig = plt.figure(figsize=figsize)
-    plt.imshow(image.data, cmap="gray")
+    ax = fig.gca()
+    ax.imshow(image.data, cmap="gray")
 
+    # `ms` is the marker's width in points, so it reaches half that from its centre.
+    marker_size_points = 20
     for i, pt in enumerate(points):
         # if points outside image, don't plot
         if bound and not is_inside_image_bounds(
@@ -266,13 +414,28 @@ def plot_stage_positions_on_image(
             c = POSITION_COLOURS[i % len(POSITION_COLOURS)]
         else:
             c = color
-        plt.plot(
-            pt.x, pt.y, ms=20, c=c, marker="+", markeredgewidth=2, label=f"{pt.name}"
+        ax.plot(
+            pt.x,
+            pt.y,
+            ms=marker_size_points,
+            c=c,
+            marker="+",
+            markeredgewidth=2,
+            label=f"{pt.name}",
         )
 
         if show_names:
             # draw position name next to point
-            plt.text(pt.x, pt.y - 50, pt.name, fontsize=14, color=c, alpha=0.75)
+            _draw_position_label(
+                ax,
+                pt.x,
+                pt.y,
+                label=pt.name if pt.name else f"Position {i:02d}",
+                colour=c,
+                fontsize=14,
+                image_shape=image.data.shape,
+                marker_half_points=marker_size_points / 2.0,
+            )
 
     if show_scalebar:
         try:
@@ -286,11 +449,11 @@ def plot_stage_positions_on_image(
                 box_alpha=0.5,
                 location="lower right",
             )
-            plt.gca().add_artist(scalebar)
+            ax.add_artist(scalebar)
         except Exception as e:
             logging.debug(f"Could not add scalebar: {e}")
 
-    plt.axis("off")
+    ax.axis("off")
     if show:
         plt.show()
 
@@ -312,7 +475,7 @@ def plot_minimap(
     show_grid_radius: bool = False,
     fontsize: int = 12,
     markersize: int = 20,
-    figsize: Optional[Tuple[int, int]] = (15, 15),
+    figsize: Optional[Tuple[int, int]] = None,
     ax: Optional[plt.Axes] = None,
 ) -> Figure:
     """Plot stage positions reprojected on an image as matplotlib figure. Assumes image is flat to beam.
@@ -327,7 +490,9 @@ def plot_minimap(
         show_scalebar: Whether to show a scalebar
         show_names: Whether to show position names as labels
         fontsize: Font size for position name labels (default: 14)
-        figsize: Figure size in inches (default: (15, 15))
+        figsize: Figure size in inches. None (the default) sizes the figure to the
+            image's aspect -- see :func:`figsize_for_image` for why that is not merely
+            tidier. Ignored when `ax` is supplied.
     Returns:
         The matplotlib figure."""
     if image.metadata is None or image.metadata.microscope_state is None:
@@ -343,6 +508,8 @@ def plot_minimap(
 
     # construct matplotlib figure/axes
     if ax is None:
+        if figsize is None:
+            figsize = figsize_for_image(image.data.shape)
         fig, ax = plt.subplots(figsize=figsize)
     else:
         fig = ax.figure
@@ -399,30 +566,22 @@ def plot_minimap(
         )
 
         if show_names:
+            # `s` is an area in points squared, so a marker drawn at `markersize ** 2`
+            # spans `markersize` points and reaches half that from its centre.
+            marker_half_points = markersize / 2.0
             for entry in marker_entries:
                 x, y = entry["point"]
-                ax.text(
-                    x + 10,
-                    y - 10,
-                    entry["label"],
+                _draw_position_label(
+                    ax,
+                    x,
+                    y,
+                    label=entry["label"],
+                    colour=entry["color"],
                     fontsize=fontsize,
-                    color=entry["color"],
-                    alpha=0.75,
-                    clip_on=True,
+                    image_shape=image.data.shape,
+                    marker_half_points=marker_half_points,
+                    description=(entry["description"] if show_descriptions else ""),
                 )
-                # description as a smaller subtitle just below the name
-                if show_descriptions and entry["description"]:
-                    ax.annotate(
-                        entry["description"],
-                        xy=(x + 10, y - 10),
-                        xytext=(0, -(fontsize + 2)),
-                        textcoords="offset points",
-                        fontsize=max(6, int(round(fontsize * 0.7))),
-                        color=entry["color"],
-                        alpha=0.6,
-                        va="top",
-                        annotation_clip=True,
-                    )
 
     if show_scalebar:
         try:

--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -170,8 +170,7 @@ _STATUS_FLASH_STYLE = (
 # Padded vertically, unlike the status chips: those are a fixed row height, this one
 # sizes to however many lines it is given.
 _INFO_BAR_STYLE = (
-    f"QLabel {{ color: #e8e8e8; font-size: 9px; padding: 3px 6px;"
-    f" {_STATUS_PLAQUE} }}"
+    f"QLabel {{ color: #e8e8e8; font-size: 9px; padding: 3px 6px; {_STATUS_PLAQUE} }}"
 )
 
 
@@ -232,10 +231,18 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
     """
 
     # Trailing ``object`` is a tuple of napari-style modifier strings, e.g. ("Alt",).
-    canvas_clicked = pyqtSignal(float, float, object)  # left single-click (x, y) px, mods
-    canvas_double_clicked = pyqtSignal(float, float, object)  # left double-click (x, y) px, mods
-    canvas_right_clicked = pyqtSignal(float, float, object)  # right single-click (x, y) px, mods
-    canvas_scrolled = pyqtSignal(float, float, int, object)  # (x, y) px, dir +1/-1, mods
+    canvas_clicked = pyqtSignal(
+        float, float, object
+    )  # left single-click (x, y) px, mods
+    canvas_double_clicked = pyqtSignal(
+        float, float, object
+    )  # left double-click (x, y) px, mods
+    canvas_right_clicked = pyqtSignal(
+        float, float, object
+    )  # right single-click (x, y) px, mods
+    canvas_scrolled = pyqtSignal(
+        float, float, int, object
+    )  # (x, y) px, dir +1/-1, mods
     # Where the cursor is, in canvas coordinates, or (None, None) once it leaves the
     # axes -- so a readout can blank rather than freeze on the last point it saw.
     # Typed `object` for exactly that: pyqtSignal(float, float) cannot carry None.
@@ -338,7 +345,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self.mpl_connect("resize_event", lambda _: self.draw_idle())
         # A motion event with `inaxes` unset covers most exits, but a fast flick off
         # the widget can skip one and leave a readout showing a stale point.
-        self.mpl_connect("figure_leave_event", lambda _: self.cursor_moved.emit(None, None))
+        self.mpl_connect(
+            "figure_leave_event", lambda _: self.cursor_moved.emit(None, None)
+        )
 
         # Overlay buttons (parented to self; repositioned in resizeEvent)
         self._overlay_buttons: List[QPushButton] = []
@@ -351,7 +360,10 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             "mdi:fit-to-screen-outline", "Reset view", self.reset_view
         )
         self.btn_toggle_scalebar = self._add_overlay_button(
-            "mdi:arrow-expand-horizontal", "Hide scalebar", self.toggle_scalebar, checkable=True
+            "mdi:arrow-expand-horizontal",
+            "Hide scalebar",
+            self.toggle_scalebar,
+            checkable=True,
         )
         self.btn_toggle_scalebar.setChecked(True)
         self.btn_toggle_crosshair = self._add_overlay_button(
@@ -534,11 +546,21 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             self._title_artist = None
         if self._title_text:
             self._title_artist = self._ax.text(
-                0.5, self._top_chrome_y(), self._title_text,
-                transform=self.figure.transFigure, ha="center", va="top",
-                fontsize=10, color=WHITE_ICON_COLOR, zorder=11,
-                bbox=dict(boxstyle="round,pad=0.3", facecolor=_BG,
-                          edgecolor="none", alpha=0.55),
+                0.5,
+                self._top_chrome_y(),
+                self._title_text,
+                transform=self.figure.transFigure,
+                ha="center",
+                va="top",
+                fontsize=10,
+                color=WHITE_ICON_COLOR,
+                zorder=11,
+                bbox=dict(
+                    boxstyle="round,pad=0.3",
+                    facecolor=_BG,
+                    edgecolor="none",
+                    alpha=0.55,
+                ),
             )
 
     def set_info_text(self, text: Optional[str]) -> None:
@@ -727,18 +749,34 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             marker = entry[2] if len(entry) > 2 else None
             labels.append(label)
             if marker:
-                handles.append(Line2D(
-                    [], [], linestyle="None", marker=marker, markersize=9,
-                    color=color, markeredgewidth=1.6, label=label,
-                ))
+                handles.append(
+                    Line2D(
+                        [],
+                        [],
+                        linestyle="None",
+                        marker=marker,
+                        markersize=9,
+                        color=color,
+                        markeredgewidth=1.6,
+                        label=label,
+                    )
+                )
             else:
-                handles.append(mpatches.Patch(facecolor=color, edgecolor="white", label=label))
+                handles.append(
+                    mpatches.Patch(facecolor=color, edgecolor="white", label=label)
+                )
         # Build the Legend directly (not ax.legend) so it doesn't replace an overlay's
         # own legend (e.g. milling stages); styled like the point/milling legends.
         leg = Legend(
-            self._ax, handles, labels, loc=self._legend_loc,
-            fontsize=7, facecolor=_BG, edgecolor="#555555",
-            labelcolor="#d1d2d4", framealpha=0.85,
+            self._ax,
+            handles,
+            labels,
+            loc=self._legend_loc,
+            fontsize=7,
+            facecolor=_BG,
+            edgecolor="#555555",
+            labelcolor="#d1d2d4",
+            framealpha=0.85,
         )
         leg.set_zorder(10)
         self._ax.add_artist(leg)
@@ -752,7 +790,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._ax.cla()
         self._scalebar_artist = None
         self._crosshair_artists = []
-        self._hint_text = None  # the status chip is a widget; hidden below, not by cla()
+        self._hint_text = (
+            None  # the status chip is a widget; hidden below, not by cla()
+        )
         self._title_artist = None
         self._title_text = None
         self._info_text = None
@@ -849,7 +889,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         metrics = QFontMetrics(label.font())
         # `sizeHint` carries the stylesheet padding, which the metrics do not.
         label.setText(self._status_full_text)
-        padding = max(label.sizeHint().width() - metrics.width(self._status_full_text), 0)
+        padding = max(
+            label.sizeHint().width() - metrics.width(self._status_full_text), 0
+        )
         label.setText(
             metrics.elidedText(
                 self._status_full_text, Qt.ElideRight, max(available - padding, 0)
@@ -873,7 +915,8 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._toolbar_visible = visible
         if not visible:
             self._toolbar_hidden = [
-                b for b in self._overlay_buttons
+                b
+                for b in self._overlay_buttons
                 if b is not self.btn_mode and not b.isHidden()
             ]
             for b in self._toolbar_hidden:
@@ -1100,7 +1143,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         if self._mode_overlay is None:
             return
         if self.btn_mode.isChecked():
-            self.btn_mode.setToolTip(f"{self._mode_label} active — click to enable Move")
+            self.btn_mode.setToolTip(
+                f"{self._mode_label} active — click to enable Move"
+            )
             self.set_active_overlay(self._mode_overlay)
         else:
             self.btn_mode.setToolTip(f"Click to resume {self._mode_label}")
@@ -1168,7 +1213,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         """Show or hide the floating contrast / gamma popover."""
         self._contrast.set_open(self.btn_contrast.isChecked(), self.btn_contrast)
 
-    def _contrast_display(self) -> Tuple[Optional[np.ndarray], Optional[Tuple[float, float]]]:
+    def _contrast_display(
+        self,
+    ) -> Tuple[Optional[np.ndarray], Optional[Tuple[float, float]]]:
         """Return (array_to_show, clim) for the current contrast state.
 
         When the control is at its defaults (or the image is RGB) the raw
@@ -1197,7 +1244,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             im.set_clim(*clim)
         elif self._is_gray and self._display_base is not None:
             # back to default → restore the raw intensity range
-            im.set_clim(float(self._display_base.min()), float(self._display_base.max()))
+            im.set_clim(
+                float(self._display_base.min()), float(self._display_base.max())
+            )
         self.draw_idle()
 
     def _refresh_scalebar(self):
@@ -1322,7 +1371,9 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
                 and event.xdata is not None
                 and event.ydata is not None
             ):
-                self.canvas_clicked.emit(event.xdata, event.ydata, self._press_modifiers)
+                self.canvas_clicked.emit(
+                    event.xdata, event.ydata, self._press_modifiers
+                )
         self._pan_start = None
 
     def wheelEvent(self, event):
@@ -1355,8 +1406,11 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
             steps = (angle.x() / 120) or pixel.x()
             if steps:
                 MouseEvent(
-                    "scroll_event", self, *self.mouseEventCoords(event),
-                    step=steps, guiEvent=event,
+                    "scroll_event",
+                    self,
+                    *self.mouseEventCoords(event),
+                    step=steps,
+                    guiEvent=event,
                 )._process()
                 event.accept()
                 return

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -562,6 +562,12 @@ class TitledPanel(QWidget):
 
         # Header
         self._header = QWidget()
+        # Fixed height, or the header absorbs whatever vertical slack the panel is given.
+        # A QVBoxLayout hands spare space to every child that will take it, and a bare
+        # QWidget will: in a horizontal layout beside a tall canvas that grew the header
+        # row to 416 px, leaving the title floating in the middle of an empty block with
+        # the controls pushed below it.
+        self._header.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
         self._header.setStyleSheet(
             f"background: {CANVAS_BG}; border-radius: 3px 3px 0 0;"
         )

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -71,7 +71,7 @@ class QFilePathLineEdit(QWidget):
 
     def text(self) -> str:
         return self.lineEdit.text()
-    
+
     def setText(self, text: str) -> None:
         self.lineEdit.setText(text)
 
@@ -100,7 +100,9 @@ class QDirectoryLineEdit(QWidget):
         self.lineEdit.editingFinished.connect(self.editingFinished.emit)
 
     def browse_directory(self):
-        directory = QFileDialog.getExistingDirectory(self, "Select Directory", self.lineEdit.text())
+        directory = QFileDialog.getExistingDirectory(
+            self, "Select Directory", self.lineEdit.text()
+        )
         if directory:
             self.lineEdit.setText(directory)
             self.textChanged.emit(directory)
@@ -111,6 +113,7 @@ class QDirectoryLineEdit(QWidget):
 
     def setText(self, text: str) -> None:
         self.lineEdit.setText(text)
+
 
 class QFileLineEdit(QWidget):
     """Line edit with a browse button that opens a file picker dialog."""
@@ -153,11 +156,13 @@ class QFileLineEdit(QWidget):
         self.lineEdit.setText(text)
 
 
-def _create_combobox_control(value: Union[str, int, float, Enum],
-                             items: list, 
-                             units: Optional[str], 
-                             format_fn: Optional[Callable] = None, 
-                             control: Optional[QComboBox] = None) -> QComboBox:
+def _create_combobox_control(
+    value: Union[str, int, float, Enum],
+    items: list,
+    units: Optional[str],
+    format_fn: Optional[Callable] = None,
+    control: Optional[QComboBox] = None,
+) -> QComboBox:
     """Create a QComboBox control for selecting from a list of items."""
     if control is None:
         control = QComboBox()
@@ -165,7 +170,7 @@ def _create_combobox_control(value: Union[str, int, float, Enum],
         if isinstance(item, (float, int)):
             item_str = format_value(val=item, unit=units, precision=1)
         elif isinstance(item, Enum):
-            item_str = item.name # TODO: migrate to QEnumComboBox
+            item_str = item.name  # TODO: migrate to QEnumComboBox
         elif format_fn is not None:
             item_str = format_fn(item)
         else:
@@ -186,7 +191,9 @@ def _create_combobox_control(value: Union[str, int, float, Enum],
         if len(items) == 0:
             logging.warning(f"No items available for combobox with value {value}")
         else:
-            logging.debug(f"Warning: No matching item or nearest found for {items} with value {value}. Using first item.")
+            logging.debug(
+                f"Warning: No matching item or nearest found for {items} with value {value}. Using first item."
+            )
             idx = 0
 
     if idx >= 0:
@@ -327,7 +334,10 @@ class ValueSpinBox(QDoubleSpinBox):
         super().__init__(parent)
         if suffix:
             self.setSuffix(f" {suffix}")
-        self.setRange(minimum if minimum is not None else 0.0, maximum if maximum is not None else 1e6)
+        self.setRange(
+            minimum if minimum is not None else 0.0,
+            maximum if maximum is not None else 1e6,
+        )
         self.setSingleStep(step if step is not None else 0.01)
         self.setDecimals(decimals if decimals is not None else 3)
         if tooltip:
@@ -341,6 +351,7 @@ class ValueSpinBox(QDoubleSpinBox):
 @dataclass
 class ContextMenuAction:
     """Represents a single action in a context menu."""
+
     label: str
     callback: Optional[Callable] = None
     icon: Optional[QIcon] = None
@@ -353,6 +364,7 @@ class ContextMenuAction:
 @dataclass
 class ContextMenuConfig:
     """Configuration for a context menu."""
+
     actions: list[ContextMenuAction] = field(default_factory=list)
 
     def add_action(
@@ -366,15 +378,17 @@ class ContextMenuConfig:
         data: Optional[Any] = None,
     ) -> "ContextMenuConfig":
         """Add an action to the menu configuration. Returns self for chaining."""
-        self.actions.append(ContextMenuAction(
-            label=label,
-            callback=callback,
-            icon=icon,
-            tooltip=tooltip,
-            enabled=enabled,
-            separator_after=separator_after,
-            data=data,
-        ))
+        self.actions.append(
+            ContextMenuAction(
+                label=label,
+                callback=callback,
+                icon=icon,
+                tooltip=tooltip,
+                enabled=enabled,
+                separator_after=separator_after,
+                data=data,
+            )
+        )
         return self
 
     def add_separator(self) -> "ContextMenuConfig":
@@ -476,7 +490,9 @@ class ContextMenu(QMenu):
             if menu_action.callback is not None:
                 menu_action.callback()
         except Exception:
-            logging.exception("Context menu action '%s' raised an exception.", menu_action.label)
+            logging.exception(
+                "Context menu action '%s' raised an exception.", menu_action.label
+            )
             try:
                 from fibsem.ui import notification_service
 
@@ -514,6 +530,7 @@ def show_context_menu(
     selected = menu.show_at_cursor()
     return selected.label if selected else None
 
+
 class TitledPanel(QWidget):
     """A styled panel with a dark header row (title label + optional widgets) and a collapsible content area.
 
@@ -525,8 +542,13 @@ class TitledPanel(QWidget):
         fixed = TitledPanel("Setup", content=setup_widget, collapsible=False)
     """
 
-    def __init__(self, title: str, content: Optional[QWidget] = None,
-                 collapsible: bool = True, parent=None) -> None:
+    def __init__(
+        self,
+        title: str,
+        content: Optional[QWidget] = None,
+        collapsible: bool = True,
+        parent=None,
+    ) -> None:
         super().__init__(parent)
         self._collapsible = collapsible
         self.setObjectName("TitledPanel")
@@ -540,7 +562,9 @@ class TitledPanel(QWidget):
 
         # Header
         self._header = QWidget()
-        self._header.setStyleSheet(f"background: {CANVAS_BG}; border-radius: 3px 3px 0 0;")
+        self._header.setStyleSheet(
+            f"background: {CANVAS_BG}; border-radius: 3px 3px 0 0;"
+        )
         self._header_layout = QHBoxLayout(self._header)
         self._header_layout.setContentsMargins(8, 3, 4, 3)
         self._header_layout.setSpacing(4)
@@ -615,8 +639,15 @@ class _SpinnerLabel(QLabel):
     it ``autostart`` and drive visibility via :meth:`start`/:meth:`stop`.
     """
 
-    def __init__(self, icon_name="mdi:loading", color="#4fc3f7", size=24,
-                 step_deg=20, interval_ms=40, parent=None):
+    def __init__(
+        self,
+        icon_name="mdi:loading",
+        color="#4fc3f7",
+        size=24,
+        step_deg=20,
+        interval_ms=40,
+        parent=None,
+    ):
         super().__init__(parent)
         self._spin = qta.Spin(self, interval=interval_ms, step=step_deg)
         self._icon = fibsem_icon(icon_name, color=color, animation=self._spin)
@@ -645,7 +676,7 @@ class _SpinnerLabel(QLabel):
     def stop(self):
         self._active = False
         self._spin.stop()
-        self.update()        # repaint blank
+        self.update()  # repaint blank
 
     def clear(self):
         # blanking the spinner implies stopping its animation
@@ -699,11 +730,17 @@ class IconToolButton(QToolButton):
         self._icon = icon
         self._color = color
         self._checked_icon = checked_icon if checked_icon is not None else icon
-        self._checked_color = checked_color if checked_color is not None else stylesheets.GRAY_WHITE_COLOR
+        self._checked_color = (
+            checked_color if checked_color is not None else stylesheets.GRAY_WHITE_COLOR
+        )
         self._tooltip = tooltip
-        self._checked_tooltip = checked_tooltip if checked_tooltip is not None else tooltip
+        self._checked_tooltip = (
+            checked_tooltip if checked_tooltip is not None else tooltip
+        )
 
-        self._has_state = checkable or checked_icon is not None or checked_color is not None
+        self._has_state = (
+            checkable or checked_icon is not None or checked_color is not None
+        )
 
         self.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
         if size is not None:
@@ -765,7 +802,9 @@ class TaskNameListWidget(QWidget):
         header_layout.addWidget(lbl)
         header_layout.addStretch()
         self.btn_add = IconToolButton("mdi:plus", tooltip="Add task", size=24)
-        self.btn_remove = IconToolButton("mdi:trash-can-outline", tooltip="Remove task", size=24)
+        self.btn_remove = IconToolButton(
+            "mdi:trash-can-outline", tooltip="Remove task", size=24
+        )
         header_layout.addWidget(self.btn_add)
         header_layout.addWidget(self.btn_remove)
         outer.addWidget(header)
@@ -819,8 +858,6 @@ class TaskNameListWidget(QWidget):
             self.select(preferred)
         elif self._list.count() > 0:
             self._list.setCurrentRow(0)
-
-
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_overview_plot_rendering.py
+++ b/tests/test_overview_plot_rendering.py
@@ -1,0 +1,237 @@
+"""What the exported overview plot must look like, as opposed to what it contains.
+
+The reprojection these plots draw is covered elsewhere (`test_reprojection.py`,
+`test_beam_stage_projection.py`); this file covers the *rendering*, which had nothing.
+Three defects motivate it, all reproduced against a real experiment before being fixed:
+
+- a wide overview drawn into a square figure spent about two thirds of the exported page
+  on blank paper, and `bbox_inches="tight"` could not reclaim any of it;
+- labels were offset a fixed number of *image pixels* from their marker, which at any
+  real overview scale is inside the crosshair, and were clipped rather than moved at the
+  image border, so a name near the edge silently lost its tail;
+- `TitledPanel` grew its header row to fill whatever vertical space the panel was given.
+
+Each test below fails on the behaviour it replaces.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+from fibsem import utils
+from fibsem.imaging.tiling.plotting import (
+    _label_placement,
+    figsize_for_image,
+    plot_minimap,
+)
+from fibsem.structures import (
+    BeamType,
+    FibsemImage,
+    FibsemStagePosition,
+    ImageSettings,
+)
+
+matplotlib = pytest.importorskip("matplotlib")
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402  (after the backend is chosen)
+
+# Deliberately wide. A square test image would pass the figure-shape assertions no
+# matter what the code did, which is how this went unnoticed.
+_WIDE_SHAPE = (256, 768)  # (height, width) -> 3:1
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    import fibsem.config as fibsem_config
+
+    path = os.path.join(
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "microscope-configuration.yaml",
+    )
+    scope, _ = utils.setup_session(manufacturer="Demo", config_path=path)
+    return scope
+
+
+@pytest.fixture(scope="module")
+def wide_overview(microscope) -> FibsemImage:
+    """A 3:1 image carrying enough metadata for the reprojection to run."""
+    image = FibsemImage.generate_blank_image(
+        resolution=(_WIDE_SHAPE[1], _WIDE_SHAPE[0]), hfw=900e-6
+    )
+    image.data = np.zeros(_WIDE_SHAPE, dtype=np.uint8)
+    state = microscope.get_microscope_state(beam_type=BeamType.ELECTRON)
+    image.metadata.image_settings = ImageSettings(
+        hfw=900e-6, beam_type=BeamType.ELECTRON
+    )
+    image.metadata.microscope_state = state
+    image.metadata.system_info = microscope.system.info
+    image.metadata.hardware_geometry = microscope.hardware_geometry()
+    return image
+
+
+def _page_used_by_axes(ax) -> float:
+    """The fraction of the figure's height the axes occupies.
+
+    Deliberately *not* the axes box's aspect ratio, which was the first thing tried and
+    is useless here: `imshow` fixes the axes aspect to the image's, and `tight_layout`
+    shrinks the box to suit, so the box comes out at the image's aspect whatever shape
+    the figure is. The waste is the page *around* that box -- which is exactly what
+    `bbox_inches="tight"` also cannot see, since a bounding box is a rectangle and the
+    gap between the title and the image lies inside it.
+    """
+    return ax.get_position().bounds[3]
+
+
+class TestFigureShape:
+    """The figure follows the image, so the page is not mostly margin."""
+
+    def test_matches_the_image_aspect(self):
+        width, height = figsize_for_image(_WIDE_SHAPE)
+        assert width / height == pytest.approx(3.0)
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (0, 0),  # a degenerate array
+            (10,),  # a shape too short to have two axes
+            (),  # no shape at all
+        ],
+    )
+    def test_degenerate_shapes_do_not_raise(self, shape):
+        """Rendering must not be the thing that reports a malformed image."""
+        width, height = figsize_for_image(shape)
+        assert width > 0 and height > 0
+
+    @pytest.mark.parametrize("shape", [(1, 10_000), (10_000, 1)])
+    def test_extreme_aspects_are_clamped(self, shape):
+        """A ribbon of a mosaic still has to leave room for a readable label."""
+        width, height = figsize_for_image(shape)
+        assert 0.2 <= height / width <= 5.0
+
+    def test_the_axes_fills_the_figure_it_is_given(self, wide_overview):
+        """The assertion the old square default failed: 0.355 of the figure height.
+
+        End to end rather than on `figsize_for_image` alone, so that wiring the helper
+        up but not calling it -- which is the likelier regression -- is caught too.
+        """
+        fig = plot_minimap(wide_overview, positions=[], figsize=None)
+        try:
+            fig.tight_layout()
+            used = _page_used_by_axes(fig.axes[0])
+            assert used > 0.6, (
+                f"the image occupies {used:.0%} of the exported page height; "
+                "the rest is blank paper that no bbox can trim"
+            )
+        finally:
+            plt.close(fig)
+
+    def test_an_explicit_figsize_still_wins(self, wide_overview):
+        """Callers that know what page they are filling keep control."""
+        fig = plot_minimap(wide_overview, positions=[], figsize=(6, 6))
+        try:
+            assert tuple(fig.get_size_inches()) == (6, 6)
+        finally:
+            plt.close(fig)
+
+
+class TestLabelPlacement:
+    """Labels clear their marker, and stay on the page."""
+
+    def test_offset_clears_the_marker(self):
+        """In points, and scaled to the marker -- not a fixed count of image pixels."""
+        (dx_small, _), _, _ = _label_placement(100, 100, _WIDE_SHAPE, 5.0)
+        (dx_large, _), _, _ = _label_placement(100, 100, _WIDE_SHAPE, 50.0)
+        assert abs(dx_large) > abs(dx_small)
+        assert abs(dx_small) > 5.0
+        assert abs(dx_large) > 50.0
+
+    def test_a_marker_near_the_right_edge_is_labelled_to_its_left(self):
+        (dx, _), ha, _ = _label_placement(
+            x=_WIDE_SHAPE[1] - 5, y=128, image_shape=_WIDE_SHAPE, marker_half_points=10
+        )
+        assert dx < 0 and ha == "right"
+
+    def test_a_marker_near_the_top_is_labelled_below_it(self):
+        """Offsets are display-space, so a negative dy is down the page."""
+        (_, dy), _, va = _label_placement(
+            x=384, y=2, image_shape=_WIDE_SHAPE, marker_half_points=10
+        )
+        assert dy < 0 and va == "top"
+
+    def test_a_marker_in_open_ground_is_labelled_above_and_right(self):
+        (dx, dy), ha, va = _label_placement(
+            x=384, y=128, image_shape=_WIDE_SHAPE, marker_half_points=10
+        )
+        assert dx > 0 and dy > 0
+        assert (ha, va) == ("left", "bottom")
+
+    def test_edge_labels_are_drawn_inside_the_image(self, wide_overview):
+        """End to end: the name of a position at the right-hand edge lands on the image.
+
+        The behaviour this replaces offset every label the same way and set
+        `clip_on=True`, so this label was drawn past the edge and then silently cut in
+        half -- which reads as a shorter name, not as a bug.
+        """
+        state = wide_overview.metadata.microscope_state
+        assert state.stage_position is not None
+        # A position a little to the right of the image centre, so it reprojects near
+        # the right-hand edge of a 900 um field.
+        edge = FibsemStagePosition(
+            x=state.stage_position.x + 380e-6,
+            y=state.stage_position.y,
+            z=state.stage_position.z,
+            r=state.stage_position.r,
+            t=state.stage_position.t,
+            coordinate_system="RAW",
+        )
+        edge.name = "a-long-lamella-name"
+
+        fig = plot_minimap(
+            wide_overview, positions=[edge], show_names=True, figsize=None
+        )
+        try:
+            ax = fig.axes[0]
+            fig.canvas.draw()
+            labels = [a for a in ax.texts if a.get_text() == "a-long-lamella-name"]
+            assert labels, "the position was not labelled at all"
+            box = labels[0].get_window_extent(fig.canvas.get_renderer())
+            axes_box = ax.get_window_extent()
+            assert box.x1 <= axes_box.x1 + 1, "the label ran off the right of the image"
+            assert box.x0 >= axes_box.x0 - 1, "the label ran off the left of the image"
+        finally:
+            plt.close(fig)
+
+
+class TestTitledPanelHeader:
+    """The header is a row, not a claim on the whole panel."""
+
+    def test_header_does_not_absorb_vertical_slack(self, qapp):
+        from PyQt5.QtWidgets import QHBoxLayout, QLabel, QWidget
+
+        from fibsem.ui.widgets.custom_widgets import TitledPanel
+
+        content = QWidget()
+        QHBoxLayout(content).addWidget(QLabel("a row of controls"))
+        panel = TitledPanel("Options", content=content, collapsible=False)
+
+        # A tall neighbour, which is what the overview export dialog is: a panel beside
+        # a canvas. Before the fix the header took half of the 800 px.
+        tall = QLabel()
+        tall.setMinimumHeight(800)
+
+        host = QWidget()
+        row = QHBoxLayout(host)
+        row.addWidget(tall)
+        row.addWidget(panel)
+        host.resize(1000, 800)
+        host.show()
+        qapp.processEvents()
+
+        header_height = panel._header.height()
+        assert header_height < 60, (
+            f"the header grew to {header_height} px; it should stay a single row"
+        )
+
+        host.close()


### PR DESCRIPTION
First of five stacked PRs turning the overview plot into a document you could actually send someone. This one is only bug fixes — no new features, no new UI — and is worth taking on its own.

Reproduced against a real two-lamella experiment before being touched.

## What was wrong

**Two thirds of the exported page was blank.** The figure was pinned to `figsize=(15, 15)` while a stitched overview is typically much wider than tall. Measured on a 3:1 overview: the image occupied **0.355** of the page height. `bbox_inches="tight"` cannot reclaim that — a bounding box is a rectangle, so it spans the gap between the title and the image rather than removing it.

**Labels sat inside their own markers, and ran off the edge.** Text was offset a flat ten *image pixels* from the marker, which at any real overview scale is well within the crosshair. Near a border it was clipped rather than moved — and `clip_on` truncates silently, so a name running off the right-hand edge read as a lamella that had been given a shorter name.

**`TitledPanel`'s header absorbed the panel's vertical slack.** Measured at **416 px** beside a tall canvas, with the title floating in the middle of an empty block. This affects every `TitledPanel` used in a horizontal layout, not just this dialog.

## Two things that turned out differently once the code was open

Sizing the figure is necessary but **not sufficient**. A `FigureCanvas` resizes its figure to the *widget* as soon as the preview is shown, so what got saved was the dialog's shape rather than the overview's. The export now renders its own figure and copies the axes limits across, so a zoomed preview still exports the region it is showing. That also retires the trick it replaces — recolouring the preview's title black, saving, and putting it back — which was correct only for callers going through that one method and no use to a headless one.

Fixing the panel header exposed a second layout bug behind it: the dialog's canvas had only ever *looked* full because the stretching header was filling the row. The canvas now expands.

## Correction to an earlier claim

I originally reported the exported title as invisible. That was wrong: it came from calling `savefig` directly, which is not what the button does. Through Save Image the title is black and correct, and the PDF report was never affected either — it draws its own suptitle in the default black. The real issue was narrower (correctness depending on one method mutating an artist) and is fixed as a side effect of the above.

## Blast radius

`figsize_for_image` and the label placement live in the shared renderer, so **the PDF report's overview page gets them too**.

The `TitledPanel` change touches all 87 panels. Swept six layout combinations (vertical/horizontal × 1/3/10 content rows): header is a consistent 31 px in every one. Collapse behaviour is byte-identical to `main` — verified by comparing `sizeHint` before and after on both.

## Verification

- Exported image occupies **33% → 79%** of page height.
- `TitledPanel` header **416 px → 26 px**.
- 14 new tests, in the first test file the reporting render path has ever had. **Each was checked to fail on the behaviour it replaces** — I reverted each fix individually. The first version of the whitespace test passed on the old code (`tight_layout` gives the axes box the image's aspect even inside a square figure — the waste is *around* it), so the metric was replaced.
- Real menu path driven via `AutoLamellaUI.action_generate_overview_plot()`: dialog opens, **0 Qt warnings**.
- `tests/ui` + `tests/autolamella`: 2794 passed, 2 failed — both `test_coincidence_viewer_layering.py`, which pass in isolation and **fail identically on `main`** (known window-leak interaction).
- ruff clean; parses under Python 3.8.

Screen recording is blocked on this machine, so the visual checks are `QWidget.grab()` renders with the real `NAPARI_STYLE` applied, not photographs of the live window.

## Two commits

`[format] Apply ruff format to the files this series touches` comes first, separated so the review is not several hundred lines of whitespace around the substance — `structures.py` and `reporting.py` carry most of it. Same shape as #564.

Verified at the AST level rather than by reading: parsed before and after and compared `ast.dump`. Five files are AST-identical; two differ only in docstring constants, which is ruff re-indenting continuation lines — confirmed by normalising string whitespace and re-comparing, which takes both to zero.

Rebased onto #564, whose marker change is preserved.
