### PR TITLE
[ui] The old napari overview is off by default, not on

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -2927,10 +2927,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
     def _apply_napari_overview_visibility(self) -> None:
         """Show or hide the old napari Minimap tab.
 
-        `features.napari_overview_tab`, on by default and on its way out: the canvas
-        Overview replaced this tab, and the flag is what holds the old one open for
-        anyone still moving off it. Both it and this method go with the tab before the
-        full release (FIB-405, FIB-413).
+        `features.napari_overview_tab`, off by default and on its way out: the canvas
+        Overview replaced this tab, and the flag is what brings the old one back for
+        anyone who needs it for the one release before it goes. Both it and this method
+        go with the tab before the full release (FIB-405, FIB-413).
 
         Visibility only, unlike the flag it replaced. The overview host tabs are built
         and dropped because their widgets subscribe to the microscope for their lifetime;

--- a/fibsem/applications/autolamella/ui/overview_container_tab.py
+++ b/fibsem/applications/autolamella/ui/overview_container_tab.py
@@ -70,8 +70,8 @@ This tab ships to everyone, and so do both of its chips. `features.overview_canv
 gated the beam side while the canvas overview sat beside the napari one; it is retired
 here rather than carried, because there is nothing left for it to gate -- the canvas
 overview *is* the Overview tab now. What survives is `features.napari_overview_tab`,
-pointing the other way: it holds the old Minimap tab open for anyone still moving off it,
-and goes with that tab before the full release.
+pointing at the old tab instead: off by default, it brings the Minimap tab back for
+anyone who needs it, and goes with that tab before the full release.
 
 A modality is therefore unavailable only when there is no hardware behind it, which is
 the FM tab's existing capability check and nothing new.

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -396,19 +396,24 @@ class FeatureFlags:
     # microscope and none of its guard rails, so the menu is not offered to anyone
     # who has not asked for it (FIB-338).
     scripts_enabled: bool = False
-    # The old napari Minimap tab, beside the Overview tab that replaced it. **On**, and
-    # that direction is the point: the canvas Overview now ships to everyone and holds
-    # both modalities (FIB-780), so this flag is not gating a new thing -- it is holding
-    # the door open on the old one while people finish moving off it.
+    # The old napari Minimap tab, beside the Overview tab that replaced it. **Off**: the
+    # canvas Overview ships to everyone and holds both modalities (FIB-780), so the old
+    # tab is not what anyone should land on -- it is here to be turned back on by anyone
+    # who finds something the new tab cannot do yet, for the one release before it goes.
     #
-    # It replaces `overview_canvas_tab`, which pointed the other way and was retired
-    # rather than flipped: a flipped flag reads as "off means the new tab is gone", and
-    # anyone who had turned the old one on would silently have the napari tab hidden
-    # instead. A new name gets the new default on every install, including the ones with
-    # a saved preferences file -- a changed default alone reaches only fresh ones.
+    # This hides the tab; it does not stop it being built. The widget owns a
+    # `napari.Viewer` that cannot be rebuilt safely mid-session, so it is constructed
+    # either way -- see `_apply_napari_overview_visibility`. Off means "not in the tab
+    # bar", not "not paid for".
+    #
+    # It replaces `overview_canvas_tab`, retired rather than flipped: that flag gated the
+    # *new* tab, and a flag that changes which tab it points at while keeping its name is
+    # a flag nobody can reason about from a preferences file. A new name also gets the
+    # new default on every install, including the ones with a saved preferences file --
+    # a changed default alone reaches only fresh ones.
     #
     # Deleted with the tab itself before the full release (FIB-405, FIB-413).
-    napari_overview_tab: bool = True
+    napari_overview_tab: bool = False
     # The connection chip in the tab-corner header, and the experiment buttons
     # waiting for a microscope alongside it. Off while the Connection tab is still
     # how people connect: this is the header half of FIB-775, landing ahead of the

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -58,10 +58,10 @@ _TIP_BUG_REPORT = (
 )
 _LBL_NAPARI_OVERVIEW = "Show the old Minimap Tab"
 _TIP_NAPARI_OVERVIEW = (
-    "Keep the previous napari-based overview beside the Overview tab that replaced it. "
-    "The Overview tab places tiles where they were acquired rather than stitching them "
-    "first, and holds both the FIB/SEM and fluorescence overviews. This is here for "
-    "anyone still relying on the old tab, and is removed in a future release."
+    "Bring back the previous napari-based overview, beside the Overview tab that "
+    "replaced it. The Overview tab places tiles where they were acquired rather than "
+    "stitching them first, and holds both the FIB/SEM and fluorescence overviews. This "
+    "is here for anyone still relying on the old tab, and is removed in the next release."
 )
 _LBL_CONNECTION_CHIP = "Enable Connection Chip"
 _TIP_CONNECTION_CHIP = (

--- a/tests/ui/test_overview_tab_wiring.py
+++ b/tests/ui/test_overview_tab_wiring.py
@@ -258,10 +258,11 @@ def test_the_napari_tab_is_behind_the_flag(window_source):
 def test_the_retired_flag_is_gone_everywhere(window_source):
     """`overview_canvas_tab` was retired rather than flipped.
 
