### PR TITLE
[refactor] Teach the milling progress consumers the typed contract (FIB-797)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -78,6 +78,11 @@ from fibsem.applications.autolamella.workflows.workflow_estimate import (
     estimate_workflow,
 )
 from fibsem.imaging.tiling.progress import TiledProgress, TiledStatus
+from fibsem.milling.progress import (
+    MillingMessageTracker,
+    MillingProgress,
+    MillingStatus,
+)
 from fibsem.structures import BeamType
 from fibsem.ui import notification_service
 from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
@@ -404,6 +409,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     def __init__(self):
         super().__init__()
+        # The last words a producer supplied, so a backend's messageless tick still
+        # has a label to show. See `MillingMessageTracker`.
+        self._milling_label = MillingMessageTracker()
         self.setWindowTitle(f"AutoLamella v{get_version_string()} ")
         self.resize(1600, 1000)
 
@@ -1547,43 +1555,46 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self._update_instructions()
 
     @ensure_main_thread
-    def _on_milling_progress(self, progress: dict):
+    def _on_milling_progress(self, payload: object):
         """Handle milling progress updates from the microscope."""
-        progress_info = progress.get("progress", None)
-        if progress_info is None:
+        # `payload` is still a nested dict from every producer; `from_payload` decodes
+        # it, and is a no-op once they emit `MillingProgress` directly (FIB-797).
+        report = MillingProgress.from_payload(payload)
+
+        if report.status.is_terminal:
+            self.milling_progress_bar.setVisible(False)
             return
 
-        state = progress_info.get("state", None)
+        label = self._milling_label.label(report)
 
-        if state == "start":
-            msg = progress.get("msg", "Milling...")
-            current_stage = progress_info.get("current_stage", 0)
-            total_stages = progress_info.get("total_stages", 1)
-            stage_name = progress_info.get("stage_name", f"Stage {current_stage + 1}")
+        if report.status is MillingStatus.STAGE_STARTED:
+            # `or 1` rather than a `.get` default: a producer that sends 0 total stages
+            # is as much a division by zero as one that sends nothing.
+            total_stages = report.total_stages or 1
+            stage = report.display_stage or 1
+            stage_name = report.stage_name or f"Stage {stage}"
             self.milling_progress_bar.setVisible(True)
             self.milling_progress_bar.setValue(0)
-            self.milling_progress_bar.setFormat(msg)
+            self.milling_progress_bar.setFormat(label)
             self.milling_progress_bar.setToolTip(
-                f"Milling Stage: {current_stage + 1}/{total_stages} - {stage_name}"
+                f"Milling Stage: {stage}/{total_stages} - {stage_name}"
             )
 
-        elif state == "update":
-            estimated_time = progress_info.get("estimated_time", None)
-            remaining_time = progress_info.get("remaining_time", None)
-
-            if (
-                remaining_time is not None
-                and estimated_time is not None
-                and estimated_time > 0
-            ):
-                percent_complete = int((1 - (remaining_time / estimated_time)) * 100)
+        elif report.status is MillingStatus.STAGE_UPDATE:
+            remaining_time = report.remaining_time
+            if remaining_time is not None and report.estimated_time:
+                percent_complete = int(
+                    (1 - (remaining_time / report.estimated_time)) * 100
+                )
                 self.milling_progress_bar.setValue(percent_complete)
                 self.milling_progress_bar.setFormat(
-                    f"Milling: {format_duration(remaining_time)} remaining"
+                    f"{label} - {format_duration(remaining_time)} remaining"
                 )
-
-        elif state == "finished":
-            self.milling_progress_bar.setVisible(False)
+            else:
+                # No countdown to draw, but the producer's words are still worth showing:
+                # this is the branch a strategy's own report lands in, and it used to
+                # match nothing at all and render nowhere.
+                self.milling_progress_bar.setFormat(label)
 
     @ensure_main_thread
     def _on_spot_burn_progress(self, ddict: dict) -> None:

--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -67,6 +67,11 @@ from fibsem.applications.autolamella.ui.selected_lamella_widget import (
 )
 from fibsem.constants import METRE_TO_MICRON, MICRON_TO_METRE
 from fibsem.fm.structures import FluorescenceImage
+from fibsem.milling.progress import (
+    MillingMessageTracker,
+    MillingProgress,
+    MillingStatus,
+)
 from fibsem.milling.strategy.coincidence import CoincidenceMillingStrategy
 from fibsem.structures import BeamType, FibsemImage, Point
 from fibsem.ui import notification_service, stylesheets
@@ -1128,6 +1133,10 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         )
         self.btn_milling.setStyleSheet(stylesheets.CONFIRM_BUTTON_STYLESHEET)
 
+        # The last words a producer supplied, so a backend's messageless tick still has
+        # a label to show. See `MillingMessageTracker`.
+        self._milling_label = MillingMessageTracker()
+
         # single pause control: tool button with milling/acquisition menu options
         self._milling_paused = False
         self.btn_pause = QToolButton()
@@ -2088,26 +2097,25 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         )
 
     @ensure_main_thread
-    def _on_milling_progress(self, progress: dict):
-        progress_info: dict = progress.get("progress", {})
-        state = progress_info.get("state")
+    def _on_milling_progress(self, payload: object):
+        # `payload` is still a nested dict from every producer; `from_payload` decodes
+        # it, and is a no-op once they emit `MillingProgress` directly (FIB-797).
+        report = MillingProgress.from_payload(payload)
+        label = self._milling_label.label(report)
 
-        if state == "start":
+        if report.status is MillingStatus.STAGE_STARTED:
             self._set_border_state("supervised" if self._supervised else "automated")
