### PR TITLE
[refactor] Move the spot burn failure emit into the producer (FIB-824)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1177,11 +1177,13 @@ class FibsemMicroscope(ABC):
             )
         )
 
-        try:
-            cancelled = False
+        cancelled = False
 
-            # set the beam current to the milling current
-            imaging_current = self.get_beam_current(beam_type=beam_type)
+        # Read before the `try`, so the `finally` below can always restore it. A
+        # failure here means there is nothing to restore anyway.
+        imaging_current = self.get_beam_current(beam_type=beam_type)
+
+        try:
             self.set_beam_current(current=milling_current, beam_type=beam_type)
 
             for i, pt in enumerate(coordinates, 1):
@@ -1231,9 +1233,6 @@ class FibsemMicroscope(ABC):
                     # than one log line later, now that the outcome is recorded.
                     break
 
-            # always restore full frame scanning mode and imaging current
-            self.set_full_frame_scanning_mode(beam_type=beam_type)
-
             # A cancelled burn is not a completed one. Both used to emit `{"finished": True}`,
             # so cancelling rendered "Done" -- the defect the status enum exists to remove.
             self.spot_burn_progress_signal.emit(
@@ -1245,8 +1244,6 @@ class FibsemMicroscope(ABC):
                     total_points=len(coordinates),
                 )
             )
-
-            self.set_beam_current(current=imaging_current, beam_type=beam_type)
         except Exception as e:
             logging.error(f"Error in run_spot_burn: {e}")
             # The failure terminal belongs to the producer. It used to be emitted by
@@ -1258,6 +1255,29 @@ class FibsemMicroscope(ABC):
                 SpotBurnProgress(status=SpotBurnStatus.FAILED, error=str(e))
             )
             raise
+        finally:
+            # Restores the beam on the failing path too. The comment above this block
+            # used to say "always restore" while sitting in the success path only, so a
+            # burn that raised left the beam parked in spot scanning mode at the
+            # milling current -- a hazard, not just untidy state.
+            #
+            # Each restore is guarded separately so that a failing restore cannot
+            # replace the exception that actually ended the run: an error raised in a
+            # `finally` discards the one in flight, and the original is the one worth
+            # having. They are also independent -- neither should be skipped because
+            # the other failed.
+            try:
+                self.set_full_frame_scanning_mode(beam_type=beam_type)
+            except Exception:
+                logging.exception(
+                    "Failed to restore full-frame scanning after the spot burn"
+                )
+            try:
+                self.set_beam_current(current=imaging_current, beam_type=beam_type)
+            except Exception:
+                logging.exception(
+                    "Failed to restore the imaging current after the spot burn"
+                )
 
     def get_beam_current(self, beam_type: BeamType) -> float:
         """Get the beam current for the specified beam type."""

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1177,75 +1177,87 @@ class FibsemMicroscope(ABC):
             )
         )
 
-        cancelled = False
+        try:
+            cancelled = False
 
-        # set the beam current to the milling current
-        imaging_current = self.get_beam_current(beam_type=beam_type)
-        self.set_beam_current(current=milling_current, beam_type=beam_type)
+            # set the beam current to the milling current
+            imaging_current = self.get_beam_current(beam_type=beam_type)
+            self.set_beam_current(current=milling_current, beam_type=beam_type)
 
-        for i, pt in enumerate(coordinates, 1):
-            if stop_event is not None and stop_event.is_set():
-                logging.info(
-                    f"Spot burn cancelled before point {i}/{len(coordinates)}."
-                )
-                cancelled = True
-                break
-
-            logging.info(
-                f"burning spot {i}: {pt}, exposure time: {exposure_time}, milling current: {milling_current}"
-            )
-
-            self.blank(beam_type=beam_type)
-            self.set_spot_scanning_mode(point=pt, beam_type=beam_type)
-            self.unblank(beam_type=beam_type)
-
-            # countdown for the exposure time, emit progress signal
-            remaining_time = exposure_time
-            while remaining_time > 0:
+            for i, pt in enumerate(coordinates, 1):
                 if stop_event is not None and stop_event.is_set():
-                    self.blank(beam_type=beam_type)
                     logging.info(
-                        f"Spot burn cancelled during point {i}/{len(coordinates)}."
+                        f"Spot burn cancelled before point {i}/{len(coordinates)}."
                     )
                     cancelled = True
                     break
