### PR TITLE
[fix] Focus a tiled overview the way everything else focuses (FIB-646)

### DIFF
--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -10,6 +10,7 @@ from typing import List, Optional, Tuple
 import numpy as np
 
 from fibsem import acquire, conversions
+from fibsem.autofunctions.autofocus import run_auto_focus
 from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
 from fibsem.constants import DATETIME_FILE
 
@@ -185,6 +186,20 @@ class TiledAcquisitionRunner:
         image_settings = self.settings.image_settings
         self._focus_stack_settings = self.settings.focus_stack_settings
         self._af_mode = self.settings.autofocus_mode
+        self._af_settings = self.settings.autofocus_settings
+        # Once a working distance turns out not to be settable, say so once rather than
+        # per tile: on a 5 x 5 at EACH_TILE the per-tile version is 25 identical lines.
+        self._af_unavailable_logged = False
+
+        # Refused here rather than at the first tile. A sweep with every pass disabled
+        # raises inside `run_auto_focus`, and a run that dies on tile 1 of 25 has already
+        # moved the stage, made a folder and emitted progress. The fluorescence runner
+        # validates in its own `_setup_autofocus` for the same reason.
+        if self._af_mode is not AutoFocusMode.NONE and not self._af_settings.enabled:
+            raise ValueError(
+                f"Autofocus mode is {self._af_mode.value} but every sweep pass is "
+                f"disabled, so there is nothing to focus with."
+            )
 
         image_settings.autocontrast = False
         image_settings.save = True
@@ -513,13 +528,50 @@ class TiledAcquisitionRunner:
     # ── helpers ──────────────────────────────────────────────────────────
 
     def _autofocus_if_mode(self, mode: AutoFocusMode) -> None:
