### PR TITLE
[ui] Remove the old napari Minimap tab and the flag that hid it

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -13,10 +13,8 @@ try:
 except Exception:
     pass
 
-import warnings
 from datetime import datetime
 
-import napari
 import numpy as np
 from PyQt5.QtCore import QSize, Qt, QTimer, pyqtSignal
 from PyQt5.QtGui import QIcon, QKeySequence, QPainter, QPixmap
@@ -100,7 +98,6 @@ from fibsem.milling.progress import (
 )
 from fibsem.structures import BeamType
 from fibsem.ui import notification_service
-from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
 from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.qt.gc import install_main_thread_gc
@@ -131,14 +128,6 @@ from fibsem.ui.widgets.notifications import NotificationBell, ToastManager
 from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpdate
 from fibsem.utils import format_duration
 from fibsem.versioning import get_version_string
-
-# Suppress a specific upstream Napari/NumPy warning from shapes miter computation.
-warnings.filterwarnings(
-    "ignore",
-    message=r"'where' used without 'out', expect unit?ialized memory in output\. If this is intentional, use out=None\.",
-    category=UserWarning,
-    module=r"napari\.layers\.shapes\._shapes_utils",
-)
 
 # How wide the experiment name button in the tab corner is allowed to grow. Wide
 # enough that a default name -- "AutoLamella-" plus a date stamp -- is never elided;
@@ -427,7 +416,12 @@ def _absorbed_note(estimate: Optional[AdditionEstimate]) -> str:
 
 
 class AutoLamellaSingleWindowUI(QMainWindow):
-    """Main window for AutoLamella UI with embedded napari viewers."""
+    """Main window for AutoLamella UI.
+
+    No napari viewer of its own any more: every tab here renders on the matplotlib
+    canvas. napari survives in this application only in labelling and segmentation,
+    which open windows of their own (FIB-407).
+    """
 
     # Whether a workflow currently permits the overview tabs to work. Held rather than
     # applied where it arrives, because each tab's interactivity is derived from this
@@ -461,10 +455,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         _frame_layout.addWidget(self.tab_widget)
         self.setCentralWidget(self._border_frame)
 
-        self.viewers: list[napari.Viewer] = []
         self.autolamella_ui: AutoLamellaUI
-        self.minimap_widget: FibsemMinimapWidget
-        self.minimap_viewer: napari.Viewer
 
         # Toast notification manager
         self.toast_manager = ToastManager(self)
@@ -576,22 +567,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.action_show_minimap.setCheckable(True)
         self.action_show_minimap.setChecked(False)
         self.action_show_minimap.triggered.connect(self._on_toggle_minimap_widget)
-        # Hidden pending rework of the minimap widget itself.
+        # `MinimapPlotWidget` -- a matplotlib window, and nothing to do with the napari
+        # Minimap tab that used to sit beside the Overview one. That tab is gone; this
+        # stays, hidden pending a rework of the plot widget itself.
         self.action_show_minimap.setVisible(False)
-
-        layer_controls_menu = view_menu.addMenu("Show Layer Controls")
-
-        self.action_layer_controls_overview = QAction("Overview", self)
-        self.action_layer_controls_overview.setCheckable(True)
-        self.action_layer_controls_overview.setChecked(True)
-        self.action_layer_controls_overview.triggered.connect(
-            lambda checked: self._on_toggle_viewer_layer_controls(checked, "overview")
-        )
-
-        # Overview is the only entry left: the Lamella Editor and now the Microscope tab
-        # both render on the matplotlib canvas and have no napari layer docks to show.
-        # The submenu goes entirely when the minimap migrates (FIB-405).
-        layer_controls_menu.addAction(self.action_layer_controls_overview)
 
         view_menu.addAction(self.action_show_minimap)
 
@@ -997,10 +976,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.action_report_issue.setVisible(
             self._preferences.features.bug_report_enabled
         )
-        # Show or hide the old napari Minimap tab. The Overview tab is not here: it
-        # ships to everyone, and which of its modalities can be reached follows the
-        # instrument rather than a flag.
-        self._apply_napari_overview_visibility()
+        # Which of the grid-workflow surfaces are shown follows its flag. The Overview
+        # tab is not here: it ships to everyone, and which of its modalities can be
+        # reached follows the instrument rather than a flag.
         self._apply_grid_workflow_visibility()
         # Toggle Tools -> Scripts. Hiding the menu hides the whole feature: it is the
         # only route to the manager dialog, and the dialog is the only thing that runs
@@ -1284,24 +1262,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             logging.info("F11 autofocus: only SEM/FIB supported")
             return
         image_widget.run_autofocus()
-
-    def _on_toggle_viewer_layer_controls(self, checked: bool, viewer_key: str):
-        """Toggle the layer list and layer controls for a specific viewer.
-
-        getattr, not attribute access: tabs move off napari one at a time, so a tab that
-        has already migrated never sets its viewer attribute. A dict literal would
-        dereference all three eagerly and raise AttributeError for *every* entry, not
-        just the migrated one — and an exception escaping a Qt slot aborts the process
-        under PyQt5 (FIB-329).
-        """
-        viewer_map = {
-            "overview": getattr(self, "minimap_viewer", None),
-        }
-        viewer = viewer_map.get(viewer_key)
-        if viewer is not None:
-            qt_viewer = viewer.window._qt_viewer
-            qt_viewer.dockLayerList.setVisible(checked)
-            qt_viewer.dockLayerControls.setVisible(checked)
 
     def _on_generate_report(self):
         """Handle Generate Report action."""
@@ -1762,7 +1722,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.stop_workflow_btn.show()
         if message and self.status_bar is not None:
             self.status_bar.showMessage(message)
