### PR TITLE
[refactor] Leave only the move in the two stage-move workers

### DIFF
--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -510,17 +510,33 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     def _move_to_absolute_position(self, stage_position: FibsemStagePosition):
         """Move the stage to the specified position"""
         self._toggle_interactions(enable=False)
+        # Said here rather than from inside the worker: this is the GUI thread, so the
+        # status is on the info bar before the stage starts moving instead of racing the
+        # move through the event loop.
+        self.movement_progress_signal.emit(
+            {"msg": f"Moving to {stage_position.pretty}…"}
+        )
         worker = self.absolute_movement_worker(stage_position=stage_position)
+        worker.returned.connect(self._on_stage_move_returned)
         worker.finished.connect(self.move_stage_finished)
         worker.start()
 
     @thread_worker
     def absolute_movement_worker(self, stage_position: FibsemStagePosition) -> None:
-        """Worker function to move the stage to the specified position"""
-        self.movement_progress_signal.emit(
-            {"msg": f"Moving to {stage_position.pretty}…"}
-        )
+        """Move the stage. Runs off the GUI thread — only signals may cross back."""
         self.microscope.safe_absolute_stage_movement(stage_position)
+
+    def _on_stage_move_returned(self, _result: object = None) -> None:
+        """The move landed: say the images are coming, and retake them. GUI thread.
+
+        Hangs off ``returned``, not ``finished``, so a move that raised skips it — the
+        widget never claims to be retaking images for a move that did not happen.
+
+        Ordering matters here and is not incidental. ``FunctionWorker`` emits
+        ``returned`` before ``finished``, so the acquisition this queues is already
+        under way by the time ``move_stage_finished`` asks whether it is, and the
+        buttons stay disabled until the images actually land.
+        """
         self.movement_progress_signal.emit({"msg": ACQUIRING_IMAGES})
         self.update_ui_after_movement()
 
@@ -685,18 +701,18 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         if orientation not in ["SEM", "FIB", "MILLING"]:
             raise ValueError(f"Invalid orientation: {orientation}")
         self._toggle_interactions(False)
+        self.movement_progress_signal.emit(
+            {"msg": f"Moving to the {orientation} orientation…"}
+        )
         worker = self.move_to_orientation_worker(orientation)
+        # The orientation path never reported the acquisition, so the label sat on
+        # "Moving to the SEM orientation…" while the move had finished and the images
+        # were being retaken. Both paths now share the one slot that says it.
+        worker.returned.connect(self._on_stage_move_returned)
         worker.finished.connect(self.move_stage_finished)
         worker.start()
 
     @thread_worker
     def move_to_orientation_worker(self, orientation: str) -> None:
-        """Threaded worker function to move the stage to the specified orientation"""
-        self.movement_progress_signal.emit(
-            {"msg": f"Moving to the {orientation} orientation…"}
-        )
+        """Move the stage. Runs off the GUI thread — only signals may cross back."""
         self.microscope.move_to_orientation(orientation)
-        # The orientation path never said this, so the label sat on "Moving to the SEM
-        # orientation…" while the move had finished and the images were being retaken.
-        self.movement_progress_signal.emit({"msg": ACQUIRING_IMAGES})
-        self.update_ui_after_movement()

--- a/tests/ui/test_movement_worker_bodies.py
+++ b/tests/ui/test_movement_worker_bodies.py
@@ -1,20 +1,21 @@
-"""What the two stage-move workers actually do, in order, before FIB-828 rewrites them.
+"""What the two stage-move workers do, in order, and where each part of it runs.
 
-``absolute_movement_worker`` and ``move_to_orientation_worker`` each run one operation
-off the GUI thread and interleave three cross-thread effects around it: a message
-naming the target, the blocking move, a message saying the images are being retaken,
-and the refresh itself. FIB-828 splits the operation out of the reporting, so these
-tests exist to say what "the same behaviour" means once it has.
+``absolute_movement_worker`` and ``move_to_orientation_worker`` each perform one
+operation off the GUI thread and arrange three effects around it: a message naming the
+target, the blocking move, a message saying the images are being retaken, and the
+refresh itself. The workers used to do all four themselves, from the worker thread.
+They now do only the move; the reporting sits on the GUI thread on either side, before
+``start()`` and in the ``returned`` slot.
 
 Two layers, deliberately:
 
