### PR TITLE
[ui] Toasts always show, instead of never (FIB-781)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -443,7 +443,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # User attention tracking
         self._user_interaction_sound_played = False  # Track if sound was played
         self._sound_enabled = self._preferences.display.sound_enabled
-        self._toasts_enabled = self._preferences.display.toasts_enabled
         self._border_enabled = self._preferences.display.border_enabled
         self.dev_mode = self._preferences.display.dev_mode
 
@@ -761,11 +760,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.action_sound_toggle.setChecked(self._sound_enabled)
         self.action_sound_toggle.triggered.connect(self._on_sound_toggle)
 
-        self.action_toasts_toggle = QAction("Toasts Enabled", self)
-        self.action_toasts_toggle.setCheckable(True)
-        self.action_toasts_toggle.setChecked(self._toasts_enabled)
-        self.action_toasts_toggle.triggered.connect(self._on_toasts_toggle)
-
         # Border state test actions
         self.action_border_toggle = QAction("Show Workflow Border", self)
         self.action_border_toggle.setCheckable(True)
@@ -828,7 +822,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         test_menu.addSeparator()  # type: ignore
         test_menu.addAction(self.action_beep)  # type: ignore
         test_menu.addAction(self.action_sound_toggle)  # type: ignore
-        test_menu.addAction(self.action_toasts_toggle)  # type: ignore
 
         self._test_menu = test_menu
         self._test_menu.menuAction().setVisible(self.dev_mode)
@@ -837,12 +830,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         """Handle sound toggle."""
         self._sound_enabled = checked
         self._preferences.display.sound_enabled = checked
-        fibsem_cfg.save_user_preferences(self._preferences)
-
-    def _on_toasts_toggle(self, checked: bool):
-        """Handle toasts toggle."""
-        self._toasts_enabled = checked
-        self._preferences.display.toasts_enabled = checked
         fibsem_cfg.save_user_preferences(self._preferences)
 
     def _on_border_toggle(self, checked: bool):
@@ -867,7 +854,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         """Apply current preferences to UI state."""
         d = self._preferences.display
         self._sound_enabled = d.sound_enabled
-        self._toasts_enabled = d.toasts_enabled
         self._border_enabled = d.border_enabled
         self.dev_mode = d.dev_mode
         # The lamella strip's density. Guarded because _apply_preferences also runs
@@ -876,7 +862,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.lamella_card_container.set_mode(d.lamella_card_mode)
         # Sync Test menu toggle actions
         self.action_sound_toggle.setChecked(d.sound_enabled)
-        self.action_toasts_toggle.setChecked(d.toasts_enabled)
         self.action_border_toggle.setChecked(d.border_enabled)
         # Toggle dev/test menu visibility
         self._dev_menu.menuAction().setVisible(d.dev_mode)
@@ -940,16 +925,16 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         duration: int = 5000,
         temporary: bool = False,
     ):
-        """Show a toast notification."""
-        if self._toasts_enabled:
-            self.toast_manager.show_toast(
-                message, notification_type, duration, temporary=temporary
-            )
-        elif self.toast_manager.notification_bell and not temporary:
-            # Still log to notification bell even when toasts are disabled
-            self.toast_manager.notification_bell.add_notification(
-                message, notification_type
-            )
+        """Show a toast notification.
+
+        Unconditional: there is no longer a preference for turning toasts off, so the
+        branch that used to route a suppressed message to the notification bell has
+        gone with it. Nothing is lost -- `ToastManager.show_toast` records every
+        non-temporary message in the bell itself.
+        """
+        self.toast_manager.show_toast(
+            message, notification_type, duration, temporary=temporary
+        )
 
     def _on_connect_microscope(self):
         """Connect from the dialog, then hand the session to the system widget.

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -353,7 +353,17 @@ def card_mode_label(mode: str) -> str:
 @dataclass
 class DisplayPreferences:
     sound_enabled: bool = False
-    toasts_enabled: bool = False
+    # No `toasts_enabled` here: toasts are how the application talks, not a nicety
+    # sitting beside sound. It was a preference defaulting to False, which meant 165
+    # call sites emitted feedback that reached nowhere at all -- `show_toast`
+    # deliberately bypasses notification history, so off was not "quieter", it was
+    # silent.
+    #
+    # Removed rather than flipped. `to_dict` is `dataclasses.asdict`, so every save
+    # writes the key and opening an experiment is enough to trigger a save: a new
+    # default would have reached only a machine that had never run the app, while
+    # everyone else kept the pinned `false` (FIB-781). Older files still carry the
+    # key and `_sub_from_dict` drops it.
     border_enabled: bool = True
     dev_mode: bool = False
     # How the lamella strip draws each card: "cozy" (large thumbnail), "standard"

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -381,8 +381,8 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         the refreshing images do not already show. On the info bar the same words stay
         put for the duration of the move, which is when they are worth reading.
 
-        They are invisible today because `display.toasts_enabled` defaults to False.
-        That default should change, and this is what has to be true first.
+        Toasts show unconditionally (FIB-781), so that wall of popups is what these
+        messages would actually produce rather than a thing to worry about later.
         """
         msg = ddict.get("msg", None)
         if msg is not None:

