### PR TITLE
[feat] Export a handoff map: the document a grid travels to the TEM with

### DIFF
--- a/fibsem/applications/autolamella/tools/handoff_map.py
+++ b/fibsem/applications/autolamella/tools/handoff_map.py
@@ -1,0 +1,461 @@
+"""The document a grid travels to the TEM with.
+
+The person who loads the grid into the TEM is usually not the person who milled it, and
+never has fibsemOS installed. What they get is whatever was exported before the operator
+went home, so this document is the entire downstream interface -- which is why it is a
+PDF rather than anything that needs software to read.
+
+Three pages, in the order the questions get asked:
+
+1. **The map.** Where the lamellae are on the grid, marked and named, with a scalebar and
+   a provenance line. One page per *view*: a fluorescence overview and a beam overview
+   are pictures taken from different directions -- different stage tilt, different
+   instrument -- so they cannot be composited, and putting them on one page would imply
+   they could. See `Experiment.find_overview_images`.
+2. **The table.** Every lamella with the facts that decide whether to spend beam time on
+   it: how thick, how wide, at what angle, when it finished, whether anyone flagged it.
+3. **The cards.** One per lamella, with its final ion-beam image, so it can be recognised
+   in an atlas before a hole is committed to it.
+
+Everything here is read from the experiment record. Nothing is inferred: in particular a
+lamella is *not* called ready, finished or good anywhere, because the only judgement in
+the record is `defect.state`, which a human sets by hand. A lamella whose polishing task
+never ran is unfinished, which is a different claim from defective, and this document
+makes neither on anyone's behalf -- it reports the last task that completed and lets the
+reader draw the conclusion.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from fibsem.applications.autolamella.structures import (
+    DefectType,
+    Experiment,
+    Lamella,
+)
+from fibsem.constants import DATETIME_DISPLAY_SHORT, SI_TO_MICRO, SI_TO_NANO
+
+logger = logging.getLogger(__name__)
+
+# What the defect states are called on the page. The record's own names (NONE, FAILURE,
+# REWORK) are the wrong register for a document someone reads once, at a microscope.
+DEFECT_LABELS = {
+    DefectType.NONE: "-",
+    DefectType.REWORK: "rework",
+    DefectType.FAILURE: "failed",
+}
+
+
+@dataclass
+class HandoffOptions:
+    """What goes in the document, and what it is called.
+
+    `grid` and `slot` are free text and deliberately so. Nothing in the codebase records
+    which physical grid a lamella is on or which cassette slot it travels in -- there is
+    no grid record yet -- and for a single-grid experiment the experiment *is* the grid,
+    so a typed-in string carries the whole of what is known. They are stored on
+    `Experiment.metadata` so they survive the dialog closing, and a real grid record can
+    later fill the same two header fields without the page changing.
+    """
+
+    title: str = ""
+    note: str = ""
+    grid: str = ""
+    slot: str = ""
+    include_map: bool = True
+    include_table: bool = True
+    include_cards: bool = True
+    # None means every lamella. A list of names means only those, in the experiment's
+    # own order -- so a map of the four that survived is a matter of unticking the rest.
+    lamella_names: Optional[List[str]] = None
+    marker_color: str = "cyan"
+    show_descriptions: bool = True
+    dpi: int = 200
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def selected(self, experiment: Experiment) -> List[Lamella]:
+        """The lamellae this document covers."""
+        if self.lamella_names is None:
+            return list(experiment.positions)
+        wanted = set(self.lamella_names)
+        return [lam for lam in experiment.positions if lam.name in wanted]
+
+
+def _final_trench_pattern(lamella: Lamella):
+    """The pattern whose gap *is* the lamella, or None.
+
+    Walks the completed tasks backwards and returns the last stage of the last one whose
+    final pattern has a `spacing` -- that gap being the lamella itself, left between the
+    two trenches cut either side of it.
+
+    The `spacing` requirement is the whole of the discrimination, and it is load-bearing.
+    "The last completed milling task" is not good enough: on a real experiment that is
+    routinely `Mill Fiducial`, and a fiducial pattern has a `width` like a trench does.
+    Reading it produced a straight-faced "lamella width: 1.0 um" for a lamella whose
+    milling had barely started. A pattern with no spacing describes something that is not
+    a lamella, so it is skipped rather than read.
+    """
+    completed = [t.name for t in lamella.task_history if t.name in lamella.task_config]
+    for name in reversed(completed):
+        config = lamella.task_config.get(name)
+        if config is None or not config.milling:
+            continue
+
+        stages = []
+        for milling_task in config.milling.values():
+            stages.extend(
+                [s for s in milling_task.stages if getattr(s, "enabled", True)]
+            )
+        if not stages:
+            continue
+
+        pattern = getattr(stages[-1], "pattern", None)
+        if pattern is not None and getattr(pattern, "spacing", None):
+            return pattern
+    return None
+
+
+def final_geometry(lamella: Lamella) -> Dict[str, Optional[float]]:
+    """The lamella's final thickness and width, in metres, or Nones.
+
+    Read off the last trench milled into it: the pattern's `spacing` is the gap left
+    between its two trenches -- the lamella -- and its `width` is how wide that gap was
+    cut.
+
+    Nones rather than guesses when no trench has been milled yet. A dash on the page is
+    honest; a number lifted from a fiducial is not.
+    """
+    pattern = _final_trench_pattern(lamella)
+    if pattern is None:
+        return {"thickness": None, "width": None}
+    return {
+        "thickness": getattr(pattern, "spacing", None),
+        "width": getattr(pattern, "width", None),
+    }
+
+
+def lamella_row(lamella: Lamella) -> Dict[str, str]:
+    """One lamella as the strings that go in the table.
+
+    Formatting lives here rather than in the PDF layer so the same row can back a CSV or
+    a card without the numbers being rendered twice, differently.
+    """
+    geometry = final_geometry(lamella)
+    last = lamella.last_completed_task
+
+    thickness = geometry["thickness"]
+    width = geometry["width"]
+    angle = lamella.milling_angle
+
+    finished = "-"
+    if last is not None and getattr(last, "end_timestamp", None):
+        try:
+            finished = datetime.fromtimestamp(last.end_timestamp).strftime(
+                DATETIME_DISPLAY_SHORT
+            )
+        except (ValueError, OSError, TypeError):
+            finished = "-"
+
+    fm_count = 0
+    for task in lamella.task_history:
+        fm_count += len((task.outputs or {}).get("fluorescence", []))
+
+    return {
+        "Lamella": lamella.name,
+        "Defect": DEFECT_LABELS.get(lamella.defect.state, "-"),
+        "Last task": last.name if last is not None else "-",
+        "Thickness": f"{thickness * SI_TO_NANO:.0f} nm" if thickness else "-",
+        "Width": f"{width * SI_TO_MICRO:.1f} um" if width else "-",
+        "Angle": f"{angle:.1f} deg" if angle is not None else "-",
+        "Finished": finished,
+        "FM": str(fm_count) if fm_count else "-",
+        "Note": lamella.description or lamella.defect.description or "",
+    }
+
+
+def provenance_line(experiment: Experiment) -> str:
+    """Instrument, operator, version and date, for the header of every page.
+
+    Empty when no session has adopted the experiment -- which is every experiment written
+    before the session record existed. A header that admits it knows nothing beats one
+    filled with "unknown", which reads as a measurement.
+    """
+    session = getattr(experiment, "session", None)
+    parts: List[str] = []
+    if session is not None:
+        system = getattr(session, "system", None)
+        user = getattr(session, "user", None)
+        model = getattr(system, "model", "") or ""
+        serial = getattr(system, "serial_number", "") or ""
+        if model:
+            parts.append(f"{model} ({serial})" if serial else model)
+        operator = getattr(user, "name", "") or ""
+        if operator:
+            parts.append(operator)
+        version = getattr(system, "fibsem_version", "") or ""
+        if version:
+            parts.append(f"fibsemOS {version}")
+
+    created = getattr(experiment, "created_at", None)
+    if created:
+        try:
+            parts.append(
+                "milled "
+                + datetime.fromtimestamp(created).strftime(DATETIME_DISPLAY_SHORT)
+            )
+        except (ValueError, OSError, TypeError):
+            pass
+
+    if not parts:
+        return ""
+    parts.append("map " + datetime.now().strftime(DATETIME_DISPLAY_SHORT))
+    return "  |  ".join(parts)
+
+
+def summary_line(experiment: Experiment, options: HandoffOptions) -> str:
+    """The one line under the title: what is on this grid, and where it is.
+
+    Counts only what a human flagged. There is deliberately no "N ready" here: readiness
+    is not recorded anywhere, and inventing it from task history would put a judgement
+    nobody made onto the page that travels with the sample.
+    """
+    lamellae = options.selected(experiment)
+    failed = sum(1 for lam in lamellae if lam.defect.state is DefectType.FAILURE)
+    rework = sum(1 for lam in lamellae if lam.defect.state is DefectType.REWORK)
+
+    parts: List[str] = []
+    if options.grid:
+        parts.append(f"Grid {options.grid}")
+    if options.slot:
+        parts.append(f"slot {options.slot}")
+    parts.append(f"{len(lamellae)} lamellae")
+    if rework:
+        parts.append(f"{rework} rework")
+    if failed:
+        parts.append(f"{failed} failed")
+    return "  |  ".join(parts)
+
+
+def generate_handoff_map(
+    experiment: Experiment,
+    output_filename: str,
+    options: Optional[HandoffOptions] = None,
+) -> str:
+    """Write the handoff document for *experiment* to *output_filename*.
+
+    No Qt anywhere in here, deliberately: the artifact is most wanted at the end of a run
+    that nobody stayed for, so it has to be reachable from a workflow hook and not only
+    from a dialog someone remembered to open.
+
+    Returns:
+        The path written.
+    """
+    # Imported here rather than at module scope so that reading a lamella's geometry --
+    # which the dialog does on every keystroke -- does not cost a reportlab import.
+    from reportlab.lib.units import inch
+
+    from fibsem.applications.autolamella.tools.reporting import PDFReportGenerator
+
+    options = options or HandoffOptions()
+    lamellae = options.selected(experiment)
+
+    pdf = PDFReportGenerator(output_filename=output_filename)
+    pdf.add_title(
+        options.title or f"Handoff Map: {experiment.name}",
+        summary_line(experiment, options),
+    )
+
+    provenance = provenance_line(experiment)
+    if provenance:
+        pdf.add_paragraph(provenance)
+    if options.note:
+        pdf.add_paragraph(options.note)
+
+    if options.include_map:
+        _add_map_pages(pdf, experiment, lamellae, options, inch)
+
+    if options.include_table:
+        _add_table_page(pdf, lamellae)
+
+    if options.include_cards:
+        _add_card_pages(pdf, lamellae, inch)
+
+    pdf.generate()
+    logger.info(f"Wrote handoff map for {experiment.name} to {output_filename}")
+    return output_filename
+
+
+def _add_map_pages(pdf, experiment, lamellae, options: HandoffOptions, inch) -> None:
+    """A page per beam overview, each marked with the selected lamellae.
+
+    A page *per overview* rather than one page with everything on it. Two overviews of
+    the same grid at different times are two pictures, and a fluorescence overview is a
+    picture from a different direction entirely -- so there is no single set of axes they
+    all belong on.
+    """
+    from fibsem.imaging.tiled import (
+        DEFECT_FAILURE_COLOUR,
+        DEFECT_REWORK_COLOUR,
+        plot_minimap,
+    )
+    from fibsem.structures import FibsemImage
+
+    paths = experiment.find_overview_images()
+    if not paths:
+        pdf.add_page_break()
+        pdf.add_heading("Map")
+        pdf.add_paragraph(
+            "No overview image was saved with this experiment, so there is no map. "
+            "The table below still locates each lamella by stage position."
+        )
+        return
+
+    selected = {lam.name for lam in lamellae}
+    positions = [
+        pos for pos in experiment.get_milling_positions() if pos.name in selected
+    ]
+    descriptions = {lam.name: lam.description for lam in lamellae}
+    colours = {}
+    for lam in lamellae:
+        if lam.defect.state is DefectType.FAILURE:
+            colours[lam.name] = DEFECT_FAILURE_COLOUR
+        elif lam.defect.state is DefectType.REWORK:
+            colours[lam.name] = DEFECT_REWORK_COLOUR
+
+    for path in paths:
+        try:
+            image = FibsemImage.load(path)
+        except Exception as e:
+            logger.warning(f"Could not load the overview {path}: {e}")
+            continue
+        try:
+            fig = plot_minimap(
+                image,
+                positions,
+                color=options.marker_color,
+                colors=colours,
+                show_scalebar=True,
+                show_names=True,
+                show_descriptions=options.show_descriptions,
+                descriptions=descriptions,
+                figsize=None,
+            )
+        except Exception as e:
+            logger.warning(f"Could not draw the map for {path}: {e}")
+            continue
+
+        pdf.add_page_break()
+        pdf.add_heading(f"Map - {os.path.basename(path)}")
+        pdf.add_mpl_figure(fig, width=6.5 * inch, height=4.0 * inch)
+
+    fm_paths = experiment.find_fluorescence_overview_images()
+    if fm_paths:
+        # Named rather than drawn. They belong to a different view and cannot be marked
+        # on these axes, but a reader who knows a fluorescence overview was acquired
+        # should not have to wonder where it went.
+        pdf.add_paragraph(
+            f"{len(fm_paths)} fluorescence overview(s) were also acquired, and are not "
+            "shown here: they are a different view of the sample and do not register "
+            "with a beam overview. Files: "
+            + ", ".join(os.path.basename(p) for p in fm_paths)
+        )
+
+
+def _add_table_page(pdf, lamellae) -> None:
+    """Every lamella, and the numbers that decide whether to spend beam time on it."""
+    import pandas as pd
+
+    pdf.add_page_break()
+    pdf.add_heading("Lamellae")
+    if not lamellae:
+        pdf.add_paragraph("No lamellae were selected for this map.")
+        return
+    rows = [lamella_row(lam) for lam in lamellae]
+    pdf.add_dataframe(pd.DataFrame(rows))
+
+
+def _add_card_pages(pdf, lamellae, inch) -> None:
+    """One card per lamella: its final ion-beam image, so it can be recognised.
+
+    The ion beam rather than the electron beam: the ion image is the view the lamella was
+    milled in, and so the one that shows the trenches, the tabs and the curtaining a
+    reader is checking for.
+    """
+    from fibsem.structures import FibsemImage
+
+    if not lamellae:
+        return
+
+    pdf.add_page_break()
+    pdf.add_heading("Lamella detail")
+
+    for lam in lamellae:
+        row = lamella_row(lam)
+        pdf.add_heading(lam.name, level=3)
+        pdf.add_paragraph(
+            " | ".join(
+                f"{key}: {row[key]}"
+                for key in ("Defect", "Last task", "Thickness", "Width", "Angle", "FM")
+            )
+        )
+        if row["Note"]:
+            pdf.add_paragraph(row["Note"])
+
+        path = _final_ion_image(lam)
+        if path is None:
+            pdf.add_paragraph("No final ion-beam image was recorded for this lamella.")
+            continue
+        try:
+            image = FibsemImage.load(path)
+        except Exception as e:
+            logger.warning(f"Could not load {path} for {lam.name}: {e}")
+            continue
+        fig = _plot_bare_image(image)
+        pdf.add_mpl_figure(fig, width=4.0 * inch, height=3.0 * inch)
+
+
+def _final_ion_image(lamella: Lamella) -> Optional[str]:
+    """The last final ion-beam reference image the lamella recorded, or None.
+
+    From `task_history[].outputs`, which records paths relative to the lamella directory
+    -- which is where they are, so they resolve against it as-is.
+    """
+    for task in reversed(lamella.task_history):
+        names = (task.outputs or {}).get("final_fib", [])
+        for name in reversed(names):
+            path = os.path.join(str(lamella.path), name)
+            if os.path.exists(path):
+                return path
+    return None
+
+
+def _plot_bare_image(image) -> "Any":
+    """The image, a scalebar, and nothing else."""
+    import matplotlib.pyplot as plt
+
+    from fibsem.imaging.tiling.plotting import figsize_for_image
+
+    fig, ax = plt.subplots(figsize=figsize_for_image(image.data.shape, width_in=6.0))
+    ax.imshow(image.data, cmap="gray")
+    ax.axis("off")
+    try:
+        from matplotlib_scalebar.scalebar import ScaleBar
+
+        ax.add_artist(
+            ScaleBar(
+                dx=image.metadata.pixel_size.x,
+                color="black",
+                box_color="white",
+                box_alpha=0.5,
+                location="lower right",
+            )
+        )
+    except Exception as e:
+        logger.debug(f"Could not add a scalebar: {e}")
+    fig.tight_layout()
+    return fig

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -622,8 +622,15 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.action_generate_overview_plot.triggered.connect(
             self._on_generate_overview_plot
         )
+        # The multi-page document a grid travels to the TEM with. Built unconditionally
+        # and hidden by _apply_preferences while the handoff_map flag is off, which is
+        # the default -- hidden rather than absent so toggling the preference takes
+        # effect without a restart, the same way Scripts does.
+        self.action_export_handoff_map = QAction("Export Handoff Map...", self)
+        self.action_export_handoff_map.triggered.connect(self._on_export_handoff_map)
         reporting_menu.addAction(self.action_generate_report)
         reporting_menu.addAction(self.action_generate_overview_plot)
+        reporting_menu.addAction(self.action_export_handoff_map)
 
         # user scripts (FIB-338). The menu itself is application-agnostic; this
         # supplies only the folder, the context, and how to notify.
@@ -899,6 +906,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # a script. If a script is mid-run, leave it visible -- taking away the only
         # Stop button while the microscope is moving would be worse than the flag
         # being briefly wrong.
+        self.action_export_handoff_map.setVisible(
+            self._preferences.features.handoff_map
+        )
         self.scripts_menu.menuAction().setVisible(
             self._preferences.features.scripts_enabled
             or self.script_menu_controller.runner.is_running
@@ -1144,6 +1154,11 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         """Handle Generate Report action."""
         if self.autolamella_ui is not None:
             self.autolamella_ui.action_generate_report()
+
+    def _on_export_handoff_map(self):
+        """Tools -> Reporting -> Export Handoff Map."""
+        if self.autolamella_ui is not None:
+            self.autolamella_ui.action_export_handoff_map()
 
     def _on_generate_overview_plot(self):
         """Handle Generate Overview Plot action."""

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -765,6 +765,24 @@ class AutoLamellaUI(QMainWindow):
         generate_report_dialog(self.experiment, parent=self)
         return
 
+    def action_export_handoff_map(self) -> None:
+        """Export the multi-page document the grid travels to the TEM with."""
+        if self.experiment is None:
+            return
+
+        if not REPORTING_AVAILABLE:
+            notification_service.show_toast(
+                "Reporting tools are not available.", "warning"
+            )
+            return
+
+        from fibsem.applications.autolamella.ui.autolamella_handoff_map_widget import (
+            create_handoff_map_dialog,
+        )
+
+        dialog = create_handoff_map_dialog(experiment=self.experiment, parent=self)
+        dialog.exec_()
+
     def action_generate_overview_plot(self) -> None:
         """Generate an plot with the lamella position on an overview image."""
         if self.experiment is None:

--- a/fibsem/applications/autolamella/ui/autolamella_handoff_map_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_handoff_map_widget.py
@@ -1,0 +1,230 @@
+"""Dialog for exporting the handoff map.
+
+Deliberately thin. Everything about *what the document says* lives in
+`tools.handoff_map`, which has no Qt in it, because the artifact is most wanted at the
+end of a run nobody stayed for -- so it has to be reachable from a workflow hook and not
+only from a dialog someone remembered to open. This is the half that collects what the
+operator knows and the record does not: which grid, which slot, and any note for whoever
+opens the box.
+
+Behind the `handoff_map` feature flag while it sits beside Generate Overview Plot rather
+than replacing it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import List, Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.applications.autolamella.structures import DefectType, Experiment
+from fibsem.applications.autolamella.tools.handoff_map import (
+    DEFECT_LABELS,
+    HandoffOptions,
+    generate_handoff_map,
+    lamella_row,
+)
+from fibsem.ui import notification_service
+from fibsem.ui import utils as ui_utils
+from fibsem.ui.stylesheets import (
+    CONFIRM_BUTTON_STYLESHEET,
+    SECONDARY_BUTTON_STYLESHEET,
+)
+from fibsem.ui.tokens import TEXT_MUTED_COLOR
+from fibsem.ui.widgets.custom_widgets import TitledPanel
+
+logger = logging.getLogger(__name__)
+
+# Where the operator's answers are kept between exports. On the experiment rather than in
+# preferences: which slot a grid is in is a fact about that grid, not a setting.
+GRID_KEY = "grid"
+SLOT_KEY = "slot"
+NOTE_KEY = "handoff_note"
+
+
+class HandoffMapDialog(QDialog):
+    """Collect what only the operator knows, then write the document."""
+
+    def __init__(self, experiment: Experiment, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        if experiment is None:
+            raise ValueError("HandoffMapDialog requires an experiment.")
+        self.experiment = experiment
+        self.setWindowTitle(f"Export Handoff Map - {experiment.name}")
+        self.setMinimumWidth(560)
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+
+        # ── what the record cannot know ──────────────────────────────────
+        about = QFormLayout()
+        self.edit_title = QLineEdit(f"Handoff Map: {self.experiment.name}")
+        self.edit_grid = QLineEdit(self.experiment.metadata.get(GRID_KEY, ""))
+        self.edit_grid.setPlaceholderText("e.g. A")
+        self.edit_slot = QLineEdit(self.experiment.metadata.get(SLOT_KEY, ""))
+        self.edit_slot.setPlaceholderText("e.g. 3")
+        self.edit_note = QLineEdit(self.experiment.metadata.get(NOTE_KEY, ""))
+        self.edit_note.setPlaceholderText("Anything the recipient should know")
+
+        about.addRow("Title", self.edit_title)
+        about.addRow("Grid", self.edit_grid)
+        about.addRow("Cassette slot", self.edit_slot)
+        about.addRow("Note", self.edit_note)
+
+        about_panel = QWidget()
+        about_panel.setLayout(about)
+        layout.addWidget(
+            TitledPanel("This grid", content=about_panel, collapsible=False)
+        )
+
+        # ── which lamellae ───────────────────────────────────────────────
+        self.lamella_list = QListWidget()
+        self.lamella_list.setAlternatingRowColors(True)
+        for lamella in self.experiment.positions:
+            row = lamella_row(lamella)
+            label = f"{lamella.name}"
+            detail = DEFECT_LABELS.get(lamella.defect.state, "-")
+            if detail != "-":
+                label = f"{label}   [{detail}]"
+            if row["Thickness"] != "-":
+                label = f"{label}   {row['Thickness']}"
+            item = QListWidgetItem(label)
+            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+            # Everything ticked, including the flagged ones: a map that silently omits
+            # the failures tells the recipient a grid is better than it is, and they
+            # will find the empty positions anyway.
+            item.setCheckState(Qt.CheckState.Checked)
+            item.setData(Qt.ItemDataRole.UserRole, lamella.name)
+            if lamella.defect.state is DefectType.FAILURE:
+                item.setToolTip(lamella.defect.description or "Flagged as failed")
+            self.lamella_list.addItem(item)
+        layout.addWidget(
+            TitledPanel("Lamellae", content=self.lamella_list, collapsible=False)
+        )
+
+        # ── what goes in it ──────────────────────────────────────────────
+        sections = QWidget()
+        sections_layout = QVBoxLayout(sections)
+        self.chk_map = QCheckBox("Map pages (one per overview)")
+        self.chk_table = QCheckBox("Lamella table")
+        self.chk_cards = QCheckBox("Lamella detail cards (with final images)")
+        for box in (self.chk_map, self.chk_table, self.chk_cards):
+            box.setChecked(True)
+            sections_layout.addWidget(box)
+        layout.addWidget(TitledPanel("Pages", content=sections, collapsible=False))
+
+        overviews = len(self.experiment.find_overview_images())
+        fm = len(self.experiment.find_fluorescence_overview_images())
+        hint = f"{overviews} overview(s) found"
+        if fm:
+            # Said plainly rather than left as an absence. They cannot be marked on a
+            # beam overview's axes -- different stage tilt, different instrument -- so
+            # their omission is a fact about the geometry, not an oversight.
+            hint += (
+                f"; {fm} fluorescence overview(s) will be listed but not drawn "
+                "(different view, does not register)"
+            )
+        self.label_hint = QLabel(hint)
+        self.label_hint.setWordWrap(True)
+        self.label_hint.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 11px;")
+        layout.addWidget(self.label_hint)
+
+        buttons = QDialogButtonBox()
+        self.btn_export = QPushButton("Export")
+        self.btn_export.setStyleSheet(CONFIRM_BUTTON_STYLESHEET)
+        self.btn_export.setDefault(True)
+        self.btn_cancel = QPushButton("Cancel")
+        self.btn_cancel.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
+        buttons.addButton(self.btn_export, QDialogButtonBox.ButtonRole.AcceptRole)
+        buttons.addButton(self.btn_cancel, QDialogButtonBox.ButtonRole.RejectRole)
+        self.btn_export.clicked.connect(self._on_export)
+        self.btn_cancel.clicked.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def selected_names(self) -> List[str]:
+        names = []
+        for i in range(self.lamella_list.count()):
+            item = self.lamella_list.item(i)
+            if item.checkState() == Qt.CheckState.Checked:
+                names.append(item.data(Qt.ItemDataRole.UserRole))
+        return names
+
+    def options(self) -> HandoffOptions:
+        return HandoffOptions(
+            title=self.edit_title.text().strip(),
+            note=self.edit_note.text().strip(),
+            grid=self.edit_grid.text().strip(),
+            slot=self.edit_slot.text().strip(),
+            include_map=self.chk_map.isChecked(),
+            include_table=self.chk_table.isChecked(),
+            include_cards=self.chk_cards.isChecked(),
+            lamella_names=self.selected_names(),
+        )
+
+    def _remember_answers(self) -> None:
+        """Keep grid, slot and note on the experiment so the next export starts there."""
+        self.experiment.metadata[GRID_KEY] = self.edit_grid.text().strip()
+        self.experiment.metadata[SLOT_KEY] = self.edit_slot.text().strip()
+        self.experiment.metadata[NOTE_KEY] = self.edit_note.text().strip()
+        try:
+            self.experiment.save()
+        except Exception as e:
+            # Not fatal: the document is what was asked for, and it has already been
+            # written by the time this runs.
+            logger.warning(f"Could not save the grid details onto the experiment: {e}")
+
+    def _on_export(self) -> None:
+        if not self.selected_names():
+            QMessageBox.warning(
+                self, "Nothing to map", "Select at least one lamella to include."
+            )
+            return
+
+        default = os.path.join(
+            str(self.experiment.path), f"{self.experiment.name}-handoff-map.pdf"
+        )
+        path = ui_utils.open_save_file_dialog(
+            msg="Save the handoff map",
+            path=default,
+            _filter="PDF Document (*.pdf)",
+            parent=self,
+        )
+        if not path:
+            return
+
+        try:
+            generate_handoff_map(self.experiment, path, self.options())
+        except Exception as e:
+            logger.error(f"Could not write the handoff map: {e}", exc_info=True)
+            QMessageBox.critical(
+                self, "Export failed", f"Could not write the handoff map:\n{e}"
+            )
+            return
+
+        self._remember_answers()
+        notification_service.show_toast(f"Saved {os.path.basename(path)}", "success")
+        self.accept()
+
+
+def create_handoff_map_dialog(
+    experiment: Experiment, parent: Optional[QWidget] = None
+) -> HandoffMapDialog:
+    """Build the dialog for *experiment*."""
+    return HandoffMapDialog(experiment=experiment, parent=parent)

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -409,6 +409,15 @@ class FeatureFlags:
     # goes, and the geometry it rests on is only checkable against real data
     # (FIB-597). Staging, like the flag above -- deleted when it ships, not kept.
     sparse_fm_selection: bool = False
+    # Tools -> Reporting -> Export Handoff Map. The multi-page document a grid travels
+    # to the TEM with: a map page per view, the lamella table, then a card per lamella.
+    # Off while it sits *beside* the existing Generate Overview Plot rather than
+    # replacing it, so the plot people rely on is untouched while this is checked
+    # against real experiments.
+    #
+    # A staging flag like the three above, and it goes the same way: deleted when it
+    # replaces the overview plot, not kept as a preference.
+    handoff_map: bool = False
 
 
 @dataclass

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -73,6 +73,12 @@ _TIP_OVERVIEW_CANVAS = (
     "Tiles are placed where they were acquired rather than stitched first. Still being "
     "finished, and it drives the same microscope as the Overview tab it will replace."
 )
+_LBL_HANDOFF_MAP = "Enable Handoff Map Export"
+_TIP_HANDOFF_MAP = (
+    "Add Tools > Reporting > Export Handoff Map: the multi-page document a grid "
+    "travels to the TEM with -- a map page per overview, the lamella table, and a "
+    "card per lamella. Also writes it automatically when a workflow run finishes."
+)
 _LBL_CONNECTION_CHIP = "Enable Connection Chip"
 _TIP_CONNECTION_CHIP = (
     "Show the connected instrument in the tab bar, beside the experiment, and add "
@@ -189,6 +195,8 @@ class PreferencesDialog(QDialog):
         self._chk_sparse_fm.setToolTip(_TIP_SPARSE_FM)
         self._chk_connection_chip = QCheckBox()
         self._chk_connection_chip.setToolTip(_TIP_CONNECTION_CHIP)
+        self._chk_handoff_map = QCheckBox()
+        self._chk_handoff_map.setToolTip(_TIP_HANDOFF_MAP)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
         features_form.addRow(_LBL_SAMPLE_HOLDER, self._chk_sample_holder)
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
@@ -196,6 +204,7 @@ class PreferencesDialog(QDialog):
         features_form.addRow(_LBL_OVERVIEW_CANVAS, self._chk_overview_canvas)
         features_form.addRow(_LBL_SPARSE_FM, self._chk_sparse_fm)
         features_form.addRow(_LBL_CONNECTION_CHIP, self._chk_connection_chip)
+        features_form.addRow(_LBL_HANDOFF_MAP, self._chk_handoff_map)
         self._stack.addWidget(features_page)
 
         # --- Experiment Defaults ---
@@ -269,6 +278,7 @@ class PreferencesDialog(QDialog):
         self._chk_scripts.setChecked(f.scripts_enabled)
         self._chk_overview_canvas.setChecked(f.overview_canvas_tab)
         self._chk_sparse_fm.setChecked(f.sparse_fm_selection)
+        self._chk_handoff_map.setChecked(f.handoff_map)
         self._chk_connection_chip.setChecked(f.connection_chip)
 
         e = prefs.experiment
@@ -343,6 +353,7 @@ class PreferencesDialog(QDialog):
                 overview_canvas_tab=self._chk_overview_canvas.isChecked(),
                 connection_chip=self._chk_connection_chip.isChecked(),
                 sparse_fm_selection=self._chk_sparse_fm.isChecked(),
+                handoff_map=self._chk_handoff_map.isChecked(),
             ),
             movement=MovementPreferences(
                 acquire_sem_after_stage_movement=self._chk_acquire_sem.isChecked(),

--- a/tests/autolamella/test_handoff_map.py
+++ b/tests/autolamella/test_handoff_map.py
@@ -1,0 +1,240 @@
+"""What the handoff document is allowed to say about a lamella.
+
+The document travels with the grid to a TEM, is read by someone who was not there, and
+is the only thing they have. So the tests that matter are the ones about *restraint*:
+what it must not claim, and where it must print a dash instead of a number.
+
+Two defects motivated most of this, both found by looking at real output:
+
+- reading "the last completed milling task" for the final geometry picks up
+  `Mill Fiducial` on a lamella whose milling had barely started, and reported the
+  fiducial's width as the lamella's;
+- there is no field in the record that says a lamella is *ready*, so the document must
+  not compute one.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskConfig,
+    AutoLamellaTaskState,
+    AutoLamellaTaskStatus,
+    DefectType,
+    Experiment,
+    Lamella,
+)
+from fibsem.applications.autolamella.tools.handoff_map import (
+    HandoffOptions,
+    final_geometry,
+    lamella_row,
+    provenance_line,
+    summary_line,
+)
+from fibsem.milling import FibsemMillingStage
+from fibsem.milling.patterning.patterns2 import RectanglePattern, TrenchPattern
+
+
+@pytest.fixture
+def lamella(tmp_path: Path) -> Lamella:
+    lam = Lamella(path=tmp_path / "lam", number=1, petname="01-test-lamella")
+    lam.milling_angle = 15.0
+    return lam
+
+
+def _completed(name: str) -> AutoLamellaTaskState:
+    return AutoLamellaTaskState(name=name, status=AutoLamellaTaskStatus.Completed)
+
+
+def _milling_config(stage: FibsemMillingStage) -> AutoLamellaTaskConfig:
+    """A task config whose one milling task holds *stage*."""
+    from fibsem.milling.tasks import FibsemMillingTaskConfig
+
+    config = AutoLamellaTaskConfig()
+    config.milling = {"task": FibsemMillingTaskConfig(stages=[stage])}
+    return config
+
+
+def _trench(spacing: float, width: float) -> FibsemMillingStage:
+    return FibsemMillingStage(
+        name="Polish", pattern=TrenchPattern(width=width, spacing=spacing)
+    )
+
+
+def _fiducial(width: float) -> FibsemMillingStage:
+    """A rectangle -- like a fiducial, it has a width but no spacing."""
+    return FibsemMillingStage(name="Fiducial", pattern=RectanglePattern(width=width))
+
+
+class TestFinalGeometry:
+    def test_a_trench_gives_the_thickness_and_width(self, lamella):
+        lamella.task_config["Polishing"] = _milling_config(_trench(300e-9, 9e-6))
+        lamella.task_history.append(_completed("Polishing"))
+
+        geometry = final_geometry(lamella)
+        assert geometry["thickness"] == pytest.approx(300e-9)
+        assert geometry["width"] == pytest.approx(9e-6)
+
+    def test_a_fiducial_is_not_read_as_a_lamella(self, lamella):
+        """The defect this file exists for.
+
+        A fiducial is milled early and has a width, so "the last completed milling task"
+        reported it as the lamella's own -- a straight-faced "width: 1.0 um" for a
+        lamella that had not been cut yet.
+        """
+        lamella.task_config["Mill Fiducial"] = _milling_config(_fiducial(1e-6))
+        lamella.task_history.append(_completed("Mill Fiducial"))
+
+        geometry = final_geometry(lamella)
+        assert geometry == {"thickness": None, "width": None}
+
+    def test_the_trench_wins_over_a_later_fiducial(self, lamella):
+        """Order in the history does not override what the pattern actually describes."""
+        lamella.task_config["Rough Milling"] = _milling_config(_trench(4e-6, 10e-6))
+        lamella.task_config["Mill Fiducial"] = _milling_config(_fiducial(1e-6))
+        lamella.task_history.append(_completed("Rough Milling"))
+        lamella.task_history.append(_completed("Mill Fiducial"))
+
+        assert final_geometry(lamella)["thickness"] == pytest.approx(4e-6)
+
+    def test_the_most_recent_trench_wins(self, lamella):
+        lamella.task_config["Rough Milling"] = _milling_config(_trench(4e-6, 10e-6))
+        lamella.task_config["Polishing"] = _milling_config(_trench(300e-9, 9e-6))
+        lamella.task_history.append(_completed("Rough Milling"))
+        lamella.task_history.append(_completed("Polishing"))
+
+        assert final_geometry(lamella)["thickness"] == pytest.approx(300e-9)
+
+    def test_an_unmilled_lamella_reports_nothing(self, lamella):
+        assert final_geometry(lamella) == {"thickness": None, "width": None}
+
+    def test_a_task_that_never_completed_is_not_read(self, lamella):
+        """Configured is not the same as done."""
+        lamella.task_config["Polishing"] = _milling_config(_trench(300e-9, 9e-6))
+        assert final_geometry(lamella) == {"thickness": None, "width": None}
+
+
+class TestTheRow:
+    def test_unknown_values_are_dashes_not_zeroes(self, lamella):
+        row = lamella_row(lamella)
+        assert row["Thickness"] == "-"
+        assert row["Width"] == "-"
+        assert row["Last task"] == "-"
+        assert row["Finished"] == "-"
+
+    def test_a_flagged_lamella_says_so(self, lamella):
+        lamella.defect.set_defect("lost the fiducial", DefectType.FAILURE)
+        row = lamella_row(lamella)
+        assert row["Defect"] == "failed"
+        assert row["Note"] == "lost the fiducial"
+
+    def test_rework_is_distinct_from_failed(self, lamella):
+        lamella.defect.set_defect("too thick", DefectType.REWORK)
+        assert lamella_row(lamella)["Defect"] == "rework"
+
+    def test_an_unflagged_lamella_is_not_called_anything(self, lamella):
+        """Not "ok", not "ready" -- the record holds no such judgement to report."""
+        row = lamella_row(lamella)
+        assert row["Defect"] == "-"
+
+    def test_the_description_is_preferred_over_the_defect_note(self, lamella):
+        lamella.description = "mitochondria cluster"
+        lamella.defect.set_defect("too thick", DefectType.REWORK)
+        assert lamella_row(lamella)["Note"] == "mitochondria cluster"
+
+
+class TestTheSummaryLine:
+    @pytest.fixture
+    def experiment(self, tmp_path):
+        exp = Experiment(path=tmp_path, name="handoff")
+        for i, state in enumerate(
+            (DefectType.NONE, DefectType.NONE, DefectType.REWORK, DefectType.FAILURE)
+        ):
+            lam = Lamella(path=Path(exp.path) / f"L{i}", number=i, petname=f"L{i}")
+            if state is not DefectType.NONE:
+                lam.defect.set_defect("", state)
+            exp.positions.append(lam)
+        return exp
+
+    def test_it_counts_only_what_a_human_flagged(self, experiment):
+        line = summary_line(experiment, HandoffOptions())
+        assert "4 lamellae" in line
+        assert "1 rework" in line
+        assert "1 failed" in line
+
+    def test_it_never_claims_a_lamella_is_ready(self, experiment):
+        """There is no readiness field, so there is no readiness claim."""
+        line = summary_line(experiment, HandoffOptions()).lower()
+        for word in ("ready", "good", "usable", "ok"):
+            assert word not in line
+
+    def test_the_grid_and_slot_appear_when_given(self, experiment):
+        line = summary_line(experiment, HandoffOptions(grid="A", slot="3"))
+        assert "Grid A" in line and "slot 3" in line
+
+    def test_a_selection_narrows_the_counts(self, experiment):
+        options = HandoffOptions(lamella_names=["L0", "L1"])
+        line = summary_line(experiment, options)
+        assert "2 lamellae" in line
+        assert "failed" not in line
+
+
+class TestProvenance:
+    def test_it_is_empty_without_a_session(self, tmp_path):
+        """Better to say nothing than to print a line of "unknown"s.
+
+        Every experiment written before the session record existed has none, and a
+        header full of blanks reads as a measurement that came back empty.
+        """
+        exp = Experiment(path=tmp_path, name="no-session")
+        exp.created_at = None
+        exp.session = None
+        assert provenance_line(exp) == ""
+
+    def test_it_names_the_instrument_and_operator(self, tmp_path):
+        from fibsem.structures import FibsemUser, SessionInfo, SystemInfo
+
+        exp = Experiment(path=tmp_path, name="with-session")
+        exp.session = SessionInfo(
+            system=SystemInfo(
+                name="config",
+                ip_address="0.0.0.0",
+                manufacturer="Thermo",
+                model="Aquilos 2",
+                serial_number="9876",
+                hardware_version="1",
+                software_version="1",
+                fibsem_revision="abc",
+            ),
+            user=FibsemUser(name="operator"),
+        )
+        line = provenance_line(exp)
+        assert "Aquilos 2" in line and "9876" in line and "operator" in line
+
+
+class TestSelection:
+    def test_none_means_every_lamella(self, tmp_path):
+        exp = Experiment(path=tmp_path, name="sel")
+        for i in range(3):
+            exp.positions.append(
+                Lamella(path=Path(exp.path) / f"L{i}", number=i, petname=f"L{i}")
+            )
+        assert len(HandoffOptions().selected(exp)) == 3
+
+    def test_names_select_in_experiment_order(self, tmp_path):
+        exp = Experiment(path=tmp_path, name="sel")
+        for i in range(3):
+            exp.positions.append(
+                Lamella(path=Path(exp.path) / f"L{i}", number=i, petname=f"L{i}")
+            )
+        chosen = HandoffOptions(lamella_names=["L2", "L0"]).selected(exp)
+        assert [lam.name for lam in chosen] == ["L0", "L2"]
+
+
+class TestTheFlagIsOffByDefault:
+    def test_handoff_map_is_not_enabled_for_anyone_yet(self):
+        """It ships beside the overview plot, not in place of it, until it has been used."""
+        from fibsem.config import FeatureFlags
+
+        assert FeatureFlags().handoff_map is False


### PR DESCRIPTION
Fourth of five. Stacked on #567. **No CI runs on a stacked PR.**

Behind the `handoff_map` feature flag, **off by default**, sitting beside Generate Overview Plot rather than replacing it — the same staging pattern as `overview_canvas_tab`, `connection_chip` and `sparse_fm_selection`, and it goes the same way: deleted when it takes over, never kept as a preference.

## Why a document rather than a picture

The person who loads the grid into the TEM is usually not the person who milled it, and never has fibsemOS installed. Whatever was exported before the operator went home is the entire downstream interface. A single PNG of crosses on a grid is not enough to plan a session from.

Three pages, in the order the questions get asked:

1. **A map page per overview** — marked, named, scalebar, provenance line. One page *per overview* rather than one page for all of them, because two overviews are two pictures. A fluorescence overview is a picture from a different direction entirely, so it is named on the page but not drawn on beam axes it does not register with.
2. **The table** — thickness, width, milling angle, last completed task, when it finished, how many fluorescence stacks, and any note.
3. **A card per lamella** — with its final ion-beam image, so it can be recognised in an atlas before a hole is committed to it. The ion beam rather than the electron beam: that is the view it was milled in, so it shows the trenches, the tabs and the curtaining a reader is checking for.

## Nothing is inferred

No lamella is called ready, finished or good anywhere. The only judgement in the record is `defect.state`, which a human sets by hand; a lamella whose polishing never ran is *unfinished* rather than *defective*. The document reports the last task that completed and leaves the conclusion to the reader. There is a test asserting the summary line contains none of "ready", "good", "usable", "ok".

## The geometry needed more care than expected

"The last completed milling task" is routinely `Mill Fiducial`, and a fiducial pattern has a `width` like a trench does. The first version reported a fiducial's **1.0 µm as the lamella's width** for a lamella that had barely been cut — I caught it by reading real output rather than by reasoning.

The discriminator is the pattern's `spacing`, which is the gap the lamella actually *is*. A pattern without one describes something else and is skipped. Where nothing qualifies, the page prints a dash — a dash is honest, a borrowed number is not. Six tests cover this specifically.

## Grid and slot are a deliberate placeholder

Free text on `Experiment.metadata`. Nothing in the codebase records which physical grid a lamella is on or which cassette slot it travels in — there is no grid record yet — and for a single-grid experiment the experiment *is* the grid, so a typed string carries the whole of what is known. Shaped so a real record can later fill the same two header fields without the page changing.

## No Qt in the document builder

Deliberately. The artifact is most wanted at the end of a run nobody stayed for, so it has to be reachable from a workflow hook and not only from a dialog someone remembered to open. That is what #568 uses. `reportlab` is imported inside the function so that reading a lamella's geometry — which the dialog does per keystroke — does not pay for it.

## Verification

- Generated end to end against a real experiment: **5 pages**, rendered and read. Defect colouring, the fluorescence note, the table and both detail cards all correct.
- 20 new tests, focused on restraint: what it must not claim, and where it must print a dash.
- Dialog driven offscreen with the real `NAPARI_STYLE`: **0 Qt warnings** beyond the offscreen platform plugin's own.
- `tests/autolamella` + the two new overview suites: 606 passed.
- ruff clean; static 3.8 scan across the stack clean.

## The flag has a toggle in Preferences

`Preferences > Features > Enable Handoff Map Export`, alongside the other staging flags.

Added after `tests/ui/test_preferences_dialog.py::test_every_feature_flag_survives_the_dialog` caught the omission — the repo asserts that *every* `FeatureFlags` field round-trips through the dialog, and a flag with no checkbox fails it. Good test; it found this before a human had to.
