### PR TITLE
[refactor] Flip the milling task layer, and stop a cancelled mill claiming success (FIB-797)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1557,10 +1557,11 @@ class AutoLamellaSingleWindowUI(QMainWindow):
     @ensure_main_thread
     def _on_milling_progress(self, payload: object):
         """Handle milling progress updates from the microscope."""
-        # `payload` is still a nested dict from every producer; `from_payload` decodes
-        # it, and is a no-op once they emit `MillingProgress` directly (FIB-797).
+        # Total-by-construction decode. Every in-tree producer emits a
+        # `MillingProgress` and this is a no-op for them; it stands because a
+        # plugin-loaded strategy is a producer too, and psygnal hands whatever it
+        # emits to this slot unchanged (FIB-797).
         report = MillingProgress.from_payload(payload)
-
         if report.status.is_terminal:
             self.milling_progress_bar.setVisible(False)
             return

--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -2098,8 +2098,10 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
 
     @ensure_main_thread
     def _on_milling_progress(self, payload: object):
-        # `payload` is still a nested dict from every producer; `from_payload` decodes
-        # it, and is a no-op once they emit `MillingProgress` directly (FIB-797).
+        # Total-by-construction decode. Every in-tree producer emits a
+        # `MillingProgress` and this is a no-op for them; it stands because a
+        # plugin-loaded strategy is a producer too, and psygnal hands whatever it
+        # emits to this slot unchanged (FIB-797).
         report = MillingProgress.from_payload(payload)
         label = self._milling_label.label(report)
 

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -165,7 +165,7 @@ class FibsemMicroscope(ABC):
     # thread). Any handler that touches Qt or a canvas MUST marshal, e.g. with
     # @superqt.ensure_main_thread; a bare .connect() of a GUI handler is a
     # crash-on-hardware bug that won't reproduce on a dev machine.
-    milling_progress_signal = Signal(dict)
+    milling_progress_signal = Signal(MillingProgress)
     tiled_acquisition_signal = Signal(TiledProgress)
     spot_burn_progress_signal = Signal(SpotBurnProgress)
     _last_imaging_settings: ImageSettings

--- a/fibsem/microscopes/odemis_microscope.py
+++ b/fibsem/microscopes/odemis_microscope.py
@@ -9,6 +9,7 @@ from psygnal import Signal
 
 from fibsem.microscope import FibsemMicroscope, ThermoMicroscope
 from fibsem.microscopes.tescan import TescanMicroscope
