### PR TITLE
A simulated microscope with an offset fluorescence microscope

### DIFF
--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -1,0 +1,111 @@
+# A simulated Aquilos with an iFLM: the first OFFSET fluorescence configuration.
+#
+# The Arctis sim (sim-arctis-configuration.yaml) is the only other simulator config
+# with a fluorescence microscope, and it is a compustage -- the objective sits under
+# the grid and the stage turns over to face it. This one is the other mounting: the
+# objective is off to the side, and the stage travels to reach it.
+#
+# That difference is the whole point of the file. Every offset-mount code path
+# (`fibsem/microscope.py:move_to_microscope`, the device transform, the fluorescence
+# pose derivation) is currently unreachable without hardware, because
+# `microscope.fm` is refused on any non-compustage system. This config is where those
+# paths can be exercised, and where they can be seen to fail while they are still
+# incomplete.
+#
+# Geometry copied from tfs-aquilos2-configuration.yaml so the poses are realistic: a
+# 35 degree pre-tilted shuttle and a half turn to reach the ion beam, which is what
+# puts the FM orientation at (r=180, t=17) -- identical to the FIB one, and the reason
+# an offset system cannot tell the two apart. See FIB-830.
+info:
+    name: sim-iflm-configuration                            # a descriptive name for your configuration                     [SPECIFIED]
+    ip_address: 192.168.0.1                                 # the ip address of the microscope PC                           [SPECIFIED]
+    manufacturer: Demo                                      # the microscope manufactuer                                    [SPECIFIED]
+stage:
+    enabled:                    true                        # the stage is enabled                                          [USER]
+    rotation:                   true                        # the stage is able to rotate                                   [USER]
+    tilt:                       true                        # the stage is able to tilt                                     [USER]
+    rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED]
+    rotation_180:               180                         # the reference rotation + 180 degrees                          [DERIVED - rotation-reference]
+    shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
+    manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
+electron:
+    enabled:                    true                        # the electron beam is enabled                                  [USER]
+    column_tilt:                0                           # the column tilt of the electron beam                          [DERIVED - manufactuer]
+    eucentric_height:           7.0e-3                      # the eucentric height of the electron beam                     [SPECIFIED]
+    voltage:                    2000                        # the voltage of the electron beam                              [USER]
+    current:                    50.0e-12                    # the current of the electron beam                              [USER]
+    resolution:                 [1536, 1024]                # the default electron resolution                       [pixel] [USER]
+    hfw:                        150.0e-6                    # the default electron hfw                              [metres][USER]
+    dwell_time:                 1.0e-06                     # the default electron dwell time
+    detector_mode:              SecondaryElectrons          # the detector mode of the electron beam                        [USER]
+    detector_type:              ETD                         # the detector type of the electron beam                        [USER]
+ion:
+    enabled:                    true                        # the ion beam is enabled                                       [USER]
+    column_tilt:                52                          # the column tilt of the ion beam                               [SPECIFIED]
+    eucentric_height:           19.0e-3                     # the eucentric height of the ion beam                          [SPECIFIED]
+    plasma:                     false                       # ion beam is a plasma column                                   [USER]
+    plasma_gas:                 None                        # the plasma gas for the ion beam (plasma fib only)             [USER]
+    voltage:                    30000                       # the voltage of the ion beam                                   [USER]
+    current:                    2.0e-11                     # the current of the ion beam                                   [USER]
+    resolution:                 [1536, 1024]                # the default ion resolution                            [pixel] [USER]
+    hfw:                        150.0e-6                    # the default ion hfw                                   [metres][USER]
+    dwell_time:                 1.0e-06                     # the default ion dwell time
+    detector_mode:              SecondaryElectrons          # the detector mode of the ion beam                             [USER]
+    detector_type:              ETD                         # the detector type of the ion beam                             [USER]
+manipulator:
+    enabled:                    true                        # manipulator is enabled                                        [USER]
+    rotation:                   false                       # manipulator is able to rotate                                 [USER]
+    tilt:                       false                       # manipulator is able to tilt                                   [USER]
+gis:
+    enabled:                    true                        # gis is enabled                                                [USER]
+    multichem:                  false                       # multichem is enabled                                          [USER]
+    sputter_coater:             false                       # sputter coater is enabled                                     [USER]
+imaging:
+    beam_type:                  ELECTRON                    # the default imaging beam type (ELECTRON, or ION)              [USER]
+    resolution:                 [1536, 1024]                # the default imaging resolution                        [pixel] [USER]
+    hfw:                        150.0e-6                    # the default imaging hfw                               [metres][USER]
+    dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
+    imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
+    autocontrast:               false                       # use autocontrast                                              [USER]
+    save:                       false                       # auto save images                                              [USER]
+milling:
+    milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]
+    milling_current:            2.0e-09                     # the default milling current       (Thermo)            [amp]   [USER]
+    dwell_time:                 1.0e-06                     # the default milling dwell time    (TESCAN)            [second][USER]
+    rate:                       3.4e-09                     # the default milling spuuter rate  (TESCAN)            [um3/s] [USER]
+    spot_size:                  5.4e-08                     # the default milling spot size     (TESCAN)            [metres][USER]
+    preset:                     "30 keV; 20 nA"             # the default milling preset        (TESCAN)                    [USER]
+sim:
+    sem: null # "/path/to/sem/image/data"                   # the path to the SEM image data for simulation                 [USER]
+    fib: null # "/path/to/fib/image/data"                   # the path to the FIB image data for simulation                 [USER]
+    use_cycle: true                                         # infinitely cycle sem/fib dataset                              [USER]
+    is_compustage: false                                    # this stage rotates; the objective is off to the side          [USER]
+    has_fm: true                                            # stand in for the hardware probe -- see below                  [USER]
+
+# `has_fm` stands in for a capability read, not for configuration.
+#
+# On a real Thermo system there is no `is_installed` for the fluorescence microscope
+# (every other subsystem has one), so the only way to know is to try selecting it and
+# see whether the microscope refuses -- which `ThermoMicroscope.__init__` already
+# does. The simulator has no hardware to ask, so it needs to be told what the pretend
+# hardware would have answered, and that belongs in `sim:` rather than in a real
+# configuration block.
+#
+# Keeping it separate from the fluorescence geometry is deliberate: it makes the
+# three real states distinguishable, including the one that matters most.
+#
+#   has_fm  |  geometry  |  simulates
+#   --------|------------|---------------------------------------------------------
+#    true   |  present   |  offset support working
+#    true   |  absent    |  a site upgrading -- an FM is detected, nothing is
+#           |            |  configured for it, so the features stay off
+#    false  |  either    |  a beam-only system
+#
+# The middle row is the leak-protection path (FIB-830): an existing Aquilos with an
+# iFLM fitted must not silently acquire half-built offset support on upgrade. Infer
+# presence from the geometry block instead and that row becomes unrepresentable --
+# configured-but-not-detected and detected-but-not-configured collapse into one
+# thing, and the case most worth testing is the one that cannot be.
+#
+# Defaults to `is_compustage`, so every existing simulator configuration keeps the
+# behaviour it has today without adding the key.

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -449,16 +449,31 @@ class DemoMicroscope(FibsemMicroscope):
             logging.error("Failed to set up sim image iterators: %s", str(e))
 
         # fluorescence microscope
