### PR TITLE
[refactor] Declare a typed contract for spot burn progress (FIB-824)

### DIFF
--- a/fibsem/imaging/spot.py
+++ b/fibsem/imaging/spot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import threading
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING, List, Optional
 
 from fibsem.structures import BeamType, Point
@@ -42,6 +43,62 @@ class SpotBurnSettings:
             milling_current=ddict.get("milling_current", 60e-12),
             exposure_time=ddict.get("exposure_time", 10.0),
         )
+
+
+class SpotBurnStatus(str, Enum):
+    """What a spot burn is doing, or how it ended.
+
+    A `str` mixin so a report reads as itself in a log line, matching `TiledStatus`
+    and `FluorescenceAcquisitionStatus`.
+    """
+
+    BURNING = "burning"
+    FINISHED = "finished"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether the run is over, however it ended.
+
+        Asked by both consumers. Answered once here rather than restated as a
+        membership tuple at each of them: the next status added is the one somebody
+        forgets to add to one of the two, and the symptom is a progress bar that
+        never clears.
+        """
+        return self is not SpotBurnStatus.BURNING
+
+
+@dataclass(frozen=True)
+class SpotBurnProgress:
+    """One report on ``spot_burn_progress_signal``.
+
+    Replaces the bare dict the signal carried, whose three shapes were told apart by
+    the presence of a `finished` key and then a nested `error` flag -- two booleans
+    encoding four outcomes, one of which could not be expressed at all. A cancelled
+    burn reported `{"finished": True}`, identical to a completed one, so cancelling
+    rendered "Done".
+
+    Every field but `status` is absent on some report, so every field but `status`
+    has a default -- which also keeps this constructible on Python 3.8, where
+    `kw_only` does not exist: exactly one required field, and it comes first.
+
+    Equality is left generated. Nothing here carries a numpy array, so unlike
+    `TiledProgress` there is no reason to turn it off.
+    """
+
+    status: SpotBurnStatus
+    # 1-based, because `run_spot_burn` counts with `enumerate(coordinates, 1)`. The
+    # initial report carries 0, meaning "not started". Deliberately unlike
+    # `milling_progress_signal`'s 0-based `current_stage`: there is nothing to correct
+    # here, so do not port a `display_*` property over -- it would double-count.
+    current_point: Optional[int] = None
+    total_points: Optional[int] = None
+    remaining_time: Optional[float] = None
+    total_remaining_time: Optional[float] = None
+    total_estimated_time: Optional[float] = None
+    # Only on FAILED. The text of the exception that ended the run.
+    error: Optional[str] = None
 
 
 def run_spot_burn(

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from typing import Union
 
 from PyQt5.QtCore import Qt, QTimer, pyqtSignal
 from PyQt5.QtWidgets import (
@@ -13,7 +14,12 @@ from PyQt5.QtWidgets import (
 )
 from superqt import ensure_main_thread
 
-from fibsem.imaging.spot import SpotBurnSettings, run_spot_burn
+from fibsem.imaging.spot import (
+    SpotBurnProgress,
+    SpotBurnSettings,
+    SpotBurnStatus,
+    run_spot_burn,
+)
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType
 from fibsem.ui import notification_service, stylesheets
@@ -27,11 +33,56 @@ DEFAULT_BEAM_CURRENT = 60e-12  # 60 pA
 HIDE_PROGRESS_DELAY_MS = 2000  # how long the "Done" bar stays up before hiding
 
 
-def build_spot_burn_progress_update(ddict: dict) -> ProgressUpdate:
-    """Map a spot-burn progress dict (see run_spot_burn) to a ProgressUpdate.
+def build_spot_burn_progress_update(
+    report: Union[SpotBurnProgress, dict],
+) -> ProgressUpdate:
+    """Map a spot-burn progress report to a ProgressUpdate.
 
     Shared by the spot burn widget and the main-window status bar so both render
-    progress with identical text and formatting.
+    progress with identical text and formatting. That sharing is why typing this
+    signal is cheap: there is one decode to migrate, not one per consumer.
+
+    Accepts both the typed report and the dict the signal still carries. The dict
+    branch goes when the producers flip; until then it is the live path, and the
+    typed one is exercised only by tests.
+    """
+    if isinstance(report, SpotBurnProgress):
+        return _typed_spot_burn_progress_update(report)
+    return _dict_spot_burn_progress_update(report)
+
+
+def _typed_spot_burn_progress_update(report: SpotBurnProgress) -> ProgressUpdate:
+    """The typed form. Not reached until the producers flip."""
+    if report.status.is_terminal:
+        return _spot_burn_outcome(report)
+    return ProgressUpdate.combined(
+        current=report.current_point or 0,
+        total=report.total_points or 0,
+        remaining_seconds=report.total_remaining_time or 0.0,
+        total_seconds=report.total_estimated_time or 0.0,
+        message="Burning spots",
+    )
+
+
+def _spot_burn_outcome(report: SpotBurnProgress) -> ProgressUpdate:
+    """How a finished burn reads once the bar is full.
+
+    A cancel is deliberately not `failed`, which paints the bar red: it is someone
+    getting what they asked for. Mirrors `AutoLamellaSingleWindowUI._overview_outcome`,
+    which makes the same distinction for a tiled acquisition.
+    """
+    if report.status is SpotBurnStatus.FAILED:
+        return ProgressUpdate.failed(report.error or "Spot burn failed")
+    if report.status is SpotBurnStatus.CANCELLED:
+        return ProgressUpdate(finished=True, message="Cancelled")
+    return ProgressUpdate.done()
+
+
+def _dict_spot_burn_progress_update(ddict: dict) -> ProgressUpdate:
+    """The dict form, unchanged. Deleted once the producers flip.
+
+    Note what it cannot express: a cancelled burn arrives here as `{"finished": True}`,
+    indistinguishable from a completed one, and renders "Done".
     """
     if ddict.get("finished"):
         if ddict.get("error"):

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -14,7 +14,12 @@ import pytest
 from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
     SpotBurnFiducialTaskConfig,
 )
