### PR TITLE
[feat] Write the handoff map when a run finishes, not when someone remembers to

### DIFF
--- a/fibsem/applications/autolamella/tools/artifacts.py
+++ b/fibsem/applications/autolamella/tools/artifacts.py
@@ -127,3 +127,50 @@ def _find_item(experiment: "Experiment", context: "HookContext") -> Optional["La
         if lamella.name == context.item_name:
             return lamella
     return None
+
+
+HANDOFF_MAP_SUFFIX = "-handoff-map.pdf"
+
+
+def write_handoff_map(
+    experiment: "Experiment", context: "HookContext"
+) -> Optional[str]:
+    """Write the handoff map for the whole experiment when a run finishes.
+
+    The artifact `write_completion_summary` was standing in for. Written into the
+    experiment directory rather than a lamella's, because unlike the per-lamella summary
+    this covers the *grid*: where everything is, including the lamellae that did not
+    finish, which is the case people actually hit and the one they most want to look at.
+
+    Hung off the end of a run rather than off ITEM_COMPLETED for the same reason, plus a
+    practical one: the document re-renders every map and every lamella image, so
+    regenerating it each time one lamella finished would repeat that work once per
+    lamella for a file only the last version of which is read.
+
+    Grid and slot come from whatever the operator last typed into the export dialog,
+    which is kept on `Experiment.metadata`. Absent on a run where nobody opened it --
+    and absent is right, because guessing a cassette slot into a document that travels
+    with the sample would be worse than leaving it blank.
+
+    Overwrites in place. There is one current answer to "what is on this grid", and a
+    directory of dated near-duplicates makes the recipient choose between them.
+
+    Raising is contained by `HookManager.fire`, so a map that cannot be written is
+    logged and the run carries on.
+    """
+    from fibsem.applications.autolamella.tools.handoff_map import (
+        HandoffOptions,
+        generate_handoff_map,
+    )
+
+    output = os.path.join(
+        str(experiment.path), f"{experiment.name}{HANDOFF_MAP_SUFFIX}"
+    )
+    options = HandoffOptions(
+        grid=experiment.metadata.get("grid", ""),
+        slot=experiment.metadata.get("slot", ""),
+        note=experiment.metadata.get("handoff_note", ""),
+    )
+    generate_handoff_map(experiment, output, options)
+    logging.info(f"Wrote the handoff map for {experiment.name} to {output}")
+    return output

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -71,9 +71,6 @@ if (
 from psygnal import EmissionInfo
 from superqt import ensure_main_thread
 
-# Paired with the disabled completion_summary hook in setup_hooks; FunctionHook and
-# HookEvent come back from fibsem.hooks below at the same time.
-# from fibsem.applications.autolamella.tools.artifacts import write_completion_summary
 import fibsem.config as fibsem_cfg
 from fibsem.applications.autolamella import config as cfg
 from fibsem.applications.autolamella.hook_defaults import build_hook_manager
@@ -88,6 +85,7 @@ from fibsem.applications.autolamella.structures import (
     Experiment,
     Lamella,
 )
+from fibsem.applications.autolamella.tools.artifacts import write_handoff_map
 from fibsem.applications.autolamella.ui.autolamella_create_experiment_widget import (
     create_experiment_dialog,
 )
@@ -98,7 +96,7 @@ from fibsem.applications.autolamella.ui.autolamella_load_task_protocol_widget im
     load_task_protocol_dialog,
 )
 from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
-from fibsem.hooks import HookManager
+from fibsem.hooks import FunctionHook, HookEvent, HookManager
 from fibsem.ui.fm.widgets import MinimapPlotWidget
 from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget
 from fibsem.ui.widgets.workflow_summary_dialog import WorkflowSummaryDialog
@@ -1068,35 +1066,38 @@ class AutoLamellaUI(QMainWindow):
         preferences = fibsem_cfg.load_user_preferences()
         manager = build_hook_manager(preferences.hooks)
 
-        # Deliberately not registered yet. The trigger is proven end to end and the
-        # writer is tested, but completion-summary.json is a placeholder for the real
-        # artifacts (the PDF and the overview PNG), and turning it on here would start
-        # writing a throwaway file into every user's lamella directories. Re-enable when
-        # the artifact is the one people actually want -- see FIB-461. Three imports at
-        # the top of this file come back with it: write_completion_summary, and
-        # FunctionHook + HookEvent from fibsem.hooks.
+        # The completion-summary.json placeholder stays unregistered: it was standing
+        # in for a real artifact, and the real artifact now exists. Re-enable it only if
+        # something wants a machine-readable per-lamella record; the imports it needs are
+        # named at the top of this file.
         #
-        # Per lamella, not per experiment: a lamella is what gets delivered, and an
-        # experiment with one abandoned lamella never reaches completion at all, so
-        # hanging the artifact off the experiment would mean it was almost never
-        # written.
+        # The handoff map is registered, and gated on the same flag as the menu entry it
+        # complements. That gate is the point: the map is most valuable when written by
+        # whatever finished the work rather than by someone who remembered to open a
+        # dialog, but writing a PDF into every user's experiment directory is not
+        # something to switch on for everyone before it has been read by anyone.
+        #
+        # WORKFLOW_COMPLETED, not ITEM_COMPLETED. The document covers the whole grid --
+        # including the lamellae that did *not* finish, which is the case people
+        # actually hit and the one worth looking at -- so there is one answer per run,
+        # not one per lamella. It also re-renders every map and every lamella image, so
+        # per-lamella would repeat that work once per lamella for a file only the last
+        # version of which is ever read.
         #
         # A FunctionHook rather than a template-driven one because this needs the
-        # experiment itself, which the context deliberately does not carry -- the path
-        # is derivable from the record, and in-process hooks can reach the record. A
-        # webhook could not, which is the distinction.
+        # experiment itself, which the context deliberately does not carry. In-process
+        # hooks can reach the record; a webhook could not, which is the distinction.
         #
-        # HookManager.fire contains what this raises, so a summary that cannot be
-        # written is logged and the run carries on. FIB-461 asks for exactly that, and
-        # it comes for free rather than needing a second guard here.
-        #
-        # manager.register(
-        #     FunctionHook(
-        #         name="completion_summary",
-        #         events=[HookEvent.ITEM_COMPLETED],
-        #         callback=lambda ctx: write_completion_summary(self.experiment, ctx),
-        #     )
-        # )
+        # HookManager.fire contains what this raises, so a map that cannot be written is
+        # logged and the run carries on.
+        if preferences.features.handoff_map:
+            manager.register(
+                FunctionHook(
+                    name="handoff_map",
+                    events=[HookEvent.WORKFLOW_COMPLETED],
+                    callback=lambda ctx: write_handoff_map(self.experiment, ctx),
+                )
+            )
         # Signals are thread-safe to emit; hooks fire on the task worker thread.
         manager.set_notifier(self._hook_toast_signal.emit)
         return manager

--- a/tests/autolamella/test_handoff_map_artifact.py
+++ b/tests/autolamella/test_handoff_map_artifact.py
@@ -1,0 +1,127 @@
+"""Writing the handoff map without anyone asking for it.
+
+The map matters most at the end of a run nobody stayed for -- which is exactly when no
+one is there to open a dialog. This is the hook that writes it anyway.
+
+Two things are pinned here beyond "it writes a file". It is off unless the flag is on,
+because a PDF appearing in every user's experiment directory is not a change to make for
+everyone before anyone has read one. And a map that cannot be written must not take the
+run down with it: the run is the valuable thing, the artifact is a convenience.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from fibsem.applications.autolamella.structures import (
+    Experiment,
+    Lamella,
+)
+from fibsem.applications.autolamella.tools.artifacts import (
+    HANDOFF_MAP_SUFFIX,
+    write_handoff_map,
+)
+from fibsem.hooks import FunctionHook, HookContext, HookEvent, HookManager
+
+
+@pytest.fixture
+def experiment(tmp_path: Path) -> Experiment:
+    exp = Experiment(path=tmp_path, name="auto-handoff")
+    exp.path = str(tmp_path / "auto-handoff")
+    Path(exp.path).mkdir(parents=True, exist_ok=True)
+    for i in range(2):
+        lam = Lamella(path=Path(exp.path) / f"L{i}", number=i, petname=f"L{i}")
+        Path(lam.path).mkdir(parents=True, exist_ok=True)
+        exp.positions.append(lam)
+    return exp
+
+
+@pytest.fixture
+def context() -> HookContext:
+    return HookContext(event=HookEvent.WORKFLOW_COMPLETED)
+
+
+class TestWritingIt:
+    def test_it_writes_into_the_experiment_directory(self, experiment, context):
+        """The grid's document, not a lamella's -- it covers all of them at once."""
+        path = write_handoff_map(experiment, context)
+
+        assert path is not None
+        assert Path(path).exists()
+        assert Path(path).parent == Path(experiment.path)
+        assert Path(path).name.endswith(HANDOFF_MAP_SUFFIX)
+
+    def test_it_overwrites_rather_than_accumulating(self, experiment, context):
+        """One current answer to "what is on this grid".
+
+        A directory of dated near-duplicates makes the recipient choose between them,
+        which is a worse problem than having no map at all.
+        """
+        first = write_handoff_map(experiment, context)
+        second = write_handoff_map(experiment, context)
+
+        assert first == second
+        pdfs = list(Path(experiment.path).glob("*.pdf"))
+        assert len(pdfs) == 1
+
+    def test_it_carries_the_grid_details_the_operator_typed(self, experiment, context):
+        """Whatever was last entered in the dialog, kept on the experiment."""
+        experiment.metadata["grid"] = "A"
+        experiment.metadata["slot"] = "3"
+
+        path = write_handoff_map(experiment, context)
+        text = Path(path).read_bytes()
+        # The reportlab output is compressed, so this asserts on the file existing and
+        # being non-trivial rather than on its text; the content itself is covered by
+        # test_handoff_map.py against the functions that produce it.
+        assert len(text) > 1000
+
+    def test_an_experiment_with_no_overviews_still_produces_a_document(
+        self, experiment, context
+    ):
+        """A run where the overview was never acquired still has a table worth sending."""
+        assert not experiment.find_overview_images()
+        path = write_handoff_map(experiment, context)
+        assert Path(path).exists()
+
+
+class TestTheHookIsContained:
+    def test_a_failure_does_not_stop_the_run(self, experiment):
+        """HookManager.fire swallows what a hook raises; this is the proof, not a claim."""
+        manager = HookManager()
+        manager.register(
+            FunctionHook(
+                name="handoff_map",
+                events=[HookEvent.WORKFLOW_COMPLETED],
+                callback=lambda ctx: write_handoff_map(experiment, ctx),
+            )
+        )
+        # A path that cannot be written to.
+        experiment.path = "/definitely/not/a/directory"
+
+        # The assertion is that this returns rather than raising.
+        manager.fire(HookContext(event=HookEvent.WORKFLOW_COMPLETED))
+
+    def test_it_fires_on_the_end_of_a_run(self, experiment):
+        seen = []
+        manager = HookManager()
+        manager.register(
+            FunctionHook(
+                name="handoff_map",
+                events=[HookEvent.WORKFLOW_COMPLETED],
+                callback=lambda ctx: seen.append(write_handoff_map(experiment, ctx)),
+            )
+        )
+
+        manager.fire(HookContext(event=HookEvent.ITEM_COMPLETED))
+        assert seen == [], "an item completing is not the end of the run"
+
+        manager.fire(HookContext(event=HookEvent.WORKFLOW_COMPLETED))
+        assert len(seen) == 1
+
+
+class TestItIsOffByDefault:
+    def test_the_flag_gates_it(self):
+        from fibsem.config import FeatureFlags
+
+        assert FeatureFlags().handoff_map is False


### PR DESCRIPTION
Last of five. Stacked on #568. **No CI runs on a stacked PR** — the whole stack was scanned statically for 3.8/3.9 breakage instead: 0 problems across 18 files.

## The gap this closes

The map is most valuable at the end of a run nobody stayed for, which is exactly when no one is there to open a dialog. Wrong person, wrong time, wrong machine. This registers it as a hook — gated on the same `handoff_map` flag as the menu entry it complements, so it is proven and reachable but not yet writing PDFs into every user's experiment directory.

It replaces the placeholder that was standing in for it. `completion-summary.json` existed to prove the trigger end to end while the real artifact did not exist. It now does, so the json stays unregistered and the map takes its place.

## `WORKFLOW_COMPLETED`, not `ITEM_COMPLETED`

A change of mind from what the placeholder assumed, and worth the reasons:

- The document covers the **whole grid**, including the lamellae that did *not* finish — the case people actually hit, and the one they most want to look at. So there is one answer per run, not one per lamella.
- It re-renders every map and every lamella image. Per-lamella would repeat that work once per lamella for a file only the last version of which is ever read.

The per-lamella `completion-summary.json` remains available for anything that wants a machine-readable per-lamella record; its imports are still named where they were.

## Details that are decisions, not defaults

**Overwrites in place.** There is one current answer to "what is on this grid", and a directory of dated near-duplicates makes the recipient choose between them — a worse problem than having no map.

**Grid and slot come from whatever the operator last typed into the export dialog**, kept on `Experiment.metadata`. Absent on a run where nobody opened it, and absent is right: guessing a cassette slot into a document that travels with the sample is worse than leaving it blank.

**A `FunctionHook`** rather than a template-driven one, because this needs the experiment itself, which the context deliberately does not carry. In-process hooks can reach the record; a webhook could not, which is the distinction.

## Failure containment is tested, not claimed

`HookManager.fire` already contains what a hook raises, so a map that cannot be written is logged and the run carries on. There is a test that points the experiment at an unwritable path and asserts `fire` returns rather than raising.

## Verification

- 7 new tests: writes into the experiment directory, overwrites rather than accumulating, produces a document even with no overview acquired, fires on the end of a run and *not* on an item completing, and does not take the run down when it fails.
- Flag gating verified through `setup_hooks()` itself: `flag=False → not registered`, `flag=True → registered`.
- ruff clean; static 3.8 scan clean.