-        if self.stage_is_compustage:
+        #
+        # `has_fm` stands in for a capability read, not for configuration. A real
+        # Thermo system has no `is_installed` for the FM -- every other subsystem has
+        # one -- so the only way to know is to try selecting it and see whether the
+        # microscope refuses, which `ThermoMicroscope.__init__` already does. The
+        # simulator has nothing to ask, so it is told what the pretend hardware would
+        # have answered, and that belongs in `sim:` rather than in a configuration
+        # block describing the instrument.
+        #
+        # Deliberately separate from the fluorescence *geometry*, so that "an FM is
+        # present but nothing is configured for it" stays representable -- that is the
+        # state an existing site hits on upgrade, and the one worth testing (FIB-830).
+        #
+        # Defaults to `stage_is_compustage`, which is what this branched on before, so
+        # every simulator configuration keeps its current behaviour without the key.
+        has_fm = bool(self.system.sim.get("has_fm", self.stage_is_compustage))
+
+        if has_fm:
             self.fm = SimulatedFluorescenceMicroscope(self)
             # Bringing the FM up leaves the shared channel on it, as
             # `ThermoMicroscope.__init__` does; taking it back is the next beam
             # operation's job.
             self.fm.set_active_channel()
         else:
-            logging.warning(
-                "Fluorescence microscope module is currently only implemented for compustage systems. FM will not be available."
-            )
+            logging.info("No fluorescence microscope in this simulated system.")
             self.fm = None
 
         # user, experiment metadata

