### PR TITLE
[test] Destroy the top-level widgets tests/ui builds, in the two files that build most

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,3 +65,41 @@ def qapp():
         gc.collect()
         if gc_was_enabled:
             gc.enable()
+
+
+@pytest.fixture
+def destroy_widgets_after_test(qapp):
+    """Destroy every top-level widget the test creates, once it is over.
+
+    ``close()`` is not destruction -- it hides. A test that builds a window, closes it
+    in teardown and drops its reference leaves the window alive for the rest of the
+    session, because the Qt object outlives the Python wrapper and nothing has asked
+    for it to go. ``tests/ui/`` reaches 2541 live top-level widgets in a full run this
+    way, and the files that leak most are the ones that *do* call ``close()``.
+
+    That matters less for memory than for what the next test sees.
+    ``QApplication.activeWindow()`` is process-global, so an abandoned window is still
+    a candidate answer to it -- which is how three tests in
+    test_coincidence_viewer_layering.py came to assert about the window stack rather
+    than about the code (#583).
+
+    Two things are needed and neither is obvious. ``deleteLater()`` posts a
+    ``DeferredDelete`` event rather than deleting anything, and ``processEvents()``
+    does **not** deliver that event -- only ``sendPostedEvents`` with the type named
+    explicitly does. Using ``processEvents`` here measures as a complete no-op: the
+    widget count does not move, which reads as "the fix does not work" rather than as
+    "the deletion never ran".
+
+    Only widgets that appear during the test are touched, so a module-scoped fixture's
+    widget built by an earlier test is left alone.
+    """
+    from PyQt5.QtCore import QEvent
+    from PyQt5.QtWidgets import QApplication
+
+    before = set(QApplication.topLevelWidgets())
+    yield
+    for widget in QApplication.topLevelWidgets():
+        if widget not in before:
+            widget.close()
+            widget.deleteLater()
+    QApplication.sendPostedEvents(None, QEvent.DeferredDelete)

--- a/tests/ui/test_overview_container_tab.py
+++ b/tests/ui/test_overview_container_tab.py
@@ -36,6 +36,11 @@ def qapp():
     yield app
 
 
+@pytest.fixture(autouse=True)
+def _destroy_widgets(destroy_widgets_after_test):
+    """The tabs below are built inline in each test and never torn down."""
+
+
 def _ui(microscope=None, experiment=None):
     return type("_UI", (), {"microscope": microscope, "experiment": experiment})()
 

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -103,11 +103,20 @@ def microscope():
     return scope
 
 
+@pytest.fixture(autouse=True)
+def _destroy_widgets(destroy_widgets_after_test):
+    """Autouse because the leak is not confined to the `widget` fixture below: each
+    test leaves around nine live top-levels, most of them frames and buttons built
+    without a parent, and this file alone accounted for 2000 of the 2519 that
+    `tests/ui/` reached in a full run."""
+
+
 @pytest.fixture
 def widget(microscope):
     w = FibsemOverviewWidget(microscope)
     w.resize(900, 700)
     yield w
+    # close() only hides; _destroy_widgets above is what disposes of it.
     w.close()
 
 


### PR DESCRIPTION
A full `tests/ui/` run reaches **2541 live top-level Qt widgets**. That costs almost
nothing in memory — 68 of them survive a forced collect — but `QApplication` is
process-global, so an abandoned window is still a candidate answer to
`QApplication.activeWindow()`. That is how three tests in
`test_coincidence_viewer_layering.py` came to assert about the window stack instead of
the code (#583), and it is what lets a test pass alone and fail in a full run with
nothing wrong in the production code.

Two files are 92% of it: `test_overview_widget.py` leaves 2000 behind across its 211
tests, `test_overview_container_tab.py` 328 across 18. Both now take a shared
`destroy_widgets_after_test` fixture that disposes of whatever top-levels a test
created.

### Measured over the whole directory

| | before | after |
|---|---|---|
| peak live top-level widgets | 2541 | **525** |
| tests | 2280 passed, 1 skipped | 2280 passed, 1 skipped |
| wall clock | 195s | 190s |

### Two traps, both written into the fixture's docstring

**`close()` does not destroy a widget, it hides one.** The file that leaked most
already called `close()` in its teardown — which is precisely why nobody noticed. The
cleanup was there and did nothing.

**`deleteLater()` posts a `DeferredDelete` event, and `processEvents()` does not
deliver it.** Only `sendPostedEvents` with the type named explicitly does. My first
attempt used `processEvents` and measured as a perfect no-op: the widget count did not
move by one, which reads as "the fix does not work" rather than "the deletion never
ran". Anyone adding teardown to a UI test will hit both of these.

### On the per-file numbers

They need care. Attributing leaks from a plain run charges each file for garbage that
*earlier* files left uncollected, because the shared `qapp` fixture disables the
collector for the length of a module. On that basis I had two other files on the
target list at +496 and +262; re-measured with a collect forced at every teardown, one
of them leaks **nothing** and the other 28. The figures above come from the forced-
collect run.

### Not done here

The remaining ~500 — a long tail of five or six files at roughly 100 each. None has
the ratio these two did, so this stops where the return does.