-            current_stage = progress_info.get("current_stage", 0)
-            total_stages = progress_info.get("total_stages", 1)
-            msg = progress.get("msg", "Preparing...")
+            # `or 1` rather than a `.get` default: a producer that sends 0 total stages
+            # is as much a division by zero as one that sends nothing.
+            total_stages = report.total_stages or 1
+            stage = report.display_stage or 1
             self.progressBar_stage.setRange(0, 100)
             self.progressBar_stage.setValue(0)
-            self.progressBar_stage.setFormat(msg)
+            self.progressBar_stage.setFormat(label)
             self.progressBar_stage.setVisible(True)
             self.progressBar_stages.setRange(0, 100)
-            self.progressBar_stages.setValue(
-                int((current_stage + 1) / total_stages * 100)
-            )
-            self.progressBar_stages.setFormat(
-                f"Stage {current_stage + 1}/{total_stages}"
-            )
+            self.progressBar_stages.setValue(int(stage / total_stages * 100))
+            self.progressBar_stages.setFormat(f"Stage {stage}/{total_stages}")
             self.progressBar_stages.setVisible(True)
             self.btn_milling.setText("Stop Milling")
             self.btn_milling.setIcon(
@@ -2128,22 +2136,26 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             )
             self.label_threshold_chip.setVisible(True)
 
-        elif state == "update":
-            remaining = progress_info.get("remaining_time")
-            estimated = progress_info.get("estimated_time")
-            if remaining is not None and estimated is not None and estimated > 0:
-                pct = int((1 - remaining / estimated) * 100)
+        elif report.status is MillingStatus.STAGE_UPDATE:
+            remaining = report.remaining_time
+            if remaining is not None and report.estimated_time:
+                pct = int((1 - remaining / report.estimated_time) * 100)
                 self.progressBar_stage.setValue(pct)
                 from fibsem.utils import format_duration
 
                 self.progressBar_stage.setFormat(
-                    f"{format_duration(remaining)} remaining"
+                    f"{label} - {format_duration(remaining)} remaining"
                 )
+            else:
+                # No countdown to draw, but the producer's words are still worth showing:
+                # this is the branch a strategy's own report lands in, and it used to
+                # match nothing at all and render nowhere.
+                self.progressBar_stage.setFormat(label)
 
-        # NOTE: no "finished" handling here. The progress "finished" state fires
-        # before finish_milling + the post-stop final image, so the viewer is kept
-        # frozen until the milling widget reports true completion — see
-        # _finalize_milling_ui (wired to finished_milling_signal).
+        # NOTE: no terminal handling here. The task's terminal report fires before
+        # finish_milling + the post-stop final image, so the viewer is kept frozen until
+        # the milling widget reports true completion — see _finalize_milling_ui (wired
+        # to finished_milling_signal).
 
     @ensure_main_thread
     def _finalize_milling_ui(self) -> None:

--- a/fibsem/milling/progress.py
+++ b/fibsem/milling/progress.py
@@ -71,6 +71,7 @@ from fibsem.structures import MillingState
 __all__ = [
     "MillingStatus",
     "MillingProgress",
+    "MillingMessageTracker",
 ]
 
 
@@ -242,3 +243,108 @@ class MillingProgress:
         # The trailing ellipsis reads as "and then the name" rather than as a pause once
         # something follows it, so it is dropped when the label is qualified.
         return f"{default.rstrip('.')}: {name}"
