### PR TITLE
[refactor] Declare a typed contract for workflow status updates (FIB-827)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -71,6 +71,9 @@ from fibsem.applications.autolamella.ui.workflow_timeline_widget import (
     WorkflowProgressWidget,
 )
 from fibsem.applications.autolamella.workflows.tasks.queue import QueueOp, QueueResult
+from fibsem.applications.autolamella.workflows.tasks.status import (
+    WorkflowStatusUpdate,
+)
 from fibsem.applications.autolamella.workflows.tasks.tasks import get_task_supervision
 from fibsem.applications.autolamella.workflows.workflow_estimate import (
     AdditionEstimate,
@@ -2626,20 +2629,29 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             # through the same path.
             self.workflow_timeline.update_from_status(status_msg)
 
-            task_name = status_msg.get("task_name", "Unknown Task")
-            lamella_name = status_msg.get("item_name", "Unknown Lamella")
-            queue_position = status_msg.get("queue_position", None)
-            queue_total = status_msg.get("queue_total", None)
-            error_msg = status_msg.get("error_message", None)
-            timestamp = status_msg.get("timestamp", None)
-            task_duration = status_msg.get("task_duration", None)
+            # One decode at the boundary rather than a `.get()` per field. Accepts the
+            # dict the signal still carries and the typed report the producer will send
+            # (FIB-827); total by construction, because raising here is a process abort
+            # rather than a missing label (FIB-329).
+            report = WorkflowStatusUpdate.from_payload(status_msg)
+
+            task_name = report.task_name
+            lamella_name = report.item_name
+            queue_position = report.queue_position
+            queue_total = report.queue_total
+            error_msg = report.error_message
+            timestamp = report.timestamp
+            task_duration = report.task_duration
             msg = info.get("msg", "No message")
-            status = status_msg.get("status", "info")
+            status = report.status
 
             # Position in the live queue, not the launch matrix — stays correct
             # when the queue is added to or reordered mid-run.
             txt = f"Workflow: {task_name} | {lamella_name}"
-            if queue_position is not None and queue_total is not None:
+            # `queue_total` is a count, so 0 means "nothing to be in the middle of"
+            # rather than "unknown" -- truthiness, not `is not None`, or a malformed
+            # payload renders "3/0".
+            if queue_position is not None and queue_total:
                 txt += f" | {queue_position}/{queue_total}"
 
             self.set_workflow_running(txt)

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -2639,9 +2639,11 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             lamella_name = report.item_name
             queue_position = report.queue_position
             queue_total = report.queue_total
-            error_msg = report.error_message
-            timestamp = report.timestamp
-            task_duration = report.task_duration
+            # `error_message`, `timestamp` and `task_duration` were decoded here and
+            # never used -- dead before this change, so not converted into typed dead
+            # code. The timeline renders all three from the same report; the status bar
+            # never did. If the intent was for it to, that is a feature to add rather
+            # than three assignments to keep warm.
             msg = info.get("msg", "No message")
             status = report.status
 

--- a/fibsem/applications/autolamella/ui/workflow_timeline_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_timeline_widget.py
@@ -878,7 +878,10 @@ class WorkflowProgressWidget(QWidget):
         report = WorkflowStatusUpdate.from_payload(status)
 
         queue_items = report.queue_items
-        if not queue_items:
+        if queue_items is None:
+            # No snapshot in this payload -- leave the rows as they are. An *empty*
+            # snapshot is a different thing and does fall through, to reconcile the
+            # timeline down to zero rows.
             return
 
         task_status = report.status
@@ -900,7 +903,9 @@ class WorkflowProgressWidget(QWidget):
                 n for n, i in enumerate(self._items) if i.id == active_id
             )
             self._inner_finished = False
-            self._active_start_time = report.timestamp or time.time()
+            self._active_start_time = (
+                report.timestamp if report.timestamp is not None else time.time()
+            )
             # The pause accounting belongs to one task, not to the workflow.
             self._waiting_for_user = False
             self._paused_total = 0.0

