### PR TITLE
[style] Format the files the spot burn progress work touches (FIB-824)

### DIFF
--- a/fibsem/imaging/spot.py
+++ b/fibsem/imaging/spot.py
@@ -26,7 +26,7 @@ class SpotBurnSettings:
 
     coordinates: List[Point] = field(default_factory=list)
     milling_current: float = 60e-12  # amperes
-    exposure_time: float = 10.0      # seconds
+    exposure_time: float = 10.0  # seconds
 
     def to_dict(self) -> dict:
         return {
@@ -44,10 +44,12 @@ class SpotBurnSettings:
         )
 
 
-def run_spot_burn(microscope: FibsemMicroscope,
-                  settings: SpotBurnSettings,
-                  beam_type: BeamType = BeamType.ION,
-                  stop_event: Optional[threading.Event] = None) -> None:
+def run_spot_burn(
+    microscope: FibsemMicroscope,
+    settings: SpotBurnSettings,
+    beam_type: BeamType = BeamType.ION,
+    stop_event: Optional[threading.Event] = None,
+) -> None:
     """Run a spot burn job on the microscope. Exposes the coordinates in *settings* for
     the exposure time at the milling current it specifies.
 

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -83,7 +83,9 @@ class FibsemSpotBurnWidget(QWidget):
 
         # coordinate editor (shared canvas overlay + list)
         self.coord_editor = SpotBurnCoordinatesWidget(
-            controller=self._view_controller(), beam=BeamType.ION, parent=self,
+            controller=self._view_controller(),
+            beam=BeamType.ION,
+            parent=self,
         )
         layout.addWidget(self.coord_editor)
 
@@ -91,10 +93,16 @@ class FibsemSpotBurnWidget(QWidget):
         beam_currents = self.microscope.get_available_values("current", BeamType.ION)
         closest = min(beam_currents, key=lambda x: abs(x - DEFAULT_BEAM_CURRENT))
         self.comboBox_beam_current = ValueComboBox(
-            items=beam_currents, value=closest, unit="A", decimals=1,
+            items=beam_currents,
+            value=closest,
+            unit="A",
+            decimals=1,
         )
         self.doubleSpinBox_exposure_time = ValueSpinBox(
-            suffix="s", minimum=0.1, maximum=60, decimals=3,
+            suffix="s",
+            minimum=0.1,
+            maximum=60,
+            decimals=3,
         )
         self.doubleSpinBox_exposure_time.setValue(10)
         form = QFormLayout()
@@ -134,7 +142,9 @@ class FibsemSpotBurnWidget(QWidget):
 
         # run button
         self.pushButton_run_spot_burn.clicked.connect(self.run_spot_burn_worker)
-        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.pushButton_run_spot_burn.setStyleSheet(
+            stylesheets.PRIMARY_BUTTON_STYLESHEET
+        )
         self.pushButton_run_spot_burn.setEnabled(False)
 
         # the workflow task drives the burn via start_spot_burn_signal (mirrors milling).
@@ -142,7 +152,8 @@ class FibsemSpotBurnWidget(QWidget):
         # so the burn is then either in progress (is_burning=True) or was refused (no
         # in-bounds points), in which case the task re-prompts.
         self.start_spot_burn_signal.connect(
-            self.run_spot_burn_worker, Qt.BlockingQueuedConnection  # type: ignore
+            self.run_spot_burn_worker,
+            Qt.BlockingQueuedConnection,  # type: ignore
         )
 
         # coordinate signal
@@ -225,7 +236,9 @@ class FibsemSpotBurnWidget(QWidget):
         would fire ``_update_progress_bar`` on a deleted object.
         """
         try:
-            self.microscope.spot_burn_progress_signal.disconnect(self._update_progress_bar)
+            self.microscope.spot_burn_progress_signal.disconnect(
+                self._update_progress_bar
+            )
         except Exception:
             pass
 