-* **The body**, called directly through ``__wrapped__`` on the GUI thread. Nothing is
-  queued, so the *order* of the effects is observable -- which is the whole point of
-  the messages. A worker that emitted both up front, or moved before it said where to,
-  would satisfy a test that only checked both messages arrived.
-* **The path**, started for real through the public entry points. These assert what
-  must survive the extraction whatever shape the body ends up in, including the
-  failure case, where the operation raises and the widget still has to come back.
+* **The body**, called directly through ``__wrapped__``. These say the operation is all
+  that is left in there -- the rule the split exists to establish, and the one a later
+  edit is most likely to walk back by reaching for ``self`` from the thread again.
+* **The path**, started for real through the public entry points. Everything except the
+  move now happens on the GUI thread, so the *order* of the effects is observable end to
+  end rather than scrambled by queued delivery. These assertions predate the split and
+  are unchanged by it, which is what makes them the equivalence argument.
 """
 
 from __future__ import annotations
@@ -71,17 +72,21 @@ def movement(qapp):
 
 
 def _trace(movement, monkeypatch) -> list:
-    """Every cross-thread effect the worker performs, in the order it performs them.
+    """Every reported effect, in the order it happens.
 
     ``update_ui_after_movement`` is replaced on the instance, which bypasses its
-    ``@ensure_main_thread`` -- the recorder runs wherever the caller is rather than
-    being queued. That is what makes the ordering below readable, and it is why the
-    *threading* of the refresh is pinned by the path tests instead of here.
+    ``@ensure_main_thread``. Harmless now that the caller is already the GUI thread,
+    and it keeps the recorder from being queued behind the assertions.
     """
     seen = []
-    movement.movement_progress_signal.connect(
-        lambda d: seen.append(("msg", d.get("msg")))
-    )
+
+    def _reported(ddict: dict) -> None:
+        # Only the messages. `move_stage_finished` also emits {"finished": True}, which
+        # carries no message and is pinned by the buttons-back test instead.
+        if ddict.get("msg") is not None:
+            seen.append(("msg", ddict["msg"]))
+
+    movement.movement_progress_signal.connect(_reported)
 
     def _moved(stage_position, *args, **kwargs):
         seen.append(("move", stage_position))
@@ -103,9 +108,13 @@ def _trace(movement, monkeypatch) -> list:
     return seen
 
 
+def _kinds(seen) -> list:
+    return [kind for kind, _ in seen]
+
+
 def _body(name):
     """The undecorated worker function -- ``@thread_worker`` would put it on a thread,
-    where a raise is swallowed into ``errored`` and the ordering is unobservable."""
+    where the raise is swallowed into ``errored`` and nothing is observable in place."""
     return getattr(FibsemMovementWidget, name).__wrapped__
 
 
@@ -113,7 +122,43 @@ def _explode(*args, **kwargs):
     raise RuntimeError("the stage did not get there")
 
 
-# --- absolute moves ----------------------------------------------------------
+# --- the body performs the operation and nothing else ------------------------
+
+
+def test_the_absolute_worker_body_only_moves(movement, monkeypatch):
+    """No message, no refresh -- one call to the microscope.
+
+    This is the rule the split exists to establish. Anything the body adds here is a
+    widget touched from a worker thread, which is the whole hazard.
+    """
+    seen = _trace(movement, monkeypatch)
+    _body("absolute_movement_worker")(movement, stage_position=TARGET)
+
+    assert _kinds(seen) == ["move"], seen
+    assert seen[0][1] is TARGET, "the worker did not move to the position it was given"
+
+
+def test_the_orientation_worker_body_only_moves(movement, monkeypatch):
+    seen = _trace(movement, monkeypatch)
+    _body("move_to_orientation_worker")(movement, "SEM")
+
+    assert _kinds(seen) == ["orient"], seen
+    assert seen[0][1] == "SEM"
+
+
+def test_a_failed_body_raises_rather_than_reporting(movement, monkeypatch):
+    """The exception leaves the body, so ``FunctionWorker`` turns it into ``errored``
+    and the ``returned`` slot -- which is where the reporting now lives -- never runs."""
+    seen = _trace(movement, monkeypatch)
+    monkeypatch.setattr(movement.microscope, "safe_absolute_stage_movement", _explode)
+
+    with pytest.raises(RuntimeError):
+        _body("absolute_movement_worker")(movement, stage_position=TARGET)
+
+    assert seen == [], seen
+
+
+# --- the whole path, unchanged by the split ----------------------------------
 
 
 def test_the_absolute_move_is_bracketed_by_its_two_messages(movement, monkeypatch):
@@ -125,65 +170,60 @@ def test_the_absolute_move_is_bracketed_by_its_two_messages(movement, monkeypatc
     is still travelling.
     """
     seen = _trace(movement, monkeypatch)