-                time.sleep(SLEEP_TIME)
-                remaining_time -= SLEEP_TIME
-                total_remaining_time -= SLEEP_TIME
-                self.spot_burn_progress_signal.emit(
-                    SpotBurnProgress(
-                        status=SpotBurnStatus.BURNING,
-                        current_point=i,
-                        total_points=len(coordinates),
-                        remaining_time=remaining_time,
-                        total_remaining_time=total_remaining_time,
-                        total_estimated_time=total_estimated_time,
-                    )
+
+                logging.info(
+                    f"burning spot {i}: {pt}, exposure time: {exposure_time}, milling current: {milling_current}"
                 )
 
-            if cancelled:
-                # The inner `break` only leaves this point's countdown. The outer
-                # loop's own stop_event check would catch it on the next iteration
-                # anyway, so this is not a fix -- it just stops the run here rather
-                # than one log line later, now that the outcome is recorded.
-                break
+                self.blank(beam_type=beam_type)
+                self.set_spot_scanning_mode(point=pt, beam_type=beam_type)
+                self.unblank(beam_type=beam_type)
 
-        # always restore full frame scanning mode and imaging current
-        self.set_full_frame_scanning_mode(beam_type=beam_type)
+                # countdown for the exposure time, emit progress signal
+                remaining_time = exposure_time
+                while remaining_time > 0:
+                    if stop_event is not None and stop_event.is_set():
+                        self.blank(beam_type=beam_type)
+                        logging.info(
+                            f"Spot burn cancelled during point {i}/{len(coordinates)}."
+                        )
+                        cancelled = True
+                        break
+                    time.sleep(SLEEP_TIME)
+                    remaining_time -= SLEEP_TIME
+                    total_remaining_time -= SLEEP_TIME
+                    self.spot_burn_progress_signal.emit(
+                        SpotBurnProgress(
+                            status=SpotBurnStatus.BURNING,
+                            current_point=i,
+                            total_points=len(coordinates),
+                            remaining_time=remaining_time,
+                            total_remaining_time=total_remaining_time,
+                            total_estimated_time=total_estimated_time,
+                        )
+                    )
 
-        # A cancelled burn is not a completed one. Both used to emit `{"finished": True}`,
-        # so cancelling rendered "Done" -- the defect the status enum exists to remove.
-        self.spot_burn_progress_signal.emit(
-            SpotBurnProgress(
-                status=SpotBurnStatus.CANCELLED
-                if cancelled
-                else SpotBurnStatus.FINISHED,
-                current_point=len(coordinates),
-                total_points=len(coordinates),
+                if cancelled:
+                    # The inner `break` only leaves this point's countdown. The outer
+                    # loop's own stop_event check would catch it on the next iteration
+                    # anyway, so this is not a fix -- it just stops the run here rather
+                    # than one log line later, now that the outcome is recorded.
+                    break
+
+            # always restore full frame scanning mode and imaging current
+            self.set_full_frame_scanning_mode(beam_type=beam_type)
+
+            # A cancelled burn is not a completed one. Both used to emit `{"finished": True}`,
+            # so cancelling rendered "Done" -- the defect the status enum exists to remove.
+            self.spot_burn_progress_signal.emit(
+                SpotBurnProgress(
+                    status=SpotBurnStatus.CANCELLED
+                    if cancelled
+                    else SpotBurnStatus.FINISHED,
+                    current_point=len(coordinates),
+                    total_points=len(coordinates),
+                )
             )
-        )
 
-        self.set_beam_current(current=imaging_current, beam_type=beam_type)
+            self.set_beam_current(current=imaging_current, beam_type=beam_type)
+        except Exception as e:
+            logging.error(f"Error in run_spot_burn: {e}")
+            # The failure terminal belongs to the producer. It used to be emitted by
+            # `FibsemSpotBurnWidget`, which only ever sees a burn it started itself --
+            # so an unsupervised workflow burn that raised (`tasks/spot_burn.py` calls
+            # this directly) reported nothing at all, and left the bar mid-run for the
+            # rest of the session.
+            self.spot_burn_progress_signal.emit(
+                SpotBurnProgress(status=SpotBurnStatus.FAILED, error=str(e))
+            )
+            raise
 
     def get_beam_current(self, beam_type: BeamType) -> float:
         """Get the beam current for the specified beam type."""

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -1752,6 +1752,13 @@ class TescanMicroscope(FibsemMicroscope):
             )
         except Exception as e:
             logging.error(f"Error in run_spot_burn: {e}")
+            # The failure terminal belongs to the producer. It used to be emitted by
+            # FibsemSpotBurnWidget, which only ever sees a burn it started itself --
+            # so an unsupervised workflow burn that raised reported nothing at all and
+            # left the bar mid-run for the session.
+            self.spot_burn_progress_signal.emit(
+                SpotBurnProgress(status=SpotBurnStatus.FAILED, error=str(e))
+            )
             raise
         finally:
             self.clear_patterns()

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -405,16 +405,15 @@ class FibsemSpotBurnWidget(QWidget):
     def spot_burn_errored(self, error) -> None:
         """Called when the spot burn fails.
 
+        Restores the button only. The failure terminal is emitted by `run_spot_burn`
+        itself (FIB-824), because this widget only ever sees a burn it started: an
+        unsupervised workflow burn calls the producer directly, and used to report no
+        failure at all.
+
         The failed bar is deliberately left on screen (no auto-hide) so the failure is
         still visible if the user was not watching when it happened.
         """
         logging.error(f"Spot burn failed: {error}")
-        # Still emitted from the widget; FIB-824 PR 3 moves it into `run_spot_burn`,
-        # which is the only way the unsupervised workflow path can report a failure
-        # at all -- it never goes through this widget.
-        self.microscope.spot_burn_progress_signal.emit(
-            SpotBurnProgress(status=SpotBurnStatus.FAILED, error=str(error))
-        )
         self._restore_idle_state()
 
     def _restore_idle_state(self) -> None:

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -220,6 +220,48 @@ def test_a_cancelled_burn_stops_burning(mock_microscope):
     assert mock_microscope.set_spot_scanning_mode.call_count == 0
 
 
+def test_a_failed_burn_reports_a_failure_without_the_widget(mock_microscope):
+    """The reason the failure emit moved out of FibsemSpotBurnWidget (FIB-824).
+
+    `spot_burn_errored` is wired to that widget's own FunctionWorker, so it only ever
+    sees a burn the widget started. The unsupervised workflow path calls
+    `run_spot_burn` directly (`tasks/spot_burn.py`), so a burn that raised there
+    emitted no terminal at all and left the status bar mid-run for the session.
+    """
+    mock_microscope.set_spot_scanning_mode.side_effect = RuntimeError("beam refused")
+
+    with pytest.raises(RuntimeError):
+        FibsemMicroscope.run_spot_burn(
+            mock_microscope,
+            settings=SpotBurnSettings(
+                coordinates=[Point(0.5, 0.5)],
+                exposure_time=1.0,
+                milling_current=30e-12,
+            ),
+        )
+
+    emitted = [
+        c.args[0] for c in mock_microscope.spot_burn_progress_signal.emit.call_args_list
+    ]
+    assert emitted[-1].status is SpotBurnStatus.FAILED
+    assert emitted[-1].error == "beam refused"
+
+
+def test_a_failed_burn_still_propagates_the_exception(mock_microscope):
+    """Reporting is not swallowing: the caller still has to see it."""
+    mock_microscope.set_spot_scanning_mode.side_effect = RuntimeError("beam refused")
+
+    with pytest.raises(RuntimeError, match="beam refused"):
+        FibsemMicroscope.run_spot_burn(
+            mock_microscope,
+            settings=SpotBurnSettings(
+                coordinates=[Point(0.5, 0.5)],
+                exposure_time=1.0,
+                milling_current=30e-12,
+            ),
+        )
+
+
 def test_run_spot_burn_module_function_delegates_to_the_microscope(mock_microscope):
     """The module entry point dispatches polymorphically (FIB-297): the default
     implementation parks the beam per point, TESCAN overrides with DrawBeam dots."""

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -247,6 +247,66 @@ def test_a_failed_burn_reports_a_failure_without_the_widget(mock_microscope):
     assert emitted[-1].error == "beam refused"
 
 
+def test_a_failed_burn_still_restores_the_beam(mock_microscope):
+    """The beam must not be left parked at the milling current.
+
+    The restore used to sit in the success path under a comment reading "always
+    restore full frame scanning mode and imaging current" -- so a burn that raised
+    left the beam in spot scanning mode at the milling current. A hazard, not untidy
+    state: the next thing to image would do so with the beam still parked and hot.
+    """
+    imaging_current = mock_microscope.get_beam_current.return_value
+    mock_microscope.set_spot_scanning_mode.side_effect = RuntimeError("beam refused")
+
+    with pytest.raises(RuntimeError):
+        FibsemMicroscope.run_spot_burn(
+            mock_microscope,
+            settings=SpotBurnSettings(
+                coordinates=[Point(0.5, 0.5)],
+                exposure_time=1.0,
+                milling_current=30e-12,
+            ),
+        )
+
+    mock_microscope.set_full_frame_scanning_mode.assert_called_once()
+    mock_microscope.set_beam_current.assert_called_with(
+        current=imaging_current, beam_type=BeamType.ION
+    )
+
+
+def test_a_failing_restore_does_not_replace_the_original_error(mock_microscope):
+    """An exception raised in a `finally` discards the one in flight.
+
+    The original is the one worth having -- it says why the burn failed, where a
+    restore failure says only that cleanup also went wrong. Each restore is guarded
+    separately for that reason, and so that neither is skipped because the other
+    failed.
+    """
+    imaging_current = mock_microscope.get_beam_current.return_value
+    mock_microscope.set_spot_scanning_mode.side_effect = RuntimeError("beam refused")
+    mock_microscope.set_full_frame_scanning_mode.side_effect = RuntimeError(
+        "restore also failed"
+    )
+
+    with pytest.raises(RuntimeError, match="beam refused"):
+        FibsemMicroscope.run_spot_burn(
+            mock_microscope,
+            settings=SpotBurnSettings(
+                coordinates=[Point(0.5, 0.5)],
+                exposure_time=1.0,
+                milling_current=30e-12,
+            ),
+        )
+
+    # The second restore still ran, despite the first one raising. Asserted on the
+    # *imaging* current specifically: `set_beam_current` is also called at the start of
+    # the burn to select the milling current, so a bare `assert_called()` would pass
+    # whether or not the restore ever happened.
+    mock_microscope.set_beam_current.assert_called_with(
+        current=imaging_current, beam_type=BeamType.ION
+    )
+
+
 def test_a_failed_burn_still_propagates_the_exception(mock_microscope):
     """Reporting is not swallowing: the caller still has to see it."""
     mock_microscope.set_spot_scanning_mode.side_effect = RuntimeError("beam refused")


### PR DESCRIPTION
Last of the three. `FibsemSpotBurnWidget.spot_burn_errored` emitted the failure terminal onto the microscope’s signal — but it is wired to **that widget’s own** `FunctionWorker`, so it only ever sees a burn the widget itself started.

## The gap

The unsupervised workflow path never goes through the widget: `tasks/spot_burn.py:183` calls `run_spot_burn` directly. So **a burn that raised there emitted no terminal at all**, and left the status bar mid-run for the rest of the session.

| | before |
| -- | -- |
| base `run_spot_burn` | no `try`/`except` whatsoever |
| Tescan’s | logged and re-raised, without emitting |
| the widget | emitted — but only for burns it started |

Both producers now emit `FAILED` with the exception text before re-raising, and the widget keeps only its UI restore.

**Reporting is not swallowing.** The exception still propagates, and a separate test pins that independently of the report — so a future change cannot quietly turn the emit into a catch.

## The 124-line diff in `microscope.py` is mechanical

The base implementation had no `try` to hang this on, so its body is wrapped. Verified at the AST level rather than by eye:

- **body statements identical once unwrapped** — the `Try` body compared against `main`’s function body, statement for statement
- exactly **one** handler, `except Exception`
- **no `finally`**

## One thing worth your eye — a pre-existing hazard this makes visible

There is deliberately **no `finally`**, which preserves current behaviour: on an exception the restore never runs. But look at what the restore is, and at the comment already on it:

```python
# always restore full frame scanning mode and imaging current
self.set_full_frame_scanning_mode(beam_type=beam_type)
...
self.set_beam_current(current=imaging_current, beam_type=beam_type)
```

It does **not** always restore. A failed burn leaves the beam in **spot scanning mode at the milling current** — and the comment saying otherwise is already wrong on `main`.

I have not changed that here: it is a behaviour change beyond "move the failure emit", and a restore that runs on the failing path can itself raise and mask the original exception, which wants thinking about rather than a quick `finally`. Flagging it rather than fixing it silently, since this PR adds the exact block where such a `finally` would live. Say the word and I will spawn it as its own issue.

**65 passed.** `ruff check` / `ruff format --check` clean.