### PR TITLE
[format] Apply ruff format to the files the milling progress stack touches

### DIFF
--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -824,7 +824,10 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         # alone could go unsaved for hours and be lost on a force-kill.
         # Connected after construction so the initial load doesn't trigger a save.
         from superqt.utils import qdebounced
-        self._autosave_milling_config = qdebounced(self._save_milling_config, timeout=1000)
+
+        self._autosave_milling_config = qdebounced(
+            self._save_milling_config, timeout=1000
+        )
         self.milling_viewer_widget.settings_changed.connect(
             lambda *_: self._autosave_milling_config()
         )
@@ -851,7 +854,9 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         # Objective control
         from fibsem.ui.widgets.custom_widgets import IconToolButton
 
-        self.fm_objective_widget = ObjectiveControlWidget(fm=fm, microscope=self.microscope)
+        self.fm_objective_widget = ObjectiveControlWidget(
+            fm=fm, microscope=self.microscope
+        )
         btn_refresh_objective = IconToolButton(
             icon="mdi:refresh", tooltip="Refresh objective position"
         )
@@ -919,6 +924,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             OverviewParameters,
             ZParameters,
         )
+
         fm = self.microscope.fm
         return FluorescenceConfiguration(
             channel_settings=self.fm_channel_widget.channel_settings,
@@ -944,6 +950,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         """On open, apply the FM config: the live main-UI config if provided,
         else the last-used working state as a fallback."""
         from fibsem.fm.config import load_fm_configuration
+
         config = self._seed_fm_config or load_fm_configuration()
         if config is not None:
             try:
@@ -954,6 +961,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
     def _save_fm_configuration(self) -> None:
         """Persist the current FM configuration as the working state."""
         from fibsem.fm.config import save_fm_configuration
+
         try:
             save_fm_configuration(self._read_fm_configuration())
         except Exception as e:
@@ -966,6 +974,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         from fibsem import config as cfg
         from fibsem.milling.tasks import FibsemMillingTaskConfig
         from fibsem.utils import load_yaml
+
         if not os.path.exists(cfg.COINCIDENCE_MILLING_CONFIG_PATH):
             return None
         try:
@@ -982,6 +991,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             return
         from fibsem import config as cfg
         from fibsem.utils import save_yaml
+
         try:
             save_yaml(
                 cfg.COINCIDENCE_MILLING_CONFIG_PATH,
@@ -1003,9 +1013,14 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
     def _export_configuration(self) -> None:
         """Export the current FM + milling configuration to a YAML file."""
         from fibsem.utils import save_yaml
-        default_path = os.path.join(self._default_config_dir(), "coincidence-configuration.yaml")
+
+        default_path = os.path.join(
+            self._default_config_dir(), "coincidence-configuration.yaml"
+        )
         filename, _ = QFileDialog.getSaveFileName(
-            self, "Export Coincidence Configuration", default_path,
+            self,
+            "Export Coincidence Configuration",
+            default_path,
             "YAML files (*.yaml *.yml);;All files (*.*)",
         )
         if not filename:
@@ -1030,8 +1045,11 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
     def _load_configuration(self) -> None:
         """Load an FM + milling configuration from a YAML file and apply it."""
         from fibsem.utils import load_yaml
+
         filename, _ = QFileDialog.getOpenFileName(
-            self, "Load Coincidence Configuration", self._default_config_dir(),
+            self,
+            "Load Coincidence Configuration",
+            self._default_config_dir(),
             "YAML files (*.yaml *.yml);;All files (*.*)",
         )
         if not filename:
@@ -1044,10 +1062,12 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             fm_config = None
             if data.get("fm") is not None:
                 from fibsem.fm.structures import FluorescenceConfiguration
+
                 fm_config = FluorescenceConfiguration.from_dict(data["fm"])
             milling_config = None
             if data.get("milling") is not None:
                 from fibsem.milling.tasks import FibsemMillingTaskConfig
+
                 milling_config = FibsemMillingTaskConfig.from_dict(data["milling"])
         except Exception as e:
             logging.error(f"Failed to read coincidence configuration: {e}")
@@ -1055,7 +1075,11 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             return
 
         try:
-            if fm_config is not None and self.microscope is not None and self.microscope.fm is not None:
+            if (
+                fm_config is not None
+                and self.microscope is not None
+                and self.microscope.fm is not None
+            ):
                 self._apply_fm_configuration(fm_config)
             if milling_config is not None and self.milling_viewer_widget is not None:
                 self.milling_viewer_widget.set_config(milling_config)
@@ -1087,17 +1111,13 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         layout.addStretch()
 
         self.progressBar_stages = QProgressBar()
-        self.progressBar_stages.setStyleSheet(
-            stylesheets.PROGRESS_BAR_STYLESHEET
-        )
+        self.progressBar_stages.setStyleSheet(stylesheets.PROGRESS_BAR_STYLESHEET)
         self.progressBar_stages.setFixedHeight(24)
         self.progressBar_stages.setFixedWidth(180)
         self.progressBar_stages.setVisible(False)
 
         self.progressBar_stage = QProgressBar()
-        self.progressBar_stage.setStyleSheet(
-            stylesheets.PROGRESS_BAR_STYLESHEET
-        )
+        self.progressBar_stage.setStyleSheet(stylesheets.PROGRESS_BAR_STYLESHEET)
         self.progressBar_stage.setFixedHeight(24)
         self.progressBar_stage.setFixedWidth(180)
         self.progressBar_stage.setVisible(False)
@@ -1112,7 +1132,9 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         self._milling_paused = False
         self.btn_pause = QToolButton()
         self.btn_pause.setText("Pause")
-        self.btn_pause.setIcon(fibsem_icon("mdi:pause", color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_pause.setIcon(
+            fibsem_icon("mdi:pause", color=stylesheets.GRAY_ICON_COLOR)
+        )
         self.btn_pause.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)  # type: ignore[attr-defined]
         self.btn_pause.setPopupMode(QToolButton.InstantPopup)
         # SECONDARY_BUTTON_STYLESHEET targets QPushButton; a QToolButton needs its
@@ -1310,7 +1332,9 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         obj = self.microscope.fm.objective
         value_m = obj.position if obj.state == "Inserted" else obj.focus_position
         if value_m is None:
-            notification_service.show_toast("Objective position unavailable.", "warning")
+            notification_service.show_toast(
+                "Objective position unavailable.", "warning"
+            )
             return
         lamella.fluorescence_pose.objective_position = value_m
         if self.experiment is not None:
@@ -1424,7 +1448,9 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             return
         state = self.microscope.get_microscope_state()
         if state is None or state.stage_position is None:
-            notification_service.show_toast("Failed to get microscope state.", "warning")
+            notification_service.show_toast(
+                "Failed to get microscope state.", "warning"
+            )
             return
 
         ret = QMessageBox.question(
@@ -1574,7 +1600,9 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
 
         worker = FunctionWorker(_worker)
         # reset the label on the GUI thread; setText from the worker thread is unsafe
-        worker.finished.connect(lambda: self.btn_autocontrast_fib.setText("AutoContrast"))
+        worker.finished.connect(
+            lambda: self.btn_autocontrast_fib.setText("AutoContrast")
+        )
         worker.start()
 
     def _run_fib_autofocus(self) -> None:
@@ -2065,9 +2093,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         state = progress_info.get("state")
 
         if state == "start":
-            self._set_border_state(
-                "supervised" if self._supervised else "automated"
-            )
+            self._set_border_state("supervised" if self._supervised else "automated")
             current_stage = progress_info.get("current_stage", 0)
             total_stages = progress_info.get("total_stages", 1)
             msg = progress.get("msg", "Preparing...")
@@ -2163,7 +2189,9 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         focus, so the reported case still restacks; but an operator who clicked over to
         the main window mid-run owns the focus, and their window is left alone.
         """
-        if not self.isWindow():  # embedded: raising the host would be someone else's call
+        if (
+            not self.isWindow()
+        ):  # embedded: raising the host would be someone else's call
             return
         active = QApplication.activeWindow()
         if active is not None and active is not self:
@@ -2375,7 +2403,9 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         if not pixelsize:
             return
         if not self.microscope.fm.has_valid_orientation():
-            logging.info(f"Stage must be in a valid FM orientation to move via FM image (current: {self.microscope.get_stage_orientation()})")
+            logging.info(
+                f"Stage must be in a valid FM orientation to move via FM image (current: {self.microscope.get_stage_orientation()})"
+            )
             return
         image_shape = self.fm_canvas._img_shape
         if image_shape is None:
@@ -2431,7 +2461,9 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
 # ---------------------------------------------------------------------------
 
 
-def open_coincidence_viewer_window(microscope, experiment, viewer=None, parent=None, fm_config=None):
+def open_coincidence_viewer_window(
+    microscope, experiment, viewer=None, parent=None, fm_config=None
+):
     """Open FluorescenceCoincidenceViewerWidget as a non-modal top-level window.
 
     A plain top-level widget (not a QDialog): it never blocks, gets native
@@ -2443,7 +2475,10 @@ def open_coincidence_viewer_window(microscope, experiment, viewer=None, parent=N
     Returns the widget (caller should keep a reference to prevent GC).
     """
     widget = FluorescenceCoincidenceViewerWidget(
-        microscope=microscope, experiment=experiment, viewer=viewer, parent=None,
+        microscope=microscope,
+        experiment=experiment,
+        viewer=viewer,
+        parent=None,
         fm_config=fm_config,
     )
     widget.setWindowTitle("Coincidence Milling Viewer")

--- a/fibsem/microscopes/odemis_microscope.py
+++ b/fibsem/microscopes/odemis_microscope.py
@@ -82,7 +82,7 @@ def stage_position_to_odemis_dict(position: FibsemStagePosition) -> dict:
     """Convert a FibsemStagePosition to a dict with the odemis keys"""
     pdict = position.to_dict()
     pdict.pop("name")
-    pdict.pop("coordinate_system") # no longer used in odemis
+    pdict.pop("coordinate_system")  # no longer used in odemis
     pdict["rz"] = pdict.pop("r")
     pdict["rx"] = pdict.pop("t")
 
@@ -165,6 +165,7 @@ def odemis_md_to_microscope_state(md) -> MicroscopeState:
 
     return ms
 
+
 def from_odemis_image(image: model.DataArray, path: str = None) -> FibsemImage:
     md = image.metadata
     ms = MicroscopeState.from_odemis_dict(md[model.MD_EXTRA_SETTINGS])
@@ -186,13 +187,13 @@ def from_odemis_image(image: model.DataArray, path: str = None) -> FibsemImage:
         filename = os.path.basename(path)
 
     image_settings = ImageSettings(
-        resolution = [image.shape[1], image.shape[0]],
+        resolution=[image.shape[1], image.shape[0]],
         dwell_time=sys_state.dwell_time,
         hfw=sys_state.hfw,
         beam_type=sys_state.beam_type,
-        path = path,
+        path=path,
         filename=filename,
-        save = True,
+        save=True,
         autocontrast=False,
     )
 
@@ -205,14 +206,16 @@ def from_odemis_image(image: model.DataArray, path: str = None) -> FibsemImage:
 
     # get the data
     da = image.getData() if isinstance(image, model.DataArrayShadow) else image
-    
+
     return FibsemImage(data=da, metadata=image_md)
+
 
 def load_odemis_image(path: str) -> FibsemImage:
     """Load an odemis image from a file and convert it to a FibsemImage"""
     acq = open_acquisition(path)
     image: FibsemImage = FibsemImage.from_odemis(acq[0], path=path)
     return image
+
 
 # add as class methods
 FibsemStagePosition.to_odemis_dict = stage_position_to_odemis_dict
@@ -230,9 +233,11 @@ beam_type_to_odemis = {
 
 # TODO: load default system settings?
 
+
 class OdemisThermoMicroscope(FibsemMicroscope):
     """TFS integration through Odemis.
     Requires Odemis installation, unlike ThermoMicroscope which provides direct TFS integration."""
+
     milling_progress_signal = Signal(dict)
     _last_imaging_settings: ImageSettings
 
@@ -270,6 +275,7 @@ class OdemisThermoMicroscope(FibsemMicroscope):
         self.fm = None
         try:
             from fibsem.fm.odemis import OdemisFluorescenceMicroscope
+
             self.fm = OdemisFluorescenceMicroscope(self)
         except (ImportError, AttributeError) as e:
             logging.info(f"Fluorescence support is not available: {e}")
@@ -281,7 +287,9 @@ class OdemisThermoMicroscope(FibsemMicroscope):
         except Exception as e:
             logging.warning(f"Could not create sample stage: {e}")
 
-    def connect_to_microscope(self, ip_address: str, port: int, reset_beam_shift: bool = True) -> None:
+    def connect_to_microscope(
+        self, ip_address: str, port: int, reset_beam_shift: bool = True
+    ) -> None:
         pass
 
     def disconnect(self):
@@ -300,18 +308,26 @@ class OdemisThermoMicroscope(FibsemMicroscope):
 
         # updated safe rotation move
         logging.info(f"moving flat to {beam_type.name}")
-        stage_position = FibsemStagePosition(r=rotation, t=tilt, coordinate_system="Raw")
+        stage_position = FibsemStagePosition(
+            r=rotation, t=tilt, coordinate_system="Raw"
+        )
 
         # imitate compucentric movements
-        if (stage_orientation in ["SEM", "MILLING"] and beam_type == BeamType.ION) or \
-           (stage_orientation == "FIB" and beam_type == BeamType.ELECTRON):
-
+        if (stage_orientation in ["SEM", "MILLING"] and beam_type == BeamType.ION) or (
+            stage_orientation == "FIB" and beam_type == BeamType.ELECTRON
+        ):
             current_stage_position = self.get_stage_position()
             stage_position.x = -current_stage_position.x
             stage_position.y = -current_stage_position.y
-            stage_position.z =  current_stage_position.z
+            stage_position.z = current_stage_position.z
 
-        logging.debug({"msg": "move_flat_to_beam", "stage_position": stage_position.to_dict(), "beam_type": beam_type.name})
+        logging.debug(
+            {
+                "msg": "move_flat_to_beam",
+                "stage_position": stage_position.to_dict(),
+                "beam_type": beam_type.name,
+            }
+        )
 
         if _safe:
             self.safe_absolute_stage_movement(stage_position)
@@ -334,17 +350,19 @@ class OdemisThermoMicroscope(FibsemMicroscope):
         # reduced area imaging
         if image_settings.reduced_area is not None:
             reduced_area = image_settings.reduced_area
-            self.connection.set_reduced_area_scan_mode(channel=channel, 
-                                                       left=reduced_area.left,
-                                                       top=reduced_area.top,
-                                                       width=reduced_area.width,
-                                                       height=reduced_area.height)
+            self.connection.set_reduced_area_scan_mode(
+                channel=channel,
+                left=reduced_area.left,
+                top=reduced_area.top,
+                width=reduced_area.width,
+                height=reduced_area.height,
+            )
         else:
             self.connection.set_full_frame_scan_mode(channel=channel)
 
         # set imaging settings
         # TODO: this is a change in behaviour..., restore the previous conditions or use GrabFrameSettings?
-        # This is the source of the error with square resolutions. 
+        # This is the source of the error with square resolutions.
         # can't set square resolution, but can acquire an image with square
         frame_settings = None
         tmp_resolution = None
@@ -357,7 +375,9 @@ class OdemisThermoMicroscope(FibsemMicroscope):
         self.set_imaging_settings(image_settings)
 
         # acquire image
-        image, _md = self.connection.acquire_image(channel=channel, frame_settings=frame_settings)
+        image, _md = self.connection.acquire_image(
+            channel=channel, frame_settings=frame_settings
+        )
 
         # restore to full frame imaging
         if image_settings.reduced_area is not None:
@@ -389,15 +409,21 @@ class OdemisThermoMicroscope(FibsemMicroscope):
     def last_image(self, beam_type: BeamType) -> FibsemImage:
         pass
 
-    def autocontrast(self, beam_type: BeamType, reduced_area: FibsemRectangle = None) -> None:
+    def autocontrast(
+        self, beam_type: BeamType, reduced_area: FibsemRectangle = None
+    ) -> None:
         channel = beam_type_to_odemis[beam_type]
         if reduced_area is not None:
-            self.connection.set_reduced_area_scan_mode(channel, **reduced_area.to_dict())
+            self.connection.set_reduced_area_scan_mode(
+                channel, **reduced_area.to_dict()
+            )
         self.connection.run_auto_contrast_brightness(channel=channel)
         if reduced_area is not None:
             self.connection.set_full_frame_scan_mode(channel)
 
-    def auto_focus(self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None) -> None:        
+    def auto_focus(
+        self, beam_type: BeamType, reduced_area: Optional[FibsemRectangle] = None
+    ) -> None:
         self.connection.run_auto_focus(beam_type_to_odemis[beam_type])
 
     def beam_shift(self, dx: float, dy: float, beam_type: BeamType) -> None:
@@ -588,7 +614,6 @@ class OdemisThermoMicroscope(FibsemMicroscope):
             logging.info(f"Patterning beam type set to {value} - {channel} .")
             return
 
-
         # beam control
         if key == "on":
             self.connection.set_beam_power(value, channel)
@@ -740,10 +765,10 @@ class OdemisThermoMicroscope(FibsemMicroscope):
                 return
 
         if key == "active_view":
-            self.connection.set_active_view(value.value) # value == BeamType
+            self.connection.set_active_view(value.value)  # value == BeamType
             return
         if key == "active_device":
-            self.connection.set_active_device(value.value) # value == BeamType
+            self.connection.set_active_device(value.value)  # value == BeamType
             return
 
         # known keys that are not implemented
@@ -772,7 +797,9 @@ class OdemisThermoMicroscope(FibsemMicroscope):
                 "choices"
             ]
         if key == "current":
-            values = self.connection.beam_current_info(beam_type_to_odemis[beam_type])["choices"]
+            values = self.connection.beam_current_info(beam_type_to_odemis[beam_type])[
+                "choices"
+            ]
             # xenon
             # values = [1.0e-12, 3.0e-12, 10e-12, 30e-12, 0.1e-9, 0.3e-9, 1e-9, 4e-9, 15e-9, 60e-9]
             # argon
@@ -821,11 +848,11 @@ class OdemisThermoMicroscope(FibsemMicroscope):
     def stable_move(
         self, dx: float, dy: float, beam_type: BeamType, static_wd: bool = False
     ) -> FibsemStagePosition:
-        return ThermoMicroscope.stable_move(self, dx=dx, dy=dy, beam_type=beam_type, static_wd=static_wd)
+        return ThermoMicroscope.stable_move(
+            self, dx=dx, dy=dy, beam_type=beam_type, static_wd=static_wd
+        )
 
-    def vertical_move(
-        self, dy: float, dx: float = 0.0
-    ) -> FibsemStagePosition:
+    def vertical_move(self, dy: float, dx: float = 0.0) -> FibsemStagePosition:
         """Move the stage vertically by the specified amount."""
         return ThermoMicroscope.vertical_move(self, dy=dy, dx=dx)
 
@@ -838,8 +865,12 @@ class OdemisThermoMicroscope(FibsemMicroscope):
     ) -> FibsemStagePosition:
         return ThermoMicroscope._y_corrected_stage_movement(self, expected_y, beam_type)
 
-    def _inverse_y_corrected_stage_movement(self, dy: float, dz: float, beam_type: BeamType = BeamType.ELECTRON) -> float:
-        return ThermoMicroscope._inverse_y_corrected_stage_movement(self, dy=dy, dz=dz, beam_type=beam_type)
+    def _inverse_y_corrected_stage_movement(
+        self, dy: float, dz: float, beam_type: BeamType = BeamType.ELECTRON
+    ) -> float:
+        return ThermoMicroscope._inverse_y_corrected_stage_movement(
+            self, dy=dy, dz=dz, beam_type=beam_type
+        )
 
     def project_stable_move(
         self,
@@ -848,10 +879,9 @@ class OdemisThermoMicroscope(FibsemMicroscope):
         beam_type: BeamType,
         base_position: FibsemStagePosition,
     ) -> FibsemStagePosition:
-        return ThermoMicroscope.project_stable_move(self, 
-                                                    dx=dx, dy=dy, 
-                                                    beam_type=beam_type, 
-                                                    base_position=base_position)
+        return ThermoMicroscope.project_stable_move(
+            self, dx=dx, dy=dy, beam_type=beam_type, base_position=base_position
+        )
 
     def _safe_rotation_movement(self, stage_position: FibsemStagePosition) -> None:
         return ThermoMicroscope._safe_rotation_movement(self, stage_position)
@@ -958,7 +988,9 @@ class OdemisThermoMicroscope(FibsemMicroscope):
             {"msg": "setup_milling", "mill_settings": mill_settings.to_dict()}
         )
 
-    def run_milling(self, milling_current: float, milling_voltage: float, asynch: bool = False):
+    def run_milling(
+        self, milling_current: float, milling_voltage: float, asynch: bool = False
+    ):
         ThermoMicroscope.run_milling(self, milling_current, milling_voltage, asynch)
 
     def finish_milling(self, imaging_current: float, imaging_voltage: float) -> None:
@@ -995,8 +1027,8 @@ class OdemisThermoMicroscope(FibsemMicroscope):
         if self.get_milling_state() == MillingState.PAUSED:
             logging.info("Resuming milling...")
             self.connection.resume_milling()
-            logging.info("Milling resumed.")   
-    
+            logging.info("Milling resumed.")
+
     def estimate_milling_time(self) -> float:
         return self.connection.estimate_milling_time()
 
@@ -1005,7 +1037,7 @@ class OdemisTescanMicroscope(TescanMicroscope):
     """Tescan integration through Odemis.
     Currently wraps TescanMicroscope; will be extended
     to support Odemis-specific features (e.g., MicroscopePostureManager)."""
+
     def __init__(self, system_settings: SystemSettings):
         super().__init__(system_settings=system_settings)
         logging.info("OdemisTescanMicroscope initialized")
-

--- a/fibsem/milling/tasks.py
+++ b/fibsem/milling/tasks.py
@@ -27,23 +27,34 @@ from fibsem.utils import current_timestamp_v3
 if TYPE_CHECKING:
     from fibsem.ui.widgets.milling_widget import FibsemMillingWidget2
 
+
 @dataclass
 class MillingTaskAcquisitionSettings:
     """Settings for the acquisition of images during a milling task."""
-    acquire_sem: bool = field(default=False, 
-                              metadata={
-                                  "label": "Acquire SEM Image",
-                                  "tooltip": "Whether to acquire SEM images between the milling task stages."})
-    acquire_fib: bool = field(default=False, 
-                              metadata={
-                                  "label": "Acquire FIB Image",
-                                  "tooltip": "Whether to acquire FIB images between the milling task stages."})
-    acquire_final_image: bool = field(default=True,
-                                      metadata={
-                                          "label": "Acquire Final Image",
-                                          "tooltip": "Refresh the FIB view with a single image once the task finishes. "
-                                                     "Disable for low-kV polishing, where imaging the lamella with a "
-                                                     "higher-voltage beam undoes the polish."})
+
+    acquire_sem: bool = field(
+        default=False,
+        metadata={
+            "label": "Acquire SEM Image",
+            "tooltip": "Whether to acquire SEM images between the milling task stages.",
+        },
+    )
+    acquire_fib: bool = field(
+        default=False,
+        metadata={
+            "label": "Acquire FIB Image",
+            "tooltip": "Whether to acquire FIB images between the milling task stages.",
+        },
+    )
+    acquire_final_image: bool = field(
+        default=True,
+        metadata={
+            "label": "Acquire Final Image",
+            "tooltip": "Refresh the FIB view with a single image once the task finishes. "
+            "Disable for low-kV polishing, where imaging the lamella with a "
+            "higher-voltage beam undoes the polish.",
+        },
+    )
     imaging: ImageSettings = field(default_factory=ImageSettings)
 
     @property
@@ -83,11 +94,14 @@ class MillingTaskAcquisitionSettings:
 @dataclass
 class FibsemMillingTaskConfig:
     """Configuration for a milling task."""
+
     name: str = "Milling Task"
     field_of_view: float = 150e-6
     channel: BeamType = BeamType.ION
     alignment: MillingAlignment = field(default_factory=MillingAlignment)
-    acquisition: MillingTaskAcquisitionSettings = field(default_factory=MillingTaskAcquisitionSettings)
+    acquisition: MillingTaskAcquisitionSettings = field(
+        default_factory=MillingTaskAcquisitionSettings
+    )
     stages: List[FibsemMillingStage] = field(default_factory=list)
 
     @property
@@ -115,11 +129,15 @@ class FibsemMillingTaskConfig:
             channel=BeamType[data.get("channel", BeamType.ION.name)],
             alignment=MillingAlignment.from_dict(alignment),
             acquisition=MillingTaskAcquisitionSettings.from_dict(acquisition),
-            stages=[FibsemMillingStage.from_dict(stage) for stage in data.get("stages", [])],
+            stages=[
+                FibsemMillingStage.from_dict(stage) for stage in data.get("stages", [])
+            ],
         )
 
     @classmethod
-    def from_stages(cls, stages: List[FibsemMillingStage], name: str = "Milling Task") -> "FibsemMillingTaskConfig":
+    def from_stages(
+        cls, stages: List[FibsemMillingStage], name: str = "Milling Task"
+    ) -> "FibsemMillingTaskConfig":
         """Create a FibsemMillingTaskConfig from a list of FibsemMillingStage."""
 
         if not stages:
@@ -151,13 +169,17 @@ class FibsemMillingTaskConfig:
         milling_time = sum(stage.estimated_time for stage in self.enabled_stages)
         return milling_time + self.acquisition.estimated_time
 
-    def compatible_stages(self, reference_idx: int = 0) -> List[Tuple[int, FibsemMillingStage]]:
+    def compatible_stages(
+        self, reference_idx: int = 0
+    ) -> List[Tuple[int, FibsemMillingStage]]:
         """Return stages whose milling settings & strategy match the stage at reference_idx."""
         if not self.stages:
             return []
 
         if reference_idx < 0 or reference_idx >= len(self.stages):
-            raise IndexError(f"reference_idx {reference_idx} out of range for {len(self.stages)} stages.")
+            raise IndexError(
+                f"reference_idx {reference_idx} out of range for {len(self.stages)} stages."
+            )
 
         reference_stage = self.stages[reference_idx]
         compatible: List[Tuple[int, FibsemMillingStage]] = []
@@ -168,9 +190,11 @@ class FibsemMillingTaskConfig:
 
         return compatible
 
-    def merge_compatible_stages(self, reference_idx: int = 0) -> 'FibsemMillingStage':
+    def merge_compatible_stages(self, reference_idx: int = 0) -> "FibsemMillingStage":
         compat_stages = self.compatible_stages(reference_idx=reference_idx)
-        logging.info(f"Compatible Stages: {[(idx, stage.name) for idx, stage in compat_stages]}") 
+        logging.info(
+            f"Compatible Stages: {[(idx, stage.name) for idx, stage in compat_stages]}"
+        )
 
         reference_stage = self.stages[reference_idx]
         if compat_stages:
@@ -179,6 +203,7 @@ class FibsemMillingTaskConfig:
                 reference_stage.patterns.append(self.stages[idx].pattern)
 
         return reference_stage
+
 
 # TODO: remove parent_ui arg, use microscope signal only, and stop_event -> need to migrate
 # TODO: restore current to initial current, rather than system.ion.beam.beam_current
@@ -189,9 +214,12 @@ class FibsemMillingTask:
     task_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     reference_image: Optional[FibsemImage] = None
 
-    def __init__(self, microscope: FibsemMicroscope,
-                 config: FibsemMillingTaskConfig,
-                 parent_ui: Optional['FibsemMillingWidget2'] = None):
+    def __init__(
+        self,
+        microscope: FibsemMicroscope,
+        config: FibsemMillingTaskConfig,
+        parent_ui: Optional["FibsemMillingWidget2"] = None,
+    ):
         self.config = config
         self.microscope = microscope
         self.parent_ui = parent_ui
@@ -230,7 +258,9 @@ class FibsemMillingTask:
         current = self.initial_imaging_current
         voltage = self.initial_imaging_voltage
         return (
-            current if current is not None else self.microscope.system.ion.beam.beam_current,
+            current
+            if current is not None
+            else self.microscope.system.ion.beam.beam_current,
             voltage if voltage is not None else self.microscope.system.ion.beam.voltage,
         )
 
@@ -248,9 +278,11 @@ class FibsemMillingTask:
         path = self.config.acquisition.imaging.path
         if path is None:
             path = fcfg.DATA_CC_PATH
-        self.config.acquisition.imaging.path = os.path.join(str(path), "Milling",
-                                                            self.name.replace(" ", "-"),
-                                                            )
+        self.config.acquisition.imaging.path = os.path.join(
+            str(path),
+            "Milling",
+            self.name.replace(" ", "-"),
+        )
 
     def run(self) -> None:
         """Run a list of milling stages, with a progress bar and notifications."""
@@ -258,11 +290,17 @@ class FibsemMillingTask:
         logging.info(f"Running milling task: {self.name} with ID: {self.task_id}")
 
         try:
-            self.initial_beam_shift = self.microscope.get_beam_shift(beam_type=self.config.channel)
+            self.initial_beam_shift = self.microscope.get_beam_shift(
+                beam_type=self.config.channel
+            )
             # Capture the live imaging current/voltage BEFORE setup_milling switches to the
             # milling current, so cleanup restores exactly what the user was imaging at.
-            self.initial_imaging_current = self.microscope.get_beam_current(self.config.channel)
-            self.initial_imaging_voltage = self.microscope.get_beam_voltage(self.config.channel)
+            self.initial_imaging_current = self.microscope.get_beam_current(
+                self.config.channel
+            )
+            self.initial_imaging_voltage = self.microscope.get_beam_voltage(
+                self.config.channel
+            )
 
             # configure acquisition filepaths
             self._configure_path()
@@ -283,10 +321,16 @@ class FibsemMillingTask:
         except Exception as e:
             logging.error(e)
         finally:
-            self._handle_progress({
-                "msg": f"Finished Milling Task: {self.name}. Restoring Imaging Conditions...",
-                "progress": {"state": "finished", "task_id": self.task_id, "task_name": self.name}
-            })
+            self._handle_progress(
+                {
+                    "msg": f"Finished Milling Task: {self.name}. Restoring Imaging Conditions...",
+                    "progress": {
+                        "state": "finished",
+                        "task_id": self.task_id,
+                        "task_name": self.name,
+                    },
+                }
+            )
             # restore the captured pre-milling imaging current/voltage
             imaging_current, imaging_voltage = self._imaging_conditions()
             self.microscope.finish_milling(
@@ -295,7 +339,9 @@ class FibsemMillingTask:
             )
             # restore initial beam shift
             if self.initial_beam_shift is not None:
-                self.microscope.set_beam_shift(self.initial_beam_shift, beam_type=self.config.channel)
+                self.microscope.set_beam_shift(
+                    self.initial_beam_shift, beam_type=self.config.channel
+                )
 
             self._post_task_acquisition()
 
@@ -305,9 +351,14 @@ class FibsemMillingTask:
             # refresh the view with a single image if the task didn't already acquire one.
             # NB: acquisition.enabled is (acquire_sem or acquire_fib), so it subsumes the
             # acquire_fib check this condition used to carry.
-            if self.config.acquisition.acquire_final_image and not self.config.acquisition.enabled:
+            if (
+                self.config.acquisition.acquire_final_image
+                and not self.config.acquisition.enabled
+            ):
                 self.microscope.autocontrast(beam_type=self.config.channel)
-                fib_image = self.microscope.acquire_image(image_settings=None, beam_type=self.config.channel)
+                fib_image = self.microscope.acquire_image(
+                    image_settings=None, beam_type=self.config.channel
+                )
                 self.microscope.fib_acquisition_signal.emit(fib_image)
         except Exception as e:
             logging.error(f"Error acquiring image after milling task: {e}")
@@ -322,20 +373,23 @@ class FibsemMillingTask:
         start_time = time.time()
         raise_if_cancelled(self._stop_event)
 
-        msgd =  {"msg": f"Preparing: {stage.name}",
-                "progress": {"state": "start", 
-                            "start_time": start_time,
-                            "current_stage": idx, 
-                            "total_stages": len(self.stages),
-                            "task_id": self.task_id,
-                            "task_name": self.name,
-                            "stage_name": stage.name,
-                            }}
+        msgd = {
+            "msg": f"Preparing: {stage.name}",
+            "progress": {
+                "state": "start",
+                "start_time": start_time,
+                "current_stage": idx,
+                "total_stages": len(self.stages),
+                "task_id": self.task_id,
+                "task_name": self.name,
+                "stage_name": stage.name,
+            },
+        }
         self._handle_progress(msgd)
 
         try:
             # if self.config.acquisition.enabled:
-                # self._acquire_milling_task_images(stage_name=stage.name, tag="start")
+            # self._acquire_milling_task_images(stage_name=stage.name, tag="start")
 
             # Set up the stage with the task configuration
             stage.reference_image = self.reference_image
@@ -354,24 +408,30 @@ class FibsemMillingTask:
             )
             # TODO: pass task as parent into strategy.run()?, allow logging from strategy?
             # performance logging
-            msgd = {"msg": "milling_task",
-                    "milling_task_id": self.task_id,
-                    "milling_task_name": self.name,
-                    "idx": idx,
-                    "stage": stage.to_dict(),
-                    "start_time": start_time,
-                    "end_time": time.time(),
-                    "timestamp": datetime.now().isoformat()}
+            msgd = {
+                "msg": "milling_task",
+                "milling_task_id": self.task_id,
+                "milling_task_name": self.name,
+                "idx": idx,
+                "stage": stage.to_dict(),
+                "start_time": start_time,
+                "end_time": time.time(),
+                "timestamp": datetime.now().isoformat(),
+            }
             logging.debug(f"{msgd}")
 
             # optionally acquire images after milling
             if self.config.acquisition.enabled:
-                self._acquire_milling_task_images(stage_name=f"{self.name}-{stage.name}", tag="finished")
+                self._acquire_milling_task_images(
+                    stage_name=f"{self.name}-{stage.name}", tag="finished"
+                )
 
         except OperationCancelledError:
             raise  # unwind to run() so the whole task aborts + restores conditions
         except Exception as e:
-            logging.error(f"Error running milling stage: {stage.name}, {e}", exc_info=True)
+            logging.error(
+                f"Error running milling stage: {stage.name}, {e}", exc_info=True
+            )
 
     def _acquire_reference_image(self) -> Optional[FibsemImage]:
         """Acquire a reference image for the milling task."""
@@ -383,7 +443,9 @@ class FibsemMillingTask:
         if path is None:
             path = Path(fcfg.DATA_CC_PATH)
 
-        filename = f"{self.name}_{fcfg.REFERENCE_FILENAME}_{current_timestamp_v3(timeonly=True)}".replace(' ', '-')
+        filename = f"{self.name}_{fcfg.REFERENCE_FILENAME}_{current_timestamp_v3(timeonly=True)}".replace(
+            " ", "-"
+        )
         image_settings = ImageSettings(
             hfw=self.config.field_of_view,
             dwell_time=self.config.alignment.imaging.dwell_time,
@@ -394,7 +456,9 @@ class FibsemMillingTask:
             path=path,
             filename=filename,
         )
-        self.reference_image = acquire.acquire_image(microscope=self.microscope, settings=image_settings)
+        self.reference_image = acquire.acquire_image(
+            microscope=self.microscope, settings=image_settings
+        )
 
     def _acquire_milling_task_images(
         self,
@@ -407,16 +471,23 @@ class FibsemMillingTask:
             tag (str): Tag to append to the filename
         """
         imaging_current, imaging_voltage = self._imaging_conditions()
-        self.microscope.finish_milling(imaging_current=imaging_current,
-                                       imaging_voltage=imaging_voltage)
+        self.microscope.finish_milling(
+            imaging_current=imaging_current, imaging_voltage=imaging_voltage
+        )
 
         acq_date = current_timestamp_v3(timeonly=True)
-        self.config.acquisition.imaging.filename = f"{stage_name}_{tag}_{acq_date}".replace(' ', '-')
+        self.config.acquisition.imaging.filename = (
+            f"{stage_name}_{tag}_{acq_date}".replace(" ", "-")
+        )
         self.config.acquisition.imaging.save = True
-        self.config.acquisition.imaging.hfw = self.config.field_of_view # force field of view to match task
+        self.config.acquisition.imaging.hfw = (
+            self.config.field_of_view
+        )  # force field of view to match task
 
         if self.config.acquisition.imaging.path is None:
-            self.config.acquisition.imaging.path = self.microscope._last_imaging_settings.path
+            self.config.acquisition.imaging.path = (
+                self.microscope._last_imaging_settings.path
+            )
 
         # support specifying acquiring sem and/or fib images only
         sem_image, fib_image = acquire.acquire_channels(
@@ -428,16 +499,18 @@ class FibsemMillingTask:
 
         try:
             if sem_image is not None:
-                self.microscope.sem_acquisition_signal.emit(sem_image) # sem image
+                self.microscope.sem_acquisition_signal.emit(sem_image)  # sem image
             if fib_image is not None:
-                self.microscope.fib_acquisition_signal.emit(fib_image) # ion image
+                self.microscope.fib_acquisition_signal.emit(fib_image)  # ion image
         except Exception as e:
             logging.error(f"Error emitting acquisition signals: {e}")
 
 
-def run_milling_task(microscope: FibsemMicroscope, 
-                     config: FibsemMillingTaskConfig, 
-                     parent_ui: Optional['FibsemMillingWidget2'] = None) -> FibsemMillingTask:
+def run_milling_task(
+    microscope: FibsemMicroscope,
+    config: FibsemMillingTaskConfig,
+    parent_ui: Optional["FibsemMillingWidget2"] = None,
+) -> FibsemMillingTask:
     """Run a milling task with the given configuration.
     Args:
         microscope (FibsemMicroscope): The microscope to use for milling.
@@ -446,8 +519,6 @@ def run_milling_task(microscope: FibsemMicroscope,
     Returns:
         FibsemMillingTask: The milling task that was run.
     """
-    task = FibsemMillingTask(microscope=microscope, 
-                             config=config, 
-                             parent_ui=parent_ui)
+    task = FibsemMillingTask(microscope=microscope, config=config, parent_ui=parent_ui)
     task.run()
     return task

--- a/fibsem/ui/widgets/milling_widget.py
+++ b/fibsem/ui/widgets/milling_widget.py
@@ -50,9 +50,7 @@ class FibsemMillingWidget2(QWidget):
 
         self.pushButton_stop_milling = QPushButton("Stop Milling")
         self.pushButton_stop_milling.clicked.connect(self.stop_milling)
-        self.pushButton_stop_milling.setStyleSheet(
-            stylesheets.DANGER_BUTTON_STYLESHEET
-        )
+        self.pushButton_stop_milling.setStyleSheet(stylesheets.DANGER_BUTTON_STYLESHEET)
         self.pushButton_stop_milling.setVisible(False)
 
         self.pushButton_pause_milling = QPushButton("Pause Milling")
@@ -69,9 +67,7 @@ class FibsemMillingWidget2(QWidget):
         self.progressBar_milling_stages.setStyleSheet(
             stylesheets.PROGRESS_BAR_STYLESHEET
         )
-        self.progressBar_milling.setStyleSheet(
-            stylesheets.PROGRESS_BAR_STYLESHEET
-        )
+        self.progressBar_milling.setStyleSheet(stylesheets.PROGRESS_BAR_STYLESHEET)
 
         self.start_milling_signal.connect(self.run_milling, Qt.BlockingQueuedConnection)  # type: ignore
 
@@ -202,7 +198,9 @@ class FibsemMillingWidget2(QWidget):
             )
 
         except Exception as e:
-            logging.error(f"Error occurred while running milling task: {e}", exc_info=True)
+            logging.error(
+                f"Error occurred while running milling task: {e}", exc_info=True
+            )
 
         finally:
             self._milling_thread = None


### PR DESCRIPTION
Formatting only, ahead of the FIB-797 milling-progress work. No behaviour change.

CI's lint job runs **both** `ruff check` and `ruff format --check` over every changed file. Four of the files FIB-797 has to touch are not currently format-clean, so the first behaviour change in any of them would have to carry that file's whole reformatting alongside it — which is exactly what makes the behaviour change unreviewable.

| file | reformatted lines |
| -- | -- |
| `fibsem/milling/tasks.py` | 217 |
| `fibsem/microscopes/odemis_microscope.py` | 112 |
| `fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py` | 81 |
| `fibsem/ui/widgets/milling_widget.py` | 12 |

## Verification

`ruff format` was the only thing run. Proven formatting-only rather than asserted: for each file, `ast.dump(ast.parse(...))` is byte-identical before and after, and the decorator lists are compared separately — a scripted patch has displaced an `@ensure_main_thread` here before, and that is invisible to a diff read at a glance.

```
fibsem/milling/tasks.py                        IDENTICAL   decorators MATCH (12)
fibsem/ui/widgets/milling_widget.py            IDENTICAL   decorators MATCH (3)
fluorescence_coincidence_viewer_widget.py      IDENTICAL   decorators MATCH (6)
fibsem/microscopes/odemis_microscope.py        IDENTICAL   decorators MATCH (0)
```

`ruff check` and `ruff format --check` both pass on all four.