### PR TITLE
[ci] Run the UI test suite on one job that installs the [ui] extra

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,8 +39,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        # UI deps (the [ui] extra) are intentionally not installed: the
-        # napari/PyQt5 tests importorskip and are skipped on CI.
+        # UI deps (the [ui] extra) are intentionally not installed *here*. Not
+        # because the tests that need them do not matter -- the `ui-tests` job
+        # below runs every one of them -- but because installing napari adds 100
+        # packages and 116 MB to a job that runs eight times, and registers three
+        # pytest plugins (napari, napari-plugin-engine, npe2) into the session,
+        # one of them an autouse fixture that would run around all 2000-odd tests
+        # here to serve none of them.
         python -m pip install ".[test]"
     - name: Install the plugin entry point fixture
       # A packaged plugin is the only way into two of the three extension
@@ -56,6 +61,65 @@ jobs:
         # leave the build green -- the exact silent breakage they exist to catch.
         FIBSEM_REQUIRE_PLUGIN_FIXTURE: "1"
       run: pytest tests/ -n auto --dist worksteal --timeout=300
+
+  ui-tests:
+    # The one job that installs the [ui] extra, and the only place the 2270 tests
+    # under tests/ui/ are ever run.
+    #
+    # Every file there opens with `pytest.importorskip("PyQt5")`. The matrix job
+    # above installs `.[test]` without it, so all 103 files skip silently and its
+    # green says nothing whatsoever about that directory. That is not theoretical:
+    # main reported success while tests/ui/test_fm_overview_widget.py failed 17
+    # tests locally, because two pull requests that were each green alone bound the
+    # same name to two different constants (#581). Only a run with PyQt5 installed
+    # could have caught it, and this is that run.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        # One version, not the matrix. What this job answers -- does the UI code
+        # import, and does it behave -- does not vary across Python versions, so
+        # running it six times would repeat the same answer. 3.11 rather than the
+        # ends of the range because the `ui` extra resolves differently at both:
+        # 3.8 gets napari 0.4.x, a different codebase to the 0.5.x everyone
+        # develops against.
+        python-version: "3.11"
+        cache: 'pip'
+    - name: Install the libraries Qt's offscreen platform plugin links against
+      # libqoffscreen.so needs libGL, libX11, libXext, libfontconfig, libfreetype
+      # and libglib (read off the wheel's ELF DT_NEEDED entries). All but libGL are
+      # already on the runner image. Note it does NOT need the xcb/xkbcommon stack
+      # that the normal `xcb` platform pulls in -- that is the point of running
+      # offscreen rather than under a virtual display.
+      #
+      # If one of the others ever goes missing the failure is loud and immediate:
+      # Qt refuses to load the platform plugin, names the library, and every test
+      # errors at QApplication construction. There is no version of this that
+      # passes while broken.
+      run: sudo apt-get update && sudo apt-get install -y libgl1 libegl1
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ".[test,ui]"
+    - name: Fail if the UI extra did not actually install
+      # A green job that skipped everything is the exact failure mode this job
+      # exists to end. Because every file guards on importorskip, a broken install
+      # does not turn the run red -- it empties it, and empty reads as passing.
+      # So check the imports directly, where absence is an error.
+      run: python -c "import PyQt5, napari, qtawesome"
+    - name: Test with pytest
+      env:
+        QT_QPA_PLATFORM: offscreen
+      # Deliberately serial, unlike the matrix job above. These tests share one
+      # QApplication and leak top-level widgets across files, so some of them
+      # depend on what the files before them left behind. `-n auto --dist
+      # worksteal` would shuffle that order differently on every run and turn a
+      # deterministic failure into a flake; `--dist loadfile` does not help either,
+      # since it only holds order *within* a file. Three minutes is a fair price
+      # for a result that means the same thing twice in a row.
+      run: pytest tests/ui/ -q --timeout=300
 
   lint:
     # Its own job, not a step inside the matrix above: ruff's result does not


