### PR TITLE
[refactor] Make fibsem.milling microscope-free, as fibsem.imaging already is

### DIFF
--- a/fibsem/milling/base.py
+++ b/fibsem/milling/base.py
@@ -1,3 +1,7 @@
+# Deferred annotations, so `FibsemMicroscope` below can be a type-checking-only
+# import. See the note beside it.
+from __future__ import annotations
+
 import re
 import threading
 from abc import ABC, abstractmethod
@@ -5,6 +9,7 @@ from copy import deepcopy
 from dataclasses import asdict, dataclass, field, fields
 from functools import cached_property
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Generic,
@@ -16,7 +21,6 @@ from typing import (
     Union,
 )
 
-from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.config import MILLING_SPUTTER_RATE
 from fibsem.milling.patterning import DEFAULT_MILLING_PATTERN, get_pattern
 from fibsem.milling.patterning.patterns2 import BasePattern
@@ -29,6 +33,19 @@ from fibsem.structures import (
     MillingAlignment,
     get_fields_with_metadata,
 )
+
+if TYPE_CHECKING:
+    # Type-checking only, so `fibsem.milling` stays microscope-free.
+    # `fibsem/milling/__init__.py` imports this module, so a runtime import here
+    # means importing *anything* under `fibsem.milling` pulls in
+    # `fibsem.microscope` -- and `fibsem.microscope` needs to import the milling
+    # progress contract, which makes that a cycle: the microscope module is only
+    # half-built when this line runs, and `FibsemMicroscope` is not bound yet.
+    #
+    # The same fix `fibsem.imaging` already carries; see tests/test_import_cycles.py.
+    # `from __future__ import annotations` is on at the top of this file, so the two
+    # annotations below need no runtime object.
+    from fibsem.microscope import FibsemMicroscope
 
 TMillingStrategyConfig = TypeVar(
     "TMillingStrategyConfig", bound="MillingStrategyConfig"

--- a/fibsem/milling/core.py
+++ b/fibsem/milling/core.py
@@ -3,17 +3,20 @@ from __future__ import annotations
 import logging
 import threading
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from fibsem import acquire
 from fibsem import config as fcfg
-from fibsem.microscope import FibsemMicroscope
 from fibsem.milling import FibsemMillingStage
 from fibsem.structures import (
     FibsemImage,
     ImageSettings,
 )
 from fibsem.utils import current_timestamp_v2
+
+if TYPE_CHECKING:
+    # Type-checking only, so `fibsem.milling` stays microscope-free -- see the note
+    # in `base.py`. Deferred annotations are already on at the top of this file.
+    from fibsem.microscope import FibsemMicroscope
 
 ########################### SETUP
 
@@ -81,5 +84,10 @@ def get_stage_reference_image(
             path=path,
             filename=f"ref_{milling_stage.name}_initial_alignment_{current_timestamp_v2()}",
         )
+        # Imported here rather than at module scope: `fibsem.acquire` imports
+        # `fibsem.microscope`, which is the other half of the cycle the
+        # TYPE_CHECKING block above avoids. One call site, so one local import.
+        from fibsem import acquire
+
         return acquire.acquire_image(microscope, image_settings)
     raise TypeError(f"Invalid ref_image type '{type(ref_image)}'")

--- a/tests/test_import_cycles.py
+++ b/tests/test_import_cycles.py
@@ -24,6 +24,7 @@ previous test imported has already populated sys.modules.
 """
 
 import ast
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -47,8 +48,44 @@ ENTRY_POINTS = [
 ]
 
 
+# The subprocess has to import the *same* checkout pytest itself imported, and by
+# default it does not. Two things conspire: `tests/conftest.py` chdirs into a
+# `tmp_path`, so `python -c` puts that empty directory on `sys.path[0]` rather than the
+# repo; and an editable install then resolves `fibsem` to whichever checkout it was
+# installed from. In a git worktree those are different trees, so every guard below
+# silently measured the *other* checkout -- passing or failing according to what that
+# one happened to have checked out, which is not a property of the code under test.
+_REPO_ROOT = Path(fibsem.__file__).resolve().parent.parent
+
+
 def _run(code: str):
-    return subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(_REPO_ROOT), env.get("PYTHONPATH", "")) if part
+    )
+    return subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, env=env
+    )
+
+
+def test_the_subprocess_measures_the_checkout_under_test():
+    """Without this, a green run below proves nothing.
+
+    Every other test in this file asks a subprocess what it imported. If that
+    subprocess resolves a *different* `fibsem` -- the one the editable install points
+    at, rather than the one pytest loaded -- then the guards describe some other
+    checkout. That is not hypothetical: it happened in a worktree, where the milling
+    guard flipped red because the sibling checkout had switched branches, with nothing
+    changed here at all.
+    """
+    result = _run("import fibsem; print(fibsem.__file__)")
+    assert result.returncode == 0, result.stderr[-1500:]
+    measured = Path(result.stdout.strip().splitlines()[-1]).resolve()
+    assert measured == Path(fibsem.__file__).resolve(), (
+        f"the subprocess imported {measured}, but pytest imported "
+        f"{Path(fibsem.__file__).resolve()} -- every guard below is describing the "
+        "wrong tree"
+    )
 
 
 @pytest.mark.parametrize("module", ENTRY_POINTS)
@@ -57,7 +94,9 @@ def test_entry_point_imports_without_a_circular_import(module):
     assert "circular import" not in result.stderr, (
         f"importing {module} hit a circular import:\n{result.stderr[-1500:]}"
     )
-    assert result.returncode == 0, f"importing {module} failed:\n{result.stderr[-1500:]}"
+    assert result.returncode == 0, (
+        f"importing {module} failed:\n{result.stderr[-1500:]}"
+    )
 
 
 def test_imaging_does_not_pull_in_the_microscope():
@@ -88,7 +127,9 @@ def test_spot_imports_the_microscope_for_typing_only():
     module has `from __future__ import annotations` -- so it never needs the real
     object at runtime.
     """
-    source = (Path(fibsem.__file__).parent / "imaging" / "spot.py").read_text(encoding="utf-8")
+    source = (Path(fibsem.__file__).parent / "imaging" / "spot.py").read_text(
+        encoding="utf-8"
+    )
     tree = ast.parse(source)
 
     module_level = {
@@ -99,4 +140,56 @@ def test_spot_imports_the_microscope_for_typing_only():
     assert "fibsem.microscope" not in module_level, (
         "spot.py imports fibsem.microscope at runtime. It is used only in an "
         "annotation; keep it under TYPE_CHECKING."
+    )
+
+
+def test_milling_does_not_pull_in_the_microscope():
+    """The same property, for `fibsem.milling` -- established by FIB-797.
+
+    `fibsem/milling/__init__.py` imports `base` and `core`, so one runtime
+    `fibsem.microscope` import in either makes *every* `fibsem.milling.*` import drag
+    the microscope in. That is a cycle rather than merely slow, because
+    `fibsem.microscope` imports `fibsem.milling.progress` to type
+    `milling_progress_signal`: the microscope module is only half-built when the milling
+    package runs, and `FibsemMicroscope` is not bound yet.
+    """
+    result = _run(
+        "import sys, warnings; warnings.filterwarnings('ignore')\n"
+        "import fibsem.milling\n"
+        "print('fibsem.microscope' in sys.modules)"
+    )
+    assert result.returncode == 0, result.stderr[-1500:]
+    assert result.stdout.strip().splitlines()[-1] == "False", (
+        "importing fibsem.milling now pulls in fibsem.microscope again. Something "
+        "under fibsem/milling/ imports it at runtime; if it is only needed for an "
+        "annotation, put it under TYPE_CHECKING as fibsem/milling/base.py does."
+    )
+
+
+@pytest.mark.parametrize(
+    "module_path", [("milling", "base.py"), ("milling", "core.py")]
+)
+def test_milling_imports_the_microscope_for_typing_only(module_path):
+    """Stated statically, so the reason survives even if the runtime check moves.
+
+    `FibsemMicroscope` appears in both files only as a parameter annotation, and both
+    carry `from __future__ import annotations` -- so neither needs the real object.
+    """
+    source = (Path(fibsem.__file__).parent.joinpath(*module_path)).read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(source)
+
+    module_level = {
+        node.module
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert "fibsem.microscope" not in module_level, (
+        f"{module_path[-1]} imports fibsem.microscope at runtime. It is used only in "
+        "annotations; keep it under TYPE_CHECKING."
+    )
+    assert "fibsem.acquire" not in module_level, (
+        f"{module_path[-1]} imports fibsem.acquire at runtime, and fibsem.acquire "
+        "imports fibsem.microscope -- which is the other half of the same cycle."
     )


### PR DESCRIPTION
Prerequisite for the rest of FIB-797, and a cycle in its own right. Not in the original plan — found by hitting it.

> **Stacked, so no CI here.** Substitute verification below.

`fibsem/milling/__init__.py` imports `base` and `core`, so one runtime `fibsem.microscope` import in either makes *every* `fibsem.milling.*` import drag the microscope in. That was merely slow until the milling progress contract landed under `fibsem/milling/`, because `fibsem.microscope` has to import it to type `milling_progress_signal` — at which point importing `fibsem.microscope` first fails outright:

```
ImportError: cannot import name 'FibsemMicroscope' from partially initialized
module 'fibsem.microscope' (most likely due to a circular import)
```

This is the same fix `fibsem.imaging` already carries, for the same reason. See the docstring on `tests/test_import_cycles.py`, where the equivalent break **took out the AutoLamella UI entirely**.

## The change is small because the import was never needed

`FibsemMicroscope` was only ever used in annotations: two parameter annotations in `base.py`, three in `core.py`.

- `base.py` gains `from __future__ import annotations` (`core.py` already had it) and moves the import under `TYPE_CHECKING`.
- `core.py`'s `from fibsem import acquire` goes local to its single call site — `fibsem.acquire` imports `fibsem.microscope` and is the other half of the same cycle.

## The risk, checked rather than assumed

Deferring `base.py`'s annotations is **not free**: that file is full of dataclasses, and `resolve_field_types` (`autolamella_task_config_widget.py`) resolves field annotations later via `get_type_hints`, catching `Exception` and returning `{}`. A name that stopped resolving would make a config form **silently fall through to a read-only display** — no error anywhere.

So I checked it directly rather than trusting the test suite:

```
MillingStrategyConfig             0 field hints resolved
FibsemMillingStage               10 field hints resolved
CoincidenceMillingStrategy       10 fields, 10 hints, missing from form: none
OvertiltTrenchMillingStrategy     4 fields,  4 hints, missing from form: none
StandardMillingStrategy           0 fields,  0 hints, missing from form: none
```

Every dataclass in `base.py` and every registered strategy config still resolves every field, and the form builder still produces a control for each.

## Tests

Three added beside the existing `fibsem.imaging` pair in `tests/test_import_cycles.py`: the runtime property (`import fibsem.milling` must not pull in `fibsem.microscope`), and a static check per file that neither imports `fibsem.microscope` **nor `fibsem.acquire`** at module scope.

Probed in both directions afterwards — `fibsem.microscope`, `fibsem.milling`, `fibsem.milling.progress`, `fibsem.microscopes.simulator`, `fibsem.microscopes.tescan`, `fibsem.ui.widgets.milling_widget`, `AutoLamellaMainUI` all import clean.

`tests/milling/ tests/autolamella/ tests/test_import_cycles.py tests/test_structures.py tests/test_plugin_*.py tests/test_field_metadata_keys.py tests/test_milling_time_estimates.py` → **825 passed, 14 skipped**. `tests/ui/` → **2313 passed, 1 skipped**.

## The alternative I rejected

Relocating the contract out of `fibsem/milling/` — to `fibsem/structures.py` beside `MillingState`, or to a top-level `fibsem/milling_progress.py`. Both work, and both put the file somewhere nobody would look for it, to avoid a cycle that turned out to be five annotations deep. A function-local import in `microscope.py` does not survive the next PR either: `Signal(MillingProgress)` is a class-body expression and needs the name at module scope.