@@ -273,7 +286,9 @@ class FibsemSpotBurnWidget(QWidget):
 
         self._feed_image_shape()
         # the editor only owns coordinates; current/exposure live on the form
-        self.coord_editor.set_settings(SpotBurnSettings(coordinates=list(settings.coordinates)))
+        self.coord_editor.set_settings(
+            SpotBurnSettings(coordinates=list(settings.coordinates))
+        )
         self._refresh_info()  # set_settings is programmatic (no settings_changed)
 
     def get_settings(self) -> SpotBurnSettings:
@@ -326,7 +341,9 @@ class FibsemSpotBurnWidget(QWidget):
         self.stop_event.clear()
         self._is_burning = True
         self.pushButton_run_spot_burn.setText("Cancel")
-        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.DANGER_BUTTON_STYLESHEET)
+        self.pushButton_run_spot_burn.setStyleSheet(
+            stylesheets.DANGER_BUTTON_STYLESHEET
+        )
         self.pushButton_run_spot_burn.clicked.disconnect()
         self.pushButton_run_spot_burn.clicked.connect(self.cancel_spot_burn)
         # in workflow mode the button is hidden when idle — show it as "Cancel" while burning
@@ -347,10 +364,12 @@ class FibsemSpotBurnWidget(QWidget):
         ``microscope.spot_burn_progress_signal``; completion is delivered on the GUI
         thread via the FunctionWorker's returned / errored signals, so a failure anywhere
         here — including the post-burn acquire — resets the UI via spot_burn_errored."""
-        run_spot_burn(microscope=self.microscope,
-                      settings=settings,
-                      beam_type=BeamType.ION,
-                      stop_event=self.stop_event)
+        run_spot_burn(
+            microscope=self.microscope,
+            settings=settings,
+            beam_type=BeamType.ION,
+            stop_event=self.stop_event,
+        )
         # acquire a post-burn fib image and push it to the view (off the GUI thread)
         image = self.microscope.acquire_image(beam_type=BeamType.ION)
         self.microscope.fib_acquisition_signal.emit(image)
@@ -361,7 +380,9 @@ class FibsemSpotBurnWidget(QWidget):
         # hide the "Done" bar after a moment, so it doesn't linger for the rest of the
         # session (mirrors the status bar). reset_if_finished leaves the widget alone if
         # another burn has already started rendering progress in the meantime.
-        QTimer.singleShot(HIDE_PROGRESS_DELAY_MS, self.progress_widget.reset_if_finished)
+        QTimer.singleShot(
+            HIDE_PROGRESS_DELAY_MS, self.progress_widget.reset_if_finished
+        )
 
     def spot_burn_errored(self, error) -> None:
         """Called when the spot burn fails.
