### PR TITLE
[refactor] Flip the workflow status producer to the typed contract (FIB-827)

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -10,6 +10,9 @@ import pandas as pd
 
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
 from fibsem.applications.autolamella.workflows.tasks.queue import TaskQueue, WorkItem
+from fibsem.applications.autolamella.workflows.tasks.status import (
+    WorkflowStatusUpdate,
+)
 from fibsem.applications.autolamella.workflows.ui import update_status_ui
 from fibsem.cancellation import AnyStopEvent, OperationCancelledError
 from fibsem.constants import DATETIME_DISPLAY_AMPM
@@ -571,27 +574,28 @@ class TaskManager:
         items = self.queue.items
         position = next((i for i, it in enumerate(items) if it.id == item.id), None)
 
-        status_dict = {
-            "task_name": item.task_name,
-            "item_name": lamella.name,
-            # Deprecated alias for item_name, kept for consumers outside this repo.
-            # Drop alongside the HookContext shims after v0.6.
-            "lamella_name": lamella.name,
-            "status": status,
-            "timestamp": time.time(),
-            "error_message": error_message,
-            "task_duration": task_duration,
-            "skip_reason": skip_reason,
-            "queue_position": position + 1 if position is not None else None,
-            "queue_total": len(items),
-            "queue_items": items,  # thread-safe snapshot
+        # `lamella_name` is no longer a field: `WorkflowStatusUpdate` derives it from
+        # `item_name` as a property, so the deprecated alias cannot drift from the name
+        # it aliases, and drops cleanly with the HookContext shims after v0.6.
+        update = WorkflowStatusUpdate(
+            task_name=item.task_name,
+            item_name=lamella.name,
+            status=status,
+            timestamp=time.time(),
+            error_message=error_message,
+            task_duration=task_duration,
+            skip_reason=skip_reason,
+            # Already 1-based on the wire. Consumers render it as-is.
+            queue_position=position + 1 if position is not None else None,
+            queue_total=len(items),
+            queue_items=items,  # thread-safe snapshot: Queue.items returns copies
             # The plan this run was launched with. Informational only — the live
             # queue may since have diverged from it.
-            "task_names": self.queue.task_names,
-            "lamella_names": self.queue.lamella_names,
-        }
+            task_names=self.queue.task_names,
+            lamella_names=self.queue.lamella_names,
+        )
 