### PR DESCRIPTION
CI has never once run `tests/ui/`. Every file there opens with
`pytest.importorskip("PyQt5")`, the workflow installs `.[test]` without the `ui`
extra, and so all 103 files — 2270 tests — skip. A green build says nothing about any
of them.

That is not a theoretical hole. `main` reported success while
`tests/ui/test_fm_overview_widget.py` was failing 17 tests locally: two pull requests
that were each green in isolation bound `MODALITY_FLUORESCENCE` to two different
constants, and the conflict only existed once both had landed (#581). Restoring the
pre-fix file and running it under this job's command reproduces it exactly — **17
failed, 245 passed, in 33 seconds**.

### Why the old comment does not survive contact

It gave its own consequence as its reason: *"the napari/PyQt5 tests importorskip and
are skipped on CI."* The real argument is cost, and it holds for the matrix and not
for one job. Resolved for cp312/manylinux and diffed against `.[test]`, the `ui` extra
adds **100 packages and 116 MB** — 61 MB of that is `pyqt5-qt5`, and napari pulls
Sphinx, ipykernel, jedi, debugpy and qtconsole in behind `napari-console`. Installing
that eight times to serve one directory would be absurd. Installing it once is three
minutes.

There is a second reason to keep it off the matrix: installing napari registers three
pytest plugins into whatever session finds them — `napari`, `napari-plugin-engine`,
`npe2` — one of which is an autouse fixture that would then run around all 2000-odd
tests in the matrix job to serve none of them.

### Shape of the job

- **One Python version.** Whether the UI code imports and behaves does not vary across
  the matrix. 3.11 rather than an end of the range, because the extra resolves
  differently at both — on 3.8 the pin admits napari 0.4.x, a different codebase to
  the 0.5.x this is developed against.
- **Serial, not `-n auto`.** These tests share a `QApplication` and leak top-level
  widgets across files, so a few depend on what ran before them. `worksteal` would
  reshuffle that on every run and convert a deterministic failure into a flake;
  `--dist loadfile` does not help, since it only holds order *within* a file.
- **An explicit import check before pytest.** The failure mode being closed here is a
  green run that tested nothing, and since every file guards on `importorskip`, a
  broken install would empty the run rather than fail it.
- **No xcb libraries.** Read off the `DT_NEEDED` entries of the Linux `pyqt5-qt5`
  wheel, `libqoffscreen.so` needs `libGL`, `libX11`, `libXext`, `libfontconfig`,
  `libfreetype` and `libglib`; all but `libGL` are already on the runner image. The
  xcb/xkbcommon stack is only needed under a virtual display, which this does not use.

No test constructs a real `napari.Viewer` — the six files that would need one already
borrow handlers onto stubs, because a Viewer segfaults offscreen (exit 139). That is
why offscreen works at all here.

### Verification

Full `tests/ui/` locally on macOS, Python 3.11, `QT_QPA_PLATFORM=offscreen`: **2269
passed, 1 skipped in 190s**, zero segfaults.

The runner's system libraries were the one thing I could not verify locally, having no
Linux host. **The first CI run on this PR settles it**: Qt's offscreen plugin loaded,
and the job ran the whole directory in 3m24s —

```
3 failed, 2277 passed, 1 skipped in 204.69s
```

`libgl1` and `libegl1` are enough; nothing else was missing. (Linux also collects a
few more tests than macOS does.)

### The three failures, and what they tell us

Two are the order-dependent layering tests, already known and fixed in #583.

The third had never failed anywhere: `test_elided_label.py` asserted that a 200px
label paints a fixed 20-character prefix, which is the platform's font rather than the
widget's contract — macOS fits `"Overview acquisition"`, the runner elides one
character earlier. Nothing had ever run that file off macOS. Also fixed in #583.

Neither is a production bug, and that is rather the point: the first run of a suite CI
has never executed found three tests making claims about their environment. That is
the cheap end of what this job is for.

### Merge order

#583 landed first, this was rebased onto it, and the job is now green on the merge
commit:

```
ui-tests    pass    5m14s
2280 passed, 1 skipped in 250.09s (0:04:10)
```

Worth making this a required check once it has run on main a few times.