--- a/fibsem/applications/autolamella/ui/workflow_timeline_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_timeline_widget.py
@@ -869,13 +869,20 @@ class WorkflowProgressWidget(QWidget):
         Reads queue_items snapshot to update all row statuses directly.
         """
         from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+        from fibsem.applications.autolamella.workflows.tasks.status import (
+            WorkflowStatusUpdate,
+        )
 
-        queue_items = status.get("queue_items", None)
-        if queue_items is None:
+        # One decode at the boundary: accepts the dict the signal still carries and the
+        # typed report the producer will send (FIB-827).
+        report = WorkflowStatusUpdate.from_payload(status)
+
+        queue_items = report.queue_items
+        if not queue_items:
             return
 
-        task_status = status.get("status", None)
-        task_duration = status.get("task_duration", None)
+        task_status = report.status
+        task_duration = report.task_duration
 
         # Reconcile rows with the snapshot; this also refreshes every status.
         self._sync(queue_items)
@@ -893,7 +900,7 @@ class WorkflowProgressWidget(QWidget):
                 n for n, i in enumerate(self._items) if i.id == active_id
             )
             self._inner_finished = False
-            self._active_start_time = status.get("timestamp", time.time())
+            self._active_start_time = report.timestamp or time.time()
             # The pause accounting belongs to one task, not to the workflow.
             self._waiting_for_user = False
             self._paused_total = 0.0
@@ -919,11 +926,11 @@ class WorkflowProgressWidget(QWidget):
             if 0 <= idx < len(self._outer._rows):
                 task_name = self._items[idx].task_name
                 self._set_completion_subtitle(
-                    idx, task_duration, task_name, completed_at=status.get("timestamp")
+                    idx, task_duration, task_name, completed_at=report.timestamp
                 )
                 # Show error message on failed rows, before the refresh that renders it
                 if task_status == AutoLamellaTaskStatus.Failed:
-                    error_msg = status.get("error_message", None)
+                    error_msg = report.error_message
                     if error_msg:
                         self._outer._rows[idx].set_error(error_msg)
                 # Refresh the row so the updated subtitle is rendered
@@ -932,9 +939,9 @@ class WorkflowProgressWidget(QWidget):
             self._finish_inner(failed=(task_status == AutoLamellaTaskStatus.Failed))
 
         elif task_status == AutoLamellaTaskStatus.Skipped:
-            skip_reason = status.get("skip_reason", None)
-            task_name = status.get("task_name", "")
-            item_name = status.get("item_name", "")
+            skip_reason = report.skip_reason
+            task_name = report.task_name
+            item_name = report.item_name
             reason_str = _SKIP_REASON_LABELS.get(skip_reason, skip_reason or "Skipped")
             for i, item in enumerate(self._items):
                 if item.lamella_name == item_name and item.task_name == task_name:

--- a/fibsem/applications/autolamella/workflows/tasks/status.py
+++ b/fibsem/applications/autolamella/workflows/tasks/status.py
@@ -51,7 +51,12 @@ class WorkflowStatusUpdate:
     # A snapshot of copies, not the live queue: `Queue.items` returns
     # `[copy.copy(i) for i in self._items]` under a lock. Safe to read from the GUI
     # thread, and no further defensive copying is wanted.
-    queue_items: List["WorkItem"] = field(default_factory=list)
+    #
+    # `None` rather than `[]` when absent, and the difference is load-bearing: the
+    # timeline treats "this payload carries no snapshot" as "leave the rows alone",
+    # and "the snapshot is empty" as "reconcile to zero rows". Defaulting to `[]`
+    # would collapse the two and leave stale rows on screen when a queue empties.
+    queue_items: Optional[List["WorkItem"]] = None
     # The plan this run was launched with. Informational only -- the live queue may
     # since have diverged from it. No in-repo production consumer reads either of
     # these; they are kept for the same reason `lamella_name` is, and should be
@@ -104,7 +109,11 @@ class WorkflowStatusUpdate:
             skip_reason=payload.get("skip_reason"),
             queue_position=payload.get("queue_position"),
             queue_total=payload.get("queue_total") or 0,
-            queue_items=list(payload.get("queue_items") or []),
+            queue_items=(
+                list(payload["queue_items"])
+                if payload.get("queue_items") is not None
+                else None
+            ),
             task_names=list(payload.get("task_names") or []),
             lamella_names=list(payload.get("lamella_names") or []),
         )

--- a/fibsem/applications/autolamella/workflows/tasks/status.py
+++ b/fibsem/applications/autolamella/workflows/tasks/status.py
@@ -1,0 +1,110 @@
+"""The typed payload carried on ``workflow_update_signal``'s ``status`` key.
+
+Only the *nested* record, deliberately. The envelope around it -- ``{"msg": ...,
+"status": ...}`` -- is untouched, because most of that signal is not a signal at all:
+ten of its thirteen emits are blocking calls built from a shared mutable bool and a
+polling loop, and untangling those is a threading redesign (FIB-826). This record is
+independent of that work in both directions and can land before or after it.
+
+Unlike the other progress signals, there was no vocabulary to design here. ``status``
+has always been a real ``AutoLamellaTaskStatus`` on the wire; what was missing was a
+declared shape around it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+
+if TYPE_CHECKING:
+    from fibsem.applications.autolamella.workflows.tasks.queue import WorkItem
+
+
+@dataclass(frozen=True, eq=False)
+class WorkflowStatusUpdate:
+    """One report on a task's lifecycle, from ``TaskManager._emit_status``.
+
+    ``eq=False`` is load-bearing, for a different reason than ``TiledProgress``'s.
+    Three fields hold lists, and ``WorkItem`` is a *mutable* dataclass, so it is
+    unhashable. ``frozen=True`` with the default ``eq=True`` generates a ``__hash__``
+    over every field, which raises ``TypeError: unhashable type: 'list'`` the moment
+    anything puts a report in a set or uses it as a key. There is no numpy here --
+    if you came looking for the tiled contract's reason, this is not it.
+    """
+
+    task_name: str = "Unknown Task"
+    item_name: str = "Unknown Lamella"
+    status: AutoLamellaTaskStatus = AutoLamellaTaskStatus.NotStarted
+    timestamp: Optional[float] = None
+    error_message: Optional[str] = None
+    task_duration: Optional[float] = None
+    skip_reason: Optional[str] = None
+    # Position in the *live* queue, and ALREADY 1-based: the producer writes
+    # `position + 1`. Deliberately unlike `milling_progress_signal`'s 0-based
+    # `current_stage`, which seven consumers each increment. There is nothing to
+    # correct here, so do not port a `display_*` property over -- it would
+    # double-count.
+    queue_position: Optional[int] = None
+    queue_total: int = 0
+    # A snapshot of copies, not the live queue: `Queue.items` returns
+    # `[copy.copy(i) for i in self._items]` under a lock. Safe to read from the GUI
+    # thread, and no further defensive copying is wanted.
+    queue_items: List["WorkItem"] = field(default_factory=list)
+    # The plan this run was launched with. Informational only -- the live queue may
+    # since have diverged from it. No in-repo production consumer reads either of
+    # these; they are kept for the same reason `lamella_name` is, and should be
+    # dropped together with it.
+    task_names: List[str] = field(default_factory=list)
+    lamella_names: List[str] = field(default_factory=list)
+
+    @property
+    def lamella_name(self) -> str:
+        """Deprecated alias for :attr:`item_name`.
+
+        A property rather than a field so there is one source of truth and the two
+        cannot drift. Drop it alongside the ``HookContext`` shims after v0.6.
+        """
+        return self.item_name
+
+    @classmethod
+    def from_payload(
+        cls, payload: Union["WorkflowStatusUpdate", Dict[str, Any], None]
+    ) -> "WorkflowStatusUpdate":
+        """Accept either the typed report or the dict the signal still carries.
+
+        Total by construction, and that is the point rather than politeness. This
+        runs inside a queued Qt slot, where PyQt5 turns any escaping exception into
+        ``qFatal`` -- the process aborts mid-run and the abort reaches no logfile
+        (FIB-329). This signal has already killed the app that way once, over a
+        missing ``msg`` key. So every field has a default and nothing here indexes.
+
+        Deleted once the producer flips; until then the dict is the live path.
+        """
+        if isinstance(payload, cls):
+            return payload
+        if not payload:
+            return cls()
+
+        status = payload.get("status")
+        if not isinstance(status, AutoLamellaTaskStatus):
+            # Not a lie worth telling loudly: `NotStarted` fires no consumer branch,
+            # so an unrecognised value renders as "nothing in particular happened"
+            # rather than crashing or picking a wrong outcome.
+            status = AutoLamellaTaskStatus.NotStarted
+
+        return cls(
+            task_name=payload.get("task_name") or "Unknown Task",
+            item_name=payload.get("item_name") or "Unknown Lamella",
+            status=status,
+            timestamp=payload.get("timestamp"),
+            error_message=payload.get("error_message"),
+            task_duration=payload.get("task_duration"),
+            skip_reason=payload.get("skip_reason"),
+            queue_position=payload.get("queue_position"),
+            queue_total=payload.get("queue_total") or 0,
+            queue_items=list(payload.get("queue_items") or []),
+            task_names=list(payload.get("task_names") or []),
+            lamella_names=list(payload.get("lamella_names") or []),
+        )

