### PR TITLE
[fix] Stop a tab-page key shadowing the modality carried on the wire

### DIFF
--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -2047,9 +2047,18 @@ def test_an_empty_grid_still_forbids_acquiring_after_a_lock_is_lifted(qapp):
 # ── the host side: building and retiring the tab ─────────────────────────
 
 
+# Aliased: this module already imports `MODALITY_FLUORESCENCE` from
+# `fibsem.imaging.tiling.progress` at the top, and the two are different strings for
+# different things -- 'fluorescence', the value carried on the wire, against
+# 'FLUORESCENCE', the key naming a page of the merged Overview tab. Imported bare, this
+# rebinds the module global, and `_fm()` above then stamps every report it builds with
+# the tab's key. The modality filter drops all of them and seventeen tests fail from
+# inside an early return.
 from fibsem.applications.autolamella.ui.overview_container_tab import (
-    MODALITY_FIBSEM,
-    MODALITY_FLUORESCENCE,
+    MODALITY_FIBSEM as TAB_MODALITY_FIBSEM,
+)
+from fibsem.applications.autolamella.ui.overview_container_tab import (
+    MODALITY_FLUORESCENCE as TAB_MODALITY_FLUORESCENCE,
 )
 
 
@@ -2193,7 +2202,7 @@ def test_a_microscope_without_fluorescence_greys_the_chip_and_says_why(qapp):
 
     host._refresh_overview_microscope()
 
-    chip = host.overview_tab.modality_chip(MODALITY_FLUORESCENCE)
+    chip = host.overview_tab.modality_chip(TAB_MODALITY_FLUORESCENCE)
     assert not chip.isEnabled()
     assert chip.toolTip() == "No Fluorescence Microscope Available"
     assert host.fm_overview_widget is None
@@ -2225,7 +2234,7 @@ def test_connecting_a_microscope_without_fluorescence_keeps_the_chip(qapp):
     does not move -- only the reason it gives changes, from 'connect one' to 'this system
     has none'."""
     host = _StubHost(microscope=None)
-    chip = host.overview_tab.modality_chip(MODALITY_FLUORESCENCE)
+    chip = host.overview_tab.modality_chip(TAB_MODALITY_FLUORESCENCE)
     assert not chip.isEnabled()
     assert chip.toolTip() == "Connect a microscope to use the Overview"
 
@@ -2245,7 +2254,7 @@ def test_a_microscope_with_fluorescence_brings_the_chip_back(qapp):
 
     host = _StubHost(microscope=_plain_microscope())
     host._refresh_overview_microscope()
-    chip = host.overview_tab.modality_chip(MODALITY_FLUORESCENCE)
+    chip = host.overview_tab.modality_chip(TAB_MODALITY_FLUORESCENCE)
     assert not chip.isEnabled()
 
     host.autolamella_ui.microscope = build_microscope()
@@ -2289,7 +2298,7 @@ def test_nothing_unreachable_is_ever_silent(qapp):
                 f"{label}: greyed out with nothing to say why"
             )
 
-        for modality in (MODALITY_FIBSEM, MODALITY_FLUORESCENCE):
+        for modality in (TAB_MODALITY_FIBSEM, TAB_MODALITY_FLUORESCENCE):
             chip = host.overview_tab.modality_chip(modality)
             assert chip.isVisible() or not host.overview_tab.isVisible(), (
                 f"{label}: the {modality} chip was withdrawn rather than greyed"


### PR DESCRIPTION
Seventeen tests in `tests/ui/test_fm_overview_widget.py` fail on `main` today. CI does not see it.

## The collision

The file imports `MODALITY_FLUORESCENCE` twice, from two modules, under one name:

| line | value | source |
| -- | -- | -- |
| 31 | `'fluorescence'` | `fibsem.imaging.tiling.progress` — the value a `TiledProgress` carries |
| 2052 | `'FLUORESCENCE'` | `overview_container_tab` — the key naming a page of the merged Overview tab |

The second sits **mid-file**, so it rebinds the module global. `_fm()` is defined above it but resolves the name at call time, so every report it builds is stamped with the tab's key. The widget's modality filter drops all of them and the tests fail from inside an early return — asserting on an untouched progress bar rather than on anything to do with modalities:

```
assert (0, 100) == (4, 9)
```

## Why nothing caught it

Neither side introduced this alone. The wire constant arrived with the typed tiled contract, the tab key with the Overview consolidation; each was green on its own branch and the two were never tested together.

And CI structurally cannot see it. The workflow installs `.[test]` and [deliberately not the `[ui]` extra](https://github.com/fibsem-os/fibsem-os/blob/main/.github/workflows/python-package.yml), so `pytest.importorskip("PyQt5")` skips this entire file. That is why `main` reports success at `aeff3daa` while failing 17 tests locally.

## The fix

Alias the tab constants to `TAB_MODALITY_*` rather than hoisting the import, so the two names stay visibly distinct at every use.

## Verification

Run locally with the `[ui]` extra installed, which is the only way to exercise this file:

| | before | after |
| -- | -- | -- |
| `tests/ui/test_fm_overview_widget.py` | 17 failed, 245 passed | **262 passed** |

`ruff check` and `ruff format --check` both clean.

Note that this PR's own CI cannot demonstrate the fix, for the same reason the bug landed — the file is skipped there.