-    _body("absolute_movement_worker")(movement, stage_position=TARGET)
+    movement._move_to_absolute_position(TARGET)
+    _run(lambda: _kinds(seen) == ["msg", "move", "msg", "refresh"])
 
-    kinds = [kind for kind, _ in seen]
-    assert kinds == ["msg", "move", "msg", "refresh"], seen
-    assert seen[1][1] is TARGET, "the worker did not move to the position it was given"
+    assert _kinds(seen) == ["msg", "move", "msg", "refresh"], seen
+    assert seen[1][1] is TARGET
+    assert seen[2][1] == ACQUIRING_IMAGES
+
+
+def test_the_orientation_move_is_bracketed_by_its_two_messages(movement, monkeypatch):
+    seen = _trace(movement, monkeypatch)
+    movement.move_to_orientation("SEM")
+    _run(lambda: _kinds(seen) == ["msg", "orient", "msg", "refresh"])
+
+    assert _kinds(seen) == ["msg", "orient", "msg", "refresh"], seen
+    assert seen[1][1] == "SEM"
     assert seen[2][1] == ACQUIRING_IMAGES
 
 
 def test_the_absolute_move_names_its_target(movement, monkeypatch):
     """The operator is told which position, not just that something is moving."""
     seen = _trace(movement, monkeypatch)
-    _body("absolute_movement_worker")(movement, stage_position=TARGET)
+    movement._move_to_absolute_position(TARGET)
+    _run(lambda: seen)
     assert TARGET.pretty in seen[0][1], seen[0][1]
-
-
-def test_a_failed_absolute_move_reports_nothing_further(movement, monkeypatch):
-    """The exception leaves the body -- ``FunctionWorker`` turns it into ``errored``.
-
-    Nothing after the move runs, so the widget never claims to be acquiring images
-    for a move that did not happen. Whatever FIB-828 does with the reporting, a
-    failure must still stop the sequence here rather than continue past it.
-    """
-    seen = _trace(movement, monkeypatch)
-    monkeypatch.setattr(movement.microscope, "safe_absolute_stage_movement", _explode)
-
-    with pytest.raises(RuntimeError):
-        _body("absolute_movement_worker")(movement, stage_position=TARGET)
-
-    assert [kind for kind, _ in seen] == ["msg"], seen
-    assert ACQUIRING_IMAGES not in [value for _, value in seen]
-
-
-# --- orientation moves -------------------------------------------------------
-
-
-def test_the_orientation_move_is_bracketed_by_its_two_messages(movement, monkeypatch):
-    seen = _trace(movement, monkeypatch)
-    _body("move_to_orientation_worker")(movement, "SEM")
-
-    kinds = [kind for kind, _ in seen]
-    assert kinds == ["msg", "orient", "msg", "refresh"], seen
-    assert seen[1][1] == "SEM"
-    assert seen[2][1] == ACQUIRING_IMAGES
 
 
 def test_the_orientation_move_names_its_orientation(movement, monkeypatch):
     seen = _trace(movement, monkeypatch)
-    _body("move_to_orientation_worker")(movement, "MILLING")
-    assert "MILLING" in seen[0][1], seen[0][1]
+    movement.move_to_orientation("MILLING")
+    _run(lambda: seen)
+    assert "MILLING orientation" in seen[0][1], seen[0][1]
+
+
+def test_a_failed_move_reports_nothing_further(movement, monkeypatch):
+    """Nothing after the move runs, so the widget never claims to be acquiring images
+    for a move that did not happen."""
+    seen = _trace(movement, monkeypatch)
+    monkeypatch.setattr(movement.microscope, "safe_absolute_stage_movement", _explode)
+
+    movement._move_to_absolute_position(TARGET)
+    _run(lambda: movement.pushButton_move.isEnabled())
+
+    assert _kinds(seen) == ["msg"], seen
+    assert ACQUIRING_IMAGES not in [value for _, value in seen]
 
 
 def test_a_failed_orientation_move_reports_nothing_further(movement, monkeypatch):
     seen = _trace(movement, monkeypatch)
     monkeypatch.setattr(movement.microscope, "move_to_orientation", _explode)
 
-    with pytest.raises(RuntimeError):
-        _body("move_to_orientation_worker")(movement, "SEM")
+    movement.move_to_orientation("SEM")
+    _run(lambda: movement.pushButton_move.isEnabled())
 
