### PR TITLE
Remove the sparse FM selection feature flag; enable it for everyone

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -893,7 +893,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # match. The FM Overview tab used to be here too; it ships to everyone with an
         # FM now (FIB-611), so its visibility follows the instrument rather than a flag.
         self._apply_overview_canvas_visibility()
-        self._apply_sparse_fm_selection_flag()
         # Toggle Tools -> Scripts. Hiding the menu hides the whole feature: it is the
         # only route to the manager dialog, and the dialog is the only thing that runs
         # a script. If a script is mid-run, leave it visible -- taking away the only
@@ -1531,7 +1530,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # Same for the rebuilt Overview tab, which holds its microscope for life and
         # has to be handed the new one (or let go of the old) on every connection.
         self._apply_overview_canvas_visibility()
-        self._apply_sparse_fm_selection_flag()
         if (
             self.autolamella_ui is not None
             and self.autolamella_ui.microscope is not None
@@ -2961,23 +2959,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.tab_widget.indexOf(self.overview_canvas_tab), False
         )
         self._apply_overview_canvas_visibility()
-        self._apply_sparse_fm_selection_flag()
-
-    def _apply_sparse_fm_selection_flag(self) -> None:
-        """Offer planning an FM overview from a beam one, or do not.
-
-        A control inside a tab rather than a tab, so there is nothing to show or hide
-        here -- the widget is told and decides. Read off `self._preferences` for the same
-        reason as the flag below: this is a method on the window that owns them, and a
-        module-level copy would only be a second thing to keep in step.
-        """
-        tab = getattr(self, "fm_overview_tab", None)
-        overview = getattr(tab, "overview", None) if tab is not None else None
-        if overview is None:
-            return
-        overview.set_sparse_selection_enabled(
-            self._preferences.features.sparse_fm_selection
-        )
 
     def _apply_overview_canvas_visibility(self) -> None:
         """Show or hide the rebuilt Overview tab, and build or tear down its widget.

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -404,11 +404,6 @@ class FeatureFlags:
     # A staging flag like `overview_canvas_tab`, and it goes the same way: deleted
     # when the chip replaces the tab, not kept as a preference.
     connection_chip: bool = False
-    # Planning a sparse fluorescence overview by drawing regions on a FIB/SEM one.
-    # Off while it has had no bench time: it decides where an expensive acquisition
-    # goes, and the geometry it rests on is only checkable against real data
-    # (FIB-597). Staging, like the flag above -- deleted when it ships, not kept.
-    sparse_fm_selection: bool = False
 
 
 @dataclass

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -284,7 +284,6 @@ class FMOverviewWidget(QWidget):
         # Set only while `_on_drag_finished` is running the refresh a drag deferred.
         # See there: that refresh must not re-frame the view.
         self._finishing_drag = False
-        self._sparse_selection_enabled = False
         # Where acquired overviews are written. None means nowhere: the widget opens
         # standalone against a simulator as often as it runs inside an experiment, and
         # inventing a directory for those runs would scatter files through whatever
@@ -575,7 +574,6 @@ class FMOverviewWidget(QWidget):
             size=_HEADER_BTN_SIZE,
         )
         self.button_select_ground.clicked.connect(self.select_ground_to_image)
-        self.button_select_ground.setVisible(False)
         self.settings_widget.add_grid_header_widget(self.button_select_ground)
 
         buttons = QWidget()
@@ -1220,17 +1218,6 @@ class FMOverviewWidget(QWidget):
         """Where a run would write, as the Output panel has it."""
         return self.settings_widget.save_directory
 
-    def set_sparse_selection_enabled(self, enabled: bool) -> None:
-        """Offer planning an overview by selecting on a FIB/SEM one, or do not.
-
-        Part of the host contract, like `set_save_directory`: this widget is handed a
-        microscope and knows nothing about preferences. Carried past the button rather
-        than only to it -- a control nobody can see is not a feature that is off, and
-        `select_ground_to_image` refuses on the same flag.
-        """
-        self._sparse_selection_enabled = bool(enabled)
-        self.button_select_ground.setVisible(self._sparse_selection_enabled)
-
     def select_ground_to_image(self) -> None:
         """Draw regions on a saved beam overview, and take the grid they produce.
 