+
+    @classmethod
+    def from_payload(cls, payload: object) -> "MillingProgress":
+        """Decode whatever arrived on `milling_progress_signal` into one of these.
+
+        **Temporary**, for the window in which the producers still build nested dicts
+        and the consumers have already been taught the typed report. Deleted in the last
+        PR of FIB-797, along with `Signal(dict)` itself.
+
+        **Total by construction.** Every branch returns; nothing here indexes, and the
+        one `int()` that could raise is guarded. This runs inside a queued Qt slot, and
+        on PyQt5 an exception escaping one of those is `qFatal`: the process aborts with
+        nothing written to the logfile (FIB-329). A report that decodes to
+        `MillingStatus.STAGE_UPDATE` carrying nothing is a progress bar that does not
+        move; a raise here is a dead application.
+        """
+        if isinstance(payload, cls):
+            return payload
+        if not isinstance(payload, dict):
+            return cls(MillingStatus.STAGE_UPDATE)
+
+        inner = payload.get("progress")
+        if not isinstance(inner, dict):
+            inner = {}
+        message = payload.get("msg")
+
+        state = inner.get("state")
+        if state == "start":
+            status = MillingStatus.STAGE_STARTED
+        elif state == "finished":
+            status = MillingStatus.TASK_FINISHED
+        else:
+            # `"update"`, and also the shape that carries no `state` at all -- the
+            # strategy's own report, whose only content is its `msg`. It matched no
+            # branch in any consumer before, so its message rendered nowhere; decoding
+            # it as an update is what puts those words on the screen.
+            status = MillingStatus.STAGE_UPDATE
+
+        return cls(
+            status=status,
+            message=message if isinstance(message, str) else None,
+            task_id=inner.get("task_id"),
+            task_name=inner.get("task_name"),
+            # `name` is the strategy's spelling of `stage_name`.
+            stage_name=inner.get("stage_name") or inner.get("name"),
+            current_stage=_as_int(inner.get("current_stage")),
+            total_stages=_as_int(inner.get("total_stages")),
+            start_time=_as_float(inner.get("start_time")),
+            estimated_time=_as_float(inner.get("estimated_time")),
+            remaining_time=_as_float(inner.get("remaining_time")),
+            milling_state=_as_milling_state(inner.get("milling_state")),
+        )
+
+
+def _as_int(value: object) -> Optional[int]:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _as_float(value: object) -> Optional[float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _as_milling_state(value: object) -> Optional[MillingState]:
+    """Coerce the legacy field, which three producers send as an enum and one as a str.
+
+    The odd one out is `strategy/coincidence.py`, whose `"UNKNOWN"` is deliberate: it
+    declines to call `get_milling_state()` because that getter sets the active view, and
+    the strategy is running a fluorescence acquisition that holds it.
+    """
+    if isinstance(value, MillingState):
+        return value
+    if isinstance(value, str):
+        return MillingState.__members__.get(value.upper())
+    return None
+
+
+class MillingMessageTracker:
+    """Keeps the last words a producer supplied, so a messageless tick still has a label.
+
+    The stickiness rule, in one testable place rather than reimplemented in each of the
+    three widgets that need it.
+
+    It exists for the *delegating* strategy: one that calls `microscope.run_milling()`
+    and hands the loop to a backend. Such a strategy emits its label once, and every tick
+    after that comes from a backend that has no idea what the strategy calls itself. The
+    considered alternative -- threading the message through `run_milling()` so the
+    backend stamps every tick -- changes three backend signatures and still leaves the
+    backend not owning the words.
+
+    Only `STAGE_UPDATE` inherits. Every other status is its own moment and gets its own
+    label: a task that has finished should not still be captioned "Running Rough Mill".
+    """
+
+    def __init__(self) -> None:
+        self._message = ""
+
+    def label(self, report: MillingProgress) -> str:
+        """What to show for *report*, given everything before it."""
+        if report.message:
+            self._message = report.message
+        elif report.status is not MillingStatus.STAGE_UPDATE:
+            self._message = ""
+        return self._message or report.display_message

--- a/fibsem/ui/widgets/milling_widget.py
+++ b/fibsem/ui/widgets/milling_widget.py
@@ -12,6 +12,11 @@ from PyQt5.QtWidgets import (
 from superqt import ensure_main_thread
 
 from fibsem.microscope import FibsemMicroscope
+from fibsem.milling.progress import (
+    MillingMessageTracker,
+    MillingProgress,
+    MillingStatus,
+)
 from fibsem.milling.tasks import FibsemMillingTaskConfig, run_milling_task
 from fibsem.structures import MillingState
 from fibsem.ui import stylesheets
@@ -41,6 +46,9 @@ class FibsemMillingWidget2(QWidget):
         self._milling_thread: Optional[FunctionWorker] = None
         self._milling_stop_event = threading.Event()
         self._has_stages = False
+        # The last words a producer supplied, so a backend's messageless tick still
+        # has a label to show. See `MillingMessageTracker`.
+        self._milling_label = MillingMessageTracker()
         layout = QGridLayout()
 
         # pushbutton for run milling
@@ -95,63 +103,57 @@ class FibsemMillingWidget2(QWidget):
         return self._milling_thread is not None and self._milling_thread.is_alive()
 
     @ensure_main_thread
-    def _on_milling_progress(self, progress: dict):
-        logging.info(f"Milling progress: {progress}")
+    def _on_milling_progress(self, payload: object) -> None:
+        # `payload` is still a nested dict from every producer; `from_payload` decodes
+        # it, and is a no-op once they emit `MillingProgress` directly (FIB-797).
+        report = MillingProgress.from_payload(payload)
+        logging.debug("Milling progress: %s", report)
 
         # update the UI based on the progress information
         self._update_button_states()
 
-        progress_info: dict = progress.get("progress", None)  # type: ignore
-        if progress_info is None:
-            logging.warning("No progress information provided.")
+        if report.status.is_terminal:
+            self.progressBar_milling.setVisible(False)
+            self.progressBar_milling_stages.setVisible(False)
             return
 
-        state = progress_info.get("state", None)
+        label = self._milling_label.label(report)
 
-        # start milling stage progress bar
-        if state == "start":
-            msg = progress.get("msg", "Preparing Milling Conditions...")
-            current_stage = progress_info.get("current_stage", 0)
-            total_stages = progress_info.get("total_stages", 1)
-            stage_name = progress_info.get("stage_name", f"Stage {current_stage + 1}")
+        if report.status is MillingStatus.STAGE_STARTED:
+            # `or 1` rather than a `.get` default: a producer that sends 0 total stages
+            # is as much a division by zero as one that sends nothing.
+            total_stages = report.total_stages or 1
+            stage = report.display_stage or 1
+            stage_name = report.stage_name or f"Stage {stage}"
             self.progressBar_milling.setVisible(True)
             self.progressBar_milling_stages.setVisible(True)
             self.progressBar_milling.setValue(0)
             self.progressBar_milling.setRange(0, 100)
-            self.progressBar_milling.setFormat(msg)
+            self.progressBar_milling.setFormat(label)
             self.progressBar_milling_stages.setRange(0, 100)
-            self.progressBar_milling_stages.setValue(
-                int((current_stage + 1) / total_stages * 100)
-            )
+            self.progressBar_milling_stages.setValue(int(stage / total_stages * 100))
             self.progressBar_milling_stages.setFormat(
-                f"Milling Stage: {current_stage + 1}/{total_stages} - {stage_name}"
+                f"Milling Stage: {stage}/{total_stages} - {stage_name}"
             )
 
-        # update
-        if state == "update":
-            logging.debug(progress_info)
-
-            estimated_time = progress_info.get("estimated_time", None)
-            remaining_time = progress_info.get("remaining_time", None)
-            start_time = progress_info.get("start_time", None)
-
-            if remaining_time is None or estimated_time is None:
-                logging.warning(
-                    "Remaining time or estimated time not provided in progress info."
-                )
+        elif report.status is MillingStatus.STAGE_UPDATE:
+            remaining_time = report.remaining_time
+            # Falsy rather than `is None`, so an estimate of zero takes this branch
+            # instead of dividing by it. That division runs inside a queued Qt slot, and
+            # on PyQt5 an exception escaping one is `qFatal` -- the process aborts with
+            # nothing in the logfile (FIB-329).
+            if remaining_time is None or not report.estimated_time:
+                # No countdown to draw, but the producer's words are still worth showing:
+                # this is the branch a strategy's own report lands in, and it used to
+                # match nothing at all and render nowhere.
+                self.progressBar_milling.setFormat(label)
                 return
 
-            # calculate the percent complete
-            percent_complete = int((1 - (remaining_time / estimated_time)) * 100)
+            percent_complete = int((1 - (remaining_time / report.estimated_time)) * 100)
             self.progressBar_milling.setValue(percent_complete)
             self.progressBar_milling.setFormat(
-                f"Current Stage: {format_duration(remaining_time)} remaining..."
+                f"{label} - {format_duration(remaining_time)} remaining"
             )
-
-        # finished
-        if state == "finished":
-            self.progressBar_milling.setVisible(False)
-            self.progressBar_milling_stages.setVisible(False)
 
     def run_milling(self, config: Optional[FibsemMillingTaskConfig] = None):
         """Start the milling task in a separate thread.

--- a/tests/milling/test_progress.py
+++ b/tests/milling/test_progress.py
@@ -15,6 +15,7 @@ import pytest
 
 from fibsem.milling.progress import (
     _DEFAULT_MESSAGES,
+    MillingMessageTracker,
     MillingProgress,
     MillingStatus,
 )
@@ -177,3 +178,170 @@ class TestMillingStateUnknown:
         early; included, a stopped mill spins forever. Exiting early is bounded and
         recoverable; spinning is not."""
         assert MillingState.UNKNOWN not in ACTIVE_MILLING_STATES
+
+
+class TestDecodingTheLegacyPayload:
+    """`from_payload` is the migration shim: the producers still build nested dicts
+    while the consumers have already been taught the typed report. It is deleted with
+    `Signal(dict)` in the last PR of FIB-797."""
+
+    def test_a_stage_start_decodes(self):
+        report = MillingProgress.from_payload(
+            {
+                "msg": "Preparing: Rough Mill",
+                "progress": {
+                    "state": "start",
+                    "current_stage": 0,
+                    "total_stages": 3,
+                    "task_id": "abc",
+                    "task_name": "Trench",
+                    "stage_name": "Rough Mill",
+                    "start_time": 100.0,
+                },
+            }
+        )
+        assert report.status is MillingStatus.STAGE_STARTED
+        assert report.display_stage == 1
+        assert report.total_stages == 3
+        assert report.stage_name == "Rough Mill"
+        assert report.message == "Preparing: Rough Mill"
+
+    def test_an_update_decodes(self):
+        report = MillingProgress.from_payload(
+            {
+                "progress": {
+                    "state": "update",
+                    "start_time": 100.0,
+                    "milling_state": MillingState.RUNNING,
+                    "estimated_time": 60.0,
+                    "remaining_time": 12.0,
+                }
+            }
+        )
+        assert report.status is MillingStatus.STAGE_UPDATE
+        assert report.remaining_time == 12.0
+        assert report.milling_state is MillingState.RUNNING
+
+    def test_the_task_terminal_decodes(self):
+        report = MillingProgress.from_payload(
+            {
+                "msg": "Finished Milling Task: Trench...",
+                "progress": {
+                    "state": "finished",
+                    "task_id": "abc",
+                    "task_name": "Trench",
+                },
+            }
+        )
+        assert report.status is MillingStatus.TASK_FINISHED
+        assert report.status.is_terminal
+
+    def test_the_shape_that_rendered_nowhere_now_decodes_to_something(self):
+        """`strategy/standard.py` emits a payload carrying no `state` at all, so it
+        matched no branch in any of the three consumers and its message -- the strategy's
+        own words, the feature users asked for -- rendered nowhere."""
+        report = MillingProgress.from_payload(
+            {
+                "msg": "Running Rough Mill...",
+                "progress": {
+                    "started": True,
+                    "start_time": 100.0,
+                    "estimated_time": 60.0,
+                    "name": "Rough Mill",
+                },
+            }
+        )
+        assert report.status is MillingStatus.STAGE_UPDATE
+        assert report.display_message == "Running Rough Mill..."
+        # `name` is the strategy's spelling of `stage_name`.
+        assert report.stage_name == "Rough Mill"
+
+    def test_the_coincidence_strategys_string_state_becomes_the_enum(self):
+        """It sends `"UNKNOWN"` where the other three producers send a `MillingState`,
+        and that is deliberate -- calling the getter would steal the active view from
+        the fluorescence acquisition the strategy is running."""
+        report = MillingProgress.from_payload(
+            {"progress": {"state": "update", "milling_state": "UNKNOWN"}}
+        )
+        assert report.milling_state is MillingState.UNKNOWN
+
+    def test_a_typed_report_passes_straight_through(self):
+        """So a consumer can be flipped before its producers are, which is the whole
+        point of the shim."""
+        original = MillingProgress(MillingStatus.TASK_CANCELLED, error=None)
+        assert MillingProgress.from_payload(original) is original
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            None,
+            "not a dict",
+            42,
+            {},
+            {"progress": None},
+            {"progress": "not a dict"},
+            {"msg": 42, "progress": {"state": "start"}},
+            {"progress": {"state": "start", "current_stage": "one"}},
+            {"progress": {"state": "update", "remaining_time": object()}},
+            {"progress": {"state": "update", "milling_state": "NOT_A_STATE"}},
+            {"progress": {"state": "update", "milling_state": 3}},
+        ],
+    )
+    def test_nothing_makes_it_raise(self, payload):
+        """Total by construction. This runs inside a queued Qt slot, and on PyQt5 an
+        exception escaping one of those is `qFatal`: the process aborts with nothing
+        written to the logfile (FIB-329). A bar that does not move is recoverable; a
+        dead application is not."""
+        report = MillingProgress.from_payload(payload)
+        assert isinstance(report, MillingProgress)
+        assert report.display_message
+
+    def test_a_boolean_is_not_a_count(self):
+        """`bool` is an `int` subclass, so an unguarded `isinstance` check turns the
+        legacy `"started": True` into stage 1."""
+        report = MillingProgress.from_payload(
+            {"progress": {"state": "start", "current_stage": True}}
+        )
+        assert report.current_stage is None
+
+
+class TestTheStickyMessage:
+    """The rule that lets a *delegating* strategy -- one that calls
+    `microscope.run_milling()` and hands the loop to a backend -- set its label once and
+    have it survive every messageless tick that follows."""
+
+    def test_a_message_survives_the_ticks_that_follow_it(self):
+        tracker = MillingMessageTracker()
+        tracker.label(MillingProgress(MillingStatus.STAGE_UPDATE, message="Polishing"))
+        plain = MillingProgress(MillingStatus.STAGE_UPDATE, remaining_time=4.0)
+        assert tracker.label(plain) == "Polishing"
+
+    def test_a_new_stage_drops_the_previous_stages_words(self):
+        """Only `STAGE_UPDATE` inherits. Every other status is its own moment: a stage
+        that has just started is not still "Polishing" the one before it."""
+        tracker = MillingMessageTracker()
+        tracker.label(MillingProgress(MillingStatus.STAGE_UPDATE, message="Polishing"))
+        started = MillingProgress(MillingStatus.STAGE_STARTED, stage_name="Rough Mill")
+        assert tracker.label(started) == "Preparing: Rough Mill"
+
+    def test_a_finished_task_is_not_captioned_with_what_it_was_doing(self):
+        tracker = MillingMessageTracker()
+        tracker.label(MillingProgress(MillingStatus.STAGE_UPDATE, message="Polishing"))
+        assert (
+            tracker.label(MillingProgress(MillingStatus.TASK_FINISHED))
+            == "Finished milling task"
+        )
+
+    def test_an_empty_message_does_not_blank_the_label(self):
+        """Falsy, not `is not None`: a plugin returning `""` is a bug, not a request for
+        a blank label."""
+        tracker = MillingMessageTracker()
+        tracker.label(MillingProgress(MillingStatus.STAGE_UPDATE, message="Polishing"))
+        blank = MillingProgress(MillingStatus.STAGE_UPDATE, message="")
+        assert tracker.label(blank) == "Polishing"
+
+    def test_a_tracker_that_has_seen_nothing_still_renders(self):
+        tracker = MillingMessageTracker()
+        assert (
+            tracker.label(MillingProgress(MillingStatus.STAGE_UPDATE)) == "Milling..."
+        )

