### PR TITLE
[refactor] Flip the spot burn producers to the typed contract (FIB-824)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -102,6 +102,7 @@ except Exception:
 import fibsem.constants as constants
 from fibsem import manufacturers
 from fibsem.fm.microscope import FluorescenceMicroscope
+from fibsem.imaging.spot import SpotBurnProgress, SpotBurnStatus
 from fibsem.imaging.tiling.progress import TiledProgress
 from fibsem.microscopes.autoscript import (
     fibsem_image_from_adorned_image,
@@ -165,7 +166,7 @@ class FibsemMicroscope(ABC):
     # crash-on-hardware bug that won't reproduce on a dev machine.
     milling_progress_signal = Signal(dict)
     tiled_acquisition_signal = Signal(TiledProgress)
-    spot_burn_progress_signal = Signal(dict)
+    spot_burn_progress_signal = Signal(SpotBurnProgress)
     _last_imaging_settings: ImageSettings
     system: SystemSettings
     _patterns: List
@@ -1166,14 +1167,17 @@ class FibsemMicroscope(ABC):
 
         # emit initial progress signal
         self.spot_burn_progress_signal.emit(
-            {
-                "current_point": 0,
-                "total_points": len(coordinates),
-                "remaining_time": exposure_time,
-                "total_remaining_time": total_remaining_time,
-                "total_estimated_time": total_estimated_time,
-            }
+            SpotBurnProgress(
+                status=SpotBurnStatus.BURNING,
+                current_point=0,
+                total_points=len(coordinates),
+                remaining_time=exposure_time,
+                total_remaining_time=total_remaining_time,
+                total_estimated_time=total_estimated_time,
+            )
         )
+
+        cancelled = False
 
         # set the beam current to the milling current
         imaging_current = self.get_beam_current(beam_type=beam_type)
@@ -1184,6 +1188,7 @@ class FibsemMicroscope(ABC):
                 logging.info(
                     f"Spot burn cancelled before point {i}/{len(coordinates)}."
                 )
+                cancelled = True
                 break
 
             logging.info(
@@ -1202,25 +1207,43 @@ class FibsemMicroscope(ABC):
                     logging.info(
                         f"Spot burn cancelled during point {i}/{len(coordinates)}."
                     )
+                    cancelled = True
                     break
                 time.sleep(SLEEP_TIME)
                 remaining_time -= SLEEP_TIME
                 total_remaining_time -= SLEEP_TIME
                 self.spot_burn_progress_signal.emit(
-                    {
-                        "current_point": i,
-                        "total_points": len(coordinates),
-                        "remaining_time": remaining_time,
-                        "total_remaining_time": total_remaining_time,
-                        "total_estimated_time": total_estimated_time,
-                    }
+                    SpotBurnProgress(
+                        status=SpotBurnStatus.BURNING,
+                        current_point=i,
+                        total_points=len(coordinates),
+                        remaining_time=remaining_time,
+                        total_remaining_time=total_remaining_time,
+                        total_estimated_time=total_estimated_time,
+                    )
                 )
+
+            if cancelled:
+                # The inner `break` only leaves this point's countdown. The outer
+                # loop's own stop_event check would catch it on the next iteration
+                # anyway, so this is not a fix -- it just stops the run here rather
+                # than one log line later, now that the outcome is recorded.
+                break
 
         # always restore full frame scanning mode and imaging current
         self.set_full_frame_scanning_mode(beam_type=beam_type)
 
-        # emit finished signal
-        self.spot_burn_progress_signal.emit({"finished": True})
+        # A cancelled burn is not a completed one. Both used to emit `{"finished": True}`,
+        # so cancelling rendered "Done" -- the defect the status enum exists to remove.
+        self.spot_burn_progress_signal.emit(
+            SpotBurnProgress(
+                status=SpotBurnStatus.CANCELLED
+                if cancelled
+                else SpotBurnStatus.FINISHED,
+                current_point=len(coordinates),
+                total_points=len(coordinates),
+            )
+        )
 
         self.set_beam_current(current=imaging_current, beam_type=beam_type)
 

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -53,7 +53,11 @@ try:
 except Exception as e:
     logging.debug(f"Automation (TESCAN) not installed. {e}")
 
-from fibsem.imaging.spot import SpotBurnSettings
+from fibsem.imaging.spot import (
+    SpotBurnProgress,
+    SpotBurnSettings,
+    SpotBurnStatus,
+)
 from fibsem.milling.base import set_preset_driven_estimation
 from fibsem.structures import (  # noqa
     ACTIVE_MILLING_STATES,
@@ -1693,14 +1697,17 @@ class TescanMicroscope(FibsemMicroscope):
         )
 
         self.spot_burn_progress_signal.emit(
-            {
-                "current_point": 0,
-                "total_points": total_points,
-                "remaining_time": exposure_time,
-                "total_remaining_time": estimated_time,
-                "total_estimated_time": estimated_time,
-            }
+            SpotBurnProgress(
+                status=SpotBurnStatus.BURNING,
+                current_point=0,
+                total_points=total_points,
+                remaining_time=exposure_time,
+                total_remaining_time=estimated_time,
+                total_estimated_time=estimated_time,
+            )
         )
+
+        cancelled = False
 
         with self._connection_lock:
             self.connection.DrawBeam.Start()
@@ -1710,6 +1717,7 @@ class TescanMicroscope(FibsemMicroscope):
                 if stop_event is not None and stop_event.is_set():
                     logging.info("Spot burn cancelled.")
                     self.stop_milling()
+                    cancelled = True
                     break
 
                 time.sleep(SPOT_BURN_POLL_INTERVAL)
@@ -1719,18 +1727,29 @@ class TescanMicroscope(FibsemMicroscope):
                 elapsed = time.time() - start_time
                 current_point = min(total_points, int(elapsed // exposure_time) + 1)
                 self.spot_burn_progress_signal.emit(
-                    {
-                        "current_point": current_point,
-                        "total_points": total_points,
-                        "remaining_time": max(
+                    SpotBurnProgress(
+                        status=SpotBurnStatus.BURNING,
+                        # Inferred from elapsed time, not measured: DrawBeam exposes
+                        # no per-dot progress. Not authoritative.
+                        current_point=current_point,
+                        total_points=total_points,
+                        remaining_time=max(
                             0.0, current_point * exposure_time - elapsed
                         ),
-                        "total_remaining_time": max(0.0, estimated_time - elapsed),
-                        "total_estimated_time": estimated_time,
-                    }
+                        total_remaining_time=max(0.0, estimated_time - elapsed),
+                        total_estimated_time=estimated_time,
+                    )
                 )
 
-            self.spot_burn_progress_signal.emit({"finished": True})
+            self.spot_burn_progress_signal.emit(
+                SpotBurnProgress(
+                    status=SpotBurnStatus.CANCELLED
+                    if cancelled
+                    else SpotBurnStatus.FINISHED,
+                    current_point=total_points,
+                    total_points=total_points,
+                )
+            )
         except Exception as e:
             logging.error(f"Error in run_spot_burn: {e}")
             raise

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Union
 
 from PyQt5.QtCore import Qt, QTimer, pyqtSignal
 from PyQt5.QtWidgets import (
@@ -33,26 +32,13 @@ DEFAULT_BEAM_CURRENT = 60e-12  # 60 pA
 HIDE_PROGRESS_DELAY_MS = 2000  # how long the "Done" bar stays up before hiding
 
 
-def build_spot_burn_progress_update(
-    report: Union[SpotBurnProgress, dict],
-) -> ProgressUpdate:
+def build_spot_burn_progress_update(report: SpotBurnProgress) -> ProgressUpdate:
     """Map a spot-burn progress report to a ProgressUpdate.
 
     Shared by the spot burn widget and the main-window status bar so both render
     progress with identical text and formatting. That sharing is why typing this
-    signal is cheap: there is one decode to migrate, not one per consumer.
-
-    Accepts both the typed report and the dict the signal still carries. The dict
-    branch goes when the producers flip; until then it is the live path, and the
-    typed one is exercised only by tests.
+    signal was cheap: there was one decode to migrate, not one per consumer.
     """
-    if isinstance(report, SpotBurnProgress):
-        return _typed_spot_burn_progress_update(report)
-    return _dict_spot_burn_progress_update(report)
-
-
-def _typed_spot_burn_progress_update(report: SpotBurnProgress) -> ProgressUpdate:
-    """The typed form. Not reached until the producers flip."""
     if report.status.is_terminal:
         return _spot_burn_outcome(report)
     return ProgressUpdate.combined(
@@ -76,25 +62,6 @@ def _spot_burn_outcome(report: SpotBurnProgress) -> ProgressUpdate:
     if report.status is SpotBurnStatus.CANCELLED:
         return ProgressUpdate(finished=True, message="Cancelled")
     return ProgressUpdate.done()
-
-
-def _dict_spot_burn_progress_update(ddict: dict) -> ProgressUpdate:
-    """The dict form, unchanged. Deleted once the producers flip.
-
-    Note what it cannot express: a cancelled burn arrives here as `{"finished": True}`,
-    indistinguishable from a completed one, and renders "Done".
-    """
-    if ddict.get("finished"):
-        if ddict.get("error"):
-            return ProgressUpdate.failed("Spot burn failed")
-        return ProgressUpdate.done()
-    return ProgressUpdate.combined(
-        current=ddict.get("current_point", 0),
-        total=ddict.get("total_points", 0),
-        remaining_seconds=ddict.get("total_remaining_time", 0.0),
-        total_seconds=ddict.get("total_estimated_time", 0.0),
-        message="Burning spots",
-    )
 
 
 class FibsemSpotBurnWidget(QWidget):
@@ -442,8 +409,11 @@ class FibsemSpotBurnWidget(QWidget):
         still visible if the user was not watching when it happened.
         """
         logging.error(f"Spot burn failed: {error}")
+        # Still emitted from the widget; FIB-824 PR 3 moves it into `run_spot_burn`,
+        # which is the only way the unsupervised workflow path can report a failure
+        # at all -- it never goes through this widget.
         self.microscope.spot_burn_progress_signal.emit(
-            {"finished": True, "error": True}
+            SpotBurnProgress(status=SpotBurnStatus.FAILED, error=str(error))
         )
         self._restore_idle_state()
 

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -7,6 +7,7 @@ These cover the failure modes that crashed the unsupervised (automatic) path:
 - the widget factory rendering float/int fields as a text box instead of a spinbox.
 """
 
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -166,10 +167,57 @@ def test_run_spot_burn_emits_progress_via_microscope(mock_microscope):
         c.args[0] for c in mock_microscope.spot_burn_progress_signal.emit.call_args_list
     ]
     # initial progress reports the total number of points
-    assert emitted[0]["current_point"] == 0
-    assert emitted[0]["total_points"] == 2
-    # final emission signals completion
-    assert emitted[-1] == {"finished": True}
+    assert emitted[0].status is SpotBurnStatus.BURNING
+    assert emitted[0].current_point == 0
+    assert emitted[0].total_points == 2
+    # final emission signals completion, and says which kind
+    assert emitted[-1].status is SpotBurnStatus.FINISHED
+    assert emitted[-1].status.is_terminal
+
+
+def test_a_cancelled_burn_reports_cancelled_not_finished(mock_microscope):
+    """The defect this contract exists to remove.
+
+    Both outcomes used to emit `{"finished": True}`, so cancelling a burn rendered
+    "Done" in the status bar and in the widget. Cancel is a normal action here -- it is
+    on a button, and the workflow task passes a stop_event too.
+    """
+    stop_event = threading.Event()
+    stop_event.set()  # already cancelled before the first point
+
+    FibsemMicroscope.run_spot_burn(
+        mock_microscope,
+        settings=SpotBurnSettings(
+            coordinates=[Point(0.5, 0.5), Point(0.6, 0.6)],
+            exposure_time=1.0,
+            milling_current=30e-12,
+        ),
+        stop_event=stop_event,
+    )
+
+    emitted = [
+        c.args[0] for c in mock_microscope.spot_burn_progress_signal.emit.call_args_list
+    ]
+    assert emitted[-1].status is SpotBurnStatus.CANCELLED
+    assert emitted[-1].status is not SpotBurnStatus.FINISHED
+
+
+def test_a_cancelled_burn_stops_burning(mock_microscope):
+    """Not just a label: the run must actually stop placing spots."""
+    stop_event = threading.Event()
+    stop_event.set()
+
+    FibsemMicroscope.run_spot_burn(
+        mock_microscope,
+        settings=SpotBurnSettings(
+            coordinates=[Point(0.5, 0.5), Point(0.6, 0.6)],
+            exposure_time=1.0,
+            milling_current=30e-12,
+        ),
+        stop_event=stop_event,
+    )
+
+    assert mock_microscope.set_spot_scanning_mode.call_count == 0
 
 
 def test_run_spot_burn_module_function_delegates_to_the_microscope(mock_microscope):
@@ -187,30 +235,6 @@ def test_run_spot_burn_module_function_delegates_to_the_microscope(mock_microsco
     mock_microscope.run_spot_burn.assert_called_once_with(
         settings=settings, beam_type=BeamType.ION, stop_event=None
     )
-
-
-@requires_ui
-def test_build_spot_burn_progress_update_mapping():
-    """Progress dicts map to ProgressUpdate: running, done, and failed states."""
-    from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
-
-    running = build_spot_burn_progress_update(
-        {
-            "current_point": 1,
-            "total_points": 3,
-            "total_remaining_time": 20.0,
-            "total_estimated_time": 30.0,
-        }
-    )
-    assert (running.current, running.total) == (1, 3)
-    assert running.remaining_seconds == 20.0
-    assert not running.finished
-
-    done = build_spot_burn_progress_update({"finished": True})
-    assert done.finished and not done.message
-
-    failed = build_spot_burn_progress_update({"finished": True, "error": True})
-    assert failed.finished and failed.message == "Spot burn failed"
 
 
 def test_a_terminal_status_says_so_itself():
@@ -338,16 +362,6 @@ class TestTheTypedDecode:
 
         assert update.is_failed
         assert update.message == "Spot burn failed"
-
-    def test_the_dict_form_still_works(self):
-        """Both shapes flow until the producers flip, and the dict is the live one."""
-        from fibsem.ui.FibsemSpotBurnWidget import build_spot_burn_progress_update
-
-        update = build_spot_burn_progress_update(
-            {"current_point": 2, "total_points": 4, "total_remaining_time": 5.0}
-        )
-
-        assert (update.current, update.total) == (2, 4)
 
 
 # --- SpotBurnFiducialTask.update_spot_burn_parameters_ui ------------------------

--- a/tests/test_tescan_spot_burn.py
+++ b/tests/test_tescan_spot_burn.py
@@ -310,7 +310,9 @@ def test_stop_event_during_exposure_stops_the_exposition(monkeypatch):
 
 
 def test_progress_uses_the_spot_burn_widget_shape(monkeypatch):
-    """Progress goes out on spot_burn_progress_signal in the dict shape the widget parses."""
+    """Progress goes out on spot_burn_progress_signal as the typed report (FIB-824)."""
+    from fibsem.imaging.spot import SpotBurnProgress, SpotBurnStatus
+
     m = make_microscope(monkeypatch, busy_polls=2)
     events = collect_progress(m)
 
@@ -319,23 +321,45 @@ def test_progress_uses_the_spot_burn_widget_shape(monkeypatch):
     assert len(events) >= 3, "expected initial + at least one update + finished"
     initial, updates, finished = events[0], events[1:-1], events[-1]
 
-    assert initial["current_point"] == 0
-    assert initial["total_points"] == 2
-    assert initial["total_estimated_time"] == 4.0  # 2 points x 2s
+    assert all(isinstance(e, SpotBurnProgress) for e in events)
+
+    assert initial.status is SpotBurnStatus.BURNING
+    assert initial.current_point == 0
+    assert initial.total_points == 2
+    assert initial.total_estimated_time == 4.0  # 2 points x 2s
 
     for update in updates:
-        assert set(update) == {
-            "current_point",
-            "total_points",
-            "remaining_time",
-            "total_remaining_time",
-            "total_estimated_time",
-        }
-        assert 1 <= update["current_point"] <= 2
-        assert 0.0 <= update["remaining_time"] <= 2.0
-        assert 0.0 <= update["total_remaining_time"] <= 4.0
+        assert update.status is SpotBurnStatus.BURNING
+        # Inferred from elapsed time -- DrawBeam exposes no per-dot progress -- so the
+        # assertion is a range, not a value.
+        assert 1 <= update.current_point <= 2
+        assert 0.0 <= update.remaining_time <= 2.0
+        assert 0.0 <= update.total_remaining_time <= 4.0
 
-    assert finished == {"finished": True}
+    assert finished.status is SpotBurnStatus.FINISHED
+    assert finished.status.is_terminal
+
+
+def test_a_cancelled_tescan_burn_reports_cancelled(monkeypatch):
+    """The Tescan path had the same defect as the default one: a burn stopped by the
+    stop_event emitted the same terminal as a completed one, and rendered "Done"."""
+    import threading
+
+    from fibsem.imaging.spot import SpotBurnStatus
+
+    m = make_microscope(monkeypatch, busy_polls=4)
+    events = collect_progress(m)
+    stop_event = threading.Event()
+    stop_event.set()
+
+    run_burn(
+        m,
+        coordinates=[Point(0.5, 0.5), Point(0.2, 0.2)],
+        exposure_time=2.0,
+        stop_event=stop_event,
+    )
+
+    assert events[-1].status is SpotBurnStatus.CANCELLED
 
 
 def test_layer_is_unloaded_even_when_drawbeam_raises(monkeypatch):


### PR DESCRIPTION
All seven emit sites now send `SpotBurnProgress`, the signal is declared `Signal(SpotBurnProgress)`, and the decoder’s dict branch is deleted.

## The defect this removes

**A cancelled spot burn rendered "Done".** It emitted `{"finished": True}` — byte-identical to a completed one — so the widget and the status bar could not tell them apart. Both backends did it.

Cancel is not an edge case here: it is on a button, and the workflow task passes a `stop_event` too. Both backends now track the outcome and emit `CANCELLED` or `FINISHED`.

**A cancel is deliberately not painted as a failure** — the bar does not go red, because it is someone getting what they asked for. Mirrors `_overview_outcome` for tiled runs.

## What is *not* in this PR

The widget’s failure emit is **converted in place, not moved**. Moving it into `run_spot_burn` — which is what makes an unsupervised workflow burn able to report a failure at all, since that path never touches the widget — is the next PR, kept separate because it changes *who produces* on the signal rather than what the payload looks like.

## Two things I checked rather than assumed

**The import cycle.** `fibsem/imaging/spot.py` carries a `TYPE_CHECKING` guard with a comment explaining that `fibsem/imaging/__init__.py` star-imports it, so a runtime import can pull the microscope in and loop back. Importing the contract into `microscope.py` at runtime does **not** reintroduce that — `fibsem.microscope`, `fibsem.imaging` and the contract all import cleanly.

**Surviving dict usage, after the suite went green.** Grepped for dict emits and dict-style reads of this payload: there are none. That grep is what caught two tests passing for the wrong reason on FIB-402, so it is not a formality.

## One correction worth flagging

I added a `break` when a burn is cancelled mid-point, and first wrote that it stopped the loop burning the remaining coordinates. Reading the original control flow properly, **that was wrong** — the outer loop’s own `stop_event` check already caught it on the next iteration. The comment now says accurately that the break only saves a log line, now that the outcome is recorded. The behaviour was never broken.

## Tests

Ported from dict assertions to typed ones, plus new coverage for the defect: a cancelled burn reports `CANCELLED`, and — separately — actually stops placing spots, so the label and the behaviour are pinned independently. Tescan gets the same cancellation test.

Tescan’s `current_point` gains a comment saying it is **inferred from elapsed time, not measured** (DrawBeam exposes no per-dot progress); its test asserts a range rather than a value for the same reason.

**63 passed.** `ruff check` / `ruff format --check` clean. Static 3.8 scan clean.