### PR TITLE
[test] The revision test has to survive being run on a tag

### DIFF
--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -479,7 +479,9 @@ def test_failure_is_logged_quietly(monkeypatch, caplog):
 @pytest.mark.parametrize(
     "describe",
     [
-        pytest.param(lambda: (_ for _ in ()).throw(RuntimeError("kaboom")), id="raises"),
+        pytest.param(
+            lambda: (_ for _ in ()).throw(RuntimeError("kaboom")), id="raises"
+        ),
         pytest.param(lambda: None, id="none"),
         pytest.param(lambda: "v0.5.1-48-g4cd11d9c", id="value"),
     ],

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -105,17 +105,52 @@ def test_revision_and_branch_from_real_checkout(monkeypatch):
 
     revision = get_revision()
     assert revision is not None
-    assert DESCRIBE_RE.match(revision), revision
 
-    # Cross-check against git itself rather than hardcoding a sha.
-    head = subprocess.run(
-        ["git", "rev-parse", "--short", "HEAD"],
+    # Cross-check against git itself rather than hardcoding a sha. This is the whole
+    # contract -- `get_revision` is `git describe` and nothing else -- and it holds
+    # wherever HEAD is, which the shape assertions below do not.
+    described = subprocess.run(
+        ["git", "describe", "--tags", "--always", "--dirty", "--match", "v*"],
         cwd=str(REPO_ROOT),
         capture_output=True,
         encoding="utf-8",
         errors="replace",
     ).stdout.strip()
-    assert head in revision
+    assert revision == described
+
+    # `git describe` returns a *bare tag name* when HEAD sits exactly on a tag, and
+    # <tag>-<n>-g<sha> otherwise. Every release commit is the first case, so asserting
+    # the second shape unconditionally made this test fail on precisely the commits a
+    # release is cut from -- it blocked v0.5.2rc1, in the publish workflow, after the
+    # version check had passed.
+    #
+    # Only the described form carries a sha, so only it can be checked against HEAD.
+    if DESCRIBE_RE.match(revision):
+        head = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+        ).stdout.strip()
+        assert head in revision
+    else:
+        # On a tag, the tag itself is the identifier, and it must be one git agrees
+        # points at HEAD rather than any string that failed the pattern.
+        tags = subprocess.run(
+            ["git", "tag", "--points-at", "HEAD"],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            encoding="utf-8",
+            errors="replace",
+        ).stdout.split()
+        # Not str.removesuffix: that is 3.9+, and CI builds 3.8 (#553 fixed the same
+        # thing in fibsem/ itself).
+        suffix = "-dirty"
+        name = revision[: -len(suffix)] if revision.endswith(suffix) else revision
+        assert name in tags, (
+            f"{revision} is neither a describe with a sha nor a tag on HEAD"
+        )
 
     # Branch is None on a detached HEAD, which is legitimate; when present it
     # must not be the literal "HEAD" that `rev-parse --abbrev-ref` would give.


### PR DESCRIPTION
**This blocked `v0.5.2rc1` about fifteen minutes ago.** The publish workflow got past `check-version` and failed in `test`:

```
>       assert DESCRIBE_RE.match(revision), revision
E       AssertionError: v0.5.2rc1
E        +  where None = re.compile('^(.+-g)?[0-9a-f]{7,40}(-dirty)?$').match('v0.5.2rc1')
tests/test_versioning.py:108
```

**Nothing was uploaded.** `publish` and `github-release` are gated on the tests, so both skipped and `0.5.2rc1` is still free on PyPI. The failure cost the tag, not the version.

## The bug

`git describe` returns a **bare tag name** when HEAD sits exactly on a tag, and `<tag>-<n>-g<sha>` everywhere else. The test asserted the second shape unconditionally — so it failed on precisely the commits a release is cut from, and there is no other kind of commit a release is cut from.

This is the first release since `versioning.py` landed (#202, #350), which is why it has not bitten before. It would have bitten every release from here.

Two assertions had to move, not one: the shape regex, and `head in revision`, which looks for a sha that a bare tag does not contain.

## The fix

The cross-check is now against `git describe` itself, with the same arguments the module uses. That holds wherever HEAD is, and is a stronger statement than either shape assertion — `get_revision` is `git describe` and nothing else.

The shape check becomes a discriminator rather than an assertion: with a sha, check the sha; on a tag, check that git agrees the tag points at HEAD, so a string that merely failed the pattern cannot pass instead.

## Verified in both states

Run from a checkout sitting on `v0.5.2rc1`, it takes the tag branch and passes — including the `-dirty` variant, since the working tree was dirty at the time. Run from an ordinary commit it takes the sha branch, as before. 25 passed either way.

Not `str.removesuffix` for the `-dirty` suffix: 3.9+, and CI builds 3.8 — the same trap #553 fixed in `fibsem/` itself.