@@ -370,7 +391,9 @@ class FibsemSpotBurnWidget(QWidget):
         still visible if the user was not watching when it happened.
         """
         logging.error(f"Spot burn failed: {error}")
-        self.microscope.spot_burn_progress_signal.emit({"finished": True, "error": True})
+        self.microscope.spot_burn_progress_signal.emit(
+            {"finished": True, "error": True}
+        )
         self._restore_idle_state()
 
     def _restore_idle_state(self) -> None:
@@ -380,7 +403,9 @@ class FibsemSpotBurnWidget(QWidget):
         self.pushButton_run_spot_burn.clicked.connect(self.run_spot_burn_worker)
         self.pushButton_run_spot_burn.setEnabled(True)
         self.pushButton_run_spot_burn.setText("Run Spot Burn")
-        self.pushButton_run_spot_burn.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.pushButton_run_spot_burn.setStyleSheet(
+            stylesheets.PRIMARY_BUTTON_STYLESHEET
+        )
         # in workflow mode, hide the button again now the burn is done
         self._update_run_button_visibility()
 

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -70,16 +70,17 @@ def _burned_points(mic: MagicMock) -> list:
 def test_run_spot_burn_filters_out_of_bounds_coordinates(mock_microscope):
     """Coordinates outside the 0-1 image bounds are skipped, not sent to set_spot."""
     coords = [
-        Point(0.5, 0.5),   # valid
-        Point(0.9, 0.2),   # valid
+        Point(0.5, 0.5),  # valid
+        Point(0.9, 0.2),  # valid
         Point(1.02, 0.5),  # x > 1
         Point(-0.1, 0.3),  # x < 0
-        Point(0.5, 1.5),   # y > 1
+        Point(0.5, 1.5),  # y > 1
     ]
     FibsemMicroscope.run_spot_burn(
         mock_microscope,
-        settings=SpotBurnSettings(coordinates=coords, exposure_time=1.0,
-                                  milling_current=30e-12),
+        settings=SpotBurnSettings(
+            coordinates=coords, exposure_time=1.0, milling_current=30e-12
+        ),
         beam_type=BeamType.ION,
     )
     assert _burned_points(mock_microscope) == [Point(0.5, 0.5), Point(0.9, 0.2)]
@@ -90,8 +91,9 @@ def test_run_spot_burn_keeps_boundary_coordinates(mock_microscope):
     coords = [Point(0.0, 0.0), Point(1.0, 1.0)]
     FibsemMicroscope.run_spot_burn(
         mock_microscope,
-        settings=SpotBurnSettings(coordinates=coords, exposure_time=1.0,
-                                  milling_current=30e-12),
+        settings=SpotBurnSettings(
+            coordinates=coords, exposure_time=1.0, milling_current=30e-12
+        ),
     )
     assert _burned_points(mock_microscope) == coords
 
@@ -100,8 +102,9 @@ def test_run_spot_burn_empty_coordinates_does_not_burn(mock_microscope):
     """No coordinates -> no spot exposures, but the beam state is still restored."""
     FibsemMicroscope.run_spot_burn(
         mock_microscope,
-        settings=SpotBurnSettings(coordinates=[], exposure_time=1.0,
-                                  milling_current=30e-12),
+        settings=SpotBurnSettings(
+            coordinates=[], exposure_time=1.0, milling_current=30e-12
+        ),
     )
     mock_microscope.set_spot_scanning_mode.assert_not_called()
     mock_microscope.set_full_frame_scanning_mode.assert_called_once()
@@ -114,8 +117,9 @@ def test_run_spot_burn_coerces_string_parameters(mock_microscope):
     """String milling_current/exposure_time (from the editor QLineEdit bug) don't crash."""
     FibsemMicroscope.run_spot_burn(
         mock_microscope,
-        settings=SpotBurnSettings(coordinates=[Point(0.5, 0.5)], exposure_time="2",
-                                  milling_current="3e-11"),
+        settings=SpotBurnSettings(
+            coordinates=[Point(0.5, 0.5)], exposure_time="2", milling_current="3e-11"
+        ),
         beam_type=BeamType.ION,
     )
     # the milling current is applied as a real float, not the string "3e-11"
@@ -131,8 +135,9 @@ def test_run_spot_burn_restores_full_frame_and_imaging_current(mock_microscope):
     """After burning, scanning returns to full frame and the imaging current is restored."""
     FibsemMicroscope.run_spot_burn(
         mock_microscope,
-        settings=SpotBurnSettings(coordinates=[Point(0.5, 0.5)], exposure_time=1.0,
-                                  milling_current=30e-12),
+        settings=SpotBurnSettings(
+            coordinates=[Point(0.5, 0.5)], exposure_time=1.0, milling_current=30e-12
+        ),
     )
     mock_microscope.set_full_frame_scanning_mode.assert_called_once()
     last_current = mock_microscope.set_beam_current.call_args_list[-1].kwargs["current"]
