### PR TITLE
[style] Format the files the workflow status work touches (FIB-827)

### DIFF
--- a/fibsem/applications/autolamella/ui/workflow_timeline_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_timeline_widget.py
@@ -34,18 +34,18 @@ from fibsem.ui.widgets.custom_widgets import ElidedLabel
 from fibsem.ui.widgets.preflight import format_clock, format_duration
 
 # ── Colours ───────────────────────────────────────────────────────────────────
-_DOT_COMPLETED  = stylesheets.GREEN_COLOR
-_DOT_ACTIVE     = stylesheets.ORANGE_COLOR
-_DOT_PENDING    = NEUTRAL_700
-_DOT_FAILED     = stylesheets.RED_COLOR
-_DOT_SKIPPED    = NEUTRAL_500
+_DOT_COMPLETED = stylesheets.GREEN_COLOR
+_DOT_ACTIVE = stylesheets.ORANGE_COLOR
+_DOT_PENDING = NEUTRAL_700
+_DOT_FAILED = stylesheets.RED_COLOR
+_DOT_SKIPPED = NEUTRAL_500
 # Slate, not amber: the old #e0a030 was indistinguishable from the active orange,
 # so a cancelled row read as still running — especially when it was the last thing
 # to run and there was no active row beside it to compare against. Still not red:
 # a user abort is not an error.
-_DOT_CANCELLED  = "#6f7d8c"
+_DOT_CANCELLED = "#6f7d8c"
 
