### PR TITLE
[refactor] Declare a typed contract for milling progress (FIB-797)

### DIFF
--- a/fibsem/milling/progress.py
+++ b/fibsem/milling/progress.py
@@ -1,0 +1,244 @@
+"""What a milling task says about itself while it runs.
+
+`FibsemMicroscope.milling_progress_signal` used to carry a **nested** dict --
+`{"msg": ..., "progress": {...}}` -- with no declared shape, so every consumer opened
+with a `.get("progress")`, a `None` guard, and then a second level of `.get` before it
+could read anything. Four payload shapes were in flight, one of which matched no branch
+in any consumer and therefore rendered nowhere.
+
+`MillingProgress` is the whole contract, and `MillingStatus` is the whole vocabulary.
+
+# One flat record, not a union -- but it is the closest call of the three
+
+Unlike `TiledProgress` and `FluorescenceAcquisitionProgress`, this signal *is* a genuine
+tagged union today: all three consumers open with the same `state ==` ladder over a
+closed vocabulary, so a union of dataclasses would fit the dispatch. Three things tip it
+to a flat record anyway.
+
+The variants are not cleanly disjoint. `task_id`/`task_name` ride on every report;
+`start_time` on both a stage start and a stage update. Every shared field becomes a base
+class or a repeat.
+
+The real win is orthogonal to the choice. The wart is the *nesting*, not the flatness --
+removing a level of `.get` and its `None` guard is the same job either way.
+
+And a third convention costs more than it buys. The other two typed progress signals are
+flat records with a status enum; a union here means three signals with three shapes for
+one concept.
+
+# Two levels of status, because "start" and "finished" were not a pair
+
+The original three-value vocabulary mixed two scales, and that is a live trap rather
+than a cosmetic one. `state: "start"` was emitted per *stage*, N times; `state:
+"finished"` from `run()`'s `finally`, once per *task*. They read like a matched pair and
+are not one, so a consumer bracketing them is wrong N-1 times. The tiled work hit the
+identical collision between `TILES_ACQUIRED` and `FINISHED`.
+
+# `message` is the one open field, and it is a feature
+
+The tiled signal dropped its message because its producers are a closed set of two, both
+internal, so each consumer could own its wording. That argument does not hold here: the
+producer set is **open**. Milling strategies are plugin-loadable (`register_strategy`
+plus entry points in `fibsem/milling/strategy/__init__.py`), a strategy implements its
+own execution loop, and users have specifically asked to customise the text a strategy
+shows while it runs.
+
+So `message` stays -- as the single free field on an otherwise closed record. `status`
+does **not** open up. A free-form, caller-supplied discriminator is what broke the union
+on FIB-401, where it turned out to be written by producers and read by nobody.
+
+Two rules make it work, both carried here rather than at each consumer:
+
+* **Sticky.** A consumer keeps the last non-empty message and renders it beside the
+  countdown. That is what lets a *delegating* strategy -- one that calls
+  `microscope.run_milling()` and hands off -- set the text once and have it survive the
+  backend's messageless ticks. The backend has no idea what the strategy calls itself.
+* **Falsy, not `is None`.** A plugin returning `""` is a bug, not a request for a blank
+  label. FIB-401 hit this exactly: an empty channel rendered `"Acquiring  (1/1)..."`.
+
+`display_message` is a convenience, not a mandate -- a consumer that wants its own
+wording still writes `report.message or my_label(report.status)`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional
+
+from fibsem.structures import MillingState
+
+__all__ = [
+    "MillingStatus",
+    "MillingProgress",
+]
+
+
+class MillingStatus(str, Enum):
+    """Where a milling task has got to.
+
+    Seven members across **two scales**, and the prefixes are the whole point: `TASK_*`
+    is the run, `STAGE_*` is one stage within it. The vocabulary this replaces had
+    `start` (per stage) and `finished` (per task) sitting side by side looking like a
+    pair.
+
+    A `str` mixin so a member compares equal to its own value: these are persisted
+    nowhere, but they reach log lines, and `"stage-update"` reads better than
+    `MillingStatus.STAGE_UPDATE`.
+    """
+
+    # The task is beginning, before any stage has started. No producer emitted an
+    # equivalent before, and it still earns its place: a sticky `message` needs a reset
+    # boundary or a stale label bleeds from one task into the next. Without it a
+    # consumer has to infer "new task" from `current_stage == 0`, which is the sort of
+    # inference a typed contract exists to delete.
+    TASK_STARTED = "task-started"
+    # One stage is beginning. Emitted *before* the stage runs, so it carries no elapsed
+    # progress -- a bar driven off it reads zero, which is correct.
+    STAGE_STARTED = "stage-started"
+    # A tick from whoever is driving the beam: a backend's poll loop, or a self-driving
+    # strategy's own. The only status that carries a countdown.
+    STAGE_UPDATE = "stage-update"
+    # One stage is done. The weakest of the seven -- every one but the last is followed
+    # immediately by a `STAGE_STARTED` -- but it makes per-stage duration measurable,
+    # and it is the natural emit point in `_mill_stage`.
+    STAGE_FINISHED = "stage-finished"
+    # The task ran to completion. Terminal.
+    TASK_FINISHED = "task-finished"
+    # Someone stopped the task. Terminal, and deliberately not `TASK_FAILED`: a cancel
+    # is a person getting what they asked for, so a consumer paints it neutrally.
+    TASK_CANCELLED = "task-cancelled"
+    # The task raised. Terminal, and the only status that carries `error`.
+    TASK_FAILED = "task-failed"
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether this ends the *task*.
+
+        Answered here rather than restated at each consumer: three of them need it, and
+        a membership tuple copied into three files is a tuple that drifts -- the next
+        status added is one somebody forgets, and the symptom is a progress bar that
+        never clears.
+
+        `STAGE_FINISHED` is **not** terminal. Getting that backwards hides the bar
+        after the first stage of an N-stage task.
+        """
+        return self in _TERMINAL_STATUSES
+
+
+_TERMINAL_STATUSES = frozenset(
+    {
+        MillingStatus.TASK_FINISHED,
+        MillingStatus.TASK_CANCELLED,
+        MillingStatus.TASK_FAILED,
+    }
+)
+
+
+# The label shown when no producer supplied a `message`. One table rather than a default
+# argument at each consumer's `.get`: today the three of them default three different
+# ways -- "Preparing Milling Conditions...", "Preparing...", "Milling..." -- for the
+# same report, which is the drift a single home removes.
+#
+# `{stage}` and `{task}` are filled by `display_message` when the report carries a name,
+# and the whole clause is dropped when it does not. A label reading "Preparing: None" is
+# worse than one reading "Preparing...".
+_DEFAULT_MESSAGES: Dict[MillingStatus, str] = {
+    MillingStatus.TASK_STARTED: "Preparing milling task...",
+    MillingStatus.STAGE_STARTED: "Preparing...",
+    MillingStatus.STAGE_UPDATE: "Milling...",
+    MillingStatus.STAGE_FINISHED: "Finished stage",
+    MillingStatus.TASK_FINISHED: "Finished milling task",
+    MillingStatus.TASK_CANCELLED: "Milling cancelled",
+    MillingStatus.TASK_FAILED: "Milling failed",
+}
+
+# Which name each default is qualified by, when the report carries one -- a stage report
+# says which stage, a task report says which task. The three outcomes are in neither
+# set: "Milling cancelled: Rough Mill" invites the reading that one *stage* was
+# cancelled, which is the two-scale confusion the status vocabulary exists to remove.
+_STAGE_QUALIFIED = frozenset(
+    {
+        MillingStatus.STAGE_STARTED,
+        MillingStatus.STAGE_UPDATE,
+        MillingStatus.STAGE_FINISHED,
+    }
+)
+_TASK_QUALIFIED = frozenset({MillingStatus.TASK_STARTED, MillingStatus.TASK_FINISHED})
+
+
+@dataclass(frozen=True)
+class MillingProgress:
+    """One report from a milling task.
+
+    Most fields are absent on most reports, and that is the point: an outcome carries no
+    countdown, a stage tick carries no error. `status` is the only thing every report
+    has and the only required field -- which is also what keeps this constructible on
+    Python 3.8, where `kw_only` does not exist and required fields must come first.
+
+    `current_stage` is 0-based on the wire, matching every other index in the codebase.
+    `display_stage` is the only thing that adds one; that offset was applied seven times
+    across three files before.
+
+    Equality is left generated, unlike `TiledProgress`. Nothing here carries a numpy
+    array, so no field's `__eq__` returns an array and blows up the comparison -- which
+    makes these usable in `assert emitted == [...]` and in a set.
+    """
+
+    status: MillingStatus
+    # The producer's own wording, and the one free field on this record. `None` means
+    # "no opinion, use the default"; see the module docstring for why it is sticky and
+    # why it is tested falsy rather than `is not None`.
+    message: Optional[str] = None
+    task_id: Optional[str] = None
+    task_name: Optional[str] = None
+    # Which stage. Carried by the `STAGE_*` statuses only.
+    stage_name: Optional[str] = None
+    current_stage: Optional[int] = None
+    total_stages: Optional[int] = None
+    start_time: Optional[float] = None
+    estimated_time: Optional[float] = None
+    remaining_time: Optional[float] = None
+    # What the instrument says it is doing, carried on the report so a consumer does not
+    # have to ask. Asking is not free: on ThermoFisher `get_milling_state()` is a getter
+    # that *sets the active view* as a side effect, so a UI polling it during a
+    # coincidence mill competes for the view with the fluorescence acquisition the
+    # strategy is running. `MillingState.UNKNOWN` is a producer declining to look for
+    # exactly that reason -- see `fibsem.structures.MillingState`.
+    milling_state: Optional[MillingState] = None
+    # Why the task ended, on `TASK_FAILED` only. The *reason* -- an exception's text --
+    # never the label: a consumer words `TASK_FAILED` itself and puts this behind it.
+    error: Optional[str] = None
+
+    @property
+    def display_stage(self) -> Optional[int]:
+        """Which stage this report is about, 1-based, for people.
+
+        The one place the offset is applied. Stage 0 is "1" to a reader and 0 to a
+        `self.stages[...]` lookup, and both spellings were written out by hand at seven
+        call sites across three widgets.
+        """
+        if self.current_stage is None:
+            return None
+        return self.current_stage + 1
+
+    @property
+    def display_message(self) -> str:
+        """The producer's words if it supplied any, otherwise composed from `status`.
+
+        Falsy rather than `is not None`, so a plugin that returns `""` gets the default
+        instead of a blank label.
+        """
+        if self.message:
+            return self.message
+        default = _DEFAULT_MESSAGES[self.status]
+        name = None
+        if self.status in _STAGE_QUALIFIED:
+            name = self.stage_name
+        elif self.status in _TASK_QUALIFIED:
+            name = self.task_name
+        if not name:
+            return default
+        # The trailing ellipsis reads as "and then the name" rather than as a pause once
+        # something follows it, so it is dropped when the label is qualified.
+        return f"{default.rstrip('.')}: {name}"

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -293,8 +293,28 @@ class MillingState(Enum):
     STOPPING = 2
     PAUSED = 3
     ERROR = 4
