### PR TITLE
[refactor] Delete movement_progress_signal, which duplicated ensure_main_thread (FIB-825)

### DIFF
--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -37,8 +37,6 @@ ACQUIRING_IMAGES = "Acquiring images…"
 
 
 class FibsemMovementWidget(QtWidgets.QWidget):
-    movement_progress_signal = QtCore.pyqtSignal(dict)
-
     def __init__(
         self,
         microscope: FibsemMicroscope,
@@ -233,7 +231,6 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.saved_positions_widget.move_to_requested.connect(self.move_to_position)
 
         # signals
-        self.movement_progress_signal.connect(self.handle_movement_progress_update)
         self.image_widget.acquisition_progress_signal.connect(
             self.handle_acquisition_update
         )
@@ -372,42 +369,33 @@ class FibsemMovementWidget(QtWidgets.QWidget):
                 else SECONDARY_BUTTON_STYLESHEET
             )
 
-    def handle_movement_progress_update(self, ddict: dict) -> None:
-        """Handle movement progress updates from the microscope.
+    @ensure_main_thread
+    def _on_move_finished(self) -> None:
+        """A stage move is over: clear the status line and refresh the readout.
 
-        Written to the canvas info bar rather than shown as toasts. These messages
-        bracket a blocking move -- one click-to-move emits four of them inside ~45 ms
-        -- so as popups they stack into a wall that says nothing the moving stage and
-        the refreshing images do not already show. On the info bar the same words stay
-        put for the duration of the move, which is when they are worth reading.
+        Called directly from `move_stage_finished`, which Qt already runs on the GUI
+        thread -- the decorator is there so the contract holds wherever it is called
+        from, not because this path needs marshalling.
 
-        Toasts show unconditionally (FIB-781), so that wall of popups is what these
-        messages would actually produce rather than a thing to worry about later.
+        Cleared, or the last line sits there afterwards as though the stage were still
+        moving. Except while the images are still being retaken -- which is the usual
+        case, because `update_ui_after_movement` only *queues* the acquisition before
+        the worker returns. `move_stage_finished` already declines to re-enable the
+        buttons in that window; the status has to keep the same counsel or it says
+        "done" over a second of acquisition, and offers a double-click that is still
+        disabled. `handle_acquisition_update` clears it when the images actually land.
         """
-        msg = ddict.get("msg", None)
-        if msg is not None:
-            logging.debug(msg)
-            self._set_move_status(msg)
+        if not self.image_widget.is_acquiring:
+            self._set_move_status(None)
+        self._update_position_readout()
 
-        is_finished = ddict.get("finished", False)
-        if is_finished:
-            # Cleared, or the last line sits there afterwards as though the stage were
-            # still moving. Every path reaches here: each worker connects `finished` to
-            # `move_stage_finished`, which emits this.
-            #
-            # Except while the images are still being retaken -- which is the usual
-            # case, because `update_ui_after_movement` only *queues* the acquisition
-            # before the worker returns. `move_stage_finished` already declines to
-            # re-enable the buttons in that window; the status has to keep the same
-            # counsel or it says "done" over a second of acquisition, and offers a
-            # double-click that is still disabled. `handle_acquisition_update` clears
-            # it when the images actually land.
-            if not self.image_widget.is_acquiring:
-                self._set_move_status(None)
-            self._update_position_readout()
-
+    @ensure_main_thread
     def _set_move_status(self, msg: Optional[str]) -> None:
         """Put *msg* on the info bar of every canvas, or clear it when None.
