### PR TITLE
[docs] Correct a comment that promised controls FIB-646 did not deliver

### DIFF
--- a/fibsem/ui/widgets/fibsem_overview_settings_widget.py
+++ b/fibsem/ui/widgets/fibsem_overview_settings_widget.py
@@ -176,10 +176,14 @@ class FibsemOverviewSettingsWidget(QWidget):
         stack below, which is whether to acquire a stack at each tile -- either can be
         wanted without the other, and putting them in one panel said otherwise.
 
-        One row, because a mode is all the runner can currently act on: it calls the
-        instrument's own routine, which takes a beam and a reduced area and nothing
-        else. Method and sweep passes arrive with FIB-646, which connects the tiled
-        runner to `run_auto_focus` like every other autofocus caller in the codebase.
+        One row, and no longer because that is all the runner can act on. Until FIB-646
+        the runner called the instrument's own routine -- a beam, a reduced area, nothing
+        else -- so a mode was genuinely everything there was to offer. It now runs
+        `run_auto_focus` against a full sweep config: method, passes, probe frame.
+
+        None of that is exposed here, so the sweep runs at its default. Adding controls
+        for it is unbuilt rather than pending -- there is no issue tracking it, which is
+        worth knowing before assuming one exists.
         """
         self.combo_autofocus = self._field(
             ValueComboBox(


### PR DESCRIPTION
Comment-only. One file, one docstring.

`_focus_panel` in the beam overview settings widget said:

> One row, because a mode is all the runner can currently act on: it calls the instrument's own routine, which takes a beam and a reduced area and nothing else. Method and sweep passes arrive with FIB-646, which connects the tiled runner to `run_auto_focus` like every other autofocus caller in the codebase.

Both halves stopped being true when [#578](https://github.com/fibsem-os/fibsem-os/pull/578) merged:

- **The runner no longer calls the instrument's own routine.** It runs `run_auto_focus` against a full sweep config — method, passes, probe frame.
- **The controls did not arrive.** Exposing them in the Focus panel was a suggestion during planning, outside FIB-646's scope, and that issue closed without it.

So the comment named a *completed* issue to explain a control that does not exist — which sends a reader looking for work that was never done, and is worse than saying nothing.

It now states what is true and points nowhere: the config exists, the panel does not expose it, and nothing tracks that. The last part is deliberate — "unbuilt rather than pending" is the bit a reader needs, and inventing an issue to reference would just move the problem.

Every other `FIB-646` reference in the codebase was checked and is fine — they describe what happened in the past tense rather than promising anything.

Related: FIB-813 has been re-sequenced, since it was ordered "after FIB-646's PR 3" and that no longer means anything.