-        self.parent_ui.workflow_update_signal.emit({"msg": msg, "status": status_dict})
+        self.parent_ui.workflow_update_signal.emit({"msg": msg, "status": update})
 
     def _run_single_task(
         self, task_name: str, lamella: "Lamella"

--- a/tests/autolamella/test_status_dict_vocabulary.py
+++ b/tests/autolamella/test_status_dict_vocabulary.py
@@ -63,7 +63,7 @@ def _emit(manager: TaskManager, name: str = "lam-1") -> dict:
 def test_the_status_dict_names_the_item_the_way_the_hook_does(manager: TaskManager):
     status = _emit(manager)
 
-    assert status["item_name"] == "lam-1"
+    assert status.item_name == "lam-1"
     # the hook payload names it identically
     assert "item_name" in HookContext(event="task_started").__dict__
 
@@ -72,7 +72,7 @@ def test_the_old_key_is_still_emitted_for_outside_consumers(manager: TaskManager
     """Same deprecation shape as the HookContext shims: emit both until v0.6."""
     status = _emit(manager, name="lam-7")
 
-    assert status["lamella_name"] == status["item_name"]
+    assert status.lamella_name == status.item_name
 
 
 def test_the_positioning_fields_keep_their_names(manager: TaskManager):
@@ -84,8 +84,16 @@ def test_the_positioning_fields_keep_their_names(manager: TaskManager):
     added to and reordered mid-run and a matrix coordinate then has no answer. That
     is FIB-472, not a vocabulary change — the point this test makes is unaffected.
     """
-    status = _emit(manager)
+    import dataclasses
 
-    assert "lamella_names" in status
-    assert "queue_position" in status
-    assert "queue_total" in status
+    from fibsem.applications.autolamella.workflows.tasks.status import (
+        WorkflowStatusUpdate,
+    )
+
+    _emit(manager)
+
+    # Field names on the type rather than keys in a dict, now that the payload is a
+    # record (FIB-827). A stronger check than membership: a field cannot be present
+    # on one emission and absent on another.
+    fields = {f.name for f in dataclasses.fields(WorkflowStatusUpdate)}
+    assert {"lamella_names", "queue_position", "queue_total"} <= fields

--- a/tests/autolamella/test_task_manager_status.py
+++ b/tests/autolamella/test_task_manager_status.py
@@ -151,8 +151,8 @@ def test_emit_reports_position_in_the_live_queue(manager):
         status=Status.InProgress,
     )
     status = last_status(manager)
-    assert status["queue_position"] == 3
-    assert status["queue_total"] == 4
+    assert status.queue_position == 3
+    assert status.queue_total == 4
 
 
 def test_emit_for_a_task_outside_the_launch_plan(manager):
@@ -166,9 +166,9 @@ def test_emit_for_a_task_outside_the_launch_plan(manager):
         status=Status.InProgress,
     )
     status = last_status(manager)
-    assert status["task_name"] == "Polishing"
-    assert status["queue_position"] == 5
-    assert status["queue_total"] == 5
+    assert status.task_name == "Polishing"
+    assert status.queue_position == 5
+    assert status.queue_total == 5
 
 
 def test_emit_for_a_lamella_outside_the_launch_plan(manager):
@@ -179,10 +179,10 @@ def test_emit_for_a_lamella_outside_the_launch_plan(manager):
         status=Status.InProgress,
     )
     status = last_status(manager)
-    assert status["item_name"] == "L99"
+    assert status.item_name == "L99"
     # deprecated alias, dropped with the HookContext shims after v0.6 (FIB-464)
-    assert status["lamella_name"] == "L99"
-    assert status["queue_position"] == 5
+    assert status.lamella_name == "L99"
+    assert status.queue_position == 5
 
 
 def test_emit_position_follows_a_reorder(manager):
@@ -193,7 +193,7 @@ def test_emit_position_follows_a_reorder(manager):
         lamella=manager.experiment.get_lamella_by_name(item.lamella_name),
         status=Status.InProgress,
     )
-    assert last_status(manager)["queue_position"] == 1
+    assert last_status(manager).queue_position == 1
 
 
 def test_emit_carries_the_launch_plan_as_context(manager):
@@ -204,8 +204,8 @@ def test_emit_carries_the_launch_plan_as_context(manager):
         status=Status.InProgress,
     )
     status = last_status(manager)
-    assert status["task_names"] == ["Trench", "Undercut"]
-    assert status["lamella_names"] == ["L1", "L2"]
+    assert status.task_names == ["Trench", "Undercut"]
+    assert status.lamella_names == ["L1", "L2"]
 
 
 def test_emit_includes_a_queue_snapshot(manager):
@@ -215,7 +215,7 @@ def test_emit_includes_a_queue_snapshot(manager):
         lamella=manager.experiment.get_lamella_by_name("L1"),
         status=Status.InProgress,
     )
-    snapshot = last_status(manager)["queue_items"]
+    snapshot = last_status(manager).queue_items
     assert len(snapshot) == 4
     snapshot[0].status = Status.Failed
     assert manager.queue.items[0].status is not Status.Failed
@@ -232,8 +232,8 @@ def test_emit_passes_through_error_and_skip_detail(manager):
         task_duration=12.5,
     )
     status = last_status(manager)
-    assert status["error_message"] == "it broke"
-    assert status["task_duration"] == 12.5
+    assert status.error_message == "it broke"
+    assert status.task_duration == 12.5
     assert manager.parent_ui.workflow_update_signal.emitted[-1]["msg"] == "boom"
 
 
@@ -371,5 +371,5 @@ def test_status_bar_text_is_derivable_for_added_items(manager):
         status = payload.get("status")
         if status is None:
             continue
-        assert status["queue_position"] is not None
-        assert 1 <= status["queue_position"] <= status["queue_total"]
+        assert status.queue_position is not None
+        assert 1 <= status.queue_position <= status.queue_total


### PR DESCRIPTION
Stacked on #594 — review that one first. **Only the last commit belongs to this PR.**

`TaskManager._emit_status` now builds a `WorkflowStatusUpdate` instead of a 13-key dict. The envelope is unchanged — still `{"msg": ..., "status": ...}` — so none of FIB-826's threading work is touched.

### `lamella_name` stops being written at all

The record derives it from `item_name` as a property, so the deprecated alias cannot drift from the name it aliases, and it drops cleanly with the `HookContext` shims after v0.6. The vocabulary test that pinned the two equal still passes — now by construction rather than by the producer remembering to write both.

### Deliberate deviation from the plan: `from_payload` keeps its dict branch

The plan had it deleted once the last dict producer went. It is no longer converting anything this producer sends, but it is the totality guard at a queued-Qt-slot boundary, where an escaping exception is a `qFatal` process abort with nothing in the logfile rather than a missing label (FIB-329). This signal has already killed the app that way once. The branch costs nothing and removes a whole failure mode, so it stays.

That also means this PR is safe ahead of its own base landing: both consumers go through `from_payload`, which accepts either shape.

### Tests

Ported from subscripts to attributes. One had to change shape rather than syntax: `assert "queue_position" in status` was a membership check on a dict, and is now a check that the field exists on the type — a stronger contract, since a field cannot be present on one emission and absent on another.

`577 passed` across `tests/autolamella` on the rebased branch; `ruff check` and `ruff format --check` clean on all three files.

Note this branch gets **no CI** while it targets a non-`main` branch — retarget once #594 lands.