+
+        Marshalled here rather than relayed through a signal: the workers call it
+        directly, and `@ensure_main_thread` is the contract the rest of the UI uses
+        -- `update_ui` and `update_ui_after_movement` in this same class already do.
 
         Not the instructions label on this tab. Five of the six paths that start a
         stage move start it from somewhere else -- the canvas beside the tabs (which
@@ -417,6 +405,8 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         the canvas that was clicked, is visible from every tab, and is already where
         the stage position this move is changing gets written.
         """
+        if msg is not None:
+            logging.debug(msg)
         controller = self._view_controller()
         if controller is None:
             return
@@ -517,16 +507,14 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     @thread_worker
     def absolute_movement_worker(self, stage_position: FibsemStagePosition) -> None:
         """Worker function to move the stage to the specified position"""
-        self.movement_progress_signal.emit(
-            {"msg": f"Moving to {stage_position.pretty}…"}
-        )
+        self._set_move_status(f"Moving to {stage_position.pretty}…")
         self.microscope.safe_absolute_stage_movement(stage_position)
-        self.movement_progress_signal.emit({"msg": ACQUIRING_IMAGES})
+        self._set_move_status(ACQUIRING_IMAGES)
         self.update_ui_after_movement()
 
     def move_stage_finished(self):
         """Handle the completion of a stage movement"""
-        self.movement_progress_signal.emit({"finished": True})
+        self._on_move_finished()
         if self.image_widget.is_acquiring:
             return
         self._toggle_interactions(enable=True)
@@ -605,12 +593,8 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         # along the beam axis to hold eucentricity. "Vertically" rather than
         # "eucentric" so the message matches the words already on screen in
         # INSTRUCTIONS_TEXT.
-        self.movement_progress_signal.emit(
-            {
-                "msg": "Moving the stage vertically…"
-                if vertical_move
-                else "Moving the stage…"
-            }
+        self._set_move_status(
+            "Moving the stage vertically…" if vertical_move else "Moving the stage…"
         )
         # eucentric is only supported for ION beam
         if beam_type is BeamType.ION and vertical_move:
@@ -627,7 +611,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
                 dy=point.y,
                 beam_type=beam_type,
             )
-        self.movement_progress_signal.emit({"msg": ACQUIRING_IMAGES})
+        self._set_move_status(ACQUIRING_IMAGES)
         self.update_ui_after_movement()
 
     def _on_canvas_double_click(
@@ -692,11 +676,9 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     @thread_worker
     def move_to_orientation_worker(self, orientation: str) -> None:
         """Threaded worker function to move the stage to the specified orientation"""
-        self.movement_progress_signal.emit(
-            {"msg": f"Moving to the {orientation} orientation…"}
-        )
+        self._set_move_status(f"Moving to the {orientation} orientation…")
         self.microscope.move_to_orientation(orientation)
         # The orientation path never said this, so the label sat on "Moving to the SEM
         # orientation…" while the move had finished and the images were being retaken.
-        self.movement_progress_signal.emit({"msg": ACQUIRING_IMAGES})
+        self._set_move_status(ACQUIRING_IMAGES)
         self.update_ui_after_movement()

--- a/tests/test_movement_widget_vertical_gate.py
+++ b/tests/test_movement_widget_vertical_gate.py
@@ -66,7 +66,7 @@ def make_widget(microscope):
     # allocates just the Python wrapper (no QApplication / C++ widget needed)
     widget = FibsemMovementWidget.__new__(FibsemMovementWidget)
     widget.microscope = microscope
-    widget.movement_progress_signal = Mock()
+    widget._set_move_status = Mock()  # was movement_progress_signal (FIB-825)
     widget.update_ui_after_movement = Mock()
     return widget
 

--- a/tests/ui/test_movement_progress.py
+++ b/tests/ui/test_movement_progress.py
@@ -26,7 +26,7 @@ from PyQt5.QtCore import QEventLoop, QTimer
 
 # The real construction seam: a host with a view controller, a real image widget and a
 # Demo microscope. Building the widget through `__new__` and hand-injecting a label
-# would let every test here pass with `movement_progress_signal` disconnected.
+# would let every test here pass with the info bar never wired up at all.
 sys.path.insert(0, os.path.dirname(__file__))  # not str.rsplit: Windows paths
 from test_viewer_less_widgets import (  # noqa: E402
     _CanvasHost,
@@ -80,10 +80,30 @@ def _status(widget, beam: BeamType = BeamType.ELECTRON):
     return _info(widget, beam).get("move")
 
 
+def _spy_on_info(widget, record):
+    """Call *record* for every info-bar write, on the thread that writes it.
+
+    Hooked on the controller rather than on a signal. `movement_progress_signal` is
+    gone (FIB-825) -- the workers now call `_set_move_status` directly and
+    `@ensure_main_thread` marshals it -- so there is no emission to subscribe to.
+    Hooking the write itself is a truer observation anyway: it samples the value that
+    actually reached the bar, at the moment it reached it.
+    """
+    controller = widget._view_controller()
+    original = controller.set_info
+
+    def spy(beam, key, text):
+        original(beam, key, text)
+        if key == "move" and beam is BeamType.ELECTRON:
+            record(text)
+
+    controller.set_info = spy
+
+
 def _record(widget) -> list:
     """Every status the info bar held, in order, as the move ran."""
     seen = []
-    widget.movement_progress_signal.connect(lambda _d: seen.append(_status(widget)))
+    _spy_on_info(widget, seen.append)
     return seen
 
 
@@ -144,8 +164,8 @@ def test_the_status_shows_from_another_tab(movement):
 def test_the_instructions_label_is_left_alone(movement):
     """It says what a double-click does, which does not change while the stage moves."""
     seen = []
-    movement.movement_progress_signal.connect(
-        lambda _d: seen.append(movement.label_movement_instructions.text())
+    _spy_on_info(
+        movement, lambda _t: seen.append(movement.label_movement_instructions.text())
     )
     movement._move_to_absolute_position(TARGET)
     _run(lambda: seen and _status(movement) is None)
@@ -170,8 +190,7 @@ def test_progress_does_not_toast(movement, monkeypatch):
         "show_toast",
         lambda *a, **k: shown.append(a[0] if a else ""),
     )
-    progress = []
-    movement.movement_progress_signal.connect(lambda d: progress.append(d.get("msg")))
+    progress = _record(movement)
     movement._move_to_absolute_position(TARGET)
     _run(lambda: _status(movement) is None)
 
@@ -189,14 +208,15 @@ def test_it_clears_when_the_images_land_not_before(movement):
     the status cleared there it would read "nothing is happening" over the acquisition
     it just announced, and offer a double-click that is still disabled."""
     at_finished = []
-    movement.movement_progress_signal.connect(
-        lambda d: (
-            d.get("finished")
-            and at_finished.append(
-                (_status(movement), movement.image_widget.is_acquiring)
-            )
-        )
-    )
+    original = movement._on_move_finished
+
+    def spy():
+        # Sampled *before* the clear, which is the moment under test: the question is
+        # what the bar said while the acquisition was still running.
+        at_finished.append((_status(movement), movement.image_widget.is_acquiring))
+        original()
+
+    movement._on_move_finished = spy
     movement._move_to_absolute_position(TARGET)
     _run(lambda: at_finished and not movement.image_widget.is_acquiring)
 
@@ -271,15 +291,18 @@ def test_no_progress_message_says_updating_ui(movement):
 
 
 def test_the_status_is_written_on_the_gui_thread(movement):
-    """`movement_progress_signal` is a `pyqtSignal` on a widget with main-thread
-    affinity, so emitting it from a worker queues delivery onto the GUI thread -- which
-    is why the handler needs no `@ensure_main_thread` (`update_ui_after_movement` does,
-    because a worker calls *that* directly rather than through a signal). Asserted
-    rather than assumed: writing the info bar off-thread would be a Qt violation."""
+    """The invariant that survived deleting the signal (FIB-825).
+
+    It used to hold because `movement_progress_signal` was a `pyqtSignal` on a widget
+    with main-thread affinity, so emitting from a worker queued delivery onto the GUI
+    thread. It now holds because `_set_move_status` carries `@ensure_main_thread`,
+    which is what the workers call directly -- the same mechanism `update_ui` and
+    `update_ui_after_movement` in that class already used.
+
+    Asserted rather than assumed either way: writing a `QLabel` off-thread is a Qt
+    violation, and it is the one thing that change could plausibly have broken."""
     threads = []
-    movement.movement_progress_signal.connect(
-        lambda _d: threads.append(threading.current_thread().name)
-    )
+    _spy_on_info(movement, lambda _t: threads.append(threading.current_thread().name))
     movement._move_to_absolute_position(TARGET)
     _run(lambda: _status(movement) is None)
     assert threads, "the handler never ran"


### PR DESCRIPTION
FIB-402 has this signal on its list to be *typed*. Looking at what it is **for** rather than what it carries turned that into a deletion.

## It was a thread hop, and the widget already had one

Seven emits in `@thread_worker` bodies, one consumer on the same class, writing a `QLabel`. Something must marshal that — but this widget already marshals a different way, in the same file, **on the line adjacent to an emit**:

```python
self.movement_progress_signal.emit({"msg": ACQUIRING_IMAGES})   # via the signal
self.update_ui_after_movement()                                  # @ensure_main_thread, direct
```

`update_ui` (`:445`) and `update_ui_after_movement` (`:468`) were already decorated. That decorator is the house contract — 23 sites across `fibsem/ui/` — and `FMOverviewWidget` says so in a comment: relaying through a signal is *"this widget's own dialect"*.

**And one emit marshalled nothing at all.** `move_stage_finished` is connected to `worker.finished`, which Qt delivers on the GUI thread, so its `{"finished": True}` was a GUI-thread → signal → GUI-thread round trip.

## The change

`_set_move_status` gains the decorator; the `finished` branch becomes `_on_move_finished`; the seven emits become seven direct calls that say what they mean. The declaration, the `connect`, the dict-parsing handler and the dict all go.

**No new types.** Typing this payload would have been ceremony — `msg` is producer-authored (`f"Moving to {stage_position.pretty}…"`), so the "consumer owns the wording" argument that justified dropping `message` from the tiled and fluorescence signals never applied here.

## Semantics — checked, not assumed

| | |
| -- | -- |
| cross-thread | `superqt.ensure_main_thread` is non-blocking by default; a cross-thread Qt emit is queued too. Both deliver through the main-thread event loop **in call order**, so the message sequence a move produces is unchanged. |
| same-thread | becomes a direct call — affects only the round trip that was already pointless. |
| `await_return=True` | **not used.** Blocking a worker on the GUI thread is how a stage move becomes a freeze. |

## Tests

They used the signal as an *observation hook*, so they now hook the controller's `set_info` instead — a truer observation, since it samples the value that actually reached the bar at the moment it reached it, on the thread that wrote it.

`test_the_status_is_written_on_the_gui_thread` keeps its assertion and gets a new reason: the invariant used to hold because a queued signal delivered onto the GUI thread, and now holds because of the decorator. That is the one thing this change could plausibly have broken, so it stays asserted rather than dropped.

**17 passed** (`test_movement_progress.py`, `test_movement_widget_vertical_gate.py`), plus **40** in `test_viewer_less_widgets.py` / `test_stage_frame.py`. Decorators AST-checked onto the right methods. `ruff check` and `ruff format --check` clean.

Note `tests/ui/` does not run in CI (the `[ui]` extra is deliberately not installed), so those 17 were run locally with `QT_QPA_PLATFORM=offscreen`.