-        self._set_minimap_workflow_enabled(False)
+        self._set_overviews_allowed(False)
         # A run owns the loader: no manual exchange from the Grids tab meanwhile.
         if getattr(self, "grids_tab", None) is not None:
             self.grids_tab.set_controls_enabled(False)
@@ -1781,13 +1741,13 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.stop_workflow_btn.hide()
         self.supervised_status_btn.hide()
         self.run_workflow_btn.show()
-        self._set_minimap_workflow_enabled(True)
+        self._set_overviews_allowed(True)
         # The timeline stays on screen after a run, but there is no longer a
         # queue behind it — offering to reorder one would be a lie.
         if hasattr(self, "workflow_timeline"):
             self.workflow_timeline.set_actions_enabled(False)
 
-    def _set_minimap_workflow_enabled(self, enabled: bool):
+    def _set_overviews_allowed(self, enabled: bool):
         """Record whether a workflow currently permits the overviews to work.
 
         A running workflow owns the instrument, so neither tab should be able to start
@@ -1798,9 +1758,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         The answer is recorded rather than applied: `_apply_overview_locks` is what
         reaches the tabs, because it is not the only fact that decides.
         """
-        if hasattr(self, "minimap_widget"):
-            self.minimap_widget.pushButton_run_tile_collection.setEnabled(enabled)
-            self.minimap_widget.pushButton_load_image.setEnabled(enabled)
         self._overviews_allowed = bool(enabled)
         self._apply_overview_locks()
 
@@ -2147,31 +2104,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             return ProgressUpdate(finished=True, message=message)
         return ProgressUpdate.done()
 
-    def _on_tile_acquisition_finished(self, result: dict) -> None:
-        self.progress_widget.reset()
-        tiles = result.get("tiles", 0)
-        total = result.get("total", 0)
-        elapsed = result.get("elapsed", 0.0)
-        cancelled = result.get("cancelled", False)
-        error: Exception | None = result.get("error", None)
-
-        tile_info = f"{tiles}/{total} tiles" if total else ""
-        elapsed_info = f" in {format_duration(elapsed)}" if elapsed else ""
-
-        if error is not None:
-            if cancelled:
-                self.show_toast(
-                    f"Tile acquisition cancelled. {tile_info} collected.", "warning"
-                )
-            else:
-                self.show_toast(
-                    f"Tile acquisition failed. {tile_info} collected. {error}", "error"
-                )
-        else:
-            self.show_toast(
-                f"Tile acquisition complete. {tile_info}{elapsed_info}.", "success"
-            )
-
     def _on_tab_changed(self, index: int):
         """Handle tab change and update status bar."""
         self.status_bar.setStyleSheet(STATUS_BAR_STYLESHEET)
@@ -2184,7 +2116,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         layout.setContentsMargins(0, 0, 0, 0)
 
         # Viewer-less: the quad-view controller is the display, so no napari viewer is
-        # created here. (The minimap keeps its own until FIB-405.)
+        # created here.
         self.main_viewer = None
 
         # Create the AutoLamellaUI widget
@@ -2240,8 +2172,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # The F5/Esc (View) and F2/F6/F9/F11 (Imaging) shortcuts are defined on QActions —
         # one source of truth for the menu item and its keybinding. Adding those actions to
         # the Microscope-tab container makes their WidgetWithChildrenShortcut scope resolve
