### PR TITLE
[test] Stop two tests/ui files asserting about the environment instead of the code

### DIFF
--- a/tests/ui/test_coincidence_viewer_layering.py
+++ b/tests/ui/test_coincidence_viewer_layering.py
@@ -14,6 +14,7 @@ Driven through the real widget rather than a stub: the raise has to happen after
 result is recorded and the finished signal is emitted, and only the real method has
 that order in it.
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -56,7 +57,28 @@ def viewer_widget(qapp, tmp_path):
     )
 
 
-def test_the_viewer_restacks_itself_when_a_run_ends(viewer_widget, monkeypatch):
+@pytest.fixture()
+def no_other_window_is_active(monkeypatch):
+    """Pin ``QApplication.activeWindow`` to nothing for the duration of a test.
+
+    ``_restack_after_run`` declines to raise when another of the app's windows is
+    active, so a test that asserts anything about the raise is really asserting about
+    whichever window the process happens to have left active. Run alone that is
+    nothing and the tests pass; run as part of ``tests/ui/`` it is some earlier test's
+    widget, the guard fires, and the two tests below failed while passing in isolation
+    (FIB-793). The third passed either way -- and would have kept passing had the raise
+    grown an ``activateWindow`` call, because the guard returned before reaching it.
+
+    Pinning is the lever ``test_it_leaves_alone_a_window_the_operator_moved_to``
+    already uses to turn the guard *on*. These use it to turn the guard off, so what
+    they assert is the production code rather than the state of the window stack.
+    """
+    monkeypatch.setattr(QApplication, "activeWindow", staticmethod(lambda: None))
+
+
+def test_the_viewer_restacks_itself_when_a_run_ends(
+    viewer_widget, monkeypatch, no_other_window_is_active
+):
     calls = []
     monkeypatch.setattr(
         type(viewer_widget), "raise_", lambda self: calls.append(self), raising=False
@@ -71,7 +93,7 @@ def test_the_viewer_restacks_itself_when_a_run_ends(viewer_widget, monkeypatch):
 
 
 def test_the_raise_comes_after_the_run_is_recorded_and_announced(
-    viewer_widget, monkeypatch
+    viewer_widget, monkeypatch, no_other_window_is_active
 ):
     """Ordering, not just the call: the main window reacts to both the recording and
     the finished signal, so a raise that ran before them could be undone by what they
@@ -92,7 +114,9 @@ def test_the_raise_comes_after_the_run_is_recorded_and_announced(
     assert order == ["record", "finished", "raise"], f"unexpected order: {order}"
 
 
-def test_the_viewer_does_not_take_focus(viewer_widget, monkeypatch):
+def test_the_viewer_does_not_take_focus(
+    viewer_widget, monkeypatch, no_other_window_is_active
+):
     """raise_() restacks inside the application; activateWindow() would take keyboard
     focus and pull the app in front of the microscope software. Only the first is
     wanted -- the complaint being fixed is a window stealing the front."""
@@ -125,9 +149,7 @@ def test_it_leaves_alone_a_window_the_operator_moved_to(viewer_widget, monkeypat
     monkeypatch.setattr(
         type(viewer_widget), "raise_", lambda self: calls.append(self), raising=False
     )
-    monkeypatch.setattr(
-        QApplication, "activeWindow", staticmethod(lambda: elsewhere)
-    )
+    monkeypatch.setattr(QApplication, "activeWindow", staticmethod(lambda: elsewhere))
 
     viewer_widget._finalize_milling_ui()
 

--- a/tests/ui/test_elided_label.py
+++ b/tests/ui/test_elided_label.py
@@ -6,6 +6,7 @@ label built empty and filled later would have painted itself blank -- latent, si
 callers all passed the text to the constructor and never set it again. The surviving
 class is the overview's, whose behaviour these pin, plus the other's paint-time elide.
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -81,7 +82,18 @@ class TestTheContract:
             label.repaint()
 
         assert label.text() == LONG
-        assert drawn(label).startswith("Overview acquisition")
+        painted = drawn(label)
+        # Not a fixed prefix: how much fits in 200px is the platform's font, not this
+        # widget's contract. macOS fits "Overview acquisition"; the Linux CI runner
+        # elides a character earlier, to "Overview acquisiti…", and the test failed
+        # there for a difference it was never about. What it is about is that the label
+        # paints the text it was given after construction rather than the empty string
+        # it was built with, so assert that: something was painted, and it is the start
+        # of the new text.
+        assert painted, "painted nothing: the label kept its empty constructor text"
+        assert LONG.startswith(painted.rstrip("…")), (
+            f"painted something that is not the start of the new text: {painted!r}"
+        )
 
     def test_none_is_not_the_string_none(self, shown):
         label = shown(LONG)


### PR DESCRIPTION
Two tests under `tests/ui/` assert about the environment they happen to run in rather
than about the code. Both block the companion PR that starts running this directory on
CI, so they are fixed here first — the new job should be green on the day it is added,
not red for reasons unrelated to it.

### The window stack

Three tests in `tests/ui/test_coincidence_viewer_layering.py` assert about
`_restack_after_run`, which declines to raise when another of the app's windows is
active. None of them pinned `QApplication.activeWindow`, so what they actually
asserted was whichever window the process happened to have left active.

Run alone that is nothing and they pass. Run as part of `tests/ui/` it is some earlier
test's widget — the directory accumulates around 150 live top-level widgets over a run
— the guard fires, and two of the three fail from inside an early return:

- `test_the_viewer_restacks_itself_when_a_run_ends`
- `test_the_raise_comes_after_the_run_is_recorded_and_announced`

The third, `test_the_viewer_does_not_take_focus`, passed either way, which is worse
rather than better. It asserts that `activateWindow` is *not* called, and the guard
returned before reaching the line that would have called it — so it would have kept
passing had the production code grown exactly the call it exists to forbid.

All three now take a fixture that pins `activeWindow` to nothing. That is the lever
`test_it_leaves_alone_a_window_the_operator_moved_to` already uses to turn the guard
on; these use it to turn the guard off, so what they assert is the production code
rather than the state of the window stack.

The widget leak itself is untouched, and its tracking issue is deliberately not
referenced here so that merging this does not close it.

### The platform font

`test_a_label_built_empty_keeps_what_it_is_given_later` asserted that a 200px-wide
label paints text starting with `"Overview acquisition"`. How many characters fit in
200px is the platform's font, not the widget's contract: macOS fits that word, the
Linux runner elides one character earlier to `"Overview acquisiti…"`.

What the test is about is in its name — a label built empty must paint what it is
given afterwards, rather than the empty string it was constructed with, which is what
the class that did not override `setText` used to do. It now asserts that: something
was painted, and what was painted is the start of the new text.

This one was found by running `tests/ui/` on Linux for the first time, on the
companion PR. It had never failed anywhere, because nothing had ever run it off macOS.

No production code changes in either.

### Verification

Full `tests/ui/`, `QT_QPA_PLATFORM=offscreen`:

| | macOS / py3.11 | ubuntu-latest / py3.11 |
|---|---|---|
| before | 2267 passed, **2 failed** | 2277 passed, **3 failed** |
| after | 2269 passed, 0 failed | pending — the job that runs it arrives in the companion PR |

(The Linux column is from the companion PR's first CI run. It collects a few more
tests than macOS does.)
