### PR TITLE
[docs] The release notes document is part of the release, so name it in the process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,7 +23,12 @@ pip does not install a pre-release unless asked, so a published `rc` reaches onl
 
 ## Cutting a release candidate
 
-1. **Update the changelog** in `CHANGES.md` for the version being prepared. Do this *before* the candidate, not at final release: testers cannot know what to exercise otherwise.
+1. **Write down what shipped**, in both places. Do this *before* the candidate, not at final release: testers cannot know what to exercise otherwise.
+
+   - `CHANGES.md`, in the repository.
+   - The **release notes document in Linear**, which is the user-facing narrative and the page Early Access is pointed at. There is one document, renamed per release rather than replaced — find it with `list_documents`, and add to it rather than creating a second page.
+
+   **Re-read the Linear document against the code before you tag it.** It is written as features land, so by release day parts of it are months old and describe a state that has since changed — flags that were removed, work that has since merged, a known issue that has since been fixed. Every stale line in it is a line that ships to users. The changelog is written from `git log v<previous>..main` and does not have this problem; the document does.
 
 2. **Bump the version** in `pyproject.toml`:
    ```
@@ -61,7 +66,7 @@ For a second candidate, repeat with `rc2`.
 
 ## Cutting a release
 
-1. **Finalise the changelog** in `CHANGES.md`.
+1. **Finalise the changelog** in `CHANGES.md`, giving the version its release date, and bring the Linear release notes document in line with anything that changed since the candidate.
 
 2. **Bump the version** in `pyproject.toml`, dropping the suffix:
    ```


### PR DESCRIPTION
Step 1 said "update the changelog in `CHANGES.md`" and stopped there. The user-facing release notes are a **document in Linear** — the page Early Access is pointed at — and it is not mentioned anywhere in `RELEASE.md`.

So it drifts, and nothing catches it.

## What that cost, concretely

Preparing v0.5.2 found that document a month old and wrong in five places:

- the feature-flag table listed **three flags that no longer exist** (FIB-609 removed them)
- a **live-sample** feature was described as opt-in after its flag had been removed, so it is on for everyone
- the July Tescan hardware work was called unmerged; #559 had merged it, hardware-verified
- it claimed Tescan has no native spot burn, which `tescan.py` implements via `DrawBeam`
- it carried a known issue — multi-channel z-stack saves corrupting — that is not true

Every one of those would have shipped to users. None were caught by anything in this process, because nothing in this process looks at that page.

## The change

Step 1 of *Cutting a release candidate* now covers both artefacts, and says why the document needs re-reading in a way the changelog does not: the changelog is written from `git log v<previous>..main` at release time, so it describes the release. The document is written **as features land**, so parts of it are months old by the time it ships — being old is exactly how it goes wrong.

Step 1 of *Cutting a release* gains the same, plus setting the version's date. The entry is written at the candidate, when the release date is not yet known.