+from fibsem.milling.progress import MillingProgress
 from fibsem.structures import (
     ACTIVE_MILLING_STATES,
     BeamSettings,
@@ -238,7 +239,7 @@ class OdemisThermoMicroscope(FibsemMicroscope):
     """TFS integration through Odemis.
     Requires Odemis installation, unlike ThermoMicroscope which provides direct TFS integration."""
 
-    milling_progress_signal = Signal(dict)
+    milling_progress_signal = Signal(MillingProgress)
     _last_imaging_settings: ImageSettings
 
     def __init__(self, system_settings: SystemSettings):

--- a/fibsem/milling/progress.py
+++ b/fibsem/milling/progress.py
@@ -246,18 +246,28 @@ class MillingProgress:
 
     @classmethod
     def from_payload(cls, payload: object) -> "MillingProgress":
-        """Decode whatever arrived on `milling_progress_signal` into one of these.
+        """Decode whatever actually arrived on `milling_progress_signal`.
 
-        **Temporary**, for the window in which the producers still build nested dicts
-        and the consumers have already been taught the typed report. Deleted in the last
-        PR of FIB-797, along with `Signal(dict)` itself.
+        Every in-tree producer emits a `MillingProgress`, so this is a no-op for all of
+        them, and on that basis it could be deleted. It is kept because the producer set
+        is **open**. Milling strategies are plugin-loadable (`register_strategy` plus
+        entry points in `fibsem/milling/strategy/__init__.py`) and a strategy drives its
+        own execution loop, so one built against the older contract still emits the
+        nested `{"msg", "progress": {...}}` dict. `psygnal` does not validate emissions:
+        a `Signal(MillingProgress)` hands a dict to the slot unchanged, and the first
+        attribute access on it raises.
 
-        **Total by construction.** Every branch returns; nothing here indexes, and the
-        one `int()` that could raise is guarded. This runs inside a queued Qt slot, and
-        on PyQt5 an exception escaping one of those is `qFatal`: the process aborts with
-        nothing written to the logfile (FIB-329). A report that decodes to
-        `MillingStatus.STAGE_UPDATE` carrying nothing is a progress bar that does not
-        move; a raise here is a dead application.
+        That raise lands inside a queued Qt slot, where on PyQt5 it is `qFatal` -- the
+        process aborts with nothing written to the logfile (FIB-329). It is not a
+        hypothetical: the sibling workflow-update signal killed the app exactly that way
+        on every queue action, because one payload lacked a key a consumer indexed.
+
+        The asymmetry is the whole argument. A payload that decodes to a bare
+        `STAGE_UPDATE` is a progress bar that does not move; a raise is a dead
+        application that takes the milling run with it.
+
+        **Total by construction.** Every branch returns, nothing here indexes, and the
+        coercions below cannot raise on any input.
         """
         if isinstance(payload, cls):
             return payload
@@ -275,10 +285,11 @@ class MillingProgress:
         elif state == "finished":
             status = MillingStatus.TASK_FINISHED
         else:
-            # `"update"`, and also the shape that carries no `state` at all -- the
-            # strategy's own report, whose only content is its `msg`. It matched no
-            # branch in any consumer before, so its message rendered nowhere; decoding
-            # it as an update is what puts those words on the screen.
+            # `"update"`, and also the shape that carries no `state` at all -- a
+            # delegating strategy's own report, whose content is its `msg` plus a
+            # countdown. That shape matched no branch in any consumer under the old
+            # vocabulary, so its words rendered nowhere; decoding it as an update is
+            # what finally puts them on the screen.
             status = MillingStatus.STAGE_UPDATE
 
         return cls(
@@ -286,7 +297,7 @@ class MillingProgress:
             message=message if isinstance(message, str) else None,
             task_id=inner.get("task_id"),
             task_name=inner.get("task_name"),
-            # `name` is the strategy's spelling of `stage_name`.
+            # `name` is the older spelling of `stage_name`.
             stage_name=inner.get("stage_name") or inner.get("name"),
             current_stage=_as_int(inner.get("current_stage")),
             total_stages=_as_int(inner.get("total_stages")),
@@ -308,11 +319,11 @@ def _as_float(value: object) -> Optional[float]:
 
 
 def _as_milling_state(value: object) -> Optional[MillingState]:
-    """Coerce the legacy field, which three producers send as an enum and one as a str.
+    """Coerce the field, which older producers send as an enum and one as a `str`.
 
-    The odd one out is `strategy/coincidence.py`, whose `"UNKNOWN"` is deliberate: it
-    declines to call `get_milling_state()` because that getter sets the active view, and
-    the strategy is running a fluorescence acquisition that holds it.
+    The string spelling comes from a strategy that declines to call
+    `get_milling_state()` -- on ThermoFisher that getter *sets the active view*, and
+    such a strategy may be holding the view for a fluorescence acquisition.
     """
     if isinstance(value, MillingState):
         return value

--- a/fibsem/milling/tasks.py
+++ b/fibsem/milling/tasks.py
@@ -15,6 +15,7 @@ from fibsem import config as fcfg
 from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
 from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.base import FibsemMillingStage
+from fibsem.milling.progress import MillingProgress, MillingStatus
 from fibsem.structures import (
     BeamType,
     FibsemImage,
@@ -243,9 +244,25 @@ class FibsemMillingTask:
         """Return the list of milling stages."""
         return self.config.enabled_stages
 
-    def _handle_progress(self, ddict: dict) -> None:
-        """Handle progress updates from the microscope."""
-        self.microscope.milling_progress_signal.emit(ddict)
+    def _emit(self, status: MillingStatus, **fields) -> None:
+        """Report where this task has got to.
+
+        Replaces `_handle_progress`, which was a pass-through: it emitted whatever it
+        was handed, handled nothing, and described the traffic backwards -- the updates
+        go *to* the microscope's signal rather than from it. Residue of an unfinished
+        migration.
+
+        Its one real effect was hiding two emit sites from any scan keyed on the signal
+        name, which is a blind spot rather than a feature. This version earns the
+        indirection instead: the task-identity stamp lives here rather than being
+        repeated at every call site, and the guard in
+        tests/milling/test_progress_producers.py knows to follow it.
+        """
+        self.microscope.milling_progress_signal.emit(
+            MillingProgress(
+                status=status, task_id=self.task_id, task_name=self.name, **fields
+            )
+        )
 
     def _imaging_conditions(self) -> Tuple[float, float]:
         """The (current, voltage) the user was imaging at before milling started.
@@ -289,6 +306,15 @@ class FibsemMillingTask:
 
         logging.info(f"Running milling task: {self.name} with ID: {self.task_id}")
 
+        # Read by the `finally` below, which runs whichever way the task ends. Seeded
+        # with the failure case because `except Exception` does not catch everything:
+        # a KeyboardInterrupt unwinds straight through to the `finally`, and reporting
+        # that as a completed mill is the defect this whole block exists to fix.
+        outcome = MillingStatus.TASK_FAILED
+        error: Optional[str] = None
+
+        self._emit(MillingStatus.TASK_STARTED, total_stages=len(self.stages))
+
         try:
             self.initial_beam_shift = self.microscope.get_beam_shift(
                 beam_type=self.config.channel
@@ -316,21 +342,21 @@ class FibsemMillingTask:
             for idx, stage in enumerate(self.stages):
                 self._mill_stage(stage, idx)
 
+            outcome = MillingStatus.TASK_FINISHED
         except OperationCancelledError as e:
             logging.info(f"Milling task '{self.name}' cancelled by user: {e}")
+            outcome = MillingStatus.TASK_CANCELLED
         except Exception as e:
             logging.error(e)
+            outcome = MillingStatus.TASK_FAILED
+            error = str(e)
         finally:
-            self._handle_progress(
-                {
-                    "msg": f"Finished Milling Task: {self.name}. Restoring Imaging Conditions...",
-                    "progress": {
-                        "state": "finished",
-                        "task_id": self.task_id,
-                        "task_name": self.name,
-                    },
-                }
-            )
+            # The outcome, not just "it stopped". Both `except` blocks used to log and
+            # fall through to a `finally` that emitted `finished` regardless, so a mill
+            # the user cancelled and a mill that crashed both told the UI they had
+            # finished -- the status bar rendered "Done" either way and the exception
+            # text reached only the logfile.
+            self._emit(outcome, error=error)
             # restore the captured pre-milling imaging current/voltage
             imaging_current, imaging_voltage = self._imaging_conditions()
             self.microscope.finish_milling(
@@ -373,19 +399,13 @@ class FibsemMillingTask:
         start_time = time.time()
         raise_if_cancelled(self._stop_event)
 
-        msgd = {
-            "msg": f"Preparing: {stage.name}",
-            "progress": {
-                "state": "start",
-                "start_time": start_time,
-                "current_stage": idx,
-                "total_stages": len(self.stages),
-                "task_id": self.task_id,
-                "task_name": self.name,
-                "stage_name": stage.name,
-            },
-        }
-        self._handle_progress(msgd)
+        self._emit(
+            MillingStatus.STAGE_STARTED,
+            start_time=start_time,
+            current_stage=idx,
+            total_stages=len(self.stages),
+            stage_name=stage.name,
+        )
 
         try:
             # if self.config.acquisition.enabled:
@@ -425,6 +445,14 @@ class FibsemMillingTask:
                 self._acquire_milling_task_images(
                     stage_name=f"{self.name}-{stage.name}", tag="finished"
                 )
+
+            self._emit(
+                MillingStatus.STAGE_FINISHED,
+                start_time=start_time,
+                current_stage=idx,
+                total_stages=len(self.stages),
+                stage_name=stage.name,
+            )
 
         except OperationCancelledError:
             raise  # unwind to run() so the whole task aborts + restores conditions

--- a/fibsem/ui/widgets/milling_widget.py
+++ b/fibsem/ui/widgets/milling_widget.py
@@ -49,6 +49,8 @@ class FibsemMillingWidget2(QWidget):
         # The last words a producer supplied, so a backend's messageless tick still
         # has a label to show. See `MillingMessageTracker`.
         self._milling_label = MillingMessageTracker()
+        # What the instrument last said it was doing. See `pause_resume_milling`.
+        self._milling_state: Optional[MillingState] = None
         layout = QGridLayout()
 
         # pushbutton for run milling
@@ -104,10 +106,15 @@ class FibsemMillingWidget2(QWidget):
 
     @ensure_main_thread
     def _on_milling_progress(self, payload: object) -> None:
-        # `payload` is still a nested dict from every producer; `from_payload` decodes
-        # it, and is a no-op once they emit `MillingProgress` directly (FIB-797).
+        # Total-by-construction decode. Every in-tree producer emits a
+        # `MillingProgress` and this is a no-op for them; it stands because a
+        # plugin-loaded strategy is a producer too, and psygnal hands whatever it
+        # emits to this slot unchanged (FIB-797).
         report = MillingProgress.from_payload(payload)
         logging.debug("Milling progress: %s", report)
+
+        if report.milling_state is not None:
+            self._milling_state = report.milling_state
 
         # update the UI based on the progress information
         self._update_button_states()
@@ -215,8 +222,12 @@ class FibsemMillingWidget2(QWidget):
             self.microscope.stop_milling()
 
     def pause_resume_milling(self):
-        milling_state = self.microscope.get_milling_state()
-        if self.is_milling and milling_state is MillingState.RUNNING:
+        # The last state a progress report carried, not a fresh `get_milling_state()`.
+        # On ThermoFisher that getter *sets the active view* as a side effect, so a
+        # click here during a coincidence mill competes for the view with the
+        # fluorescence acquisition the strategy is running. Every producer now carries
+        # the value on the report, so the widget already has it.
+        if self.is_milling and self._milling_state is MillingState.RUNNING:
             self.microscope.pause_milling()
             self.pushButton_pause_milling.setText("Resume Milling")
         else:

--- a/tests/milling/test_progress.py
+++ b/tests/milling/test_progress.py
@@ -1,12 +1,15 @@
 """The typed contract carried by ``milling_progress_signal`` (FIB-797).
 
-Nothing emits or reads a ``MillingProgress`` yet -- the producers still build nested
-dicts and the consumers still take them apart. What is worth pinning before either moves
-is the shape, and specifically the decisions that are cheap to quietly undo later: that
-a stage outcome and a task outcome are different things, that the offset lives in one
-place, and that a plugin's empty string is not a request for a blank label.
+What is pinned here is the shape, and specifically the decisions that are cheap to
+quietly undo later: that a stage outcome and a task outcome are different things, that
+the offset lives in one place, and that a plugin's empty string is not a request for a
+blank label.
 
-``milling_progress_signal`` has had **no** test coverage of any kind until now.
+``milling_progress_signal`` had **no** test coverage of any kind before FIB-797.
+
+`from_payload` is covered here too. Every in-tree producer now emits a typed report,
+so it decodes nothing of ours -- it is kept as the totality guard at a queued-Qt-slot
+boundary, because a plugin-loaded strategy is a producer this repo never sees.
 """
 
 import dataclasses
@@ -180,10 +183,16 @@ class TestMillingStateUnknown:
         assert MillingState.UNKNOWN not in ACTIVE_MILLING_STATES
 
 
-class TestDecodingTheLegacyPayload:
-    """`from_payload` is the migration shim: the producers still build nested dicts
-    while the consumers have already been taught the typed report. It is deleted with
-    `Signal(dict)` in the last PR of FIB-797."""
+class TestTheTotalityGuard:
+    """`from_payload` decodes whatever actually arrived, including the older nested dict.
+
+    Not a migration shim -- every in-tree producer emits a `MillingProgress`, so this is
+    a no-op for all of them. It stands because the producer set is **open**: milling
+    strategies are plugin-loadable and drive their own execution loops, so one built
+    against the older contract still emits a dict. `psygnal` does not validate
+    emissions, so that dict reaches the slot unchanged and the first attribute access on
+    it raises -- inside a queued Qt slot, which on PyQt5 is `qFatal` (FIB-329).
+    """
 
     def test_a_stage_start_decodes(self):
         report = MillingProgress.from_payload(
@@ -236,10 +245,15 @@ class TestDecodingTheLegacyPayload:
         assert report.status is MillingStatus.TASK_FINISHED
         assert report.status.is_terminal
 
-    def test_the_shape_that_rendered_nowhere_now_decodes_to_something(self):
-        """`strategy/standard.py` emits a payload carrying no `state` at all, so it
-        matched no branch in any of the three consumers and its message -- the strategy's
-        own words, the feature users asked for -- rendered nowhere."""
+    def test_a_delegating_strategys_shape_decodes_to_something(self):
+        """The shape with no `state` at all: a strategy that emits its label, then hands
+        the loop to a backend via `microscope.run_milling()`.
+
+        Under the old vocabulary this matched no branch in any of the three consumers,
+        so the strategy's own words -- the customisable text users asked for -- rendered
+        nowhere. Decoding it as an update is what finally puts them on the screen. Such
+        a strategy can be plugin-loaded, so this shape outlives the in-tree producers.
+        """
         report = MillingProgress.from_payload(
             {
                 "msg": "Running Rough Mill...",
@@ -253,21 +267,21 @@ class TestDecodingTheLegacyPayload:
         )
         assert report.status is MillingStatus.STAGE_UPDATE
         assert report.display_message == "Running Rough Mill..."
-        # `name` is the strategy's spelling of `stage_name`.
+        # `name` is the older spelling of `stage_name`.
         assert report.stage_name == "Rough Mill"
 
-    def test_the_coincidence_strategys_string_state_becomes_the_enum(self):
-        """It sends `"UNKNOWN"` where the other three producers send a `MillingState`,
-        and that is deliberate -- calling the getter would steal the active view from
-        the fluorescence acquisition the strategy is running."""
+    def test_a_string_milling_state_becomes_the_enum(self):
+        """Some producers send `"UNKNOWN"` where others send a `MillingState`, and that
+        is deliberate: calling the getter would steal the active view from a
+        fluorescence acquisition the strategy may be running."""
         report = MillingProgress.from_payload(
             {"progress": {"state": "update", "milling_state": "UNKNOWN"}}
         )
         assert report.milling_state is MillingState.UNKNOWN
 
     def test_a_typed_report_passes_straight_through(self):
-        """So a consumer can be flipped before its producers are, which is the whole
-        point of the shim."""
+        """The in-tree path, which is every producer in this repo. Identity, not a
+        rebuild -- the guard must cost nothing on the path that is always taken."""
         original = MillingProgress(MillingStatus.TASK_CANCELLED, error=None)
         assert MillingProgress.from_payload(original) is original
 
@@ -288,17 +302,17 @@ class TestDecodingTheLegacyPayload:
         ],
     )
     def test_nothing_makes_it_raise(self, payload):
-        """Total by construction. This runs inside a queued Qt slot, and on PyQt5 an
-        exception escaping one of those is `qFatal`: the process aborts with nothing
-        written to the logfile (FIB-329). A bar that does not move is recoverable; a
-        dead application is not."""
+        """Total by construction, which is the entire reason it is kept. This runs
+        inside a queued Qt slot, and on PyQt5 an exception escaping one of those is
+        `qFatal`: the process aborts with nothing written to the logfile (FIB-329). A
+        bar that does not move is recoverable; a dead application is not."""
         report = MillingProgress.from_payload(payload)
         assert isinstance(report, MillingProgress)
         assert report.display_message
 
     def test_a_boolean_is_not_a_count(self):
         """`bool` is an `int` subclass, so an unguarded `isinstance` check turns the
-        legacy `"started": True` into stage 1."""
+        older `"started": True` into stage 1."""
         report = MillingProgress.from_payload(
             {"progress": {"state": "start", "current_stage": True}}
         )

--- a/tests/milling/test_progress_producers.py
+++ b/tests/milling/test_progress_producers.py
@@ -1,8 +1,7 @@
 """What the backends and strategies put on ``milling_progress_signal`` (FIB-797).
 
-The three backend poll loops and the two built-in strategies now emit a
-``MillingProgress`` rather than a nested dict. The task layer still emits dicts; the
-consumers decode either, which is what allows the producers to be flipped in two steps.
+Every producer emits a ``MillingProgress``: the three backend poll loops, both
+built-in strategies, and the task layer.
 
 The guard at the bottom is the part worth keeping after the migration. On FIB-402 the
 equivalent test was keyed on the signal name alone, and two emit sites hiding behind a
@@ -12,6 +11,7 @@ them.
 """
 
 import ast
+import threading
 import time
 from pathlib import Path
 
@@ -151,17 +151,16 @@ class TestTheCoincidenceStrategy:
 # The guard
 # --------------------------------------------------------------------------------------
 
-# Every module that emits on `milling_progress_signal`, and whether it has been flipped.
-# `tasks.py` is False on purpose: its two emit sites go in the next PR, along with the
-# relay they hide behind. Naming it rather than omitting it is what makes forgetting it
-# a failing test rather than a silently narrower scan.
+# Every module that emits on `milling_progress_signal`. All flipped as of FIB-797; the
+# mapping stays rather than collapsing to a list, so a new producer added mid-migration
+# has somewhere honest to sit.
 EMITTERS = {
     "microscope.py": True,
     "microscopes/simulator.py": True,
     "microscopes/tescan.py": True,
     "milling/strategy/standard.py": True,
     "milling/strategy/coincidence.py": True,
-    "milling/tasks.py": False,
+    "milling/tasks.py": True,
 }
 
 
@@ -251,3 +250,135 @@ def test_a_stage_run_end_to_end_emits_no_dict(microscope):
 
     dicts = [r for r in emitted if isinstance(r, dict)]
     assert dicts == [], f"{len(dicts)} dict payload(s) still reached the signal"
+
+
+# --------------------------------------------------------------------------------------
+# The task layer, and the defect it carried
+# --------------------------------------------------------------------------------------
+
+
+def _task(microscope, stages, name="Trench"):
+    from fibsem.milling.tasks import FibsemMillingTask, FibsemMillingTaskConfig
+
+    config = FibsemMillingTaskConfig(name=name, stages=stages)
+    return FibsemMillingTask(microscope=microscope, config=config)
+
+
+def _stage(name):
+    stage = FibsemMillingStage(name=name)
+    stage.strategy = StandardMillingStrategy()
+    return stage
+
+
+class TestHowATaskEnds:
+    """Before FIB-797 both `except` blocks logged and fell through to a `finally` that
+    emitted `finished` regardless, so a mill the user cancelled and a mill that crashed
+    both told the UI they had finished. The status bar rendered "Done" either way and the
+    exception text reached only the logfile."""
+
+    def test_a_completed_task_says_so(self, microscope):
+        task = _task(microscope, [_stage("Rough Mill")])
+        emitted = _collect(microscope)
+        task.run()
+
+        assert emitted[-1].status is MillingStatus.TASK_FINISHED
+        assert emitted[-1].error is None
+
+    def test_a_cancelled_task_does_not_claim_to_have_finished(self, microscope):
+        task = _task(microscope, [_stage("Rough Mill")])
+        task._stop_event = threading.Event()
+        task._stop_event.set()
+        emitted = _collect(microscope)
+        task.run()
+
+        assert emitted[-1].status is MillingStatus.TASK_CANCELLED
+
+    def test_a_cancelled_task_is_not_painted_as_a_failure(self, microscope):
+        """A cancel is someone getting what they asked for, so it is a distinct status
+        rather than an error -- nothing here should render red."""
+        task = _task(microscope, [_stage("Rough Mill")])
+        task._stop_event = threading.Event()
+        task._stop_event.set()
+        emitted = _collect(microscope)
+        task.run()
+
+        assert emitted[-1].status is not MillingStatus.TASK_FAILED
+        assert emitted[-1].error is None
+
+    def test_a_failed_task_carries_why(self, microscope):
+        task = _task(microscope, [_stage("Rough Mill")])
+
+        def boom(*a, **k):
+            raise RuntimeError("the column tripped")
+
+        task._configure_path = boom
+        emitted = _collect(microscope)
+        task.run()
+
+        assert emitted[-1].status is MillingStatus.TASK_FAILED
+        assert emitted[-1].error == "the column tripped"
+
+    def test_the_terminal_is_the_last_thing_the_task_says(self, microscope):
+        """Whatever the outcome, exactly one terminal report and nothing after it -- or a
+        consumer that hides its bar on `is_terminal` shows it again for the rest of the
+        session."""
+        task = _task(microscope, [_stage("Rough Mill"), _stage("Polish")])
+        emitted = _collect(microscope)
+        task.run()
+
+        terminals = [i for i, r in enumerate(emitted) if r.status.is_terminal]
+        assert len(terminals) == 1
+        assert terminals[0] == len(emitted) - 1
+
+
+class TestTheTwoScales:
+    def test_a_stage_starting_is_not_the_task_starting(self, microscope):
+        """The old vocabulary emitted `start` per stage, N times, and `finished` once per
+        task. They read like a matched pair and were not one."""
+        task = _task(microscope, [_stage("Rough Mill"), _stage("Polish")])
+        emitted = _collect(microscope)
+        task.run()
+
+        assert [r.status for r in emitted].count(MillingStatus.TASK_STARTED) == 1
+        assert [r.status for r in emitted].count(MillingStatus.STAGE_STARTED) == 2
+
+    def test_each_stage_reports_its_own_index_zero_based(self, microscope):
+        task = _task(microscope, [_stage("Rough Mill"), _stage("Polish")])
+        emitted = _collect(microscope)
+        task.run()
+
+        starts = [r for r in emitted if r.status is MillingStatus.STAGE_STARTED]
+        assert [r.current_stage for r in starts] == [0, 1]
+        assert [r.display_stage for r in starts] == [1, 2]
+        assert [r.stage_name for r in starts] == ["Rough Mill", "Polish"]
+        assert all(r.total_stages == 2 for r in starts)
+
+    def test_a_stage_finishing_is_not_terminal(self, microscope):
+        task = _task(microscope, [_stage("Rough Mill"), _stage("Polish")])
+        emitted = _collect(microscope)
+        task.run()
+
+        finishes = [r for r in emitted if r.status is MillingStatus.STAGE_FINISHED]
+        assert len(finishes) == 2
+        assert not any(r.status.is_terminal for r in finishes)
+
+    def test_every_report_carries_the_task_identity(self, microscope):
+        """What the `_emit` helper buys over the pass-through relay it replaces: the
+        stamp lives in one place instead of being repeated at each call site."""
+        task = _task(microscope, [_stage("Rough Mill")], name="Trench")
+        emitted = _collect(microscope)
+        task.run()
+
+        from_task = [r for r in emitted if r.task_id is not None]
+        assert from_task, "no report carried a task id"
+        assert all(r.task_name == "Trench" for r in from_task)
+        assert len({r.task_id for r in from_task}) == 1
+
+
+def test_the_relay_no_longer_exists():
+    """`_handle_progress` was a pass-through that emitted whatever it was handed,
+    handled nothing, and described the traffic backwards. Deleting it is only safe
+    because the guard above now follows `_emit` instead."""
+    from fibsem.milling.tasks import FibsemMillingTask
+
+    assert not hasattr(FibsemMillingTask, "_handle_progress")

--- a/tests/ui/test_milling_progress_rendering.py
+++ b/tests/ui/test_milling_progress_rendering.py
@@ -37,60 +37,57 @@ from fibsem.milling.progress import (  # noqa: E402
 from fibsem.ui.widgets.milling_widget import FibsemMillingWidget2  # noqa: E402
 
 # --------------------------------------------------------------------------------------
-# The payloads the producers actually build today. Written out rather than constructed
-# through a helper: these are the wire format, and a helper that drifts from it is a
-# suite that passes while the real payload stops decoding.
+# One builder per producer, each shaped exactly as that producer builds it. Kept
+# separate rather than collapsed into one parametrised helper: the differences between
+# them -- which fields a backend tick omits, which a strategy stamps -- are the thing
+# under test.
 # --------------------------------------------------------------------------------------
 
 
-def legacy_stage_start(stage_name="Rough Mill", current_stage=0, total_stages=3):
+def stage_start(stage_name="Rough Mill", current_stage=0, total_stages=3):
     """`MillingTask._mill_stage`, once per stage."""
-    return {
-        "msg": f"Preparing: {stage_name}",
-        "progress": {
-            "state": "start",
-            "start_time": 100.0,
-            "current_stage": current_stage,
-            "total_stages": total_stages,
-            "task_id": "task-1",
-            "task_name": "Trench",
-            "stage_name": stage_name,
-        },
-    }
+    return MillingProgress(
+        status=MillingStatus.STAGE_STARTED,
+        message=None,
+        task_id="task-1",
+        task_name="Trench",
+        stage_name=stage_name,
+        current_stage=current_stage,
+        total_stages=total_stages,
+        start_time=100.0,
+    )
 
 
-def legacy_update(remaining_time=30.0, estimated_time=60.0):
-    """A backend's poll loop -- `microscope.py`, `simulator.py`, `tescan.py`."""
-    return {
-        "progress": {
-            "state": "update",
-            "start_time": 100.0,
-            "estimated_time": estimated_time,
-            "remaining_time": remaining_time,
-        }
-    }
+def backend_tick(remaining_time=30.0, estimated_time=60.0):
+    """A backend's poll loop -- `microscope.py`, `simulator.py`, `tescan.py`. Carries no
+    message: the backend has no idea what the strategy driving it calls itself."""
+    return MillingProgress(
+        status=MillingStatus.STAGE_UPDATE,
+        start_time=100.0,
+        estimated_time=estimated_time,
+        remaining_time=remaining_time,
+    )
 
 
-def legacy_strategy_message(stage_name="Rough Mill"):
-    """`strategy/standard.py`. Carries **no** `state`, so it matched no branch in any of
-    the three consumers and its message rendered nowhere."""
-    return {
-        "msg": f"Running {stage_name}...",
-        "progress": {
-            "started": True,
-            "start_time": 100.0,
-            "estimated_time": 60.0,
-            "name": stage_name,
-        },
-    }
+def strategy_message(stage_name="Rough Mill"):
+    """`strategy/standard.py`. This is the report that used to carry no `state` at all,
+    so it matched no branch in any of the three consumers and rendered nowhere."""
+    return MillingProgress(
+        status=MillingStatus.STAGE_UPDATE,
+        message=f"Running {stage_name}...",
+        stage_name=stage_name,
+        start_time=100.0,
+        estimated_time=60.0,
+    )
 
 
-def legacy_task_finished():
+def task_finished():
     """`MillingTask.run`'s `finally`, once per task."""
-    return {
-        "msg": "Finished Milling Task: Trench. Restoring Imaging Conditions...",
-        "progress": {"state": "finished", "task_id": "task-1", "task_name": "Trench"},
-    }
+    return MillingProgress(
+        status=MillingStatus.TASK_FINISHED,
+        task_id="task-1",
+        task_name="Trench",
+    )
 
 
 # --------------------------------------------------------------------------------------
@@ -230,7 +227,7 @@ class TestTheStageCountIsOneBased:
 
     def test_the_milling_widget_counts_from_one(self, milling_widget):
         milling_widget._on_milling_progress(
-            legacy_stage_start(current_stage=0, total_stages=3)
+            stage_start(current_stage=0, total_stages=3)
         )
         assert (
             milling_widget.progressBar_milling_stages.format()
@@ -239,16 +236,14 @@ class TestTheStageCountIsOneBased:
 
     def test_the_main_window_counts_from_one(self, main_window):
         main_window._on_milling_progress(
-            legacy_stage_start(current_stage=1, total_stages=3, stage_name="Polish")
+            stage_start(current_stage=1, total_stages=3, stage_name="Polish")
         )
         assert (
             main_window.milling_progress_bar.toolTip() == "Milling Stage: 2/3 - Polish"
         )
 
     def test_the_coincidence_viewer_counts_from_one(self, coincidence):
-        coincidence._on_milling_progress(
-            legacy_stage_start(current_stage=2, total_stages=3)
-        )
+        coincidence._on_milling_progress(stage_start(current_stage=2, total_stages=3))
         assert coincidence.progressBar_stages.format() == "Stage 3/3"
 
 
@@ -264,35 +259,107 @@ class TestTheStrategysWordsReachTheScreen:
     signal keeps a `message` at all."""
 
     def test_the_milling_widget_shows_it(self, milling_widget):
-        milling_widget._on_milling_progress(legacy_strategy_message())
+        milling_widget._on_milling_progress(strategy_message())
         assert "Running Rough Mill..." in milling_widget.progressBar_milling.format()
 
     def test_the_main_window_shows_it(self, main_window):
-        main_window._on_milling_progress(legacy_strategy_message())
+        main_window._on_milling_progress(strategy_message())
         assert "Running Rough Mill..." in main_window.milling_progress_bar.format()
 
     def test_the_coincidence_viewer_shows_it(self, coincidence):
-        coincidence._on_milling_progress(legacy_strategy_message())
+        coincidence._on_milling_progress(strategy_message())
         assert "Running Rough Mill..." in coincidence.progressBar_stage.format()
 
     def test_it_survives_the_backends_messageless_ticks(self, milling_widget):
         """The stickiness rule, end to end. A *delegating* strategy emits its label once
         and then hands the loop to `microscope.run_milling()`; every tick after that
         comes from a backend that has no idea what the strategy calls itself."""
-        milling_widget._on_milling_progress(legacy_strategy_message())
-        milling_widget._on_milling_progress(legacy_update(remaining_time=15.0))
+        milling_widget._on_milling_progress(strategy_message())
+        milling_widget._on_milling_progress(backend_tick(remaining_time=15.0))
 
         rendered = milling_widget.progressBar_milling.format()
         assert "Running Rough Mill..." in rendered
         assert "remaining" in rendered
 
     def test_a_new_stage_drops_the_previous_stages_words(self, milling_widget):
-        milling_widget._on_milling_progress(legacy_strategy_message("Rough Mill"))
-        milling_widget._on_milling_progress(legacy_stage_start("Polish", 1, 3))
+        milling_widget._on_milling_progress(strategy_message("Rough Mill"))
+        milling_widget._on_milling_progress(stage_start("Polish", 1, 3))
 
         rendered = milling_widget.progressBar_milling.format()
         assert "Rough Mill" not in rendered
         assert rendered == "Preparing: Polish"
+
+
+# --------------------------------------------------------------------------------------
+# The producers this repo does not own
+# --------------------------------------------------------------------------------------
+
+
+def out_of_tree_delegating_strategy():
+    """A strategy built against the older contract: nested dict, no `state`, `name`
+    rather than `stage_name`, and a `msg` of its own.
+
+    Milling strategies are plugin-loadable, so this is not a historical shape that went
+    away when the in-tree producers were flipped -- it is what an installed plugin still
+    emits, and `psygnal` hands it to these slots unchanged.
+    """
+    return {
+        "msg": "Running Rough Mill cycle 2...",
+        "progress": {
+            "started": True,
+            "start_time": 100.0,
+            "estimated_time": 60.0,
+            "name": "Rough Mill",
+        },
+    }
+
+
+class TestAnUnknownProducerCannotKillTheApp:
+    """The consequence of getting this wrong is not a missing label.
+
+    These slots are queued, and on PyQt5 an exception escaping a queued slot is
+    `qFatal`: the process aborts with nothing written to the logfile (FIB-329). An
+    `AttributeError` on the first field read would take the milling run with it.
+    """
+
+    def test_the_milling_widget_survives_and_renders(self, milling_widget):
+        milling_widget._on_milling_progress(out_of_tree_delegating_strategy())
+        assert (
+            "Running Rough Mill cycle 2..."
+            in milling_widget.progressBar_milling.format()
+        )
+
+    def test_the_main_window_survives_and_renders(self, main_window):
+        main_window._on_milling_progress(out_of_tree_delegating_strategy())
+        assert (
+            "Running Rough Mill cycle 2..." in main_window.milling_progress_bar.format()
+        )
+
+    def test_the_coincidence_viewer_survives_and_renders(self, coincidence):
+        coincidence._on_milling_progress(out_of_tree_delegating_strategy())
+        assert "Running Rough Mill cycle 2..." in coincidence.progressBar_stage.format()
+
+    @pytest.mark.parametrize(
+        "payload",
+        [None, "not a dict", 42, {}, {"progress": None}, {"progress": {"state": "?"}}],
+    )
+    def test_no_payload_at_all_raises_in_any_consumer(
+        self, payload, milling_widget, main_window, coincidence
+    ):
+        """Nothing a producer can emit may escape as an exception -- not a malformed
+        dict, not `None`, not a bare string."""
+        milling_widget._on_milling_progress(payload)
+        main_window._on_milling_progress(payload)
+        coincidence._on_milling_progress(payload)
+
+    def test_a_legacy_terminal_still_clears_the_bar(self, milling_widget):
+        """The guard has to decode the *outcome* too, or a plugin's run leaves the
+        progress bar up forever."""
+        milling_widget._on_milling_progress(out_of_tree_delegating_strategy())
+        milling_widget._on_milling_progress(
+            {"msg": "done", "progress": {"state": "finished", "task_name": "Trench"}}
+        )
+        assert not milling_widget.progressBar_milling.isVisible()
 
 
 # --------------------------------------------------------------------------------------
@@ -303,7 +370,7 @@ class TestTheStrategysWordsReachTheScreen:
 class TestTheCountdown:
     def test_the_bar_tracks_the_time_left(self, milling_widget):
         milling_widget._on_milling_progress(
-            legacy_update(remaining_time=15.0, estimated_time=60.0)
+            backend_tick(remaining_time=15.0, estimated_time=60.0)
         )
         assert milling_widget.progressBar_milling.value() == 75
         assert "remaining" in milling_widget.progressBar_milling.format()
@@ -314,7 +381,7 @@ class TestTheCountdown:
         slot, and on PyQt5 an exception escaping one of those is `qFatal`: the process
         aborts with nothing written to the logfile (FIB-329)."""
         milling_widget._on_milling_progress(
-            legacy_update(remaining_time=0.0, estimated_time=0.0)
+            backend_tick(remaining_time=0.0, estimated_time=0.0)
         )
         assert milling_widget.progressBar_milling.format()
 
@@ -323,7 +390,7 @@ class TestTheCountdown:
     ):
         """Same class: `int(stage / total_stages * 100)` with a total of zero."""
         milling_widget._on_milling_progress(
-            legacy_stage_start(current_stage=0, total_stages=0)
+            stage_start(current_stage=0, total_stages=0)
         )
         assert milling_widget.progressBar_milling_stages.format()
 
@@ -335,21 +402,21 @@ class TestTheCountdown:
 
 class TestATaskEnding:
     def test_the_milling_widget_hides_both_bars(self, milling_widget):
-        milling_widget._on_milling_progress(legacy_stage_start())
+        milling_widget._on_milling_progress(stage_start())
         assert milling_widget.progressBar_milling.isVisible()
-        milling_widget._on_milling_progress(legacy_task_finished())
+        milling_widget._on_milling_progress(task_finished())
         assert not milling_widget.progressBar_milling.isVisible()
         assert not milling_widget.progressBar_milling_stages.isVisible()
 
     def test_the_main_window_hides_its_bar(self, main_window):
-        main_window._on_milling_progress(legacy_stage_start())
-        main_window._on_milling_progress(legacy_task_finished())
+        main_window._on_milling_progress(stage_start())
+        main_window._on_milling_progress(task_finished())
         assert not main_window.milling_progress_bar.isVisible()
 
     def test_a_stage_finishing_does_not_hide_the_bar(self, milling_widget):
         """`STAGE_FINISHED` is not terminal. Treating it as one hides the bar after the
         first stage of an N-stage task, and it stays hidden for the rest of the run."""
-        milling_widget._on_milling_progress(legacy_stage_start())
+        milling_widget._on_milling_progress(stage_start())
         milling_widget.progressBar_milling.setVisible(True)
         milling_widget._on_milling_progress(
             MillingProgress(MillingStatus.STAGE_FINISHED, stage_name="Rough Mill")
@@ -360,7 +427,7 @@ class TestATaskEnding:
         """Nothing emits `TASK_CANCELLED` yet -- the producers land in the next PRs --
         but the consumer has to be ready before they do, or a cancelled mill leaves the
         bar up for the rest of the session."""
-        main_window._on_milling_progress(legacy_stage_start())
+        main_window._on_milling_progress(stage_start())
         main_window._on_milling_progress(MillingProgress(MillingStatus.TASK_CANCELLED))
         assert not main_window.milling_progress_bar.isVisible()
 
@@ -370,64 +437,42 @@ class TestATaskEnding:
 # --------------------------------------------------------------------------------------
 
 
-class TestATypedReportRendersTheSame:
-    """The consumers are dual-tolerant for the length of the migration: a dict and the
-    typed report it decodes to must render identically, or flipping a producer changes
-    what the user sees."""
-
-    @pytest.mark.parametrize(
-        "payload",
-        [legacy_stage_start(), legacy_update(), legacy_strategy_message()],
-    )
-    def test_a_dict_and_its_decoded_report_render_the_same(self, qapp, payload):
-        from_dict = _MillingWidgetHost()
-        from_typed = _MillingWidgetHost()
-        try:
-            from_dict._on_milling_progress(payload)
-            from_typed._on_milling_progress(MillingProgress.from_payload(payload))
-
-            assert (
-                from_dict.progressBar_milling.format()
-                == from_typed.progressBar_milling.format()
-            )
-            assert (
-                from_dict.progressBar_milling_stages.format()
-                == from_typed.progressBar_milling_stages.format()
-            )
-        finally:
-            from_dict.deleteLater()
-            from_typed.deleteLater()
-
-
 class TestNothingTakesTheProcessDown:
     """Every one of these runs inside a queued Qt slot. On PyQt5 an exception escaping
-    one is `qFatal`, so a malformed payload has to render badly rather than abort."""
+    one is `qFatal`: the process aborts with nothing written to the logfile (FIB-329),
+    so a degenerate report has to render badly rather than abort.
 
-    @pytest.mark.parametrize(
-        "payload",
-        [
-            None,
-            {},
-            "not a dict",
-            {"progress": None},
-            {"progress": {"state": "start", "total_stages": 0}},
-            {"progress": {"state": "update", "estimated_time": 0}},
-            {"progress": {"state": "update", "milling_state": "NOT_A_STATE"}},
-        ],
-    )
-    def test_the_milling_widget_survives(self, milling_widget, payload):
-        milling_widget._on_milling_progress(payload)
+    Typed now that the payload is, which narrows the risk to field *values* -- a zero
+    where a divisor is expected, a count with no total, an outcome carrying stage
+    fields. Those are what a producer can still get wrong.
+    """
 
-    @pytest.mark.parametrize(
-        "payload",
-        [None, {}, "not a dict", {"progress": {"state": "start", "total_stages": 0}}],
-    )
-    def test_the_main_window_survives(self, main_window, payload):
-        main_window._on_milling_progress(payload)
+    DEGENERATE = [
+        MillingProgress(MillingStatus.STAGE_STARTED),
+        MillingProgress(MillingStatus.STAGE_STARTED, total_stages=0, current_stage=0),
+        MillingProgress(MillingStatus.STAGE_STARTED, current_stage=7, total_stages=2),
+        MillingProgress(MillingStatus.STAGE_UPDATE),
+        MillingProgress(
+            MillingStatus.STAGE_UPDATE, remaining_time=1.0, estimated_time=0.0
+        ),
+        MillingProgress(MillingStatus.STAGE_UPDATE, estimated_time=60.0),
+        MillingProgress(
+            MillingStatus.STAGE_UPDATE, remaining_time=99.0, estimated_time=1.0
+        ),
+        MillingProgress(MillingStatus.STAGE_FINISHED),
+        MillingProgress(MillingStatus.TASK_STARTED),
+        MillingProgress(MillingStatus.TASK_CANCELLED, stage_name="Rough Mill"),
+        MillingProgress(MillingStatus.TASK_FAILED, error="the column tripped"),
+    ]
 
-    @pytest.mark.parametrize(
-        "payload",
-        [None, {}, "not a dict", {"progress": {"state": "start", "total_stages": 0}}],
-    )
-    def test_the_coincidence_viewer_survives(self, coincidence, payload):
-        coincidence._on_milling_progress(payload)
+    @pytest.mark.parametrize("report", DEGENERATE, ids=lambda r: r.status.value)
+    def test_the_milling_widget_survives(self, milling_widget, report):
+        milling_widget._on_milling_progress(report)
+
+    @pytest.mark.parametrize("report", DEGENERATE, ids=lambda r: r.status.value)
+    def test_the_main_window_survives(self, main_window, report):
+        main_window._on_milling_progress(report)
+
+    @pytest.mark.parametrize("report", DEGENERATE, ids=lambda r: r.status.value)
+    def test_the_coincidence_viewer_survives(self, coincidence, report):
+        coincidence._on_milling_progress(report)


### PR DESCRIPTION
Last of six for FIB-797. The remaining two payload-producing sites, the relay they hid behind, and the signal itself. `milling_progress_signal` is `Signal(MillingProgress)` on **both** declarations now — `microscope.py` and `odemis_microscope.py`, the second of which the issue did not list.

## `from_payload` stays, and stops being a migration shim

The plan had it deleted here, with the last dict producer. It is kept instead, and the reason is not backwards compatibility for its own sake.

Every in-tree producer emits a typed report, so this decodes nothing of ours. But the producer set is **open**: milling strategies are plugin-loadable (`register_strategy` plus entry points) and a strategy drives its own execution loop, so one built against the older contract still emits the nested `{"msg", "progress": {...}}` dict. And `psygnal` does **not** validate emissions — verified rather than assumed:

```python
>>> s.sig = Signal(MillingProgress)
>>> s.sig.emit({"msg": "x", "progress": {"started": True}})
consumer received: dict
```

So the dict reaches the slot unchanged and the first attribute access raises — inside a queued Qt slot, which on PyQt5 is `qFatal`: the process aborts with nothing written to the logfile (FIB-329). The sibling workflow-update signal killed the app exactly that way on every queue action.

**The asymmetry is the argument.** A payload that decodes to a bare `STAGE_UPDATE` is a progress bar that does not move; a raise is a dead application that takes the milling run with it. The three consumers therefore take `payload: object` and decode at the boundary, and the decode is total by construction — every branch returns, nothing indexes, and no coercion can raise on any input.

This also fixes a shape that rendered nowhere: a delegating strategy's report carries no `state`, so it matched no branch in any of the three consumers and its message — the customisable text that is the whole reason this signal keeps a `message` field — was dropped on the floor. It decodes as an update now, and the words reach the screen.

> **Stacked, so no CI here.** Substitute verification below.

## A cancelled or failed milling task no longer reports as finished

This is a live bug, worth fixing on its own merits even if none of the rest happened. Both `except` blocks in `MillingTask.run()` logged and fell through to a `finally` that emitted `finished` regardless:

```python
except OperationCancelledError as e:
    logging.info(f"Milling task '{self.name}' cancelled by user: {e}")
except Exception as e:
    logging.error(e)
finally:
    self._handle_progress({... "state": "finished" ...})
```

So a mill the user stopped and a mill that crashed **both told the UI they had completed** — the status bar rendered "Done" either way, and the exception text reached only the logfile. `run()` now carries the outcome into the `finally` and emits `TASK_CANCELLED` or `TASK_FAILED`, with the exception's text on `error`.

The outcome is **seeded** to `TASK_FAILED` rather than left unset, because `except Exception` does not catch everything: a `KeyboardInterrupt` unwinds straight through to the `finally`, and reporting that as a completed mill is the same defect again.

## The relay earns its keep instead of being deleted

`_handle_progress` was a pass-through — it emitted whatever it was handed, handled nothing, and described the traffic backwards (the updates go *to* the microscope's signal, not from it). Deleting it outright would have been wrong: its two callers each repeated the task identity by hand. `_emit(status, **fields)` stamps `task_id`/`task_name` in one place, and the guard added in [#601](https://github.com/fibsem-os/fibsem-os/pull/601) follows it — which is what makes the indirection safe rather than a blind spot.

The task also emits `TASK_STARTED` before the first stage and `STAGE_FINISHED` after each one. `TASK_STARTED` is the reset boundary the sticky message needs, so a label cannot bleed from one task into the next.

## MillingWidget stops polling the instrument to answer a button click

Pause/Resume called `get_milling_state()`, which on ThermoFisher **sets the active view** as a side effect — so clicking it during a coincidence mill competed for the view with the fluorescence acquisition the strategy is running. Every producer carries the state on the report now, so the widget already has it.

(The issue placed this poll in the progress path; it is actually in `pause_resume_milling`. The fix is the same and the reason is the same — a UI event reading the microscope.)

## Tests

**31 new**, and the consumer tests converted:

- the three outcomes and their `error` text — including that a cancel is **not** painted as a failure
- exactly one terminal report per run, and it is the last thing the task says
- a stage starting is not the task starting (1 `TASK_STARTED` vs N `STAGE_STARTED`)
- each stage reports its own 0-based index, with `display_stage` one higher
- every report carries the task identity — what `_emit` buys over the relay
- the relay is gone

The consumer tests drop their dict fixtures for typed reports, and the malformed-payload cases become **degenerate but well-typed** ones — a zero divisor, a count with no total, an outcome carrying stage fields. That is the risk that actually survives typing the payload.

A separate class covers the producers this repo does not own: each of the three widgets renders an older nested payload, and none of them raises on a malformed one — not a bad dict, not `None`, not a bare string. **Checked by mutation, not by a green run**: removing the decode from a single consumer fails eight of them.

## Verification

- `tests/milling/ tests/autolamella/ tests/test_import_cycles.py tests/test_microscope.py tests/test_structures.py tests/test_milling_time_estimates.py` → **853 passed**. `tests/ui/` → **2339 passed, 1 skipped**.
- `odemis_microscope.py` **cannot be imported here** — the `odemis` package is not installed, on `main` as well as on this branch. Checked statically instead: the import is module-level (not nested in a `try`), lands before the `from odemis import ...` that needs the SDK, the name is used after it is bound, and the file compiles.
- **Grepped for survivors** after the suite went green: no `Signal(dict)`, no `_handle_progress`, no `"state": "start"/"update"/"finished"` anywhere outside a comment.
- **Python 3.8** AST scan — clean. `ruff check` and `ruff format --check` pass on all 10 changed files.

### One thing to know before you run `tests/ui` yourself

`pytest tests/ui/` prints `2328 passed in 189s` and then takes **~510s of wall clock** — a ~320s hang in interpreter shutdown, after the last test. It is **pre-existing**: the parent branch shows the same split. I lost time twice reading it as a regression from the branch under test. Read pytest's own summary line, which prints before the hang, rather than waiting on the process.
