### PR TITLE
[ui] The holder overlays ship off, so a system without a holder is not drawn one

### DIFF
--- a/fibsem/ui/widgets/canvas/overlays/stage_context.py
+++ b/fibsem/ui/widgets/canvas/overlays/stage_context.py
@@ -44,10 +44,20 @@ OVERLAY_SLOTS = "slots"
 
 # Label and default for each, so the two tabs cannot offer the same switch under
 # different words.
+#
+# Grid boundaries and holder slots default **off**. Both describe a cryo sample holder --
+# where its grids sit, and where its slots are -- so on a system without one they draw a
+# holder that is not there, over an overview of a sample that is. Travel limits stay on:
+# they are a property of the stage itself, and true on every system.
+#
+# Off for everyone rather than gated on the stage type, which is the narrower change: the
+# switch is one click away in the overlays popover, and a default that read the hardware
+# would have to be resolved per-microscope at construction rather than being the module
+# constant both tabs share.
 CONTEXT_OVERLAY_ENTRIES = (
     (OVERLAY_LIMITS, "Stage travel limits", True),
-    (OVERLAY_BOUNDARIES, "Grid boundaries", True),
-    (OVERLAY_SLOTS, "Holder slots", True),
+    (OVERLAY_BOUNDARIES, "Grid boundaries", False),
+    (OVERLAY_SLOTS, "Holder slots", False),
 )
 
 __all__ = [

--- a/fibsem/ui/widgets/canvas/overlays/stage_context.py
+++ b/fibsem/ui/widgets/canvas/overlays/stage_context.py
@@ -152,8 +152,12 @@ def slot_landmark(microscope, slot: object) -> Optional[FibsemStagePosition]:
         logger.debug(f"Could not resolve the holder's reference orientation: {e}")
         return None
     return FibsemStagePosition(
-        name=position.name or "", x=position.x, y=position.y,
-        z=position.z or 0.0, r=pose.r, t=pose.t,
+        name=position.name or "",
+        x=position.x,
+        y=position.y,
+        z=position.z or 0.0,
+        r=pose.r,
+        t=pose.t,
     )
 
 
@@ -186,8 +190,15 @@ def limit_shapes(microscope, frame: StageFrame) -> List[ShapeSpec]:
         logger.debug(f"Could not draw the stage limits: {e}")
         return []
     return [
-        ShapeSpec(kind="rect", cx=box_cx, cy=box_cy, width=width, height=height,
-                  color=STAGE_LIMITS_COLOUR, label="Stage Limits"),
+        ShapeSpec(
+            kind="rect",
+            cx=box_cx,
+            cy=box_cy,
+            width=width,
+            height=height,
+            color=STAGE_LIMITS_COLOUR,
+            label="Stage Limits",
+        ),
     ]
 
 
@@ -221,9 +232,17 @@ def boundary_shapes(microscope, frame: StageFrame) -> List[ShapeSpec]:
         except Exception as e:
             logger.debug(f"Could not draw a grid boundary: {e}")
             continue
-        specs.append(ShapeSpec(kind="ellipse", cx=cx, cy=cy,
-                               width=2 * span_x, height=2 * span_y,
-                               color=GRID_BOUNDARY_COLOUR, label="Grid Boundary"))
+        specs.append(
+            ShapeSpec(
+                kind="ellipse",
+                cx=cx,
+                cy=cy,
+                width=2 * span_x,
+                height=2 * span_y,
+                color=GRID_BOUNDARY_COLOUR,
+                label="Grid Boundary",
+            )
+        )
     return specs
 
 
@@ -243,8 +262,15 @@ def slot_shapes(microscope, frame: StageFrame) -> List[ShapeSpec]:
         except Exception as e:
             logger.debug(f"Could not draw a holder slot: {e}")
             continue
-        specs.append(ShapeSpec(kind="crosshair", cx=cx, cy=cy,
-                               color=SLOT_COLOUR, label=place.name or ""))
+        specs.append(
+            ShapeSpec(
+                kind="crosshair",
+                cx=cx,
+                cy=cy,
+                color=SLOT_COLOUR,
+                label=place.name or "",
+            )
+        )
     return specs
 
 

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -1231,6 +1231,18 @@ def test_the_grid_keeps_its_scale_under_a_decimated_preview(qapp, overview_widge
     assert after[3] == pytest.approx(before[3])
 
 
+def _show_holder_overlays(widget):
+    """Turn the holder overlays on, and redraw.
+
+    Grid boundaries and holder slots default *off*: both describe a cryo sample holder,
+    so on a system without one they draw a holder that is not there. Tests about what
+    those shapes look like have to ask for them.
+    """
+    widget.overlay_controls.set_visible("boundaries", True)
+    widget.overlay_controls.set_visible("slots", True)
+    widget._refresh_stage_metadata()
+
+
 def test_the_stage_and_grid_limits_are_drawn_in_the_canvas_frame(qapp, overview_widget):
     """Same context the minimap gives, without its indirection: on a real-space canvas
     stage coordinates map straight to canvas coordinates, so there is no stitched image
@@ -1239,6 +1251,7 @@ def test_the_stage_and_grid_limits_are_drawn_in_the_canvas_frame(qapp, overview_
     image = widget.microscope.fm.acquire_image(ChannelSettings(name="Channel-01"))
     widget.set_image(image)
     qapp.processEvents()
+    _show_holder_overlays(widget)
 
     by_label = {s.label: s for s in widget.stage_overlay._specs}
     reference = widget.canvas.canvas.reference_pixel_size
@@ -1276,7 +1289,7 @@ def test_stage_metadata_does_not_wait_for_an_image(qapp, overview_widget):
     widget._records.clear()
     widget._origin = None
 
-    widget._refresh_stage_metadata()
+    _show_holder_overlays(widget)
 
     labels = [spec.label for spec in widget.stage_overlay._specs]
     assert "Stage Limits" in labels

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -120,6 +120,18 @@ def widget(microscope):
     w.close()
 
 
+def _show_holder_overlays(widget):
+    """Turn the holder overlays on, and redraw.
+
+    Grid boundaries and holder slots default *off*: both describe a cryo sample holder,
+    so on a system without one they draw a holder that is not there. Tests about what
+    those shapes look like have to ask for them.
+    """
+    widget.overlay_controls.set_visible("boundaries", True)
+    widget.overlay_controls.set_visible("slots", True)
+    widget._refresh_context_overlays()
+
+
 def _beam_report(status, **fields):
     """A beam report, the shape `imaging.tiled` emits."""
     from fibsem.imaging.tiling.progress import MODALITY_BEAM, TiledProgress
@@ -606,6 +618,7 @@ class TestWhatIsDrawn:
     ):
         base = microscope.get_stage_position()
         widget.place_image(_tile(microscope, _at(base)))
+        _show_holder_overlays(widget)
         labels = {spec.label for spec in widget.context_overlay._specs}
         # The limits and the holder slots are configuration-dependent; on a compustage
         # system all of these are present, and this fixture is one.
@@ -1362,6 +1375,7 @@ class TestTheCanvasDrawsBeforeAnythingIsAcquired:
     def test_it_draws_the_context_with_nothing_placed(self, widget):
         """The whole point. Every one of these used to wait for the first tile."""
         assert not widget.canvas.placed_keys, "this test is about the empty canvas"
+        _show_holder_overlays(widget)
         drawn = {spec.label for spec in widget.context_overlay._specs}
         assert "Stage Limits" in drawn
         assert "Grid Boundary" in drawn
@@ -1472,6 +1486,7 @@ class TestOverlaysAreDrawnInTheView:
     def _show(self, widget, view):
         """Put the canvas in *view* and return its frame."""
         widget.set_image(self._image(widget.microscope, *view))
+        _show_holder_overlays(widget)
         return widget._frame()
 
     @staticmethod
@@ -1642,7 +1657,7 @@ class TestTheHolderIsDrawnOnEveryStage:
             "Slot-02": self._slot("Slot-02", 5.0e-3),
         }
         monkeypatch.setattr(holder, "slots", slots)
-        widget._refresh_context_overlays()
+        _show_holder_overlays(widget)
         return slots
 
     @staticmethod
@@ -1727,6 +1742,7 @@ class TestTheHolderIsDrawnOnEveryStage:
     def test_a_single_centred_slot_still_draws_the_one_circle(self, widget):
         """The compustage case, unchanged: one slot at the origin, one circle on it.
         The simulator's own holder, so this is the behaviour that shipped."""
+        _show_holder_overlays(widget)
         boundaries = self._specs(widget, "ellipse", "Grid Boundary")
         crosshairs = [
             s for s in self._specs(widget, "crosshair") if s.label.startswith("Slot-")
@@ -3882,8 +3898,26 @@ class TestTheOverlaysCanBeTurnedOff:
         widget.context_overlay.set_shapes = real
         return seen.get("n", 0)
 
+    def test_the_holder_overlays_ship_off_and_the_travel_box_ships_on(self, widget):
+        """Grid boundaries and holder slots describe a cryo sample holder, so on a system
+        without one they draw a holder that is not there, over an overview of a sample
+        that is. Travel limits stay on: they are a property of the stage itself.
+
+        Asserted rather than left to the module constant, because the default is the
+        whole of what these switches do for anyone who never opens the popover.
+        """
+        assert widget.overlay_controls.is_visible("limits")
+        assert not widget.overlay_controls.is_visible("boundaries")
+        assert not widget.overlay_controls.is_visible("slots")
+
+        drawn = {spec.label for spec in widget.context_overlay._specs}
+        assert "Stage Limits" in drawn
+        assert "Grid Boundary" not in drawn
+
     @pytest.mark.parametrize("key", ["limits", "boundaries", "slots"])
     def test_turning_one_off_stops_it_being_drawn(self, widget, key):
+        # Two of the three ship off, so "turning it off" starts by turning it on.
+        widget.overlay_controls.set_visible(key, True)
         before = self._context_shapes(widget)
 
         widget.overlay_controls.set_visible(key, False)


### PR DESCRIPTION
From GUI testing ahead of v0.5.2.

Grid boundaries and holder slot markers now default **off** in both overview tabs. Both shapes describe a cryo sample holder — where its grids sit, and where its slots are — so on a system without one they draw a holder that is not there, on top of an overview of a sample that is.

**Stage travel limits stay on.** They are a property of the stage itself and true on every system, which is the distinction FIB-698 drew when it stopped one guard answering both questions.

## Off for everyone, rather than gated on the stage type

This is the narrower of the two possible changes, and worth flagging because the request was "unless the stage is compustage".

`CONTEXT_OVERLAY_ENTRIES` is a module constant both tabs read at construction. A default that varied with the hardware would have to be resolved per-microscope instead, and both tabs would need to agree on how. The switch is one click away in the overlays popover either way — so this trades "a compustage user ticks two boxes" against "every other system is drawn a holder it does not have".

Say the word if you want the hardware-dependent version; it is a bigger change than this one and I did not want it in a pre-release.

## Two commits

`cf94bbbd` is **format only**. `stage_context.py` carried about forty lines of pre-existing reformat, and the lint job checks formatting on every file a PR touches — so separating it keeps the review of the actual change from being argument wrapping. Verified AST-identical before and after.

`7a59a4ee` is the change: two words in a tuple, a comment saying why, and the tests.

## Tests

Eight tests asserted these shapes are drawn and relied on them being on. They now ask for them, through one helper per file that explains why they have to — which reads better regardless: a test about what the grid boundary *looks like* should not depend on it happening to be enabled.

The default itself is now asserted. It is the whole of what these switches do for anyone who never opens the popover, which is most people.

Full `tests/ui/` passes locally the way CI runs it — 2281 passed, 1 skipped.

Release-Note: The Overview tab no longer draws grid boundaries or holder slot markers by default. Turn them back on under the overlays button on the canvas.
