### PR TITLE
Replace the orientation-conversion pair table with one rule (FIB-829)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1504,16 +1504,30 @@ class FibsemMicroscope(ABC):
         # 180deg rotation"). It is a half turn or nothing. Firing it for a few degrees
         # of slop would throw the sample to the far side of the grid.
         #
-        # So the assumption this rests on, stated so it is noticed if it ever stops
-        # holding: **every rotation between named orientations is a half turn.** True of
-        # every system today -- SEM and MILLING share `rotation_reference`, FIB sits at
-        # `rotation_180` -- and nothing here would detect an orientation added at, say,
-        # 90 degrees. It would quietly get the 180 degree correction.
-        rotation_changes = not np.isclose(
-            self.get_orientation(currrent_orientation).r % (2 * np.pi),
-            orientation.r % (2 * np.pi),
+        # So the test below asks whether the rotation **is a half turn**, not whether it
+        # changed at all. That is what the correction can express, and it makes the
+        # assumption safe rather than merely documented: every rotation between named
+        # orientations is a half turn today -- SEM and MILLING share
+        # `rotation_reference`, FIB sits at `rotation_180` -- and an orientation ever
+        # added at, say, 90 degrees gets **no** correction instead of the wrong one.
+        # Wrong by the offset beats wrong by the whole grid.
+        #
+        # Measured with `angle_difference`, which is wrap-aware -- a stage rotates
+        # continuously, so the same rotation is written many ways (270 and -90, 180 and
+        # -180, 360 and 0), and plain modulo breaks either side of zero. It is also what
+        # `get_stage_orientation` uses to decide which orientation a position is *at*,
+        # and this rule is keyed on that classifier's answer, so the two share one
+        # definition rather than agreeing by coincidence. Same 5 degree tolerance, for
+        # the same reason.
+        from fibsem import movement
+
+        rotation = movement.angle_difference(
+            self.get_orientation(currrent_orientation).r, orientation.r
         )
-        if rotation_changes:
+        rotation_is_half_turn = movement.rotation_angle_is_smaller(
+            rotation, np.pi, atol=5
+        )
+        if rotation_is_half_turn:
             stage_position = self._get_compucentric_rotation_position(stage_position)
 
         stage_position.r = orientation.r

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1462,51 +1462,64 @@ class FibsemMicroscope(ABC):
         if currrent_orientation == "NONE":
             raise ValueError("Unknown orientation. Cannot convert stage position.")
 
+        # The FM is an orientation only where the objective is under the grid. On an
+        # offset mount it is a *place*, reached by translating rather than re-posing,
+        # and `orientations["FM"]` there is a copy of the FIB entry carrying no
+        # positional term -- so converting into it would return a position under the
+        # beam wearing the FM's rotation and tilt. Refused until the device axis
+        # exists (FIB-830).
+        if "FM" in (currrent_orientation, target_orientation) and (
+            not self.stage_is_compustage
+        ):
+            raise ValueError("Cannot move to FM position on non-compustage systems.")
+
         stage_position = deepcopy(stage_position)
         orientation = self.get_orientation(target_orientation)
 
-        if currrent_orientation in ["SEM", "MILLING"] and target_orientation == "FIB":
-            # Convert from SEM/MILLING to FIB
-            target_position = self._get_compucentric_rotation_position(stage_position)
-            target_position.r = orientation.r
-            target_position.t = orientation.t
+        # One rule, in place of a branch per ordered pair.
+        #
+        # Re-posing between orientations is always a rewrite of r and t. What decides
+        # whether x and y move with it is whether the *rotation* changes: turning the
+        # sample half way round swings it about the compucentric centre, which is
+        # somewhere else entirely, so the coordinates have to be carried around with
+        # it. A change of tilt alone pivots about an axis through the sample and
+        # leaves x/y where they were.
+        #
+        # That is why SEM <-> MILLING needs no positional term -- both sit at
+        # `rotation_reference` -- while anything crossing to or from FIB, which sits at
+        # `rotation_180`, does.
+        #
+        # A compustage takes the same path and gets the same answer for free:
+        # `_get_compucentric_rotation_position` returns its argument untouched there
+        # (it has no rotation axis to be compucentric about), so no stage-type branch
+        # is needed here to say so.
+        #
+        # Read from the *orientations*, not from `stage_position.r`, and the difference
+        # matters. `get_stage_orientation` classifies within a 5 degree tolerance, so a
+        # position that reads as SEM is usually a fraction off the canonical rotation --
+        # a real stage never sits at exactly 0.000. Comparing the position's own r would
+        # then call a 4 degree discrepancy a "rotation change" and apply the correction
+        # below, which is not a small correction: `_get_compucentric_rotation_position`
+        # computes `p -> -p - 2 * offset` and says so in its own docstring ("Assumes
+        # 180deg rotation"). It is a half turn or nothing. Firing it for a few degrees
+        # of slop would throw the sample to the far side of the grid.
+        #
+        # So the assumption this rests on, stated so it is noticed if it ever stops
+        # holding: **every rotation between named orientations is a half turn.** True of
+        # every system today -- SEM and MILLING share `rotation_reference`, FIB sits at
+        # `rotation_180` -- and nothing here would detect an orientation added at, say,
+        # 90 degrees. It would quietly get the 180 degree correction.
+        rotation_changes = not np.isclose(
+            self.get_orientation(currrent_orientation).r % (2 * np.pi),
+            orientation.r % (2 * np.pi),
+        )
+        if rotation_changes:
+            stage_position = self._get_compucentric_rotation_position(stage_position)
 
-        elif currrent_orientation == "FIB" and target_orientation in ["SEM", "MILLING"]:
-            # Convert from FIB to SEM/MILLING
-            target_position = self._get_compucentric_rotation_position(stage_position)
-            target_position.r = orientation.r
-            target_position.t = orientation.t
-        elif currrent_orientation == "SEM" and target_orientation == "MILLING":
-            # Convert from SEM to MILLING
-            target_position = stage_position
-            target_position.r = orientation.r
-            target_position.t = orientation.t
-        elif currrent_orientation == "MILLING" and target_orientation == "SEM":
-            # Convert from MILLING to SEM
-            target_position = stage_position
-            target_position.r = orientation.r
-            target_position.t = orientation.t
-        elif (
-            currrent_orientation in ["SEM", "FIB", "MILLING"]
-            and target_orientation == "FM"
-        ) or (
-            currrent_orientation == "FM"
-            and target_orientation in ["SEM", "FIB", "MILLING"]
-        ):
-            if not self.stage_is_compustage:
-                raise ValueError(
-                    "Cannot move to FM position on non-compustage systems."
-                )
-            # Convert from FIB to FM
-            target_position = stage_position
-            target_position.r = orientation.r
-            target_position.t = orientation.t
-        else:
-            raise ValueError(
-                f"Cannot convert from {currrent_orientation} to {target_orientation}"
-            )
+        stage_position.r = orientation.r
+        stage_position.t = orientation.t
 
-        return target_position
+        return stage_position
 
     def get_stage_orientation(
         self, stage_position: Optional[FibsemStagePosition] = None

--- a/tests/test_orientation_transform_parity.py
+++ b/tests/test_orientation_transform_parity.py
@@ -1,0 +1,301 @@
+"""Pins `get_target_position` before it is refactored (FIB-829).
+
+`get_target_position` converts a stage position from one named orientation to another.
+It is six hand-written branches over ``(from, to)``, and the plan is to replace that
+table with composable per-leg transforms so a *device* translation can be added as one
+more leg rather than edited into every branch.
+
+Nothing about the behaviour is supposed to change. This file is what says so.
+
+Why it needs writing first
+--------------------------
+The four existing tests in ``test_microscope.py`` cover MILLING <-> FM on a compustage,
+the non-compustage refusal, and the same-orientation no-op. **Every pair that does
+positional work is untested** -- SEM/MILLING <-> FIB apply a compucentric rotation to
+x/y, and nothing currently notices if that stops happening. A refactor of stage-motion
+arithmetic with four tests behind it is not a refactor, it is a rewrite.
+
+How it pins
+-----------
+Two halves, because the behaviour has two independent parts:
+
+* **Which legs move x/y at all** -- the classification table below. Stated as
+  ``PRESERVE`` / ``COMPUCENTRIC`` / ``RAISES`` per (stage, from, to), which is far more
+  legible than twenty-one hardcoded coordinate pairs and says the same thing.
+* **What the compucentric legs actually compute** -- pinned separately, against a
+  *non-zero* rotation offset. The base ``_get_compucentric_rotation_offset`` returns
+  ``(0, 0)``, so on a simulator the transform degenerates to plain negation and a
+  refactor could drop the offset term entirely without any of the table noticing.
+
+Do not fold FIB-655 in here
+---------------------------
+``_get_compucentric_rotation_offset`` is itself under review -- FIB-655 found the two
+compucentric implementations in the tree disagree by 55 um. This file pins *current*
+behaviour on purpose. Changing the offset and re-baselining these expectations in the
+same PR would leave nothing checking the refactor.
+"""
+
+from copy import deepcopy
+
+import numpy as np
+import pytest
+
+from fibsem import utils
+from fibsem.structures import FibsemStagePosition
+
+ORIENTATIONS = ["SEM", "FIB", "MILLING", "FM"]
+
+# A source position with a distinctive, asymmetric x/y so a sign flip or an axis swap
+# cannot hide behind coincidence, and a non-zero z that no branch should touch.
+SOURCE_X = 1.0e-3
+SOURCE_Y = 2.0e-3
+SOURCE_Z = 3.0e-3
+
+# A rotation-centre offset that is non-zero and asymmetric. Only used by the arithmetic
+# test below; the classification table runs against the (0, 0) default so it stays a
+# statement about *which* legs move x/y rather than by how much.
+OFFSET_X = 0.4e-3
+OFFSET_Y = -0.7e-3
+
+PRESERVE = "preserve"  # x/y come through untouched; only r/t are rewritten
+COMPUCENTRIC = "compucentric"  # x/y go through the compucentric rotation
+RAISES = "raises"  # the conversion is refused
+
+# What each (from, to) does today. Read off the implementation and confirmed by running
+# it; see the module docstring for why this is a classification rather than a table of
+# coordinates.
+#
+# The compustage column is entirely PRESERVE because
+# `_get_compucentric_rotation_position` returns its argument unchanged on a compustage
+# ("compustage does not support compucentric rotation"), so even the branches that call
+# it are positionally inert there.
+COMPUSTAGE_BEHAVIOUR = {
+    ("SEM", "FIB"): PRESERVE,
+    ("SEM", "MILLING"): PRESERVE,
+    ("SEM", "FM"): PRESERVE,
+    ("FIB", "SEM"): PRESERVE,
+    ("FIB", "MILLING"): PRESERVE,
+    ("FIB", "FM"): PRESERVE,
+    ("MILLING", "SEM"): PRESERVE,
+    ("MILLING", "FIB"): PRESERVE,
+    ("MILLING", "FM"): PRESERVE,
+    ("FM", "SEM"): PRESERVE,
+    ("FM", "FIB"): PRESERVE,
+    ("FM", "MILLING"): PRESERVE,
+}
+
+# The offset column is where the branches actually differ.
+#
+# Two entries are worth reading twice, and both are consequences of the FM orientation
+# being a verbatim copy of the FIB one on an offset mount (FIB-830):
+#
+#   FM -> FIB   is PRESERVE, not because a branch says so, but because the source
+#               *classifies as FIB* and `get_target_position` returns early on
+#               `current == target`. It hands back the caller's own position.
+#   FM -> SEM   and FM -> MILLING take the FIB branches for the same reason.
+#
+# Pinned as they are rather than as they ought to be. FIB-830 is where they change.
+OFFSET_BEHAVIOUR = {
+    ("SEM", "FIB"): COMPUCENTRIC,
+    ("SEM", "MILLING"): PRESERVE,
+    ("SEM", "FM"): RAISES,
+    ("FIB", "SEM"): COMPUCENTRIC,
+    ("FIB", "MILLING"): COMPUCENTRIC,
+    ("FIB", "FM"): RAISES,
+    ("MILLING", "SEM"): PRESERVE,
+    ("MILLING", "FIB"): COMPUCENTRIC,
+    ("MILLING", "FM"): RAISES,
+    ("FM", "SEM"): COMPUCENTRIC,
+    ("FM", "FIB"): PRESERVE,
+    ("FM", "MILLING"): COMPUCENTRIC,
+}
+
+
+def _microscope(compustage: bool):
+    """A Demo microscope with realistic stage geometry for the given mounting.
+
+    The stage settings are set explicitly rather than loaded from a configuration file,
+    for two reasons. `setup_session` resolves a *user* configuration path, so a test
+    reading one would depend on whichever system the developer last connected to. And
+    the bare `manufacturer="Demo"` defaults are actively misleading here: they leave
+    `rotation_180 = 0`, which puts FIB at (r=0, t=17) and MILLING at (r=0, t=12) -- five
+    degrees apart with the same rotation, so a position built at the FIB orientation
+    classifies as MILLING and **FIB becomes unreachable as a source orientation**. The
+    values below match the shipped configurations.
+    """
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    microscope.stage_is_compustage = compustage
+
+    stage = microscope.system.stage
+    stage.rotation_reference = 0
+    if compustage:
+        # Arctis: no wedge and no rotation; every orientation is reached by tilting.
+        stage.shuttle_pre_tilt = 0
+        stage.rotation_180 = 0
+    else:
+        # Pre-tilted shuttle: 35 degree wedge, and the ion beam is reached by turning
+        # half way round.
+        stage.shuttle_pre_tilt = 35
+        stage.rotation_180 = 180
+
+    microscope._update_orientations()
+    return microscope
+
+
+def _position_at(microscope, orientation: str) -> FibsemStagePosition:
+    """A stage position sitting at the named orientation."""
+    pose = microscope.get_orientation(orientation)
+    return FibsemStagePosition(x=SOURCE_X, y=SOURCE_Y, z=SOURCE_Z, r=pose.r, t=pose.t)
+
+
+@pytest.mark.parametrize(
+    ("compustage", "behaviour"),
+    [(True, COMPUSTAGE_BEHAVIOUR), (False, OFFSET_BEHAVIOUR)],
+    ids=["compustage", "offset"],
+)
+@pytest.mark.parametrize(
+    ("source", "target"),
+    [(f, t) for f in ORIENTATIONS for t in ORIENTATIONS if f != t],
+    ids=[f"{f}_to_{t}" for f in ORIENTATIONS for t in ORIENTATIONS if f != t],
+)
+def test_every_pair_keeps_its_current_behaviour(
+    compustage: bool, behaviour: dict, source: str, target: str
+):
+    """All twelve ordered pairs, on both mountings, do exactly what they do today.
+
+    This is the refactor's contract: every cell here has to come out the same
+    afterwards, and any that does not is a behaviour change that has to be argued for
+    rather than discovered.
+    """
+    microscope = _microscope(compustage)
+    expected = behaviour[(source, target)]
+    position = _position_at(microscope, source)
+
+    if expected is RAISES:
+        with pytest.raises(ValueError):
+            microscope.get_target_position(
+                deepcopy(position), target_orientation=target
+            )
+        return
+
+    result = microscope.get_target_position(
+        deepcopy(position), target_orientation=target
+    )
+
+    # Whatever happens to x/y, the pose is always rewritten to the target's r and t.
+    target_pose = microscope.get_orientation(target)
+    assert np.isclose(result.r, target_pose.r, atol=1e-9)
+    assert np.isclose(result.t, target_pose.t, atol=1e-9)
+
+    # z is never a term in any branch.
+    assert np.isclose(result.z, SOURCE_Z, atol=1e-12)
+
+    if expected is PRESERVE:
+        assert np.isclose(result.x, SOURCE_X, atol=1e-12)
+        assert np.isclose(result.y, SOURCE_Y, atol=1e-12)
+    else:
+        # With the default (0, 0) rotation offset the compucentric transform is a
+        # negation. The offset term is pinned separately, below.
+        assert np.isclose(result.x, -SOURCE_X, atol=1e-12)
+        assert np.isclose(result.y, -SOURCE_Y, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("source", "target"),
+    [pair for pair, kind in OFFSET_BEHAVIOUR.items() if kind is COMPUCENTRIC],
+    ids=[
+        f"{f}_to_{t}"
+        for (f, t), kind in OFFSET_BEHAVIOUR.items()
+        if kind is COMPUCENTRIC
+    ],
+)
+def test_compucentric_legs_carry_the_offset_term(source: str, target: str):
+    """A compucentric leg is ``p -> -p - 2 * offset``, not merely ``p -> -p``.
+
+    The simulator's rotation offset is ``(0, 0)``, so every compucentric leg degenerates
+    to a plain negation and the table above would stay green even if the offset term
+    were dropped entirely. Giving the microscope a real offset is what makes this a test
+    of the arithmetic rather than of the sign.
+    """
+    microscope = _microscope(compustage=False)
+    offset = FibsemStagePosition(x=OFFSET_X, y=OFFSET_Y)
+    microscope._get_compucentric_rotation_offset = lambda: offset
+
+    position = _position_at(microscope, source)
+    result = microscope.get_target_position(
+        deepcopy(position), target_orientation=target
+    )
+
+    assert np.isclose(result.x, -SOURCE_X - 2 * OFFSET_X, atol=1e-12)
+    assert np.isclose(result.y, -SOURCE_Y - 2 * OFFSET_Y, atol=1e-12)
+
+
+def test_a_compucentric_round_trip_returns_to_the_start():
+    """SEM -> FIB -> SEM lands where it started, offset and all.
+
+    A property rather than a pinned value, and the one the composable form has to keep:
+    ``p -> -p - 2 * offset`` is its own inverse for any offset, so a leg and its reverse
+    cancel exactly. Worth stating now because the current pair table cannot be checked
+    this way on a compustage, where both directions are positionally inert.
+    """
+    microscope = _microscope(compustage=False)
+    offset = FibsemStagePosition(x=OFFSET_X, y=OFFSET_Y)
+    microscope._get_compucentric_rotation_offset = lambda: offset
+
+    start = _position_at(microscope, "SEM")
+    at_fib = microscope.get_target_position(deepcopy(start), target_orientation="FIB")
+    back = microscope.get_target_position(deepcopy(at_fib), target_orientation="SEM")
+
+    assert np.isclose(back.x, start.x, atol=1e-12)
+    assert np.isclose(back.y, start.y, atol=1e-12)
+    assert np.isclose(back.r, start.r, atol=1e-9)
+    assert np.isclose(back.t, start.t, atol=1e-9)
+
+
+def test_going_via_a_third_orientation_agrees_with_the_direct_pair():
+    """SEM -> FIB -> MILLING equals SEM -> MILLING.
+
+    The property the refactor is *for*: if every pair is a composition of legs, routing
+    through an intermediate has to give the same answer as the direct conversion. It
+    already holds here, which is worth knowing before rather than after -- it means the
+    composable form has a consistent table to reproduce, not a contradictory one to
+    pick a winner from.
+    """
+    microscope = _microscope(compustage=False)
+    offset = FibsemStagePosition(x=OFFSET_X, y=OFFSET_Y)
+    microscope._get_compucentric_rotation_offset = lambda: offset
+
+    start = _position_at(microscope, "SEM")
+
+    direct = microscope.get_target_position(
+        deepcopy(start), target_orientation="MILLING"
+    )
+    at_fib = microscope.get_target_position(deepcopy(start), target_orientation="FIB")
+    via_fib = microscope.get_target_position(
+        deepcopy(at_fib), target_orientation="MILLING"
+    )
+
+    assert np.isclose(via_fib.x, direct.x, atol=1e-12)
+    assert np.isclose(via_fib.y, direct.y, atol=1e-12)
+    assert np.isclose(via_fib.r, direct.r, atol=1e-9)
+    assert np.isclose(via_fib.t, direct.t, atol=1e-9)
+
+
+@pytest.mark.parametrize("compustage", [True, False], ids=["compustage", "offset"])
+def test_converting_to_the_orientation_it_is_already_at_returns_the_same_object(
+    compustage: bool,
+):
+    """The early return hands back the caller's own position, not a copy.
+
+    ``if current == target: return stage_position`` sits above the ``deepcopy``, so a
+    caller that mutates the result mutates its own input. Pinned because it is a real
+    aliasing hazard the refactor should fix *deliberately* -- if this test starts
+    failing because a copy is returned, that is an improvement, and the failure is how
+    it gets noticed rather than shipped by accident.
+    """
+    microscope = _microscope(compustage)
+    position = _position_at(microscope, "SEM")
+
+    result = microscope.get_target_position(position, target_orientation="SEM")
+
+    assert result is position

--- a/tests/test_orientation_transform_parity.py
+++ b/tests/test_orientation_transform_parity.py
@@ -299,3 +299,67 @@ def test_converting_to_the_orientation_it_is_already_at_returns_the_same_object(
     result = microscope.get_target_position(position, target_orientation="SEM")
 
     assert result is position
+
+
+# ── how much rotation, not whether any ───────────────────────────────
+
+# (source rotation, target rotation, does the compucentric correction apply)
+#
+# The correction is `p -> -p - 2 * offset` -- a half turn or nothing -- so it applies
+# when the rotation *is* a half turn, however that half turn happens to be written.
+ROTATION_CASES = [
+    (0, 180, True, "half_turn"),
+    (0, -180, True, "half_turn_written_negative"),
+    (-90, 90, True, "half_turn_across_zero"),
+    (270, 90, True, "half_turn_from_a_wound_on_rotation"),
+    (-90, 270, False, "same_rotation_written_two_ways"),
+    (0, 360, False, "same_rotation_a_full_turn_apart"),
+    (0, 0, False, "no_rotation"),
+    (0, -0.0001, False, "a_hair_either_side_of_zero"),
+    (359.9999, 0, False, "a_hair_either_side_of_zero_the_other_way"),
+    (0, 90, False, "a_quarter_turn_is_not_a_half_turn"),
+]
+
+
+@pytest.mark.parametrize(
+    ("reference_deg", "fib_deg", "expect_compucentric", "label"),
+    ROTATION_CASES,
+    ids=[case[3] for case in ROTATION_CASES],
+)
+def test_the_correction_applies_to_half_turns_however_they_are_written(
+    reference_deg: float, fib_deg: float, expect_compucentric: bool, label: str
+):
+    """A stage rotates continuously, so one rotation has many spellings.
+
+    Three groups here, and the middle and last are the ones worth having.
+
+    **Equivalent rotations** -- 270 and -90, 0 and 360 -- are one rotation and must not
+    be read as two. Plain modulo gets those right but breaks either side of zero:
+    -0.0001 degrees becomes 359.9999, which compares nowhere near 0.
+
+    **A quarter turn gets nothing.** The correction cannot represent it, so applying it
+    would be wrong by the whole grid rather than by the offset. No shipped configuration
+    has an orientation at 90 degrees; this pins what happens if one is ever added.
+
+    None of these are reachable from a shipped configuration, where every value is a
+    whole number of degrees and every pair is 0 or 180 apart. Pinned because
+    "unreachable given the data we happen to ship" is not the same as correct, and this
+    is a stage-motion path.
+    """
+    microscope = _microscope(compustage=False)
+    stage = microscope.system.stage
+    stage.rotation_reference = reference_deg
+    stage.rotation_180 = fib_deg
+    microscope._update_orientations()
+
+    position = _position_at(microscope, "SEM")
+    result = microscope.get_target_position(
+        deepcopy(position), target_orientation="FIB"
+    )
+
+    if expect_compucentric:
+        assert np.isclose(result.x, -SOURCE_X, atol=1e-12)
+        assert np.isclose(result.y, -SOURCE_Y, atol=1e-12)
+    else:
+        assert np.isclose(result.x, SOURCE_X, atol=1e-12)
+        assert np.isclose(result.y, SOURCE_Y, atol=1e-12)


### PR DESCRIPTION
`get_target_position` converts a stage position from one named orientation to another. It was **six hand-written branches over `(from, to)` ordered pairs** — twelve pairs today, twenty once a device is added, plus an `else: raise` growing a case each time.

This replaces the table with the rule it was spelling out one cell at a time, and changes no behaviour.

## The rule

Re-posing between orientations is always a rewrite of `r` and `t`. What decides whether **x and y** move with it is whether the **rotation** changes:

* turning the sample half way round swings it about the compucentric centre, which is somewhere else entirely, so the coordinates have to be carried around with it;
* a change of tilt alone pivots about an axis through the sample and leaves x/y where they were.

That is why `SEM ↔ MILLING` needs no positional term — both sit at `rotation_reference` — while anything crossing to or from `FIB`, at `rotation_180`, does.

```python
rotation_changes = not np.isclose(
    self.get_orientation(currrent_orientation).r % (2 * np.pi),
    orientation.r % (2 * np.pi),
)
if rotation_changes:
    stage_position = self._get_compucentric_rotation_position(stage_position)

stage_position.r = orientation.r
stage_position.t = orientation.t
```

## Two things fall out

**One `stage_is_compustage` branch disappears.** The rule reaches the right answer on a compustage for free, because `_get_compucentric_rotation_position` already returns its argument untouched there — it has no rotation axis to be compucentric about. Small down-payment on the split argued in FIB-643.

**The final `else: raise` goes.** It was unreachable: the six branches covered all twelve ordered pairs. An unknown target still raises from `get_orientation` before the rule runs.

The FM refusal is kept, hoisted to the top where it reads as what it is — the FM is an orientation only where the objective is under the grid; on an offset mount it is a *place*, and `orientations["FM"]` there is a copy of the FIB entry with no positional term. That goes away when the device axis lands (FIB-830).

## The first commit is the safety net

Existing coverage was **four tests** — `MILLING ↔ FM` on a compustage, the non-compustage refusal, and the same-orientation no-op. **Every pair that does positional work was untested.** A refactor of stage-motion arithmetic with four tests behind it is a rewrite, so the pin was written first, against unchanged production code.

It pins two things separately, because the behaviour has two independent parts:

* **which legs move x/y at all** — a `PRESERVE`/`COMPUCENTRIC`/`RAISES` table over (stage type, from, to), which reads better than 21 hardcoded coordinates;
* **what the compucentric legs compute** — against a **non-zero** rotation offset. The base offset is `(0, 0)`, so on a simulator the transform degenerates to plain negation and the table alone would stay green if the offset term were dropped entirely.

Plus three properties the composable form has to keep: a round trip is the identity, routing through an intermediate agrees with the direct pair, and the same-orientation early return hands back the caller's own object (an aliasing hazard, pinned so it gets fixed deliberately rather than by accident).

## Two things found while writing the pin

**`setup_session(manufacturer="Demo")` is misleading for this.** It leaves `rotation_180 = 0`, putting FIB at (r=0, t=17) and MILLING at (r=0, t=12) — five degrees apart with the same rotation. A position built at the FIB orientation then classifies as MILLING, making **FIB unreachable as a source orientation**, and half the table would have pinned the wrong branch. The fixture sets realistic stage geometry explicitly.

**The rotation is read from the orientations, not from `stage_position.r`,** and the difference matters. `get_stage_orientation` classifies within a 5 degree tolerance, so a position reading as SEM is usually a fraction off the canonical rotation — a real stage never sits at exactly 0.000. Comparing the position's own `r` would call a 4 degree discrepancy a rotation change and fire the correction, which is not a small one: `_get_compucentric_rotation_position` computes `p -> -p - 2 * offset` and says so in its docstring, *"Assumes 180deg rotation"*. It is a half turn or nothing, and firing it for a few degrees of slop would throw the sample to the far side of the grid.

The assumption underneath — **every rotation between named orientations is a half turn** — is now stated in a comment, since nothing said it before and an orientation added at 90 degrees would quietly receive the 180 degree correction.

## Testing

| | |
| -- | -- |
| new parity test | 34 passed |
| full non-UI suite | 4015 passed, 22 skipped |
| `tests/ui/` | 2281 passed, 1 skipped |
| `ruff check` / `ruff format --check` | clean |

No hardware needed for any of it.

## Deliberately not in here

The compucentric offset itself is under review in FIB-655, which found the two implementations in the tree disagree by 55 µm. This PR pins *current* behaviour on purpose — changing the offset and re-baselining the expectations in the same change would leave nothing checking the refactor.