--- a/tests/ui/test_milling_progress_rendering.py
+++ b/tests/ui/test_milling_progress_rendering.py
@@ -1,0 +1,433 @@
+"""What each widget renders for a milling progress report (FIB-797).
+
+This decode path has never had a test of any kind -- nothing in `tests/` referenced
+`_on_milling_progress` or `milling_progress_signal` before this file. Three widgets each
+took the same nested dict apart by hand, and the bugs that produced were all rendering
+ones: a message that matched no branch and appeared nowhere, an offset applied seven
+times across three files, three different defaults for the same report.
+
+So these assert the **rendered text**, not which branch ran. Asserting on control flow
+would have caught none of the above.
+
+Each widget's decode is borrowed onto a host carrying the real Qt controls it writes to.
+The widgets themselves need a microscope, a canvas and (for the main window) a whole
+`QMainWindow` of tabs; the decode is a method that reads a report and writes to a
+progress bar, so what it writes to is what has to be real.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (  # noqa: E402
+    AutoLamellaSingleWindowUI,
+)
+from fibsem.applications.autolamella.ui.fluorescence_coincidence_viewer_widget import (  # noqa: E402
+    FluorescenceCoincidenceViewerWidget,
+)
+from fibsem.milling.progress import (  # noqa: E402
+    MillingMessageTracker,
+    MillingProgress,
+    MillingStatus,
+)
+from fibsem.ui.widgets.milling_widget import FibsemMillingWidget2  # noqa: E402
+
+# --------------------------------------------------------------------------------------
+# The payloads the producers actually build today. Written out rather than constructed
+# through a helper: these are the wire format, and a helper that drifts from it is a
+# suite that passes while the real payload stops decoding.
+# --------------------------------------------------------------------------------------
+
+
+def legacy_stage_start(stage_name="Rough Mill", current_stage=0, total_stages=3):
+    """`MillingTask._mill_stage`, once per stage."""
+    return {
+        "msg": f"Preparing: {stage_name}",
+        "progress": {
+            "state": "start",
+            "start_time": 100.0,
+            "current_stage": current_stage,
+            "total_stages": total_stages,
+            "task_id": "task-1",
+            "task_name": "Trench",
+            "stage_name": stage_name,
+        },
+    }
+
+
+def legacy_update(remaining_time=30.0, estimated_time=60.0):
+    """A backend's poll loop -- `microscope.py`, `simulator.py`, `tescan.py`."""
+    return {
+        "progress": {
+            "state": "update",
+            "start_time": 100.0,
+            "estimated_time": estimated_time,
+            "remaining_time": remaining_time,
+        }
+    }
+
+
+def legacy_strategy_message(stage_name="Rough Mill"):
+    """`strategy/standard.py`. Carries **no** `state`, so it matched no branch in any of
+    the three consumers and its message rendered nowhere."""
+    return {
+        "msg": f"Running {stage_name}...",
+        "progress": {
+            "started": True,
+            "start_time": 100.0,
+            "estimated_time": 60.0,
+            "name": stage_name,
+        },
+    }
+
+
+def legacy_task_finished():
+    """`MillingTask.run`'s `finally`, once per task."""
+    return {
+        "msg": "Finished Milling Task: Trench. Restoring Imaging Conditions...",
+        "progress": {"state": "finished", "task_id": "task-1", "task_name": "Trench"},
+    }
+
+
+# --------------------------------------------------------------------------------------
+# Hosts
+# --------------------------------------------------------------------------------------
+
+
+class _MillingWidgetHost:
+    """`FibsemMillingWidget2`'s two bars, plus the real button-state method the decode
+    calls on every report."""
+
+    _on_milling_progress = FibsemMillingWidget2._on_milling_progress
+    _update_button_states = FibsemMillingWidget2._update_button_states
+    is_milling = FibsemMillingWidget2.is_milling
+
+    def __init__(self):
+        from PyQt5.QtWidgets import QProgressBar, QPushButton, QWidget
+
+        self.progressBar_milling = QProgressBar()
+        self.progressBar_milling_stages = QProgressBar()
+        self.pushButton_run_milling = QPushButton()
+        self.pushButton_stop_milling = QPushButton()
+        self.pushButton_pause_milling = QPushButton()
+        self._milling_thread = None
+        self._has_stages = True
+        self._milling_label = MillingMessageTracker()
+
+        class _Parent:
+            pass
+
+        self.parent_widget = _Parent()
+        self.parent_widget.config_widget = QWidget()
+
+    def deleteLater(self):
+        for widget in (
+            self.progressBar_milling,
+            self.progressBar_milling_stages,
+            self.pushButton_run_milling,
+            self.pushButton_stop_milling,
+            self.pushButton_pause_milling,
+            self.parent_widget.config_widget,
+        ):
+            widget.deleteLater()
+
+
+class _MainWindowHost:
+    """`AutoLamellaSingleWindowUI`'s status-bar progress bar."""
+
+    _on_milling_progress = AutoLamellaSingleWindowUI._on_milling_progress
+
+    def __init__(self):
+        from PyQt5.QtWidgets import QProgressBar
+
+        self.milling_progress_bar = QProgressBar()
+        self._milling_label = MillingMessageTracker()
+
+    def deleteLater(self):
+        self.milling_progress_bar.deleteLater()
+
+
+class _CoincidenceHost:
+    """`FluorescenceCoincidenceViewerWidget`'s two bars and the controls its stage-start
+    branch reveals."""
+
+    _on_milling_progress = FluorescenceCoincidenceViewerWidget._on_milling_progress
+
+    def __init__(self):
+        from PyQt5.QtWidgets import (
+            QAction,
+            QDoubleSpinBox,
+            QLabel,
+            QProgressBar,
+            QPushButton,
+            QToolButton,
+        )
+
+        self.progressBar_stage = QProgressBar()
+        self.progressBar_stages = QProgressBar()
+        self.btn_milling = QPushButton()
+        self.btn_pause = QToolButton()
+        self.btn_supervised = QPushButton()
+        self.spin_drop_threshold = QDoubleSpinBox()
+        self.label_threshold_chip = QLabel()
+        self._act_pause_milling = QAction("Pause Milling")
+        self._act_pause_acquisition = QAction("Pause Acquisition")
+        self._milling_paused = False
+        self._supervised = True
+        self._milling_label = MillingMessageTracker()
+        self.border_states = []
+
+    def _set_border_state(self, state):
+        self.border_states.append(state)
+
+    def deleteLater(self):
+        for widget in (
+            self.progressBar_stage,
+            self.progressBar_stages,
+            self.btn_milling,
+            self.btn_pause,
+            self.btn_supervised,
+            self.spin_drop_threshold,
+            self.label_threshold_chip,
+        ):
+            widget.deleteLater()
+
+
+@pytest.fixture
+def milling_widget(qapp):
+    host = _MillingWidgetHost()
+    yield host
+    host.deleteLater()
+
+
+@pytest.fixture
+def main_window(qapp):
+    host = _MainWindowHost()
+    yield host
+    host.deleteLater()
+
+
+@pytest.fixture
+def coincidence(qapp):
+    host = _CoincidenceHost()
+    yield host
+    host.deleteLater()
+
+
+# --------------------------------------------------------------------------------------
+# The offset, in each of the three widgets that used to apply it by hand
+# --------------------------------------------------------------------------------------
+
+
+class TestTheStageCountIsOneBased:
+    """`current_stage` is 0-based on the wire. `display_stage` is the one place the
+    offset is applied now; it was written out at seven call sites across these three
+    files, and the two spellings sat one function apart on the fluorescence runner."""
+
+    def test_the_milling_widget_counts_from_one(self, milling_widget):
+        milling_widget._on_milling_progress(
+            legacy_stage_start(current_stage=0, total_stages=3)
+        )
+        assert (
+            milling_widget.progressBar_milling_stages.format()
+            == "Milling Stage: 1/3 - Rough Mill"
+        )
+
+    def test_the_main_window_counts_from_one(self, main_window):
+        main_window._on_milling_progress(
+            legacy_stage_start(current_stage=1, total_stages=3, stage_name="Polish")
+        )
+        assert (
+            main_window.milling_progress_bar.toolTip() == "Milling Stage: 2/3 - Polish"
+        )
+
+    def test_the_coincidence_viewer_counts_from_one(self, coincidence):
+        coincidence._on_milling_progress(
+            legacy_stage_start(current_stage=2, total_stages=3)
+        )
+        assert coincidence.progressBar_stages.format() == "Stage 3/3"
+
+
+# --------------------------------------------------------------------------------------
+# The strategy's message: the feature that was silently dropped
+# --------------------------------------------------------------------------------------
+
+
+class TestTheStrategysWordsReachTheScreen:
+    """`strategy/standard.py` emits its `msg` carrying no `state`, so it matched no
+    branch in any consumer. The one message a strategy sends today is precisely the one
+    that was dropped -- and milling strategies are plugin-loadable, which is why this
+    signal keeps a `message` at all."""
+
+    def test_the_milling_widget_shows_it(self, milling_widget):
+        milling_widget._on_milling_progress(legacy_strategy_message())
+        assert "Running Rough Mill..." in milling_widget.progressBar_milling.format()
+
+    def test_the_main_window_shows_it(self, main_window):
+        main_window._on_milling_progress(legacy_strategy_message())
+        assert "Running Rough Mill..." in main_window.milling_progress_bar.format()
+
+    def test_the_coincidence_viewer_shows_it(self, coincidence):
+        coincidence._on_milling_progress(legacy_strategy_message())
+        assert "Running Rough Mill..." in coincidence.progressBar_stage.format()
+
+    def test_it_survives_the_backends_messageless_ticks(self, milling_widget):
+        """The stickiness rule, end to end. A *delegating* strategy emits its label once
+        and then hands the loop to `microscope.run_milling()`; every tick after that
+        comes from a backend that has no idea what the strategy calls itself."""
+        milling_widget._on_milling_progress(legacy_strategy_message())
+        milling_widget._on_milling_progress(legacy_update(remaining_time=15.0))
+
+        rendered = milling_widget.progressBar_milling.format()
+        assert "Running Rough Mill..." in rendered
+        assert "remaining" in rendered
+
+    def test_a_new_stage_drops_the_previous_stages_words(self, milling_widget):
+        milling_widget._on_milling_progress(legacy_strategy_message("Rough Mill"))
+        milling_widget._on_milling_progress(legacy_stage_start("Polish", 1, 3))
+
+        rendered = milling_widget.progressBar_milling.format()
+        assert "Rough Mill" not in rendered
+        assert rendered == "Preparing: Polish"
+
+
+# --------------------------------------------------------------------------------------
+# The countdown
+# --------------------------------------------------------------------------------------
+
+
+class TestTheCountdown:
+    def test_the_bar_tracks_the_time_left(self, milling_widget):
+        milling_widget._on_milling_progress(
+            legacy_update(remaining_time=15.0, estimated_time=60.0)
+        )
+        assert milling_widget.progressBar_milling.value() == 75
+        assert "remaining" in milling_widget.progressBar_milling.format()
+
+    def test_an_estimate_of_zero_does_not_take_the_process_down(self, milling_widget):
+        """`milling_widget` divided by `estimated_time` after checking only that it was
+        not `None`, unlike the other two consumers. That division runs inside a queued Qt
+        slot, and on PyQt5 an exception escaping one of those is `qFatal`: the process
+        aborts with nothing written to the logfile (FIB-329)."""
+        milling_widget._on_milling_progress(
+            legacy_update(remaining_time=0.0, estimated_time=0.0)
+        )
+        assert milling_widget.progressBar_milling.format()
+
+    def test_a_stage_start_with_no_stages_does_not_take_the_process_down(
+        self, milling_widget
+    ):
+        """Same class: `int(stage / total_stages * 100)` with a total of zero."""
+        milling_widget._on_milling_progress(
+            legacy_stage_start(current_stage=0, total_stages=0)
+        )
+        assert milling_widget.progressBar_milling_stages.format()
+
+
+# --------------------------------------------------------------------------------------
+# The task ending
+# --------------------------------------------------------------------------------------
+
+
+class TestATaskEnding:
+    def test_the_milling_widget_hides_both_bars(self, milling_widget):
+        milling_widget._on_milling_progress(legacy_stage_start())
+        assert milling_widget.progressBar_milling.isVisible()
+        milling_widget._on_milling_progress(legacy_task_finished())
+        assert not milling_widget.progressBar_milling.isVisible()
+        assert not milling_widget.progressBar_milling_stages.isVisible()
+
+    def test_the_main_window_hides_its_bar(self, main_window):
+        main_window._on_milling_progress(legacy_stage_start())
+        main_window._on_milling_progress(legacy_task_finished())
+        assert not main_window.milling_progress_bar.isVisible()
+
+    def test_a_stage_finishing_does_not_hide_the_bar(self, milling_widget):
+        """`STAGE_FINISHED` is not terminal. Treating it as one hides the bar after the
+        first stage of an N-stage task, and it stays hidden for the rest of the run."""
+        milling_widget._on_milling_progress(legacy_stage_start())
+        milling_widget.progressBar_milling.setVisible(True)
+        milling_widget._on_milling_progress(
+            MillingProgress(MillingStatus.STAGE_FINISHED, stage_name="Rough Mill")
+        )
+        assert milling_widget.progressBar_milling.isVisible()
+
+    def test_a_cancelled_task_ends_the_run_too(self, main_window):
+        """Nothing emits `TASK_CANCELLED` yet -- the producers land in the next PRs --
+        but the consumer has to be ready before they do, or a cancelled mill leaves the
+        bar up for the rest of the session."""
+        main_window._on_milling_progress(legacy_stage_start())
+        main_window._on_milling_progress(MillingProgress(MillingStatus.TASK_CANCELLED))
+        assert not main_window.milling_progress_bar.isVisible()
+
+
+# --------------------------------------------------------------------------------------
+# Typed reports, which is what the producers send from the next PR onwards
+# --------------------------------------------------------------------------------------
+
+
+class TestATypedReportRendersTheSame:
+    """The consumers are dual-tolerant for the length of the migration: a dict and the
+    typed report it decodes to must render identically, or flipping a producer changes
+    what the user sees."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [legacy_stage_start(), legacy_update(), legacy_strategy_message()],
+    )
+    def test_a_dict_and_its_decoded_report_render_the_same(self, qapp, payload):
+        from_dict = _MillingWidgetHost()
+        from_typed = _MillingWidgetHost()
+        try:
+            from_dict._on_milling_progress(payload)
+            from_typed._on_milling_progress(MillingProgress.from_payload(payload))
+
+            assert (
+                from_dict.progressBar_milling.format()
+                == from_typed.progressBar_milling.format()
+            )
+            assert (
+                from_dict.progressBar_milling_stages.format()
+                == from_typed.progressBar_milling_stages.format()
+            )
+        finally:
+            from_dict.deleteLater()
+            from_typed.deleteLater()
+
+
+class TestNothingTakesTheProcessDown:
+    """Every one of these runs inside a queued Qt slot. On PyQt5 an exception escaping
+    one is `qFatal`, so a malformed payload has to render badly rather than abort."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            None,
+            {},
+            "not a dict",
+            {"progress": None},
+            {"progress": {"state": "start", "total_stages": 0}},
+            {"progress": {"state": "update", "estimated_time": 0}},
+            {"progress": {"state": "update", "milling_state": "NOT_A_STATE"}},
+        ],
+    )
+    def test_the_milling_widget_survives(self, milling_widget, payload):
+        milling_widget._on_milling_progress(payload)
+
+    @pytest.mark.parametrize(
+        "payload",
+        [None, {}, "not a dict", {"progress": {"state": "start", "total_stages": 0}}],
+    )
+    def test_the_main_window_survives(self, main_window, payload):
+        main_window._on_milling_progress(payload)
+
+    @pytest.mark.parametrize(
+        "payload",
+        [None, {}, "not a dict", {"progress": {"state": "start", "total_stages": 0}}],
+    )
+    def test_the_coincidence_viewer_survives(self, coincidence, payload):
+        coincidence._on_milling_progress(payload)