--- a/fibsem/ui/FibsemSystemSetupWidget.py
+++ b/fibsem/ui/FibsemSystemSetupWidget.py
@@ -34,9 +34,9 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
         self.microscope: Optional[FibsemMicroscope] = None
         self.settings: Optional[MicroscopeSettings] = None
         # Why the last attempt failed, or None if the last thing that happened was not
-        # a failure. Held rather than only toasted: toasts are off by default
-        # (`display.toasts_enabled`), so a toast alone turns the crash this guards
-        # against into silence, which is not much of an improvement.
+        # a failure. Held rather than only toasted: a toast is gone in five seconds,
+        # and the reason a connection failed is exactly what the status card should
+        # keep showing until the next attempt.
         self._last_connection_error: Optional[str] = None
 
         # grid layout

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -31,10 +31,6 @@ from fibsem.ui.widgets.custom_widgets import QDirectoryLineEdit, QFileLineEdit
 # Display
 _LBL_SOUND = "Enable Sound Notifications"
 _TIP_SOUND = "Play an audio alert when the workflow requires the user's attention."
-_LBL_TOASTS = "Enable Toast Notifications"
-_TIP_TOASTS = (
-    "Show brief pop-up messages in the corner of the screen for workflow events."
-)
 _LBL_BORDER = "Enable Workflow Border"
 _TIP_BORDER = "Highlight the viewport border while an automated workflow is running."
 _LBL_CARD_MODE = "Lamella Card Layout"
@@ -152,8 +148,6 @@ class PreferencesDialog(QDialog):
         display_form = QFormLayout(display_page)
         self._chk_sound = QCheckBox()
         self._chk_sound.setToolTip(_TIP_SOUND)
-        self._chk_toasts = QCheckBox()
-        self._chk_toasts.setToolTip(_TIP_TOASTS)
         self._chk_border = QCheckBox()
         self._chk_border.setToolTip(_TIP_BORDER)
         self._chk_dev_mode = QCheckBox()
@@ -166,7 +160,6 @@ class PreferencesDialog(QDialog):
         for mode in CARD_MODES:
             self._combo_card_mode.addItem(card_mode_label(mode), mode)
         display_form.addRow(_LBL_SOUND, self._chk_sound)
-        display_form.addRow(_LBL_TOASTS, self._chk_toasts)
         display_form.addRow(_LBL_BORDER, self._chk_border)
         display_form.addRow(_LBL_CARD_MODE, self._combo_card_mode)
         display_form.addRow(_LBL_DEV_MODE, self._chk_dev_mode)
@@ -247,7 +240,6 @@ class PreferencesDialog(QDialog):
         """Populate widgets from a UserPreferences instance."""
         d = prefs.display
         self._chk_sound.setChecked(d.sound_enabled)
-        self._chk_toasts.setChecked(d.toasts_enabled)
         self._chk_border.setChecked(d.border_enabled)
         self._chk_dev_mode.setChecked(d.dev_mode)
         card_index = self._combo_card_mode.findData(d.lamella_card_mode)