-        # against this tab, so the keys only fire when focus is inside it (not the minimap,
-        # editor or workflow tabs).
+        # against this tab, so the keys only fire when focus is inside it (not the
+        # overview, editor or workflow tabs).
         for action in (
             self.action_toggle_fullscreen,
             self.action_exit_fullscreen,
@@ -2252,7 +2184,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
     def create_tabs(self):
         """Create the tabs for the AutoLamella UI."""
         self._create_main_tab()
-        self.add_minimap_tab()
         self.add_overview_tab()
         self.add_protocol_editor_tab()
         self.add_lamella_editor_tab()
@@ -2271,7 +2202,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if self.autolamella_ui.experiment is None:
             return
 
-        self.minimap_widget.set_experiment()
         self.fm_overview_tab.refresh_experiment()
         self.beam_overview_tab.refresh_experiment()
         self.task_widget.set_experiment(self.autolamella_ui.experiment)
@@ -2843,13 +2773,11 @@ class AutoLamellaSingleWindowUI(QMainWindow):
                 self._syncing_selection = True
                 try:
                     self.autolamella_ui.lamella_list.select(lamella.name)
-                    if hasattr(self, "minimap_widget"):
-                        self.minimap_widget.lamella_list.select(lamella.name)
                 finally:
                     self._syncing_selection = False
 
     def _on_experiment_lamella_selected(self, lamella):
-        """Sync card container and minimap when experiment-tab list selection changes."""
+        """Sync card container and overviews when experiment-tab list selection changes."""
         self.fm_overview_tab.set_selected(lamella)
         self.beam_overview_tab.set_selected(lamella)
         if getattr(self, "_syncing_selection", False) or lamella is None:
@@ -2859,22 +2787,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self._syncing_selection = True
         try:
             self.lamella_card_container.select_lamella(lamella.name)
-            if hasattr(self, "minimap_widget"):
-                self.minimap_widget.lamella_list.select(lamella.name)
-        finally:
-            self._syncing_selection = False
-
-    def _on_minimap_lamella_selected(self, lamella):
-        """Sync experiment list and card container when minimap list selection changes."""
-        self.fm_overview_tab.set_selected(lamella)
-        self.beam_overview_tab.set_selected(lamella)
-        if getattr(self, "_syncing_selection", False) or lamella is None:
-            return
-        self._syncing_selection = True
-        try:
-            self.autolamella_ui.lamella_list.select(lamella.name)
-            if hasattr(self, "lamella_card_container"):
-                self.lamella_card_container.select_lamella(lamella.name)
         finally:
             self._syncing_selection = False
 
@@ -3599,55 +3511,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.status_bar.setStyleSheet(STATUS_BAR_STYLESHEET)
         self._set_border_state("idle")
 
-    def add_minimap_tab(self):
-        """Add the minimap as a separate tab with its own viewer."""
-        container = QWidget()
-        layout = QVBoxLayout(container)
-        layout.setContentsMargins(0, 0, 0, 0)
-
-        # Create separate napari viewer for minimap
-        self.minimap_viewer = napari.Viewer(show=False, title="AutoLamella Minimap")
-        self.minimap_viewer.window._qt_window.menuBar().hide()
-        self.minimap_viewer.window._qt_window.statusBar().hide()
-        self.viewers.append(self.minimap_viewer)
-
-        # Create the minimap widget
-        self.minimap_widget = FibsemMinimapWidget(
-            viewer=self.minimap_viewer, parent=self.autolamella_ui
-        )
-        self.minimap_widget.setMinimumWidth(500)
-        self.minimap_widget._acquisition_finished.connect(
-            self._on_tile_acquisition_finished
-        )
-        self.minimap_widget.lamella_list.lamella_selected.connect(
-            self._on_minimap_lamella_selected
-        )
-
-        # Layout: napari viewer (left) | minimap controls (right) via splitter
-        splitter = QSplitter(Qt.Horizontal)
-        splitter.setChildrenCollapsible(False)
-
-        splitter.addWidget(self.minimap_viewer.window._qt_window)
-        splitter.addWidget(self.minimap_widget)
-
-        splitter.setSizes([700, 500])
-        layout.addWidget(splitter)
-        # "Minimap", not "Overview" any more: the canvas Overview tab replaced this one
-        # and took the name. Two tabs both called Overview would leave a user guessing
-        # which is which for exactly as long as this tab survives, and the internal name
-        # for it has always been the minimap (`add_minimap_tab`, `FibsemMinimapWidget`).
-        self.tab_widget.insertTab(
-            1, container, fibsem_icon("mdi:map", color=GRAY_ICON_COLOR), "Minimap"
-        )
-        # Kept on the window so `_apply_napari_overview_visibility` can find the tab. It
-        # goes with the tab (FIB-405).
-        self._minimap_tab_container = container
-
-        # disable the tab by default
-        self.tab_widget.setTabEnabled(self.tab_widget.indexOf(container), False)
-        self._apply_napari_overview_visibility()
-        self._apply_grid_workflow_visibility()
-
     def add_overview_tab(self):
         """Reserve the Overview tab: both modalities, one tab.
 
@@ -3699,33 +3562,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # Emits availability either way, which is what puts the reason on the tab.
         self._refresh_overview_microscope()
 
-    def _apply_napari_overview_visibility(self) -> None:
-        """Show or hide the old napari Minimap tab.
-
-        `features.napari_overview_tab`, off by default and on its way out: the canvas
-        Overview replaced this tab, and the flag is what brings the old one back for
-        anyone who needs it for the one release before it goes. Both it and this method
-        go with the tab before the full release (FIB-405, FIB-413).
-
-        Visibility only, unlike the flag it replaced. The overview host tabs are built
-        and dropped because their widgets subscribe to the microscope for their lifetime;
-        this one owns a `napari.Viewer` that cannot be rebuilt safely mid-session, and it
-        is the tab that is going away rather than the one being staged in, so hidden is
-        the whole of what off has to mean.
-
-        Read straight off `self._preferences` rather than through a module-level
-        `FEATURE_*` global. FIB-609 removed five of those and kept the one whose caller
-        is a widget constructor with no preferences to hand; this one is a method on the
-        window that owns them, so a global would only be a second copy to keep in step.
-        """
-        container = getattr(self, "_minimap_tab_container", None)
-        if container is None:
-            return
-        self.tab_widget.setTabVisible(
-            self.tab_widget.indexOf(container),
-            self._preferences.features.napari_overview_tab,
-        )
-
     def _on_overview_availability(self, available: bool) -> None:
         """Enable the tab when either modality has something to drive, and say why not.
 
@@ -3765,7 +3601,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
     def _on_beam_overview_lamella_selected(self, lamella):
         """Sync the other lists when the rebuilt Overview tab's list changes.
 
-        The same shape as `_on_minimap_lamella_selected`, minus the call back into the
+        The same shape as its fluorescence twin below, minus the call back into the
         tab that raised it -- that list already shows the selection.
         """
         self.fm_overview_tab.set_selected(lamella)
@@ -3776,15 +3612,13 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.autolamella_ui.lamella_list.select(lamella.name)
             if hasattr(self, "lamella_card_container"):
                 self.lamella_card_container.select_lamella(lamella.name)
-            if hasattr(self, "minimap_widget"):
-                self.minimap_widget.lamella_list.select(lamella.name)
         finally:
             self._syncing_selection = False
 
     def _on_fm_overview_lamella_selected(self, lamella):
         """Sync the other lists when the FM overview's list selection changes.
 
-        The same shape as `_on_minimap_lamella_selected`, minus the call back into the
+        The same shape as its beam-side twin above, minus the call back into the
         FM tab: it raised this, and it has already highlighted what was clicked.
         """
         if getattr(self, "_syncing_selection", False) or lamella is None:
@@ -3825,7 +3659,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.show_toast(message, notification_type, temporary=temporary)
 
     def closeEvent(self, event):
-        """Clean up viewers on close."""
+        """Flush what is still pending, then let the application go."""
         # The editor holds edits for a moment before writing them (FIB-683); this is
         # the last chance to get the final one onto disk.
         if getattr(self, "lamella_widget", None) is not None:
@@ -3850,11 +3684,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             )
         except RuntimeError:
             pass