@@ -146,8 +151,11 @@ def test_run_spot_burn_emits_progress_via_microscope(mock_microscope):
     """Progress is reported through microscope.spot_burn_progress_signal (both run paths)."""
     FibsemMicroscope.run_spot_burn(
         mock_microscope,
-        settings=SpotBurnSettings(coordinates=[Point(0.5, 0.5), Point(0.6, 0.6)],
-                                  exposure_time=1.0, milling_current=30e-12),
+        settings=SpotBurnSettings(
+            coordinates=[Point(0.5, 0.5), Point(0.6, 0.6)],
+            exposure_time=1.0,
+            milling_current=30e-12,
+        ),
     )
     emitted = [
         c.args[0] for c in mock_microscope.spot_burn_progress_signal.emit.call_args_list
@@ -162,10 +170,15 @@ def test_run_spot_burn_emits_progress_via_microscope(mock_microscope):
 def test_run_spot_burn_module_function_delegates_to_the_microscope(mock_microscope):
     """The module entry point dispatches polymorphically (FIB-297): the default
     implementation parks the beam per point, TESCAN overrides with DrawBeam dots."""
-    settings = SpotBurnSettings(coordinates=[Point(0.5, 0.5)], exposure_time=1.0,
-                                milling_current=30e-12)
-    run_spot_burn(microscope=mock_microscope, settings=settings,
-                  beam_type=BeamType.ION, stop_event=None)
+    settings = SpotBurnSettings(
+        coordinates=[Point(0.5, 0.5)], exposure_time=1.0, milling_current=30e-12
+    )
+    run_spot_burn(
+        microscope=mock_microscope,
+        settings=settings,
+        beam_type=BeamType.ION,
+        stop_event=None,
+    )
     mock_microscope.run_spot_burn.assert_called_once_with(
         settings=settings, beam_type=BeamType.ION, stop_event=None
     )
@@ -177,8 +190,12 @@ def test_build_spot_burn_progress_update_mapping():
     from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
 
     running = build_spot_burn_progress_update(
-        {"current_point": 1, "total_points": 3,
-         "total_remaining_time": 20.0, "total_estimated_time": 30.0}
+        {
+            "current_point": 1,
+            "total_points": 3,
+            "total_remaining_time": 20.0,
+            "total_estimated_time": 30.0,
+        }
     )
     assert (running.current, running.total) == (1, 3)
     assert running.remaining_seconds == 20.0
@@ -265,7 +282,9 @@ def _make_supervised_spot_burn_task(monkeypatch, tmp_path, ask_user_responses):
     widget.get_settings.return_value = SpotBurnSettings(
         coordinates=[Point(0.5, 0.5)], exposure_time=1.0, milling_current=1e-9
     )
-    parent_ui = MagicMock()  # truthy experiment.task_protocol.get_supervision -> supervised
+    parent_ui = (
+        MagicMock()
+    )  # truthy experiment.task_protocol.get_supervision -> supervised
     parent_ui.spot_burn_widget = widget
 
     responses = iter(ask_user_responses)


### PR DESCRIPTION
Whitespace only. Split out so the typing changes that follow read as typing changes, the same way [#547](https://github.com/fibsem-os/fibsem-os/pull/547) preceded the tiled progress work.

`ruff format` on the three files FIB-824 touches, none of which was formatted on `main`:

| file | changed lines |
| -- | -- |
| `fibsem/imaging/spot.py` | 12 |
| `fibsem/ui/FibsemSpotBurnWidget.py` | 55 |
| `tests/autolamella/test_spot_burn.py` | 63 |

The other files in that issue's scope — `microscope.py`, `tescan.py`, `AutoLamellaMainUI.py` — are **already formatted** and are deliberately untouched, so this stays small and does not collide with FIB-797, which edits the first two.

## Verification

AST-level, not eyeballed:

- parse trees **identical** before and after, for all three files
- the decorator set on **every** function unchanged

That second check is the point. A scripted reformat is exactly where a decorator gets displaced onto the neighbouring function, and the diff alone does not show it — that has bitten this repo before.

`ruff check` and `ruff format --check` both clean afterwards.