### PR TITLE
[docs] Catch the changelog up with the sixteen commits since it was written

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,6 +83,8 @@ correctness work landed in correlation and in what the experiment record remembe
 - A marked position is boxed with the field of view it stands for.
 - Cancelled overviews no longer report "Done"; one overview can no longer drive the
   stage while the other acquires; stitching and saving now say so.
+- A tab-page key no longer shadows the imaging modality carried on the progress payload,
+  which had let one tab's updates be read as the other's.
 
 ### Image display
 
@@ -95,6 +97,8 @@ through that migration; napari is still a dependency.
 - On a migrated surface: contrast is built into the canvas, modified-scroll no longer
   zooms, and zoom/pan persist across image updates at the same resolution.
 - Images are reduced for display by averaging rather than sampling.
+- The standalone application's minimap moved onto the Overview canvas too, so the two
+  applications no longer show different overview implementations.
 - **The old napari overview is off by default, and is removed in the next release.**
   The Overview tab replaces it. If you still need the old one for something, turn it back
   on under **Edit → Preferences… → Features**; this is the last release in which that is
@@ -137,6 +141,15 @@ through that migration; napari is still a dependency.
   process — see `RELEASE.md`.
 - The running git revision is reported in the version string.
 - CI runs on Windows as well as Linux, across Python 3.8–3.13.
+- **`tests/ui/` now actually runs in CI.** Every file there opens with
+  `pytest.importorskip("PyQt5")`, and the matrix job installs `.[test]` without it, so all
+  103 files skipped silently — a green matrix said nothing about that directory. A separate
+  job installs `.[test,ui]` and fails loudly if the extra did not resolve.
+- Progress signals for tiled acquisition, fluorescence acquisition and spot burn carry a
+  typed payload rather than a bare dict, so a consumer reading a key that is not there
+  fails at the boundary instead of deep inside a handler.
+- The UI tests destroy the top-level widgets they build, instead of leaking them across
+  files.
 - ruff runs on every pull request, formatting the files a PR touches rather than the
   whole tree.
 - `matplotlib_scalebar` became a core dependency; the core stays importable without the


### PR DESCRIPTION
The v0.5.2 entry was written against `main` at 360 commits. `main` is now at 384. Four of the sixteen are user- or developer-visible and were missing:

- the standalone application's minimap moved onto the Overview canvas (#582), so both applications now show the same overview implementation
- a tab-page key was shadowing the imaging modality carried on the progress payload (#581), which let one tab's updates be read as the other's
- `tests/ui/` now actually runs in CI (#584)
- progress signals for tiled acquisition, fluorescence and spot burn carry a typed payload instead of a bare dict (FIB-401, FIB-402, FIB-824)

The rest are formatting passes and test hygiene, which do not belong in a changelog.

## Why the `tests/ui` line earns its space

Every file there opens with `pytest.importorskip("PyQt5")`, and the matrix job installs `.[test]` without it — so all 103 files skipped silently and a green matrix said nothing whatsoever about that directory. Anyone reading this changelog to decide how much to trust the release should know that changed during the release.

## First commit using the `Release-Note:` trailer

Per #579. Verified it parses:

```console
$ git log -1 --format='%(trailers:key=Release-Note,valueonly)'
The Overview canvas now backs the standalone application's minimap as well, so both applications show the same overview.
```

**Note for whoever merges this:** the trailer must be the last paragraph of the *squash commit*, which takes this PR body verbatim. So this section stays last.

Release-Note: The Overview canvas now backs the standalone application's minimap as well, so both applications show the same overview.