-        for viewer in self.viewers:
-            try:
-                viewer.close()
-            except Exception:
-                pass
         super().closeEvent(event)
         # Force the event loop to exit even if another top-level window (e.g. a stray
         # matplotlib pyplot figure) would otherwise keep the app alive once this window

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -56,7 +56,6 @@ from fibsem.ui import (
     stylesheets,
 )
 from fibsem.ui import utils as fui
-from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
 from fibsem.ui.FibsemSampleWidget import FibsemSampleWidget
 from fibsem.ui.fm.widgets import FMImageViewerWidget
 from fibsem.ui.qt.threading import FunctionWorker
@@ -434,15 +433,26 @@ class AutoLamellaUI(QMainWindow):
         self.update_ui()
 
     @property
-    def minimap_widget(self) -> Optional[FibsemMinimapWidget]:
-        if self.parent_widget is None:
-            return None
-        return self.parent_widget.minimap_widget
+    def _overview_is_acquiring(self) -> bool:
+        """Whether either overview modality is mid-tileset.
+
+        Asked of the Overview tab rather than of a widget held here: the tab owns both
+        modalities and rebuilds its widgets on every reconnection, so anything holding
+        one of them directly would be answering for a widget that had been replaced.
+
+        This used to ask the napari minimap, which means it stopped being true the
+        moment the Overview tab took over acquisition -- a run from there did not
+        suppress anything.
+        """
+        tab = getattr(self.parent_widget, "overview_tab", None)
+        return tab is not None and tab.is_acquiring
 
     @ensure_main_thread
     def _on_stage_position_updated(self, stage_position: FibsemStagePosition) -> None:
         """Callback for when the stage position is updated."""
-        if self.minimap_widget is not None and self.minimap_widget.is_acquiring:
+        if self._overview_is_acquiring:
+            # Mid-tileset the stage moves once per tile, and refreshing the readout on
+            # each is churn nobody reads.
             return
         if self.movement_widget is not None:
             # pass the position from the signal; re-querying the microscope here races

--- a/fibsem/applications/autolamella/ui/overview_container_tab.py
+++ b/fibsem/applications/autolamella/ui/overview_container_tab.py
@@ -67,11 +67,10 @@ UI did not actually make.
 # No flag on either modality
 
 This tab ships to everyone, and so do both of its chips. `features.overview_canvas_tab`
-gated the beam side while the canvas overview sat beside the napari one; it is retired
-here rather than carried, because there is nothing left for it to gate -- the canvas
-overview *is* the Overview tab now. What survives is `features.napari_overview_tab`,
-pointing at the old tab instead: off by default, it brings the Minimap tab back for
-anyone who needs it, and goes with that tab before the full release.
+gated the beam side while the canvas overview sat beside the napari one; it was retired
+rather than carried, because there was nothing left for it to gate -- the canvas
+overview *is* the Overview tab now. `features.napari_overview_tab` replaced it,
+pointing at the old Minimap tab instead, and has gone with that tab.
 
 A modality is therefore unavailable only when there is no hardware behind it, which is
 the FM tab's existing capability check and nothing new.

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -408,24 +408,6 @@ class FeatureFlags:
     # when a microscope connects. Nothing can move hardware through it until the
     # control/hardware scopes are armed, which no configuration file can do.
     agent_server_enabled: bool = False
-    # The old napari Minimap tab, beside the Overview tab that replaced it. **Off**: the
-    # canvas Overview ships to everyone and holds both modalities (FIB-780), so the old
-    # tab is not what anyone should land on -- it is here to be turned back on by anyone
-    # who finds something the new tab cannot do yet, for the one release before it goes.
-    #
-    # This hides the tab; it does not stop it being built. The widget owns a
-    # `napari.Viewer` that cannot be rebuilt safely mid-session, so it is constructed
-    # either way -- see `_apply_napari_overview_visibility`. Off means "not in the tab
-    # bar", not "not paid for".
-    #
-    # It replaces `overview_canvas_tab`, retired rather than flipped: that flag gated the
-    # *new* tab, and a flag that changes which tab it points at while keeping its name is
-    # a flag nobody can reason about from a preferences file. A new name also gets the
-    # new default on every install, including the ones with a saved preferences file --
-    # a changed default alone reaches only fresh ones.
-    #
-    # Deleted with the tab itself before the full release (FIB-405, FIB-413).
-    napari_overview_tab: bool = False
     # The connection chip in the tab-corner header, and the experiment buttons
     # waiting for a microscope alongside it. Off while the Connection tab is still
     # how people connect: this is the header half of FIB-775, landing ahead of the
@@ -434,7 +416,7 @@ class FeatureFlags:
     # The dialog it opens is NOT gated -- File -> Connect to Microscope reaches it
     # either way, which is how it gets exercised while this is off.
     #
-    # A staging flag like `napari_overview_tab`, and it goes the same way: deleted
+    # A staging flag, and it goes the same way `napari_overview_tab` did: deleted
     # when the chip replaces the tab, not kept as a preference.
     connection_chip: bool = False
     # The grid screening workflow (FIB-892): the Grids tab and the Workflow tab's

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -56,13 +56,6 @@ _TIP_BUG_REPORT = (
     "Show the 'Report an Issue...' option in the Help menu, for reporting bugs and "
     "optionally submitting experiment data privately to the maintainers."
 )
