### PR TITLE
[refactor] Flip the milling backends and strategies to the typed contract (FIB-797)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -111,6 +111,7 @@ from fibsem.microscopes.autoscript import (
     stage_position_from_autoscript,
     stage_position_to_autoscript,
 )
+from fibsem.milling.progress import MillingProgress, MillingStatus
 from fibsem.structures import (
     ACTIVE_MILLING_STATES,
     BeamSettings,
@@ -3619,15 +3620,13 @@ class ThermoMicroscope(FibsemMicroscope):
 
             # update milling progress via signal
             self.milling_progress_signal.emit(
-                {
-                    "progress": {
-                        "state": "update",
-                        "start_time": start_time,
-                        "milling_state": self.get_milling_state(),
-                        "estimated_time": estimated_time,
-                        "remaining_time": remaining_time,
-                    }
-                }
+                MillingProgress(
+                    status=MillingStatus.STAGE_UPDATE,
+                    start_time=start_time,
+                    milling_state=self.get_milling_state(),
+                    estimated_time=estimated_time,
+                    remaining_time=remaining_time,
+                )
             )
 
         # milling complete

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -22,6 +22,7 @@ from fibsem.microscope import (
     FibsemMicroscope,
     ThermoMicroscope,
 )
+from fibsem.milling.progress import MillingProgress, MillingStatus
 from fibsem.structures import (
     ACTIVE_MILLING_STATES,
     BeamSettings,
@@ -1183,15 +1184,13 @@ class DemoMicroscope(FibsemMicroscope):
 
             # update milling progress via signal
             self.milling_progress_signal.emit(
-                {
-                    "progress": {
-                        "state": "update",
-                        "start_time": start_time,
-                        "milling_state": self.get_milling_state(),
-                        "estimated_time": estimated_time,
-                        "remaining_time": remaining_time,
-                    }
-                }
+                MillingProgress(
+                    status=MillingStatus.STAGE_UPDATE,
+                    start_time=start_time,
+                    milling_state=self.get_milling_state(),
+                    estimated_time=estimated_time,
+                    remaining_time=remaining_time,
+                )
             )
 
             if remaining_time <= 0:  # milling complete

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -59,6 +59,7 @@ from fibsem.imaging.spot import (
     SpotBurnStatus,
 )
 from fibsem.milling.base import set_preset_driven_estimation
+from fibsem.milling.progress import MillingProgress, MillingStatus
 from fibsem.structures import (  # noqa
     ACTIVE_MILLING_STATES,
     BeamSettings,
@@ -1375,15 +1376,13 @@ class TescanMicroscope(FibsemMicroscope):
 
                 # update milling progress via signal
                 self.milling_progress_signal.emit(
-                    {
-                        "progress": {
-                            "state": "update",
-                            "milling_state": self.get_milling_state(),
-                            "start_time": start_time,
-                            "estimated_time": estimated_time,
-                            "remaining_time": remaining_time,
-                        }
-                    }
+                    MillingProgress(
+                        status=MillingStatus.STAGE_UPDATE,
+                        milling_state=self.get_milling_state(),
+                        start_time=start_time,
+                        estimated_time=estimated_time,
+                        remaining_time=remaining_time,
+                    )
                 )
 
         except Exception as err:

--- a/fibsem/milling/strategy/coincidence.py
+++ b/fibsem/milling/strategy/coincidence.py
@@ -20,7 +20,14 @@ from fibsem.milling import (
     MillingStrategyConfig,
     setup_milling,
 )
-from fibsem.structures import BeamType, FibsemImage, FibsemRectangle, field_meta
+from fibsem.milling.progress import MillingProgress, MillingStatus
+from fibsem.structures import (
+    BeamType,
+    FibsemImage,
+    FibsemRectangle,
+    MillingState,
+    field_meta,
+)
 from fibsem.utils import save_json
 
 if TYPE_CHECKING:
@@ -372,15 +379,21 @@ class CoincidenceMillingStrategy(MillingStrategy[CoincidenceMillingStrategyConfi
             # update milling progress via signal
             remaining_time = max(0.0, max_end_time - time.time())
             self.microscope.milling_progress_signal.emit(
-                {
-                    "progress": {
-                        "state": "update",
-                        "start_time": start_time,
-                        "milling_state": "UNKNOWN",
-                        "estimated_time": estimated_time,
-                        "remaining_time": remaining_time,
-                    }
-                }
+                MillingProgress(
+                    status=MillingStatus.STAGE_UPDATE,
+                    message=f"Coincidence milling: {self.stage.name}",
+                    stage_name=self.stage.name,
+                    start_time=start_time,
+                    # Deliberately not `self.microscope.get_milling_state()`. On
+                    # ThermoFisher that getter *sets the active view* as a side effect,
+                    # and this strategy is running a fluorescence acquisition that holds
+                    # the view for its whole duration -- asking would yank it away
+                    # mid-acquisition. UNKNOWN says "cannot be read without disturbing
+                    # something", which is the truth here.
+                    milling_state=MillingState.UNKNOWN,
+                    estimated_time=estimated_time,
+                    remaining_time=remaining_time,
+                )
             )
             # timeout
             if time.time() >= max_end_time:

--- a/fibsem/milling/strategy/standard.py
+++ b/fibsem/milling/strategy/standard.py
@@ -12,6 +12,7 @@ from fibsem.milling.base import (
     MillingStrategy,
     MillingStrategyConfig,
 )
+from fibsem.milling.progress import MillingProgress, MillingStatus
 
 
 @dataclass
@@ -44,16 +45,20 @@ class StandardMillingStrategy(MillingStrategy[StandardMillingConfig]):
         estimated_time = microscope.estimate_milling_time()
         logging.info(f"Estimated time for {stage.name}: {estimated_time:.2f} seconds")
 
+        # The strategy's own words. This used to carry no `state` at all, so it matched
+        # no branch in any of the three consumers and rendered nowhere -- the one
+        # message a strategy sends was precisely the one that was dropped. A consumer
+        # keeps it standing across the messageless ticks that follow, which is what a
+        # *delegating* strategy needs: `run_milling` below hands the loop to a backend
+        # that has no idea what this strategy calls itself.
         microscope.milling_progress_signal.emit(
-            {
-                "msg": f"Running {stage.name}...",
-                "progress": {
-                    "started": True,
-                    "start_time": time.time(),
-                    "estimated_time": estimated_time,
-                    "name": stage.name,
-                },
-            }
+            MillingProgress(
+                status=MillingStatus.STAGE_UPDATE,
+                message=f"Running {stage.name}...",
+                stage_name=stage.name,
+                start_time=time.time(),
+                estimated_time=estimated_time,
+            )
         )
 
         raise_if_cancelled(stop_event)  # last chance before the beam starts

--- a/tests/milling/test_progress_producers.py
+++ b/tests/milling/test_progress_producers.py
@@ -1,0 +1,253 @@
+"""What the backends and strategies put on ``milling_progress_signal`` (FIB-797).
+
+The three backend poll loops and the two built-in strategies now emit a
+``MillingProgress`` rather than a nested dict. The task layer still emits dicts; the
+consumers decode either, which is what allows the producers to be flipped in two steps.
+
+The guard at the bottom is the part worth keeping after the migration. On FIB-402 the
+equivalent test was keyed on the signal name alone, and two emit sites hiding behind a
+relay method slipped through it -- so this one is keyed on the payload's *shape* at every
+emit site, and it names the files that have not been flipped yet rather than ignoring
+them.
+"""
+
+import ast
+import time
+from pathlib import Path
+
+import pytest
+
+import fibsem
+from fibsem import utils
+from fibsem.milling import FibsemMillingStage
+from fibsem.milling.progress import MillingProgress, MillingStatus
+from fibsem.milling.strategy.coincidence import (
+    CoincidenceMillingStrategy,
+    CoincidenceMillingStrategyConfig,
+)
+from fibsem.milling.strategy.standard import StandardMillingStrategy
+from fibsem.structures import MillingState
+
+
+@pytest.fixture
+def microscope():
+    scope, _ = utils.setup_session(manufacturer="Demo")
+    return scope
+
+
+def _collect(scope):
+    """Subscribe to the signal and return the list the reports land in."""
+    emitted = []
+    scope.milling_progress_signal.connect(emitted.append)
+    return emitted
+
+
+class TestADelegatingStrategy:
+    """`StandardMillingStrategy` emits its label once and hands the loop to the
+    backend's `run_milling`, which knows nothing about the strategy."""
+
+    def test_every_report_is_typed(self, microscope):
+        emitted = _collect(microscope)
+        StandardMillingStrategy().run(microscope, FibsemMillingStage(name="Rough Mill"))
+
+        assert emitted, "the strategy emitted nothing at all"
+        assert all(isinstance(report, MillingProgress) for report in emitted), [
+            type(report).__name__ for report in emitted
+        ]
+
+    def test_the_strategy_says_what_it_is_doing(self, microscope):
+        """The feature this signal keeps a `message` for. Before this change the
+        strategy's report carried no `state`, matched no consumer branch, and its words
+        reached no screen."""
+        emitted = _collect(microscope)
+        StandardMillingStrategy().run(microscope, FibsemMillingStage(name="Rough Mill"))
+
+        first = emitted[0]
+        assert first.message == "Running Rough Mill..."
+        assert first.stage_name == "Rough Mill"
+        # A status a consumer actually renders, which is what makes the message visible.
+        assert first.status is MillingStatus.STAGE_UPDATE
+
+    def test_the_backends_ticks_carry_the_countdown_and_the_instrument_state(
+        self, microscope
+    ):
+        emitted = _collect(microscope)
+        StandardMillingStrategy().run(microscope, FibsemMillingStage(name="Rough Mill"))
+
+        ticks = [r for r in emitted if r.remaining_time is not None]
+        assert ticks, "the backend poll loop reported no countdown"
+        assert all(t.status is MillingStatus.STAGE_UPDATE for t in ticks)
+        # Carried on the report so a consumer does not have to poll for it -- and on
+        # ThermoFisher that poll sets the active view as a side effect.
+        assert all(isinstance(t.milling_state, MillingState) for t in ticks)
+
+    def test_the_backend_does_not_re_say_what_the_strategy_said(self, microscope):
+        """A backend has no idea what the strategy calls itself, so it says nothing and
+        the consumer keeps the last words standing. The alternative -- threading the
+        message through `run_milling` -- changes three backend signatures and still
+        leaves the backend not owning the words."""
+        emitted = _collect(microscope)
+        StandardMillingStrategy().run(microscope, FibsemMillingStage(name="Rough Mill"))
+
+        ticks = [r for r in emitted if r.remaining_time is not None]
+        assert all(t.message is None for t in ticks)
+
+
+class TestTheCoincidenceStrategy:
+    """Self-driving: it runs its own monitor loop rather than delegating to
+    `run_milling`, which is the whole point of the strategy abstraction."""
+
+    def _monitor_once(self, microscope):
+        strategy = CoincidenceMillingStrategy()
+        strategy.microscope = microscope
+        strategy.stage = FibsemMillingStage(name="Coincidence Mill")
+        strategy.parent_ui = None
+        strategy.config = CoincidenceMillingStrategyConfig()
+        strategy._drop_detected = False
+        emitted = _collect(microscope)
+        # An estimate of zero puts the timeout in the past, so the loop emits exactly
+        # once and breaks. It still sleeps its one real second first.
+        strategy._monitor_milling_progress(estimated_time=0.0)
+        return emitted
+
+    def test_it_declines_to_read_the_milling_state(self, microscope):
+        """Not sloppiness, and not something to "fix" by calling the getter like
+        everyone else. On ThermoFisher `get_milling_state()` sets the active view, and
+        this strategy is running a fluorescence acquisition that holds the view for its
+        whole duration -- asking would yank it away mid-acquisition."""
+        calls = []
+        original = microscope.get_milling_state
+        microscope.get_milling_state = lambda *a, **k: (
+            calls.append(1) or original(*a, **k)
+        )
+        try:
+            emitted = self._monitor_once(microscope)
+        finally:
+            microscope.get_milling_state = original
+
+        assert emitted
+        assert calls == [], "the monitor loop polled the milling state"
+        assert all(r.milling_state is MillingState.UNKNOWN for r in emitted)
+
+    def test_the_gap_is_an_enum_member_not_a_string(self, microscope):
+        """Every other producer sends a `MillingState`. This one used to send the string
+        `"UNKNOWN"`, so a consumer had to pattern-match a magic value to tell the two
+        apart."""
+        emitted = self._monitor_once(microscope)
+        assert emitted[0].milling_state is MillingState.UNKNOWN
+        assert not isinstance(emitted[0].milling_state, str)
+
+    def test_a_self_driving_strategy_stamps_every_report(self, microscope):
+        """Unlike a delegating one, nothing else emits on its behalf, so it can carry
+        its own words on every tick and needs no stickiness."""
+        emitted = self._monitor_once(microscope)
+        assert all(
+            r.message == "Coincidence milling: Coincidence Mill" for r in emitted
+        )
+        assert all(r.status is MillingStatus.STAGE_UPDATE for r in emitted)
+
+
+# --------------------------------------------------------------------------------------
+# The guard
+# --------------------------------------------------------------------------------------
+
+# Every module that emits on `milling_progress_signal`, and whether it has been flipped.
+# `tasks.py` is False on purpose: its two emit sites go in the next PR, along with the
+# relay they hide behind. Naming it rather than omitting it is what makes forgetting it
+# a failing test rather than a silently narrower scan.
+EMITTERS = {
+    "microscope.py": True,
+    "microscopes/simulator.py": True,
+    "microscopes/tescan.py": True,
+    "milling/strategy/standard.py": True,
+    "milling/strategy/coincidence.py": True,
+    "milling/tasks.py": False,
+}
+
+
+# Names that put a payload on the signal. `_handle_progress` is `MillingTask`'s relay --
+# a pass-through that emits whatever it is handed -- and it is why this scan cannot be
+# keyed on the signal name alone.
+#
+# This is not hypothetical. Written the obvious way, keyed on
+# `milling_progress_signal.emit`, this scan reported `milling/tasks.py` as already
+# flipped while both of its emit sites were still building dicts, because neither
+# mentions the signal. That is precisely the blind spot that let two `_stitch` emits
+# through the equivalent guard on FIB-402.
+_PAYLOAD_SINKS = ("milling_progress_signal", "_handle_progress")
+
+
+def _dict_emits(path: Path):
+    """Every line in *path* that hands a dict literal to the milling progress signal,
+    directly or through a relay."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (node.args and isinstance(node.args[0], ast.Dict)):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        # `<...>.milling_progress_signal.emit({...})`
+        direct = (
+            func.attr == "emit"
+            and isinstance(func.value, ast.Attribute)
+            and (func.value.attr in _PAYLOAD_SINKS)
+        )
+        # `self._handle_progress({...})`
+        via_relay = func.attr in _PAYLOAD_SINKS
+        if direct or via_relay:
+            hits.append(node.lineno)
+    return hits
+
+
+@pytest.mark.parametrize("relative,flipped", sorted(EMITTERS.items()))
+def test_the_flipped_producers_no_longer_emit_dicts(relative, flipped):
+    path = Path(fibsem.__file__).parent / relative
+    assert path.exists(), f"{relative} moved; update EMITTERS"
+    hits = _dict_emits(path)
+    if flipped:
+        assert hits == [], (
+            f"{relative} still emits a dict literal on milling_progress_signal at "
+            f"line(s) {hits}"
+        )
+    else:
+        assert hits, (
+            f"{relative} no longer emits any dict, so it has been flipped -- set its "
+            "entry in EMITTERS to True."
+        )
+
+
+def test_the_scan_sees_through_the_relay(tmp_path):
+    """Shown rather than asserted, because the obvious version of this scan does not.
+
+    Keyed on `milling_progress_signal.emit` alone it reads line 3 and misses line 5 --
+    which is exactly what happened when this file was first written, and what let two
+    `_stitch` emits through the equivalent guard on FIB-402.
+    """
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        "class X:\n"
+        "    def direct(self):\n"
+        "        self.microscope.milling_progress_signal.emit({'progress': {}})\n"
+        "    def relayed(self):\n"
+        "        self._handle_progress({'progress': {}})\n"
+        "    def typed(self):\n"
+        "        self._handle_progress(MillingProgress(MillingStatus.TASK_FINISHED))\n",
+        encoding="utf-8",
+    )
+    assert _dict_emits(probe) == [3, 5]
+
+
+def test_a_stage_run_end_to_end_emits_no_dict(microscope):
+    """The static scan cannot see a dict built somewhere else and passed in, so this
+    watches a real run."""
+    emitted = _collect(microscope)
+    start = time.time()
+    StandardMillingStrategy().run(microscope, FibsemMillingStage(name="Rough Mill"))
+    assert time.time() - start < 60, "the simulated mill did not skip its delays"
+
+    dicts = [r for r in emitted if isinstance(r, dict)]
+    assert dicts == [], f"{len(dicts)} dict payload(s) still reached the signal"


### PR DESCRIPTION
Fifth of six for FIB-797. **Five of the seven payload-producing sites** now emit a `MillingProgress`: the poll loops in `microscope.py`, `simulator.py` and `tescan.py`, and both built-in strategies. The task layer's two sites and the relay they hide behind go in the last PR; the consumers decode either shape, which is what lets the flip split in two.

> **Stacked, so no CI here.** Substitute verification below.

## The strategy's message now has a status, so it renders

`standard.py`'s report carried no `state` at all and matched no consumer branch — the one message a strategy sends was the one silently dropped, which is why "let a strategy customise the text it shows" reads as unimplemented despite the field existing. It is a `STAGE_UPDATE` carrying `message` now, and a consumer keeps those words standing across the backend's messageless ticks.

That is what a **delegating** strategy needs: `run_milling` hands the loop to a backend that has no idea what the strategy calls itself. The alternative — threading the message through `run_milling()` so the backend stamps every tick — changes three backend signatures and still leaves the backend not owning the words.

## `"UNKNOWN"` becomes `MillingState.UNKNOWN`

The value is deliberate and stays. On ThermoFisher `get_milling_state()` **sets the active view** as a side effect, and the coincidence strategy runs a fluorescence acquisition that holds the view for its whole duration — so asking would yank it away mid-acquisition. It is a self-driving strategy, so unlike `standard.py` it stamps its message on every tick and needs no stickiness.

There is a test that the monitor loop makes **zero** calls to `get_milling_state()`, not just that the field says `UNKNOWN`.

## The guard is the part worth keeping

Written the obvious way — keyed on `milling_progress_signal.emit` — the no-dict scan reported `milling/tasks.py` as **already flipped while both of its sites were still building dicts**, because neither mentions the signal: they go through `MillingTask._handle_progress`.

That is exactly the blind spot that let two `_stitch` emits through the equivalent guard on FIB-402, reproduced here before it could ship. The scan follows the relay now, a probe pins that it does (`assert _dict_emits(probe) == [3, 5]` — the naive version sees only line 3), and `tasks.py` is listed as **not yet flipped**, so finishing it fails the test rather than quietly narrowing the scan.

## Tests — 15

Driven against the real Demo backend rather than asserting on shapes: a full `StandardMillingStrategy().run(...)`, and the coincidence monitor loop.

Plus an end-to-end check that no dict reaches the signal during a real run — the static scan cannot see a dict built elsewhere and passed in.

## Verification

- `tests/milling/ tests/autolamella/ tests/test_microscope.py tests/test_tescan*.py tests/test_import_cycles.py tests/test_milling_time_estimates.py` → **832 passed**. `tests/ui/` → **2313 passed, 1 skipped**.
- The producer tests re-run 3× back to back (19.5s / 19.7s / 19.7s, 25 passed each) after one unexplained slow run — see the note in the last PR of the stack about `tests/ui` wall time.
- **Python 3.8** AST scan — clean.
- **Grepped for surviving dict keys** after the suite went green, as FIB-402's notes recommend: the only `"state"` hits left in these five files are two unrelated `logging.debug` lines.
- `ruff check` and `ruff format --check` pass.