-from fibsem.imaging.spot import SpotBurnSettings, run_spot_burn
+from fibsem.imaging.spot import (
+    SpotBurnProgress,
+    SpotBurnSettings,
+    SpotBurnStatus,
+    run_spot_burn,
+)
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, Point
 
@@ -206,6 +211,143 @@ def test_build_spot_burn_progress_update_mapping():
 
     failed = build_spot_burn_progress_update({"finished": True, "error": True})
     assert failed.finished and failed.message == "Spot burn failed"
+
+
+def test_a_terminal_status_says_so_itself():
+    """The question both consumers ask, answered once on the type.
+
+    Restated as a membership tuple at each of them it drifts: the next status added is
+    the one somebody forgets, and the symptom is a progress bar that never clears.
+    """
+    terminal = {
+        SpotBurnStatus.FINISHED,
+        SpotBurnStatus.CANCELLED,
+        SpotBurnStatus.FAILED,
+    }
+    for status in SpotBurnStatus:
+        assert status.is_terminal is (status in terminal), status
+
+
+def test_a_member_compares_equal_to_its_own_value():
+    """The `str` mixin, which is what keeps these readable in a log line."""
+    assert SpotBurnStatus.BURNING == "burning"
+
+
+def test_status_is_the_only_field_a_report_must_carry():
+    """Everything else is absent on some report, so everything else has a default.
+
+    Also what keeps this constructible on Python 3.8, where `kw_only` does not exist:
+    exactly one required field, and it has to come first.
+    """
+    import dataclasses
+
+    report = SpotBurnProgress(status=SpotBurnStatus.CANCELLED)
+    assert report.current_point is None and report.error is None
+
+    required = [
+        f.name
+        for f in dataclasses.fields(SpotBurnProgress)
+        if f.default is dataclasses.MISSING and f.default_factory is dataclasses.MISSING
+    ]
+    assert required == ["status"]
+
+
+def test_a_report_cannot_be_written_to():
+    import dataclasses
+
+    report = SpotBurnProgress(status=SpotBurnStatus.BURNING)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        report.status = SpotBurnStatus.FINISHED
+
+
+@requires_ui
+class TestTheTypedDecode:
+    """What each typed report renders. Not which branch ran -- the bugs this path has
+    are rendering bugs, and asserting on control flow would not have caught them."""
+
+    def test_a_burn_in_progress_counts_points_and_time(self):
+        from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
+
+        update = build_spot_burn_progress_update(
+            SpotBurnProgress(
+                status=SpotBurnStatus.BURNING,
+                current_point=1,
+                total_points=3,
+                total_remaining_time=20.0,
+                total_estimated_time=30.0,
+            )
+        )
+
+        assert (update.current, update.total) == (1, 3)
+        assert update.remaining_seconds == 20.0
+        assert not update.finished
+        assert update.message == "Burning spots"
+
+    def test_a_completed_burn_says_done(self):
+        from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
+
+        update = build_spot_burn_progress_update(
+            SpotBurnProgress(status=SpotBurnStatus.FINISHED)
+        )
+
+        assert update.finished and not update.message
+        assert not update.is_failed
+
+    def test_a_cancelled_burn_does_not_claim_to_have_finished(self):
+        """The defect the typed contract exists to fix. Under the dict form a cancelled
+        burn emitted `{"finished": True}` -- identical to a completed one -- so
+        cancelling rendered "Done"."""
+        from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
+
+        update = build_spot_burn_progress_update(
+            SpotBurnProgress(status=SpotBurnStatus.CANCELLED, current_point=2)
+        )
+
+        assert update.finished
+        assert update.message == "Cancelled"
+
+    def test_a_cancelled_burn_is_not_painted_as_a_failure(self):
+        """A cancel is someone getting what they asked for, so the bar does not go red.
+        Mirrors the tiled acquisition's `_overview_outcome`."""
+        from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
+
+        update = build_spot_burn_progress_update(
+            SpotBurnProgress(status=SpotBurnStatus.CANCELLED)
+        )
+
+        assert not update.is_failed
+
+    def test_a_failed_burn_carries_the_error_text(self):
+        """The dict form could only ever say "Spot burn failed"; the exception text
+        reached the logfile and nowhere else."""
+        from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
+
+        update = build_spot_burn_progress_update(
+            SpotBurnProgress(status=SpotBurnStatus.FAILED, error="beam current refused")
+        )
+
+        assert update.is_failed
+        assert update.message == "beam current refused"
+
+    def test_a_failure_with_no_text_still_reads_as_a_failure(self):
+        from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
+
+        update = build_spot_burn_progress_update(
+            SpotBurnProgress(status=SpotBurnStatus.FAILED)
+        )
+
+        assert update.is_failed
+        assert update.message == "Spot burn failed"
+
+    def test_the_dict_form_still_works(self):
+        """Both shapes flow until the producers flip, and the dict is the live one."""
+        from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
+
+        update = build_spot_burn_progress_update(
+            {"current_point": 2, "total_points": 4, "total_remaining_time": 5.0}
+        )
+
+        assert (update.current, update.total) == (2, 4)
 
 
 # --- SpotBurnFiducialTask.update_spot_burn_parameters_ui ------------------------