-_LBL_NAPARI_OVERVIEW = "Show the old Minimap Tab"
-_TIP_NAPARI_OVERVIEW = (
-    "Bring back the previous napari-based overview, beside the Overview tab that "
-    "replaced it. The Overview tab places tiles where they were acquired rather than "
-    "stitching them first, and holds both the FIB/SEM and fluorescence overviews. This "
-    "is here for anyone still relying on the old tab, and is removed in the next release."
-)
 _LBL_CONNECTION_CHIP = "Enable Connection Chip"
 _TIP_CONNECTION_CHIP = (
     "Show the connected instrument in the tab bar, beside the experiment, and add "
@@ -189,14 +182,11 @@ class PreferencesDialog(QDialog):
         self._chk_bug_report.setToolTip(_TIP_BUG_REPORT)
         self._chk_scripts = QCheckBox()
         self._chk_scripts.setToolTip(_TIP_SCRIPTS)
-        self._chk_napari_overview = QCheckBox()
-        self._chk_napari_overview.setToolTip(_TIP_NAPARI_OVERVIEW)
         self._chk_connection_chip = QCheckBox()
         self._chk_connection_chip.setToolTip(_TIP_CONNECTION_CHIP)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
         features_form.addRow(_LBL_SCRIPTS, self._chk_scripts)
-        features_form.addRow(_LBL_NAPARI_OVERVIEW, self._chk_napari_overview)
         features_form.addRow(_LBL_CONNECTION_CHIP, self._chk_connection_chip)
         self._chk_grid_workflow = QCheckBox()
         self._chk_grid_workflow.setToolTip(_TIP_GRID_WORKFLOW)
@@ -295,7 +285,6 @@ class PreferencesDialog(QDialog):
         self._chk_bug_report.setChecked(f.bug_report_enabled)
         self._chk_scripts.setChecked(f.scripts_enabled)
         self._chk_agent_server.setChecked(f.agent_server_enabled)
-        self._chk_napari_overview.setChecked(f.napari_overview_tab)
         self._chk_connection_chip.setChecked(f.connection_chip)
         self._chk_grid_workflow.setChecked(f.grid_workflow)
 
@@ -370,7 +359,6 @@ class PreferencesDialog(QDialog):
                 bug_report_enabled=self._chk_bug_report.isChecked(),
                 scripts_enabled=self._chk_scripts.isChecked(),
                 agent_server_enabled=self._chk_agent_server.isChecked(),
-                napari_overview_tab=self._chk_napari_overview.isChecked(),
                 connection_chip=self._chk_connection_chip.isChecked(),
                 grid_workflow=self._chk_grid_workflow.isChecked(),
             ),

--- a/tests/ui/test_agent_config_editor_refresh.py
+++ b/tests/ui/test_agent_config_editor_refresh.py
@@ -30,12 +30,7 @@ TASK = "Rough Milling"
 def window(qapp):
     from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
 
-    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
-    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
-    try:
-        win = module.AutoLamellaSingleWindowUI()
-    finally:
-        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    win = module.AutoLamellaSingleWindowUI()
     win.autolamella_ui.system_widget.connect_to_microscope()
     win._set_border_state("idle")
     yield win

--- a/tests/ui/test_agent_supervisor_chrome.py
+++ b/tests/ui/test_agent_supervisor_chrome.py
@@ -30,12 +30,7 @@ from fibsem.structures import MicroscopeState
 def main_ui(qapp):
     from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
 
-    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
-    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
-    try:
-        window = module.AutoLamellaSingleWindowUI()
-    finally:
-        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    window = module.AutoLamellaSingleWindowUI()
     window.autolamella_ui.system_widget.connect_to_microscope()
     yield window
     if window.autolamella_ui.microscope is not None:

--- a/tests/ui/test_agent_watchdog.py
+++ b/tests/ui/test_agent_watchdog.py
@@ -29,12 +29,7 @@ from fibsem.structures import MicroscopeState
 def main_ui(qapp):
     from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
 
-    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
-    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
-    try:
-        window = module.AutoLamellaSingleWindowUI()
-    finally:
-        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    window = module.AutoLamellaSingleWindowUI()
     window.autolamella_ui.system_widget.connect_to_microscope()
     yield window
     if window.autolamella_ui.microscope is not None:

--- a/tests/ui/test_create_desktop_shortcut.py
+++ b/tests/ui/test_create_desktop_shortcut.py
@@ -24,12 +24,7 @@ from PyQt5.QtWidgets import QFileDialog, QMessageBox
 def main_ui(qapp):
     from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
 
-    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
-    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
-    try:
-        window = module.AutoLamellaSingleWindowUI()
-    finally:
-        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    window = module.AutoLamellaSingleWindowUI()
     yield window
     # closeEvent ends in app.quit(); on the shared test QApplication that latches
     # and breaks later QEventLoop.exec_() calls — run close with quit stubbed.

--- a/tests/ui/test_edit_alignment_area.py
+++ b/tests/ui/test_edit_alignment_area.py
@@ -35,12 +35,7 @@ def ui(qapp):
     """The embedded AutoLamellaUI of a real main window, connected (Demo)."""
     from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
 
-    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
-    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
-    try:
-        window = module.AutoLamellaSingleWindowUI()
-    finally:
-        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    window = module.AutoLamellaSingleWindowUI()
     window.autolamella_ui.system_widget.connect_to_microscope()
     # What _on_run_workflow_clicked does before any prompt can arrive: the main
     # window's _on_workflow_update reads _border_state unconditionally, and it is

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -2115,7 +2115,7 @@ class _StubHost:
     # The builder wires both pages' lists, so the beam handler is reached here too even
     # though nothing in this file clicks it.
     _on_beam_overview_lamella_selected = _Real._on_beam_overview_lamella_selected
-    _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
+    _set_overviews_allowed = _Real._set_overviews_allowed
     _apply_overview_locks = _Real._apply_overview_locks
     _overview_may_work = _Real._overview_may_work
     _overviews_allowed = _Real._overviews_allowed
@@ -2404,10 +2404,10 @@ def test_a_workflow_lock_reaches_the_fm_tab(qapp):
     host = _StubHost(microscope=build_microscope())
     host._build_fm_overview_widget()
 
-    host._set_minimap_workflow_enabled(False)
+    host._set_overviews_allowed(False)
     assert not host.fm_overview_widget.button_acquire.isEnabled()
 