--- a/tests/test_simulated_offset_fm.py
+++ b/tests/test_simulated_offset_fm.py
@@ -1,0 +1,154 @@
+"""A simulated microscope with an OFFSET fluorescence microscope.
+
+Until now the only simulator configuration with an FM was the Arctis, which is a
+compustage: the objective sits under the grid and the stage turns over to face it.
+Every offset-mount code path -- the traverse, the device transform, the fluorescence
+pose derivation -- was unreachable without hardware, because `microscope.fm` is
+refused on any non-compustage system.
+
+`sim-iflm-configuration.yaml` is the other mounting, and this file is what says it
+works. It also pins the things that are *known broken* on an offset mount, so that
+fixing them is noticed rather than silently absorbed. Those tests are marked below;
+each one failing is the good outcome, not a regression.
+
+See FIB-830 for the device axis that fixes them.
+"""
+
+import os
+
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.applications.autolamella.poses import _to_fluorescence, _to_milling
+
+ARCTIS_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
+IFLM_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-iflm-configuration.yaml")
+
+
+def _microscope(config_path: str):
+    microscope, _ = utils.setup_session(config_path=config_path)
+    return microscope
+
+
+# ── the capability itself ────────────────────────────────────────────
+
+
+def test_the_offset_configuration_has_a_fluorescence_microscope():
+    """The point of the file: an FM on a stage that does not flip.
+
+    Before this, `microscope.fm` was `None` on every non-compustage system, so there
+    was nowhere to exercise the offset paths at all.
+    """
+    microscope = _microscope(IFLM_CONFIG)
+
+    assert microscope.stage_is_compustage is False
+    assert microscope.fm is not None
+
+
+def test_the_compustage_configuration_still_has_one():
+    """The Arctis sim is unchanged, and did not have to gain a key to stay that way."""
+    microscope = _microscope(ARCTIS_CONFIG)
+
+    assert microscope.stage_is_compustage is True
+    assert microscope.fm is not None
+
+
+def test_has_fm_defaults_to_whether_the_stage_is_a_compustage():
+    """The default is the old branch, so no existing configuration changes behaviour.
+
+    `sim-arctis-configuration.yaml` does not set `has_fm` and still gets an FM; a
+    non-compustage configuration that does not set it still gets none.
+    """
+    assert "has_fm" not in _microscope(ARCTIS_CONFIG).system.sim
+    assert _microscope(ARCTIS_CONFIG).fm is not None
+
+    # The shipped default configuration is non-compustage and says nothing about an FM.
+    default = _microscope(cfg.MICROSCOPE_CONFIGURATION_PATH)
+    assert default.stage_is_compustage is False
+    assert default.fm is None
+
+
+def test_the_offset_fm_looks_along_the_ion_column():
+    """`camera_tilt` on an offset mount, and where the number comes from.
+
+    Not a derivation -- the FM was *designed* to share the ion column's line of sight
+    on TFS, so this is a coupling to a per-site editable value that happens to be
+    right here. Pinned because FIB-335 changes where it comes from, not what it is.
+    """
+    microscope = _microscope(IFLM_CONFIG)
+
+    assert microscope.fm.camera_tilt == microscope.system.ion.column_tilt == 52
+
+
+# ── what is known broken on an offset mount ──────────────────────────
+#
+# Each of these passes *because* the offset support is incomplete. When FIB-830 lands
+# they should start failing, and that failure is how it gets noticed. Do not "fix"
+# them by loosening the assertion.
+
+
+def test_the_fm_orientation_is_indistinguishable_from_the_fib_one():
+    """The root of it: on an offset mount the FM is a place, not a pose.
+
+    `_update_orientations` copies the FIB entry, so the two are identical and
+    `get_stage_orientation` -- which checks FIB first -- can never answer "FM".
+    Everything below is downstream of this one fact.
+    """
+    microscope = _microscope(IFLM_CONFIG)
+
+    fm_pose = microscope.get_orientation("FM")
+    fib_pose = microscope.get_orientation("FIB")
+    assert (fm_pose.r, fm_pose.t) == (fib_pose.r, fib_pose.t)
+
+    assert microscope.get_stage_orientation(fm_pose) == "FIB"
+
+
+def test_marking_from_the_fluorescence_view_is_refused():
+    """`_to_milling` declines rather than returning a plausible wrong pose.
+
+    The alternative would be a milling pose 48 mm off the beam axis that nothing
+    rejects until something tries to mill it.
+    """
+    microscope = _microscope(IFLM_CONFIG)
+
+    with pytest.raises(ValueError, match="offset mount"):
+        _to_milling(microscope, microscope.get_orientation("FM"))
+
+
+def test_marking_from_the_beam_side_yields_no_fluorescence_pose():
+    """The quieter half: the lamella is created, with only one of its two poses.
+
+    `_to_fluorescence` catches the transform's refusal and returns `None`, so a
+    lamella marked on the beam overview simply has nowhere to go under the FM.
+    """
+    microscope = _microscope(IFLM_CONFIG)
+
+    assert _to_fluorescence(microscope, microscope.get_orientation("MILLING")) is None
+
+
+def test_the_acquisition_guard_cannot_answer_and_says_yes():
+    """`is_acquisition_orientation` returns True unconditionally off a compustage.
+
+    Refusing would be worse -- it would leave the overview tab permanently dead on
+    every offset system -- so the guard gives up rather than locking out. It is not a
+    guard on this mounting; it is a placeholder for one.
+    """
+    microscope = _microscope(IFLM_CONFIG)
+
+    microscope.move_to_orientation("SEM")
+    assert microscope.fm.is_acquisition_orientation() is True
+
+
+def test_the_traverse_refuses_unless_the_stage_is_already_at_fib():
+    """Step 2 of the workflow leaves the stage at SEM; step 3 will not accept that.
+
+    A real workflow acquires the beam-side overview at the SEM orientation and then
+    moves to the FM, so this refusal is on the ordinary path, not an edge case. The
+    reorientation is something the software could do itself -- see FIB-832.
+    """
+    microscope = _microscope(IFLM_CONFIG)
+
+    microscope.move_to_orientation("SEM")
+    with pytest.raises(ValueError, match="Cannot move to FM"):
+        microscope.move_to_microscope("FM")