### PR DESCRIPTION
Third of six for FIB-797, after [#597](https://github.com/fibsem-os/fibsem-os/pull/597) (format prep) and [#598](https://github.com/fibsem-os/fibsem-os/pull/598) (the contract).

> **Stacked, so this gets no CI here** — the workflow triggers on `pull_request: branches: [main]`, and "no checks reported" reads like "queued". The substitute verification is at the bottom. Base is a throwaway branch carrying #597 + #598; it retargets to `main` once both merge.

All three consumers now decode whatever arrives into a `MillingProgress` and render from that. The producers still build nested dicts, so `MillingProgress.from_payload` is the shim for the migration window — it is deleted along with `Signal(dict)` in the last PR of the stack.

**The shim is total by construction.** Every branch returns, nothing indexes, and every coercion is guarded. This runs inside a queued Qt slot, and on PyQt5 an exception escaping one of those is `qFatal`: the process aborts with nothing in the logfile (FIB-329). A bar that does not move is recoverable; a dead application is not.

## Three fixes fall out of the decode

**The strategy's message now renders.** `strategy/standard.py` emits a payload carrying no `state` at all, so it matched no branch in any of the three consumers. The one message a strategy sends today is precisely the one silently dropped — which is why "let a strategy customise the text it shows" reads as unimplemented despite the field existing. It decodes as a stage update now, and its words reach all three widgets.

**Those words survive the ticks that follow.** A *delegating* strategy — one that calls `microscope.run_milling()` and hands the loop to a backend — emits its label once, and every tick after that comes from a backend with no idea what the strategy calls itself. `MillingMessageTracker` holds the last non-empty message. Only `STAGE_UPDATE` inherits it, so a finished task is not still captioned with what it was doing.

**Two divisions by zero can no longer take the process down.** `milling_widget` guarded `estimated_time` with `is None` only, unlike the other two consumers, so an estimate of zero raised `ZeroDivisionError` inside the queued slot. The same class of thing sat in all three stage-start branches: `int(stage / total * 100)` with a total of zero. Both are falsy-guarded now.

The 0-to-1 offset was written out by hand at **seven** call sites across these three files. They all read `display_stage`.

## Tests — 77

| where | count | what |
| -- | -- | -- |
| `tests/milling/test_progress.py` | 44 | the shim and the sticky rule, Qt-free |
| `tests/ui/test_milling_progress_rendering.py` | 33 | what each widget renders |

The widget tests assert **rendered text, not which branch ran**. Every bug this path has actually had was a rendering one, and none would have been caught by asserting on control flow.

## Verification

**Six mutants, to show the tests discriminate** rather than merely pass:

| mutation | tests failed |
| -- | -- |
| make `STAGE_FINISHED` terminal | 2 |
| drop the message stickiness | 3 |
| remove the `+ 1` in `display_stage` | 4 |
| decode the stateless payload to a status nobody renders | 7 |
| restore the `estimated_time is None` guard | 1 |
| remove `total_stages or 1` | 2 |

- `tests/ui/` + `tests/milling/` → **2462 passed, 1 skipped**; `tests/autolamella/` → **572 passed**.
- **Python 3.8** AST scan for `match`, `dataclass(kw_only=/slots=)`, runtime PEP 604, runtime builtin generics, `str.removeprefix/removesuffix` — clean.
- `ruff check` and `ruff format --check` pass on all 9 changed files.