### PR DESCRIPTION
`spot_burn_progress_signal` carries a bare dict whose three shapes are told apart by the presence of a `finished` key and then a nested `error` flag — **two booleans encoding four outcomes, one of which cannot be expressed at all.**

## The defect this sets up the fix for

A cancelled burn emits `{"finished": True}` — byte-identical to a completed one — so **cancelling a spot burn renders "Done"**, in the widget and in the status bar. Cancel is a normal action here: it is on a button, and the workflow task passes a `stop_event` too. Both backends do it.

The status enum makes that state unrepresentable. The producers start sending it in the next PR; this one only declares the shape.

## Why this signal is cheap to type

`build_spot_burn_progress_update` is **shared by both consumers** — the widget and the main-window status bar — so there is one decode to migrate, not one per consumer. It grows a typed path beside the dict one, and the dict remains the live path until the producers flip.

## Decisions worth reviewing

| | |
| -- | -- |
| **Location** | `fibsem/imaging/spot.py`, beside `SpotBurnSettings` and `run_spot_burn` — where the tiled and fluorescence contracts sit relative to their producers. |
| **No `message` field** | No producer sends one, the decoder hardcodes `"Burning spots"`, and the producer set is closed. The consumer owns the wording, as on the tiled signal. Deliberately unlike milling (FIB-797), where strategy plugins need to override it. |
| **`current_point` stays 1-based** | `enumerate(coordinates, 1)` already produces that. Deliberately unlike milling’s 0-based `current_stage` — there is nothing to correct, so **no `display_*` property**; porting one would double-count. |
| **Cancel is not a failure** | It does not paint the bar red — someone got what they asked for. Mirrors `_overview_outcome` for tiled runs. |

## Tests

11 new, all verified to actually run (they sit behind `requires_ui`, so I checked by name rather than trusting the count). They assert **rendered output**, not which branch ran — the bugs this path has are rendering bugs.

`tests/autolamella/test_spot_burn.py` runs in CI; it is not gated on the `[ui]` extra.

**46 passed.** `ruff check` / `ruff format --check` clean. Static 3.8 scan clean (`match`, `dataclass(kw_only=)`, runtime PEP 604, `str.removesuffix`).