--- a/tests/autolamella/test_workflow_status_update.py
+++ b/tests/autolamella/test_workflow_status_update.py
@@ -8,7 +8,7 @@ decode that can raise inside a Qt slot.
 """
 
 import dataclasses
-import inspect
+import pathlib
 
 import pytest
 
@@ -101,13 +101,26 @@ class TestTheQueueSnapshot:
         assert report.queue_items is not None
 
     def test_the_timeline_leaves_rows_alone_without_a_snapshot(self):
-        """ "No snapshot" means "this payload says nothing about the queue"."""
-        from fibsem.applications.autolamella.ui import workflow_timeline_widget
+        """ "No snapshot" means "this payload says nothing about the queue".
 
-        source = inspect.getsource(
-            workflow_timeline_widget.WorkflowProgressWidget.update_from_status
-        )
-        assert "is None" in source, (
+        Read as source text rather than imported. This file lives in
+        `tests/autolamella/`, which runs in CI *without* the `[ui]` extra, and
+        `workflow_timeline_widget` imports PyQt5 at module level -- importing it here
+        passes locally and fails on every CI build.
+        """
+        import fibsem
+
+        source = (
+            pathlib.Path(fibsem.__file__).parent
+            / "applications"
+            / "autolamella"
+            / "ui"
+            / "workflow_timeline_widget.py"
+        ).read_text()
+        body = source[source.index("def update_from_status") :]
+        body = body[: body.index("\n    def ", 1)]
+
+        assert "queue_items is None" in body, (
             "update_from_status must distinguish an absent snapshot from an empty one; "
             "a falsy check collapses them and leaves stale rows when a queue empties"
         )

--- a/tests/autolamella/test_workflow_status_update.py
+++ b/tests/autolamella/test_workflow_status_update.py
@@ -1,0 +1,98 @@
+"""The typed record carried on `workflow_update_signal`'s `status` key (FIB-827).
+
+Nothing emits one yet -- `TaskManager._emit_status` still builds a dict, and both
+consumers decode through `from_payload`, which accepts either. What is worth pinning
+before the producer flips is the shape, and in particular the two properties that are
+cheap to get wrong and expensive to notice: a record that cannot be hashed, and a
+decode that can raise inside a Qt slot.
+"""
+
+import dataclasses
+
+import pytest
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+from fibsem.applications.autolamella.workflows.tasks.queue import WorkItem
+from fibsem.applications.autolamella.workflows.tasks.status import WorkflowStatusUpdate
+
+
+class TestTheDecodeIsTotal:
+    """`from_payload` runs inside a queued Qt slot.
+
+    PyQt5 turns any exception escaping such a slot into `qFatal`: the process aborts
+    mid-run and the abort reaches no logfile (FIB-329). This signal has already killed
+    the app that way once, over a missing `msg` key. So these are not politeness tests
+    -- each one is a payload that must not be able to take the application down.
+    """
+
+    @pytest.mark.parametrize(
+        "payload",
+        [None, {}, {"status": {}}, {"task_name": None}, {"queue_items": None}],
+    )
+    def test_a_partial_payload_decodes_rather_than_raising(self, payload):
+        report = WorkflowStatusUpdate.from_payload(payload)
+        assert isinstance(report, WorkflowStatusUpdate)
+
+    def test_an_unrecognised_status_becomes_notstarted(self):
+        """A neutral value, chosen because it fires no consumer branch. Rendering
+        "nothing in particular happened" beats crashing or picking a wrong outcome."""
+        report = WorkflowStatusUpdate.from_payload({"status": "info"})
+
+        assert report.status is AutoLamellaTaskStatus.NotStarted
+
+    def test_a_typed_report_passes_straight_through(self):
+        original = WorkflowStatusUpdate(task_name="Trench")
+
+        assert WorkflowStatusUpdate.from_payload(original) is original
+
+
+class TestTheShape:
+    def test_a_report_carrying_queue_items_can_be_hashed(self):
+        """`eq=False` is load-bearing, and for a different reason than `TiledProgress`.
+
+        Three fields hold lists and `WorkItem` is a mutable dataclass, so it is
+        unhashable. Left as `eq=True`, `frozen=True` would generate a `__hash__` over
+        every field that raises `TypeError` here. There is no numpy involved -- if the
+        tiled contract's reason is what you came looking for, this is not it.
+        """
+        report = WorkflowStatusUpdate(
+            queue_items=[WorkItem(lamella_name="L1", task_name="Trench")]
+        )
+
+        assert {report, report} == {report}
+
+    def test_a_work_item_really_is_unhashable(self):
+        """The hazard lives in `WorkItem`, not in this test's imagination. If this ever
+        stops raising, `eq=False` has lost its reason and the comment is wrong."""
+        with pytest.raises(TypeError):
+            hash(WorkItem(lamella_name="L1", task_name="Trench"))
+
+    def test_a_report_cannot_be_written_to(self):
+        report = WorkflowStatusUpdate()
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            report.task_name = "Undercut"
+
+    def test_lamella_name_is_derived_not_stored(self):
+        """A property, so the deprecated alias cannot drift from `item_name` and
+        deletes cleanly with the HookContext shims after v0.6."""
+        report = WorkflowStatusUpdate(item_name="L99")
+
+        assert report.lamella_name == "L99"
+        assert "lamella_name" not in {f.name for f in dataclasses.fields(report)}
+
+
+class TestQueuePosition:
+    def test_it_is_already_one_based_and_is_not_adjusted(self):
+        """The producer writes `position + 1`. Deliberately unlike milling's 0-based
+        `current_stage`, which seven consumers each increment -- porting a `display_*`
+        helper here would double-count."""
+        report = WorkflowStatusUpdate.from_payload(
+            {"queue_position": 1, "queue_total": 4}
+        )
+
+        assert (report.queue_position, report.queue_total) == (1, 4)
+
+    def test_an_absent_position_stays_absent(self):
+        """`None` means "not in the queue", which is not the same as position 0."""
+        assert WorkflowStatusUpdate.from_payload({}).queue_position is None

--- a/tests/autolamella/test_workflow_status_update.py
+++ b/tests/autolamella/test_workflow_status_update.py
@@ -8,6 +8,7 @@ decode that can raise inside a Qt slot.
 """
 
 import dataclasses
+import inspect
 
 import pytest
 
@@ -80,6 +81,36 @@ class TestTheShape:
 
         assert report.lamella_name == "L99"
         assert "lamella_name" not in {f.name for f in dataclasses.fields(report)}
+
+
+class TestTheQueueSnapshot:
+    """`None` and `[]` mean different things, and the timeline acts on the difference.
+
+    The dict carried that distinction for free -- an absent key read as `None`, an empty
+    queue read as `[]`. A record defaulting the field to `[]` would collapse them, and
+    the visible symptom is stale rows left on screen when a queue empties.
+    """
+
+    def test_an_absent_snapshot_is_none_not_empty(self):
+        assert WorkflowStatusUpdate.from_payload({}).queue_items is None
+
+    def test_an_empty_snapshot_stays_empty(self):
+        report = WorkflowStatusUpdate.from_payload({"queue_items": []})
+
+        assert report.queue_items == []
+        assert report.queue_items is not None
+
+    def test_the_timeline_leaves_rows_alone_without_a_snapshot(self):
+        """ "No snapshot" means "this payload says nothing about the queue"."""
+        from fibsem.applications.autolamella.ui import workflow_timeline_widget
+
+        source = inspect.getsource(
+            workflow_timeline_widget.WorkflowProgressWidget.update_from_status
+        )
+        assert "is None" in source, (
+            "update_from_status must distinguish an absent snapshot from an empty one; "
+            "a falsy check collapses them and leaves stale rows when a queue empties"
+        )
 
 
 class TestQueuePosition:


### PR DESCRIPTION
The `status` value nested inside `workflow_update_signal`’s payload is a bare 13-key dict, read through eleven separate `.get()` calls across two consumers.

## Scope: the nested record only, deliberately

The envelope stays exactly as it is — `{"msg": …, "status": …}`. Most of that signal is **not a signal at all**: ten of its thirteen emits are blocking calls built from a shared mutable bool and a polling loop, and untangling that is a threading redesign ([FIB-826](https://linear.app/fibsemos/issue/FIB-826)). This record is independent of that work **in both directions** and can land before or after it.

## Why it is the easy half

There was no vocabulary to design. `status` has always been a real `AutoLamellaTaskStatus` on the wire — unlike the other four signals in FIB-402’s scope, the discriminator was already correct. What was missing was a shape around it.

Nothing emits one yet: both consumers decode through `WorkflowStatusUpdate.from_payload`, which accepts the dict the producer still sends and the record it will send next. **One decode at the boundary** rather than a `.get()` per field.

## `from_payload` is total by construction, and that is the point

It runs inside a queued Qt slot, where PyQt5 turns any escaping exception into `qFatal` — the process aborts mid-run and the abort reaches **no logfile** ([FIB-329](https://linear.app/fibsemos/issue/FIB-329)). This signal has already killed the app that way once, over a missing `msg` key; `tests/ui/test_workflow_update_payload.py` exists because of it.

So every field has a default, nothing indexes, and an unrecognised `status` becomes `NotStarted` — a value chosen because it fires no consumer branch, so it renders "nothing in particular happened" rather than crashing or picking a wrong outcome.

## Three decisions worth reviewing

**`eq=False`, for a different reason than `TiledProgress`’s.** Three fields hold lists and `WorkItem` is a *mutable* dataclass, so it is unhashable; `frozen=True` with the default `eq=True` generates a `__hash__` that raises `TypeError`. No numpy involved. Pinned by a test that *also* asserts `WorkItem` really is unhashable, so the reason cannot rot into a stale comment.

**`lamella_name` becomes a property, not a field** — one source of truth, so the deprecated alias cannot drift from `item_name`, and it deletes cleanly with the HookContext shims after v0.6.

**`queue_position` stays 1-based**, which is what the producer already writes. Deliberately unlike milling’s 0-based `current_stage` that seven consumers each increment — porting a display helper here would double-count.

## One behaviour difference, closed deliberately

`queue_total` now defaults to `0` rather than `None`, so the status-bar guard reads truthiness instead of `is not None`. A count of 0 means "nothing to be in the middle of", and the old guard would have rendered `"3/0"` for a malformed payload.

**607 passed** across `tests/autolamella/` plus the timeline and payload-safety suites. `tests/autolamella/` runs in CI. Static 3.8 scan clean.