### PR DESCRIPTION
The only simulator configuration with a fluorescence microscope is the Arctis, which is a **compustage** — the objective sits under the grid and the stage turns over to face it. Every *offset*-mount path is unreachable without hardware, because `microscope.fm` is refused on any non-compustage system:

```python
# simulator.py, and microscope.py:2343 identically
if self.stage_is_compustage:
    self.fm = SimulatedFluorescenceMicroscope(self)
else:
    logging.warning("...only implemented for compustage systems. FM will not be available.")
    self.fm = None
```

So the traverse, the device transform and the fluorescence pose derivation have no configuration in which they execute. This adds one.

## What it gives you

`sim-iflm-configuration.yaml` — an Aquilos with an iFLM, geometry copied from `tfs-aquilos2` so the poses are realistic:

```
=== sim-iflm ===
  compustage : False
  fm         : SimulatedFluorescenceMicroscope
  camera_tilt: 52
    FIB      r=  180.0 t=   17.0
    FM       r=  180.0 t=   17.0     <- identical
  get_stage_orientation(FM pose) -> FIB
```

**Every failure in the offset workflow now reproduces offline, in about a second:**

| workflow step | what happens today |
| -- | -- |
| move to the FM from the SEM orientation | *"Cannot move to FM from SEM or MILLING orientation"* |
| can the objective see the sample here? | `True` — unconditionally; the guard cannot ask |
| mark a site from the FM overview | refused: *"there is no transform … on an offset mount"* |
| mark a site from the beam overview | succeeds, and the fluorescence pose is `None` |

Those were previously arguments about what the code would do. They are now observed behaviour, on a laptop.

## `has_fm` stands in for a capability read, not for configuration

A real Thermo system has **no `is_installed` for the FM** — every other subsystem has one — so the only way to know is to try selecting it and see whether the microscope refuses, which `ThermoMicroscope.__init__` already does inside a `try/except`. The simulator has no hardware to ask, so it is told what the pretend hardware would have answered. That belongs in `sim:`, not in a block describing the instrument.

**Deliberately separate from the fluorescence geometry**, which keeps three states distinguishable:

| `has_fm` | geometry | simulates |
| -- | -- | -- |
| true | present | offset support working |
| **true** | **absent** | **a site upgrading** — an FM is detected, nothing is configured for it, so the features stay off |
| false | either | a beam-only system |

The middle row is the leak-protection path: an existing Aquilos with an iFLM fitted must not silently acquire half-built offset support on upgrade. Infer presence from the geometry block instead and that row becomes unrepresentable — *configured-but-not-detected* and *detected-but-not-configured* collapse into one thing, and the case most worth testing is the one that cannot be.

## No existing configuration changes behaviour

`has_fm` defaults to `stage_is_compustage`, which is exactly what the branch tested before. `sim-arctis` keeps its FM without gaining a key, and the shipped default configuration keeps having none. It is also settable both ways, so "a compustage with no FM" becomes expressible.

## Four of the nine tests pin things that are broken

Marked as such in the file. They pass *because* offset support is incomplete — the FM orientation being indistinguishable from FIB, marking refused from the fluorescence view, no fluorescence pose when marking from the beam side, and the acquisition guard answering `True` because it cannot ask.

**They should start failing when FIB-830 lands**, and that failure is how it gets noticed. There is a note in the file not to "fix" them by loosening the assertion.

## Testing

| | |
| -- | -- |
| new tests | 9 passed |
| full non-UI suite | 4013 passed, 22 skipped |
| `ruff check` / `ruff format --check` | clean |

No hardware, and no behaviour change for any existing configuration.