-        """Run autofocus and check for cancellation if the current af_mode matches."""
-        if self._af_mode is mode:
-            self.microscope.auto_focus(
-                beam_type=self._image_settings.beam_type,
-                reduced_area=self._image_settings.reduced_area,
+        """Run the configured focus sweep, if the current af_mode matches.
+
+        `run_auto_focus` rather than `microscope.auto_focus`: the vendor routine takes a
+        beam and a reduced area and nothing else, so this was the one acquisition in the
+        codebase that could be told *when* to focus but not *how* (FIB-646). It is also
+        the only autofocus path that was still vendor-specific -- `ThermoMicroscope`
+        forwards to `connection.auto_functions.run_auto_focus()`, and on Tescan and
+        Odemis that path had never been exercised for a tiled run at all.
+
+        `hfw` is the tile's own field of view, not the parameter default of 150 um. The
+        probe images have to frame what the tile frames, or the sweep scores a different
+        picture from the one being focused.
+
+        `reduced_area` comes from the sweep settings and defaults to None, which is what
+        the vendor call was passed anyway -- `_setup` clears `image_settings.reduced_area`
+        before every run, so nothing changes here yet. A centred half-frame is the thing
+        to try if tile edges turn out to drag the score around.
+        """
+        if self._af_mode is not mode:
+            return
+
+        result = run_auto_focus(
+            self.microscope,
+            beam_type=self._image_settings.beam_type,
+            hfw=self._image_settings.hfw,
+            settings=self._af_settings,
+            stop_event=self.stop_event,
+        )
+
+        # None means the backend cannot set the working distance for this beam, so the
+        # sweep declined to run rather than scoring images against a focus that never
+        # moved and reporting a WD it never applied (FIB-508, TESCAN ION). The tiles are
+        # still worth acquiring -- unfocused is not the same as wrong -- so this is a
+        # warning and not a stop. Cancellation is the case that *does* stop, and it
+        # arrives as OperationCancelledError from inside the sweep.
+        if result is None and not self._af_unavailable_logged:
+            self._af_unavailable_logged = True
+            logging.warning(
+                "Autofocus is unavailable on the %s beam for this microscope; the "
+                "overview will be acquired at the current working distance.",
+                self._image_settings.beam_type.name,
             )
-            _check_cancelled(self.stop_event)
+
+        _check_cancelled(self.stop_event)
 
     # ── future feature hooks ─────────────────────────────────────────────
 

--- a/tests/test_tiled.py
+++ b/tests/test_tiled.py
@@ -22,10 +22,13 @@ from fibsem.structures import (
 # compute_tile_grid
 # ---------------------------------------------------------------------------
 
+
 def _make_settings(nrows, ncols, hfw=100e-6, resolution=(1024, 1024), overlap=0.0):
     return OverviewAcquisitionSettings(
         image_settings=ImageSettings(resolution=resolution, hfw=hfw),
-        nrows=nrows, ncols=ncols, overlap=overlap,
+        nrows=nrows,
+        ncols=ncols,
+        overlap=overlap,
     )
 
 
@@ -66,7 +69,7 @@ def test_compute_tile_grid_dy_no_overlap():
     hfw = 100e-6
     s = _make_settings(3, 1, hfw=hfw, resolution=(1024, 1024), overlap=0.0)
     tiles = compute_tile_grid(s)
-    assert tiles[1].dy == pytest.approx(-hfw)   # row 1, one step down
+    assert tiles[1].dy == pytest.approx(-hfw)  # row 1, one step down
     assert tiles[2].dy == pytest.approx(-2 * hfw)
 
 
@@ -77,8 +80,8 @@ def test_compute_tile_grid_with_overlap():
     s = _make_settings(2, 2, hfw=hfw, overlap=overlap)
     tiles = compute_tile_grid(s)
     step = hfw * (1 - overlap)
-    assert tiles[1].dx == pytest.approx(step)    # col 1
-    assert tiles[2].dy == pytest.approx(-step)   # row 1 (index 2 in row-major for 2x2)
+    assert tiles[1].dx == pytest.approx(step)  # col 1
+    assert tiles[2].dy == pytest.approx(-step)  # row 1 (index 2 in row-major for 2x2)
 
 
 def test_compute_tile_grid_non_square_dy():
@@ -128,6 +131,7 @@ def test_compute_tile_grid_single_tile():
 # ---------------------------------------------------------------------------
 # order_tiles
 # ---------------------------------------------------------------------------
+
 
 def _grid_3x4():
     return compute_tile_grid(_make_settings(3, 4))
@@ -215,7 +219,15 @@ def test_order_tiles_spiral_same_set():
 
 def test_spiral_order_helper_3x3():
     assert _spiral_order(3, 3) == [
-        (1, 1), (1, 2), (2, 2), (2, 1), (2, 0), (1, 0), (0, 0), (0, 1), (0, 2)
+        (1, 1),
+        (1, 2),
+        (2, 2),
+        (2, 1),
+        (2, 0),
+        (1, 0),
+        (0, 0),
+        (0, 1),
+        (0, 2),
     ]
 
 
@@ -227,12 +239,17 @@ def test_spiral_order_helper_1x1():
 # plot_tile_positions
 # ---------------------------------------------------------------------------
 
+
 def test_plot_tile_positions_returns_figure():
     import matplotlib
+
     matplotlib.use("Agg")
     s = OverviewAcquisitionSettings(
         image_settings=ImageSettings(resolution=(1536, 1024), hfw=150e-6),
-        nrows=3, ncols=4, overlap=0.1, tile_order=TileOrderStrategy.SERPENTINE,
+        nrows=3,
+        ncols=4,
+        overlap=0.1,
+        tile_order=TileOrderStrategy.SERPENTINE,
     )
     tiles = order_tiles(compute_tile_grid(s), s.tile_order)
     fig = plot_tile_positions(tiles, s)
@@ -243,6 +260,7 @@ def test_plot_tile_positions_returns_figure():
 # validate_tile_stage_positions
 # ---------------------------------------------------------------------------
 
+
 def _make_limits(x_max=100e-3, y_max=100e-3):
     return {
         "x": RangeLimit(min=-x_max, max=x_max),
@@ -252,8 +270,10 @@ def _make_limits(x_max=100e-3, y_max=100e-3):
 
 def _make_pairs(positions_xy):
     """Build (TilePosition list, FibsemStagePosition list) from (x, y) tuples."""
-    tiles = [TilePosition(row=i, col=0, dx=0, dy=0, canvas_x=0, canvas_y=0)
-             for i in range(len(positions_xy))]
+    tiles = [
+        TilePosition(row=i, col=0, dx=0, dy=0, canvas_x=0, canvas_y=0)
+        for i in range(len(positions_xy))
+    ]
     stage_positions = [FibsemStagePosition(x=x, y=y) for x, y in positions_xy]
     return tiles, stage_positions
 
@@ -494,9 +514,7 @@ def test_the_grid_is_measured_from_the_centre_it_is_given(tmp_path):
     settings = _make_settings(1, 1)
     settings.image_settings.path = str(tmp_path)
     settings.image_settings.filename = "overview-image"
-    runner = TiledAcquisitionRunner(
-        microscope, settings, centre_position=elsewhere
-    )
+    runner = TiledAcquisitionRunner(microscope, settings, centre_position=elsewhere)
     runner._setup()
     runner._compute_grid()
 
@@ -616,9 +634,15 @@ def test_the_helper_asks_about_the_offsets_the_runner_projects(tmp_path, monkeyp
 def test_a_grid_within_the_travel_is_not_flagged():
     settings = _make_settings(3, 3, hfw=100e-6, resolution=(1024, 1024))
     tiles = compute_tile_grid(settings)
-    assert unreachable_tiles(
-        tiles, settings.tile_order, _identity_projection, _make_limits(150e-6, 150e-6)
-    ) == []
+    assert (
+        unreachable_tiles(
+            tiles,
+            settings.tile_order,
+            _identity_projection,
+            _make_limits(150e-6, 150e-6),
+        )
+        == []
+    )
 
 
 def test_masking_off_what_cannot_be_reached_makes_a_grid_acquirable():
@@ -641,17 +665,24 @@ def test_masking_off_what_cannot_be_reached_makes_a_grid_acquirable():
     assert sorted(flagged) == [(0, 2), (1, 2), (2, 2)]
 
     mask = [[True, True, False] for _ in range(3)]
-    assert unreachable_tiles(
-        compute_tile_grid(settings, mask=mask),
-        settings.tile_order,
-        _identity_projection,
-        limits,
-    ) == []
+    assert (
+        unreachable_tiles(
+            compute_tile_grid(settings, mask=mask),
+            settings.tile_order,
+            _identity_projection,
+            limits,
+        )
+        == []
+    )
 
 
 @pytest.mark.parametrize(
     "strategy",
-    [TileOrderStrategy.TYPEWRITER, TileOrderStrategy.SERPENTINE, TileOrderStrategy.SPIRAL],
+    [
+        TileOrderStrategy.TYPEWRITER,
+        TileOrderStrategy.SERPENTINE,
+        TileOrderStrategy.SPIRAL,
+    ],
 )
 def test_the_traversal_does_not_change_which_tiles_are_out_of_range(strategy):
     """Order decides the sequence, not the reach. Pinned because the check goes through
@@ -696,12 +727,15 @@ def test_a_grid_with_nothing_enabled_is_not_asked_about():
     "nothing is out of range" for it would be true and useless."""
     settings = _make_settings(2, 2)
     mask = [[False, False], [False, False]]
-    assert unreachable_tiles(
-        compute_tile_grid(settings, mask=mask),
-        settings.tile_order,
-        _identity_projection,
-        _make_limits(1e-9, 1e-9),
-    ) == []
+    assert (
+        unreachable_tiles(
+            compute_tile_grid(settings, mask=mask),
+            settings.tile_order,
+            _identity_projection,
+            _make_limits(1e-9, 1e-9),
+        )
+        == []
+    )
 
 
 def test_the_centring_comes_from_the_grid_it_is_given():
@@ -721,3 +755,163 @@ def test_the_centring_counts_disabled_tiles_too():
     dense = grid_centre_offset(compute_tile_grid(settings))
     mask = [[True, True, False], [True, True, False], [True, True, False]]
     assert grid_centre_offset(compute_tile_grid(settings, mask=mask)) == dense
+
+
+# ---------------------------------------------------------------------------
+# the focus sweep the runner now drives (FIB-646)
+# ---------------------------------------------------------------------------
+
+
+def _autofocus_runner(mode, settings=None, af_result="sentinel"):
+    """A runner stubbed down to the autofocus path, recording what the sweep was asked.
+
+    Real `OverviewAcquisitionSettings` again, for the reason above: the sweep is read off
+    it, and a mock would answer `settings.autofocus_settings.enabled` with another mock,
+    which is truthy -- so the guard under test would pass for the wrong reason.
+    """
+    from unittest.mock import MagicMock
+
+    from fibsem.imaging.tiled import TiledAcquisitionRunner
+    from fibsem.structures import AutoFocusMode, BeamType
+
+    s = settings if settings is not None else _make_settings(2, 2, hfw=500e-6)
+    s.autofocus_mode = mode
+
+    runner = TiledAcquisitionRunner.__new__(TiledAcquisitionRunner)
+    runner.microscope = MagicMock()
+    runner.settings = s
+    runner.stop_event = None
+    runner._af_mode = mode
+    runner._af_settings = s.autofocus_settings
+    runner._af_unavailable_logged = False
+    runner._image_settings = ImageSettings(
+        resolution=(1024, 1024), hfw=500e-6, beam_type=BeamType.ION
+    )
+
+    calls = []
+
+    def _fake_run_auto_focus(microscope, **kwargs):
+        calls.append(kwargs)
+        return af_result
+
+    return runner, calls, _fake_run_auto_focus
+
+
+def test_the_sweep_is_given_the_tiles_own_field_of_view(monkeypatch):
+    """`run_auto_focus`'s `hfw` defaults to 150 um. An overview tile is routinely 500 um
+    or wider, so taking the default would score probe images framing a different picture
+    from the one being focused -- and it would look like nothing more than soft tiles."""
+    from fibsem.structures import AutoFocusMode, BeamType
+
+    runner, calls, fake = _autofocus_runner(AutoFocusMode.EACH_TILE)
+    monkeypatch.setattr("fibsem.imaging.tiled.run_auto_focus", fake)
+
+    runner._autofocus_if_mode(AutoFocusMode.EACH_TILE)
+
+    assert len(calls) == 1
+    assert calls[0]["hfw"] == 500e-6
+    assert calls[0]["beam_type"] is BeamType.ION
+    assert calls[0]["settings"] is runner._af_settings
+
+
+def test_a_mode_that_does_not_match_does_not_focus(monkeypatch):
+    from fibsem.structures import AutoFocusMode
+
+    runner, calls, fake = _autofocus_runner(AutoFocusMode.ONCE)
+    monkeypatch.setattr("fibsem.imaging.tiled.run_auto_focus", fake)
+
+    runner._autofocus_if_mode(AutoFocusMode.EACH_TILE)
+
+    assert calls == []
+
+
+def test_the_stop_event_is_handed_to_the_sweep(monkeypatch):
+    """The vendor call could not take one, so a cancel could only land *between* tiles
+    and the column was left wherever the last focus put it. `run_auto_focus` polls
+    within the sweep and restores the starting working distance on the way out."""
+    import threading
+
+    from fibsem.structures import AutoFocusMode
+
+    runner, calls, fake = _autofocus_runner(AutoFocusMode.EACH_TILE)
+    runner.stop_event = threading.Event()
+    monkeypatch.setattr("fibsem.imaging.tiled.run_auto_focus", fake)
+
+    runner._autofocus_if_mode(AutoFocusMode.EACH_TILE)
+
+    assert calls[0]["stop_event"] is runner.stop_event
+
+
+def test_an_unavailable_focus_warns_once_and_lets_the_run_continue(monkeypatch, caplog):
+    """None means the backend cannot set the working distance, so the sweep declined
+    rather than faking a completed focus (FIB-508, TESCAN ION).
+
+    Unfocused is not the same as wrong -- the tiles are still worth having -- so this
+    warns instead of stopping. Once, not per tile: on a 5 x 5 at EACH_TILE the per-tile
+    version is 25 identical lines through the middle of the acquisition log.
+    """
+    import logging as _logging
+
+    from fibsem.structures import AutoFocusMode
+
+    runner, calls, fake = _autofocus_runner(AutoFocusMode.EACH_TILE, af_result=None)
+    monkeypatch.setattr("fibsem.imaging.tiled.run_auto_focus", fake)
+
+    with caplog.at_level(_logging.WARNING):
+        for _ in range(5):
+            runner._autofocus_if_mode(AutoFocusMode.EACH_TILE)
+
+    assert len(calls) == 5, "it should keep trying, not disable itself"
+    warnings = [r for r in caplog.records if "Autofocus is unavailable" in r.message]
+    assert len(warnings) == 1, f"warned {len(warnings)} times, expected once"
+
+
+def test_a_sweep_with_no_enabled_passes_is_refused_before_the_first_tile():
+    """`run_auto_focus` raises on an all-disabled sweep. Letting that happen at tile 1
+    of 25 means the stage has already moved, a folder exists and progress has been
+    emitted -- so it is caught in `_setup`, where nothing has happened yet."""
+    from unittest.mock import MagicMock
+
+    from fibsem.imaging.tiled import TiledAcquisitionRunner
+    from fibsem.structures import AutoFocusMode
+
+    s = _make_settings(2, 2)
+    s.autofocus_mode = AutoFocusMode.EACH_TILE
+    for p in s.autofocus_settings.passes:
+        p.enabled = False
+
+    runner = TiledAcquisitionRunner.__new__(TiledAcquisitionRunner)
+    runner.microscope = MagicMock()
+    runner.settings = s
+    with pytest.raises(ValueError, match="every sweep pass is disabled"):
+        runner._setup()
+
+
+def test_an_all_disabled_sweep_is_fine_when_autofocus_is_off(tmp_path):
+    """The guard is about a contradiction, not about the sweep in isolation. NONE plus a
+    disabled sweep is coherent -- nothing was going to focus anyway -- and refusing it
+    would make an untouched default sweep able to block a run that never wanted one.
+
+    Runs the *whole* of `_setup` rather than stopping at the guard, which is also what
+    proves the guard sits before the side effects: the refusing test above never reaches
+    the line that makes the tile folder, and this one does.
+    """
+    from unittest.mock import MagicMock
+
+    from fibsem.imaging.tiled import TiledAcquisitionRunner
+    from fibsem.structures import AutoFocusMode
+
+    s = _make_settings(2, 2)
+    s.image_settings.path = str(tmp_path)
+    s.image_settings.filename = "overview"
+    s.autofocus_mode = AutoFocusMode.NONE
+    for p in s.autofocus_settings.passes:
+        p.enabled = False
+
+    runner = TiledAcquisitionRunner.__new__(TiledAcquisitionRunner)
+    runner.microscope = MagicMock()
+    runner.settings = s
+    runner._setup()  # must not raise
+
+    assert runner._af_mode is AutoFocusMode.NONE
+    assert (tmp_path / "overview").is_dir()


### PR DESCRIPTION
Closes FIB-646. The behaviour change the previous PR ([#576](https://github.com/fibsem-os/fibsem-os/pull/576)) was groundwork for.

`TiledAcquisitionRunner` called `microscope.auto_focus(beam_type, reduced_area)` — the instrument's own routine, two arguments, nothing to configure. The beam overview was the one acquisition that could be told **when** to focus but not **how**, and the only autofocus path still vendor-specific: `ThermoMicroscope` forwards to `connection.auto_functions.run_auto_focus()`, and on Tescan and Odemis that path had never been exercised for a tiled run at all.

It now runs the same image-based sweep the image settings widget and the AutoLamella workflow tasks use.

## The default sweep

The library default — two passes, `50 µm / 5 µm` then `10 µm / 1 µm`. **22 probe frames per invocation, ~4.3 s**, so roughly +0.6 min on a 3 × 3 at `EACH_TILE` and +1.8 min on a 5 × 5. Accepted deliberately.

Worth noting it *is* narrower than a single image's sweep where it counts — the live auto-focus button searches over **1 mm**. Same frame count, one twentieth the window.

## Three behaviours the vendor call didn't have

**It can decline.** `run_auto_focus` returns `None` where the backend can't set the working distance, rather than scoring images against a focus that never moved and logging a WD it never applied (FIB-508, TESCAN ION). Warned **once per run**, and the acquisition continues — unfocused isn't the same as wrong, and per-tile this would be 25 identical lines through the middle of a 5 × 5's log.

**It can be cancelled mid-sweep, and puts the working distance back.** Previously a cancel could only land *between* tiles, leaving the column wherever the last autofocus had moved it.

**It can refuse an unrunnable configuration.** An all-disabled sweep raises. Caught in `_setup` rather than at the first tile — by then the stage has moved, a folder exists and progress has been emitted. Only when a mode is actually asking to focus: `NONE` with a disabled sweep is coherent and allowed, and refusing it would let an untouched default block a run that never wanted autofocus.

Two smaller things: `hfw` is the tile's own field of view, not the parameter default of 150 µm — probe images have to frame what the tile frames, and taking the default would show up as nothing more than soft tiles. `reduced_area` stays `None`, which is what the vendor call received anyway since `_setup` clears `image_settings.reduced_area` before every run.

## Verification

**The runner's autofocus had no test before this** — in the one place it appeared, it was stubbed out (`runner._autofocus_if_mode = lambda mode: None`). Six added, and every behaviour is mutation-checked:

| mutation | result |
| -- | -- |
| drop `hfw`, take the 150 µm default | fails |
| drop `stop_event` | fails |
| warn per-tile instead of once | fails |
| remove the disabled-passes guard | fails |
| make that guard fire when mode is `NONE` | fails |

367 passed across `test_tiled.py`, `test_structures.py`, `test_autofocus_mode.py`, `test_autofunctions.py`, `tests/ui/test_overview_widget.py`.

> ⚠️ **Focus quality and true wall-clock are not verifiable here.** The simulator's autofocus does nothing, so everything above is structure, not outcome. This wants a before/after on a real tileset against the vendor routine — FIB-646 records that as the remaining gate, and it is the reason this is a change to unattended acquisition behaviour rather than a refactor.

## Follow-ups already filed

- **FIB-813** — the live auto-focus button's sweep is still hard-coded and unadjustable, so after this the overview is tunable and the button isn't.
- **FIB-814** — why `structures.py` needs a lazy import for any of this, and why the package split isn't the fix.
