### PR TITLE
[refactor] Split an overview's autofocus mode from its sweep (FIB-646 groundwork)

### DIFF
--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -184,7 +184,7 @@ class TiledAcquisitionRunner:
         """Prepare image settings and paths; emit initial progress signal."""
         image_settings = self.settings.image_settings
         self._focus_stack_settings = self.settings.focus_stack_settings
-        self._af_mode = self.settings.autofocus_settings.mode
+        self._af_mode = self.settings.autofocus_mode
 
         image_settings.autocontrast = False
         image_settings.save = True

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -997,27 +997,21 @@ class FocusStackSettings:
         )
 
 
-@dataclass
-class AutoFocusSettings:
-    """Settings for autofocus in tiled overview acquisition.
+def _default_autofocus_settings() -> "AutoFocusSettings":
+    """The overview's focus sweep, which is simply the library default.
 
-    Attributes:
-        mode: When to apply autofocus (NONE, ONCE, EACH_ROW, EACH_TILE).
-              beam_type and reduced_area are taken from image_settings at acquisition time.
+    Deliberately not a pinned copy of the values. `AutoFocusSettings()` is two passes --
+    50 um at 5 um, then 10 um at 1 um -- and an overview wanting exactly that means it
+    should *inherit* it, so a later improvement to the default reaches overviews too
+    (FIB-646).
+
+    Imported here rather than at module scope because `autofunctions.autofocus` imports
+    this module for `BeamType`, so the arrow only points one way. `structures` already
+    reaches downstream this way for `autofunctions.gamma` and `fm.structures`.
     """
+    from fibsem.autofunctions.autofocus import AutoFocusSettings
 
-    mode: AutoFocusMode = AutoFocusMode.NONE
-
-    def to_dict(self) -> dict:
-        # By value, matching how the fluorescence side has always written this mode.
-        # Files that stored the old member name ("EVERY_ROW") still load.
-        return {"mode": self.mode.value}
-
-    @staticmethod
-    def from_dict(d: dict) -> "AutoFocusSettings":
-        return AutoFocusSettings(
-            mode=AutoFocusMode(d.get("mode", AutoFocusMode.NONE.value))
-        )
+    return AutoFocusSettings()
 
 
 @dataclass
@@ -1036,6 +1030,16 @@ class OverviewAcquisitionSettings:
             every tile. Disabled tiles are skipped but keep their place: the mosaic is
             still the full grid size and acquired tiles land at the same canvas
             coordinates they would have in a dense overview.
+        autofocus_mode: *When* to focus during the traversal (NONE, ONCE, EACH_ROW,
+            EACH_TILE).
+        autofocus_settings: *How* to focus -- sweep passes, method and probe frame.
+            Two separate questions, and they used to be conflated: this field held a
+            `fibsem.structures.AutoFocusSettings` whose only member was the mode, a
+            second class sharing a name with the real sweep config in
+            `autofunctions.autofocus`. `AutoFocusMode` had already been through exactly
+            that (two identical enums, so `NONE is NONE` was False across the two import
+            paths, with no type error to catch it), so the duplicate name is gone rather
+            than left to bite twice.
     """
 
     image_settings: ImageSettings = field(default_factory=ImageSettings)
@@ -1043,7 +1047,10 @@ class OverviewAcquisitionSettings:
     ncols: int = 3
     overlap: float = 0.1
     focus_stack_settings: FocusStackSettings = field(default_factory=FocusStackSettings)
-    autofocus_settings: AutoFocusSettings = field(default_factory=AutoFocusSettings)
+    autofocus_mode: AutoFocusMode = AutoFocusMode.NONE
+    autofocus_settings: "AutoFocusSettings" = field(
+        default_factory=_default_autofocus_settings
+    )
     tile_order: TileOrderStrategy = TileOrderStrategy.TYPEWRITER
     tile_mask: Optional[List[List[bool]]] = None
 
@@ -1108,15 +1115,43 @@ class OverviewAcquisitionSettings:
         else:
             fss = FocusStackSettings.from_dict(d.get("focus_stack_settings", {}))
         mask = d.get("tile_mask")