-    host._set_minimap_workflow_enabled(True)
+    host._set_overviews_allowed(True)
     assert host.fm_overview_widget.button_acquire.isEnabled()
 
     host._teardown_fm_overview_widget()
@@ -2418,7 +2418,7 @@ def test_the_workflow_lock_survives_there_being_no_fm_tab(qapp):
     host = _StubHost(microscope=_plain_microscope())
     host._build_fm_overview_widget()
 
-    host._set_minimap_workflow_enabled(False)  # must not raise
+    host._set_overviews_allowed(False)  # must not raise
 
 
 def test_everything_tolerates_the_tab_being_dead(qapp):
@@ -2432,7 +2432,7 @@ def test_everything_tolerates_the_tab_being_dead(qapp):
 
     host._build_fm_overview_widget()  # must not raise
     host._update_fm_overview_experiment()  # must not raise
-    host._set_minimap_workflow_enabled(False)  # must not raise
+    host._set_overviews_allowed(False)  # must not raise
     host._refresh_overview_microscope()  # must not raise
 
     assert getattr(host, "fm_overview_widget", None) is None

--- a/tests/ui/test_grid_protocol_widget.py
+++ b/tests/ui/test_grid_protocol_widget.py
@@ -221,12 +221,7 @@ def test_the_header_line_and_the_details_dialog(qapp, experiment):
 def main_ui(qapp):
     from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
 
-    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
-    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
-    try:
-        window = module.AutoLamellaSingleWindowUI()
-    finally:
-        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    window = module.AutoLamellaSingleWindowUI()
     yield window
     if window.autolamella_ui.microscope is not None:
         window.autolamella_ui.microscope.disconnect()

--- a/tests/ui/test_grid_workflow_widget.py
+++ b/tests/ui/test_grid_workflow_widget.py
@@ -203,12 +203,7 @@ def test_the_preflight_says_what_a_run_does(qapp):
 def main_ui(qapp):
     from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
 
-    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
-    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
-    try:
-        window = module.AutoLamellaSingleWindowUI()
-    finally:
-        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    window = module.AutoLamellaSingleWindowUI()
     yield window
     if window.autolamella_ui.microscope is not None:
         window.autolamella_ui.microscope.disconnect()

--- a/tests/ui/test_grids_tab.py
+++ b/tests/ui/test_grids_tab.py
@@ -258,12 +258,7 @@ def test_on_a_fixed_holder_there_is_nothing_to_load(qapp, experiment):
 def main_ui(qapp):
     from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
 
-    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
-    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
-    try:
-        window = module.AutoLamellaSingleWindowUI()
-    finally:
-        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    window = module.AutoLamellaSingleWindowUI()
     yield window
     if window.autolamella_ui.microscope is not None:
         window.autolamella_ui.microscope.disconnect()

--- a/tests/ui/test_mainui_workflow_status.py
+++ b/tests/ui/test_mainui_workflow_status.py
@@ -9,11 +9,10 @@ lifecycle tests now hold the same observable behaviour on the new channel, plus
 that the dict channel ignores a straggling status key.
 
 This is the first test to construct the real main window offscreen. The only
