### PR TITLE
[feat] Canvas: save the current view as an image

### DIFF
--- a/fibsem/ui/widgets/canvas/canvas_base.py
+++ b/fibsem/ui/widgets/canvas/canvas_base.py
@@ -1437,6 +1437,80 @@ class FibsemCanvasBase(FigureCanvasQTAgg):
         self._view_moved_by_user()
         self._schedule_redraw()
 
+    # ── export ───────────────────────────────────────────────────────────
+
+    def save_view(
+        self,
+        path: str,
+        dpi: int = 300,
+        width_in: float = 10.0,
+        facecolor: Optional[str] = None,
+    ) -> str:
+        """Write what the canvas is currently showing to an image file.
+
+        Nothing under this package could export anything before this existed, so the
+        only way to get a picture out of an overview was to open a separate dialog that
+        re-rendered the data with a different renderer. Both overview tabs get "save this
+        view" from here, and so does anything headless that wants the same picture.
+
+        **The figure is resized before saving, and that is the whole point.** A
+        FigureCanvasQTAgg keeps its figure the size of the *widget*, so saving the figure
+        as it stands writes a page shaped like whatever the window happened to be --
+        typically a wide overview letterboxed into a tall panel, with the difference
+        spent on empty background that no `bbox_inches="tight"` can trim, because a
+        bounding box is a rectangle. Here the page is sized to the *view*, so the export
+        is the picture and nothing else.
+
+        The size and facecolor are restored in a finally, and a redraw is scheduled, so a
+        failed save leaves the canvas as it found it.
+
+        Args:
+            path: Where to write. The extension chooses the format.
+            dpi: Dots per inch. 300 is print quality for a figure this size.
+            width_in: Page width in inches; the height follows the view's aspect.
+            facecolor: The ground the content sits on. None keeps the canvas's own --
+                pass "white" for something destined for a document rather than a screen.
+                Only visible where there *is* ground: the axes fills the figure and an
+                image fills the axes, so a view framed tightly on its content shows none
+                of it.
+        Returns:
+            The path written.
+        """
+        xlim = self._ax.get_xlim()
+        ylim = self._ax.get_ylim()
+        x_span = abs(xlim[1] - xlim[0])
+        y_span = abs(ylim[1] - ylim[0])
+
+        if x_span > 0 and y_span > 0:
+            # Clamped like figsize_for_image, and for the same reason: a view zoomed to a
+            # sliver would otherwise ask for a page with no room to draw on.
+            aspect = min(max(y_span / x_span, 0.2), 5.0)
+        else:
+            aspect = 1.0
+
+        original_size = self._fig.get_size_inches()
+        original_fig_face = self._fig.get_facecolor()
+        original_ax_face = self._ax.get_facecolor()
+        try:
+            self._fig.set_size_inches(width_in, width_in * aspect, forward=False)
+            if facecolor is not None:
+                self._fig.set_facecolor(facecolor)
+                self._ax.set_facecolor(facecolor)
+            self._fig.savefig(
+                path,
+                dpi=dpi,
+                facecolor=self._fig.get_facecolor(),
+                edgecolor="none",
+            )
+        finally:
+            self._fig.set_size_inches(original_size, forward=False)
+            self._fig.set_facecolor(original_fig_face)
+            self._ax.set_facecolor(original_ax_face)
+            self._schedule_redraw()
+
+        _logger.info(f"Saved canvas view to {path}")
+        return path
+
     def _zoom_allowed(self, span: float) -> bool:
         """Whether the view may show *span* data units across.
 

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -875,6 +875,18 @@ class FibsemOverviewWidget(QWidget):
         self.button_load.clicked.connect(self._prompt_for_overview)
         overviews_panel.add_header_widget(self.button_load)
 
+        # Beside Load, because the pair is the section's two directions. Saving the view
+        # rather than the overview: what you are looking at, markers and grid bars and
+        # all, at whatever zoom you set -- which is the picture worth sending someone,
+        # and until `save_view` existed no canvas in the application could produce one.
+        self.button_save_view = IconToolButton(
+            icon="mdi:content-save-outline",
+            tooltip="Save this view as an image",
+            size=_HEADER_BTN_SIZE,
+        )
+        self.button_save_view.clicked.connect(self._prompt_to_save_view)
+        overviews_panel.add_header_widget(self.button_save_view)
+
         controls = QWidget()
         controls_layout = QVBoxLayout(controls)
         self._controls_layout = controls_layout
@@ -1996,6 +2008,30 @@ class FibsemOverviewWidget(QWidget):
         if not path:
             return
         self.load_overview(path)
+
+    def _prompt_to_save_view(self) -> None:
+        """Write the current view to a PNG the user picks."""
+        default = os.path.join(
+            str(self._save_directory or os.getcwd()),
+            f"{self._current_view.label if self._current_view else 'overview'}-view.png",
+        )
+        path = ui_utils.open_save_file_dialog(
+            msg="Save this view as an image",
+            path=default,
+            _filter="PNG Image (*.png)",
+            parent=self,
+        )
+        if not path:
+            return
+        try:
+            # White, not the canvas's near-black: this is going into a document or an
+            # email, and a page of dark grey is a page of dark grey wherever it lands.
+            self.canvas.save_view(path, facecolor="white")
+        except Exception as e:
+            logger.error(f"Could not save the view to {path}: {e}")
+            notification_service.show_toast(f"Could not save the view: {e}", "error")
+            return
+        notification_service.show_toast(f"Saved {os.path.basename(path)}", "success")
 
     # ── overlays ─────────────────────────────────────────────────────────
 

--- a/tests/ui/test_canvas_save_view.py
+++ b/tests/ui/test_canvas_save_view.py
@@ -1,0 +1,129 @@
+"""Saving what a canvas is showing.
+
+Nothing under `fibsem/ui/widgets/canvas/` could export anything before `save_view`, so
+the only route to a picture of an overview was a separate dialog that re-rendered the
+data through a different renderer.
+
+The behaviour worth pinning is the non-obvious half. A `FigureCanvasQTAgg` keeps its
+figure the size of the *widget*, so saving the figure as it stands writes a page shaped
+like the window rather than like the picture -- and `bbox_inches="tight"` cannot rescue
+it, because a bounding box is a rectangle and the empty band is inside it. That is the
+same trap the overview export dialog fell into; these tests exist so the canvas does not
+fall into it again.
+"""
+
+import numpy as np
+import pytest
+
+matplotlib = pytest.importorskip("matplotlib")
+matplotlib.use("Agg")
+
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas  # noqa: E402
+
+# A window much taller than it is wide, holding a much wider than tall image. Saving
+# the figure directly would produce the window's shape; save_view must produce the
+# image's.
+_TALL_WIDGET = (400, 900)
+_WIDE_IMAGE = (200, 800)  # (h, w) -> 4:1
+
+
+@pytest.fixture
+def canvas(qapp):
+    c = FibsemImageCanvas()
+    c.resize(*_TALL_WIDGET)
+    c.set_array(np.zeros(_WIDE_IMAGE, dtype=np.uint8))
+    c.show()
+    qapp.processEvents()
+    yield c
+    c.close()
+    c.deleteLater()
+
+
+def _saved_aspect(path) -> float:
+    from PIL import Image
+
+    with Image.open(path) as im:
+        return im.width / im.height
+
+
+class TestTheSavedPageIsTheView:
+    def test_the_page_matches_the_image_not_the_window(self, canvas, tmp_path):
+        out = tmp_path / "view.png"
+        canvas.save_view(str(out), dpi=50)
+
+        assert out.exists()
+        # 4:1 image in a 0.44:1 window. Anything near the window's aspect means the
+        # figure was saved at the widget's size.
+        assert _saved_aspect(out) == pytest.approx(4.0, rel=0.05)
+
+    def test_a_zoomed_view_exports_what_it_shows(self, canvas, tmp_path):
+        """Zooming to a square region should give a square page, not the image's."""
+        canvas._ax.set_xlim(100, 300)
+        canvas._ax.set_ylim(200, 0)  # y stays inverted, as the canvas keeps it
+
+        out = tmp_path / "zoomed.png"
+        canvas.save_view(str(out), dpi=50)
+        assert _saved_aspect(out) == pytest.approx(1.0, rel=0.05)
+
+    def test_width_and_dpi_decide_the_pixel_size(self, canvas, tmp_path):
+        from PIL import Image
+
+        out = tmp_path / "sized.png"
+        canvas.save_view(str(out), dpi=100, width_in=6.0)
+        with Image.open(out) as im:
+            assert im.width == pytest.approx(600, abs=2)
+
+
+class TestItLeavesTheCanvasAlone:
+    def test_the_figure_size_is_restored(self, canvas, tmp_path):
+        before = tuple(canvas._fig.get_size_inches())
+        canvas.save_view(str(tmp_path / "x.png"), dpi=50)
+        assert tuple(canvas._fig.get_size_inches()) == pytest.approx(before)
+
+    def test_the_background_is_restored(self, canvas, tmp_path):
+        before_fig = canvas._fig.get_facecolor()
+        before_ax = canvas._ax.get_facecolor()
+        canvas.save_view(str(tmp_path / "x.png"), dpi=50, facecolor="white")
+        assert canvas._fig.get_facecolor() == before_fig
+        assert canvas._ax.get_facecolor() == before_ax
+
+    def test_a_failed_save_still_restores(self, canvas, tmp_path):
+        """The restore is in a finally, so a bad path does not leave a stretched canvas."""
+        before = tuple(canvas._fig.get_size_inches())
+        with pytest.raises(Exception):
+            canvas.save_view(str(tmp_path / "no-such-dir" / "x.png"), dpi=50)
+        assert tuple(canvas._fig.get_size_inches()) == pytest.approx(before)
+
+
+class TestBackground:
+    """`facecolor` paints the ground the content sits on.
+
+    Only visible where there *is* ground: the axes fills the whole figure and the image
+    fills the axes, so a view framed tightly on the image shows none of it. These zoom
+    out first so there is some.
+    """
+
+    @staticmethod
+    def _zoom_out(canvas):
+        canvas._ax.set_xlim(-800, 1600)
+        canvas._ax.set_ylim(800, -600)  # y stays inverted
+
+    def test_white_is_actually_white(self, canvas, tmp_path):
+        """The canvas draws on near-black; a document wants the other thing."""
+        from PIL import Image
+
+        self._zoom_out(canvas)
+        out = tmp_path / "white.png"
+        canvas.save_view(str(out), dpi=50, facecolor="white")
+        with Image.open(out) as im:
+            assert im.convert("RGB").getpixel((2, 2)) == (255, 255, 255)
+
+    def test_the_canvas_background_is_the_default(self, canvas, tmp_path):
+        from PIL import Image
+
+        self._zoom_out(canvas)
+        out = tmp_path / "dark.png"
+        canvas.save_view(str(out), dpi=50)
+        with Image.open(out) as im:
+            r, g, b = im.convert("RGB").getpixel((2, 2))
+        assert (r, g, b) != (255, 255, 255)