+    # The state could not be read. Not an error and not a guess -- a producer saying so
+    # deliberately, because on ThermoFisher `get_milling_state()` is a getter that
+    # *sets the active view* as a side effect, and a caller that must not disturb the
+    # view has no way to ask. The coincidence milling strategy is exactly that caller:
+    # it runs a fluorescence acquisition that holds the active view for the whole
+    # strategy, so polling the milling state mid-strategy would yank the view out from
+    # under it.
+    #
+    # A real member rather than `None` or the string `"UNKNOWN"`, so a consumer can
+    # render or ignore it deliberately instead of pattern-matching a magic value.
+    UNKNOWN = 5
 
 
+# Milling is under way, in the sense that the caller should keep waiting. Read as a loop
+# condition -- `while get_milling_state() in ACTIVE_MILLING_STATES` guards the milling
+# waits and TESCAN's spot-burn poll.
+#
+# `UNKNOWN` is deliberately **not** in here, and both classifications have a failure
+# mode: excluded, a genuinely-running mill that reported `UNKNOWN` makes the loop exit
+# early and the caller proceeds as though milling finished; included, a mill that has
+# actually stopped spins forever. Exiting early is recoverable and bounded. Spinning is
+# not.
 ACTIVE_MILLING_STATES = [
     MillingState.RUNNING,
     MillingState.STOPPING,

--- a/tests/milling/test_progress.py
+++ b/tests/milling/test_progress.py
@@ -1,0 +1,179 @@
+"""The typed contract carried by ``milling_progress_signal`` (FIB-797).
+
+Nothing emits or reads a ``MillingProgress`` yet -- the producers still build nested
+dicts and the consumers still take them apart. What is worth pinning before either moves
+is the shape, and specifically the decisions that are cheap to quietly undo later: that
+a stage outcome and a task outcome are different things, that the offset lives in one
+place, and that a plugin's empty string is not a request for a blank label.
+
+``milling_progress_signal`` has had **no** test coverage of any kind until now.
+"""
+
+import dataclasses
+
+import pytest
+
+from fibsem.milling.progress import (
+    _DEFAULT_MESSAGES,
+    MillingProgress,
+    MillingStatus,
+)
+from fibsem.structures import ACTIVE_MILLING_STATES, MillingState
+
+
+class TestTheStatusVocabulary:
+    def test_a_stage_finishing_is_not_the_task_finishing(self):
+        """The vocabulary this replaces had `state: "start"` (emitted per stage, N
+        times) sitting beside `state: "finished"` (emitted once, from the task's
+        `finally`). They read like a matched pair and were not one, so a consumer
+        bracketing them was wrong N-1 times."""
+        assert MillingStatus.STAGE_FINISHED is not MillingStatus.TASK_FINISHED
+        assert MillingStatus.STAGE_STARTED is not MillingStatus.TASK_STARTED
+
+    def test_only_the_task_outcomes_are_terminal(self):
+        """`STAGE_FINISHED` is not the end of anything. A consumer that hides its
+        progress bar on it hides it after the first stage of an N-stage task."""
+        terminal = {s for s in MillingStatus if s.is_terminal}
+        assert terminal == {
+            MillingStatus.TASK_FINISHED,
+            MillingStatus.TASK_CANCELLED,
+            MillingStatus.TASK_FAILED,
+        }
+        assert not MillingStatus.STAGE_FINISHED.is_terminal
+
+    def test_a_cancelled_task_is_not_a_failed_one(self):
+        """A cancel is someone getting what they asked for. Today both land in the same
+        `finally` and report as *finished*; keeping them apart in the vocabulary is what
+        lets a consumer paint one neutrally and the other red."""
+        assert MillingStatus.TASK_CANCELLED is not MillingStatus.TASK_FAILED
+        assert MillingStatus.TASK_CANCELLED is not MillingStatus.TASK_FINISHED
+
+    def test_a_member_compares_equal_to_its_own_value(self):
+        """The `str` mixin, so these read as themselves in a log line."""
+        assert MillingStatus.STAGE_UPDATE == "stage-update"
+
+    def test_every_status_has_a_default_message(self):
+        """`display_message` indexes `_DEFAULT_MESSAGES` directly. A status added
+        without one is a `KeyError` raised inside a queued Qt slot, which on PyQt5 is
+        `qFatal` -- the process aborts with nothing in the logfile (FIB-329)."""
+        assert set(_DEFAULT_MESSAGES) == set(MillingStatus)
+
+
+class TestDisplayStage:
+    def test_the_offset_is_applied_once_here(self):
+        """`current_stage` is 0-based on the wire, like every other index in the
+        codebase. The `+ 1` was written out by hand at seven call sites across three
+        widgets before this property existed."""
+        first = MillingProgress(MillingStatus.STAGE_STARTED, current_stage=0)
+        fourth = MillingProgress(MillingStatus.STAGE_STARTED, current_stage=3)
+        assert first.display_stage == 1
+        assert fourth.display_stage == 4
+
+    def test_a_report_with_no_stage_index_has_no_display_stage(self):
+        """Rather than defaulting to 0 and rendering "Stage 1" for a task-level report
+        that is about no stage at all."""
+        assert MillingProgress(MillingStatus.TASK_FINISHED).display_stage is None
+
+
+class TestDisplayMessage:
+    def test_a_producer_that_supplies_words_gets_them_back(self):
+        """The point of keeping `message` at all: milling strategies are plugin-loadable
+        and users asked to customise the text a strategy shows while it runs."""
+        words = "Polishing at 30 pA"
+        report = MillingProgress(MillingStatus.STAGE_UPDATE, message=words)
+        assert report.display_message == words
+
+    def test_an_empty_message_falls_back_to_the_default(self):
+        """Falsy, not `is not None`. A plugin returning `""` is a bug, not a request for
+        a blank label -- FIB-401 hit this exactly, where an empty channel rendered
+        "Acquiring  (1/1)..."."""
+        report = MillingProgress(MillingStatus.STAGE_UPDATE, message="")
+        assert report.display_message == _DEFAULT_MESSAGES[MillingStatus.STAGE_UPDATE]
+
+    def test_the_default_says_which_stage_when_the_report_names_one(self):
+        """One home for the wording. The three consumers defaulted three different ways
+        for the same report -- "Preparing Milling Conditions...", "Preparing...",
+        "Milling..." -- which is the drift a single table removes."""
+        report = MillingProgress(MillingStatus.STAGE_STARTED, stage_name="Rough Mill")
+        assert report.display_message == "Preparing: Rough Mill"
+
+    def test_the_default_says_which_task_when_the_report_names_one(self):
+        report = MillingProgress(MillingStatus.TASK_FINISHED, task_name="Trench")
+        assert report.display_message == "Finished milling task: Trench"
+
+    def test_an_outcome_is_not_qualified_by_a_stage_name(self):
+        """A label reading "Milling cancelled: Rough Mill" invites the reading that one
+        *stage* was cancelled. The outcomes are task-level; that is the whole reason the
+        vocabulary has two scales."""
+        report = MillingProgress(MillingStatus.TASK_CANCELLED, stage_name="Rough Mill")
+        assert report.display_message == "Milling cancelled"
+
+    def test_a_report_naming_nothing_still_renders(self):
+        """Every status, with no fields at all. A label reading "Preparing: None" is
+        worse than one reading "Preparing..."."""
+        for status in MillingStatus:
+            message = MillingProgress(status).display_message
+            assert message
+            assert "None" not in message
+
+    def test_a_qualified_label_does_not_keep_its_ellipsis(self):
+        """It reads as a pause rather than as "and then the name" once something
+        follows it."""
+        report = MillingProgress(MillingStatus.STAGE_UPDATE, stage_name="Polish")
+        assert report.display_message == "Milling: Polish"
+
+
+class TestTheRecord:
+    def test_status_is_the_only_required_field(self):
+        """Which is also what keeps this constructible on the 3.8 CI jobs, where
+        `dataclass(kw_only=...)` does not exist and required fields must come first."""
+        report = MillingProgress(MillingStatus.TASK_STARTED)
+        assert report.status is MillingStatus.TASK_STARTED
+        assert report.message is None
+        assert report.error is None
+
+    def test_a_report_is_frozen(self):
+        report = MillingProgress(MillingStatus.STAGE_UPDATE)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            report.remaining_time = 1.0  # type: ignore[misc]
+
+    def test_two_reports_carrying_the_same_thing_are_equal(self):
+        """Equality is left generated, unlike `TiledProgress` -- nothing here holds a
+        numpy array whose `__eq__` returns an array. That is what makes these usable in
+        `assert emitted == [...]`, which every consumer test in this stack relies on."""
+        a = MillingProgress(MillingStatus.STAGE_UPDATE, remaining_time=12.0)
+        b = MillingProgress(MillingStatus.STAGE_UPDATE, remaining_time=12.0)
+        assert a == b
+        assert len({a, b}) == 1
+
+    def test_a_report_can_carry_the_instrument_state(self):
+        """Carried on the report so a consumer does not have to ask -- and asking is not
+        free: on ThermoFisher `get_milling_state()` sets the active view as a side
+        effect."""
+        report = MillingProgress(
+            MillingStatus.STAGE_UPDATE, milling_state=MillingState.RUNNING
+        )
+        assert report.milling_state is MillingState.RUNNING
+
+
+class TestMillingStateUnknown:
+    def test_unknown_is_a_real_member(self):
+        """Rather than the magic string `"UNKNOWN"` the coincidence strategy sends
+        today, which every other producer sends as an enum."""
+        assert MillingState.UNKNOWN is not MillingState.ERROR
+        assert MillingState.UNKNOWN is not MillingState.IDLE
+
+    def test_adding_unknown_did_not_renumber_the_existing_states(self):
+        """Purely additive. These values reach the server client over the wire."""
+        assert MillingState.IDLE.value == 0
+        assert MillingState.RUNNING.value == 1
+        assert MillingState.STOPPING.value == 2
+        assert MillingState.PAUSED.value == 3
+        assert MillingState.ERROR.value == 4
+
+    def test_unknown_does_not_keep_a_milling_wait_spinning(self):
+        """`ACTIVE_MILLING_STATES` is a loop condition. Both classifications have a
+        failure mode -- excluded, a running mill that reported `UNKNOWN` exits the loop
+        early; included, a stopped mill spins forever. Exiting early is bounded and
+        recoverable; spinning is not."""
+        assert MillingState.UNKNOWN not in ACTIVE_MILLING_STATES


### PR DESCRIPTION
First of five for FIB-797. **Nothing emits or reads a `MillingProgress` yet** — the producers still build nested dicts and the consumers still take them apart. This declares the shape and pins the decisions that are cheap to quietly undo later.

`milling_progress_signal = Signal(dict)` carries a **nested** payload — `{"msg": ..., "progress": {...}}` — with no declared shape. Every consumer opens with a `.get("progress")`, a `None` guard, and then a second level of `.get`. Four payload shapes are in flight, and one of them matches no branch in any consumer.

## Two levels of status, because `start` and `finished` were never a pair

The old three-value vocabulary mixed two scales:

- `state: "start"` is emitted in `_mill_stage` — **once per stage**, N times.
- `state: "finished"` is emitted in `run()`'s `finally` — **once per task**.

They read like a matched pair and are not one, so a consumer bracketing them is wrong N−1 times. `STAGE_*` is one stage, `TASK_*` is the run, and `is_terminal` covers the three `TASK_` outcomes only. The tiled work hit the identical collision between `TILES_ACQUIRED` and `FINISHED`.

`TASK_CANCELLED` and `TASK_FAILED` exist because of a live bug this stack goes on to fix: today a cancelled mill and a crashed one both fall through to the same `finally` and report as **finished**. The status bar says "Done" either way and the exception text reaches only the logfile. The vocabulary has to be able to say otherwise before the producers can.

## `message` survives, unlike the tiled signal's

The tiled signal dropped its message because its producers are a closed set of two, both internal. **That argument does not hold here: the producer set is open.** Milling strategies are plugin-loadable (`register_strategy` + entry points), a strategy implements its own execution loop, and users have specifically asked to customise the text a strategy shows while it runs.

So `message` is the **single free field** on an otherwise closed record. `status` does not open up — a caller-supplied discriminator is what broke the union on FIB-401, where it turned out to be written by producers and read by nobody.

- **Sticky** across reports that omit it, which is what lets a *delegating* strategy (one that calls `microscope.run_milling()` and hands off) set the text once and have it survive the backend's messageless ticks.
- **Falsy, not `is None`** — a plugin returning `""` is a bug, not a request for a blank label. FIB-401 hit this exactly: an empty channel rendered `"Acquiring  (1/1)..."`.
- `display_message` composes a default from the status, with one table. Today the three consumers default three different ways for the same report: `"Preparing Milling Conditions..."`, `"Preparing..."`, `"Milling..."`.

`display_stage` is the one place the 0-based index gains a one. That `+ 1` is written out by hand at **seven** call sites across three widgets today.

## `MillingState.UNKNOWN`

`strategy/coincidence.py` sends the string `"UNKNOWN"` where every other producer sends the enum. **That is deliberate, not sloppy.** On ThermoFisher, reading the milling state *changes the active view*:

```python
def get_milling_state(self) -> MillingState:
    with self._threading_lock:
        self.set_channel(channel=self.milling_channel)   # -> set_active_view
        return MillingState[self.connection.patterning.state.upper()]
```

The coincidence strategy runs a fluorescence acquisition that holds the active view for the strategy's whole duration, so calling the getter mid-strategy would yank the view out from under it. `UNKNOWN` is the strategy declining to steal the view, and that deserves a real member rather than a magic string that happens to spell one.

Purely additive at value 5 — the existing members keep their values, which matters because they reach the server client over the wire. **Excluded from `ACTIVE_MILLING_STATES`**: that list is a loop condition, and both classifications have a failure mode. Excluded, a running mill that reported `UNKNOWN` exits the wait early; included, a mill that has stopped spins forever. Exiting early is bounded and recoverable.

Left out deliberately: turning the three `MillingState[<string>.upper()]` lookups into non-raising `.get(name, UNKNOWN)`. The issue lists it as a bonus, and it is a behaviour change with its own failure mode — a `KeyError` today is loud, whereas a silent `UNKNOWN` makes a milling wait exit early. Worth doing on its own merits, not as a rider.

## Tests

21, in `tests/milling/test_progress.py` — the first coverage `milling_progress_signal` has had **of any kind**.

Verified beyond the local run:

- **No PyQt5 dependency.** `tests/milling/` is not gated behind `pytest.importorskip("PyQt5")` — only `tests/ui/` is — and CI installs `.[test]`, not `[ui]`. Re-run under a `find_spec` meta-path finder that makes PyQt5/qtpy/superqt/napari unimportable: 21 passed.
- **Python 3.8.** AST scan for `match`, `dataclass(kw_only=/slots=)`, runtime PEP 604, runtime builtin generics, and `str.removeprefix`/`removesuffix`. Clean; both source files carry `from __future__ import annotations`.
- **Nothing else moved by the enum addition:** `tests/milling/ tests/test_structures.py tests/test_microscope.py tests/test_tescan*.py tests/test_milling_time_estimates.py` → 255 passed.
- `ruff check` and `ruff format --check` pass on all three files.

## Note

The branch name attaches this PR to FIB-797, so merging it will auto-complete the issue with four PRs still to come. Reopen after merge.