### PR TITLE
[ci] Run the tests on release branches, not only on main

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,10 +4,15 @@
 name: Python package
 
 on:
+  # `release/**` alongside main: a release branch is cut from a release tag and the
+  # final is tagged from it, so what lands there by cherry-pick is what ships -- and
+  # without this it would be the one code path in the repository that reaches users
+  # having run no tests at all. Nothing else is branch-scoped here, so this is the
+  # whole of what has to change.
   push:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "release/**" ]
 
 jobs:
   build:


### PR DESCRIPTION
A release branch is cut from a release tag, fixes are cherry-picked onto it, and the final release is tagged from it. With the filters scoped to `main`, **none of that runs a single check** — so the branch every user's release is cut from would be the one code path in the repository that reaches them having been tested nowhere.

Not hypothetical any more: `release/v0.5.2` exists as of tonight, cut from `v0.5.2rc1` at `b4a8f6ae`, and the final `v0.5.2` will be tagged from whatever gets cherry-picked onto it.

## Tonight showed the failure mode is real

The publish workflow's tests caught a bug `main`'s CI could not, because it only appears when the checkout sits **on a tag**: `git describe` returns a bare tag name there, and the revision test asserted a shape that always carries a sha (#606). It blocked `v0.5.2rc1` after `check-version` had already passed.

That was caught because the publish workflow runs tests. A cherry-pick onto an untested release branch has no equivalent backstop until the tag is already pushed — at which point the version is spent.

## Scope

Only the two branch filters change:

```yaml
  push:
    branches: [ "main", "release/**" ]
  pull_request:
    branches: [ "main", "release/**" ]
```

Nothing else in the workflow is branch-scoped. `publish.yml` triggers on tags rather than branches, so it already fires from a release branch — this closes the gap on the other side.

Validated the YAML parses and both filters resolve as intended, and that all three jobs are still present.