-_LINE_COLOR     = "#3a3d42"
+_LINE_COLOR = "#3a3d42"
 
 _SKIP_REASON_LABELS = {
     "not_required": "Not in required list",
@@ -60,14 +60,14 @@ _SKIP_REASON_LABELS = {
 # PRIMARY_COLOR is what selection means across the app — the lamella cards mark
 # themselves with a 2px border in it, so the timeline agrees rather than
 # inventing a second selection blue.
-_SELECTED_BG    = QColor(stylesheets.PRIMARY_COLOR)
+_SELECTED_BG = QColor(stylesheets.PRIMARY_COLOR)
 _SELECTED_BG.setAlpha(30)
-_SELECTED_BAR   = QColor(stylesheets.PRIMARY_COLOR)
+_SELECTED_BAR = QColor(stylesheets.PRIMARY_COLOR)
 _SELECTED_BAR_W = 2
-_LABEL_COLOR    = stylesheets.GRAY_TEXT_COLOR
+_LABEL_COLOR = stylesheets.GRAY_TEXT_COLOR
 _SUBTITLE_COLOR = stylesheets.GRAY_SECONDARY_COLOR
 
-_ADD_BTN_STYLE  = (
+_ADD_BTN_STYLE = (
     "QToolButton { background: transparent; border: none; border-radius: 3px;"
     " color: #d1d2d4; font-size: 13px; padding: 3px 6px; }"
     "QToolButton:hover { background: #3a3d42; }"
@@ -75,50 +75,51 @@ _ADD_BTN_STYLE  = (
     "QToolButton::menu-indicator { image: none; }"
 )
 
-_ACTIONS_BTN    = 20   # px — the hover-revealed "..." button
-_ACTIONS_STYLE  = (
+_ACTIONS_BTN = 20  # px — the hover-revealed "..." button
+_ACTIONS_STYLE = (
     "QToolButton { background: transparent; border: none; border-radius: 3px; }"
     "QToolButton:hover { background: #3a3d42; }"
     "QToolButton::menu-indicator { image: none; }"
 )
 
-_DOT_SIZE       = 12
+_DOT_SIZE = 12
 _INNER_DOT_SIZE = 8
-_LINE_W         = 2
-_LEFT_COL       = 32   # px — fixed width for dot + connector column
-_INNER_ROW_H    = 22   # px — minimum height per inner step row
+_LINE_W = 2
+_LEFT_COL = 32  # px — fixed width for dot + connector column
+_INNER_ROW_H = 22  # px — minimum height per inner step row
 
 # The estimate column. Fixed width and right-aligned so the times hold one line down the
 # panel however long the names beside them are — that column is the thing being scanned,
 # and a ragged right edge would break it. The pre-flight dialog reserves 84px for the same
 # column against a wider dialog; 78 is what fits here beside the actions button.
-_TRAILING_W     = 78
+_TRAILING_W = 78
 
 
 # ── Status mapping ───────────────────────────────────────────────────────────
 def _queue_status_to_step_status(s) -> "StepStatus":
     """Map AutoLamellaTaskStatus → StepStatus for display."""
     from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+
     return {
         AutoLamellaTaskStatus.NotStarted: StepStatus.PENDING,
         AutoLamellaTaskStatus.InProgress: StepStatus.ACTIVE,
-        AutoLamellaTaskStatus.Completed:  StepStatus.COMPLETED,
-        AutoLamellaTaskStatus.Failed:     StepStatus.FAILED,
-        AutoLamellaTaskStatus.Skipped:    StepStatus.SKIPPED,
-        AutoLamellaTaskStatus.Cancelled:  StepStatus.CANCELLED,
+        AutoLamellaTaskStatus.Completed: StepStatus.COMPLETED,
+        AutoLamellaTaskStatus.Failed: StepStatus.FAILED,
+        AutoLamellaTaskStatus.Skipped: StepStatus.SKIPPED,
+        AutoLamellaTaskStatus.Cancelled: StepStatus.CANCELLED,
         # Removed items are filtered out before they reach the timeline; mapped
         # anyway so any other caller gets the struck-through look, not a crash.
-        AutoLamellaTaskStatus.Removed:    StepStatus.SKIPPED,
+        AutoLamellaTaskStatus.Removed: StepStatus.SKIPPED,
     }.get(s, StepStatus.PENDING)  # unknown status must never crash the timeline
 
 
 # ── Data model ────────────────────────────────────────────────────────────────
 class StepStatus(Enum):
-    PENDING   = auto()
-    ACTIVE    = auto()
+    PENDING = auto()
+    ACTIVE = auto()
     COMPLETED = auto()
-    FAILED    = auto()
-    SKIPPED   = auto()
+    FAILED = auto()
+    SKIPPED = auto()
     CANCELLED = auto()
 
 
@@ -142,10 +143,10 @@ class TimelineStep:
 def _status_color(status: StepStatus) -> str:
     return {
         StepStatus.COMPLETED: _DOT_COMPLETED,
-        StepStatus.ACTIVE:    _DOT_ACTIVE,
-        StepStatus.PENDING:   _DOT_PENDING,
-        StepStatus.FAILED:    _DOT_FAILED,
-        StepStatus.SKIPPED:   _DOT_SKIPPED,
+        StepStatus.ACTIVE: _DOT_ACTIVE,
+        StepStatus.PENDING: _DOT_PENDING,
+        StepStatus.FAILED: _DOT_FAILED,
+        StepStatus.SKIPPED: _DOT_SKIPPED,
         StepStatus.CANCELLED: _DOT_CANCELLED,
     }.get(status, _DOT_PENDING)
 
@@ -179,7 +180,7 @@ class _DotWidget(QWidget):
     def __init__(self, color: str, size: int = _DOT_SIZE, parent=None):
         super().__init__(parent)
         self._color = QColor(color)
-        self._size  = size
+        self._size = size
         self.setFixedSize(size, size)
 
     def set_color(self, color: str) -> None:
@@ -510,7 +511,9 @@ class WorkflowTimelineWidget(QWidget):
         # and painting GRAY_BACKGROUND_COLOR here left the rows as a visibly
         # darker rectangle inside a lighter panel, with the header strip above
         # them a third shade again.
-        self._scroll.setStyleSheet("QScrollArea { background: transparent; border: none; }")
+        self._scroll.setStyleSheet(
+            "QScrollArea { background: transparent; border: none; }"
+        )
         self._scroll.viewport().setStyleSheet("background: transparent;")
 
         self._contents = QWidget()
@@ -589,7 +592,8 @@ class WorkflowTimelineWidget(QWidget):
         # behind on whatever moved into that position.
         self._selected_index = (
             self._keys.index(self._selected_key)
-            if self._selected_key in self._keys else None
+            if self._selected_key in self._keys
+            else None
         )
         for i, row in enumerate(self._rows):
             row.set_selected(i == self._selected_index)
@@ -728,7 +732,9 @@ class WorkflowProgressWidget(QWidget):
         self._btn_add = QToolButton()
         self._btn_add.setStyleSheet(_ADD_BTN_STYLE)
         self._btn_add.setText("Add to Queue")
-        self._btn_add.setIcon(fibsem_icon("mdi:plus", color=stylesheets.GRAY_ICON_COLOR))
+        self._btn_add.setIcon(
+            fibsem_icon("mdi:plus", color=stylesheets.GRAY_ICON_COLOR)
+        )
         self._btn_add.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
         self._btn_add.setVisible(False)
         # Nothing is selected until the owner says otherwise.
@@ -874,8 +880,10 @@ class WorkflowProgressWidget(QWidget):
         # Reconcile rows with the snapshot; this also refreshes every status.
         self._sync(queue_items)
 
-        active_id = next((i.id for i in self._items
-                          if i.status == AutoLamellaTaskStatus.InProgress), None)
+        active_id = next(
+            (i.id for i in self._items if i.status == AutoLamellaTaskStatus.InProgress),
+            None,
+        )
 
         # New active row — show inner container, start elapsed timer. Compared by
         # id, so a reorder that moves the running task does not restart it.
@@ -898,8 +906,11 @@ class WorkflowProgressWidget(QWidget):
             )
 
         # Completion/failure/cancel — set subtitle, hide inner, resolve last inner step
-        if task_status in (AutoLamellaTaskStatus.Completed, AutoLamellaTaskStatus.Failed,
-                           AutoLamellaTaskStatus.Cancelled):
+        if task_status in (
+            AutoLamellaTaskStatus.Completed,
+            AutoLamellaTaskStatus.Failed,
+            AutoLamellaTaskStatus.Cancelled,
+        ):
             self._elapsed_timer.stop()
             self._active_start_time = None
             self._waiting_for_user = False
@@ -907,7 +918,9 @@ class WorkflowProgressWidget(QWidget):
             idx = self._outer_index
             if 0 <= idx < len(self._outer._rows):
                 task_name = self._items[idx].task_name
-                self._set_completion_subtitle(idx, task_duration, task_name, completed_at=status.get("timestamp"))
+                self._set_completion_subtitle(
+                    idx, task_duration, task_name, completed_at=status.get("timestamp")
+                )
                 # Show error message on failed rows, before the refresh that renders it
                 if task_status == AutoLamellaTaskStatus.Failed:
                     error_msg = status.get("error_message", None)
@@ -939,14 +952,19 @@ class WorkflowProgressWidget(QWidget):
         """
         from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
 
-        self._items = [i for i in items
-                       if i.status is not AutoLamellaTaskStatus.Removed]
+        self._items = [
+            i for i in items if i.status is not AutoLamellaTaskStatus.Removed
+        ]
         self._outer.sync_steps(
             [i.id for i in self._items],
-            [TimelineStep(label=i.lamella_name,
-                          subtitle=i.task_name,
-                          status=_queue_status_to_step_status(i.status))
-             for i in self._items],
+            [
+                TimelineStep(
+                    label=i.lamella_name,
+                    subtitle=i.task_name,
+                    status=_queue_status_to_step_status(i.status),
+                )
+                for i in self._items
+            ],
         )
         self._outer_index = next(
             (n for n, i in enumerate(self._items) if i.id == self._active_id), -1
@@ -1000,12 +1018,18 @@ class WorkflowProgressWidget(QWidget):
         rather than through update_from_status().
         """
         self._outer_index = index
-        self._active_id = self._items[index].id if 0 <= index < len(self._items) else None
+        self._active_id = (
+            self._items[index].id if 0 <= index < len(self._items) else None
+        )
         self._show_inner_at(index)
 
     # ── Internal ──────────────────────────────────────────────────────────
-    _FINISHED = (StepStatus.COMPLETED, StepStatus.FAILED,
-                 StepStatus.SKIPPED, StepStatus.CANCELLED)
+    _FINISHED = (
+        StepStatus.COMPLETED,
+        StepStatus.FAILED,
+        StepStatus.SKIPPED,
+        StepStatus.CANCELLED,
+    )
 
     def build_row_menu(self, index: int) -> Optional[QMenu]:
         """The queue-actions menu for a row, or None if the row is unknown.
@@ -1032,8 +1056,13 @@ class WorkflowProgressWidget(QWidget):
         menu = QMenu(self)
         menu.setToolTipsVisible(True)
 
-        def add(action_id: str, label: str, icon: str, enabled: bool,
-                colour: Optional[str] = None):
+        def add(
+            action_id: str,
+            label: str,
+            icon: str,
+            enabled: bool,
+            colour: Optional[str] = None,
+        ):
             act = menu.addAction(
                 fibsem_icon(icon, color=colour or stylesheets.GRAY_ICON_COLOR), label
             )
@@ -1044,13 +1073,19 @@ class WorkflowProgressWidget(QWidget):
             if not enabled and is_active:
                 act.setToolTip("This task is already running")
             act.triggered.connect(
-                lambda _checked=False, a=action_id: self.queue_action_requested.emit(a, item_id)
+                lambda _checked=False, a=action_id: self.queue_action_requested.emit(
+                    a, item_id
+                )
             )
             return act
 
         add("move_up", "Move up", "mdi:arrow-up", is_pending and rank > 0)
-        add("move_down", "Move down", "mdi:arrow-down",
-            is_pending and rank < len(pending) - 1)
+        add(
+            "move_down",
+            "Move down",
+            "mdi:arrow-down",
+            is_pending and rank < len(pending) - 1,
+        )
         add("run_next", "Run next", "mdi:skip-next", is_pending and rank > 0)
         menu.addSeparator()
         add("remove", "Remove from queue", "mdi:trash-can-outline", is_pending)
@@ -1061,8 +1096,13 @@ class WorkflowProgressWidget(QWidget):
             # Red where Remove is grey: Remove edits a list, this interrupts an
             # operation on the sample.
             menu.addSeparator()
-            add("stop_task", "Stop Task", "mdi:stop-circle-outline", True,
-                colour=_DOT_FAILED)
+            add(
+                "stop_task",
+                "Stop Task",
+                "mdi:stop-circle-outline",
+                True,
+                colour=_DOT_FAILED,
+            )
         return menu
 
     def _show_row_menu(self, index: int, pos: QPoint) -> None:
@@ -1116,6 +1156,7 @@ class WorkflowProgressWidget(QWidget):
         over them would undo that.
         """
         from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+
         for i, item in enumerate(self._items):
             if i >= len(self._outer._steps):
                 break
@@ -1134,7 +1175,9 @@ class WorkflowProgressWidget(QWidget):
 
         active_elapsed = None
         if self._active_start_time is not None:
-            active_elapsed = self._machine_elapsed(time.time() - self._active_start_time)
+            active_elapsed = self._machine_elapsed(
+                time.time() - self._active_start_time
+            )
 
         estimate = estimate_queue(
             self._items,
@@ -1162,6 +1205,7 @@ class WorkflowProgressWidget(QWidget):
     def _update_header(self, queue_items: list) -> None:
         """Update the header label with progress counts."""
         from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+
         total = len(queue_items)
         if total == 0:
             self._header.setText("Workflow")
@@ -1170,16 +1214,27 @@ class WorkflowProgressWidget(QWidget):
         # succeeded — otherwise the counter can never reach the total once anything
         # is cancelled. Removed items are already filtered out of the view, so they
         # leave both sides of the fraction rather than counting as work done.
-        done = sum(1 for i in queue_items if i.status in (
-            AutoLamellaTaskStatus.Completed, AutoLamellaTaskStatus.Skipped,
-            AutoLamellaTaskStatus.Cancelled))
+        done = sum(
+            1
+            for i in queue_items
+            if i.status
+            in (
+                AutoLamellaTaskStatus.Completed,
+                AutoLamellaTaskStatus.Skipped,
+                AutoLamellaTaskStatus.Cancelled,
+            )
+        )
         failed = sum(1 for i in queue_items if i.status == AutoLamellaTaskStatus.Failed)
-        cancelled = sum(1 for i in queue_items
-                        if i.status == AutoLamellaTaskStatus.Cancelled)
+        cancelled = sum(
+            1 for i in queue_items if i.status == AutoLamellaTaskStatus.Cancelled
+        )
         text = f"Workflow — {done}/{total}"
         # A run that ended with tasks abandoned should not read like one that did not.
-        notes = [f"{n} {label}" for n, label in
-                 ((failed, "failed"), (cancelled, "cancelled")) if n]
+        notes = [
+            f"{n} {label}"
+            for n, label in ((failed, "failed"), (cancelled, "cancelled"))
+            if n
+        ]
         if notes:
             text += f" ({', '.join(notes)})"
         self._header.setText(text)
@@ -1191,8 +1246,11 @@ class WorkflowProgressWidget(QWidget):
         if not (0 <= self._outer_index < len(self._outer._steps)):
             return
         step = self._outer._steps[self._outer_index]
-        item = (self._items[self._outer_index]
-                if self._outer_index < len(self._items) else None)
+        item = (
+            self._items[self._outer_index]
+            if self._outer_index < len(self._items)
+            else None
+        )
         task_name = item.task_name if item is not None else ""
 
         # Wall-clock, including any wait for a human: this is the number the recorded
@@ -1212,7 +1270,9 @@ class WorkflowProgressWidget(QWidget):
             step.trailing = ""
         elif self._machine_elapsed(elapsed) < estimate:
             step.subtitle = f"{task_name} ({format_duration(elapsed)})"
-            step.trailing = f"{format_duration(estimate - self._machine_elapsed(elapsed))} left"
+            step.trailing = (
+                f"{format_duration(estimate - self._machine_elapsed(elapsed))} left"
+            )
         else:
             # The estimate is spent, so the column stops predicting and reports instead —
             # elapsed, which is the same kind of number the row will show once it is
@@ -1224,7 +1284,13 @@ class WorkflowProgressWidget(QWidget):
         self._outer._rows[self._outer_index].refresh(step)
         self._update_summary()
 
-    def _set_completion_subtitle(self, outer_idx: int, task_duration: Optional[float], task_name: str = "", completed_at: Optional[float] = None) -> None:
+    def _set_completion_subtitle(
+        self,
+        outer_idx: int,
+        task_duration: Optional[float],
+        task_name: str = "",
+        completed_at: Optional[float] = None,
+    ) -> None:
         """What a finished row says: where it got to, and what it cost.
 
         The duration goes in the estimate column rather than in brackets after the task
@@ -1240,7 +1306,9 @@ class WorkflowProgressWidget(QWidget):
             # `.lstrip("0")`, as `format_clock` does: the header now quotes a finish
             # time in the same panel, and `06:59PM` beside `7:13PM` reads as two
             # different clocks rather than one convention.
-            stamp = datetime.fromtimestamp(completed_at).strftime(TIME_DISPLAY_AMPM_SHORT)
+            stamp = datetime.fromtimestamp(completed_at).strftime(
+                TIME_DISPLAY_AMPM_SHORT
+            )
             time_str = f" · {stamp.lstrip('0')}"
         self._outer._steps[outer_idx].subtitle = f"{task_name}{time_str}"
         if task_duration is not None:
@@ -1249,14 +1317,14 @@ class WorkflowProgressWidget(QWidget):
 
 # ── Demo ──────────────────────────────────────────────────────────────────────
 DEMO_STEPS = [
-    TimelineStep("Setup session",        StepStatus.COMPLETED),
-    TimelineStep("Move to position",     StepStatus.COMPLETED, "0.32 s"),
-    TimelineStep("Acquire overview",     StepStatus.COMPLETED, "1.1 s"),
-    TimelineStep("Detect features",      StepStatus.COMPLETED, "2.4 s"),
-    TimelineStep("Mill rough trench",    StepStatus.ACTIVE,    "running…"),
-    TimelineStep("Mill fine trench",     StepStatus.PENDING),
-    TimelineStep("Polish lamella",       StepStatus.PENDING),
-    TimelineStep("Acquire final image",  StepStatus.PENDING),
+    TimelineStep("Setup session", StepStatus.COMPLETED),
+    TimelineStep("Move to position", StepStatus.COMPLETED, "0.32 s"),
+    TimelineStep("Acquire overview", StepStatus.COMPLETED, "1.1 s"),
+    TimelineStep("Detect features", StepStatus.COMPLETED, "2.4 s"),
+    TimelineStep("Mill rough trench", StepStatus.ACTIVE, "running…"),
+    TimelineStep("Mill fine trench", StepStatus.PENDING),
+    TimelineStep("Polish lamella", StepStatus.PENDING),
+    TimelineStep("Acquire final image", StepStatus.PENDING),
 ]
 
 if __name__ == "__main__":
@@ -1271,6 +1339,7 @@ if __name__ == "__main__":
     win.setStyleSheet(f"background: {stylesheets.GRAY_BACKGROUND_COLOR};")
 
     from PyQt5.QtWidgets import QVBoxLayout as VBox
+
     layout = VBox(win)
     layout.setContentsMargins(0, 0, 0, 0)
 

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -22,38 +22,47 @@ if TYPE_CHECKING:
     from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
 
 
-def run_task(microscope: FibsemMicroscope,
-          task_name: str,
-          lamella: 'Lamella',
-          parent_ui: Optional['AutoLamellaUI'] = None,
-          task_manager: Optional['TaskManager'] = None) -> None:
+def run_task(
+    microscope: FibsemMicroscope,
+    task_name: str,
+    lamella: "Lamella",
+    parent_ui: Optional["AutoLamellaUI"] = None,
+    task_manager: Optional["TaskManager"] = None,
+) -> None:
     """Run a specific AutoLamella task."""
 
     task_config = lamella.task_config.get(task_name)
     if task_config is None:
-        raise ValueError(f"Task configuration for {task_name} not found in lamella tasks.")
+        raise ValueError(
+            f"Task configuration for {task_name} not found in lamella tasks."
+        )
 
     from fibsem.applications.autolamella.workflows.tasks import get_tasks
+
     task_cls = get_tasks().get(task_config.task_type)
     if task_cls is None:
         raise ValueError(f"Task {task_config.task_type} is not registered.")
 
-    task = task_cls(microscope=microscope,
-                    config=task_config,
-                    lamella=lamella,
-                    parent_ui=parent_ui,
-                    task_manager=task_manager)
+    task = task_cls(
+        microscope=microscope,
+        config=task_config,
+        lamella=lamella,
+        parent_ui=parent_ui,
+        task_manager=task_manager,
+    )
     task.run()
 
 
 class TaskManager:
     """Manages execution of autolamella tasks across lamellas."""
 
-    def __init__(self,
-                 microscope: FibsemMicroscope,
-                 experiment: 'Experiment',
-                 parent_ui: Optional['AutoLamellaUI'] = None,
-                 hook_manager: Optional[HookManager] = None):
+    def __init__(
+        self,
+        microscope: FibsemMicroscope,
+        experiment: "Experiment",
+        parent_ui: Optional["AutoLamellaUI"] = None,
+        hook_manager: Optional[HookManager] = None,
+    ):
         self.microscope = microscope
         self.experiment = experiment
         self.parent_ui = parent_ui
@@ -80,8 +89,9 @@ class TaskManager:
 
     # --- Public API ---
 
-    def run(self, task_names: List[str],
-            required_lamella: Optional[List[str]] = None) -> None:
+    def run(
+        self, task_names: List[str], required_lamella: Optional[List[str]] = None
+    ) -> None:
         """Run the specified tasks for all lamellas in the experiment.
         Args:
             task_names: List of task names to run.
@@ -114,7 +124,9 @@ class TaskManager:
                     f"Skipping {item.task_name}: no lamella named {item.lamella_name} in the experiment."
                 )
                 self.queue.mark_done(item, AutoLamellaTaskStatus.Skipped)
-                self._fire_skipped_hook(item.task_name, item.lamella_name, "lamella_not_found")
+                self._fire_skipped_hook(
+                    item.task_name, item.lamella_name, "lamella_not_found"
+                )
                 continue
 
             skip_reason = self._should_skip(lamella, item.task_name)
@@ -130,14 +142,20 @@ class TaskManager:
                 )
                 task_config = lamella.task_config.get(item.task_name)
                 self._fire_skipped_hook(
-                    item.task_name, lamella.name, skip_reason,
+                    item.task_name,
+                    lamella.name,
+                    skip_reason,
                     task_type=task_config.task_type if task_config else "",
                     item_id=lamella.id,
                 )
                 continue
 
             # Wait until the task's scheduled start time, if set and in the future.
-            scheduled_at = self.experiment.task_protocol.workflow_config.get_scheduled_at(item.task_name)
+            scheduled_at = (
+                self.experiment.task_protocol.workflow_config.get_scheduled_at(
+                    item.task_name
+                )
+            )
             if scheduled_at is not None:
                 self._wait_until_scheduled(scheduled_at, item.task_name, lamella)
                 if self.is_stopped:
@@ -173,7 +191,10 @@ class TaskManager:
             self._maybe_fire_lamella_completed(lamella, item.task_name)
 
         # if the objective is inserted, retract for safety
-        if self.microscope.fm is not None and self.microscope.fm.objective.state == "Inserted":
+        if (
+            self.microscope.fm is not None
+            and self.microscope.fm.objective.state == "Inserted"
+        ):
             self.microscope.fm.objective.retract()
 
         # The loop exits when the queue drains *or* when the user presses Stop. Reporting
@@ -183,7 +204,9 @@ class TaskManager:
             update_status_ui(self.parent_ui, "", workflow_info="Workflow cancelled.")
         else:
             self._fire_workflow_hook(HookEvent.WORKFLOW_COMPLETED)
-            update_status_ui(self.parent_ui, "", workflow_info=self._completion_message())
+            update_status_ui(
+                self.parent_ui, "", workflow_info=self._completion_message()
+            )
             # After the run event, since finishing the run is what makes the experiment
             # finishable. Not fired on the cancelled path: an aborted run has not
             # established anything about the experiment.
@@ -210,13 +233,15 @@ class TaskManager:
                         completed_at = task.completed_at
                         duration = task.duration
                         break
-            rows.append({
-                "lamella_name": item.lamella_name,
-                "task_name": item.task_name,
-                "task_status": item.status.name,
-                "completed_at": completed_at,
-                "duration": duration,
-            })
+            rows.append(
+                {
+                    "lamella_name": item.lamella_name,
+                    "task_name": item.task_name,
+                    "task_status": item.status.name,
+                    "completed_at": completed_at,
+                    "duration": duration,
+                }
+            )
         return pd.DataFrame(rows)
 
     def stop(self) -> None:
@@ -282,10 +307,12 @@ class TaskManager:
         """
         if self.parent_ui is None:
             return
-        self.parent_ui.queue_changed_signal.emit({
-            "queue_items": self.queue.items,  # thread-safe snapshot
-            "version": self.queue.version,
-        })
+        self.parent_ui.queue_changed_signal.emit(
+            {
+                "queue_items": self.queue.items,  # thread-safe snapshot
+                "version": self.queue.version,
+            }
+        )
 
     def hook_run_context(self) -> dict:
         """The fields every hook event from this run carries: which experiment, and
@@ -311,7 +338,7 @@ class TaskManager:
         # webhook with no way to tell which experiment had finished.
         fire_event(self.hook_manager, event, **self.hook_run_context())
 
-    def _is_complete(self, lamella: 'Lamella') -> bool:
+    def _is_complete(self, lamella: "Lamella") -> bool:
         """Whether a lamella has completed every task the workflow requires of it."""
         # task_protocol is None until one is loaded ("must be set externally").
         if self.experiment.task_protocol is None:
@@ -348,7 +375,7 @@ class TaskManager:
         # produced nothing, and must not announce success. all([]) would say otherwise.
         return bool(active) and all(self._is_complete(p) for p in active)
 
-    def _maybe_fire_lamella_completed(self, lamella: 'Lamella', task_name: str) -> None:
+    def _maybe_fire_lamella_completed(self, lamella: "Lamella", task_name: str) -> None:
         """Fire ITEM_COMPLETED the first time a lamella satisfies the workflow's
         completion predicate during this run. The lamella is AutoLamella's item.
 
@@ -407,9 +434,14 @@ class TaskManager:
             return f"All tasks completed ({skipped} skipped)."
         return "All tasks completed."
 
-    def _fire_skipped_hook(self, task_name: str, item_name: str,
-                           skip_reason: str, task_type: str = "",
-                           item_id: str = "") -> None:
+    def _fire_skipped_hook(
+        self,
+        task_name: str,
+        item_name: str,
+        skip_reason: str,
+        task_type: str = "",
+        item_id: str = "",
+    ) -> None:
         """Fire TASK_SKIPPED. Unlike the other task events this cannot come from
         AutoLamellaTask, because the skip is decided before any task object exists —
         so there is no task_state to attach, and no task_id: nothing ran to have one.
@@ -427,8 +459,9 @@ class TaskManager:
 
     # --- Internal helpers ---
 
-    def _wait_until_scheduled(self, scheduled_at: datetime, task_name: str,
-                              lamella: 'Lamella') -> None:
+    def _wait_until_scheduled(
+        self, scheduled_at: datetime, task_name: str, lamella: "Lamella"
+    ) -> None:
         """Block until ``scheduled_at`` is reached, emitting a periodic countdown.
 
         The wait is interruptible by either kind of stop. The item is already
@@ -454,8 +487,10 @@ class TaskManager:
 
                 now = time.monotonic()
                 if now >= next_update:
-                    msg = (f"Waiting until {target_str} to start {task_name} on "
-                           f"{lamella.name} ({format_time_remaining(remaining)} remaining).")
+                    msg = (
+                        f"Waiting until {target_str} to start {task_name} on "
+                        f"{lamella.name} ({format_time_remaining(remaining)} remaining)."
+                    )
                     update_status_ui(self.parent_ui, "", status_bar=msg)
                     next_update = now + 15.0
 
@@ -477,7 +512,7 @@ class TaskManager:
         if self.parent_ui is not None:
             self.parent_ui.WORKFLOW_PENDING = pending
 
-    def _should_skip(self, lamella: 'Lamella', task_name: str) -> Optional[str]:
+    def _should_skip(self, lamella: "Lamella", task_name: str) -> Optional[str]:
         """Return skip reason string, or None if task should run.
 
         Deliberately does not re-check the run's lamella selection: that filter
@@ -486,22 +521,34 @@ class TaskManager:
         original selection and were previously skipped as "not_required".
         """
         if lamella.is_failure:
-            logging.info(f"Skipping lamella {lamella.name} for task {task_name}. Marked as failure or has defect.")
+            logging.info(
+                f"Skipping lamella {lamella.name} for task {task_name}. Marked as failure or has defect."
+            )
             return "failure"
 
-        task_requirements = self.experiment.task_protocol.workflow_config.requirements(task_name)
-        if task_requirements and not all(lamella.has_completed_task(req) for req in task_requirements):
-            logging.info(f"Skipping lamella {lamella.name} for task {task_name}. Required tasks {task_requirements} not completed.")
+        task_requirements = self.experiment.task_protocol.workflow_config.requirements(
+            task_name
+        )
+        if task_requirements and not all(
+            lamella.has_completed_task(req) for req in task_requirements
+        ):
+            logging.info(
+                f"Skipping lamella {lamella.name} for task {task_name}. Required tasks {task_requirements} not completed."
+            )
             return "missing_prereqs"
 
         return None
 
-    def _emit_status(self, item: WorkItem, lamella: 'Lamella',
-                     status: 'AutoLamellaTaskStatus',
-                     msg: str = "",
-                     error_message: Optional[str] = None,
-                     task_duration: Optional[float] = None,
-                     skip_reason: Optional[str] = None) -> None:
+    def _emit_status(
+        self,
+        item: WorkItem,
+        lamella: "Lamella",
+        status: "AutoLamellaTaskStatus",
+        msg: str = "",
+        error_message: Optional[str] = None,
+        task_duration: Optional[float] = None,
+        skip_reason: Optional[str] = None,
+    ) -> None:
         """Emit workflow_update_signal with the standard status dict.
 
         This stream and the hook stream describe the same lifecycle from two different
@@ -546,14 +593,18 @@ class TaskManager:
 
         self.parent_ui.workflow_update_signal.emit({"msg": msg, "status": status_dict})
 
-    def _run_single_task(self, task_name: str, lamella: 'Lamella') -> Optional[Exception]:
+    def _run_single_task(
+        self, task_name: str, lamella: "Lamella"
+    ) -> Optional[Exception]:
         """Execute one task for one lamella. Returns exception or None."""
         try:
-            run_task(microscope=self.microscope,
-                     task_name=task_name,
-                     lamella=lamella,
-                     parent_ui=self.parent_ui,
-                     task_manager=self)
+            run_task(
+                microscope=self.microscope,
+                task_name=task_name,
+                lamella=lamella,
+                parent_ui=self.parent_ui,
+                task_manager=self,
+            )
             self.experiment.save()
             return None
         except Exception as e:
@@ -567,24 +618,32 @@ class TaskManager:
             # an unknown task name, or a construction failure -- where nothing else has.
             # The predicate matches AutoLamellaTaskBase._is_cancellation so the frozen
             # history entry and the live task_state cannot disagree.
-            if self.should_abort or isinstance(e, (OperationCancelledError, InterruptedError)):
-                logging.info(f"Task {task_name} for lamella {lamella.name} cancelled by user.")
+            if self.should_abort or isinstance(
+                e, (OperationCancelledError, InterruptedError)
+            ):
+                logging.info(
+                    f"Task {task_name} for lamella {lamella.name} cancelled by user."
+                )
                 lamella.task_state.status = AutoLamellaTaskStatus.Cancelled
                 lamella.task_state.status_message = "Cancelled by user."
             else:
-                logging.warning(f"Error running task {task_name} for lamella {lamella.name}: {e}")
+                logging.warning(
+                    f"Error running task {task_name} for lamella {lamella.name}: {e}"
+                )
                 lamella.task_state.status = AutoLamellaTaskStatus.Failed
                 lamella.task_state.status_message = str(e)
             self.experiment.save()
             return e
 
 
-def run_tasks(microscope: FibsemMicroscope,
-            experiment: 'Experiment',
-            task_names: List[str],
-            required_lamella: Optional[List[str]] = None,
-            parent_ui: Optional['AutoLamellaUI'] = None,
-            hook_manager: Optional[HookManager] = None) -> None:
+def run_tasks(
+    microscope: FibsemMicroscope,
+    experiment: "Experiment",
+    task_names: List[str],
+    required_lamella: Optional[List[str]] = None,
+    parent_ui: Optional["AutoLamellaUI"] = None,
+    hook_manager: Optional[HookManager] = None,
+) -> None:
     """Run the specified tasks for all lamellas in the experiment.
     Thin wrapper around TaskManager for backward compatibility and headless usage.
     """

--- a/tests/autolamella/test_task_manager_status.py
+++ b/tests/autolamella/test_task_manager_status.py
@@ -52,13 +52,18 @@ class NoMicroscope:
     Experiment.register_metadata stamps the user and experiment ref onto it, so
     it has to be something attributes can be set on — None will not do.
     """
+
     fm = None
 
 
-def make_lamella(experiment: Experiment, name: str, is_failure: bool = False,
-                 completed=()) -> Lamella:
-    lamella = Lamella(path=Path(experiment.path) / name,
-                      number=len(experiment.positions) + 1, petname=name)
+def make_lamella(
+    experiment: Experiment, name: str, is_failure: bool = False, completed=()
+) -> Lamella:
+    lamella = Lamella(
+        path=Path(experiment.path) / name,
+        number=len(experiment.positions) + 1,
+        petname=name,
+    )
     if is_failure:
         lamella.defect.state = DefectType.FAILURE
     for task_name in completed:
@@ -69,8 +74,11 @@ def make_lamella(experiment: Experiment, name: str, is_failure: bool = False,
     return lamella
 
 
-def make_experiment(tmp_path: Path, requirements: Optional[Dict[str, List[str]]] = None,
-                    lamella_names=("L1", "L2")) -> Experiment:
+def make_experiment(
+    tmp_path: Path,
+    requirements: Optional[Dict[str, List[str]]] = None,
+    lamella_names=("L1", "L2"),
+) -> Experiment:
     """A real Experiment with a real task protocol.
 
     ``required=False`` throughout so nothing is ever "complete" — the completion
@@ -81,8 +89,12 @@ def make_experiment(tmp_path: Path, requirements: Optional[Dict[str, List[str]]]
     experiment.task_protocol = AutoLamellaTaskProtocol(
         workflow_config=AutoLamellaWorkflowConfig(
             tasks=[
-                AutoLamellaTaskDescription(name=name, supervise=False, required=False,
-                                           requires=reqs.get(name, []))
+                AutoLamellaTaskDescription(
+                    name=name,
+                    supervise=False,
+                    required=False,
+                    requires=reqs.get(name, []),
+                )
                 for name in ("Trench", "Undercut", "Polishing")
             ]
         )
@@ -115,8 +127,11 @@ def run_queue_with(manager: TaskManager, on_task=None):
 
 @pytest.fixture
 def manager(tmp_path) -> TaskManager:
-    m = TaskManager(microscope=NoMicroscope(),
-                    experiment=make_experiment(tmp_path), parent_ui=RecordingUI())
+    m = TaskManager(
+        microscope=NoMicroscope(),
+        experiment=make_experiment(tmp_path),
+        parent_ui=RecordingUI(),
+    )
     m.queue.build_from_matrix(["Trench", "Undercut"], ["L1", "L2"])
     return m
 
@@ -127,10 +142,14 @@ def last_status(manager: TaskManager) -> dict:
 
 # ── _emit_status ──────────────────────────────────────────────────────────────
 
+
 def test_emit_reports_position_in_the_live_queue(manager):
     item = manager.queue.items[2]
-    manager._emit_status(item=item, lamella=manager.experiment.get_lamella_by_name(item.lamella_name),
-                         status=Status.InProgress)
+    manager._emit_status(
+        item=item,
+        lamella=manager.experiment.get_lamella_by_name(item.lamella_name),
+        status=Status.InProgress,
+    )
     status = last_status(manager)
     assert status["queue_position"] == 3
     assert status["queue_total"] == 4
@@ -141,8 +160,11 @@ def test_emit_for_a_task_outside_the_launch_plan(manager):
     added = manager.queue.add("L1", "Polishing")
     assert added.task_name not in manager.queue.task_names
 
-    manager._emit_status(item=added, lamella=manager.experiment.get_lamella_by_name("L1"),
-                         status=Status.InProgress)
+    manager._emit_status(
+        item=added,
+        lamella=manager.experiment.get_lamella_by_name("L1"),
+        status=Status.InProgress,
+    )
     status = last_status(manager)
     assert status["task_name"] == "Polishing"
     assert status["queue_position"] == 5
@@ -151,9 +173,11 @@ def test_emit_for_a_task_outside_the_launch_plan(manager):
 
 def test_emit_for_a_lamella_outside_the_launch_plan(manager):
     added = manager.queue.add("L99", "Trench")
-    manager._emit_status(item=added,
-                         lamella=make_lamella(manager.experiment, "L99"),
-                         status=Status.InProgress)
+    manager._emit_status(
+        item=added,
+        lamella=make_lamella(manager.experiment, "L99"),
+        status=Status.InProgress,
+    )
     status = last_status(manager)
     assert status["item_name"] == "L99"
     # deprecated alias, dropped with the HookContext shims after v0.6 (FIB-464)
@@ -164,14 +188,21 @@ def test_emit_for_a_lamella_outside_the_launch_plan(manager):
 def test_emit_position_follows_a_reorder(manager):
     item = manager.queue.items[3]
     manager.queue.move_to_front(item.id)
-    manager._emit_status(item=item, lamella=manager.experiment.get_lamella_by_name(item.lamella_name),
-                         status=Status.InProgress)
+    manager._emit_status(
+        item=item,
+        lamella=manager.experiment.get_lamella_by_name(item.lamella_name),
+        status=Status.InProgress,
+    )
     assert last_status(manager)["queue_position"] == 1
 
 
 def test_emit_carries_the_launch_plan_as_context(manager):
     item = manager.queue.items[0]
-    manager._emit_status(item=item, lamella=manager.experiment.get_lamella_by_name("L1"), status=Status.InProgress)
+    manager._emit_status(
+        item=item,
+        lamella=manager.experiment.get_lamella_by_name("L1"),
+        status=Status.InProgress,
+    )
     status = last_status(manager)
     assert status["task_names"] == ["Trench", "Undercut"]
     assert status["lamella_names"] == ["L1", "L2"]
@@ -179,7 +210,11 @@ def test_emit_carries_the_launch_plan_as_context(manager):
 
 def test_emit_includes_a_queue_snapshot(manager):
     item = manager.queue.items[0]
-    manager._emit_status(item=item, lamella=manager.experiment.get_lamella_by_name("L1"), status=Status.InProgress)
+    manager._emit_status(
+        item=item,
+        lamella=manager.experiment.get_lamella_by_name("L1"),
+        status=Status.InProgress,
+    )
     snapshot = last_status(manager)["queue_items"]
     assert len(snapshot) == 4
     snapshot[0].status = Status.Failed
@@ -188,8 +223,14 @@ def test_emit_includes_a_queue_snapshot(manager):
 
 def test_emit_passes_through_error_and_skip_detail(manager):
     item = manager.queue.items[0]
-    manager._emit_status(item=item, lamella=manager.experiment.get_lamella_by_name("L1"), status=Status.Failed,
-                         msg="boom", error_message="it broke", task_duration=12.5)
+    manager._emit_status(
+        item=item,
+        lamella=manager.experiment.get_lamella_by_name("L1"),
+        status=Status.Failed,
+        msg="boom",
+        error_message="it broke",
+        task_duration=12.5,
+    )
     status = last_status(manager)
     assert status["error_message"] == "it broke"
     assert status["task_duration"] == 12.5
@@ -200,12 +241,15 @@ def test_emit_is_a_noop_headless(tmp_path):
     experiment = make_experiment(tmp_path, lamella_names=["L1"])
     m = TaskManager(microscope=NoMicroscope(), experiment=experiment, parent_ui=None)
     m.queue.build_from_matrix(["Trench"], ["L1"])
-    m._emit_status(item=m.queue.items[0],
-                   lamella=experiment.get_lamella_by_name("L1"),
-                   status=Status.InProgress)  # must not raise
+    m._emit_status(
+        item=m.queue.items[0],
+        lamella=experiment.get_lamella_by_name("L1"),
+        status=Status.InProgress,
+    )  # must not raise
 
 
 # ── _should_skip ──────────────────────────────────────────────────────────────
+
 
 def test_lamella_outside_the_launch_selection_is_not_skipped(manager):
     """Regression: the old allow-list check skipped anything added mid-run."""
@@ -221,10 +265,12 @@ def test_failed_lamella_is_skipped(manager):
 
 
 def test_missing_prerequisites_are_skipped(tmp_path):
-    experiment = make_experiment(tmp_path, requirements={"Undercut": ["Trench"]},
-                                 lamella_names=["L1"])
-    m = TaskManager(microscope=NoMicroscope(), experiment=experiment,
-                    parent_ui=RecordingUI())
+    experiment = make_experiment(
+        tmp_path, requirements={"Undercut": ["Trench"]}, lamella_names=["L1"]
+    )
+    m = TaskManager(
+        microscope=NoMicroscope(), experiment=experiment, parent_ui=RecordingUI()
+    )
     m.queue.build_from_matrix(["Trench", "Undercut"], ["L1"])
     lamella = experiment.get_lamella_by_name("L1")
     assert m._should_skip(lamella, "Undercut") == "missing_prereqs"
@@ -236,15 +282,21 @@ def test_missing_prerequisites_are_skipped(tmp_path):
 
 
 def test_no_requirements_runs(manager):
-    assert manager._should_skip(manager.experiment.get_lamella_by_name("L1"), "Trench") is None
+    assert (
+        manager._should_skip(manager.experiment.get_lamella_by_name("L1"), "Trench")
+        is None
+    )
 
 
 # ── _run_queue: mid-run queue edits ───────────────────────────────────────────
 
+
 def test_baseline_run_executes_the_whole_matrix(manager):
     assert run_queue_with(manager) == [
-        ("L1", "Trench"), ("L2", "Trench"),
-        ("L1", "Undercut"), ("L2", "Undercut"),
+        ("L1", "Trench"),
+        ("L2", "Trench"),
+        ("L1", "Undercut"),
+        ("L2", "Undercut"),
     ]
 
 


### PR DESCRIPTION
Whitespace only. Split out so the typing changes that follow read as typing changes, the same way [#547](https://github.com/fibsem-os/fibsem-os/pull/547) preceded the tiled work and [#590](https://github.com/fibsem-os/fibsem-os/pull/590) precedes the spot burn work.

`ruff format` on the three files FIB-827 touches that were not formatted on `main`:

| file | changed lines |
| -- | -- |
| `workflows/tasks/manager.py` | 197 |
| `ui/workflow_timeline_widget.py` | 223 |
| `tests/autolamella/test_task_manager_status.py` | 118 |

`AutoLamellaMainUI.py` and `test_status_dict_vocabulary.py` are in that issue's scope too but are **already formatted**, so they are deliberately untouched.

## Verification

AST-level, not eyeballed:

- parse trees **identical** before and after, for all three files
- the decorator set on **every** function unchanged

That second check is the point: a scripted reformat is exactly where a decorator gets displaced onto the neighbouring function, and the diff alone does not show it.

`tests/autolamella/test_task_manager_status.py` and `test_status_dict_vocabulary.py`: **21 passed**. Both run in CI — `tests/autolamella/` is not gated on the `[ui]` extra.