@@ -330,7 +322,6 @@ class PreferencesDialog(QDialog):
         return UserPreferences(
             display=DisplayPreferences(
                 sound_enabled=self._chk_sound.isChecked(),
-                toasts_enabled=self._chk_toasts.isChecked(),
                 border_enabled=self._chk_border.isChecked(),
                 dev_mode=self._chk_dev_mode.isChecked(),
                 lamella_card_mode=self._combo_card_mode.currentData(),

--- a/tests/ui/test_movement_progress.py
+++ b/tests/ui/test_movement_progress.py
@@ -7,8 +7,8 @@ tab, because five of the six paths that start a stage move start it from somewhe
 else, and a message on a hidden tab is one nobody reads. The info bar sits beside the
 canvas that was clicked and is visible from every tab.
 
-They are invisible today because ``display.toasts_enabled`` defaults to False. This is
-what has to be true before that default can change.
+Toasts show unconditionally (FIB-781), so this is what keeps a single click from
+producing four popups.
 """
 
 from __future__ import annotations

--- a/tests/ui/test_system_setup_widget.py
+++ b/tests/ui/test_system_setup_widget.py
@@ -117,9 +117,9 @@ def test_an_unexpected_failure_is_caught_too(widget, monkeypatch, toasts):
 
 
 def test_a_failed_connection_is_visible_without_toasts(widget, monkeypatch, toasts):
-    """Toasts are off by default (`display.toasts_enabled`), and `show_toast`
-    deliberately does not reach notification history -- so a toast alone would turn
-    the crash this guards against into silence. The status card is always on screen.
+    """`show_toast` deliberately does not reach notification history, and a toast is
+    gone in five seconds -- so a toast alone would leave nothing on screen explaining
+    why the connection failed. The status card is always there.
     """
     _fail_to_connect(monkeypatch, Exception(AUTOSCRIPT_MISSING))
     monkeypatch.setattr(widget, "load_configuration", lambda *a, **k: "/some/path.yaml")

--- a/tests/ui/test_toasts_are_not_optional.py
+++ b/tests/ui/test_toasts_are_not_optional.py
@@ -1,0 +1,126 @@
+"""Toasts are how the application talks, so there is no longer a way to turn them off.
+
+``display.toasts_enabled`` defaulted to False, and ``show_toast`` deliberately bypasses
+notification history -- so on a default install 165 call sites emitted feedback that
+reached nowhere at all, not even the bell.
+
+Removed rather than flipped. ``UserPreferences.to_dict`` is ``dataclasses.asdict``, so
+every save writes every key, and merely opening an experiment triggers a save: a new
+default would have reached only a machine that had never run the application, while
+everyone who had run it kept the ``false`` already pinned in their file (FIB-781).
+"""
+
+import dataclasses
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication, QWidget  # noqa: E402
+
+from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (  # noqa: E402
+    AutoLamellaSingleWindowUI,
+)
+from fibsem.config import DisplayPreferences, UserPreferences  # noqa: E402
+from fibsem.ui.widgets.notifications import NotificationBell, ToastManager  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+# --- the preference is gone, and gone in a way old files survive ----------------
+
+
+def test_there_is_no_preference_for_turning_toasts_off():
+    names = {f.name for f in dataclasses.fields(DisplayPreferences)}
+    assert "toasts_enabled" not in names, sorted(names)
+
+
+def test_a_save_can_no_longer_pin_the_old_value():
+    """Why this is a removal rather than a flipped default.
+
+    ``to_dict`` writes every field, so for as long as the field exists, a file written
+    before the change goes on deciding the answer no matter what the default says.
+    """
+    assert "toasts_enabled" not in UserPreferences().to_dict()["display"]
+
+
+def test_a_preferences_file_written_before_the_change_still_loads():
+    """Every install that has ever opened an experiment has this key on disk."""
+    prefs = UserPreferences.from_dict(
+        {"display": {"toasts_enabled": False, "sound_enabled": True}}
+    )
+    assert not hasattr(prefs.display, "toasts_enabled")
+    assert prefs.display.sound_enabled is True  # the rest of the file survives
+
+
+def test_sound_is_still_a_preference():
+    """The neighbour this was wrongly grouped with. An audio alert really is a taste,
+    and removing the toast switch is not an argument for removing that one too."""
+    assert DisplayPreferences().sound_enabled is False
+
+
+# --- and the messages actually arrive -------------------------------------------
+
+
+class _Host(QWidget):
+    """A real window, a real ToastManager, running the real ``show_toast``.
+
+    The method is borrowed rather than the real window built: that window wants a
+    microscope, an experiment and every tab in the application, none of which bears
+    on whether a message reaches the manager.
+    """
+
+    show_toast = AutoLamellaSingleWindowUI.show_toast
+
+    def __init__(self):
+        super().__init__()
+        self.toast_manager = ToastManager(self)
+
+
+@pytest.fixture()
+def host(qapp):
+    window = _Host()
+    window.setGeometry(0, 0, 800, 600)
+    window.show()
+    yield window
+    window.close()
+
+
+def test_a_message_reaches_the_toast_manager(host):
+    host.show_toast("Connected to microscope", "info")
+
+    assert len(host.toast_manager.toasts) == 1
+
+
+def test_the_bell_still_records_what_the_removed_branch_used_to(host):
+    """The old ``elif`` added non-temporary messages to the bell by hand, so that
+    history survived while toasts were suppressed. It went with the switch, and the
+    claim replacing it is that ToastManager does this itself either way.
+    """
+    bell = NotificationBell()
+    host.toast_manager.set_notification_bell(bell)
+
+    host.show_toast("Milling finished", "info", temporary=False)
+
+    assert bell.count == 1
+    bell.deleteLater()
+
+
+def test_a_temporary_message_stays_out_of_history(host):
+    """``notification_service.show_toast`` emits with temporary=True -- the 165 sites
+    this whole change is about. They are transient by design and must not fill the
+    bell with validation chatter.
+    """
+    bell = NotificationBell()
+    host.toast_manager.set_notification_bell(bell)
+
+    host.show_toast("No microscope connected", "warning", temporary=True)
+
+    assert bell.count == 0
+    bell.deleteLater()


### PR DESCRIPTION
`toasts_enabled` defaulted to False, and `show_toast` deliberately bypasses notification history — its docstring says so. On a default install that meant **165 call sites emitting feedback that reached nowhere at all**: not the bell, not history, nowhere.

FIB-781 originally proposed flipping the default and keeping the preference. That would have reached almost nobody.

## Why removed rather than flipped

`UserPreferences.to_dict` is `dataclasses.asdict`, so **every save writes every key** — and two paths save preferences without the user asking for anything: `record_recent_experiment` and `get_recent_experiments`. Opening an experiment is enough to pin the current value on disk, where it beats any default.

| | `toasts_enabled` after a default flip |
| -- | -- |
| Fresh install, no preferences file | True |
| Anyone who has ever opened an experiment | **False** |

Six of the seventeen `user-preferences.yaml` files on one development machine already had `false` written out.

Nothing in the file distinguishes a `false` the old default wrote from a `false` someone chose, so keeping the preference meant adding a one-time migration marker that overrides the stored value exactly once — more machinery, and it overrides a deliberate choice anyway.

So the preference goes. Toasts always show. `sound_enabled` stays where it is: an audio alert really is a taste, and this is not an argument for removing that one too.

## Upgrade path

Older preference files still carry the key. `_sub_from_dict` drops it on load and the first save rewrites the file without it. Round-tripped against a real file:

```
BEFORE:  toasts_enabled: true
loaded, and the key is not a field: True
the rest of the file survived: sound=False, dev_mode=True, cards=cozy
AFTER a save: 'toasts_enabled' present = False
```

## The notification bell

`show_toast` carried an `elif` that hand-fed non-temporary messages to the bell while toasts were suppressed. It goes with the switch, and nothing is lost — `ToastManager.show_toast` already records every non-temporary message there. Two tests pin that, one for each side of `temporary`.

## Volume

Turning toasts on exposes all 165 at once, so every call site was classified by AST — enclosing function, and whether it sits in a loop or a per-update handler.

| | count |
| -- | -- |
| Fires once per user action | **159** |
| Flagged and cleared on inspection | 5 |
| Genuinely noisy | **1** |

The one genuinely noisy site was `FibsemMovementWidget.handle_movement_progress_update`, which toasted four messages per click-to-move inside 45 ms. Fixed ahead of this in #524 by routing progress to a persistent label.

## Verification

- 165 tests pass across the affected files; `ruff check` and `ruff format --check` clean.
- The seven new tests were **mutation-tested**: putting the field back fails three, putting the gate back fails two.
- **The app was launched against this branch** and connected. `_create_menus` and `_apply_preferences` both referenced the removed menu action, so a dangling reference would have surfaced at startup rather than in a test.

## Note on size

Eight files, above the usual cap. Five are the change; three are one- and two-line comment corrections in `FibsemMovementWidget`, `FibsemSystemSetupWidget` and their tests, which described a preference that no longer exists. Splitting those out would land stale comments on main.