### PR DESCRIPTION
Third of five. Stacked on #566. **No CI runs on a stacked PR** — see #566 for what substitutes.

## Nothing under `fibsem/ui/widgets/canvas/` could export anything

No `savefig`, no clipboard, nowhere. So the only route to a picture of an overview was to leave the tab, open a separate dialog, and have it re-render the same data through a different renderer at a different zoom.

The Overview tab now has **Save beside Load**, writing what you are actually looking at: markers, grid bars, chrome, at whatever zoom you set.

## The resize is the substance, not a detail

`save_view` resizes the figure before writing. A `FigureCanvasQTAgg` keeps its figure the size of the *widget*, so saving the figure as it stands writes a page shaped like the window — a wide overview letterboxed into a tall panel, with the difference spent on empty background. `bbox_inches="tight"` does not help: a bounding box is a rectangle and the empty band is inside it.

This is the same trap #565 found in the export dialog, which is why the tests pin it here explicitly: a 4:1 image in a 0.44:1 window must produce a 4:1 page.

The aspect is clamped at both ends, so a view zoomed to a sliver cannot ask for a page with no room to draw on. Size and background are restored in a `finally`, so a failed write leaves the canvas as it found it — tested with an unwritable path.

## A note on `facecolor`

It paints the ground the content sits on, and is only visible where there *is* ground: the axes fills the figure and an image fills the axes, so a view framed tightly on its content shows none of it. The tests zoom out first. The Overview tab passes `white`, because the canvas draws on near-black, which is right on screen and wrong in an email.

I found this by writing a test that asserted a white corner pixel and getting black — worth knowing before someone reports it as a bug.

## Why it lives on the canvas base

It is also the entry point a headless artifact generator needs, which #568 uses. Both overview tabs get "save this view" from the same method.

## Verification

- 8 new tests: the saved page matches the *view* not the window; a zoomed view exports what it shows; width and dpi decide the pixel size; size and background restored, including after a failure.
- `tests/ui/test_canvas_save_view.py` + `tests/ui/test_real_space_canvas.py`: 96 passed.
- ruff clean; static 3.8 scan across the stack clean.