-    A flipped flag would read as "off means the new tab is gone", and anyone who had
-    turned the old one on would silently have had the napari tab hidden instead. A new
-    name gets the new default on every install, including the ones with a saved
-    preferences file -- a changed default alone reaches only fresh ones.
+    It gated the *new* tab. Keeping the name while pointing it at the old one would leave
+    a preferences file nobody can read: the same key meaning opposite things depending on
+    which version wrote it. A new name also gets the new default on every install,
+    including the ones with a saved preferences file -- a changed default alone reaches
+    only fresh ones.
 
     So it has to be gone from the flags, from the dialog and from the window together: a
     leftover reader would be reading a field that no longer exists.
@@ -289,16 +290,20 @@ def test_the_overview_tab_is_not_behind_any_flag(window_source):
     )
 
 
-def test_the_flag_exists_and_is_on_by_default():
-    """On by default: the napari tab is still there for anyone relying on it, and this
-    flag is what removes it rather than what adds anything."""
+def test_the_flag_exists_and_is_off_by_default():
+    """Off by default: the Overview tab is what a user lands on, and this flag is what
+    brings the superseded napari tab back for the one release before it is removed.
+
+    Asserted rather than left to the dataclass because the default is the whole of what
+    this flag does for almost everyone -- nobody opens Preferences to leave a checkbox
+    where it already was."""
     import fibsem.config as fibsem_cfg
 
-    assert fibsem_cfg.FeatureFlags().napari_overview_tab is True
+    assert fibsem_cfg.FeatureFlags().napari_overview_tab is False
 
 
 def test_the_flag_survives_a_preferences_round_trip(tmp_path):
-    """A flag that does not persist cannot be turned off by the person who wants it gone.
+    """A flag that does not persist cannot be turned on by the person who wants it back.
 
     Through `to_dict`/`from_dict` rather than through `apply_feature_flags`, which does
     not carry this one — saving and reloading is what the preferences dialog actually


### PR DESCRIPTION
FIB-780 landed `napari_overview_tab` defaulting **on**, so a fresh install shows both the Overview tab and the napari Minimap tab it replaces. Two overviews in the tab bar is not what the merge was for — the canvas Overview holds both modalities now, and it is what a user should land on.

Off, then. The flag stays as the way back for anyone who finds something the new tab cannot do yet, for the one release before both go (FIB-405, FIB-413).

## The comment had to change with it

The comment on the field argued for the old default at some length, including the claim that a differently-named flag was chosen so nobody who had enabled the old tab would silently lose it — which is precisely what this does. The argument that survives is the narrower one: `overview_canvas_tab` gated the *new* tab, so keeping that name while pointing it at the old one would leave the same key meaning opposite things depending on which version wrote the preferences file.

## One thing corrected in passing

Off **hides** the tab; it does not stop it being built. The widget owns a `napari.Viewer` that cannot be rebuilt safely mid-session, so it is constructed either way — `_apply_napari_overview_visibility` sets visibility only. The comment now says so, so nobody assumes this buys back the import.

## Sites that describe the direction

All moved with it: the visibility method's docstring, `overview_container_tab`'s module docstring, and the preferences tooltip, which said "Keep the previous napari-based overview" when there is now nothing to keep. The tooltip also now says "the next release" rather than "a future release", matching what the release notes promise.

## Tests

`test_the_flag_exists_and_is_on_by_default` asserted `is True`; it is now `test_the_flag_exists_and_is_off_by_default` asserting `is False`. The default is worth asserting rather than leaving to the dataclass — it is the whole of what this flag does for almost everyone, since nobody opens Preferences to leave a checkbox where it already was. Two neighbouring docstrings that argued for the old direction were rewritten.

`tests/ui/test_overview_tab_wiring.py` passes (19); 711 pass across `-k "feature_flag or preferences or overview"`. `ruff check` and `ruff format --check` clean on all five files.