-    assert [kind for kind, _ in seen] == ["msg"], seen
+    assert _kinds(seen) == ["msg"], seen
 
 
 def test_an_unknown_orientation_is_refused_before_any_thread_starts(movement):
@@ -193,45 +233,11 @@ def test_an_unknown_orientation_is_refused_before_any_thread_starts(movement):
         movement.move_to_orientation("SIDEWAYS")
 
 
-# --- the whole path, which must survive the extraction unchanged -------------
-
-
-def test_the_absolute_move_path_refreshes_the_ui(movement, monkeypatch):
-    """Started for real: the refresh has to reach the widget however the body is
-    arranged, and it has to reach it on the GUI thread."""
-    refreshed = []
-    monkeypatch.setattr(
-        movement.microscope, "safe_absolute_stage_movement", lambda *a, **k: None
-    )
-    monkeypatch.setattr(
-        movement, "update_ui_after_movement", lambda *a, **k: refreshed.append(True)
-    )
-
-    movement._move_to_absolute_position(TARGET)
-    _run(lambda: refreshed)
-    assert refreshed, "the move finished without refreshing the UI"
-
-
-def test_the_orientation_path_refreshes_the_ui(movement, monkeypatch):
-    refreshed = []
-    monkeypatch.setattr(
-        movement.microscope, "move_to_orientation", lambda *a, **k: None
-    )
-    monkeypatch.setattr(
-        movement, "update_ui_after_movement", lambda *a, **k: refreshed.append(True)
-    )
-
-    movement.move_to_orientation("SEM")
-    _run(lambda: refreshed)
-    assert refreshed, "the orientation move finished without refreshing the UI"
-
-
 def test_a_failed_move_gives_the_buttons_back(movement, monkeypatch):
     """``move_stage_finished`` hangs off ``finished``, which fires on both outcomes.
 
     A move that raises must not leave the widget permanently disabled -- the operator
-    would have to restart the app to try again. This is the failure path FIB-828 has
-    the most room to break, because the extraction moves what runs after the operation.
+    would have to restart the app to try again.
     """
     monkeypatch.setattr(movement.microscope, "safe_absolute_stage_movement", _explode)
     assert movement.pushButton_move.isEnabled(), "precondition: buttons start enabled"
@@ -241,3 +247,85 @@ def test_a_failed_move_gives_the_buttons_back(movement, monkeypatch):
     assert movement.pushButton_move.isEnabled(), (
         "a failed move left the movement buttons disabled"
     )
+
+
+def test_the_refresh_runs_before_the_buttons_are_reconsidered(movement, monkeypatch):
+    """``returned`` fires before ``finished``, and the widget depends on that.
+
+    ``update_ui_after_movement`` queues the acquisition; ``move_stage_finished`` then
+    asks whether one is running and declines to re-enable the buttons if so. Reverse
+    the two and the buttons come back for the second it takes the images to land,
+    offering a double-click that is still disabled. Hanging the refresh off
+    ``finished`` instead of ``returned`` would do exactly that.
+    """
+    order = []
+    monkeypatch.setattr(
+        movement.microscope, "safe_absolute_stage_movement", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        movement, "update_ui_after_movement", lambda *a, **k: order.append("refresh")
+    )
+    original = movement.move_stage_finished
+    monkeypatch.setattr(
+        movement,
+        "move_stage_finished",
+        lambda *a, **k: (order.append("finished"), original())[1],
+    )
+
+    movement._move_to_absolute_position(TARGET)
+    _run(lambda: "finished" in order)
+    assert order == ["refresh", "finished"], order
+
+
+def test_a_real_move_keeps_the_buttons_down_until_the_images_land(movement):
+    """The same dance with nothing stubbed out -- a real Demo move and a real retake.
+
+    Every other test here replaces ``update_ui_after_movement``, so none of them
+    exercises the acquisition it starts. A move that quietly stopped retaking images
+    would satisfy all of them: the refresh was called, and that is all they check.
+    This one lets it run, so ``is_acquiring`` has to actually become true -- which is
+    what ``move_stage_finished`` reads when it decides whether to give the buttons
+    back, and the one fact in this file that a stub cannot supply honestly.
+
+    The buttons must be down from the moment the move starts, still down when
+    ``finished`` arrives mid-acquisition, and back only once the images have landed.
+    """
+    seen = []
+    movement.movement_progress_signal.connect(
+        lambda d: seen.append(
+            (
+                dict(d),
+                movement.pushButton_move.isEnabled(),
+                movement.image_widget.is_acquiring,
+            )
+        )
+    )
+
+    assert movement.pushButton_move.isEnabled(), "precondition: buttons start enabled"
+    movement._move_to_absolute_position(TARGET)
+    assert not movement.pushButton_move.isEnabled(), (
+        "buttons stayed live during the move"
+    )
+
+    _run(
+        lambda: (
+            len(seen) >= 3
+            and movement.pushButton_move.isEnabled()
+            and not movement.image_widget.is_acquiring
+        ),
+        tries=60,
+    )
+
+    assert [d.get("msg") for d, _, _ in seen[:2]] == [
+        seen[0][0].get("msg"),
+        ACQUIRING_IMAGES,
+    ], seen
+    assert not any(enabled for _, enabled, _ in seen), (
+        f"the buttons came back while the move was still reporting: {seen}"
+    )
+    assert seen[-1][0].get("finished") is True, seen[-1]
+    assert seen[-1][2] is True, (
+        "the acquisition had not started when the move finished -- move_stage_finished "
+        "would have re-enabled the buttons over it"
+    )
+    assert movement.pushButton_move.isEnabled(), "the buttons never came back"