+
+        # Two shapes of the same two facts. Before FIB-646 the mode lived *inside*
+        # `autofocus_settings`, in a class that held nothing else:
+        #
+        #     {"autofocus_settings": {"mode": "EACH_ROW"}}          <- old
+        #     {"autofocus_mode": "EACH_ROW",                        <- new
+        #      "autofocus_settings": {"method": ..., "passes": [...]}}
+        #
+        # `"mode"` is a safe discriminator and not a heuristic: the real sweep config
+        # writes method / passes / probe_resolution / probe_dwell_time / reduced_area /
+        # use_autocontrast / channel_name, and never a "mode" key. So an old file is
+        # recognised by the one key the new shape cannot produce.
+        #
+        # An old file carries no sweep at all, so it gets the default -- which is the
+        # right answer rather than a fallback: it is exactly what it was running under,
+        # since the mode was the only thing it could configure.
+        raw_autofocus = d.get("autofocus_settings") or {}
+        if "mode" in raw_autofocus:
+            mode = AutoFocusMode(raw_autofocus["mode"])
+            sweep = _default_autofocus_settings()
+        else:
+            mode = AutoFocusMode(d.get("autofocus_mode", AutoFocusMode.NONE.value))
+            if raw_autofocus:
+                from fibsem.autofunctions.autofocus import AutoFocusSettings
+
+                sweep = AutoFocusSettings.from_dict(raw_autofocus)
+            else:
+                sweep = _default_autofocus_settings()
+
         return OverviewAcquisitionSettings(
             image_settings=ImageSettings.from_dict(d.get("image_settings", {})),
             nrows=d.get("nrows", 3),
             ncols=d.get("ncols", 3),
             overlap=d.get("overlap", 0.1),
             focus_stack_settings=fss,
-            autofocus_settings=AutoFocusSettings.from_dict(
-                d.get("autofocus_settings", {})
-            ),
+            autofocus_mode=mode,
+            autofocus_settings=sweep,
             tile_order=TileOrderStrategy(
                 d.get("tile_order", TileOrderStrategy.TYPEWRITER.value)
             ),
@@ -1132,6 +1167,7 @@ class OverviewAcquisitionSettings:
             "ncols": self.ncols,
             "overlap": self.overlap,
             "focus_stack_settings": self.focus_stack_settings.to_dict(),
+            "autofocus_mode": self.autofocus_mode.value,
             "autofocus_settings": self.autofocus_settings.to_dict(),
             "tile_order": self.tile_order.value,
             # plain bools: np.bool_ does not survive yaml.safe_dump, and a mask arriving

--- a/fibsem/ui/widgets/fibsem_overview_settings_widget.py
+++ b/fibsem/ui/widgets/fibsem_overview_settings_widget.py
@@ -38,7 +38,6 @@ from fibsem import constants
 from fibsem.config import AVAILABLE_RESOLUTIONS_ZIP
 from fibsem.structures import (
     AutoFocusMode,
-    AutoFocusSettings,
     BeamType,
     FocusStackSettings,
     ImageSettings,
@@ -285,7 +284,7 @@ class FibsemOverviewSettingsWidget(QWidget):
         the setting read one thing and the run did another.
         """
         promoted = (
-            settings.autofocus_settings.mode is AutoFocusMode.EACH_ROW
+            settings.autofocus_mode is AutoFocusMode.EACH_ROW
             and settings.tile_order is TileOrderStrategy.SPIRAL
         )
         self.label_focus_note.setVisible(promoted)
@@ -335,7 +334,7 @@ class FibsemOverviewSettingsWidget(QWidget):
                 n_steps=int(self.spin_focus_steps.value()),
                 auto_focus=self.check_focus_autofocus.isChecked(),
             ),
-            autofocus_settings=AutoFocusSettings(mode=self.combo_autofocus.value()),
+            autofocus_mode=self.combo_autofocus.value(),
             tile_order=self.grid.tile_order,
         )
 
@@ -361,7 +360,7 @@ class FibsemOverviewSettingsWidget(QWidget):
             self.check_focus_autofocus.setChecked(
                 settings.focus_stack_settings.auto_focus
             )
-            self.combo_autofocus.set_value(settings.autofocus_settings.mode)
+            self.combo_autofocus.set_value(settings.autofocus_mode)
             self.filename_edit.setText(image.filename or "")
             self.path_edit.setText(str(image.path) if image.path else "")
         finally:

--- a/fibsem/ui/widgets/fibsem_overview_settings_widget.py
+++ b/fibsem/ui/widgets/fibsem_overview_settings_widget.py
@@ -21,6 +21,7 @@ Two panels open, three folded, which is the fluorescence column's budget. It mat
 because these sit above a `Display` panel and the pinned action row: a third expanded
 panel puts the grid below the fold on a laptop-height window.
 """
+
 from typing import List, Optional
 
 from PyQt5.QtCore import Qt, pyqtSignal
@@ -125,18 +126,30 @@ class FibsemOverviewSettingsWidget(QWidget):
         self.combo_beam = self._field(
             ValueComboBox(items=list(BeamType), format_fn=lambda b: b.name)
         )
-        self.combo_resolution = self._field(ValueComboBox(
-            items=[value for _, value in AVAILABLE_RESOLUTIONS_ZIP],
-            format_fn=lambda r: f"{r[0]}x{r[1]}",
-        ))
-        self.spin_dwell = self._field(ValueSpinBox(
-            suffix=f" {constants.MICROSECOND_SYMBOL}",
-            minimum=0.01, maximum=1000.0, step=0.5, decimals=2,
-        ))
-        self.spin_hfw = self._field(ValueSpinBox(
-            suffix=f" {constants.MICRON_SYMBOL}",
-            minimum=1.0, maximum=10000.0, step=50.0, decimals=1,
-        ))
+        self.combo_resolution = self._field(
+            ValueComboBox(
+                items=[value for _, value in AVAILABLE_RESOLUTIONS_ZIP],
+                format_fn=lambda r: f"{r[0]}x{r[1]}",
+            )
+        )
+        self.spin_dwell = self._field(
+            ValueSpinBox(
+                suffix=f" {constants.MICROSECOND_SYMBOL}",
+                minimum=0.01,
+                maximum=1000.0,
+                step=0.5,
+                decimals=2,
+            )
+        )
+        self.spin_hfw = self._field(
+            ValueSpinBox(
+                suffix=f" {constants.MICRON_SYMBOL}",
+                minimum=1.0,
+                maximum=10000.0,
+                step=50.0,
+                decimals=1,
+            )
+        )
         self.check_autocontrast = QCheckBox()
 
         # The one number that says whether the dwell just typed means seconds or hours.
@@ -168,10 +181,12 @@ class FibsemOverviewSettingsWidget(QWidget):
         else. Method and sweep passes arrive with FIB-646, which connects the tiled
         runner to `run_auto_focus` like every other autofocus caller in the codebase.
         """
-        self.combo_autofocus = self._field(ValueComboBox(
-            items=list(AutoFocusMode),
-            format_fn=lambda m: m.name.replace("_", " ").title(),
-        ))
+        self.combo_autofocus = self._field(
+            ValueComboBox(
+                items=list(AutoFocusMode),
+                format_fn=lambda m: m.name.replace("_", " ").title(),
+            )
+        )
 
         # The runner silently promotes EACH_ROW to EACH_TILE for a spiral, because a
         # spiral has no rows -- correct, and until now invisible. The fluorescence tab
@@ -342,9 +357,16 @@ class FibsemOverviewSettingsWidget(QWidget):
         """Load every value without emitting on the way through."""
         image = settings.image_settings
         widgets = [
-            self.combo_beam, self.combo_resolution, self.spin_dwell, self.spin_hfw,
-            self.check_autocontrast, self.check_focus_stack, self.spin_focus_steps,
-            self.check_focus_autofocus, self.combo_autofocus, self.filename_edit,
+            self.combo_beam,
+            self.combo_resolution,
+            self.spin_dwell,
+            self.spin_hfw,
+            self.check_autocontrast,
+            self.check_focus_stack,
+            self.spin_focus_steps,
+            self.check_focus_autofocus,
+            self.combo_autofocus,
+            self.filename_edit,
             self.path_edit.lineEdit,
         ]
         for widget in widgets:

--- a/fibsem/ui/widgets/overview_acquisition_settings_widget.py
+++ b/fibsem/ui/widgets/overview_acquisition_settings_widget.py
@@ -18,7 +18,6 @@ from fibsem.config import (
 )
 from fibsem.structures import (
     AutoFocusMode,
-    AutoFocusSettings,
     BeamType,
     FocusStackSettings,
     ImageSettings,
@@ -384,7 +383,7 @@ class OverviewAcquisitionSettingsWidget(QWidget):
                 n_steps=int(self.focus_stack_steps.value()),
                 auto_focus=self.focus_stack_autofocus.isChecked(),
             ),
-            autofocus_settings=AutoFocusSettings(mode=self.autofocus_combo.value()),
+            autofocus_mode=self.autofocus_combo.value(),
             tile_order=self.tile_order_combo.value(),
         )
 
@@ -424,7 +423,7 @@ class OverviewAcquisitionSettingsWidget(QWidget):
         self.focus_stack_enabled.setChecked(settings.focus_stack_settings.enabled)
         self.focus_stack_steps.setValue(settings.focus_stack_settings.n_steps)
         self.focus_stack_autofocus.setChecked(settings.focus_stack_settings.auto_focus)
-        self.autofocus_combo.set_value(settings.autofocus_settings.mode)
+        self.autofocus_combo.set_value(settings.autofocus_mode)
         self.tile_order_combo.set_value(settings.tile_order)
 
         for w in [self.beam_type_combo, self.nrows_spinbox, self.ncols_spinbox,

--- a/fibsem/ui/widgets/overview_acquisition_settings_widget.py
+++ b/fibsem/ui/widgets/overview_acquisition_settings_widget.py
@@ -150,7 +150,9 @@ class OverviewAcquisitionSettingsWidget(QWidget):
 
         # Beam type
         grid_layout.addWidget(QLabel("Beam Type"), 0, 0)
-        self.beam_type_combo = ValueComboBox(items=list(BeamType), format_fn=lambda bt: bt.name)
+        self.beam_type_combo = ValueComboBox(
+            items=list(BeamType), format_fn=lambda bt: bt.name
+        )
         grid_layout.addWidget(self.beam_type_combo, 0, 1, 1, 2)
 
         # Rows / cols
@@ -178,7 +180,9 @@ class OverviewAcquisitionSettingsWidget(QWidget):
 
         # Overlap
         grid_layout.addWidget(QLabel("Overlap (%)"), 2, 0)
-        self.overlap_spinbox = ValueSpinBox(suffix="%", minimum=0.0, maximum=50.0, step=5.0, decimals=0)
+        self.overlap_spinbox = ValueSpinBox(
+            suffix="%", minimum=0.0, maximum=50.0, step=5.0, decimals=0
+        )
         grid_layout.addWidget(self.overlap_spinbox, 2, 1, 1, 2)
 
         # Total FOV label (read-only, auto-updated)
@@ -223,11 +227,11 @@ class OverviewAcquisitionSettingsWidget(QWidget):
         grid_layout.addWidget(self.tile_order_combo, 8, 1, 1, 2)
 
         self._adv_widgets = [
-            (self._label_focus_stack,          self.focus_stack_enabled),
-            (self._label_focus_stack_steps,    self.focus_stack_steps),
+            (self._label_focus_stack, self.focus_stack_enabled),
+            (self._label_focus_stack_steps, self.focus_stack_steps),
             (self._label_focus_stack_autofocus, self.focus_stack_autofocus),
-            (self._label_autofocus,            self.autofocus_combo),
-            (self._label_tile_order,           self.tile_order_combo),
+            (self._label_autofocus, self.autofocus_combo),
+            (self._label_tile_order, self.tile_order_combo),
         ]
 
         self._btn_advanced = IconToolButton(
@@ -247,7 +251,9 @@ class OverviewAcquisitionSettingsWidget(QWidget):
         self.image_settings_widget.set_show_advanced_button(False)
 
         # All standard + square resolutions are supported (non-square aspect handled in acquisition)
-        self.image_settings_widget.set_available_resolutions(AVAILABLE_RESOLUTIONS_ZIP, default=DEFAULT_STANDARD_RESOLUTION)
+        self.image_settings_widget.set_available_resolutions(
+            AVAILABLE_RESOLUTIONS_ZIP, default=DEFAULT_STANDARD_RESOLUTION
+        )
 
         self._btn_advanced_imaging = IconToolButton(
             icon="mdi:tune",
@@ -257,7 +263,9 @@ class OverviewAcquisitionSettingsWidget(QWidget):
             checked_tooltip="Hide advanced image settings",
         )
 
-        self._image_panel = TitledPanel("Tile Image Settings", content=self.image_settings_widget)
+        self._image_panel = TitledPanel(
+            "Tile Image Settings", content=self.image_settings_widget
+        )
         self._image_panel.add_header_widget(self._btn_advanced_imaging)
         self._image_panel._btn_collapse.setChecked(True)
 
@@ -282,7 +290,9 @@ class OverviewAcquisitionSettingsWidget(QWidget):
         self._btn_advanced.toggled.connect(self.set_show_advanced)
         self.beam_type_combo.currentIndexChanged.connect(self._on_changed)
         self.nrows_spinbox.valueChanged.connect(self._on_changed)
-        self._btn_advanced_imaging.toggled.connect(self.image_settings_widget.set_show_advanced)
+        self._btn_advanced_imaging.toggled.connect(
+            self.image_settings_widget.set_show_advanced
+        )
         self.ncols_spinbox.valueChanged.connect(self._on_changed)
         self.overlap_spinbox.valueChanged.connect(self._on_changed)
         self.focus_stack_enabled.toggled.connect(self._on_changed)
@@ -322,9 +332,7 @@ class OverviewAcquisitionSettingsWidget(QWidget):
         total_w = settings.total_fov_x * constants.SI_TO_MICRO
         total_h = settings.total_fov_y * constants.SI_TO_MICRO
         sym = constants.MICRON_SYMBOL
-        self._label_total_fov.setText(
-            f"Total FOV: {total_w:.0f} × {total_h:.0f} {sym}"
-        )
+        self._label_total_fov.setText(f"Total FOV: {total_w:.0f} × {total_h:.0f} {sym}")
 
     # ------------------------------------------------------------------
     # Public API
@@ -344,7 +352,9 @@ class OverviewAcquisitionSettingsWidget(QWidget):
 
     @tile_mask.setter
     def tile_mask(self, mask: Optional[List[List[bool]]]) -> None:
-        self._tile_mask = None if mask is None else [[bool(v) for v in row] for row in mask]
+        self._tile_mask = (
+            None if mask is None else [[bool(v) for v in row] for row in mask]
+        )
         self._on_changed()
 
     def set_grid_size(self, rows: int, cols: int) -> None:
@@ -356,7 +366,10 @@ class OverviewAcquisitionSettingsWidget(QWidget):
         when an edge is dragged on the canvas, which emits on every motion event.
         """
         rows, cols = int(rows), int(cols)
-        if (rows, cols) == (int(self.nrows_spinbox.value()), int(self.ncols_spinbox.value())):
+        if (rows, cols) == (
+            int(self.nrows_spinbox.value()),
+            int(self.ncols_spinbox.value()),
+        ):
             return
         for spinbox in (self.nrows_spinbox, self.ncols_spinbox):
             spinbox.blockSignals(True)
@@ -411,9 +424,17 @@ class OverviewAcquisitionSettingsWidget(QWidget):
     def update_from_settings(self, settings: OverviewAcquisitionSettings):
         """Populate all widgets from an OverviewAcquisitionSettings object."""
         # Block tile-grid signals to prevent cascading updates
-        for w in [self.beam_type_combo, self.nrows_spinbox, self.ncols_spinbox,
-                  self.overlap_spinbox, self.focus_stack_enabled, self.focus_stack_steps,
-                  self.focus_stack_autofocus, self.autofocus_combo, self.tile_order_combo]:
+        for w in [
+            self.beam_type_combo,
+            self.nrows_spinbox,
+            self.ncols_spinbox,
+            self.overlap_spinbox,
+            self.focus_stack_enabled,
+            self.focus_stack_steps,
+            self.focus_stack_autofocus,
+            self.autofocus_combo,
+            self.tile_order_combo,
+        ]:
             w.blockSignals(True)
 
         self.beam_type_combo.set_value(settings.image_settings.beam_type)
@@ -426,13 +447,22 @@ class OverviewAcquisitionSettingsWidget(QWidget):
         self.autofocus_combo.set_value(settings.autofocus_mode)
         self.tile_order_combo.set_value(settings.tile_order)
 
-        for w in [self.beam_type_combo, self.nrows_spinbox, self.ncols_spinbox,
-                  self.overlap_spinbox, self.focus_stack_enabled, self.focus_stack_steps,
-                  self.focus_stack_autofocus, self.autofocus_combo, self.tile_order_combo]:
+        for w in [
+            self.beam_type_combo,
+            self.nrows_spinbox,
+            self.ncols_spinbox,
+            self.overlap_spinbox,
+            self.focus_stack_enabled,
+            self.focus_stack_steps,
+            self.focus_stack_autofocus,
+            self.autofocus_combo,
+            self.tile_order_combo,
+        ]:
             w.blockSignals(False)
 
         self._tile_mask = (
-            None if settings.tile_mask is None
+            None
+            if settings.tile_mask is None
             else [[bool(v) for v in row] for row in settings.tile_mask]
         )
         self.image_settings_widget.update_from_settings(settings.image_settings)

--- a/tests/test_autofocus_mode.py
+++ b/tests/test_autofocus_mode.py
@@ -53,8 +53,8 @@ def test_iteration_yields_exactly_the_four_modes():
 )
 def test_the_beam_side_spellings_are_aliases_not_new_members(alias, canonical):
     assert getattr(AutoFocusMode, alias) is canonical
-    assert AutoFocusMode[alias] is canonical   # settings persisted by name
-    assert AutoFocusMode(alias) is canonical   # ... and read back by value
+    assert AutoFocusMode[alias] is canonical  # settings persisted by name
+    assert AutoFocusMode(alias) is canonical  # ... and read back by value
 
 
 @pytest.mark.parametrize(
@@ -111,6 +111,7 @@ def test_the_previously_persisted_name_form_still_loads_from_the_old_shape():
     (`EVERY_ROW`, since renamed `EACH_ROW`). Both were already handled separately; this
     pins that the shape migration did not drop the name one on the way past.
     """
+
     def mode_of(raw):
         return OverviewAcquisitionSettings.from_dict(
             {"autofocus_settings": {"mode": raw}}
@@ -138,7 +139,9 @@ def test_the_shipped_fm_configuration_still_parses():
     """The default config has `autofocus_mode: once` in it -- pin it against the enum."""
     from fibsem.fm.structures import OverviewParameters
 
-    path = Path(fibsem.__file__).parent / "config" / "fm" / "fm-configuration-default.yaml"
+    path = (
+        Path(fibsem.__file__).parent / "config" / "fm" / "fm-configuration-default.yaml"
+    )
     config = yaml.safe_load(path.read_text(encoding="utf-8"))
 
     params = OverviewParameters.from_dict(config["overview_parameters"])

--- a/tests/test_autofocus_mode.py
+++ b/tests/test_autofocus_mode.py
@@ -17,7 +17,7 @@ import pytest
 import yaml
 
 import fibsem
-from fibsem.structures import AutoFocusMode, AutoFocusSettings
+from fibsem.structures import AutoFocusMode, OverviewAcquisitionSettings
 
 
 def test_every_import_path_yields_the_same_enum():
@@ -92,14 +92,38 @@ def test_junk_still_raises(bogus):
 
 
 @pytest.mark.parametrize("mode", list(AutoFocusMode))
-def test_autofocus_settings_round_trip(mode):
-    assert AutoFocusSettings.from_dict(AutoFocusSettings(mode=mode).to_dict()).mode is mode
+def test_overview_settings_round_trip(mode):
+    """The mode now rides on `OverviewAcquisitionSettings` itself.
+
+    It used to live inside an `autofocus_settings` object that held nothing else; that
+    class is gone (FIB-646), so this follows the mode to where it went rather than
+    being deleted with it.
+    """
+    s = OverviewAcquisitionSettings(autofocus_mode=mode)
+    assert OverviewAcquisitionSettings.from_dict(s.to_dict()).autofocus_mode is mode
 
 
-def test_autofocus_settings_reads_the_previously_persisted_name_form():
-    """Beam settings on disk say {"mode": "EVERY_ROW"}; they must keep loading."""
-    assert AutoFocusSettings.from_dict({"mode": "EVERY_ROW"}).mode is AutoFocusMode.EACH_ROW
-    assert AutoFocusSettings.from_dict({"mode": "NONE"}).mode is AutoFocusMode.NONE
+def test_the_previously_persisted_name_form_still_loads_from_the_old_shape():
+    """Two layers of compatibility have to hold at once here, and they are independent.
+
+    Beam settings on disk say `{"autofocus_settings": {"mode": "EVERY_ROW"}}` -- the old
+    *shape* (mode nested inside the settings object) carrying the old *member name*
+    (`EVERY_ROW`, since renamed `EACH_ROW`). Both were already handled separately; this
+    pins that the shape migration did not drop the name one on the way past.
+    """
+    def mode_of(raw):
+        return OverviewAcquisitionSettings.from_dict(
+            {"autofocus_settings": {"mode": raw}}
+        ).autofocus_mode
+
+    assert mode_of("EVERY_ROW") is AutoFocusMode.EACH_ROW
+    assert mode_of("NONE") is AutoFocusMode.NONE
+
+
+def test_the_new_shape_also_reads_the_previously_persisted_name_form():
+    """And on the new key, for a file written after the split but before a rename."""
+    s = OverviewAcquisitionSettings.from_dict({"autofocus_mode": "EVERY_ROW"})
+    assert s.autofocus_mode is AutoFocusMode.EACH_ROW
 
 
 def test_overview_parameters_round_trip():

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -6,7 +6,6 @@ import pytest
 from fibsem.microscopes.autoscript import THERMO_API_AVAILABLE
 from fibsem.structures import (
     AutoFocusMode,
-    AutoFocusSettings,
     BeamSettings,
     BeamType,
     FibsemDetectorSettings,
@@ -187,24 +186,22 @@ def test_fibsem_image_extract_region_no_metadata():
         image.extract_region(FibsemRectangle(left=0.0, top=0.0, width=0.5, height=0.5))
 
 
-def test_autofocus_settings_defaults():
-    s = AutoFocusSettings()
-    assert s.mode is AutoFocusMode.NONE
+def test_there_is_only_one_autofocus_settings_now():
+    """The mode-only class is gone, and the name means one thing again.
 
+    `fibsem.structures` used to define an `AutoFocusSettings` whose sole member was the
+    mode, sharing a name with the real sweep config in `autofunctions.autofocus`.
+    `AutoFocusMode` had already been through the identical mistake -- two enums of one
+    name, so `NONE is NONE` was False across the two import paths with no type error to
+    catch it -- so this asserts the duplicate stayed dead (FIB-646).
+    """
+    import fibsem.structures as structures
+    from fibsem.autofunctions.autofocus import AutoFocusSettings as Canonical
 
-def test_autofocus_settings_round_trip():
-    for mode in AutoFocusMode:
-        s = AutoFocusSettings(mode=mode)
-        d = s.to_dict()
-        assert d["mode"] == mode.value
-        restored = AutoFocusSettings.from_dict(d)
-        assert restored.mode is mode
-
-
-def test_autofocus_settings_from_dict_missing_key():
-    """Missing key in dict falls back to NONE."""
-    s = AutoFocusSettings.from_dict({})
-    assert s.mode is AutoFocusMode.NONE
+    assert not hasattr(structures, "AutoFocusSettings")
+    # And the one that survives is the sweep config, not a mode holder.
+    assert not hasattr(Canonical(), "mode")
+    assert Canonical().passes
 
 
 def test_overview_acquisition_settings_defaults():
@@ -218,7 +215,12 @@ def test_overview_acquisition_settings_defaults():
     assert s.focus_stack_settings.enabled is False
     assert s.focus_stack_settings.n_steps == 3
     assert s.focus_stack_settings.auto_focus is True
-    assert s.autofocus_settings.mode is AutoFocusMode.NONE
+    assert s.autofocus_mode is AutoFocusMode.NONE
+    # The sweep is the library default rather than a pinned copy, so an improvement to
+    # the default reaches overviews too.
+    from fibsem.autofunctions.autofocus import AutoFocusSettings
+
+    assert s.autofocus_settings.to_dict() == AutoFocusSettings().to_dict()
 
 
 def test_overview_acquisition_settings_round_trip():
@@ -228,7 +230,7 @@ def test_overview_acquisition_settings_round_trip():
             image_settings=ImageSettings(resolution=(1536, 1024), hfw=150e-6),
             nrows=2, ncols=3, overlap=0.1,
             focus_stack_settings=FocusStackSettings(enabled=True, n_steps=5, auto_focus=False),
-            autofocus_settings=AutoFocusSettings(mode=mode),
+            autofocus_mode=mode,
         )
         restored = OverviewAcquisitionSettings.from_dict(s.to_dict())
         assert restored.nrows == s.nrows
@@ -237,7 +239,7 @@ def test_overview_acquisition_settings_round_trip():
         assert restored.focus_stack_settings.enabled == s.focus_stack_settings.enabled
         assert restored.focus_stack_settings.n_steps == s.focus_stack_settings.n_steps
         assert restored.focus_stack_settings.auto_focus == s.focus_stack_settings.auto_focus
-        assert restored.autofocus_settings.mode is mode
+        assert restored.autofocus_mode is mode
 
 
 def test_overview_acquisition_settings_from_dict_legacy():
@@ -248,8 +250,81 @@ def test_overview_acquisition_settings_from_dict_legacy():
         # no autofocus_settings key, no focus_stack_settings key (old format)
     }
     s = OverviewAcquisitionSettings.from_dict(d)
-    assert s.autofocus_settings.mode is AutoFocusMode.NONE
+    assert s.autofocus_mode is AutoFocusMode.NONE
     assert s.focus_stack_settings.enabled is False
+
+
+def test_a_file_written_before_the_split_still_loads_its_mode():
+    """The shape this replaced put the mode *inside* `autofocus_settings`.
+
+    Every protocol and overview-parameters file written before FIB-646 looks like this,
+    and the mode is the only thing in them worth keeping -- so losing it silently would
+    turn a saved EACH_TILE run into a run that never focuses, which produces a plausible
+    mosaic rather than an error.
+    """
+    from fibsem.autofunctions.autofocus import AutoFocusSettings
+
+    for mode in AutoFocusMode:
+        d = {
+            "image_settings": ImageSettings().to_dict(),
+            "nrows": 3, "ncols": 3, "overlap": 0.1,
+            "autofocus_settings": {"mode": mode.value},
+        }
+        s = OverviewAcquisitionSettings.from_dict(d)
+        assert s.autofocus_mode is mode
+        # An old file carries no sweep, so it gets the default -- which is what it was
+        # running under anyway, the mode having been all it could configure.
+        assert s.autofocus_settings.to_dict() == AutoFocusSettings().to_dict()
+
+
+def test_an_explicit_null_autofocus_settings_loads():
+    """A third shape, and not a hypothetical one -- it is what real runs wrote.
+
+    `overview-parameters.json` under a log directory contains
+    `"autofocus_settings": null`, so the key is present and empty rather than absent.
+    A `d.get("autofocus_settings", {})` would hand `None` to the branch below and raise
+    on `"mode" in None`; `or {}` is what makes the present-but-null case behave like the
+    absent one.
+    """
+    d = {
+        "image_settings": ImageSettings().to_dict(),
+        "nrows": 3, "ncols": 3, "overlap": 0.1,
+        "autofocus_settings": None,
+    }
+    s = OverviewAcquisitionSettings.from_dict(d)
+    assert s.autofocus_mode is AutoFocusMode.NONE
+    assert s.autofocus_settings.passes
+
+
+def test_the_old_and_new_shapes_are_told_apart_by_a_key_the_new_one_cannot_write():
+    """`"mode"` is the discriminator, and this pins why that is safe rather than lucky.
+
+    The sweep config writes method / passes / probe_resolution / probe_dwell_time /
+    reduced_area / use_autocontrast / channel_name. If it ever grows a `mode` key, every
+    new file starts being read as an old one -- silently, and as `AutoFocusMode(...)` of
+    something that is not a mode.
+    """
+    from fibsem.autofunctions.autofocus import AutoFocusSettings
+
+    assert "mode" not in AutoFocusSettings().to_dict()
+
+
+def test_a_new_shape_file_keeps_its_sweep():
+    """The other direction: a real sweep must survive, not be replaced by the default."""
+    from fibsem.autofunctions.autofocus import AutoFocusSettings, FocusMethod
+
+    sweep = AutoFocusSettings.from_coarse_fine(
+        coarse_range=123e-6, coarse_step=7e-6, fine_enabled=False, method=FocusMethod.SOBEL
+    )
+    s = OverviewAcquisitionSettings(
+        autofocus_mode=AutoFocusMode.EACH_TILE, autofocus_settings=sweep
+    )
+    restored = OverviewAcquisitionSettings.from_dict(s.to_dict())
+
+    assert restored.autofocus_mode is AutoFocusMode.EACH_TILE
+    assert restored.autofocus_settings.method is FocusMethod.SOBEL
+    assert restored.autofocus_settings.passes[0].search_range == 123e-6
+    assert restored.autofocus_settings.passes[1].enabled is False
 
 
 def test_overview_acquisition_settings_from_dict_legacy_focus_stack_enabled():

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -39,7 +39,8 @@ def test_microscope_state():
     state.ion_detector = None
 
     state.to_dict()
-    
+
+
 def test_gas_injection_settings():
 
     # gis
@@ -50,7 +51,7 @@ def test_gas_injection_settings():
     )
 
     # to dict
-    gdict = gis_settings.to_dict()  
+    gdict = gis_settings.to_dict()
     assert gdict["gas"] == gis_settings.gas
     assert gdict["port"] == gis_settings.port
     assert gdict["duration"] == gis_settings.duration
@@ -64,10 +65,7 @@ def test_gas_injection_settings():
     assert gis_settings2.insert_position == gis_settings.insert_position
 
     multichem_settings = FibsemGasInjectionSettings(
-        gas="Pt",
-        port=0,
-        duration=30,
-        insert_position="ELECTRON_DEFAULT"
+        gas="Pt", port=0, duration=30, insert_position="ELECTRON_DEFAULT"
     )
 
     # to dict
@@ -77,7 +75,7 @@ def test_gas_injection_settings():
     assert gdict["duration"] == multichem_settings.duration
     assert gdict["insert_position"] == multichem_settings.insert_position
 
-    # from dict 
+    # from dict
     multichem_settings2 = FibsemGasInjectionSettings.from_dict(gdict)
     assert multichem_settings2.gas == multichem_settings.gas
     assert multichem_settings2.port == multichem_settings.port
@@ -89,7 +87,10 @@ def test_fibsem_image_extract_region():
     """Test FibsemImage.extract_region returns cropped data with updated reduced_area metadata."""
     image = FibsemImage.generate_blank_image(resolution=(100, 100), hfw=100e-6)
     import numpy as np
-    image.data[:] = np.arange(image.data.size, dtype=image.data.dtype).reshape(image.data.shape)
+
+    image.data[:] = np.arange(image.data.size, dtype=image.data.dtype).reshape(
+        image.data.shape
+    )
 
     rect = FibsemRectangle(left=0.25, top=0.25, width=0.5, height=0.5)
     result = image.extract_region(rect)
@@ -98,7 +99,10 @@ def test_fibsem_image_extract_region():
     assert result.data.shape == (50, 50)
 
     # resolution and hfw are unchanged from the original
-    assert result.metadata.image_settings.resolution == image.metadata.image_settings.resolution
+    assert (
+        result.metadata.image_settings.resolution
+        == image.metadata.image_settings.resolution
+    )
     assert result.metadata.image_settings.hfw == image.metadata.image_settings.hfw
 
     # pixel size is unchanged
@@ -128,6 +132,7 @@ def test_fibsem_image_resize():
 def test_fibsem_image_resize_no_metadata():
     """resize() raises ValueError when image has no metadata."""
     import numpy as np
+
     image = FibsemImage(data=np.zeros((100, 100), dtype=np.uint8))
     with pytest.raises(ValueError):
         image.resize((50, 50))
@@ -136,6 +141,7 @@ def test_fibsem_image_resize_no_metadata():
 def test_fibsem_image_brightness():
     """brightness property returns mean pixel value."""
     import numpy as np
+
     data = np.full((10, 10), 128, dtype=np.uint8)
     image = FibsemImage(data=data)
     assert image.brightness == 128.0
@@ -146,6 +152,7 @@ def test_fibsem_image_apply_gamma():
     import numpy as np
 
     from fibsem.autofunctions.gamma import apply_gamma
+
     data = np.full((10, 10), 128, dtype=np.uint8)
     image = FibsemImage.generate_blank_image(resolution=(10, 10), hfw=10e-6)
     image.data[:] = data
@@ -180,6 +187,7 @@ def test_fibsem_image_extract_region_invalid_rect():
 def test_fibsem_image_extract_region_no_metadata():
     """extract_region raises ValueError when image has no metadata."""
     import numpy as np
+
     image = FibsemImage(data=np.zeros((100, 100), dtype=np.uint8))
 
     with pytest.raises(ValueError):
@@ -225,11 +233,16 @@ def test_overview_acquisition_settings_defaults():
 
 def test_overview_acquisition_settings_round_trip():
     from fibsem.structures import FocusStackSettings
+
     for mode in AutoFocusMode:
         s = OverviewAcquisitionSettings(
             image_settings=ImageSettings(resolution=(1536, 1024), hfw=150e-6),
-            nrows=2, ncols=3, overlap=0.1,
-            focus_stack_settings=FocusStackSettings(enabled=True, n_steps=5, auto_focus=False),
+            nrows=2,
+            ncols=3,
+            overlap=0.1,
+            focus_stack_settings=FocusStackSettings(
+                enabled=True, n_steps=5, auto_focus=False
+            ),
             autofocus_mode=mode,
         )
         restored = OverviewAcquisitionSettings.from_dict(s.to_dict())
@@ -238,7 +251,10 @@ def test_overview_acquisition_settings_round_trip():
         assert restored.overlap == s.overlap
         assert restored.focus_stack_settings.enabled == s.focus_stack_settings.enabled
         assert restored.focus_stack_settings.n_steps == s.focus_stack_settings.n_steps
-        assert restored.focus_stack_settings.auto_focus == s.focus_stack_settings.auto_focus
+        assert (
+            restored.focus_stack_settings.auto_focus
+            == s.focus_stack_settings.auto_focus
+        )
         assert restored.autofocus_mode is mode
 
 
@@ -246,7 +262,10 @@ def test_overview_acquisition_settings_from_dict_legacy():
     """Dicts without autofocus_settings key (old format) default to NONE."""
     d = {
         "image_settings": ImageSettings().to_dict(),
-        "nrows": 3, "ncols": 3, "overlap": 0.0, "use_focus_stack": False,
+        "nrows": 3,
+        "ncols": 3,
+        "overlap": 0.0,
+        "use_focus_stack": False,
         # no autofocus_settings key, no focus_stack_settings key (old format)
     }
     s = OverviewAcquisitionSettings.from_dict(d)
@@ -267,7 +286,9 @@ def test_a_file_written_before_the_split_still_loads_its_mode():
     for mode in AutoFocusMode:
         d = {
             "image_settings": ImageSettings().to_dict(),
-            "nrows": 3, "ncols": 3, "overlap": 0.1,
+            "nrows": 3,
+            "ncols": 3,
+            "overlap": 0.1,
             "autofocus_settings": {"mode": mode.value},
         }
         s = OverviewAcquisitionSettings.from_dict(d)
@@ -288,7 +309,9 @@ def test_an_explicit_null_autofocus_settings_loads():
     """
     d = {
         "image_settings": ImageSettings().to_dict(),
-        "nrows": 3, "ncols": 3, "overlap": 0.1,
+        "nrows": 3,
+        "ncols": 3,
+        "overlap": 0.1,
         "autofocus_settings": None,
     }
     s = OverviewAcquisitionSettings.from_dict(d)
@@ -314,7 +337,10 @@ def test_a_new_shape_file_keeps_its_sweep():
     from fibsem.autofunctions.autofocus import AutoFocusSettings, FocusMethod
 
     sweep = AutoFocusSettings.from_coarse_fine(
-        coarse_range=123e-6, coarse_step=7e-6, fine_enabled=False, method=FocusMethod.SOBEL
+        coarse_range=123e-6,
+        coarse_step=7e-6,
+        fine_enabled=False,
+        method=FocusMethod.SOBEL,
     )
     s = OverviewAcquisitionSettings(
         autofocus_mode=AutoFocusMode.EACH_TILE, autofocus_settings=sweep
@@ -331,7 +357,10 @@ def test_overview_acquisition_settings_from_dict_legacy_focus_stack_enabled():
     """Old use_focus_stack=True maps to focus_stack_settings.enabled=True."""
     d = {
         "image_settings": ImageSettings().to_dict(),
-        "nrows": 3, "ncols": 3, "overlap": 0.0, "use_focus_stack": True,
+        "nrows": 3,
+        "ncols": 3,
+        "overlap": 0.0,
+        "use_focus_stack": True,
     }
     s = OverviewAcquisitionSettings.from_dict(d)
     assert s.focus_stack_settings.enabled is True
@@ -341,7 +370,9 @@ def test_overview_acquisition_total_fov_square_no_overlap():
     """Square tiles, no overlap: total FOV == n * hfw."""
     s = OverviewAcquisitionSettings(
         image_settings=ImageSettings(resolution=(1024, 1024), hfw=100e-6),
-        nrows=3, ncols=4, overlap=0.0,
+        nrows=3,
+        ncols=4,
+        overlap=0.0,
     )
     assert s.total_fov_x == pytest.approx(4 * 100e-6)
     assert s.total_fov_y == pytest.approx(3 * 100e-6)
@@ -351,7 +382,9 @@ def test_overview_acquisition_total_fov_with_overlap():
     """Overlap reduces effective step; total FOV = (n-1)*step + hfw."""
     s = OverviewAcquisitionSettings(
         image_settings=ImageSettings(resolution=(1024, 1024), hfw=100e-6),
-        nrows=3, ncols=3, overlap=0.1,
+        nrows=3,
+        ncols=3,
+        overlap=0.1,
     )
     step = 100e-6 * 0.9
     expected = 2 * step + 100e-6
@@ -363,7 +396,9 @@ def test_overview_acquisition_total_fov_non_square():
     """Non-square tiles: total_fov_y scaled by aspect ratio."""
     s = OverviewAcquisitionSettings(
         image_settings=ImageSettings(resolution=(1536, 1024), hfw=150e-6),
-        nrows=3, ncols=3, overlap=0.1,
+        nrows=3,
+        ncols=3,
+        overlap=0.1,
     )
     step_x = 150e-6 * 0.9
     tile_fov_y = 150e-6 * (1024 / 1536)
@@ -376,7 +411,9 @@ def test_overview_acquisition_total_fov_single_tile():
     """Single tile (1x1): total FOV equals tile FOV regardless of overlap."""
     s = OverviewAcquisitionSettings(
         image_settings=ImageSettings(resolution=(1024, 1024), hfw=200e-6),
-        nrows=1, ncols=1, overlap=0.2,
+        nrows=1,
+        ncols=1,
+        overlap=0.2,
     )
     assert s.total_fov_x == pytest.approx(200e-6)
     assert s.total_fov_y == pytest.approx(200e-6)
@@ -393,7 +430,10 @@ def test_overview_acquisition_tile_order_legacy_default():
     """Dicts without tile_order key default to TYPEWRITER."""
     d = {
         "image_settings": ImageSettings().to_dict(),
-        "nrows": 3, "ncols": 3, "overlap": 0.0, "use_focus_stack": False,
+        "nrows": 3,
+        "ncols": 3,
+        "overlap": 0.0,
+        "use_focus_stack": False,
     }
     s = OverviewAcquisitionSettings.from_dict(d)
     assert s.tile_order is TileOrderStrategy.TYPEWRITER
@@ -425,7 +465,9 @@ def test_scan_time_counts_the_passes_each_pixel_gets():
     )
     assert both.scan_time == pytest.approx(base.scan_time * 12)
 
-    interlaced = ImageSettings(resolution=(512, 512), dwell_time=2e-6, scan_interlacing=8)
+    interlaced = ImageSettings(
+        resolution=(512, 512), dwell_time=2e-6, scan_interlacing=8
+    )
     assert interlaced.scan_time == pytest.approx(base.scan_time)
 
 
@@ -450,12 +492,13 @@ def test_overview_scan_time_counts_the_tiles_it_will_acquire():
 
 
 if THERMO_API_AVAILABLE:
-
     from fibsem.structures import CompustagePosition, CoordinateSystem, StagePosition
 
     def test_to_autoscript_position():
-        
-        stage_position = FibsemStagePosition(x=1, y=2, z=3, r=4, t=5, coordinate_system="RAW")
+
+        stage_position = FibsemStagePosition(
+            x=1, y=2, z=3, r=4, t=5, coordinate_system="RAW"
+        )
 
         # test conversion to StagePosition
         autoscript_stage_position = stage_position.to_autoscript_position()
@@ -468,22 +511,32 @@ if THERMO_API_AVAILABLE:
         assert autoscript_stage_position.coordinate_system == CoordinateSystem.RAW
 
         # test convesion to CompuStagePosition
-        autoscript_compustage_position = stage_position.to_autoscript_position(compustage=True)
+        autoscript_compustage_position = stage_position.to_autoscript_position(
+            compustage=True
+        )
 
         assert autoscript_compustage_position.x == stage_position.x
         assert autoscript_compustage_position.y == stage_position.y
         assert autoscript_compustage_position.z == stage_position.z
         assert autoscript_compustage_position.a == stage_position.t
-        assert autoscript_compustage_position.coordinate_system == CoordinateSystem.SPECIMEN
-
+        assert (
+            autoscript_compustage_position.coordinate_system
+            == CoordinateSystem.SPECIMEN
+        )
 
     def test_from_autoscript_position():
-        
-        autoscript_stage_position = StagePosition(x=1, y=2, z=3, r=4, t=5, coordinate_system=CoordinateSystem.RAW)
-        autoscript_compustage_position = CompustagePosition(x=1, y=2, z=3, a=5, coordinate_system=CoordinateSystem.RAW)
+
+        autoscript_stage_position = StagePosition(
+            x=1, y=2, z=3, r=4, t=5, coordinate_system=CoordinateSystem.RAW
+        )
+        autoscript_compustage_position = CompustagePosition(
+            x=1, y=2, z=3, a=5, coordinate_system=CoordinateSystem.RAW
+        )
 
         # test conversion from StagePosition
-        stage_position = FibsemStagePosition.from_autoscript_position(autoscript_stage_position)
+        stage_position = FibsemStagePosition.from_autoscript_position(
+            autoscript_stage_position
+        )
 
         assert stage_position.x == autoscript_stage_position.x
         assert stage_position.y == autoscript_stage_position.y
@@ -493,7 +546,9 @@ if THERMO_API_AVAILABLE:
         assert stage_position.coordinate_system == "RAW"
 
         # test conversion from CompuStagePosition
-        stage_position = FibsemStagePosition.from_autoscript_position(autoscript_compustage_position)
+        stage_position = FibsemStagePosition.from_autoscript_position(
+            autoscript_compustage_position
+        )
 
         assert stage_position.x == autoscript_compustage_position.x
         assert stage_position.y == autoscript_compustage_position.y
@@ -504,6 +559,7 @@ if THERMO_API_AVAILABLE:
 
 
 # ── ImageSettings.estimated_time ─────────────────────────────────────────────
+
 
 def test_image_settings_estimated_time_basic():
     img = ImageSettings(resolution=(1536, 1024), dwell_time=1e-6)
@@ -524,17 +580,27 @@ def test_image_settings_estimated_time_line_integration():
 
 
 def test_image_settings_estimated_time_both_integrations():
-    img = ImageSettings(resolution=(1536, 1024), dwell_time=1e-6, frame_integration=4, line_integration=2)
+    img = ImageSettings(
+        resolution=(1536, 1024),
+        dwell_time=1e-6,
+        frame_integration=4,
+        line_integration=2,
+    )
     expected = 1536 * 1024 * 1e-6 * 4 * 2
     assert img.estimated_time == pytest.approx(expected)
 
 
 # ── ReferenceImageParameters.estimated_time ───────────────────────────────────
 
+
 def test_reference_image_parameters_estimated_time_both_beams_both_fovs():
     img = ImageSettings(resolution=(1536, 1024), dwell_time=1e-6)
     ref = ReferenceImageParameters(
-        imaging=img, acquire_sem=True, acquire_fib=True, acquire_image1=True, acquire_image2=True
+        imaging=img,
+        acquire_sem=True,
+        acquire_fib=True,
+        acquire_image1=True,
+        acquire_image2=True,
     )
     # 2 FOVs × 2 beams = 4 images
     assert ref.estimated_time == pytest.approx(img.estimated_time * 4)
@@ -543,7 +609,11 @@ def test_reference_image_parameters_estimated_time_both_beams_both_fovs():
 def test_reference_image_parameters_estimated_time_sem_only():
     img = ImageSettings(resolution=(1536, 1024), dwell_time=1e-6)
     ref = ReferenceImageParameters(
-        imaging=img, acquire_sem=True, acquire_fib=False, acquire_image1=True, acquire_image2=True
+        imaging=img,
+        acquire_sem=True,
+        acquire_fib=False,
+        acquire_image1=True,
+        acquire_image2=True,
     )
     # 2 FOVs × 1 beam = 2 images
     assert ref.estimated_time == pytest.approx(img.estimated_time * 2)
@@ -552,7 +622,11 @@ def test_reference_image_parameters_estimated_time_sem_only():
 def test_reference_image_parameters_estimated_time_one_fov():
     img = ImageSettings(resolution=(1536, 1024), dwell_time=1e-6)
     ref = ReferenceImageParameters(
-        imaging=img, acquire_sem=True, acquire_fib=True, acquire_image1=True, acquire_image2=False
+        imaging=img,
+        acquire_sem=True,
+        acquire_fib=True,
+        acquire_image1=True,
+        acquire_image2=False,
     )
     # 1 FOV × 2 beams = 2 images
     assert ref.estimated_time == pytest.approx(img.estimated_time * 2)
@@ -561,7 +635,11 @@ def test_reference_image_parameters_estimated_time_one_fov():
 def test_reference_image_parameters_estimated_time_no_images():
     img = ImageSettings(resolution=(1536, 1024), dwell_time=1e-6)
     ref = ReferenceImageParameters(
-        imaging=img, acquire_sem=False, acquire_fib=False, acquire_image1=True, acquire_image2=True
+        imaging=img,
+        acquire_sem=False,
+        acquire_fib=False,
+        acquire_image1=True,
+        acquire_image2=True,
     )
     assert ref.estimated_time == 0.0
 
@@ -572,6 +650,7 @@ def test_reference_image_parameters_estimated_time_no_images():
 def test_fibsem_image_filepath_is_none_until_written_or_read():
     """An image that has never been saved or loaded has no file."""
     import numpy as np
+
     image = FibsemImage(data=np.zeros((10, 10), dtype=np.uint8))
     assert image.filepath is None
 
@@ -579,6 +658,7 @@ def test_fibsem_image_filepath_is_none_until_written_or_read():
 def test_fibsem_image_save_sets_filepath_to_the_resolved_file(tmp_path):
     """save() records the path it actually wrote, extension included."""
     import numpy as np
+
     image = FibsemImage(data=np.zeros((10, 10), dtype=np.uint8))
 
     # deliberately passed without a suffix: save() resolves it to .tif, and the
@@ -593,6 +673,7 @@ def test_fibsem_image_save_sets_filepath_to_the_resolved_file(tmp_path):
 def test_fibsem_image_load_sets_filepath(tmp_path):
     """load() records where the image came from."""
     import numpy as np
+
     written = FibsemImage(data=np.zeros((10, 10), dtype=np.uint8)).save(
         str(tmp_path / "ref_image")
     )
@@ -674,9 +755,7 @@ def test_metadata_round_trips_fibsem_revision():
 
     info = SystemInfo.from_dict({"fibsem_revision": "v0.5.1-48-g4cd11d9c"})
     assert info.fibsem_revision == "v0.5.1-48-g4cd11d9c"
-    assert (
-        SystemInfo.from_dict(info.to_dict()).fibsem_revision == "v0.5.1-48-g4cd11d9c"
-    )
+    assert SystemInfo.from_dict(info.to_dict()).fibsem_revision == "v0.5.1-48-g4cd11d9c"
 
 
 def test_experiment_date_is_creation_time_not_import_time():

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -3486,7 +3486,7 @@ class TestFocusAndFocusStackAreTwoQuestions:
         settings.check_focus_stack.setChecked(False)
 
         read = settings.get_settings()
-        assert read.autofocus_settings.mode is AutoFocusMode.EACH_TILE
+        assert read.autofocus_mode is AutoFocusMode.EACH_TILE
         assert read.focus_stack_settings.enabled is False
 
     def test_the_stack_parameters_grey_out_when_it_is_off(self, widget):

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -14,6 +14,7 @@ where it matters.
 Run directly (no display needed):
     QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_overview_widget.py
 """
+
 from __future__ import annotations
 
 import os
@@ -92,7 +93,9 @@ def microscope():
     import fibsem.config as fibsem_config
 
     path = os.path.join(
-        os.path.dirname(fibsem_config.__file__), "config", "sim-arctis-configuration.yaml"
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "sim-arctis-configuration.yaml",
     )
     scope, _ = utils.setup_session(manufacturer="Demo", config_path=path)
     assert scope.stage_is_compustage, "the config stopped being a compustage"
@@ -224,8 +227,9 @@ class TestTheInversion:
         # 256 px at this hfw, so the canvas's 512 px cap does not reduce it and only
         # the deliberate reduction below can shrink anything.
         hfw = 256 * 4e-7
-        widget.place_image(_tile(microscope, _at(base), shape=(256, 256), hfw=hfw),
-                           key="a")
+        widget.place_image(
+            _tile(microscope, _at(base), shape=(256, 256), hfw=hfw), key="a"
+        )
         widget.place_image(
             _tile(microscope, _at(base, dx=hfw), shape=(256, 256), hfw=hfw), key="b"
         )
@@ -245,8 +249,9 @@ class TestTheInversion:
         _hold_at(widget, cap)
         big = cap + cap // 2  # over the cap, so it reduces; not so far over it is slow
         hfw = big * 1e-7
-        widget.place_image(_tile(microscope, _at(base), shape=(big, big), hfw=hfw),
-                           key="big")
+        widget.place_image(
+            _tile(microscope, _at(base), shape=(big, big), hfw=hfw), key="big"
+        )
 
         extent = widget.canvas._placed["big"].extent
         drawn_width_m = (extent[1] - extent[0]) * widget.canvas.reference_pixel_size
@@ -314,9 +319,13 @@ class TestTheTwoCaps:
 
         assert wide * wide * 2 <= widget._store_budget_bytes
         assert deep * deep * 3 <= widget._store_budget_bytes
-        assert deep < wide, "a 16-bit detector was given the same pixel count as an 8-bit"
+        assert deep < wide, (
+            "a 16-bit detector was given the same pixel count as an 8-bit"
+        )
 
-    def test_the_budget_holds_the_complained_about_mosaic_whole(self, widget, microscope):
+    def test_the_budget_holds_the_complained_about_mosaic_whole(
+        self, widget, microscope
+    ):
         """The case behind FIB-658: a 5x5 of 1024 px tiles is 5120 px, and the point of
         the budget is that it is held at its acquired resolution rather than reduced."""
         assert widget._store_cap(np.uint8) >= 5 * 1024, (
@@ -428,7 +437,6 @@ class TestOneDerivationForBothDirections:
         x, y = frame.to_canvas(_at(base, 0.0, 0.0))
         assert widget._position_at(x + 4000, y + 4000) is None
 
-
     def test_a_hidden_marker_is_not_a_target(self, widget, microscope):
         """Turned off means gone, not merely invisible.
 
@@ -478,7 +486,8 @@ class TestAnOverviewIsReducedOnce:
         calls = []
         original = widget._stored_tile
         monkeypatch.setattr(
-            widget, "_stored_tile",
+            widget,
+            "_stored_tile",
             lambda image: calls.append(image) or original(image),
         )
 
@@ -503,9 +512,10 @@ class TestAnOverviewIsReducedOnce:
         placed = []
         original = widget._place_on_canvas
         monkeypatch.setattr(
-            widget, "_place_on_canvas",
-            lambda tile, view, **kwargs: placed.append(tile) or original(
-                tile, view, **kwargs
+            widget,
+            "_place_on_canvas",
+            lambda tile, view, **kwargs: (
+                placed.append(tile) or original(tile, view, **kwargs)
             ),
         )
 
@@ -560,7 +570,8 @@ class TestItDoesNotReadHardwareOnUiEvents:
         reads = []
         original = microscope.get_scan_rotation
         monkeypatch.setattr(
-            microscope, "get_scan_rotation",
+            microscope,
+            "get_scan_rotation",
             lambda beam_type: (reads.append(beam_type), original(beam_type))[1],
         )
 
@@ -592,9 +603,12 @@ class TestWhatIsDrawn:
         every point the same, so the selection has to be its own layer."""
         base = microscope.get_stage_position()
         widget.place_image(_tile(microscope, _at(base)))
-        widget.set_positions([
-            _at(base, 0.0, 0.0, "A"), _at(base, 30e-6, 0.0, "B"),
-        ])
+        widget.set_positions(
+            [
+                _at(base, 0.0, 0.0, "A"),
+                _at(base, 30e-6, 0.0, "B"),
+            ]
+        )
         widget.set_selected_position("B")
 
         assert len(widget.position_overlay._points) == 1
@@ -731,10 +745,14 @@ class TestThingsOnlyRunningItFound:
         assert widget.overview_list._list.count() == 1
 
         for i in (1, 2, 3):
-            widget._apply_progress({
-                "msg": "Tile Collected", "counter": i, "total": 3,
-                "preview": _tile(microscope, _at(base)),
-            })
+            widget._apply_progress(
+                {
+                    "msg": "Tile Collected",
+                    "counter": i,
+                    "total": 3,
+                    "preview": _tile(microscope, _at(base)),
+                }
+            )
             row = widget.overview_list._rows["run"]
             assert row.detail_label.text().startswith(f"{i} tile"), (
                 f"after {i} tile(s) the row still reads {row.detail_label.text()!r}"
@@ -768,8 +786,9 @@ class TestTheRunOwnsItsSettings:
     which set the run's output path back to None.
     """
 
-    def test_reading_the_settings_does_not_disturb_a_run(self, widget, microscope,
-                                                         monkeypatch, tmp_path):
+    def test_reading_the_settings_does_not_disturb_a_run(
+        self, widget, microscope, monkeypatch, tmp_path
+    ):
         """The reported sequence, end to end: start a run, then do everything a stage
         move between tiles does, and check the run's settings still name a path.
 
@@ -812,8 +831,9 @@ class TestTheRunOwnsItsSettings:
             "the second tile would die in os.path.join(None, filename)"
         )
 
-    def test_the_runner_gets_its_own_copy_of_the_settings(self, widget, microscope,
-                                                          monkeypatch, tmp_path):
+    def test_the_runner_gets_its_own_copy_of_the_settings(
+        self, widget, microscope, monkeypatch, tmp_path
+    ):
         """Even with nothing else reading, handing a background runner the widget's own
         instance means any later edit reaches into a run in progress."""
         captured = {}
@@ -857,9 +877,7 @@ class TestTheRunOwnsItsSettings:
         An empty box is also what made `get_settings()` read the path back as None.
         """
         widget.set_save_directory(str(tmp_path))
-        assert widget.settings_widget.path_edit.text() == str(
-            tmp_path
-        )
+        assert widget.settings_widget.path_edit.text() == str(tmp_path)
         assert widget._settings().image_settings.path == str(tmp_path)
 
     def test_a_run_always_has_somewhere_to_write(self, widget, monkeypatch):
@@ -919,10 +937,7 @@ class TestTheRunOwnsItsSettings:
         widget.acquire()
         assert captured["settings"].image_settings.filename.startswith("overview-image")
         # And visible, so it can be changed before a run rather than discovered after.
-        assert (
-            widget.settings_widget.filename_edit.text()
-            == "overview-image"
-        )
+        assert widget.settings_widget.filename_edit.text() == "overview-image"
 
     def test_a_run_starts_from_the_overview_defaults(self, widget, monkeypatch):
         """A 500 um tile with autocontrast, not `ImageSettings`'s generic 150 um.
@@ -1077,7 +1092,9 @@ class TestViews:
     def _image(self, scope, orientation, beam_type, dx=0.0):
         position = self._at_orientation(scope, orientation, dx)
         image = FibsemImage.generate_blank_image(resolution=(128, 128), hfw=128 * 2e-7)
-        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(np.uint8)
+        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(
+            np.uint8
+        )
         state = scope.get_microscope_state(beam_type=beam_type)
         state.stage_position = position
         image.metadata.image_settings = ImageSettings(
@@ -1124,7 +1141,9 @@ class TestViews:
         assert widget.show_view(sem_view) is True
         assert widget.current_view == sem_view
         assert len(widget.canvas.placed_keys) == 2, "the SEM images did not come back"
-        assert widget.show_view(sem_view) is False, "switching to the current view is a no-op"
+        assert widget.show_view(sem_view) is False, (
+            "switching to the current view is a no-op"
+        )
 
     def test_each_view_keeps_its_own_origin(self, widget):
         """Everything in a view is placed relative to that view's anchor. One shared
@@ -1212,7 +1231,9 @@ class TestViews:
         scope = widget.microscope
         widget._stage_position = self._at_orientation(scope, "SEM")
         widget.set_image(self._image(scope, "SEM", BeamType.ELECTRON))
-        assert widget._stage_position_at(0.0, 0.0) is not None, "blocked in its own view"
+        assert widget._stage_position_at(0.0, 0.0) is not None, (
+            "blocked in its own view"
+        )
 
         widget._stage_position = self._at_orientation(scope, "FIB")
         assert widget._stage_position_at(0.0, 0.0) is None, (
@@ -1410,7 +1431,9 @@ class TestOverlaysAreDrawnInTheView:
         position = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
         hfw = 128 * 2e-7
         image = FibsemImage.generate_blank_image(resolution=(128, 128), hfw=hfw)
-        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(np.uint8)
+        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(
+            np.uint8
+        )
         state = scope.get_microscope_state(beam_type=beam_type)
         state.stage_position = position
         image.metadata.image_settings = ImageSettings(hfw=hfw, beam_type=beam_type)
@@ -1467,7 +1490,9 @@ class TestOverlaysAreDrawnInTheView:
         assert abs(corner[0] - box.cx) == pytest.approx(box.width / 2, rel=1e-9)
         assert abs(corner[1] - box.cy) == pytest.approx(box.height / 2, rel=1e-9)
 
-    def test_the_limits_box_is_shorter_in_a_foreshortened_view(self, widget, microscope):
+    def test_the_limits_box_is_shorter_in_a_foreshortened_view(
+        self, widget, microscope
+    ):
         """The bug, pinned. The box was `frame.length(ymax - ymin)` in every view, so
         it was the same height at the milling pose as at the SEM one -- nearly four
         times too tall in the view you mill in."""
@@ -1580,7 +1605,8 @@ class TestTheHolderIsDrawnOnEveryStage:
         from fibsem.microscopes._stage import GridSlot
 
         return GridSlot(
-            name=name, index=0,
+            name=name,
+            index=0,
             position=FibsemStagePosition(name=name, x=x, y=y, z=0.0),
         )
 
@@ -1591,16 +1617,21 @@ class TestTheHolderIsDrawnOnEveryStage:
         a `property` object where a dict belongs.
         """
         holder = widget.microscope._stage.holder
-        slots = {"Slot-01": self._slot("Slot-01", -5.0e-3),
-                 "Slot-02": self._slot("Slot-02", 5.0e-3)}
+        slots = {
+            "Slot-01": self._slot("Slot-01", -5.0e-3),
+            "Slot-02": self._slot("Slot-02", 5.0e-3),
+        }
         monkeypatch.setattr(holder, "slots", slots)
         widget._refresh_context_overlays()
         return slots
 
     @staticmethod
     def _specs(widget, kind, label=None):
-        return [s for s in widget.context_overlay._specs
-                if s.kind == kind and (label is None or s.label == label)]
+        return [
+            s
+            for s in widget.context_overlay._specs
+            if s.kind == kind and (label is None or s.label == label)
+        ]
 
     def test_the_travel_box_draws_on_a_stage_that_is_not_a_compustage(
         self, widget, microscope, monkeypatch
@@ -1640,15 +1671,18 @@ class TestTheHolderIsDrawnOnEveryStage:
         with a shuttle that is 10 mm across, a full grid's width from either of them."""
         self._two_slots(widget, monkeypatch)
         boundaries = self._specs(widget, "ellipse", "Grid Boundary")
-        crosshairs = [s for s in self._specs(widget, "crosshair")
-                      if s.label.startswith("Slot-")]
+        crosshairs = [
+            s for s in self._specs(widget, "crosshair") if s.label.startswith("Slot-")
+        ]
 
         centres = sorted((round(s.cx, 6), round(s.cy, 6)) for s in boundaries)
         markers = sorted((round(s.cx, 6), round(s.cy, 6)) for s in crosshairs)
         assert centres == markers, "a boundary is not concentric with its slot marker"
         assert len({c[0] for c in centres}) == 2, "both circles landed in one place"
 
-    def test_a_slot_carries_the_orientation_it_was_defined_in(self, widget, monkeypatch):
+    def test_a_slot_carries_the_orientation_it_was_defined_in(
+        self, widget, monkeypatch
+    ):
         """The holder file is written in the SEM orientation, so that is the pose a
         slot has to carry. Without it the position is a bare x/y and `to_canvas` has
         nothing to compare against -- which is both why the shipped holder crashed and
@@ -1674,8 +1708,9 @@ class TestTheHolderIsDrawnOnEveryStage:
         """The compustage case, unchanged: one slot at the origin, one circle on it.
         The simulator's own holder, so this is the behaviour that shipped."""
         boundaries = self._specs(widget, "ellipse", "Grid Boundary")
-        crosshairs = [s for s in self._specs(widget, "crosshair")
-                      if s.label.startswith("Slot-")]
+        crosshairs = [
+            s for s in self._specs(widget, "crosshair") if s.label.startswith("Slot-")
+        ]
 
         assert len(boundaries) == 1
         assert (boundaries[0].cx, boundaries[0].cy) == pytest.approx(
@@ -1861,8 +1896,11 @@ class TestThePlannedTileset:
         """
         origin = widget._origins[widget.current_view]
         drifted = FibsemStagePosition(
-            x=origin.x, y=origin.y, z=origin.z,
-            r=origin.r, t=origin.t + np.deg2rad(0.4),
+            x=origin.x,
+            y=origin.y,
+            z=origin.z,
+            r=origin.r,
+            t=origin.t + np.deg2rad(0.4),
         )
         widget._stage_position = drifted
 
@@ -1985,10 +2023,14 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
     def _run_a_tile(self, widget, microscope, position):
         """One tile of a run: the stage arrives, then a preview lands."""
         widget._on_stage_moved(position)
-        widget._apply_progress({
-            "msg": "Tile Collected", "counter": 1, "total": 3,
-            "preview": _tile(microscope, position),
-        })
+        widget._apply_progress(
+            {
+                "msg": "Tile Collected",
+                "counter": 1,
+                "total": 3,
+                "preview": _tile(microscope, position),
+            }
+        )
 
     def test_the_planned_grid_does_not_follow_the_stage(self, widget, microscope):
         from fibsem.ui.widgets.overview_widget import OverviewRecord
@@ -2047,7 +2089,9 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         widget.place_image(_tile(microscope, _at(base, dx=100e-6)), key="preview")
         widget.place_image(_tile(microscope, _at(base, dx=200e-6)), key="preview")
 
-        assert calls == [], f"{len(calls)} overlay refresh(es) for images already framed"
+        assert calls == [], (
+            f"{len(calls)} overlay refresh(es) for images already framed"
+        )
 
     def test_the_plan_is_pinned_to_what_the_run_is_acquiring(
         self, widget, microscope, monkeypatch, tmp_path
@@ -2061,6 +2105,7 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         against a real 3x3 run of 80 um tiles, one tile off, and it stayed there for the
         rest of the acquisition. So a run pins the centre it was started with.
         """
+
         def fake_worker(fn, *args):
             class _W:
                 def start(self_inner):
@@ -2082,10 +2127,14 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         # The stage sets off, and the first preview arrives from a tile away -- which is
         # the redraw, because it is what un-provisions the origin.
         widget._on_stage_moved(_at(base, dx=300e-6, dy=300e-6))
-        widget._apply_progress({
-            "msg": "Tile Collected", "counter": 1, "total": 9,
-            "preview": _tile(microscope, _at(base)),
-        })
+        widget._apply_progress(
+            {
+                "msg": "Tile Collected",
+                "counter": 1,
+                "total": 9,
+                "preview": _tile(microscope, _at(base)),
+            }
+        )
 
         assert widget.tile_grid_overlay._anchor() == pytest.approx(anchored_at), (
             "the plan was redrawn around the tile being acquired, not around the run"
@@ -2159,7 +2208,8 @@ class TestThePlanHoldsStillWhileTheRunWalksTheGrid:
         )
         monkeypatch.setattr(
             overview_confirmation_dialog.OverviewConfirmationDialog,
-            "exec_", moves_the_stage,
+            "exec_",
+            moves_the_stage,
         )
 
         widget.acquire()
@@ -2206,10 +2256,14 @@ class TestARunDoesNotReFrameTheCanvas:
         widget._active_record = "run"
         widget._set_running(True)
         for counter in range(1, tiles + 1):
-            widget._apply_progress({
-                "msg": "Tile Collected", "counter": counter, "total": tiles,
-                "preview": _tile(microscope, _at(base)),
-            })
+            widget._apply_progress(
+                {
+                    "msg": "Tile Collected",
+                    "counter": counter,
+                    "total": tiles,
+                    "preview": _tile(microscope, _at(base)),
+                }
+            )
         widget._mosaic = _tile(microscope, _at(base), shape=(128, 128))
         widget._on_finished({})
 
@@ -2303,7 +2357,9 @@ class TestTheCanvasFollowsTheBeamYouPlanWith:
         position = scope.get_stage_position()
         hfw = 128 * 2e-7
         image = FibsemImage.generate_blank_image(resolution=(128, 128), hfw=hfw)
-        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(np.uint8)
+        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(
+            np.uint8
+        )
         state = scope.get_microscope_state(beam_type=beam_type)
         state.stage_position = position
         image.metadata.image_settings = ImageSettings(hfw=hfw, beam_type=beam_type)
@@ -2327,10 +2383,14 @@ class TestTheCanvasFollowsTheBeamYouPlanWith:
         assert len(widget.canvas.placed_keys) == 1
 
         widget.settings_widget.combo_beam.set_value(BeamType.ION)
-        assert len(widget.canvas.placed_keys) == 0, "the ion view is empty, as it should be"
+        assert len(widget.canvas.placed_keys) == 0, (
+            "the ion view is empty, as it should be"
+        )
 
         widget.settings_widget.combo_beam.set_value(BeamType.ELECTRON)
-        assert len(widget.canvas.placed_keys) == 1, "the electron overview did not come back"
+        assert len(widget.canvas.placed_keys) == 1, (
+            "the electron overview did not come back"
+        )
 
     def test_re_posing_the_stage_moves_the_canvas_with_it(self, widget, microscope):
         """Reported from the tab: moving to the milling orientation left the display and
@@ -2351,7 +2411,9 @@ class TestTheCanvasFollowsTheBeamYouPlanWith:
         assert widget.current_view.orientation == "MILLING"
         assert widget.tile_grid_overlay._tiles, "the planned grid did not come with it"
 
-    def test_a_move_within_an_orientation_leaves_the_view_alone(self, widget, microscope):
+    def test_a_move_within_an_orientation_leaves_the_view_alone(
+        self, widget, microscope
+    ):
         """The other half, and why following an orientation change is safe: steering
         around inside a view -- which is what clicking the canvas does -- must not
         reshuffle what is on screen."""
@@ -2361,7 +2423,9 @@ class TestTheCanvasFollowsTheBeamYouPlanWith:
 
         here = microscope.get_stage_position()
         widget._on_stage_moved(
-            FibsemStagePosition(x=here.x + 250e-6, y=here.y, z=here.z, r=here.r, t=here.t)
+            FibsemStagePosition(
+                x=here.x + 250e-6, y=here.y, z=here.z, r=here.r, t=here.t
+            )
         )
         assert widget.current_view == showing
         assert len(widget.canvas.placed_keys) == placed
@@ -2384,7 +2448,9 @@ class TestTheCanvasFollowsTheBeamYouPlanWith:
         widget._refresh_context_overlays()
         assert widget.current_view == sem, "the redraw undid the choice"
 
-    def test_the_view_the_run_would_land_in_is_always_selectable(self, widget, microscope):
+    def test_the_view_the_run_would_land_in_is_always_selectable(
+        self, widget, microscope
+    ):
         """And when a stage move does take the plan elsewhere, there has to be a way to
         go and look at it -- the selector only listed views something had been placed
         in, so an empty one was unreachable."""
@@ -2421,7 +2487,9 @@ class TestTheViewChips:
         position = FibsemStagePosition(x=0.0, y=0.0, z=0.0, r=pose.r, t=pose.t)
         hfw = 128 * 2e-7
         image = FibsemImage.generate_blank_image(resolution=(128, 128), hfw=hfw)
-        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(np.uint8)
+        image.data = (np.random.default_rng(0).random((128, 128)) * 255).astype(
+            np.uint8
+        )
         state = scope.get_microscope_state(beam_type=beam_type)
         state.stage_position = position
         image.metadata.image_settings = ImageSettings(hfw=hfw, beam_type=beam_type)
@@ -2440,7 +2508,9 @@ class TestTheViewChips:
             ("SEM", BeamType.ION, "FIB @ SEM"),
         ],
     )
-    def test_a_view_names_both_facts_in_the_same_shape(self, orientation, beam, expected):
+    def test_a_view_names_both_facts_in_the_same_shape(
+        self, orientation, beam, expected
+    ):
         """Beam then orientation, always both. Dropping the orientation when it matched
         the beam read well until you met the ones it kept, and then "FIB · SEM pose" had
         to be decoded rather than read."""
@@ -2454,7 +2524,9 @@ class TestTheViewChips:
     def test_orientations_are_shown_as_the_microscope_names_them(self):
         """Title-casing rendered the two acronyms as "Sem" and "Fib"; casing by rule
         instead means a rule to remember, and a new orientation to add to it."""
-        assert OverviewView(beam_type=BeamType.ION, orientation="SEM").label == "FIB @ SEM"
+        assert (
+            OverviewView(beam_type=BeamType.ION, orientation="SEM").label == "FIB @ SEM"
+        )
         assert (
             OverviewView(beam_type=BeamType.ION, orientation="MILLING").label
             == "FIB @ MILLING"
@@ -2494,11 +2566,15 @@ class TestTheViewChips:
         assert widget.current_view == sem
         assert len(widget.canvas.placed_keys) == 1, "the overview did not come back"
 
-    def test_the_chip_for_the_displayed_view_is_the_checked_one(self, widget, microscope):
+    def test_the_chip_for_the_displayed_view_is_the_checked_one(
+        self, widget, microscope
+    ):
         widget.set_image(self._image(microscope, "SEM", BeamType.ELECTRON))
         widget.settings_widget.combo_beam.set_value(BeamType.ION)
 
-        checked = {b.text() for b in widget._view_chip_buttons.values() if b.isChecked()}
+        checked = {
+            b.text() for b in widget._view_chip_buttons.values() if b.isChecked()
+        }
         assert checked == {widget.current_view.label}
 
     def test_the_view_the_run_would_land_in_is_marked_apart(self, widget, microscope):
@@ -2549,7 +2625,9 @@ class TestTheViewChips:
         ]
         before = widget.minimumSizeHint().width()
         monkeypatch.setattr(
-            type(widget), "views", property(lambda self: views)  # read-only
+            type(widget),
+            "views",
+            property(lambda self: views),  # read-only
         )
         widget._refresh_view_selector()
         _app.processEvents()
@@ -2638,10 +2716,13 @@ class TestTheMillingAngleIsOnTheBeamTab:
         assert widget.canvas._info_text != before
         assert "milling" in widget.canvas._info_text
 
-    def test_a_pose_with_no_tilt_drops_the_angle_not_the_line(self, widget, monkeypatch):
+    def test_a_pose_with_no_tilt_drops_the_angle_not_the_line(
+        self, widget, monkeypatch
+    ):
         """It can refuse, and the position is the half of the line that always works."""
         monkeypatch.setattr(
-            widget.microscope, "get_current_milling_angle",
+            widget.microscope,
+            "get_current_milling_angle",
             lambda **kwargs: (_ for _ in ()).throw(ValueError("no tilt")),
         )
         widget._refresh_stage_info()
@@ -2652,7 +2733,8 @@ class TestTheMillingAngleIsOnTheBeamTab:
         """This runs on every overlay refresh. `get_current_milling_angle` is arithmetic
         over the pose it is handed -- but only if it is handed one."""
         monkeypatch.setattr(
-            microscope, "get_stage_position",
+            microscope,
+            "get_stage_position",
             lambda *a, **k: pytest.fail("the info bar polled the stage"),
         )
         widget._refresh_stage_info()
@@ -2697,9 +2779,7 @@ class TestARunIsConfirmedFirst:
         assert len(confirmations) == 1, "the run started without asking"
         assert "args" in captured, "the run was refused after the dialog was accepted"
 
-    def test_declining_leaves_everything_as_it_was(
-        self, widget, monkeypatch, tmp_path
-    ):
+    def test_declining_leaves_everything_as_it_was(self, widget, monkeypatch, tmp_path):
         """Not merely "no worker": a refused run must leave no record behind either, or
         the overview list grows a row for something that never happened."""
         captured = {}
@@ -2792,7 +2872,8 @@ class TestARunIsConfirmedFirst:
             self._fake_worker(captured),
         )
         monkeypatch.setattr(
-            widget.microscope, "get_stage_position",
+            widget.microscope,
+            "get_stage_position",
             lambda *a, **k: pytest.fail("the confirmation dialog polled the stage"),
         )
         widget.acquire()
@@ -3094,7 +3175,9 @@ class TestTheAcquisitionButtons:
         scrolled = scroll.widget()
         for name in ("button_acquire", "button_cancel", "progress", "label_status"):
             child = getattr(widget, name)
-            assert not scrolled.isAncestorOf(child), f"{name} scrolls away with the column"
+            assert not scrolled.isAncestorOf(child), (
+                f"{name} scrolls away with the column"
+            )
 
     def test_they_stay_on_screen_in_a_window_too_short_for_the_column(
         self, microscope, qapp
@@ -3153,10 +3236,14 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
         )
 
         data = self._partial()
-        rgba = _as_colour_and_coverage(data, data > 0, _contrast_limits(data.astype(float), data > 0))
+        rgba = _as_colour_and_coverage(
+            data, data > 0, _contrast_limits(data.astype(float), data > 0)
+        )
         alpha = rgba[..., 3]
-        assert (alpha[: data.shape[0] // 3] == 255).all(), "acquired tiles went see-through"
-        assert (alpha[data.shape[0] // 3:] == 0).all(), (
+        assert (alpha[: data.shape[0] // 3] == 255).all(), (
+            "acquired tiles went see-through"
+        )
+        assert (alpha[data.shape[0] // 3 :] == 0).all(), (
             "unacquired ground is still opaque, so it paints over what is beneath"
         )
 
@@ -3170,7 +3257,9 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
         )
 
         data = np.array([[1, 40, 128, 255]], dtype=np.uint8)
-        rgba = _as_colour_and_coverage(data, data > 0, _contrast_limits(data.astype(float), data > 0))
+        rgba = _as_colour_and_coverage(
+            data, data > 0, _contrast_limits(data.astype(float), data > 0)
+        )
         assert (rgba[..., 3] == 255).all(), (
             f"alpha followed intensity: {rgba[..., 3].tolist()}"
         )
@@ -3183,7 +3272,12 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
         )
 
         data = np.zeros((16, 16), dtype=np.uint8)
-        assert (_as_colour_and_coverage(data, data > 0, _contrast_limits(data.astype(float), data > 0))[..., 3] == 0).all()
+        assert (
+            _as_colour_and_coverage(
+                data, data > 0, _contrast_limits(data.astype(float), data > 0)
+            )[..., 3]
+            == 0
+        ).all()
 
     def test_the_unacquired_zeros_do_not_set_the_contrast(self):
         """They are most of a part-finished mosaic and they are not drawn, so letting
@@ -3196,7 +3290,9 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
 
         data = self._partial()
         acquired = data > 0
-        grey = _as_colour_and_coverage(data, acquired, _contrast_limits(data.astype(float), acquired))[..., 0][acquired]
+        grey = _as_colour_and_coverage(
+            data, acquired, _contrast_limits(data.astype(float), acquired)
+        )[..., 0][acquired]
         assert grey.mean() == pytest.approx(128, abs=25), (
             f"the acquired tiles render at a mean of {grey.mean():.0f}/255"
         )
@@ -3212,8 +3308,11 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
 
         rng = np.random.default_rng(11)
         data = (rng.random((64, 64)) * 110 + 90).astype(np.uint8)
-        rgba = _as_colour_and_coverage(data, np.ones_like(data, dtype=bool),
-                                       _contrast_limits(data.astype(float), np.ones_like(data, dtype=bool)))
+        rgba = _as_colour_and_coverage(
+            data,
+            np.ones_like(data, dtype=bool),
+            _contrast_limits(data.astype(float), np.ones_like(data, dtype=bool)),
+        )
         assert (rgba[..., 3] == 255).all()
         assert rgba[..., 0].min() == 0 and rgba[..., 0].max() == 255
 
@@ -3256,7 +3355,9 @@ class TestAnOverviewDoesNotPaintOverTheOneBeneathIt:
         assert shown.ndim == 3 and shown.shape[-1] == 4, (
             f"the canvas was handed {shown.shape}, so it composites opaquely"
         )
-        assert shown[..., 3].min() == 0, "no part of a half-finished mosaic is transparent"
+        assert shown[..., 3].min() == 0, (
+            "no part of a half-finished mosaic is transparent"
+        )
 
 
 class TestTwoRunsCannotLandOnEachOther:
@@ -3334,10 +3435,7 @@ class TestTwoRunsCannotLandOnEachOther:
         """Stamped at the run, not in the control: a box that rewrote itself on every
         acquisition would make the name unusable as a thing you set once."""
         self._capture(widget, monkeypatch, tmp_path)
-        assert (
-            widget.settings_widget.filename_edit.text()
-            == "overview-image"
-        )
+        assert widget.settings_widget.filename_edit.text() == "overview-image"
 
     def test_the_dialog_reports_where_it_will_actually_land(
         self, widget, monkeypatch, tmp_path, confirmations
@@ -3390,7 +3488,9 @@ class TestContrastActsOnEveryOverview:
         before = self._drawn(widget, key)[..., 0].astype(float).std()
         self._narrow(widget)
         after = self._drawn(widget, key)[..., 0].astype(float).std()
-        assert after > before * 1.2, f"contrast did nothing: {before:.1f} -> {after:.1f}"
+        assert after > before * 1.2, (
+            f"contrast did nothing: {before:.1f} -> {after:.1f}"
+        )
 
     def test_contrast_cannot_change_what_was_acquired(self, widget, microscope):
         """The invariant. Alpha is coverage, not brightness: run the same curve over it
@@ -3578,7 +3678,9 @@ class TestAnOverviewIsDrawnFromWhatIsHeld:
         assert np.asarray(tile.acquired).dtype == np.bool_
         assert tile.clim[0] < tile.clim[1]
 
-    def test_zooming_in_recovers_detail_it_could_not_have_held(self, widget, microscope):
+    def test_zooming_in_recovers_detail_it_could_not_have_held(
+        self, widget, microscope
+    ):
         """The payoff, stated exactly: framed whole you see the *draw* cap's worth, and
         zoomed in you see everything *held*. Under a store-time reduction the two are
         necessarily the same number, so a zoom could only magnify.
@@ -3777,11 +3879,19 @@ class TestTheOverlaysCanBeTurnedOff:
         says which part of the sample you are looking at. Hiding it would make the
         canvas harder to read rather than cleaner."""
         base = microscope.get_stage_position()
-        widget.set_positions([
-            FibsemStagePosition(name=f"L{i}", x=base.x + i * 20e-6, y=base.y,
-                                z=base.z, r=base.r, t=base.t)
-            for i in range(3)
-        ])
+        widget.set_positions(
+            [
+                FibsemStagePosition(
+                    name=f"L{i}",
+                    x=base.x + i * 20e-6,
+                    y=base.y,
+                    z=base.z,
+                    r=base.r,
+                    t=base.t,
+                )
+                for i in range(3)
+            ]
+        )
         assert len(widget.position_overlay._points) == 3
 
         widget.overlay_controls.set_visible("positions", False)
@@ -3789,7 +3899,9 @@ class TestTheOverlaysCanBeTurnedOff:
         assert widget.position_overlay._points == []
         assert len(widget.current_position_overlay._points) == 1
 
-    def test_the_grid_bar_pitch_controls_match_the_checkbox_from_the_start(self, widget):
+    def test_the_grid_bar_pitch_controls_match_the_checkbox_from_the_start(
+        self, widget
+    ):
         """They were live from construction over a lattice that was not drawn, because
         the toggle handler had never run -- so adjusting them appeared to do nothing."""
         assert widget.overlay_controls.is_visible("gridbars") is False
@@ -4010,18 +4122,26 @@ class TestItOnlyDrawsItsOwnRuns:
         from fibsem.imaging.tiling.progress import MODALITY_FLUORESCENCE
 
         widget._tiles_acquired = 0
-        widget._apply_progress({
-            "modality": MODALITY_FLUORESCENCE,
-            "counter": 7, "total": 9, "msg": "Tile Collected",
-        })
+        widget._apply_progress(
+            {
+                "modality": MODALITY_FLUORESCENCE,
+                "counter": 7,
+                "total": 9,
+                "msg": "Tile Collected",
+            }
+        )
         assert widget._tiles_acquired == 0, "a fluorescence run moved this tab's count"
 
     def test_a_beam_run_is_still_drawn(self, widget):
         widget._tiles_acquired = 0
-        widget._apply_progress({
-            "modality": "beam",
-            "counter": 7, "total": 9, "msg": "Tile Collected",
-        })
+        widget._apply_progress(
+            {
+                "modality": "beam",
+                "counter": 7,
+                "total": 9,
+                "msg": "Tile Collected",
+            }
+        )
         assert widget._tiles_acquired == 7
 
     def test_an_unlabelled_run_is_still_drawn(self, widget):


### PR DESCRIPTION
Groundwork for FIB-646, which will point the tiled overview runner at `run_auto_focus` instead of the instrument's own routine. **This PR changes no behaviour** — the runner still calls `microscope.auto_focus`. It only gives the sweep settings somewhere to live, and removes a duplicate class name on the way.

Read commit 1 (`2fbcb76f`); commit 2 is `ruff format` and can be skipped — see *Size* below.

## Two classes called `AutoFocusSettings`, one holding a single enum

```
fibsem.structures.AutoFocusSettings                mode
fibsem.autofunctions.autofocus.AutoFocusSettings   method, passes, probe_*, reduced_area
```

`AutoFocusMode` had already been through exactly this — two identical enums of one name, so `NONE is NONE` was False across the two import paths, **with no type error to catch it**. The comment recording that lesson sits a few lines above where the settings class had quietly repeated it.

The mode-only one is gone. `OverviewAcquisitionSettings` now carries the two facts side by side:

```python
autofocus_mode: AutoFocusMode = AutoFocusMode.NONE          # when to focus
autofocus_settings: AutoFocusSettings = <library default>   # how to focus
```

The sweep is the library default rather than a pinned copy of its values (50/5 then 10/1), so a later improvement to that default reaches overviews too instead of drifting from them.

## Reading files written before the split

The mode used to live *inside* `autofocus_settings`, so files on disk look like `{"autofocus_settings": {"mode": "EACH_ROW"}}`. Dropping that silently would turn a saved `EACH_TILE` run into one that never focuses — which produces a **plausible mosaic rather than an error**, so it earns a compatibility branch.

`"mode"` is the discriminator, and safely rather than luckily: the real sweep config writes `method` / `passes` / `probe_resolution` / `probe_dwell_time` / `reduced_area` / `use_autocontrast` / `channel_name` and can never produce a `mode` key. There's a test pinning that — if it ever grows one, every new file starts being read as an old one, silently.

**A third shape turned up in the wild.** Real `overview-parameters.json` files under log directories write `"autofocus_settings": null` — present-but-empty rather than absent. That's why the read is `or {}` and not `.get(..., {})`; the latter hands `None` to `"mode" in …` and raises. Found by checking actual files rather than reasoning about the format, and now covered.

## The import direction

`autofunctions.autofocus` imports `fibsem.structures` for `BeamType`, so the arrow points one way and `structures` can't import the sweep class at module scope. The default is built through a function-level import instead — the same way this module already reaches `autofunctions.gamma` and `fm.structures`. Verified working in **both** import orders, since a cycle usually only bites in one.

## Verification

`tests/test_structures.py`, `test_autofocus_mode.py`, `test_tiled.py`, `test_autofunctions.py`, `tests/ui/test_overview_widget.py` — **361 passed**.

Both compatibility branches are mutation-checked:

| mutation | result |
| -- | -- |
| remove the old-shape branch | 2 tests fail |
| weaken `or {}` to `.get(..., {})` | 1 test fails |

Also confirmed the real `overview-parameters.json` from a August 26 run loads through the new `from_dict` with the right grid, mode and sweep.

> ⚠️ `tests/ui/` doesn't run on CI — it installs `.[test]` without PyQt5. The UI test here is a one-line assertion update; the substance is in the non-UI files, which CI does run.

## Size

7 files, but the logic is **192 insertions across 7 files** and the rest is formatting. Three of these files had never been `ruff format`ed, and CI runs `ruff format --check` over every file a PR touches, so touching `test_overview_widget.py` for a one-line assertion drags in 342 lines of reformat. Isolated in its own commit so it can be reviewed by skipping it.

## Next

PR 2 points `_autofocus_if_mode` at `run_auto_focus` — the actual behaviour change, and the one wanting hardware before/after. FIB-646 records the sweep decision and what still gates it.