@@ -1243,8 +1230,6 @@ class FMOverviewWidget(QWidget):
             beam_overviews_in,
         )
 
-        if not self._sparse_selection_enabled:
-            return
         views = beam_overviews_in(self._save_directory, self.microscope)
         if not views:
             notification_service.show_toast(

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -60,13 +60,6 @@ _TIP_BUG_REPORT = (
     "Show the 'Report an Issue...' option in the Help menu, for reporting bugs and "
     "optionally submitting experiment data privately to the maintainers."
 )
-_LBL_SPARSE_FM = "Enable Sparse FM Selection"
-_TIP_SPARSE_FM = (
-    "Plan a fluorescence overview by drawing regions on a FIB/SEM one, so only "
-    "the interesting parts of the grid are imaged.\n\n"
-    "Off until it has had bench time: it decides where an expensive acquisition "
-    "goes, and the geometry behind it can only be checked against real data."
-)
 _LBL_OVERVIEW_CANVAS = "Enable Overview (Canvas) Tab"
 _TIP_OVERVIEW_CANVAS = (
     "Add a rebuilt Overview tab on the real-space canvas, beside the existing one. "
@@ -185,8 +178,6 @@ class PreferencesDialog(QDialog):
         self._chk_scripts.setToolTip(_TIP_SCRIPTS)
         self._chk_overview_canvas = QCheckBox()
         self._chk_overview_canvas.setToolTip(_TIP_OVERVIEW_CANVAS)
-        self._chk_sparse_fm = QCheckBox()
-        self._chk_sparse_fm.setToolTip(_TIP_SPARSE_FM)
         self._chk_connection_chip = QCheckBox()
         self._chk_connection_chip.setToolTip(_TIP_CONNECTION_CHIP)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
@@ -194,7 +185,6 @@ class PreferencesDialog(QDialog):
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
         features_form.addRow(_LBL_SCRIPTS, self._chk_scripts)
         features_form.addRow(_LBL_OVERVIEW_CANVAS, self._chk_overview_canvas)
-        features_form.addRow(_LBL_SPARSE_FM, self._chk_sparse_fm)
         features_form.addRow(_LBL_CONNECTION_CHIP, self._chk_connection_chip)
         self._stack.addWidget(features_page)
 
@@ -268,7 +258,6 @@ class PreferencesDialog(QDialog):
         self._chk_bug_report.setChecked(f.bug_report_enabled)
         self._chk_scripts.setChecked(f.scripts_enabled)
         self._chk_overview_canvas.setChecked(f.overview_canvas_tab)
-        self._chk_sparse_fm.setChecked(f.sparse_fm_selection)
         self._chk_connection_chip.setChecked(f.connection_chip)
 
         e = prefs.experiment
@@ -342,7 +331,6 @@ class PreferencesDialog(QDialog):
                 scripts_enabled=self._chk_scripts.isChecked(),
                 overview_canvas_tab=self._chk_overview_canvas.isChecked(),
                 connection_chip=self._chk_connection_chip.isChecked(),
-                sparse_fm_selection=self._chk_sparse_fm.isChecked(),
             ),
             movement=MovementPreferences(
                 acquire_sem_after_stage_movement=self._chk_acquire_sem.isChecked(),

--- a/tests/ui/test_fm_sparse_entry_point.py
+++ b/tests/ui/test_fm_sparse_entry_point.py
@@ -5,6 +5,7 @@ FIB/SEM tab -- that tab keeps pixels and a position, not the metadata a projecti
 read from. And applying what comes back, which has to reach the *acquisition* rather than
 only the drawing, or the grid on screen and the run would disagree.
 """
+
 import os
 from contextlib import contextmanager
 
@@ -207,7 +208,9 @@ def test_it_does_open_when_there_is_something_to_select_on(widget):
 def selection(rows=4, cols=3, enabled=((0, 0), (1, 1))):
     mask = [[(r, c) in enabled for c in range(cols)] for r in range(rows)]
     return SparseSelection(
-        parameters=OverviewParameters(rows=rows, cols=cols, overlap=0.1, tile_mask=mask),
+        parameters=OverviewParameters(
+            rows=rows, cols=cols, overlap=0.1, tile_mask=mask
+        ),
         centre_position=FibsemStagePosition(
             x=1e-4, y=2e-4, z=0.0, r=0.0, t=-3.141592653589793
         ),
@@ -243,5 +246,7 @@ def test_it_says_the_grid_came_from_a_selection_and_will_be_replaced(widget):
     """
     widget.apply_sparse_selection(selection(rows=4, cols=3))
 
-    assert "2 of 12 tiles came from a selection" in widget.button_select_ground.toolTip()
+    assert (
+        "2 of 12 tiles came from a selection" in widget.button_select_ground.toolTip()
+    )
     assert "replaces it" in widget.button_select_ground.toolTip()

--- a/tests/ui/test_fm_sparse_entry_point.py
+++ b/tests/ui/test_fm_sparse_entry_point.py
@@ -141,11 +141,8 @@ def widget(microscope, experiment):
     return built
 
 
-def test_the_button_is_hidden_until_the_feature_is_turned_on(widget):
-    assert widget.button_select_ground.isVisibleTo(widget) is False
-
-    widget.set_sparse_selection_enabled(True)
-
+def test_the_button_is_there(widget):
+    """No flag left to turn it on: the entry point ships with the tab (FIB-597)."""
     assert widget.button_select_ground.isVisibleTo(widget) is True
 
 
@@ -183,24 +180,12 @@ def test_the_button_sits_with_the_grid_it_sets(widget):
     assert header.isAncestorOf(widget.button_select_ground)
 
 
-def test_the_flag_is_carried_past_the_button(widget):
-    """A control nobody can see is not a feature that is off. Someone reaching the
-    method another way must meet the same answer as someone looking for the button."""
-    widget.set_sparse_selection_enabled(False)
-
-    with dialog_never_opens() as opened:
-        widget.select_ground_to_image()
-
-    assert opened == []
-
-
 def test_with_no_overviews_it_says_so_rather_than_opening_an_empty_dialog(
     microscope, tmp_path
 ):
     """A dialog offering nothing to select on is a dead end with a Cancel button."""
     built = FMOverviewWidget(microscope)
     built.set_save_directory(str(tmp_path))
-    built.set_sparse_selection_enabled(True)
 
     with dialog_never_opens() as opened:
         built.select_ground_to_image()
@@ -210,8 +195,6 @@ def test_with_no_overviews_it_says_so_rather_than_opening_an_empty_dialog(
 
 def test_it_does_open_when_there_is_something_to_select_on(widget):
     """The guard above has to be a guard, not the only path."""
-    widget.set_sparse_selection_enabled(True)
-
     with dialog_never_opens() as opened:
         widget.select_ground_to_image()
 


### PR DESCRIPTION
Selecting the ground to image on a FIB/SEM overview has had its bench time (FIB-597), so the staging flag goes the way the others did — deleted, not kept as a preference.

- `FeatureFlags.sparse_fm_selection` is gone. Unknown keys are dropped by `_sub_from_dict`, so a stale entry in someone's preferences file is ignored rather than an error.
- The Grid-header button ships with the FM Overview tab: no `setVisible(False)` at build, no cached `_sparse_selection_enabled`, and `select_ground_to_image` has no flag left to refuse on.
- `set_sparse_selection_enabled` leaves the host contract, along with `_apply_sparse_fm_selection_flag` and its three call sites in the main window. Nothing is told about this feature any more.
- The Features page loses its checkbox, label and tooltip.

The test that asserted the button stays hidden until the flag is on becomes a plain "the button is there"; the one checking the flag was carried past the button is deleted, since there is nothing left to carry.

## Verification

- `tests/ui` in full: 2230 passed, 1 failed. The failure is `test_coincidence_viewer_layering.py::test_the_raise_comes_after_the_run_is_recorded_and_announced`, which fails identically on the unmodified tree (2233 passed, same one failure) and passes when that file runs alone — the known cross-test window-leak ordering issue, not this change.
- Ran the widget for real offscreen: `FeatureFlags()` has no such field and `button_select_ground.isVisible()` is True with no preference set.
- ruff clean on all five files.