### PR TITLE
[ui] One Overview tab, with the imaging modality chosen on the canvas chrome (FIB-780)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -47,14 +47,8 @@ from fibsem.applications.autolamella.structures import (
     Experiment,
     Lamella,
 )
-from fibsem.applications.autolamella.ui.autolamella_fluorescence_overview_tab import (
-    AutoLamellaFluorescenceOverviewTab,
-)
 from fibsem.applications.autolamella.ui.autolamella_lamella_protocol_editor import (
     AutoLamellaProtocolEditorWidget,
-)
-from fibsem.applications.autolamella.ui.autolamella_overview_tab import (
-    AutoLamellaOverviewTab,
 )
 from fibsem.applications.autolamella.ui.autolamella_task_config_editor import (
     AutoLamellaProtocolTaskConfigEditor,
@@ -66,6 +60,9 @@ from fibsem.applications.autolamella.ui.lamella_task_image_widget import (
 )
 from fibsem.applications.autolamella.ui.lamella_workflow_widget import (
     LamellaWorkflowWidget,
+)
+from fibsem.applications.autolamella.ui.overview_container_tab import (
+    AutoLamellaOverviewContainerTab,
 )
 from fibsem.applications.autolamella.ui.workflow_preflight_dialog import (
     WorkflowPreflightDialog,
@@ -889,10 +886,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.action_report_issue.setVisible(
             self._preferences.features.bug_report_enabled
         )
-        # Show or hide the rebuilt Overview tab, building or dropping its widget to
-        # match. The FM Overview tab used to be here too; it ships to everyone with an
-        # FM now (FIB-611), so its visibility follows the instrument rather than a flag.
-        self._apply_overview_canvas_visibility()
+        # Show or hide the old napari Minimap tab. The Overview tab is not here: it
+        # ships to everyone, and which of its modalities can be reached follows the
+        # instrument rather than a flag.
+        self._apply_napari_overview_visibility()
         # Toggle Tools -> Scripts. Hiding the menu hides the whole feature: it is the
         # only route to the manager dialog, and the dialog is the only thing that runs
         # a script. If a script is mid-run, leave it visible -- taking away the only
@@ -1402,13 +1399,13 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         a loop over local variables hides the calls from it.
         """
         fm = getattr(self, "fm_overview_tab", None)
-        beam = getattr(self, "overview_canvas_tab", None)
+        beam = getattr(self, "beam_overview_tab", None)
         if fm is not None:
             allowed, reason = self._overview_may_work(beam)
             self.fm_overview_tab.set_interactive(allowed, reason)
         if beam is not None:
             allowed, reason = self._overview_may_work(fm)
-            self.overview_canvas_tab.set_interactive(allowed, reason)
+            self.beam_overview_tab.set_interactive(allowed, reason)
 
     def _overview_may_work(self, other) -> Tuple[bool, str]:
         """Whether an overview tab may work given what *other* is doing, and why not.
@@ -1522,14 +1519,12 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     def _on_microscope_connected(self):
         """Handle microscope connection and connect milling progress signal."""
-        # Before the signal wiring below, which returns early on a disconnect: the FM
-        # overview tab has to hear about that case too, to let go of the old microscope.
-        # It also re-answers whether the tab can be used, which is only knowable now --
+        # Before the signal wiring below, which returns early on a disconnect: both
+        # overview modalities have to hear about that case too, to let go of the old
+        # microscope. They hold it for life, so each has to be handed the new one. It
+        # also re-answers whether the tab can be used, which is only knowable now --
         # whether this system has a fluorescence detector at all.
-        self._refresh_fm_overview_microscope()
-        # Same for the rebuilt Overview tab, which holds its microscope for life and
-        # has to be handed the new one (or let go of the old) on every connection.
-        self._apply_overview_canvas_visibility()
+        self._refresh_overview_microscope()
         if (
             self.autolamella_ui is not None
             and self.autolamella_ui.microscope is not None
@@ -1776,8 +1771,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         """Create the tabs for the AutoLamella UI."""
         self._create_main_tab()
         self.add_minimap_tab()
-        self.add_fm_overview_tab()
-        self.add_overview_canvas_tab()
+        self.add_overview_tab()
         self.add_protocol_editor_tab()
         self.add_lamella_editor_tab()
         self.add_workflow_tab()
@@ -1795,7 +1789,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         self.minimap_widget.set_experiment()
         self.fm_overview_tab.refresh_experiment()
-        self.overview_canvas_tab.refresh_experiment()
+        self.beam_overview_tab.refresh_experiment()
         self.task_widget.set_experiment(self.autolamella_ui.experiment)
         self.lamella_widget.set_experiment()
         experiment = self.autolamella_ui.experiment
@@ -1824,17 +1818,17 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             if hasattr(self, "_lamella_tab_container")
             else -1
         )
-        # The FM overview tab is enabled by the presence of a fluorescence detector, not
-        # by an experiment, so loading one must not switch it on for a system that has
-        # no FM -- it would open onto an empty container.
-        fm_overview_tab_index = (
-            self.tab_widget.indexOf(self.fm_overview_tab)
-            if getattr(self, "fm_overview_tab", None) is not None
-            and not self.fm_overview_tab.is_available
+        # The Overview tab is enabled by what the instrument has, not by an experiment,
+        # so loading one must not switch it on for a system where neither modality can be
+        # reached -- it would open onto an empty container.
+        overview_tab_index = (
+            self.tab_widget.indexOf(self.overview_tab)
+            if getattr(self, "overview_tab", None) is not None
+            and not self.overview_tab.is_available
             else -1
         )
         for i in range(self.tab_widget.count()):
-            if i in (lamella_tab_index, fm_overview_tab_index):
+            if i in (lamella_tab_index, overview_tab_index):
                 continue
             self.tab_widget.setTabEnabled(i, True)
 
@@ -2257,7 +2251,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         self._selected_card_lamella = lamella
         self.fm_overview_tab.set_selected(lamella)
-        self.overview_canvas_tab.set_selected(lamella)
+        self.beam_overview_tab.set_selected(lamella)
         self.lamella_task_image_widget.set_lamella(lamella)
         if lamella is not None:
             self.lamella_widget.select_lamella(lamella.name)
@@ -2273,7 +2267,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
     def _on_experiment_lamella_selected(self, lamella):
         """Sync card container and minimap when experiment-tab list selection changes."""
         self.fm_overview_tab.set_selected(lamella)
-        self.overview_canvas_tab.set_selected(lamella)
+        self.beam_overview_tab.set_selected(lamella)
         if getattr(self, "_syncing_selection", False) or lamella is None:
             return
         if not hasattr(self, "lamella_card_container"):
@@ -2289,7 +2283,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
     def _on_minimap_lamella_selected(self, lamella):
         """Sync experiment list and card container when minimap list selection changes."""
         self.fm_overview_tab.set_selected(lamella)
-        self.overview_canvas_tab.set_selected(lamella)
+        self.beam_overview_tab.set_selected(lamella)
         if getattr(self, "_syncing_selection", False) or lamella is None:
             return
         self._syncing_selection = True
@@ -2879,116 +2873,136 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         splitter.setSizes([700, 500])
         layout.addWidget(splitter)
+        # "Minimap", not "Overview" any more: the canvas Overview tab replaced this one
+        # and took the name. Two tabs both called Overview would leave a user guessing
+        # which is which for exactly as long as this tab survives, and the internal name
+        # for it has always been the minimap (`add_minimap_tab`, `FibsemMinimapWidget`).
         self.tab_widget.insertTab(
-            1, container, fibsem_icon("mdi:map", color=GRAY_ICON_COLOR), "Overview"
+            1, container, fibsem_icon("mdi:map", color=GRAY_ICON_COLOR), "Minimap"
         )
+        # Kept on the window so `_apply_napari_overview_visibility` can find the tab. It
+        # goes with the tab (FIB-405).
+        self._minimap_tab_container = container
 
         # disable the tab by default
         self.tab_widget.setTabEnabled(self.tab_widget.indexOf(container), False)
+        self._apply_napari_overview_visibility()
 
-    def add_fm_overview_tab(self):
-        """Reserve the FM Overview tab, beside the beam one.
+    def add_overview_tab(self):
+        """Reserve the Overview tab: both modalities, one tab.
+
+        The FIB/SEM and fluorescence overviews were two tabs here, and are now two pages
+        of one -- `AutoLamellaOverviewContainerTab` holds both host tabs and a chip strip
+        that chooses between them (FIB-780). Both host tabs stay built and stay
+        subscribed while the other is showing, so everything the window tells them is
+        still told to both.
 
         The tab is created on every system and never hidden, so the tab bar keeps the
-        same shape whether or not there is a fluorescence detector. When it has nothing
-        to drive it is greyed out with a tooltip saying why -- see
-        :meth:`_on_fm_overview_availability`. The widget inside is built and destroyed
-        to match -- see :meth:`_refresh_fm_overview_microscope` -- so a dead tab costs
-        nothing but the container.
+        same shape whatever the instrument turned out to be. When neither modality has
+        anything to drive it is greyed out with a tooltip saying why -- see
+        :meth:`_on_overview_availability`. The widgets inside are built and destroyed to
+        match, so a dead tab costs nothing but the container.
 
-        Separate from "Overview" deliberately, not as a step toward merging them: the
-        two show different stage poses -- milling pose on the beam side, FM pose here --
-        and relating them is what the correlation workflow is for.
-
-        The tab is created empty. `FMOverviewWidget` requires a microscope with a
-        fluorescence detector at construction -- it has no meaningful empty state, since
-        every scale on its canvas comes from the camera -- and at this point there may be
-        no microscope at all. :class:`AutoLamellaFluorescenceOverviewTab` fills itself in on
-        connection, and says so through `availability_changed`.
+        The tab is created empty. Both overview widgets require a microscope at
+        construction -- every scale on their canvases comes from the instrument -- and at
+        this point there may be no microscope at all. The container fills itself in on
+        connection and says so through `availability_changed`.
         """
-        self.fm_overview_tab = AutoLamellaFluorescenceOverviewTab(self.autolamella_ui)
-        self.fm_overview_tab.availability_changed.connect(
-            self._on_fm_overview_availability
-        )
+        self.overview_tab = AutoLamellaOverviewContainerTab(self.autolamella_ui)
+        # The two host tabs, under the names the window has always used for them. Aliases
+        # rather than a rename: these are the same objects, every lifecycle call the
+        # window makes still goes to the tab that owns the answer, and
+        # `test_overview_tab_wiring.py` still reads the calls out of this source.
+        self.fm_overview_tab = self.overview_tab.fm_tab
+        self.beam_overview_tab = self.overview_tab.beam_tab
+
+        self.overview_tab.availability_changed.connect(self._on_overview_availability)
         self.fm_overview_tab.lamella_selected.connect(
             self._on_fm_overview_lamella_selected
         )
+        self.beam_overview_tab.lamella_selected.connect(
+            self._on_beam_overview_lamella_selected
+        )
+        # Per host tab rather than through the container's own `acquiring_changed`: the
+        # lock is derived from both tabs every time it is applied, and connecting to each
+        # keeps the two sources of that derivation the same two objects it reads.
         self.fm_overview_tab.acquiring_changed.connect(self._apply_overview_locks)
+        self.beam_overview_tab.acquiring_changed.connect(self._apply_overview_locks)
 
         self.tab_widget.insertTab(
             2,
-            self.fm_overview_tab,
-            fibsem_icon("mdi:microscope", color=GRAY_ICON_COLOR),
-            "FM Overview",
-        )
-        self.tab_widget.setTabEnabled(
-            self.tab_widget.indexOf(self.fm_overview_tab), False
-        )
-        # Emits availability either way, which is what puts the reason on the tab.
-        self._refresh_fm_overview_microscope()
-
-    def add_overview_canvas_tab(self):
-        """Reserve the rebuilt Overview tab, beside the napari one it will replace.
-
-        Behind `features.overview_canvas_tab`, off by default, and deliberately *beside*
-        rather than instead of the existing Overview tab: the two drive the same
-        instrument, and the napari one is what people are relying on until this has had
-        bench time. Swapping them is its own change, once it has (FIB-413, FIB-405).
-
-        Same shape as `add_fm_overview_tab` in every other respect -- created empty and
-        always, hidden when the flag is off, filled in on connection by
-        :class:`AutoLamellaOverviewTab`, which needs a microscope to build its widget
-        and says so through `availability_changed`.
-        """
-        self.overview_canvas_tab = AutoLamellaOverviewTab(self.autolamella_ui)
-        self.overview_canvas_tab.availability_changed.connect(
-            self._on_overview_canvas_availability
-        )
-        self.overview_canvas_tab.lamella_selected.connect(
-            self._on_overview_canvas_lamella_selected
-        )
-        self.overview_canvas_tab.acquiring_changed.connect(self._apply_overview_locks)
-
-        self.tab_widget.insertTab(
-            3,
-            self.overview_canvas_tab,
+            self.overview_tab,
             fibsem_icon("mdi:map-search-outline", color=GRAY_ICON_COLOR),
-            "Overview (Canvas)",
+            "Overview",
         )
-        self.tab_widget.setTabEnabled(
-            self.tab_widget.indexOf(self.overview_canvas_tab), False
-        )
-        self._apply_overview_canvas_visibility()
+        self.tab_widget.setTabEnabled(self.tab_widget.indexOf(self.overview_tab), False)
+        # Emits availability either way, which is what puts the reason on the tab.
+        self._refresh_overview_microscope()
 
-    def _apply_overview_canvas_visibility(self) -> None:
-        """Show or hide the rebuilt Overview tab, and build or tear down its widget.
+    def _apply_napari_overview_visibility(self) -> None:
+        """Show or hide the old napari Minimap tab.
 
-        Unlike the FM tab there is no capability to check: every system has beams, so
-        the flag is the only condition.
+        `features.napari_overview_tab`, on by default and on its way out: the canvas
+        Overview replaced this tab, and the flag is what holds the old one open for
+        anyone still moving off it. Both it and this method go with the tab before the
+        full release (FIB-405, FIB-413).
+
+        Visibility only, unlike the flag it replaced. The overview host tabs are built
+        and dropped because their widgets subscribe to the microscope for their lifetime;
+        this one owns a `napari.Viewer` that cannot be rebuilt safely mid-session, and it
+        is the tab that is going away rather than the one being staged in, so hidden is
+        the whole of what off has to mean.
 
         Read straight off `self._preferences` rather than through a module-level
         `FEATURE_*` global. FIB-609 removed five of those and kept the one whose caller
         is a widget constructor with no preferences to hand; this one is a method on the
         window that owns them, so a global would only be a second copy to keep in step.
         """
-        if getattr(self, "overview_canvas_tab", None) is None:
+        container = getattr(self, "_minimap_tab_container", None)
+        if container is None:
             return
-        enabled = self._preferences.features.overview_canvas_tab
         self.tab_widget.setTabVisible(
-            self.tab_widget.indexOf(self.overview_canvas_tab), enabled
-        )
-        # Both, and in this order: hiding the tab is what the flag looks like, dropping
-        # the widget is what it has to mean. The refresh is unconditional because it is
-        # also the reconnection path -- `refresh_microscope` answers the flag itself.
-        self.overview_canvas_tab.set_enabled(enabled)
-        self.overview_canvas_tab.refresh_microscope()
-
-    def _on_overview_canvas_availability(self, available: bool) -> None:
-        self.tab_widget.setTabEnabled(
-            self.tab_widget.indexOf(self.overview_canvas_tab), available
+            self.tab_widget.indexOf(container),
+            self._preferences.features.napari_overview_tab,
         )
 
-    def _on_overview_canvas_lamella_selected(self, lamella):
+    def _on_overview_availability(self, available: bool) -> None:
+        """Enable the tab when either modality has something to drive, and say why not.
+
+        The one thing about the tab that is not the tab's own business: it has no
+        business reaching out to the tab bar it happens to sit in.
+
+        The tab is never hidden. A greyed tab that explains itself is easier to live
+        with than one that appears and vanishes depending on what the microscope turned
+        out to be -- but that is only true *because* of the tooltip, so the two are set
+        together here rather than in separate passes.
+
+        Qt does show a tooltip on a disabled tab: the `QTabBar` stays enabled and only
+        the tab within it is disabled, so the hover still lands. Worth stating because
+        disabled *widgets* do swallow tooltips, which makes this look doubtful.
+        """
+        index = self.tab_widget.indexOf(self.overview_tab)
+        self.tab_widget.setTabEnabled(index, available)
+        _, reason = self.overview_tab.unavailable_summary()
+        self.tab_widget.setTabToolTip(index, "" if available else reason)
+
+    def _refresh_overview_microscope(self):
+        """Build or drop both overview widgets to match the instrument.
+
+        The widgets are built and destroyed rather than left behind hidden. Each
+        subscribes to the microscope's stage signal for its lifetime, so one kept around
+        would go on doing work on every poll for a page nobody can reach -- and would
+        still be holding a psygnal reference to tear down later.
+
+        Whether the tab can be *used* is a separate question, answered by
+        `availability_changed` coming back through :meth:`_on_overview_availability`.
+        This method does not touch the tab bar.
+        """
+        if getattr(self, "overview_tab", None) is None:
+            return
+        self.overview_tab.refresh_microscope()
+
+    def _on_beam_overview_lamella_selected(self, lamella):
         """Sync the other lists when the rebuilt Overview tab's list changes.
 
         The same shape as `_on_minimap_lamella_selected`, minus the call back into the
@@ -3040,62 +3054,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         replaced in place (FIB-709). Neither tab subscribes to the experiment itself, so
         this is the only place that can see all of it.
         """
-        for name in ("fm_overview_tab", "overview_canvas_tab"):
+        for name in ("fm_overview_tab", "beam_overview_tab"):
             tab = getattr(self, name, None)
             if tab is not None:
                 tab.refresh_positions()
-
-    def _on_fm_overview_availability(self, available: bool):
-        """Enable the tab when it has something to drive, and say why when it does not.
-
-        The one thing about the tab that is not the tab's own business: it has no
-        business reaching out to the tab bar it happens to sit in.
-
-        The tab is never hidden. A greyed tab that explains itself is easier to live
-        with than one that appears and vanishes depending on what the microscope turned
-        out to be — but that is only true *because* of the tooltip, so the two are set
-        together here rather than in separate passes.
-
-        Qt does show a tooltip on a disabled tab: the `QTabBar` stays enabled and only
-        the tab within it is disabled, so the hover still lands. Worth stating because
-        disabled *widgets* do swallow tooltips, which makes this look doubtful.
-        """
-        index = self.tab_widget.indexOf(self.fm_overview_tab)
-        self.tab_widget.setTabEnabled(index, available)
-        self.tab_widget.setTabToolTip(
-            index, "" if available else self._fm_overview_unavailable_reason()
-        )
-
-    def _fm_overview_unavailable_reason(self) -> str:
-        """Why the FM Overview tab is greyed out, in the user's terms.
-
-        Two absences that look identical on the tab bar but are not: one is waiting for
-        something that is about to happen, the other is a fact about this system that
-        will not change. `availability_changed` is a bool and cannot carry the
-        difference, so it is worked out here — the window already holds the microscope.
-        """
-        microscope = (
-            self.autolamella_ui.microscope if self.autolamella_ui is not None else None
-        )
-        if microscope is None:
-            return "Connect a microscope to use the FM Overview"
-        return "No Fluorescence Microscope Available"
-
-    def _refresh_fm_overview_microscope(self):
-        """Build or drop the FM Overview widget to match the instrument.
-
-        The widget is built and destroyed rather than left behind hidden. It subscribes
-        to the microscope's stage signal for its lifetime, so one kept around would go
-        on doing work on every poll for a tab nobody can reach — and would still be
-        holding a psygnal reference to tear down later.
-
-        Whether the tab can be *used* is a separate question, answered by
-        `availability_changed` coming back through
-        :meth:`_on_fm_overview_availability`. This method does not touch the tab bar.
-        """
-        if getattr(self, "fm_overview_tab", None) is None:
-            return
-        self.fm_overview_tab.refresh_microscope()
 
     def _on_notification_service(
         self, message: str, notification_type: str, temporary: bool

--- a/fibsem/applications/autolamella/ui/autolamella_overview_tab.py
+++ b/fibsem/applications/autolamella/ui/autolamella_overview_tab.py
@@ -61,10 +61,17 @@ class AutoLamellaOverviewTab(AutoLamellaOverviewTabBase):
 
     def __init__(self, autolamella_ui, parent: Optional[QWidget] = None):
         super().__init__(autolamella_ui, parent)
-        # Whether the host wants a live widget here at all -- the feature flag, as far
-        # as this object is concerned. True by default so that building this tab and
-        # calling `refresh_microscope` is enough on its own, which is how it is used
-        # standalone and in tests; the window sets it from the flag on the way in.
+        # Whether the host wants a live widget here at all. True by default so that
+        # building this tab and calling `refresh_microscope` is enough on its own, which
+        # is how it is used standalone and in tests.
+        #
+        # **Nothing in production sets this any more.** It carried
+        # `features.overview_canvas_tab` while this tab was staged in beside the napari
+        # one; that flag is retired (FIB-780) and the tab ships to everyone, so the only
+        # callers left are the tests below. Kept rather than deleted because it is the
+        # beam-side half of the build-or-drop pair the fluorescence tab answers with
+        # `_can_build`, and a modality that can be switched off is a plausible thing to
+        # want back -- but it is dead code today and should be read as such.
         self._enabled = True
 
     # ── what makes this the beam side ────────────────────────────────────

--- a/fibsem/applications/autolamella/ui/overview_container_tab.py
+++ b/fibsem/applications/autolamella/ui/overview_container_tab.py
@@ -1,0 +1,486 @@
+"""One Overview tab, with the imaging modality chosen above the canvas.
+
+The FIB/SEM overview and the fluorescence overview were two top-level tabs sitting next
+to each other, driving the same stage over the same experiment through two widgets that
+share fifty-five method names. Every fix in the area had to be made twice, and twice it
+was not: the beam tab went silent on click-to-move (FIB-765) purely by drifting from the
+fluorescence one. This is the tab that holds both (FIB-780).
+
+# What this does and does not merge
+
+It merges the **tab**, not the widgets. Both host tabs are kept whole and put in a stack;
+picking a modality raises one. `AutoLamellaOverviewTab` and
+`AutoLamellaFluorescenceOverviewTab` are untouched, and everything they and their widgets
+do -- poses, projections, settings columns, view chips, acquisition -- goes on working
+exactly as it did as a separate tab.
+
+That is deliberate rather than a first step deferred. The two widgets composite
+differently, take pixels from different instruments and mark different stage poses; a
+single widget with a modality flag would be mostly branches, which is the finding
+FIB-693 already recorded. What was worth removing was the *second tab*, not the second
+widget.
+
+# Neither side is torn down on a switch
+
+Both tabs stay built and stay subscribed while the other is showing. Three things follow,
+and all three are wanted:
+
+* **Each modality remembers its own view.** The beam tab's chip strip is still on the
+  view it was left on, because nothing destroyed it. FIB-780 asks for this explicitly;
+  here it costs nothing.
+* **FIB-706 still applies unchanged.** One overview must not drive the stage while the
+  other is acquiring. Both can still be acquiring, so the window's `_apply_overview_locks`
+  is as necessary as it was, and reads both tabs the same way.
+* **A hidden tab is still doing work.** Which is why unavailability is answered by
+  dropping the widget (`set_enabled`, `_can_build`) rather than by hiding a page -- the
+  same build-or-drop answer both tabs already give.
+
+# The chips
+
+Two levels, one row, read left to right as it narrows:
+
+    [ FIB/SEM | Fluorescence ] | [ SEM @ SEM · FIB @ Milling ]
+       what this tab *is*          what the canvas is *showing*
+
+The view chips are **not built here.** They are the page's own -- the beam widget
+discovers its views as they are acquired in and marks the one the next run would land in
+-- so this only lends them a place to sit, beside the modality chips. Building a second
+copy would be a second thing to keep in step, which is the failure this tab exists to
+stop. `_mount_view_strip` moves the active page's strip into the bar and `_unmount_view_strip`
+hands it back before that page is rebuilt; the fluorescence page has no such strip, so
+its half of the bar is empty and the divider hides.
+
+This does move the view chips off the canvas's own width, which `overview_widget`'s
+`canvas_pane` comment had deliberately chosen -- "it keeps saying *this selects what the
+canvas is showing*". The bar is now led by a control that governs the settings column
+too, so spanning the tab is the honest width for it, and splitting the row to preserve
+the old rule would cost two rows of chrome to make a distinction the divider already
+makes.
+
+An unavailable modality keeps its chip, disabled, with a tooltip saying why -- the same
+choice the tab bar already made for the FM tab (FIB-614), and for the same reason: a
+control that appears and vanishes with the hardware is harder to live with than one that
+explains itself. That only became true when the chip styles grew a `:disabled` rule --
+before it, a greyed chip was pixel-identical to a live one, so "disabled" was a claim the
+UI did not actually make.
+
+# No flag on either modality
+
+This tab ships to everyone, and so do both of its chips. `features.overview_canvas_tab`
+gated the beam side while the canvas overview sat beside the napari one; it is retired
+here rather than carried, because there is nothing left for it to gate -- the canvas
+overview *is* the Overview tab now. What survives is `features.napari_overview_tab`,
+pointing the other way: it holds the old Minimap tab open for anyone still moving off it,
+and goes with that tab before the full release.
+
+A modality is therefore unavailable only when there is no hardware behind it, which is
+the FM tab's existing capability check and nothing new.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import partial
+from typing import Dict, List, Optional, Tuple
+
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.applications.autolamella.ui.autolamella_fluorescence_overview_tab import (
+    AutoLamellaFluorescenceOverviewTab,
+)
+from fibsem.applications.autolamella.ui.autolamella_overview_tab import (
+    AutoLamellaOverviewTab,
+)
+from fibsem.applications.autolamella.ui.overview_tab_base import (
+    AutoLamellaOverviewTabBase,
+)
+from fibsem.ui.tokens import BORDER_COLOR
+from fibsem.ui.widgets.overview_widget import (
+    MODALITY_CHIP_STYLE,
+    VIEW_CHIP_SPACING,
+    VIEW_STRIP_STYLE,
+)
+
+logger = logging.getLogger(__name__)
+
+# The two imaging systems, as the strip labels them. "FIB/SEM" rather than "Beam"
+# because it is what the instrument is called in the room, and it matches the view chips
+# below it, which spell out SEM and FIB rather than electron and ion.
+MODALITY_FIBSEM = "FIBSEM"
+MODALITY_FLUORESCENCE = "FLUORESCENCE"
+
+MODALITY_LABELS = {
+    MODALITY_FIBSEM: "FIB/SEM",
+    MODALITY_FLUORESCENCE: "Fluorescence",
+}
+
+# Left to right, and this order rather than the other: the beam overview is the one every
+# system has, and the one a session starts in. It is also the order the two tabs sat in.
+MODALITY_ORDER = (MODALITY_FIBSEM, MODALITY_FLUORESCENCE)
+
+
+class AutoLamellaOverviewContainerTab(QWidget):
+    """The Overview tab: a modality strip, and one host tab per modality beneath it."""
+
+    # Whether *either* modality has a live widget, i.e. whether the tab does anything at
+    # all. The window listens so it can enable or disable the tab; this object does not
+    # touch the tab bar, exactly as neither host tab does.
+    availability_changed = pyqtSignal(bool)
+    # Forwarded from whichever host tab raised it. The window syncs the other lists; the
+    # host tabs go on emitting their own, and the window may still connect to them
+    # directly -- this is the tab-shaped signal, not a replacement for theirs.
+    lamella_selected = pyqtSignal(object)
+    # True while *either* modality is acquiring. The window uses it to lock the other
+    # overview (FIB-706); both host tabs stay alive under the stack, so the situation it
+    # guards against is unchanged by the merge.
+    acquiring_changed = pyqtSignal(bool)
+    # The modality now showing, for a host that wants to say so somewhere.
+    modality_changed = pyqtSignal(str)
+
+    def __init__(self, autolamella_ui, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.autolamella_ui = autolamella_ui
+
+        self.beam_tab = AutoLamellaOverviewTab(autolamella_ui)
+        self.fm_tab = AutoLamellaFluorescenceOverviewTab(autolamella_ui)
+        self._tabs: Dict[str, AutoLamellaOverviewTabBase] = {
+            MODALITY_FIBSEM: self.beam_tab,
+            MODALITY_FLUORESCENCE: self.fm_tab,
+        }
+
+        self._modality = MODALITY_FIBSEM
+        self._chips: Dict[str, QPushButton] = {}
+        # The page whose view strip is currently in the bar, and the strip itself.
+        self._mounted: Optional[Tuple[QWidget, QWidget]] = None
+
+        self.stack = QStackedWidget()
+        for modality in MODALITY_ORDER:
+            self.stack.addWidget(self._tabs[modality])
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self._build_modality_strip())
+        layout.addWidget(self.stack, stretch=1)
+
+        for modality, tab in self._tabs.items():
+            # Availability is per modality and drives that chip; the tab-level answer is
+            # the or of the two, recomputed rather than tracked, so a missed signal
+            # cannot leave the tab enabled with nothing behind either chip.
+            tab.availability_changed.connect(
+                partial(self._on_tab_availability, modality)
+            )
+            tab.lamella_selected.connect(self.lamella_selected)
+            # Re-derived from both rather than forwarded: the bool arriving here says
+            # what *one* tab is doing, and a host locking on it would unlock while the
+            # other was still running.
+            tab.acquiring_changed.connect(self._on_tab_acquiring)
+
+        self._refresh_chips()
+
+    # ── the modality strip ───────────────────────────────────────────────
+
+    def _build_modality_strip(self) -> QWidget:
+        """One bar: the modality chips, a divider, then the active page's view chips.
+
+        Side by side rather than stacked, so the whole of "what am I looking at" is one
+        row of chrome instead of two. The order reads left to right as it narrows --
+        imaging system, then the view within it.
+
+        The view chips are not built here. They belong to the page's own widget, which
+        discovers its views as they are acquired in and knows which one the next run
+        would land in; this only lends them a place to sit. `_mount_view_strip` is what
+        moves the active page's strip in, and moves it back out before that page is
+        rebuilt.
+
+        The modality chips are in a scroll area for the same reason the view chips are:
+        a row of controls in a plain layout sets the *window's* minimum width. Two chips
+        is a small floor, but the whole bar has to be allowed to get narrow, and one
+        fixed half would hold the window open on its own.
+        """
+        chips_row = QWidget()
+        self._strip_layout = QHBoxLayout(chips_row)
+        self._strip_layout.setContentsMargins(0, 4, 0, 4)
+        self._strip_layout.setSpacing(VIEW_CHIP_SPACING)
+
+        for modality in MODALITY_ORDER:
+            chip = QPushButton(MODALITY_LABELS[modality])
+            chip.setCheckable(True)
+            chip.setChecked(modality == self._modality)
+            chip.setCursor(Qt.PointingHandCursor)
+            chip.setStyleSheet(MODALITY_CHIP_STYLE)
+            chip.clicked.connect(partial(self._on_chip_clicked, modality))
+            self._strip_layout.addWidget(chip)
+            self._chips[modality] = chip
+
+        self.modality_strip = QScrollArea()
+        self.modality_strip.setWidget(chips_row)
+        self.modality_strip.setWidgetResizable(True)
+        self.modality_strip.setFrameShape(QFrame.NoFrame)
+        self.modality_strip.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.modality_strip.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.modality_strip.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Fixed)
+        # The strip's own background, the same way the page's view strip carries it, and
+        # not `background: transparent` -- a scroll area's *viewport* is a separate
+        # widget that the sheet does not reach, so transparent left it painting the
+        # window's base colour instead: measured (30,32,39) against the bar's (38,41,48),
+        # a visible rectangle around the modality chips.
+        self.modality_strip.setObjectName("viewStrip")
+        self.modality_strip.setStyleSheet(VIEW_STRIP_STYLE)
+        chips_row.adjustSize()
+        self.modality_strip.setFixedHeight(chips_row.sizeHint().height())
+
+        # The divider the two levels are read across. A rule rather than a gap: with a
+        # gap alone the modality chips read as the first two of one long row, which is
+        # the reading this whole arrangement exists to prevent.
+        self._divider = QFrame()
+        self._divider.setFrameShape(QFrame.VLine)
+        self._divider.setFrameShadow(QFrame.Plain)
+        self._divider.setStyleSheet(f"color: {BORDER_COLOR};")
+        self._divider.setFixedHeight(chips_row.sizeHint().height())
+        self._divider.setVisible(False)
+
+        # Where the active page's view strip is mounted. Empty for a page that has no
+        # views to choose between -- the fluorescence one, which has a single camera.
+        self._view_slot = QWidget()
+        self._view_slot_layout = QHBoxLayout(self._view_slot)
+        self._view_slot_layout.setContentsMargins(0, 0, 0, 0)
+        self._view_slot_layout.setSpacing(0)
+
+        # A `QFrame`, not a plain `QWidget`: a bare `QWidget` does not paint a background
+        # set from a stylesheet, so the bar's own margins and spacing stayed the window's
+        # darker base colour -- measured (30,32,39) against the strip's (38,41,48) --
+        # three thin vertical gaps through what is meant to be one continuous bar. The
+        # two scroll areas inside carry the same sheet and always painted correctly,
+        # because `QScrollArea` is itself a `QFrame`.
+        bar = QFrame()
+        bar.setFrameShape(QFrame.NoFrame)
+        bar.setObjectName("viewStrip")
+        bar.setStyleSheet(VIEW_STRIP_STYLE)
+        bar_layout = QHBoxLayout(bar)
+        bar_layout.setContentsMargins(8, 0, 8, 0)
+        bar_layout.setSpacing(8)
+        bar_layout.addWidget(self.modality_strip)
+        bar_layout.addWidget(self._divider)
+        bar_layout.addWidget(self._view_slot, stretch=1)
+        bar.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
+        return bar
+
+    # ── lending the active page's view chips a place in the bar ──────────
+
+    def _mount_view_strip(self) -> None:
+        """Move the active page's view strip into the bar, beside the modality chips.
+
+        Moved rather than copied. The strip is the page's -- it rebuilds itself as views
+        are acquired in, and marks the one the next run would land in -- so building a
+        second copy here would be a second thing to keep in step, which is the failure
+        this whole tab exists to stop.
+        """
+        self._unmount_view_strip()
+        overview = self._tabs[self._modality].overview
+        strip = getattr(overview, "view_strip", None)
+        if strip is None:
+            self._divider.setVisible(False)
+            return
+        owner = strip.parentWidget()
+        if owner is not None and owner.layout() is not None:
+            owner.layout().removeWidget(strip)
+        self._view_slot_layout.addWidget(strip)
+        strip.show()
+        # Remembered as a pair: the strip alone is not enough to put it back, and the
+        # widget alone is not enough to know whether anything was taken.
+        self._mounted = (overview, strip)
+        self._divider.setVisible(True)
+
+    def _unmount_view_strip(self) -> None:
+        """Hand the strip back before its page is rebuilt or destroyed.
+
+        Without this the bar would hold a child of a widget Qt has deleted: the strip is
+        parented *here* while mounted, so it does not go with its owner, and the next
+        thing to touch it would be reading a dead C++ object. The same shape of problem
+        as the lamella list in `AutoLamellaOverviewTabBase._drop_overview`, and handled
+        the same way -- given back rather than left to be collected.
+
+        `RuntimeError` is caught rather than prevented because the page may already be
+        gone by the time this runs -- a test dropping a widget directly does exactly
+        that -- and in that case there is nothing to hand it back to.
+        """
+        if self._mounted is None:
+            return
+        owner, strip = self._mounted
+        self._mounted = None
+        self._divider.setVisible(False)
+        try:
+            self._view_slot_layout.removeWidget(strip)
+            strip.setParent(owner)
+            strip.hide()
+        except RuntimeError:
+            # The page's widget was destroyed and took the strip with it.
+            pass
+
+    def modality_chip(self, modality: str) -> QPushButton:
+        """The chip for *modality*, for a host or a test that wants to read its state.
+
+        Public because "why can I not reach fluorescence" is now answered on the chip
+        rather than on the tab, and the answer has to be readable from outside.
+        """
+        return self._chips[modality]
+
+    def _on_chip_clicked(self, modality: str) -> None:
+        self.set_modality(modality)
+
+    def _refresh_chips(self) -> None:
+        """Put each chip in the state its modality is actually in.
+
+        Called after anything that can change availability, and it is what makes the
+        strip honest: a checked chip means "this is what you are looking at", a disabled
+        one means "this system cannot be reached, and here is why".
+        """
+        for modality, chip in self._chips.items():
+            available = self._tabs[modality].is_available
+            chip.setEnabled(available)
+            chip.setChecked(available and modality == self._modality)
+            chip.setToolTip(
+                MODALITY_LABELS[modality]
+                if available
+                else self.unavailable_reason(modality)
+            )
+
+    # ── modality ─────────────────────────────────────────────────────────
+
+    @property
+    def modality(self) -> str:
+        """Which imaging system this tab is showing."""
+        return self._modality
+
+    def available_modalities(self) -> List[str]:
+        return [m for m in MODALITY_ORDER if self._tabs[m].is_available]
+
+    def set_modality(self, modality: str) -> bool:
+        """Show *modality*, if there is anything behind it.
+
+        Refuses rather than showing an empty page: an unavailable modality has no widget
+        at all -- `refresh_microscope` dropped it -- so raising its page would put a bare
+        container on screen with no way to tell that from a canvas that failed to draw.
+        The chip for it is disabled, so this is a guard rather than a path a click takes.
+        """
+        if modality not in self._tabs:
+            raise ValueError(f"unknown overview modality: {modality}")
+        if not self._tabs[modality].is_available:
+            self._refresh_chips()
+            return False
+        changed = modality != self._modality
+        self._modality = modality
+        self.stack.setCurrentWidget(self._tabs[modality])
+        self._mount_view_strip()
+        self._refresh_chips()
+        if changed:
+            self.modality_changed.emit(modality)
+        return True
+
+    def unavailable_reason(self, modality: str) -> str:
+        """Why *modality* cannot be reached, in the user's terms.
+
+        Three absences that look identical on a greyed chip and are not: no microscope at
+        all is about to change, no fluorescence detector is a fact about this system, and
+        a flag that is off is the user's own setting. `availability_changed` is a bool and
+        cannot carry the difference; this object holds the microscope, so it is worked out
+        here.
+        """
+        microscope = (
+            self.autolamella_ui.microscope if self.autolamella_ui is not None else None
+        )
+        if microscope is None:
+            return "Connect a microscope to use the Overview"
+        if modality == MODALITY_FLUORESCENCE:
+            return "No Fluorescence Microscope Available"
+        # Every system has beams, so with a microscope connected there is no second way
+        # for this one to be unavailable -- only a widget that failed to build, which
+        # `refresh_microscope` has already logged.
+        return "The FIB/SEM overview is unavailable"
+
+    # ── what the window asks of a tab ────────────────────────────────────
+
+    @property
+    def is_available(self) -> bool:
+        return any(tab.is_available for tab in self._tabs.values())
+
+    @property
+    def is_acquiring(self) -> bool:
+        return any(tab.is_acquiring for tab in self._tabs.values())
+
+    def refresh_microscope(self) -> None:
+        """Rebuild or drop both host tabs to match the instrument.
+
+        Both, on every connection, regardless of which one is showing: the hidden tab
+        holds its microscope for life, so one left unrefreshed would go on reading
+        geometry from an instrument nobody is driving the moment it was raised.
+        """
+        # Before the rebuilds, not after: `refresh_microscope` drops the old widget,
+        # and a strip still mounted here would be left pointing at it.
+        self._unmount_view_strip()
+        for tab in self._tabs.values():
+            tab.refresh_microscope()
+        self._settle_modality()
+        self._mount_view_strip()
+
+    def refresh_experiment(self) -> None:
+        for tab in self._tabs.values():
+            tab.refresh_experiment()
+
+    def refresh_positions(self) -> None:
+        for tab in self._tabs.values():
+            tab.refresh_positions()
+
+    def set_selected(self, lamella) -> None:
+        for tab in self._tabs.values():
+            tab.set_selected(lamella)
+
+    def set_interactive(self, enabled: bool, reason: str = "") -> None:
+        for tab in self._tabs.values():
+            tab.set_interactive(enabled, reason)
+
+    # ── availability ─────────────────────────────────────────────────────
+
+    def _on_tab_availability(self, modality: str, available: bool) -> None:
+        self._settle_modality()
+
+    def _on_tab_acquiring(self, _: bool) -> None:
+        self.acquiring_changed.emit(self.is_acquiring)
+
+    def _settle_modality(self) -> None:
+        """Keep the shown modality one that exists, and tell the host what is left.
+
+        The case this covers is a system with no FM, whose fluorescence chip never
+        becomes available -- and the window between a connection and the beam widget
+        being built, where neither is. Falling back rather than showing an empty page,
+        and in `MODALITY_ORDER` so the fallback is not whichever tab happened to answer
+        last.
+        """
+        available = self.available_modalities()
+        if available and self._modality not in available:
+            self.set_modality(available[0])
+        else:
+            self._refresh_chips()
+        self.availability_changed.emit(bool(available))
+
+    def unavailable_summary(self) -> Tuple[bool, str]:
+        """Whether the tab is worth opening, and what to say on it when it is not.
+
+        Only reached when neither modality is available, so the reason is the one for the
+        modality a user would otherwise be in.
+        """
+        available = self.available_modalities()
+        if available:
+            return True, ""
+        return False, self.unavailable_reason(self._modality)

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -386,13 +386,19 @@ class FeatureFlags:
     # microscope and none of its guard rails, so the menu is not offered to anyone
     # who has not asked for it (FIB-338).
     scripts_enabled: bool = False
-    # The rebuilt FIB/SEM Overview tab, on the real-space canvas. Off while it sits
-    # *beside* the napari Overview tab rather than replacing it: the two drive the same
-    # instrument, and the existing tab is the one people are relying on until this has
-    # had bench time (FIB-413, FIB-405).
+    # The old napari Minimap tab, beside the Overview tab that replaced it. **On**, and
+    # that direction is the point: the canvas Overview now ships to everyone and holds
+    # both modalities (FIB-780), so this flag is not gating a new thing -- it is holding
+    # the door open on the old one while people finish moving off it.
     #
-    # Deleted when the tab replaces the napari one, not kept as a preference.
-    overview_canvas_tab: bool = False
+    # It replaces `overview_canvas_tab`, which pointed the other way and was retired
+    # rather than flipped: a flipped flag reads as "off means the new tab is gone", and
+    # anyone who had turned the old one on would silently have the napari tab hidden
+    # instead. A new name gets the new default on every install, including the ones with
+    # a saved preferences file -- a changed default alone reaches only fresh ones.
+    #
+    # Deleted with the tab itself before the full release (FIB-405, FIB-413).
+    napari_overview_tab: bool = True
     # The connection chip in the tab-corner header, and the experiment buttons
     # waiting for a microscope alongside it. Off while the Connection tab is still
     # how people connect: this is the header half of FIB-775, landing ahead of the
@@ -401,7 +407,7 @@ class FeatureFlags:
     # The dialog it opens is NOT gated -- File -> Connect to Microscope reaches it
     # either way, which is how it gets exercised while this is off.
     #
-    # A staging flag like `overview_canvas_tab`, and it goes the same way: deleted
+    # A staging flag like `napari_overview_tab`, and it goes the same way: deleted
     # when the chip replaces the tab, not kept as a preference.
     connection_chip: bool = False
 

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -1230,11 +1230,28 @@ class FMOverviewWidget(QWidget):
             beam_overviews_in,
         )
 
-        views = beam_overviews_in(self._save_directory, self.microscope)
-        if not views:
+        # Two different nothings, and telling them apart is the whole point of the
+        # split. With no output folder there is nowhere to *look*, so "acquire one
+        # first" is not merely unhelpful -- it is wrong advice, and it sends the reader
+        # off to acquire an overview that will land somewhere this still cannot see.
+        # Reported as a bug on exactly that confusion, from an app started without an
+        # experiment.
+        directory = self._save_directory
+        if not directory:
             notification_service.show_toast(
-                "No FIB/SEM overviews found to select on. Acquire one on the Overview "
-                "tab first.",
+                "No output folder set, so there is nowhere to look for FIB/SEM "
+                "overviews. Open an experiment, or choose a folder in Output.",
+                "info",
+            )
+            return
+
+        views = beam_overviews_in(directory, self.microscope)
+        if not views:
+            # Named, because the folder being the wrong one is the likeliest reason a
+            # user who *has* acquired an overview is being told there are none.
+            notification_service.show_toast(
+                f"No FIB/SEM overviews found in {os.path.basename(directory.rstrip(os.sep))}. "
+                "Acquire one on the FIB/SEM overview first.",
                 "info",
             )
             return

--- a/fibsem/ui/fm/widgets/fm_region_selector.py
+++ b/fibsem/ui/fm/widgets/fm_region_selector.py
@@ -48,10 +48,10 @@ from fibsem.ui.widgets.canvas.real_space_canvas import FibsemRealSpaceCanvas
 from fibsem.ui.widgets.canvas.stage_frame import StageFrame
 from fibsem.ui.widgets.custom_widgets import ContextMenu, ContextMenuConfig
 from fibsem.ui.widgets.overview_widget import (
-    _VIEW_CHIP_SPACING,
-    _VIEW_CHIP_STYLE,
-    _VIEW_CHIP_STYLE_ACTIVE,
-    _VIEW_STRIP_STYLE,
+    VIEW_CHIP_SPACING,
+    VIEW_CHIP_STYLE,
+    VIEW_CHIP_STYLE_ACTIVE,
+    VIEW_STRIP_STYLE,
     OverviewView,
 )
 
@@ -102,7 +102,7 @@ class FMRegionSelectorWidget(QWidget):
         # so no corner holds them -- settled in the beam overview tab and followed here.
         self._chip_strip = QScrollArea()
         self._chip_strip.setObjectName("viewStrip")
-        self._chip_strip.setStyleSheet(_VIEW_STRIP_STYLE)
+        self._chip_strip.setStyleSheet(VIEW_STRIP_STYLE)
         self._chip_strip.setWidgetResizable(True)
         self._chip_strip.setFixedHeight(34)
         self._chip_strip.setFrameShape(QFrame.NoFrame)
@@ -159,13 +159,15 @@ class FMRegionSelectorWidget(QWidget):
         holder = QWidget()
         row = QHBoxLayout(holder)
         row.setContentsMargins(8, 5, 8, 5)
-        row.setSpacing(_VIEW_CHIP_SPACING)
+        row.setSpacing(VIEW_CHIP_SPACING)
         for view in self._views:
             chip = QPushButton(view.label)
             chip.setCheckable(True)
             chip.setChecked(view == self._current_view)
             chip.setStyleSheet(
-                _VIEW_CHIP_STYLE_ACTIVE if view == self._current_view else _VIEW_CHIP_STYLE
+                VIEW_CHIP_STYLE_ACTIVE
+                if view == self._current_view
+                else VIEW_CHIP_STYLE
             )
             chip.clicked.connect(lambda _checked, v=view: self.show_view(v))
             row.addWidget(chip)
@@ -212,7 +214,9 @@ class FMRegionSelectorWidget(QWidget):
             position = self._position_of(image)
             size = self._pixel_size_of(image)
             if position is None or not size or frame is None:
-                logger.debug("Skipping an overview that does not say where it was taken.")
+                logger.debug(
+                    "Skipping an overview that does not say where it was taken."
+                )
                 continue
             try:
                 centre = frame.offset(position)
@@ -222,16 +226,28 @@ class FMRegionSelectorWidget(QWidget):
             data = image.filtered_data
             self._placed.append(
                 self.canvas.add_image(
-                    data, centre=centre, pixel_size=size, key=f"overview-{index}",
+                    data,
+                    centre=centre,
+                    pixel_size=size,
+                    key=f"overview-{index}",
                 )
             )
-            spans.append((
-                centre[0], centre[1], data.shape[1] * size, data.shape[0] * size,
-            ))
+            spans.append(
+                (
+                    centre[0],
+                    centre[1],
+                    data.shape[1] * size,
+                    data.shape[0] * size,
+                )
+            )
 
         if spans:
-            xs = [cx - w / 2 for cx, _, w, _ in spans] + [cx + w / 2 for cx, _, w, _ in spans]
-            ys = [cy - h / 2 for _, cy, _, h in spans] + [cy + h / 2 for _, cy, _, h in spans]
+            xs = [cx - w / 2 for cx, _, w, _ in spans] + [
+                cx + w / 2 for cx, _, w, _ in spans
+            ]
+            ys = [cy - h / 2 for _, cy, _, h in spans] + [
+                cy + h / 2 for _, cy, _, h in spans
+            ]
             self._content_extent = (max(xs) - min(xs), max(ys) - min(ys))
 
     @property
@@ -252,7 +268,10 @@ class FMRegionSelectorWidget(QWidget):
         if not self.has_overview:
             return None
         overlay = RectOverlay(
-            color=REGION_COLOUR, facecolor=REGION_COLOUR, alpha=0.30, linewidth=2,
+            color=REGION_COLOUR,
+            facecolor=REGION_COLOUR,
+            alpha=0.30,
+            linewidth=2,
             resizable=True,
         )
         self.canvas.add_overlay(overlay)
@@ -292,10 +311,14 @@ class FMRegionSelectorWidget(QWidget):
         out = []
         for overlay in self._overlays:
             rect = overlay.get_rect()
-            out.append(PlaneRegion.from_points([
-                self.canvas.canvas_to_metres(rect["x0"], rect["y0"]),
-                self.canvas.canvas_to_metres(rect["x1"], rect["y1"]),
-            ]))
+            out.append(
+                PlaneRegion.from_points(
+                    [
+                        self.canvas.canvas_to_metres(rect["x0"], rect["y0"]),
+                        self.canvas.canvas_to_metres(rect["x1"], rect["y1"]),
+                    ]
+                )
+            )
         return out
 
     @property

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -84,6 +84,7 @@ from fibsem.ui.tokens import (
     GRAY_WHITE_COLOR,
     GRID_BOUNDARY_COLOUR,
     NEUTRAL_300,
+    NEUTRAL_650,
     NEUTRAL_750,
     NEUTRAL_800,
     NEUTRAL_900,
@@ -161,31 +162,64 @@ _HEADER_BTN_SIZE = 26
 # the canvas, which owns its top row -- see `chrome_below_toolbar_y`.
 _CANVAS_CHROME_MARGIN = 8
 # Gap between view chips.
-_VIEW_CHIP_SPACING = 4
+VIEW_CHIP_SPACING = 4
 
 # Chips as they have always looked -- dark and rounded rather than the app's button
-# styling, because they read as a set of states rather than a toolbar. The active one is
-# the view the next run would land in, in the accent colour the app uses for a selected
-# state.
+# styling, because they read as a set of states rather than a toolbar.
 #
-# Opaque now, where these were `rgba(..., 170)`. The translucency was doing real work
-# while they sat on the image; on a solid strip it means nothing, and a transparency
-# that means nothing is the kind of thing a later redesign preserves for no reason. The
-# values are the palette's own steps rather than the blend arithmetic -- within a couple
-# of levels of it, and picked rather than mixed (`feedback_ui_widget_style`).
-_VIEW_CHIP_STYLE = (
-    f"QPushButton {{ color: {NEUTRAL_300}; font-size: 10px; padding: 3px 8px;"
-    f" border: none; border-radius: 9px; background: {NEUTRAL_900}; }}"
-    f"QPushButton:hover {{ background: {NEUTRAL_800}; }}"
-    f"QPushButton:checked {{ color: {GRAY_WHITE_COLOR};"
-    f" background: {NEUTRAL_750}; }}"
+# Built from one function rather than written out three times, and that is the point:
+# the three differ only in a border colour and what "checked" fills with, and every time
+# they were written out separately they drifted. `VIEW_CHIP_STYLE` used `border: none`
+# against the active style's real 1px border, so a chip grew by 2px in each direction the
+# moment it became the acquisition view -- invisible until the modality chips sat beside
+# it in one row and looked a size smaller. A shared builder makes that class of drift
+# impossible rather than merely commented against.
+#
+# Public, and imported by the region selector and the Overview tab's modality strip. They
+# were private and imported anyway; a name two other modules already depend on is part of
+# this module's surface whatever the underscore claims.
+#
+# Opaque, where these were `rgba(..., 170)`. The translucency was doing real work while
+# they sat on the image; on a solid strip it means nothing, and a transparency that means
+# nothing is the kind of thing a later redesign preserves for no reason. The values are
+# the palette's own steps rather than the blend arithmetic -- within a couple of levels
+# of it, and picked rather than mixed (`feedback_ui_widget_style`).
+def _chip_style(border: str, checked_background: str) -> str:
+    """One chip, in the state the caller means.
+
+    `border` is always 1px, even when it is transparent: a border that appears only in
+    one state changes the chip's size when it enters that state.
+
+    A disabled chip has to *look* disabled. Without the last rule Qt draws it exactly
+    like a live one -- measured: the greyed Fluorescence chip on a system with no camera
+    rendered pixel-identical to the enabled one, so the only thing saying "not this one"
+    was a tooltip nobody hovers. Dimmed text on the *same* ground, not a lighter one: a
+    lighter ground would make the dead chip brighter than its live neighbours.
+    """
+    return (
+        f"QPushButton {{ color: {NEUTRAL_300}; font-size: 10px; padding: 3px 8px;"
+        f" border: 1px solid {border}; border-radius: 9px;"
+        f" background: {NEUTRAL_900}; }}"
+        f"QPushButton:hover {{ background: {NEUTRAL_800}; }}"
+        f"QPushButton:checked {{ color: {GRAY_WHITE_COLOR};"
+        f" background: {checked_background}; }}"
+        f"QPushButton:disabled {{ color: {NEUTRAL_650}; background: {NEUTRAL_900}; }}"
+    )
+
+
+# A view that is not where the next run would land.
+VIEW_CHIP_STYLE = _chip_style(border="transparent", checked_background=NEUTRAL_750)
+# The view the next acquisition *would* land in -- marked by the border whether or not it
+# is the one being shown, which is the distinction the strip exists to make.
+VIEW_CHIP_STYLE_ACTIVE = _chip_style(
+    border=ACCENT_COLOR, checked_background=ACCENT_COLOR
 )
-_VIEW_CHIP_STYLE_ACTIVE = (
-    f"QPushButton {{ color: {NEUTRAL_300}; font-size: 10px; padding: 3px 8px;"
-    f" border: 1px solid {ACCENT_COLOR}; border-radius: 9px;"
-    f" background: {NEUTRAL_900}; }}"
-    f"QPushButton:hover {{ background: {NEUTRAL_800}; }}"
-    f"QPushButton:checked {{ color: {GRAY_WHITE_COLOR}; background: {ACCENT_COLOR}; }}"
+# The imaging system this tab is showing. Accent when selected, the same as a selected
+# view, so "selected" means one thing across the row rather than grey at one level and
+# blue at the other. No border: the border is the acquisition-view marker and means
+# something the modality has no equivalent of.
+MODALITY_CHIP_STYLE = _chip_style(
+    border="transparent", checked_background=ACCENT_COLOR
 )
 
 # The strip the chips live on. Distinct from the canvas rather than seamless: seamless is
@@ -193,9 +227,17 @@ _VIEW_CHIP_STYLE_ACTIVE = (
 # screen the canvas is bright, so the boundary arrives anyway -- better as a decision
 # than as an accident. Scoped by object name, or the background would be inherited by
 # every chip on it.
-_VIEW_STRIP_STYLE = (
+#
+# The second rule is the viewport, and without it the first one never showed: these
+# strips are scroll areas, and a scroll area's viewport is a separate child widget that
+# `#viewStrip` does not match, so it filled itself from the palette instead. The strip
+# has therefore been painting SURFACE_COLOR (#262930) all along while declaring
+# PANEL_COLOR (#1e2027) -- invisible until a second strip sat beside it in one bar and
+# the two colours met. `> QWidget > QWidget` is the viewport and the row inside it.
+VIEW_STRIP_STYLE = (
     f"#viewStrip {{ background: {PANEL_COLOR};"
     f" border-bottom: 1px solid {BORDER_COLOR}; }}"
+    f"#viewStrip > QWidget > QWidget {{ background: {PANEL_COLOR}; }}"
 )
 
 # Cryo grid bar defaults, in microns -- the values the tab this replaces carried in
@@ -732,7 +774,7 @@ class FibsemOverviewWidget(QWidget):
         self._view_strip_layout.setContentsMargins(
             _CANVAS_CHROME_MARGIN, 4, _CANVAS_CHROME_MARGIN, 4
         )
-        self._view_strip_layout.setSpacing(_VIEW_CHIP_SPACING)
+        self._view_strip_layout.setSpacing(VIEW_CHIP_SPACING)
         # Packs the chips left. Added once and kept: the rebuild inserts before it.
         self._view_strip_layout.addStretch(1)
 
@@ -749,7 +791,7 @@ class FibsemOverviewWidget(QWidget):
         # far chips are reachable rather than lost.
         self.view_strip = QScrollArea()
         self.view_strip.setObjectName("viewStrip")
-        self.view_strip.setStyleSheet(_VIEW_STRIP_STYLE)
+        self.view_strip.setStyleSheet(VIEW_STRIP_STYLE)
         self.view_strip.setWidget(chips)
         self.view_strip.setWidgetResizable(True)
         self.view_strip.setFrameShape(QFrame.NoFrame)
@@ -1074,7 +1116,7 @@ class FibsemOverviewWidget(QWidget):
                 )
             )
             chip.setStyleSheet(
-                _VIEW_CHIP_STYLE_ACTIVE if view == acquisition else _VIEW_CHIP_STYLE
+                VIEW_CHIP_STYLE_ACTIVE if view == acquisition else VIEW_CHIP_STYLE
             )
             chip.clicked.connect(partial(self._on_view_chip_clicked, view))
             # Before the trailing stretch, so they pack left in the order above.

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -164,6 +164,7 @@ _CANVAS_CHROME_MARGIN = 8
 # Gap between view chips.
 VIEW_CHIP_SPACING = 4
 
+
 # Chips as they have always looked -- dark and rounded rather than the app's button
 # styling, because they read as a set of states rather than a toolbar.
 #
@@ -218,9 +219,7 @@ VIEW_CHIP_STYLE_ACTIVE = _chip_style(
 # view, so "selected" means one thing across the row rather than grey at one level and
 # blue at the other. No border: the border is the acquisition-view marker and means
 # something the modality has no equivalent of.
-MODALITY_CHIP_STYLE = _chip_style(
-    border="transparent", checked_background=ACCENT_COLOR
-)
+MODALITY_CHIP_STYLE = _chip_style(border="transparent", checked_background=ACCENT_COLOR)
 
 # The strip the chips live on. Distinct from the canvas rather than seamless: seamless is
 # only seamless while the canvas is empty and dark, and the moment an overview is on

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -60,11 +60,12 @@ _TIP_BUG_REPORT = (
     "Show the 'Report an Issue...' option in the Help menu, for reporting bugs and "
     "optionally submitting experiment data privately to the maintainers."
 )
-_LBL_OVERVIEW_CANVAS = "Enable Overview (Canvas) Tab"
-_TIP_OVERVIEW_CANVAS = (
-    "Add a rebuilt Overview tab on the real-space canvas, beside the existing one. "
-    "Tiles are placed where they were acquired rather than stitched first. Still being "
-    "finished, and it drives the same microscope as the Overview tab it will replace."
+_LBL_NAPARI_OVERVIEW = "Show the old Minimap Tab"
+_TIP_NAPARI_OVERVIEW = (
+    "Keep the previous napari-based overview beside the Overview tab that replaced it. "
+    "The Overview tab places tiles where they were acquired rather than stitching them "
+    "first, and holds both the FIB/SEM and fluorescence overviews. This is here for "
+    "anyone still relying on the old tab, and is removed in a future release."
 )
 _LBL_CONNECTION_CHIP = "Enable Connection Chip"
 _TIP_CONNECTION_CHIP = (
@@ -176,15 +177,15 @@ class PreferencesDialog(QDialog):
         self._chk_bug_report.setToolTip(_TIP_BUG_REPORT)
         self._chk_scripts = QCheckBox()
         self._chk_scripts.setToolTip(_TIP_SCRIPTS)
-        self._chk_overview_canvas = QCheckBox()
-        self._chk_overview_canvas.setToolTip(_TIP_OVERVIEW_CANVAS)
+        self._chk_napari_overview = QCheckBox()
+        self._chk_napari_overview.setToolTip(_TIP_NAPARI_OVERVIEW)
         self._chk_connection_chip = QCheckBox()
         self._chk_connection_chip.setToolTip(_TIP_CONNECTION_CHIP)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
         features_form.addRow(_LBL_SAMPLE_HOLDER, self._chk_sample_holder)
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
         features_form.addRow(_LBL_SCRIPTS, self._chk_scripts)
-        features_form.addRow(_LBL_OVERVIEW_CANVAS, self._chk_overview_canvas)
+        features_form.addRow(_LBL_NAPARI_OVERVIEW, self._chk_napari_overview)
         features_form.addRow(_LBL_CONNECTION_CHIP, self._chk_connection_chip)
         self._stack.addWidget(features_page)
 
@@ -257,7 +258,7 @@ class PreferencesDialog(QDialog):
         self._chk_sample_holder.setChecked(f.sample_holder_widget)
         self._chk_bug_report.setChecked(f.bug_report_enabled)
         self._chk_scripts.setChecked(f.scripts_enabled)
-        self._chk_overview_canvas.setChecked(f.overview_canvas_tab)
+        self._chk_napari_overview.setChecked(f.napari_overview_tab)
         self._chk_connection_chip.setChecked(f.connection_chip)
 
         e = prefs.experiment
@@ -329,7 +330,7 @@ class PreferencesDialog(QDialog):
                 sample_holder_widget=self._chk_sample_holder.isChecked(),
                 bug_report_enabled=self._chk_bug_report.isChecked(),
                 scripts_enabled=self._chk_scripts.isChecked(),
-                overview_canvas_tab=self._chk_overview_canvas.isChecked(),
+                napari_overview_tab=self._chk_napari_overview.isChecked(),
                 connection_chip=self._chk_connection_chip.isChecked(),
             ),
             movement=MovementPreferences(

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -2029,6 +2029,12 @@ def test_an_empty_grid_still_forbids_acquiring_after_a_lock_is_lifted(qapp):
 # ── the host side: building and retiring the tab ─────────────────────────
 
 
+from fibsem.applications.autolamella.ui.overview_container_tab import (
+    MODALITY_FIBSEM,
+    MODALITY_FLUORESCENCE,
+)
+
+
 class _StubHost:
     """The tab wiring, without the AutoLamella main window.
 
@@ -2048,12 +2054,18 @@ class _StubHost:
         AutoLamellaSingleWindowUI as _Real,
     )
 
-    add_fm_overview_tab = _Real.add_fm_overview_tab
-    _refresh_fm_overview_microscope = _Real._refresh_fm_overview_microscope
-    _on_fm_overview_availability = _Real._on_fm_overview_availability
-    _fm_overview_unavailable_reason = _Real._fm_overview_unavailable_reason
+    # One builder now, and it makes the merged Overview tab: the fluorescence overview is
+    # a page of it rather than a tab of its own (FIB-780). Everything below still reaches
+    # the same `AutoLamellaFluorescenceOverviewTab`, through `self.fm_overview_tab`, which
+    # the builder binds.
+    add_overview_tab = _Real.add_overview_tab
+    _refresh_overview_microscope = _Real._refresh_overview_microscope
+    _on_overview_availability = _Real._on_overview_availability
     _refresh_overview_positions = _Real._refresh_overview_positions
     _on_fm_overview_lamella_selected = _Real._on_fm_overview_lamella_selected
+    # The builder wires both pages' lists, so the beam handler is reached here too even
+    # though nothing in this file clicks it.
+    _on_beam_overview_lamella_selected = _Real._on_beam_overview_lamella_selected
     _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
     _apply_overview_locks = _Real._apply_overview_locks
     _overview_may_work = _Real._overview_may_work
@@ -2068,13 +2080,23 @@ class _StubHost:
         self.autolamella_ui = type(
             "_UI", (), {"microscope": microscope, "experiment": experiment}
         )()
-        self.add_fm_overview_tab()
+        self.add_overview_tab()
 
     @property
     def tab_enabled(self):
-        return self.tab_widget.isTabEnabled(
-            self.tab_widget.indexOf(self.fm_overview_tab)
-        )
+        """Whether the Overview tab can be opened at all.
+
+        The tab holds both modalities now, so this is no longer "is there an FM". On a
+        system without one the tab is still enabled -- for the beam page -- which is why
+        the tests that used to read this as the fluorescence answer read
+        `fm_modality_available` instead.
+        """
+        return self.tab_widget.isTabEnabled(self.tab_widget.indexOf(self.overview_tab))
+
+    @property
+    def fm_modality_available(self):
+        """Whether the fluorescence page has anything behind it -- the old `tab_enabled`."""
+        return self.fm_overview_tab.is_available
 
     # ── reading through to the tab ───────────────────────────────────────
     # Test scaffolding, not production shims: these say "what the window can see of the
@@ -2110,12 +2132,16 @@ def _plain_microscope():
     return microscope
 
 
-def test_the_fm_overview_tab_is_reserved_but_dead_without_a_microscope(qapp):
+def test_the_overview_tab_is_reserved_but_dead_without_a_microscope(qapp):
     """The widget needs a camera at construction -- every scale on its canvas comes from
-    one -- so the tab exists from startup and fills in on connection."""
+    one -- so the tab exists from startup and fills in on connection.
+
+    "Overview", not "FM Overview": the fluorescence overview is a page of the merged tab
+    (FIB-780), and the tab bar has one entry for both.
+    """
     host = _StubHost()
 
-    assert "FM Overview" in [
+    assert "Overview" in [
         host.tab_widget.tabText(i) for i in range(host.tab_widget.count())
     ]
     assert not host.tab_enabled
@@ -2130,91 +2156,99 @@ def test_the_tab_comes_alive_when_fluorescence_connects(qapp):
 
     host._build_fm_overview_widget()
 
-    assert host.tab_enabled
+    assert host.fm_modality_available
     assert isinstance(host.fm_overview_widget, FMOverviewWidget)
 
     host._teardown_fm_overview_widget()
 
 
-def test_a_microscope_without_fluorescence_greys_the_tab_and_says_why(qapp):
-    """A system with no FM will never drive this tab. It stays in the tab bar rather
-    than being withdrawn -- a tab that vanishes once you connect is more startling than
-    one that is simply dim -- so the tooltip is what keeps that from being a greyed tab
-    with nothing to say for itself."""
+def test_a_microscope_without_fluorescence_greys_the_chip_and_says_why(qapp):
+    """A system with no FM will never drive this page. The chip stays in the strip rather
+    than being withdrawn -- a control that vanishes once you connect is more startling
+    than one that is simply dim -- so the tooltip is what keeps that from being a greyed
+    chip with nothing to say for itself.
+
+    The *tab* stays enabled here, which is the merge's doing and is right: the FIB/SEM
+    page is perfectly usable on a system with no camera.
+    """
     host = _StubHost(microscope=_plain_microscope())
 
-    host._refresh_fm_overview_microscope()
+    host._refresh_overview_microscope()
 
-    index = host.tab_widget.indexOf(host.fm_overview_tab)
-    assert host.tab_widget.isTabVisible(index)
-    assert not host.tab_widget.isTabEnabled(index)
-    assert host.tab_widget.tabToolTip(index) == "No Fluorescence Microscope Available"
+    chip = host.overview_tab.modality_chip(MODALITY_FLUORESCENCE)
+    assert not chip.isEnabled()
+    assert chip.toolTip() == "No Fluorescence Microscope Available"
     assert host.fm_overview_widget is None
+    assert host.tab_enabled, "the beam page is still reachable without a camera"
 
 
 def test_no_microscope_yet_says_something_different(qapp):
-    """The other absence. Both look identical on the tab bar, but one is waiting for
-    something about to happen and the other is a fact about this system -- so telling
-    the user to connect a microscope is only right for one of them."""
+    """The other absence. Both look identical on a greyed control, but one is waiting for
+    something about to happen and the other is a fact about this system -- so telling the
+    user to connect a microscope is only right for one of them.
+
+    With no microscope neither page can be built, so this one is answered on the tab.
+    """
     host = _StubHost(microscope=None)
 
-    host._refresh_fm_overview_microscope()
+    host._refresh_overview_microscope()
 
-    index = host.tab_widget.indexOf(host.fm_overview_tab)
+    index = host.tab_widget.indexOf(host.overview_tab)
     assert host.tab_widget.isTabVisible(index)
     assert not host.tab_widget.isTabEnabled(index)
     assert (
-        host.tab_widget.tabToolTip(index)
-        == "Connect a microscope to use the FM Overview"
+        host.tab_widget.tabToolTip(index) == "Connect a microscope to use the Overview"
     )
     assert host.fm_overview_widget is None
 
 
-def test_connecting_a_microscope_without_fluorescence_keeps_the_tab(qapp):
-    """Whether the system has an FM is only known once something is connected. The tab
-    does not move -- only the reason it gives changes, from 'connect one' to 'this
-    system has none'."""
+def test_connecting_a_microscope_without_fluorescence_keeps_the_chip(qapp):
+    """Whether the system has an FM is only known once something is connected. The chip
+    does not move -- only the reason it gives changes, from 'connect one' to 'this system
+    has none'."""
     host = _StubHost(microscope=None)
-    index = host.tab_widget.indexOf(host.fm_overview_tab)
-    assert host.tab_widget.isTabVisible(index)
+    chip = host.overview_tab.modality_chip(MODALITY_FLUORESCENCE)
+    assert not chip.isEnabled()
+    assert chip.toolTip() == "Connect a microscope to use the Overview"
 
     host.autolamella_ui.microscope = _plain_microscope()
-    host._refresh_fm_overview_microscope()
+    host._refresh_overview_microscope()
 
-    assert host.tab_widget.isTabVisible(index)
-    assert not host.tab_widget.isTabEnabled(index)
-    assert host.tab_widget.tabToolTip(index) == "No Fluorescence Microscope Available"
+    assert not chip.isEnabled()
+    assert chip.toolTip() == "No Fluorescence Microscope Available"
 
 
-def test_a_microscope_with_fluorescence_brings_the_tab_back(qapp):
+def test_a_microscope_with_fluorescence_brings_the_chip_back(qapp):
     """And the reverse, so swapping between systems in one session settles correctly.
 
-    The tooltip has to be cleared, not just the tab enabled: a stale "No Fluorescence
-    Microscope Available" sitting on a working tab is worse than no tooltip at all."""
+    The tooltip has to stop being a reason, not just the chip enabled: a stale "No
+    Fluorescence Microscope Available" sitting on a working chip is worse than none."""
     from fibsem.ui.fm.overview_app import build_microscope
 
     host = _StubHost(microscope=_plain_microscope())
-    host._refresh_fm_overview_microscope()
-    index = host.tab_widget.indexOf(host.fm_overview_tab)
-    assert not host.tab_widget.isTabEnabled(index)
+    host._refresh_overview_microscope()
+    chip = host.overview_tab.modality_chip(MODALITY_FLUORESCENCE)
+    assert not chip.isEnabled()
 
     host.autolamella_ui.microscope = build_microscope()
-    host._refresh_fm_overview_microscope()
+    host._refresh_overview_microscope()
 
-    assert host.tab_widget.isTabVisible(index)
-    assert host.tab_widget.isTabEnabled(index)
-    assert host.tab_widget.tabToolTip(index) == ""
+    assert chip.isEnabled()
+    assert chip.toolTip() == "Fluorescence"
     assert isinstance(host.fm_overview_widget, FMOverviewWidget)
 
     host._teardown_fm_overview_widget()
 
 
-def test_a_greyed_tab_always_says_why(qapp):
+def test_nothing_unreachable_is_ever_silent(qapp):
     """The invariant behind the tests above, stated once over every state the tab has.
 
     Written as a sweep rather than another case-by-case test because the thing worth
-    protecting is that no *future* unavailable state can add a greyed tab with nothing
-    on it -- which is exactly the failure a per-case test cannot catch.
+    protecting is that no *future* unavailable state can add a greyed control with
+    nothing on it -- which is exactly the failure a per-case test cannot catch.
+
+    Two levels to sweep now, and the invariant is the same on both: the tab, and each
+    chip on it.
     """
     from fibsem.ui.fm.overview_app import build_microscope
 
@@ -2224,8 +2258,8 @@ def test_a_greyed_tab_always_says_why(qapp):
         ("fluorescence available", build_microscope()),
     ):
         host = _StubHost(microscope=microscope)
-        host._refresh_fm_overview_microscope()
-        index = host.tab_widget.indexOf(host.fm_overview_tab)
+        host._refresh_overview_microscope()
+        index = host.tab_widget.indexOf(host.overview_tab)
 
         assert host.tab_widget.isTabVisible(index), f"{label}: the tab is never hidden"
         if host.tab_widget.isTabEnabled(index):
@@ -2237,43 +2271,15 @@ def test_a_greyed_tab_always_says_why(qapp):
                 f"{label}: greyed out with nothing to say why"
             )
 
+        for modality in (MODALITY_FIBSEM, MODALITY_FLUORESCENCE):
+            chip = host.overview_tab.modality_chip(modality)
+            assert chip.isVisible() or not host.overview_tab.isVisible(), (
+                f"{label}: the {modality} chip was withdrawn rather than greyed"
+            )
+            assert chip.toolTip(), f"{label}: the {modality} chip says nothing at all"
+
         if host.fm_overview_widget is not None:
             host._teardown_fm_overview_widget()
-
-    host._teardown_fm_overview_widget()
-
-
-def test_the_same_microscope_connecting_again_keeps_the_widget(qapp):
-    """Rebuilding would throw away whatever is on the canvas, and a connection signal
-    can arrive more than once for one instrument."""
-    from fibsem.ui.fm.overview_app import build_microscope
-
-    host = _StubHost(microscope=build_microscope())
-    host._build_fm_overview_widget()
-    first = host.fm_overview_widget
-
-    host._build_fm_overview_widget()
-
-    assert host.fm_overview_widget is first
-
-    host._teardown_fm_overview_widget()
-
-
-def test_a_different_microscope_replaces_the_widget(qapp):
-    """The widget holds its microscope for life. Left alone across a reconnect it would
-    read geometry from an instrument nobody is driving -- FIB-433 is about doing this
-    without discarding the view."""
-    from fibsem.ui.fm.overview_app import build_microscope
-
-    host = _StubHost(microscope=build_microscope())
-    host._build_fm_overview_widget()
-    first = host.fm_overview_widget
-
-    host.autolamella_ui.microscope = build_microscope()
-    host._build_fm_overview_widget()
-
-    assert host.fm_overview_widget is not first
-    assert host.fm_overview_tab._microscope is host.autolamella_ui.microscope
 
     host._teardown_fm_overview_widget()
 
@@ -2286,8 +2292,13 @@ def test_retiring_the_widget_releases_the_stage_signal(qapp):
     from fibsem.ui.fm.overview_app import build_microscope
 
     microscope = build_microscope()
-    before = len(microscope.stage_position_changed)
     host = _StubHost(microscope=microscope)
+    # Measured with the fluorescence widget retired rather than before the host exists:
+    # the merged tab builds the beam widget too, and it subscribes to the same signal.
+    # Counting from an empty microscope would be counting both and attributing them here.
+    host._teardown_fm_overview_widget()
+    before = len(microscope.stage_position_changed)
+
     host._build_fm_overview_widget()
     assert len(microscope.stage_position_changed) == before + 1
 
@@ -2297,16 +2308,23 @@ def test_retiring_the_widget_releases_the_stage_signal(qapp):
     assert host.fm_overview_widget is None
 
 
-def test_disconnecting_the_microscope_retires_the_tab(qapp):
+def test_disconnecting_the_microscope_retires_the_page(qapp):
+    """Both pages, and the tab with them: a disconnect leaves nothing to drive.
+
+    Driven through the tab's own refresh rather than the fluorescence one, because that
+    is what a disconnect actually calls -- the fluorescence-only path would leave the
+    beam widget holding the microscope that was just taken away.
+    """
     from fibsem.ui.fm.overview_app import build_microscope
 
     host = _StubHost(microscope=build_microscope())
-    host._build_fm_overview_widget()
+    host._refresh_overview_microscope()
 
     host.autolamella_ui.microscope = None
-    host._build_fm_overview_widget()
+    host._refresh_overview_microscope()
 
     assert host.fm_overview_widget is None
+    assert not host.overview_tab.available_modalities()
     assert not host.tab_enabled
 
 
@@ -2366,7 +2384,7 @@ def test_everything_tolerates_the_tab_being_dead(qapp):
     host._build_fm_overview_widget()  # must not raise
     host._update_fm_overview_experiment()  # must not raise
     host._set_minimap_workflow_enabled(False)  # must not raise
-    host._refresh_fm_overview_microscope()  # must not raise
+    host._refresh_overview_microscope()  # must not raise
 
     assert getattr(host, "fm_overview_widget", None) is None
 
@@ -3041,7 +3059,7 @@ def test_the_host_tolerates_no_fm_overview_tab(qapp):
     """Both updates are called from paths that run on every system, including those
     with the tab switched off or no fluorescence detector at all."""
     host = _StubHost(microscope=_plain_microscope())
-    host._refresh_fm_overview_microscope()
+    host._refresh_overview_microscope()
 
     host._update_fm_overview_positions()  # must not raise
     host._update_fm_overview_selection(None)  # must not raise

--- a/tests/ui/test_fm_sparse_entry_point.py
+++ b/tests/ui/test_fm_sparse_entry_point.py
@@ -181,6 +181,16 @@ def test_the_button_sits_with_the_grid_it_sets(widget):
     assert header.isAncestorOf(widget.button_select_ground)
 
 
+def _toasts(monkeypatch):
+    """Collect what the widget says, instead of showing it."""
+    said = []
+    monkeypatch.setattr(
+        "fibsem.ui.fm.widgets.fm_overview_widget.notification_service.show_toast",
+        lambda message, level="info", *a, **k: said.append(message),
+    )
+    return said
+
+
 def test_with_no_overviews_it_says_so_rather_than_opening_an_empty_dialog(
     microscope, tmp_path
 ):
@@ -192,6 +202,42 @@ def test_with_no_overviews_it_says_so_rather_than_opening_an_empty_dialog(
         built.select_ground_to_image()
 
     assert opened == []
+
+
+def test_an_empty_folder_and_no_folder_at_all_are_not_the_same_message(
+    microscope, tmp_path, monkeypatch
+):
+    """Telling the user to acquire one first is wrong advice when there is no output
+    folder: acquiring would land somewhere this still cannot see, so the reader is sent
+    off to do something that cannot help. It was reported as a bug in the selector on
+    exactly that confusion, from an app started with no experiment loaded.
+
+    Asserted on what each message *tells the user to do*, not on the strings: the point
+    is that one directs at Output and the other at acquiring, and a test pinning the
+    wording would pass with the two advices swapped.
+    """
+    no_folder = FMOverviewWidget(microscope)
+    no_folder.set_save_directory(None)
+    said = _toasts(monkeypatch)
+    with dialog_never_opens():
+        no_folder.select_ground_to_image()
+    assert len(said) == 1
+    assert "Output" in said[0] or "experiment" in said[0]
+    assert "Acquire one" not in said[0], "told to acquire when there is nowhere to look"
+
+    empty_folder = FMOverviewWidget(microscope)
+    empty_folder.set_save_directory(str(tmp_path))
+    said = _toasts(monkeypatch)
+    with dialog_never_opens():
+        empty_folder.select_ground_to_image()
+    assert len(said) == 1
+    assert "Acquire one" in said[0]
+    # Named, because the wrong folder is the likeliest reason someone who *has* acquired
+    # an overview is being told there are none.
+    assert tmp_path.name in said[0]
+
+    no_folder.close()
+    empty_folder.close()
 
 
 def test_it_does_open_when_there_is_something_to_select_on(widget):

--- a/tests/ui/test_overview_container_tab.py
+++ b/tests/ui/test_overview_container_tab.py
@@ -1,0 +1,365 @@
+"""The merged Overview tab: one tab, two modalities, both alive at once (FIB-780).
+
+Built against a real simulator rather than a stub host. What is worth checking here is
+not that a stack raises the page you clicked -- Qt does that -- but the three things the
+merge could plausibly have broken, none of which a stub would exercise:
+
+* **Both widgets stay built.** Switching modality must not tear the other one down, or
+  each switch pays a rebuild and the view you were on is lost.
+* **Availability is per modality, not per tab.** A system with no camera has a perfectly
+  usable Overview tab; it is one chip on it that cannot be reached.
+* **The lock still has two inputs.** FIB-706 stops one overview driving the stage while
+  the other acquires, and both are still able to acquire from under a single tab.
+
+Run directly:
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_overview_container_tab.py
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.ui.overview_container_tab import (  # noqa: E402
+    MODALITY_FIBSEM,
+    MODALITY_FLUORESCENCE,
+    AutoLamellaOverviewContainerTab,
+)
+
+
+@pytest.fixture
+def qapp():
+    from PyQt5.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+def _ui(microscope=None, experiment=None):
+    return type("_UI", (), {"microscope": microscope, "experiment": experiment})()
+
+
+def _fm_microscope():
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    return build_microscope()
+
+
+def _plain_microscope():
+    """A Demo microscope with no fluorescence detector attached."""
+    from fibsem import utils
+
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    microscope.fm = None
+    return microscope
+
+
+def _built(qapp, microscope):
+    tab = AutoLamellaOverviewContainerTab(_ui(microscope))
+    tab.refresh_microscope()
+    return tab
+
+
+def _teardown(tab):
+    for host in (tab.beam_tab, tab.fm_tab):
+        host._drop_overview()
+    tab.deleteLater()
+
+
+# ── both sides stay alive ────────────────────────────────────────────────
+
+
+def test_switching_modality_does_not_tear_the_other_side_down(qapp):
+    """The whole reason the view state survives a switch. If the hidden page were
+    dropped, every switch would rebuild a widget and lose the view it was left on --
+    which is the thing FIB-780 asked for and the thing a stack gets for free."""
+    tab = _built(qapp, _fm_microscope())
+    assert tab.beam_tab.overview is not None
+    assert tab.fm_tab.overview is not None
+
+    assert tab.set_modality(MODALITY_FLUORESCENCE)
+    assert tab.beam_tab.overview is not None, "the beam widget was dropped on a switch"
+
+    assert tab.set_modality(MODALITY_FIBSEM)
+    assert tab.fm_tab.overview is not None, "the FM widget was dropped on a switch"
+
+    _teardown(tab)
+
+
+def test_the_shown_page_is_the_one_the_chip_names(qapp):
+    tab = _built(qapp, _fm_microscope())
+
+    tab.set_modality(MODALITY_FLUORESCENCE)
+    assert tab.stack.currentWidget() is tab.fm_tab
+    assert tab.modality == MODALITY_FLUORESCENCE
+
+    tab.set_modality(MODALITY_FIBSEM)
+    assert tab.stack.currentWidget() is tab.beam_tab
+
+    _teardown(tab)
+
+
+def test_a_switch_announces_itself_once(qapp):
+    """Once per actual change. Re-picking the modality already showing is a no-op, or a
+    host listening to this would act on a click that changed nothing."""
+    tab = _built(qapp, _fm_microscope())
+    seen = []
+    tab.modality_changed.connect(seen.append)
+
+    tab.set_modality(MODALITY_FLUORESCENCE)
+    tab.set_modality(MODALITY_FLUORESCENCE)
+
+    assert seen == [MODALITY_FLUORESCENCE]
+
+    _teardown(tab)
+
+
+# ── availability is per modality ─────────────────────────────────────────
+
+
+def test_a_system_with_no_camera_still_has_a_usable_tab(qapp):
+    """The merge's most visible consequence, and the one worth pinning: what used to
+    grey out a whole tab now greys out one chip."""
+    tab = _built(qapp, _plain_microscope())
+
+    assert tab.is_available, "the tab is dead on a system that has beams"
+    assert tab.available_modalities() == [MODALITY_FIBSEM]
+    assert not tab.modality_chip(MODALITY_FLUORESCENCE).isEnabled()
+    assert tab.modality_chip(MODALITY_FIBSEM).isEnabled()
+
+    _teardown(tab)
+
+
+def test_an_unreachable_modality_cannot_be_raised(qapp):
+    """A guard rather than a path a click takes -- the chip for it is disabled. It
+    matters because the page behind an unavailable modality has no widget at all, so
+    raising it would put a bare container on screen, which reads as a canvas that failed
+    to draw rather than as a system without a camera."""
+    tab = _built(qapp, _plain_microscope())
+
+    assert not tab.set_modality(MODALITY_FLUORESCENCE)
+    assert tab.modality == MODALITY_FIBSEM
+    assert tab.stack.currentWidget() is tab.beam_tab
+
+    _teardown(tab)
+
+
+def test_no_microscope_leaves_the_tab_unavailable_with_a_reason(qapp):
+    tab = AutoLamellaOverviewContainerTab(_ui(None))
+    tab.refresh_microscope()
+
+    assert not tab.is_available
+    available, reason = tab.unavailable_summary()
+    assert not available
+    assert reason == "Connect a microscope to use the Overview"
+
+    tab.deleteLater()
+
+
+def test_availability_is_announced_for_the_tab_not_the_page(qapp):
+    """The window enables the tab off this signal. It has to mean "either page works",
+    or a system with no camera would have its Overview tab greyed out entirely."""
+    tab = AutoLamellaOverviewContainerTab(_ui(_plain_microscope()))
+    seen = []
+    tab.availability_changed.connect(seen.append)
+
+    tab.refresh_microscope()
+
+    assert seen and seen[-1] is True
+    _teardown(tab)
+
+
+def test_an_unknown_modality_is_refused(qapp):
+    tab = AutoLamellaOverviewContainerTab(_ui(None))
+    with pytest.raises(ValueError):
+        tab.set_modality("XRAY")
+    tab.deleteLater()
+
+
+# ── the lock still has two inputs ────────────────────────────────────────
+
+
+def test_acquiring_is_true_while_either_side_runs(qapp):
+    """FIB-706 unchanged by the merge: both pages stay alive, so both can still be
+    mid-tileset, and the answer the window locks on has to cover both.
+
+    Re-derived from the tabs rather than forwarded, so a bool arriving from the side that
+    just *stopped* cannot unlock the stage while the other is still placing tiles.
+    """
+    tab = _built(qapp, _fm_microscope())
+    seen = []
+    tab.acquiring_changed.connect(seen.append)
+
+    tab.beam_tab.overview._set_running(True)
+    assert tab.is_acquiring
+    assert seen[-1] is True
+
+    tab.fm_tab.overview._set_running(True)
+    tab.beam_tab.overview._set_running(False)
+    assert tab.is_acquiring, "unlocked while the fluorescence side was still running"
+    assert seen[-1] is True
+
+    tab.fm_tab.overview._set_running(False)
+    assert not tab.is_acquiring
+    assert seen[-1] is False
+
+    _teardown(tab)
+
+
+# ── the shared bar: lending the page's view chips a place in it ──────────
+
+
+def test_the_active_pages_view_chips_move_into_the_bar(qapp):
+    """One row, not two. The strip is the page's own -- it discovers views as they are
+    acquired in -- so it is moved rather than copied."""
+    tab = _built(qapp, _fm_microscope())
+
+    strip = tab.beam_tab.overview.view_strip
+    assert tab._view_slot.isAncestorOf(strip), "the beam view chips are not in the bar"
+    assert not tab._divider.isHidden()
+
+    _teardown(tab)
+
+
+def test_the_fluorescence_page_has_no_view_chips_and_no_divider(qapp):
+    """One camera, one view. A divider with nothing after it is a rule pointing at
+    empty space."""
+    tab = _built(qapp, _fm_microscope())
+    tab.set_modality(MODALITY_FLUORESCENCE)
+
+    assert getattr(tab.fm_tab.overview, "view_strip", None) is None
+    assert tab._divider.isHidden()
+
+    _teardown(tab)
+
+
+def test_switching_back_and_forth_keeps_lending_the_strip(qapp):
+    """The strip is handed back on the way out, so coming back has to re-mount it.
+    Left un-mounted the beam page would silently lose its view chips on the second
+    visit -- and there is no error to notice, just chips that stop appearing."""
+    tab = _built(qapp, _fm_microscope())
+    strip = tab.beam_tab.overview.view_strip
+
+    tab.set_modality(MODALITY_FLUORESCENCE)
+    assert not tab._view_slot.isAncestorOf(strip), "the strip was never handed back"
+
+    tab.set_modality(MODALITY_FIBSEM)
+    assert tab._view_slot.isAncestorOf(strip), "the strip was not lent back"
+
+    _teardown(tab)
+
+
+def test_a_rebuild_does_not_leave_the_bar_holding_a_dead_strip(qapp):
+    """The reason `_unmount_view_strip` runs *before* the rebuild rather than after.
+
+    While mounted the strip is parented here, so it does not go when Qt destroys the
+    widget that owns it -- and the bar would be left holding a deleted C++ object, which
+    is a segfault on the next paint rather than an exception. Reconnecting to a different
+    microscope is the path that does this.
+    """
+    tab = _built(qapp, _fm_microscope())
+    first = tab.beam_tab.overview.view_strip
+
+    # A different microscope object is what makes `refresh_microscope` rebuild.
+    tab.autolamella_ui.microscope = _fm_microscope()
+    tab.refresh_microscope()
+
+    second = tab.beam_tab.overview.view_strip
+    assert second is not first, "the widget was not rebuilt; this test proves nothing"
+    assert tab._view_slot.isAncestorOf(second)
+
+    _teardown(tab)
+
+
+def test_dropping_a_page_out_from_under_the_bar_is_survivable(qapp):
+    """Nothing in production drops a widget without going through `refresh_microscope`,
+    but tests do, and the guard costs one `except`. What it must not do is raise while
+    tearing down."""
+    tab = _built(qapp, _fm_microscope())
+    tab.beam_tab._drop_overview()
+
+    tab._unmount_view_strip()  # must not raise
+    tab._mount_view_strip()  # must not raise
+    assert tab._divider.isHidden()
+
+    _teardown(tab)
+
+
+# ── the strip itself ─────────────────────────────────────────────────────
+
+
+def test_a_disabled_chip_does_not_look_like_a_live_one(qapp):
+    """It read as clickable until `VIEW_CHIP_STYLE` grew a `:disabled` rule -- the greyed
+    Fluorescence chip on a system with no camera rendered pixel-identical to the enabled
+    one, so the only thing saying "not this one" was a tooltip nobody hovers.
+
+    Compared by rendering rather than by reading the stylesheet: the sheet is shared with
+    the view chips and a rule can be present and still lose to another selector.
+    """
+    live = _built(qapp, _fm_microscope())
+    dead = AutoLamellaOverviewContainerTab(_ui(_plain_microscope()))
+    dead.refresh_microscope()
+
+    enabled = live.modality_chip(MODALITY_FLUORESCENCE)
+    disabled = dead.modality_chip(MODALITY_FLUORESCENCE)
+    assert enabled.isEnabled() and not disabled.isEnabled()
+
+    enabled.resize(120, 24)
+    disabled.resize(120, 24)
+    assert enabled.grab().toImage() != disabled.grab().toImage(), (
+        "a disabled chip renders identically to a live one"
+    )
+
+    _teardown(live)
+    _teardown(dead)
+
+
+def test_a_chip_is_the_same_size_whichever_state_it_is_in(qapp):
+    """The active view chip carries a 1px border and the resting one used `border: none`,
+    so a chip grew by 2px the moment it became the acquisition view -- and sat 2px taller
+    than the modality chips beside it once the two shared a row."""
+    from PyQt5.QtWidgets import QPushButton
+
+    from fibsem.ui.widgets.overview_widget import (
+        VIEW_CHIP_STYLE,
+        VIEW_CHIP_STYLE_ACTIVE,
+    )
+
+    sizes = set()
+    for sheet in (VIEW_CHIP_STYLE, VIEW_CHIP_STYLE_ACTIVE):
+        chip = QPushButton("SEM @ SEM")
+        chip.setStyleSheet(sheet)
+        chip.adjustSize()
+        sizes.add((chip.sizeHint().width(), chip.sizeHint().height()))
+    assert len(sizes) == 1, f"the chip changes size with its state: {sizes}"
+
+
+def test_every_chip_says_something(qapp):
+    """Enabled or not. A greyed control with an empty tooltip is the failure this whole
+    pattern exists to avoid, and it is the one that appears by omission when a new
+    unavailable state is added later."""
+    for microscope in (None, _plain_microscope(), _fm_microscope()):
+        tab = AutoLamellaOverviewContainerTab(_ui(microscope))
+        tab.refresh_microscope()
+        for modality in (MODALITY_FIBSEM, MODALITY_FLUORESCENCE):
+            chip = tab.modality_chip(modality)
+            assert chip.toolTip(), f"{modality} chip is silent"
+        _teardown(tab)
+
+
+def test_the_checked_chip_is_the_page_on_screen(qapp):
+    """Two ways to be wrong: a chip checked for a page that is not showing, and none
+    checked at all. Both read as the strip having lost track of the tab."""
+    tab = _built(qapp, _fm_microscope())
+
+    for modality in (MODALITY_FLUORESCENCE, MODALITY_FIBSEM):
+        tab.set_modality(modality)
+        checked = [
+            m
+            for m in (MODALITY_FIBSEM, MODALITY_FLUORESCENCE)
+            if tab.modality_chip(m).isChecked()
+        ]
+        assert checked == [modality]
+
+    _teardown(tab)

--- a/tests/ui/test_overview_tab_host.py
+++ b/tests/ui/test_overview_tab_host.py
@@ -14,6 +14,7 @@ window, and the window's own wiring is checked structurally in
 Run directly (no display needed):
     QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_overview_tab_host.py
 """
+
 from __future__ import annotations
 
 import os
@@ -58,7 +59,9 @@ def microscope():
     import fibsem.config as fibsem_config
 
     path = os.path.join(
-        os.path.dirname(fibsem_config.__file__), "config", "sim-arctis-configuration.yaml"
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "sim-arctis-configuration.yaml",
     )
     scope, _ = utils.setup_session(manufacturer="Demo", config_path=path)
     assert scope.stage_is_compustage, "the config stopped being a compustage"
@@ -91,10 +94,14 @@ class _StubWindow:
         name = f"Lamella-{number:02d}"
         if stage_position is None:
             beam = self.microscope.get_orientation(MILLING_ORIENTATION)
-            stage_position = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=beam.r, t=beam.t)
+            stage_position = FibsemStagePosition(
+                x=0.0, y=0.0, z=0.0, r=beam.r, t=beam.t
+            )
         poses = build_lamella_poses(self.microscope, stage_position)
         lamella = Lamella(
-            petname=name, path=os.path.join(str(self.experiment.path), name), number=number
+            petname=name,
+            path=os.path.join(str(self.experiment.path), name),
+            number=number,
         )
         lamella.milling_pose = poses.milling
         lamella.fluorescence_pose = poses.fluorescence
@@ -222,7 +229,9 @@ class TestMovingAPosition:
         sync_fluorescence_pose(microscope, lamella)
         before = lamella.fluorescence_pose
         before_position = (
-            None if before is None else (before.stage_position.x, before.stage_position.y)
+            None
+            if before is None
+            else (before.stage_position.x, before.stage_position.y)
         )
 
         target = _at(microscope.get_stage_position(), dx=250e-6, dy=-125e-6)
@@ -334,7 +343,10 @@ class TestTheFlagOff:
         and connected here, and the tab still has to decline to build."""
         experiment = Experiment(path=tmp_path, name="overview-flag-off")
         os.makedirs(str(experiment.path), exist_ok=True)
-        signals = (microscope.tiled_acquisition_signal, microscope.stage_position_changed)
+        signals = (
+            microscope.tiled_acquisition_signal,
+            microscope.stage_position_changed,
+        )
         before = [len(s) for s in signals]
 
         tab = AutoLamellaOverviewTab(_StubWindow(microscope, experiment))
@@ -348,7 +360,10 @@ class TestTheFlagOff:
         )
 
     def test_turning_it_off_drops_what_was_built(self, tab, microscope):
-        signals = (microscope.tiled_acquisition_signal, microscope.stage_position_changed)
+        signals = (
+            microscope.tiled_acquisition_signal,
+            microscope.stage_position_changed,
+        )
         before = [len(s) for s in signals]
         tab.set_enabled(False)
         assert tab.overview is None
@@ -434,7 +449,9 @@ class TestItMarksTheFluorescenceSidePose:
         fm_tab.refresh_positions()
 
         assert fm_tab.overview._positions == []
-        assert [row.lamella.name for row in fm_tab.lamella_list._rows()] == [lamella.name]
+        assert [row.lamella.name for row in fm_tab.lamella_list._rows()] == [
+            lamella.name
+        ]
 
     def test_move_to_drives_to_the_fluorescence_pose(self, fm_tab, microscope):
         """Moving to the milling pose from here would swing the stage 180 degrees away
@@ -489,7 +506,7 @@ def locked_pair(tab, fm_tab):
         _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
 
         def __init__(self, beam, fluorescence):
-            self.overview_canvas_tab = beam
+            self.beam_overview_tab = beam
             self.fm_overview_tab = fluorescence
             for one in (beam, fluorescence):
                 one.acquiring_changed.connect(self._apply_overview_locks)

--- a/tests/ui/test_overview_tab_wiring.py
+++ b/tests/ui/test_overview_tab_wiring.py
@@ -41,6 +41,7 @@ WINDOW = (
     / "ui"
     / "AutoLamellaMainUI.py"
 )
+PREFERENCES_DIALOG = REPO_ROOT / "fibsem" / "ui" / "widgets" / "preferences_dialog.py"
 CONTAINER_SOURCE = (
     REPO_ROOT
     / "fibsem"
@@ -257,13 +258,13 @@ def test_the_retired_flag_is_gone_everywhere(window_source):
     leftover reader would be reading a field that no longer exists.
     """
     import fibsem.config as fibsem_cfg
-    from fibsem.ui.widgets import preferences_dialog
 
     assert not hasattr(fibsem_cfg.FeatureFlags(), "overview_canvas_tab")
     assert "overview_canvas_tab" not in window_source
-    assert "overview_canvas_tab" not in Path(preferences_dialog.__file__).read_text(
-        encoding="utf-8"
-    )
+    # Read from disk, not imported. This is one of the few CI runs *without* PyQt5, and
+    # `import preferences_dialog` pulls it in -- taking the whole module down at
+    # collection, which is the failure the static approach here exists to avoid.
+    assert "overview_canvas_tab" not in PREFERENCES_DIALOG.read_text(encoding="utf-8")
 
 
 def test_the_overview_tab_is_not_behind_any_flag(window_source):

--- a/tests/ui/test_overview_tab_wiring.py
+++ b/tests/ui/test_overview_tab_wiring.py
@@ -207,13 +207,22 @@ def test_the_container_rebuilds_both(self_calls):
     container = ast.parse(CONTAINER_SOURCE.read_text(encoding="utf-8"))
     for node in ast.walk(container):
         if isinstance(node, ast.FunctionDef) and node.name == "refresh_microscope":
-            body = ast.dump(node)
             break
     else:
         pytest.fail("the container has no refresh_microscope; this test is stale")
-    assert "self._tabs" in ast.unparse(node), (
-        "refresh_microscope no longer fans out over both tabs"
+
+    # Walked rather than unparsed: `ast.unparse` is 3.9+ and CI still builds on 3.8,
+    # where it is an AttributeError at run time rather than anything a local run or a
+    # linter would show. Matching the node is also stricter than a substring -- it finds
+    # `self._tabs` as an actual attribute access and not as a mention in a comment.
+    reaches_both = any(
+        isinstance(inner, ast.Attribute)
+        and inner.attr == "_tabs"
+        and isinstance(inner.value, ast.Name)
+        and inner.value.id == "self"
+        for inner in ast.walk(node)
     )
+    assert reaches_both, "refresh_microscope no longer fans out over both tabs"
 
 
 def test_every_selection_handler_reaches_the_new_tab(methods_calling):

--- a/tests/ui/test_overview_tab_wiring.py
+++ b/tests/ui/test_overview_tab_wiring.py
@@ -1,4 +1,11 @@
-"""The Overview (Canvas) tab is wired into every lifecycle point its twin is.
+"""Both overview modalities are wired into every lifecycle point the other is.
+
+The two used to be separate tabs. They are now two pages of one Overview tab
+(`AutoLamellaOverviewContainerTab`, FIB-780) -- but both host tabs stay built and stay
+subscribed under the stack, and the window still tells each of them the things only it
+can answer, so the parity these tests check is exactly as necessary as it was. What
+changed is that a third name has to be checked too: anything the *container* is told
+reaches both, and anything a host tab is told individually must be told to both.
 
 Checked *statically*, against the window's source, because the window cannot be built
 here: it still constructs the napari minimap, and a `napari.Viewer` segfaults under the
@@ -17,6 +24,7 @@ which builds the tab against a live simulator.
 Run directly:
     python -m pytest tests/ui/test_overview_tab_wiring.py
 """
+
 from __future__ import annotations
 
 import ast
@@ -25,13 +33,30 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-WINDOW = REPO_ROOT / "fibsem" / "applications" / "autolamella" / "ui" / "AutoLamellaMainUI.py"
+WINDOW = (
+    REPO_ROOT
+    / "fibsem"
+    / "applications"
+    / "autolamella"
+    / "ui"
+    / "AutoLamellaMainUI.py"
+)
+CONTAINER_SOURCE = (
+    REPO_ROOT
+    / "fibsem"
+    / "applications"
+    / "autolamella"
+    / "ui"
+    / "overview_container_tab.py"
+)
 
-# The tab the new one was modelled on, and the calls that keep it in step with the
-# window. Anything the fluorescence tab is told, the beam one has to be told too --
-# they are the same shape of thing in the same window.
+# The two host tabs, under the names the window keeps for them. Anything the
+# fluorescence one is told, the beam one has to be told too -- they are the same shape of
+# thing in the same window, and they were the pair that kept drifting (FIB-765).
 TWIN = "fm_overview_tab"
-NEW = "overview_canvas_tab"
+NEW = "beam_overview_tab"
+# The tab that holds them both, and the only thing in the tab bar.
+CONTAINER = "overview_tab"
 
 
 @pytest.fixture(scope="module")
@@ -106,15 +131,28 @@ def _is_own_method(caller: str, tab_attribute: str) -> bool:
     return _stem(tab_attribute) in caller
 
 
-def test_the_new_tab_is_created(window_source):
-    assert "self.add_overview_canvas_tab()" in window_source, (
+def test_the_overview_tab_is_created(window_source):
+    assert "self.add_overview_tab()" in window_source, (
         "the tab is defined but never added to the window"
     )
 
 
+def test_both_host_tabs_are_reachable_from_the_window(window_source):
+    """The container owns them; the window keeps its own names for them.
+
+    Not cosmetic. Every per-tab call below goes through these names, and the pair is what
+    `_apply_overview_locks` reads to decide whether either may drive the stage -- a
+    binding dropped here would take the lock's second input with it silently (FIB-706).
+    """
+    assert "self.fm_overview_tab = self.overview_tab.fm_tab" in window_source
+    assert "self.beam_overview_tab = self.overview_tab.beam_tab" in window_source
+
+
 @pytest.mark.parametrize(
     "method",
-    ["refresh_microscope", "refresh_experiment", "set_interactive", "set_selected"],
+    # `refresh_microscope` is not here any more: it is asked of the container, which
+    # fans it out to both. `test_the_container_rebuilds_both` is what covers it.
+    ["refresh_experiment", "set_interactive", "set_selected"],
 )
 def test_the_new_tab_is_told_what_its_twin_is_told(method, methods_calling):
     """Each of these is a way the window's state changes underneath a tab.
@@ -142,28 +180,38 @@ def test_the_new_tab_is_told_what_its_twin_is_told(method, methods_calling):
     )
 
 
-def test_the_new_tab_is_rebuilt_wherever_its_twin_is(self_calls):
-    """The per-tab builders are self-calls, so the attribute-based check above cannot
-    see them -- each tab's builder is excluded there as its own method.
+def test_the_container_is_rebuilt_on_every_connection(self_calls):
+    """The per-tab builders were self-calls, so the attribute-based check above could not
+    see them. There is one builder now, and it is the same story one level up.
 
-    This is the one that matters most: the twin's builder is what hands a tab the
-    current microscope, and a tab that holds its microscope for life and is not told
-    about a reconnection goes on reading geometry from an instrument nobody is driving.
-    Both call sites count -- a preferences change and a connection -- and a mutation
-    removing only the connection one survived until this existed.
-
-    The twin's builder is `_refresh_fm_overview_microscope` since FIB-609 shipped that
-    tab to everyone with an FM: it no longer answers a preference, only "is there an
-    instrument". The assertion below is a superset check, so the new tab having the
-    extra preference-driven call site of its own is fine -- it still has a flag.
+    This is the one that matters most: the builder is what hands each tab the current
+    microscope, and a tab that holds its microscope for life and is not told about a
+    reconnection goes on reading geometry from an instrument nobody is driving. A
+    mutation removing the connection call site survived until a test like this existed.
     """
-    twin = self_calls.get("_refresh_fm_overview_microscope", set())
-    new = self_calls.get("_apply_overview_canvas_visibility", set())
-    assert twin, "the twin's builder is no longer called; this test is stale"
-    missing = {c for c in twin - new if "fm_overview" not in c and "overview_canvas" not in c}
-    assert not missing, (
-        f"_apply_overview_canvas_visibility() is not called from {sorted(missing)}, "
-        "where the fluorescence tab's builder is"
+    callers = self_calls.get("_refresh_overview_microscope", set())
+    assert "_on_microscope_connected" in callers, (
+        "the overview tabs are not rebuilt on a connection; each would go on driving "
+        "the previous microscope"
+    )
+
+
+def test_the_container_rebuilds_both(self_calls):
+    """One call has to reach two tabs, or the merge quietly halved this.
+
+    Checked against the container's source rather than the window's: the window can no
+    longer tell them apart, which is the point, so the fan-out is the container's promise
+    to keep.
+    """
+    container = ast.parse(CONTAINER_SOURCE.read_text(encoding="utf-8"))
+    for node in ast.walk(container):
+        if isinstance(node, ast.FunctionDef) and node.name == "refresh_microscope":
+            body = ast.dump(node)
+            break
+    else:
+        pytest.fail("the container has no refresh_microscope; this test is stale")
+    assert "self._tabs" in ast.unparse(node), (
+        "refresh_microscope no longer fans out over both tabs"
     )
 
 
@@ -184,70 +232,86 @@ def test_every_selection_handler_reaches_the_new_tab(methods_calling):
     assert not missing, f"the new tab is not synced from: {sorted(missing)}"
 
 
-def test_the_new_tab_is_behind_its_own_feature_flag(window_source):
-    """Beside the napari tab rather than replacing it, so it has to be possible to not
-    see it at all.
+def test_the_napari_tab_is_behind_the_flag(window_source):
+    """The flag points at the *old* tab now. The Overview tab ships to everyone.
 
     Read from the window's own preferences, not from a module-level `FEATURE_*` global.
     FIB-609 removed five of those; the one it kept exists because its caller is a widget
     constructor with no preferences to hand, which is not the case here.
     """
-    assert "self._preferences.features.overview_canvas_tab" in window_source
-    assert "FEATURE_OVERVIEW_CANVAS_TAB_ENABLED" not in window_source, (
+    assert "self._preferences.features.napari_overview_tab" in window_source
+    assert "FEATURE_NAPARI_OVERVIEW_TAB_ENABLED" not in window_source, (
         "the flag went back to a module global; read the preference directly"
     )
 
 
-def test_the_flag_reaches_the_widget_and_not_just_the_tab_bar(window_source):
-    """Off has to mean "not built", not "built and hidden".
+def test_the_retired_flag_is_gone_everywhere(window_source):
+    """`overview_canvas_tab` was retired rather than flipped.
 
-    The widget subscribes to the microscope for its lifetime, so one left behind goes on
-    working for a tab nobody can open. `set_enabled` is what carries the flag past the
-    tab bar; the behaviour it buys is tested in `test_overview_tab_host.py`.
+    A flipped flag would read as "off means the new tab is gone", and anyone who had
+    turned the old one on would silently have had the napari tab hidden instead. A new
+    name gets the new default on every install, including the ones with a saved
+    preferences file -- a changed default alone reaches only fresh ones.
+
+    So it has to be gone from the flags, from the dialog and from the window together: a
+    leftover reader would be reading a field that no longer exists.
     """
+    import fibsem.config as fibsem_cfg
+    from fibsem.ui.widgets import preferences_dialog
+
+    assert not hasattr(fibsem_cfg.FeatureFlags(), "overview_canvas_tab")
+    assert "overview_canvas_tab" not in window_source
+    assert "overview_canvas_tab" not in Path(preferences_dialog.__file__).read_text(
+        encoding="utf-8"
+    )
+
+
+def test_the_overview_tab_is_not_behind_any_flag(window_source):
+    """It replaced a tab that shipped to everyone with an FM (FIB-611). Putting the merged
+    tab behind a flag would take the fluorescence overview away from every user who had
+    not turned that flag on."""
     import re
 
-    body = re.search(
-        r"def _apply_overview_canvas_visibility\(.*?\n(?=    def )",
-        window_source,
-        re.S,
-    )
-    assert body, "_apply_overview_canvas_visibility is gone; this test is stale"
-    body = body.group(0)
-    assert "set_enabled(enabled)" in body, (
-        "the flag only reaches setTabVisible; the widget is still built when it is off"
+    body = re.search(r"def add_overview_tab\(.*?\n(?=    def )", window_source, re.S)
+    assert body, "add_overview_tab is gone; this test is stale"
+    assert "features." not in body.group(0), (
+        "the Overview tab reads a feature flag; it ships to everyone"
     )
 
 
-def test_the_flag_exists_and_is_off_by_default():
-    """Off by default: the napari Overview tab is the one people are relying on until
-    this has had bench time."""
+def test_the_flag_exists_and_is_on_by_default():
+    """On by default: the napari tab is still there for anyone relying on it, and this
+    flag is what removes it rather than what adds anything."""
     import fibsem.config as fibsem_cfg
 
-    assert fibsem_cfg.FeatureFlags().overview_canvas_tab is False
+    assert fibsem_cfg.FeatureFlags().napari_overview_tab is True
 
 
 def test_the_flag_survives_a_preferences_round_trip(tmp_path):
-    """A flag that does not persist cannot be turned on by the person who wants it,
-    which is the only way this tab gets exercised before the swap.
+    """A flag that does not persist cannot be turned off by the person who wants it gone.
 
-    Through `to_dict`/`from_dict` rather than through `apply_feature_flags`, which no
-    longer carries this one — saving and reloading is what the preferences dialog
-    actually does, and it is the step that would silently drop an unknown field.
+    Through `to_dict`/`from_dict` rather than through `apply_feature_flags`, which does
+    not carry this one — saving and reloading is what the preferences dialog actually
+    does, and it is the step that would silently drop an unknown field.
     """
     import fibsem.config as fibsem_cfg
 
     prefs = fibsem_cfg.UserPreferences()
-    prefs.features.overview_canvas_tab = True
+    prefs.features.napari_overview_tab = False
     reloaded = fibsem_cfg.UserPreferences.from_dict(prefs.to_dict())
-    assert reloaded.features.overview_canvas_tab is True
+    assert reloaded.features.napari_overview_tab is False
 
 
-def test_the_napari_overview_tab_is_untouched(window_source):
-    """This change adds a tab; it does not remove one. The old tab is what a user falls
-    back to, and the swap is its own change."""
+def test_the_napari_tab_is_still_built(window_source):
+    """This change merges two tabs; it does not remove the third. The old tab is what a
+    user falls back to, and removing it is its own change (FIB-405).
+
+    It is renamed, though: "Minimap", because the canvas tab took the name "Overview" and
+    two tabs called Overview would leave a user guessing which is which.
+    """
     assert "self.add_minimap_tab()" in window_source
     assert "FibsemMinimapWidget(" in window_source
+    assert '"Minimap"' in window_source
 
 
 def test_the_done_state_in_the_status_bar_clears_itself(window_source):
@@ -263,7 +327,8 @@ def test_the_done_state_in_the_status_bar_clears_itself(window_source):
 
     tree = ast.parse(window_source)
     handler = next(
-        node for node in ast.walk(tree)
+        node
+        for node in ast.walk(tree)
         if isinstance(node, ast.FunctionDef)
         and node.name == "_on_tile_acquisition_progress"
     )
@@ -279,14 +344,16 @@ def test_the_done_state_in_the_status_bar_clears_itself(window_source):
 UI_DIR = REPO_ROOT / "fibsem" / "applications" / "autolamella" / "ui"
 HOST_TABS = {
     "AutoLamellaOverviewTab": UI_DIR / "autolamella_overview_tab.py",
-    "AutoLamellaFluorescenceOverviewTab": UI_DIR / "autolamella_fluorescence_overview_tab.py",
+    "AutoLamellaFluorescenceOverviewTab": UI_DIR
+    / "autolamella_fluorescence_overview_tab.py",
 }
 
 
 def _class_def(path: Path, name: str) -> ast.ClassDef:
     tree = ast.parse(path.read_text(encoding="utf-8"))
-    return next(n for n in ast.walk(tree)
-                if isinstance(n, ast.ClassDef) and n.name == name)
+    return next(
+        n for n in ast.walk(tree) if isinstance(n, ast.ClassDef) and n.name == name
+    )
 
 
 def test_the_two_host_tabs_share_one_base():
@@ -306,19 +373,34 @@ def test_the_two_host_tabs_share_one_base():
     one tab and derives both on the other, after asking. Those are different operations
     sharing a name.
     """
-    shared = {"is_available", "is_acquiring", "microscope", "experiment",
-              "refresh_experiment", "refresh_microscope", "refresh_positions",
-              "set_selected", "set_interactive", "_drop_overview",
-              "_on_list_selection", "_on_marker_clicked", "_on_move_to_requested",
-              "_on_add_requested", "_on_remove_requested"}
+    shared = {
+        "is_available",
+        "is_acquiring",
+        "microscope",
+        "experiment",
+        "refresh_experiment",
+        "refresh_microscope",
+        "refresh_positions",
+        "set_selected",
+        "set_interactive",
+        "_drop_overview",
+        "_on_list_selection",
+        "_on_marker_clicked",
+        "_on_move_to_requested",
+        "_on_add_requested",
+        "_on_remove_requested",
+    }
 
     for name, path in HOST_TABS.items():
         cls = _class_def(path, name)
         bases = {b.id for b in cls.bases if isinstance(b, ast.Name)}
         assert "AutoLamellaOverviewTabBase" in bases, f"{name} bases are {bases}"
 
-        defined = {n.name for n in cls.body
-                   if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+        defined = {
+            n.name
+            for n in cls.body
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
         again = defined & shared
         assert not again, (
             f"{name} defines {sorted(again)} again; the base is what stops the two tabs "
@@ -332,8 +414,13 @@ def test_the_two_host_tabs_share_one_base():
 
         # Both signals are declared once, on the base. A subclass redeclaring one
         # shadows it, and the window connects to whichever it happens to see first.
-        assigned = {t.id for n in cls.body if isinstance(n, ast.Assign)
-                    for t in n.targets if isinstance(t, ast.Name)}
+        assigned = {
+            t.id
+            for n in cls.body
+            if isinstance(n, ast.Assign)
+            for t in n.targets
+            if isinstance(t, ast.Name)
+        }
         assert not assigned & {"availability_changed", "lamella_selected"}, (
             f"{name} redeclares a signal the base owns"
         )
@@ -341,8 +428,13 @@ def test_the_two_host_tabs_share_one_base():
 
 def test_the_base_owns_the_signals_the_window_connects_to():
     base = _class_def(UI_DIR / "overview_tab_base.py", "AutoLamellaOverviewTabBase")
-    assigned = {t.id for n in base.body if isinstance(n, ast.Assign)
-                for t in n.targets if isinstance(t, ast.Name)}
+    assigned = {
+        t.id
+        for n in base.body
+        if isinstance(n, ast.Assign)
+        for t in n.targets
+        if isinstance(t, ast.Name)
+    }
     assert {"availability_changed", "lamella_selected"} <= assigned
 
 
@@ -364,8 +456,12 @@ def test_a_lamella_added_anywhere_reaches_both_canvases(window_source):
     """
     tree = ast.parse(window_source)
     handler = next(
-        (n for n in ast.walk(tree)
-         if isinstance(n, ast.FunctionDef) and n.name == "_refresh_overview_positions"),
+        (
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef)
+            and n.name == "_refresh_overview_positions"
+        ),
         None,
     )
     assert handler is not None, (
@@ -377,7 +473,9 @@ def test_a_lamella_added_anywhere_reaches_both_canvases(window_source):
     # `self.<tab>.refresh_positions` never appears as an attribute chain to walk.
     body = ast.get_source_segment(window_source, handler) or ""
     for tab in (TWIN, NEW):
-        assert tab in body, f"{tab} is not re-marked when the experiment's lamellae change"
+        assert tab in body, (
+            f"{tab} is not re-marked when the experiment's lamellae change"
+        )
     assert "refresh_positions" in body
 
     # And the handler has to be what the experiment's events actually reach.
@@ -400,6 +498,7 @@ def test_both_tabs_tell_the_window_when_they_start_acquiring(window_source):
             f"{tab} never tells the window it is acquiring, so the other overview is "
             "free to drive the stage during its run"
         )
-    assert window_source.count("acquiring_changed.connect(self._apply_overview_locks)") == 2, (
-        "the tabs report to something other than the one place that derives the lock"
-    )
+    assert (
+        window_source.count("acquiring_changed.connect(self._apply_overview_locks)")
+        == 2
+    ), "the tabs report to something other than the one place that derives the lock"


### PR DESCRIPTION
Consolidates the FIB/SEM and fluorescence overviews into a single **Overview** tab, with the imaging modality chosen on the canvas chrome. Closes FIB-780.

Both overview tabs were signed off on hardware before this.

## It merges the tab, not the widgets

`AutoLamellaOverviewContainerTab` is a shell: a chip strip and a `QStackedWidget` holding the two existing host tabs, **untouched**. The seam was already there from FIB-697 — both subclasses are ~180-line `QWidget`s whose layout holds exactly one child, so neither widget needed changing.

That is deliberate rather than a first step deferred. The two widgets composite differently, take pixels from different instruments and mark different stage poses; one widget with a modality flag would be mostly branches, which is what FIB-693 already found. What was worth removing was the *second tab*, not the second widget.

**Both pages stay built and subscribed while the other shows.** Three consequences, all wanted:

- Each modality keeps its own view state for free — nothing destroys the strip it was left on.
- FIB-706's lock still has two real inputs: both pages can still be mid-tileset.
- Unavailability still has to be answered by *dropping the widget*, not hiding a page, since a hidden page goes on doing work on every stage poll.

## The bar

```
[ FIB/SEM | Fluorescence ] | [ SEM @ SEM · FIB @ Milling ]
     what this tab is           what the canvas is showing
```

The view chips are **not built here**. The beam widget discovers its views as they are acquired in and marks the one the next run would land in, so the bar only lends them a place to sit; building a second copy would be a second thing to keep in step, which is the failure this tab exists to stop.

This does move them off the canvas's own width, which `overview_widget` had deliberately chosen ("it keeps saying *this selects what the canvas is showing*"). The bar is now led by a control that governs the settings column too, so spanning the tab is the honest width — and splitting the row to preserve the old rule would cost two rows of chrome to make a distinction the divider already makes.

An unavailable modality keeps its chip, dimmed, with a tooltip saying why — the same choice FIB-614 made for the FM tab.

## The flag was swapped, not flipped

`features.overview_canvas_tab` is **retired**. `features.napari_overview_tab` replaces it, **on** by default, gating the old napari tab — renamed **Minimap**, since the merged tab took the name "Overview" — until that tab is removed before the full release.

Two constraints forced this, and either alone would have caused a silent regression:

- **The merged tab cannot be behind a flag.** The fluorescence overview ships to everyone (FIB-611), so gating the merged tab would take it away from anyone who had not opted in.
- **A flipped flag reaches the wrong people.** A changed default only reaches fresh installs, so reusing the name would have left anyone who *had* turned the old flag on with the napari tab silently hidden instead.

> **Consequence worth stating plainly: the FIB/SEM canvas overview now ships to everyone**, since nothing gates it any more.

`AutoLamellaOverviewTab.set_enabled` is left in place but is **dead in production** — it only ever carried that flag — and now says so in a comment.

## Three latent chip/strip defects (first commit)

All pre-existing, all invisible until a second strip of chips sat beside the first in one row:

1. **A chip changed size with its state.** The resting style used `border: none` against the active style's real 1px accent border, so a chip grew 2px in each direction the moment it became the acquisition view.
2. **No `:disabled` rule at all** — a greyed chip rendered *pixel-identical* to a live one, so "disabled" was a claim the UI never actually made. Worth noting as a method, not just a fix: *"should this be disabled or hidden?" cannot be answered until you check that disabled actually looks disabled.*
3. **`VIEW_STRIP_STYLE` never reached the scroll area's viewport** — a separate child widget `#viewStrip` does not match — so the strip has always painted `SURFACE_COLOR` (`#262930`) while declaring `PANEL_COLOR` (`#1e2027`).

The three styles now come from one `_chip_style(border, checked_background)` builder rather than three hand-written sheets, since they differ only in those two arguments and separate copies are exactly how they drifted.

## The sparse selector's toast (third commit)

It said *"No FIB/SEM overviews found to select on. Acquire one on the Overview tab first"* whether or not there was anywhere to look. With no output folder that is wrong advice, not merely unhelpful — acquiring lands the overview somewhere the selector still cannot see. Now two messages, and the second names the folder, because the wrong folder is the likeliest reason someone who *has* acquired an overview is told there are none.

That makes the underlying problem **diagnosable, not fixed**: the two pages keep separate save directories and can point at different folders. Filed as FIB-812.

## Verification

`tests/ui/` + the autolamella UI tests: **2306 passed**. The two failures are the `test_coincidence_viewer_layering` pair already tracked as FIB-793 — pre-existing on main, and failing only in a full-directory run.

> ⚠️ CI installs `.[test]` without PyQt5, so **none of `tests/ui/` runs there**. A green CI says nothing about this change; the numbers above are from a local run.

Driven by hand against the Arctis simulator (the only sim config with a compustage, hence the only one where the fluorescence page is reachable at all): both modalities, switching between them, and the sparse selector.

Three tests caught real wiring gaps rather than needing updates — the stub host's unlisted helper, and the FIB-706 lock fixture still binding the old attribute name, which would have left the lock silently reading `None` on one side.

## Size

13 files, over the usual cap. Split into three commits so it can be read in pieces. The chip/strip commit is the only genuinely separable part, but the tab commit does not compile without it, and stacking gets no CI here — so it is one PR.