### PR DESCRIPTION
Follows #611, now merged — this PR is the extraction itself, one commit over `main`.

## What changed

Both workers ran their operation off the GUI thread and then reached back for the widget from that thread: two `movement_progress_signal` emits and a direct `update_ui_after_movement()`, all from the worker. The emits were queued and therefore safe; the direct call relied on `@ensure_main_thread` further down, which makes the safety a property of the callee rather than of the call.

The bodies are now one line each — the move. The reporting sits on the GUI thread on either side: the target message before `start()`, and the acquisition message plus the refresh in a `returned` slot the two paths share.

```python
@thread_worker
def absolute_movement_worker(self, stage_position: FibsemStagePosition) -> None:
    """Move the stage. Runs off the GUI thread — only signals may cross back."""
    self.microscope.safe_absolute_stage_movement(stage_position)
```

Two incidental wins: the orientation path picks up the acquisition message it used to lack (its label sat on "Moving to the SEM orientation…" through the retake), and the target message is now on the info bar *before* the stage starts moving rather than racing the move through the event loop.

`movement_progress_signal` is untouched — the emits only changed threads. Deleting it stays a separate decision (#591).

## Why `returned` and not `finished`

- A move that raised skips the reporting entirely, rather than announcing an acquisition for a move that did not happen.
- `FunctionWorker` emits `returned` before `finished`, so the acquisition is already under way when `move_stage_finished` asks whether one is — which is what keeps the buttons down until the images land.

Connection order does not enter into it: swapping the two `connect` lines changes nothing, since the ordering comes from `FunctionWorker` rather than from Qt's slot order. Checked, not assumed.

## Equivalence

The three path-level tests added in #611 are **untouched** and pass on both shapes. That is the argument that behaviour is preserved.

The body-level tests necessarily moved — they pinned the pre-split shape. They now pin the new rule (the body performs the operation and nothing else), re-verified by mutation:

| mutation | caught by |
| --- | --- |
| report from inside the worker body again | body-only + ordering tests |
| emit the target message after `start()` | ordering + naming tests |
| move the refresh into `move_stage_finished` | ordering + refresh-before-finished + failure tests |
| hang the reporting off `finished` | both failure tests |
| stop retaking images after a move | the unstubbed end-to-end test |

That last row is why one test runs the retake for real. Every other test in the file stubs `update_ui_after_movement`, so a move that quietly stopped acquiring would pass all of them.

## Verification

- 94 passed across `test_movement_worker_bodies.py`, `test_movement_progress.py`, `test_click_to_move_says_so.py`, `test_viewer_less_widgets.py`, `test_fm_overview_orientation.py`.
- Ran the whole path unstubbed against a Demo microscope: buttons down at `start()`, still down when `finished` arrives mid-acquisition, back once the images land.
- No callers of either worker exist outside the widget.
- `ruff check` and `ruff format --check` clean; both files parse under 3.8.

## Not in scope

`_canvas_double_click_worker` is the third movement-side site of this shape. It carries a separate decision — its guards run on the worker thread while its FM sibling deliberately does the opposite — and moving them would make this a behaviour change rather than a refactor. Milling has the same shape but is also `parent_ui=self`, so it belongs with that work instead.

