### PR TITLE
[docs] Write down what belongs in a worker body

### DIFF
--- a/fibsem/ui/qt/threading.py
+++ b/fibsem/ui/qt/threading.py
@@ -27,7 +27,56 @@ Migration is a one-line import swap::
 
 This intentionally implements only the non-generator, bare-decorator subset. A generator body
 or ``@thread_worker(connect=...)`` will fail loudly rather than silently misbehave.
+
+What belongs in a worker body
+-----------------------------
+
+**The operation, and nothing else.** A worker body runs on a plain daemon thread, so the
+widget it was started from is off limits in there. The codebase settles this two ways,
+depending on whether the worker has anything to say before it is done.
+
+**It only reports afterwards** — return a value, and put every GUI update in a slot on
+``returned`` / ``errored``. ``ObjectiveControlWidget`` is the model::
+
+    def _wheel_move_worker(self, position_m: float) -> float:
+        # Worker: move the objective, and report back where it was sent.
+        self.fm.objective.move_absolute(position_m)
+        return position_m
+
+    worker = self._wheel_move_worker(position_um * MICRON_TO_METRE)
+    worker.returned.connect(self._on_wheel_move_finished)
+    worker.errored.connect(self._on_wheel_move_error)
+
+Prefer this one. ``returned`` fires only on success and before ``finished``, so the success
+path and the failure path separate themselves and anything queued from ``returned`` is already
+under way by the time a ``finished`` slot runs.
+
+**It reports while it runs** — emit one of the widget's own ``pyqtSignal``s. Both overview
+widgets state the rule on their ``_move_worker``, and it is worth quoting whole: *"Runs off the
+GUI thread. Only signals may cross back."* Emitting is safe from any thread; calling is not.
+
+Either way, **let the exception out**. ``FunctionWorker`` logs it with a traceback and re-emits
+it as ``errored`` on the GUI thread, which is the only way the widget can tell a failed run from
+a finished one. Swallowing it inside the body left a status line reading "Moving to …" for the
+rest of the session (FIB-765).
+
+The one sanctioned exception to "no calls": ``notification_service.show_toast`` (and ``show``),
+which is a queued ``pyqtSignal`` behind a function and may be called from anywhere. It is queued
+only because the service ``QObject`` lives on the GUI thread, and ``_get_service()`` constructs
+it lazily on first use — so the affinity is decided by whoever calls first. ``AutoLamellaMainUI``
+connects to it during setup, which is what settles it today.
+
+Why the rule is about coupling, not safety
+------------------------------------------
+
+``@ensure_main_thread`` (39 sites, 23 of them under ``fibsem/ui/``) marshals a widget method onto
+the GUI thread, so a worker that calls one is *correctly synchronised*. The reason not to write
+it that way anyway is that the sequence — do the thing, then update these five widgets — ends up
+expressed only as a widget method, and cannot be run, tested, or reused without the widget. A
+body holding just the operation keeps the schedule-and-report half where the widget can see it,
+and the reusable half where it can be called without one (FIB-828).
 """
+
 from __future__ import annotations
 
 import functools

--- a/fibsem/ui/qt/threading.py
+++ b/fibsem/ui/qt/threading.py
@@ -61,10 +61,12 @@ a finished one. Swallowing it inside the body left a status line reading "Moving
 rest of the session (FIB-765).
 
 The one sanctioned exception to "no calls": ``notification_service.show_toast`` (and ``show``),
-which is a queued ``pyqtSignal`` behind a function and may be called from anywhere. It is queued
-only because the service ``QObject`` lives on the GUI thread, and ``_get_service()`` constructs
-it lazily on first use — so the affinity is decided by whoever calls first. ``AutoLamellaMainUI``
-connects to it during setup, which is what settles it today.
+which is a queued ``pyqtSignal`` behind a function and may be called from anywhere. Qt picks the
+connection type from the *receiver's* thread affinity, not the sender's, and every receiver here
+is a widget on the GUI thread — so this holds even though ``_get_service()`` constructs the
+service lazily and could bind it to whichever thread happens to call first. Measured, not
+assumed: a service built on a worker thread still delivers to a GUI-thread slot on the GUI
+thread.
 
 Why the rule is about coupling, not safety
 ------------------------------------------


### PR DESCRIPTION
Follows #611 and #612. Docstring only — no behaviour change.

The rule existed, but only as folklore plus one docstring on a worker two directories away. Both overview widgets say *"Runs off the GUI thread. Only signals may cross back"*; the module that hands out the threads said nothing, so a new worker had no reason to find either.

## What is recorded

**The two tiers, and which to prefer.** A worker that only reports afterwards returns a value and does its GUI work in `returned`/`errored` slots — `ObjectiveControlWidget` is the model, and it is the one to reach for. A worker that must report *while* it runs emits the widget's own signals instead. Either way the exception stays uncaught, because `errored` is the only thing that distinguishes a failed run from a finished one (FIB-765 — a status line stuck on "Moving to …" for the rest of the session).

**`notification_service.show_toast` is a sanctioned off-thread call**, being a queued signal behind a function — together with *why* it is queued. Qt picks the connection type from the **receiver's** thread affinity, not the sender's, and every receiver here is a widget on the GUI thread. So the guarantee holds even though `_get_service()` constructs lazily and could bind the service to whichever thread calls first.

The second commit corrects this. My first version claimed the opposite — that lazy construction left the guarantee conditional and a toast from an early worker could break delivery. I measured it before filing an issue about it: a service forced onto a worker thread (its `thread()` is then not the GUI thread) still delivers to a GUI-thread slot, on the GUI thread. There is no footgun; the note now says so, and says it was measured.

**Why the rule is about coupling, not safety.** `@ensure_main_thread` marshals correctly at all 39 of its sites (23 under `fibsem/ui/`); a worker that calls one is not racing anything. The problem is that the sequence ends up expressed only as a widget method, and cannot then be run or tested without the widget.

## Notes for review

- Claims were checked against source rather than recalled: the `ObjectiveControlWidget` snippet is quoted from the file, the decorator counts freshly grepped, and the exemplar reference corrected once I found *both* overview widgets carry that docstring, not only the one I started from.
- The one non-comment line in the diff is the blank line after the module docstring that `ruff format` wants. The file predates that rule; the format-on-touch gate pulls it in here.
- `ruff check` and `ruff format --check` clean; parses under 3.8; 50 tests pass across the three UI suites that import this module.

## Scope

This is the last of the three steps on the worker/UI-mixing issue, but it does not finish it, so the issue is deliberately not referenced (which would auto-complete it on merge). Still outstanding there: `_canvas_double_click_worker` is a third site of the same shape and carries a separate decision about where its guards run, and the milling worker is also `parent_ui=self`, so it belongs with that work instead.