-thing that ever prevented it is `add_minimap_tab`, which builds a `napari.Viewer`
-whose vispy canvas calls `glGetIntegerv` with no GL context and takes the process
-down with SIGSEGV — so the fixture stubs that one method out. Nothing here goes
-near the minimap; every other tab is real. When the minimap tab is deleted
-(#585/#586) the stub can go.
+thing that ever prevented it was the napari Minimap tab, whose vispy canvas called
+`glGetIntegerv` with no GL context and took the process down with SIGSEGV; the
+fixture used to stub that one method out. The tab is gone (#585/#586), so every
+tab here is real.
 
 Latent init gap, found by these tests and now fixed: `_border_state` used to be
 first assigned on the Run-workflow click, never in `__init__`, and every workflow
@@ -42,12 +41,7 @@ from fibsem.imaging.spot import SpotBurnProgress, SpotBurnStatus
 def main_ui(qapp):
     from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
 
-    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
-    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
-    try:
-        window = module.AutoLamellaSingleWindowUI()
-    finally:
-        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    window = module.AutoLamellaSingleWindowUI()
     # First connect builds the protocol editor's full UI (its lock path runs on
     # every lifecycle report); Demo, so no hardware.
     window.autolamella_ui.system_widget.connect_to_microscope()

--- a/tests/ui/test_overview_tab_host.py
+++ b/tests/ui/test_overview_tab_host.py
@@ -503,7 +503,7 @@ def locked_pair(tab, fm_tab):
         _overviews_allowed = _Real._overviews_allowed
         _apply_overview_locks = _Real._apply_overview_locks
         _overview_may_work = _Real._overview_may_work
-        _set_minimap_workflow_enabled = _Real._set_minimap_workflow_enabled
+        _set_overviews_allowed = _Real._set_overviews_allowed
 
         def __init__(self, beam, fluorescence):
             self.beam_overview_tab = beam
@@ -577,10 +577,10 @@ class TestOneOverviewDoesNotDriveTheStageWhileTheOtherAcquires:
         own half of the truth is how a control gets stuck on: the workflow says "you may
         work again" while a tileset is still walking the grid."""
         host, beam, fluorescence = locked_pair
-        host._set_minimap_workflow_enabled(False)
+        host._set_overviews_allowed(False)
         fluorescence.overview._set_running(True)
         try:
-            host._set_minimap_workflow_enabled(True)
+            host._set_overviews_allowed(True)
             assert beam.overview._may_move() is False, (
                 "the workflow finishing unlocked a tab the other run still owns"
             )

--- a/tests/ui/test_overview_tab_wiring.py
+++ b/tests/ui/test_overview_tab_wiring.py
@@ -242,19 +242,6 @@ def test_every_selection_handler_reaches_the_new_tab(methods_calling):
     assert not missing, f"the new tab is not synced from: {sorted(missing)}"
 
 
-def test_the_napari_tab_is_behind_the_flag(window_source):
-    """The flag points at the *old* tab now. The Overview tab ships to everyone.
-
-    Read from the window's own preferences, not from a module-level `FEATURE_*` global.
-    FIB-609 removed five of those; the one it kept exists because its caller is a widget
-    constructor with no preferences to hand, which is not the case here.
-    """
-    assert "self._preferences.features.napari_overview_tab" in window_source
-    assert "FEATURE_NAPARI_OVERVIEW_TAB_ENABLED" not in window_source, (
-        "the flag went back to a module global; read the preference directly"
-    )
-
-
 def test_the_retired_flag_is_gone_everywhere(window_source):
     """`overview_canvas_tab` was retired rather than flipped.
 
@@ -290,42 +277,45 @@ def test_the_overview_tab_is_not_behind_any_flag(window_source):
     )
 
 
-def test_the_flag_exists_and_is_off_by_default():
-    """Off by default: the Overview tab is what a user lands on, and this flag is what
-    brings the superseded napari tab back for the one release before it is removed.
+def test_the_napari_tab_and_its_flag_are_gone(window_source):
+    """The Minimap tab was the fallback while the Overview tab earned its place; it has
+    now been removed, and `features.napari_overview_tab` with it.
 
-    Asserted rather than left to the dataclass because the default is the whole of what
-    this flag does for almost everyone -- nobody opens Preferences to leave a checkbox
-    where it already was."""
-    import fibsem.config as fibsem_cfg
+    Flag and tab together, in one test, because either alone is a defect: a flag with
+    nothing to gate is a checkbox that does nothing, and a tab still built with no flag
+    to hide it would come back for everyone.
 
-    assert fibsem_cfg.FeatureFlags().napari_overview_tab is False
-
-
-def test_the_flag_survives_a_preferences_round_trip(tmp_path):
-    """A flag that does not persist cannot be turned on by the person who wants it back.
-
-    Through `to_dict`/`from_dict`: saving and reloading is what the preferences dialog
-    actually does, and it is the step that would silently drop an unknown field.
+    `_sub_from_dict` drops unknown keys, so a saved preferences file still carrying
+    `napari_overview_tab: true` loads without complaint -- checked here rather than
+    assumed, because the failure would be at every startup for exactly the users who had
+    turned it on.
     """
     import fibsem.config as fibsem_cfg
 
-    prefs = fibsem_cfg.UserPreferences()
-    prefs.features.napari_overview_tab = False
-    reloaded = fibsem_cfg.UserPreferences.from_dict(prefs.to_dict())
-    assert reloaded.features.napari_overview_tab is False
+    assert not hasattr(fibsem_cfg.FeatureFlags(), "napari_overview_tab")
+    for gone in (
+        "add_minimap_tab",
+        "FibsemMinimapWidget",
+        "napari_overview_tab",
+        '"Minimap"',
+    ):
+        assert gone not in window_source, f"{gone} survived the tab removal"
+    # Read from disk rather than imported: this is one of the few CI runs *without*
+    # PyQt5, and importing the dialog would take the module down at collection.
+    assert "napari_overview" not in PREFERENCES_DIALOG.read_text(encoding="utf-8")
+
+    stale = {"features": {"napari_overview_tab": True}}
+    assert fibsem_cfg.UserPreferences.from_dict(stale) is not None
 
 
-def test_the_napari_tab_is_still_built(window_source):
-    """This change merges two tabs; it does not remove the third. The old tab is what a
-    user falls back to, and removing it is its own change (FIB-405).
+def test_the_window_no_longer_imports_napari(window_source):
+    """The tab was the window's only use of it.
 
-    It is renamed, though: "Minimap", because the canvas tab took the name "Overview" and
-    two tabs called Overview would leave a user guessing which is which.
+    Worth pinning: napari stays installed for labelling and segmentation, so an import
+    creeping back here would cost nothing visible and would quietly re-couple the main
+    window to it (FIB-407).
     """
-    assert "self.add_minimap_tab()" in window_source
-    assert "FibsemMinimapWidget(" in window_source
-    assert '"Minimap"' in window_source
+    assert "import napari" not in window_source
 
 
 def test_the_done_state_in_the_status_bar_clears_itself(window_source):

--- a/tests/ui/test_pick_poi.py
+++ b/tests/ui/test_pick_poi.py
@@ -33,12 +33,7 @@ def window(qapp):
     """A real main window, connected (Demo), minimap stubbed."""
     from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
 
-    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
-    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
-    try:
-        win = module.AutoLamellaSingleWindowUI()
-    finally:
-        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    win = module.AutoLamellaSingleWindowUI()
     win.autolamella_ui.system_widget.connect_to_microscope()
     # The main window's _on_workflow_update reads _border_state unconditionally,
     # and it is first assigned on the Run click (the latent init gap

--- a/tests/ui/test_run_spot_burn_question.py
+++ b/tests/ui/test_run_spot_burn_question.py
@@ -61,12 +61,7 @@ def ui(qapp):
 
     original_run = sbw.run_spot_burn
     sbw.run_spot_burn = fake_run_spot_burn
-    original_minimap = module.AutoLamellaSingleWindowUI.add_minimap_tab
-    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
-    try:
-        window = module.AutoLamellaSingleWindowUI()
-    finally:
-        module.AutoLamellaSingleWindowUI.add_minimap_tab = original_minimap
+    window = module.AutoLamellaSingleWindowUI()
     window.autolamella_ui.system_widget.connect_to_microscope()
     # The main window's _on_workflow_update reads _border_state unconditionally,
     # first assigned on the Run click (the latent init gap documented in

--- a/tests/ui/test_sample_control_tab.py
+++ b/tests/ui/test_sample_control_tab.py
@@ -9,12 +9,7 @@ pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is delibe
 def main_ui(qapp):
     from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
 
-    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
-    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
-    try:
-        window = module.AutoLamellaSingleWindowUI()
-    finally:
-        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    window = module.AutoLamellaSingleWindowUI()
     yield window
     if window.autolamella_ui.microscope is not None:
         window.autolamella_ui.microscope.disconnect()


### PR DESCRIPTION
> [!IMPORTANT]
> **Held, not ready to merge.** Waiting on user testing of the new Overview tab before the
> old Minimap tab is taken away. Draft until that comes back.

**PR 1 of 2.** The widget itself is deleted in the PR stacked on top of this one; this is
the one visible change.

The canvas Overview tab replaced the Minimap tab in #573, and `features.napari_overview_tab`
has defaulted **off** ever since — so on a default install this tab has been built on every
launch, hidden, and paid for. #582 took the standalone app off the same widget; this is the
other host.

## What goes

- `add_minimap_tab`, `_apply_napari_overview_visibility`, `_minimap_tab_container`, and the
  `napari.Viewer` the tab owned — with it `self.viewers`, the `closeEvent` loop over them,
  `import napari`, and the napari shapes-miter warnings filter. **The main window no longer
  imports napari at all.**
- `features.napari_overview_tab`, its preferences row, label and tooltip. Deleted rather
  than deprecated: `_sub_from_dict` drops unknown keys, so a saved `user-preferences.yaml`
  still carrying `napari_overview_tab: true` loads without complaint. Same precedent as
  `toasts_enabled`. Asserted in the test rather than assumed — the failure would be at every
  startup, for exactly the users who had turned it on.
- **Show Layer Controls**, the whole View submenu. Its `viewer_map` had one entry and it was
  the minimap's; with no napari viewer left in this window there are no layer docks to show.
- `_on_tile_acquisition_finished` — wired only to the minimap's own signal, and
  `FibsemOverviewWidget._on_finished` already raises the same three outcomes.
- `_on_minimap_lamella_selected`, and the minimap branch of the three surviving
  selection-sync handlers.

## Three controls go with it, unreplaced

Everything else the minimap offered has an Overview-tab equivalent — Run/Cancel, grid bars,
stage limits, grid boundaries, saved positions, load-from-file. These three do not, and are
being dropped rather than ported: **Display Pattern** (milling patterns reprojected onto the
overview), **correlation mode** (superseded in practice by the dedicated correlation UI and
the FM Overview tab), and **Show TEM Stage Limits**. Each is filed against the Overview tab
so the capability question stays on record rather than disappearing.

## Two things that are not what they look like

**`action_show_minimap` stays.** It toggles `MinimapPlotWidget` — a matplotlib window with no
napari in it and nothing to do with this tab. Two unrelated things share the word "minimap"
here, and this is the trap in the diff.

**`_set_minimap_workflow_enabled` is renamed, not deleted.** Only its minimap half goes; the
`_overviews_allowed` half is what actually locks the overview tabs during a run. Now
`_set_overviews_allowed`.

## One latent bug fixed on the way

`AutoLamellaUI._on_stage_position_updated` skipped the movement-widget refresh while
`minimap_widget.is_acquiring` — which stopped being true the moment the Overview tab took
over acquisition, so a run from there refreshed the readout once per tile. It now asks
`overview_tab.is_acquiring`, which covers both modalities and survives the widget rebuild on
reconnection.

## Verified

With the minimap gone, **`AutoLamellaSingleWindowUI` constructs under
`QT_QPA_PLATFORM=offscreen` for the first time** — the napari viewer was what prevented it.
So this was checked by driving the window, not by reading source:

- tab bar is Microscope / Overview / Protocol / Lamella / Workflow;
- View menu has no Show Layer Controls and still has Show Minimap Widget;
- Preferences → Features has no Minimap row;
- against a real two-lamella experiment, selecting from the experiment list, the beam
  overview and the FM overview each still syncs the other two — every list parked on the
  *other* lamella first, so a pass means propagation rather than a no-op;
- `set_workflow_running` / `hide_workflow_running` still toggle `_overviews_allowed`.

`pytest tests/ui/` → **2268 passed, 0 failed**, after rebasing onto current `main`.

An earlier revision of this note said two `test_coincidence_viewer_layering` tests failed as
a known pre-existing leak (FIB-793). That is no longer true — #583 fixed them, and this
branch now sits on top of it. Rebased for a second reason too: #584 added a `ui-tests` job
that installs the `[ui]` extra and actually runs `tests/ui/`, so this PR's UI changes are
covered by CI rather than skipped.

napari is still in the import graph via `fibsem/ui/napari/patterns.py`, which the matplotlib
canvas imports for its napari-free geometry. That is the extraction FIB-407 §1 tracks, not
this change.

Completes FIB-405's remaining phase; part of FIB-407 §5c.

---

**Rebased 2026-09-03** onto `main` after 276 commits. Nine conflict hunks, all of the shape "the PR deleted it, `main` added a neighbour" (the agent-server flag beside the napari one, the grid-loader lock lines beside `_set_overviews_allowed`, the sample-widget import beside the minimap one). One addition beyond the resolution: thirteen test fixtures had grown a hand-rolled stub of `add_minimap_tab` to keep the napari viewer out of offscreen window construction — with the method gone the stub raised, so those stubs are removed here (−60 lines of scaffolding), and the one docstring that said "when the minimap tab is deleted the stub can go" now says it went. The startup call to `_apply_grid_workflow_visibility()` that `main` had placed at the end of `add_minimap_tab` is not lost: `create_tabs` makes it separately, and the Grids tab shows up in an app run on this tree.
