### PR TITLE
bump version to 0.5.2.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fibsem"
-version = "0.5.2rc1"
+version = "0.5.2.dev0"
 
 description = "a universal api for fibsem control"
 authors = [{ name = "Patrick Cleeve", email = "patrick@openfibsem.org" }]


### PR DESCRIPTION
Step 5 of *Cutting a release candidate*. `v0.5.2rc1` is [on PyPI](https://pypi.org/project/fibsem/0.5.2rc1/), so `main` must stop claiming that version.

`.devN` is the marker for "between releases": never tagged, never published, and the publish workflow rejects a tag that resolves to one — which is the check that stops `main`'s current state being taggable by accident.

Not incremented beyond `.dev0`, deliberately: `fibsem_revision` already identifies the exact commit, which is finer than any hand-bumped dev number.

The `release/v0.5.2` branch is cut from the tag at `b4a8f6ae`, so fixes for the final go there by cherry-pick and do not depend on `main`'s version string.