### PR TITLE
[refactor] Decide a canvas double-click on the GUI thread

### DIFF
--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -581,11 +581,15 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         vertical_move: bool,
         coords: Optional[dict] = None,
     ) -> None:
-        """Dispatch a stage move from a microscope-space delta (worker thread).
+        """Start a stage move from a microscope-space delta (GUI thread).
 
         ``coords`` is the
         originating image-space click, carried through purely so the debug log still
         records where the operator actually clicked when a move goes wrong on hardware.
+
+        The backend-capability refusal below is the last thing that can decline the
+        move, so nothing is committed until it has had its say: the buttons are not
+        disabled, and no worker is started, for a move that is about to be refused.
         """
         movement_mode = "Vertical" if vertical_move else "Stable"
 
@@ -616,6 +620,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             )
             return
 
+        self._toggle_interactions(enable=False)
         # Which kind of move, because they are different operations and the user chose
         # between them: a plain double-click moves laterally, Alt + double-click moves
         # along the beam axis to hold eucentricity. "Vertically" rather than
@@ -628,6 +633,21 @@ class FibsemMovementWidget(QtWidgets.QWidget):
                 else "Moving the stage…"
             }
         )
+        worker = self._stage_move_worker(beam_type, point, vertical_move)
+        worker.returned.connect(self._on_stage_move_returned)
+        worker.finished.connect(self.move_stage_finished)
+        worker.start()
+
+    @thread_worker
+    def _stage_move_worker(
+        self, beam_type: BeamType, point: Point, vertical_move: bool
+    ) -> None:
+        """Move the stage. Runs off the GUI thread — only signals may cross back.
+
+        Which of the three calls applies is decided from arguments, not from widget
+        state: the beam and the modifier were resolved by the caller while it was still
+        on the GUI thread.
+        """
         # eucentric is only supported for ION beam
         if beam_type is BeamType.ION and vertical_move:
             self.microscope.vertical_move(dx=point.x, dy=point.y)
@@ -643,29 +663,27 @@ class FibsemMovementWidget(QtWidgets.QWidget):
                 dy=point.y,
                 beam_type=beam_type,
             )
-        self.movement_progress_signal.emit({"msg": ACQUIRING_IMAGES})
-        self.update_ui_after_movement()
 
     def _on_canvas_double_click(
         self, beam_type: BeamType, x: float, y: float, modifiers
     ) -> None:
-        """Canvas double-click -> move stage."""
-        if not self._click_to_move_available():
-            return
-        self._toggle_interactions(enable=False)
-        worker = self._canvas_double_click_worker(beam_type, x, y, modifiers)
-        worker.finished.connect(self.move_stage_finished)
-        worker.start()
+        """Canvas double-click -> move stage.
 
-    @thread_worker
-    def _canvas_double_click_worker(
-        self, beam_type: BeamType, x: float, y: float, modifiers
-    ):
-        """Thread worker for quad-view double-clicks (one image per canvas).
+        Every guard is answered here, on the GUI thread, before anything is committed.
+        They used to run inside the worker, which meant a click that was never going to
+        move the stage still disabled the buttons, spawned a thread to decide that, and
+        re-enabled them — and still reported ``finished``, refreshing the stage readout
+        for a move that never happened.
+
+        Answering them here also makes them atomic with respect to the event loop: the
+        whole decision is one handler, so nothing can change ``is_milling`` or swap the
+        image out between the check and the dispatch.
 
         ``x, y`` are already beam-local, full-resolution image pixels — the canvas emits
         data coords, one image per canvas, so there is no side-by-side offset to undo.
         """
+        if not self._click_to_move_available():
+            return
         if "Shift" in modifiers:
             return
         if (

--- a/tests/test_movement_widget_vertical_gate.py
+++ b/tests/test_movement_widget_vertical_gate.py
@@ -1,14 +1,19 @@
 """The SEM-view vertical-move gate (FIB-507 T4a).
 
-``FibsemMovementWidget._execute_stage_move`` dispatches an Alt-click vertical move
-to ``move_coincident_from_sem`` for the ELECTRON view -- a method only some
-backends implement (ThermoFisher, Odemis). Backends without it (e.g. TESCAN) used
-to fall through to ``stable_move`` silently: the operator asked to restore
-coincidence and got a sample-plane move instead. The widget must refuse with a
-toast, and leave every other dispatch branch untouched.
+An Alt-click vertical move dispatches to ``move_coincident_from_sem`` for the
+ELECTRON view -- a method only some backends implement (ThermoFisher, Odemis).
+Backends without it (e.g. TESCAN) used to fall through to ``stable_move``
+silently: the operator asked to restore coincidence and got a sample-plane move
+instead. The widget must refuse with a toast, and leave every other dispatch
+branch untouched.
+
+The refusal and the dispatch now live either side of a thread. ``_execute_stage_move``
+decides, on the GUI thread, whether the move may go ahead at all; ``_stage_move_worker``
+performs whichever of the three calls applies. So the refusal is asserted on the former
+and the three branches on the latter, called through ``__wrapped__``.
 
 No Qt event loop or microscope required: the widget is created without __init__
-and only the attributes ``_execute_stage_move`` touches are provided.
+and only the attributes each function touches are provided.
 """
 
 from unittest.mock import Mock
@@ -71,15 +76,23 @@ def make_widget(microscope):
     return widget
 
 
-def execute(widget, beam_type, vertical):
+def refuse_or_start(widget, beam_type, vertical):
+    """The GUI-thread half: it either declines, or commits to starting a worker."""
     widget._execute_stage_move(
         beam_type=beam_type, point=Point(1e-6, 2e-6), vertical_move=vertical
     )
 
 
+def dispatch(widget, beam_type, vertical):
+    """The worker half, run in place -- `@thread_worker` would put it on a thread."""
+    FibsemMovementWidget._stage_move_worker.__wrapped__(
+        widget, beam_type, Point(1e-6, 2e-6), vertical
+    )
+
+
 def test_sem_vertical_without_backend_support_refuses_with_a_toast(toasts):
     m = RecordingMicroscope()
-    execute(make_widget(m), BeamType.ELECTRON, vertical=True)
+    refuse_or_start(make_widget(m), BeamType.ELECTRON, vertical=True)
 
     assert m.calls == []  # no silent stable_move fallback
     assert len(toasts) == 1
@@ -90,7 +103,7 @@ def test_sem_vertical_without_backend_support_refuses_with_a_toast(toasts):
 
 def test_sem_vertical_with_backend_support_moves_coincident(toasts):
     m = SemCoincidentMicroscope()
-    execute(make_widget(m), BeamType.ELECTRON, vertical=True)
+    dispatch(make_widget(m), BeamType.ELECTRON, vertical=True)
 
     assert [c[0] for c in m.calls] == ["move_coincident_from_sem"]
     assert toasts == []
@@ -98,7 +111,7 @@ def test_sem_vertical_with_backend_support_moves_coincident(toasts):
 
 def test_fib_vertical_is_unaffected(toasts):
     m = RecordingMicroscope()
-    execute(make_widget(m), BeamType.ION, vertical=True)
+    dispatch(make_widget(m), BeamType.ION, vertical=True)
 
     assert [c[0] for c in m.calls] == ["vertical_move"]
     assert toasts == []
@@ -106,7 +119,7 @@ def test_fib_vertical_is_unaffected(toasts):
 
 def test_sem_stable_move_is_unaffected(toasts):
     m = RecordingMicroscope()
-    execute(make_widget(m), BeamType.ELECTRON, vertical=False)
+    dispatch(make_widget(m), BeamType.ELECTRON, vertical=False)
 
     assert [c[0] for c in m.calls] == ["stable_move"]
     assert toasts == []

--- a/tests/ui/test_canvas_double_click_guards.py
+++ b/tests/ui/test_canvas_double_click_guards.py
@@ -3,17 +3,13 @@
 Five guards stand between a double-click and a stage move: the Shift modifier, milling
 in progress, no image acquired yet, a click landing outside the image, and -- one level
 down in ``_execute_stage_move`` -- a SEM-view vertical move on a backend that cannot do
-one. Only the first of those is checked on the GUI thread today. The rest are evaluated
-inside ``_canvas_double_click_worker``, on the worker thread, after the widget has
-already disabled its buttons in anticipation of a move.
+one. All five are answered on the GUI thread, in ``_on_canvas_double_click``, before
+anything is committed.
 
-Nothing here is a threading bug; the guards give the right answers. What is untested is
-the answers themselves, so this file pins them before they are moved.
-
-Two of these tests pin behaviour that is expected to *change*: a refused click currently
-disables and re-enables the buttons, and reports ``finished`` for a move that never
-happened. They are marked where they appear. Recording them is the point -- it is what
-makes the follow-up visible as a behaviour change rather than a silent one.
+They used to be evaluated inside the worker, after the widget had already disabled its
+buttons in anticipation of a move -- so a click that was never going to move the stage
+still flickered the buttons and reported ``finished``. The last two tests here pin that
+those side effects are gone; they previously pinned that they happened.
 """
 
 from __future__ import annotations
@@ -43,7 +39,10 @@ from test_viewer_less_widgets import (  # noqa: E402
 
 from fibsem.structures import BeamType, Point  # noqa: E402
 from fibsem.ui import notification_service  # noqa: E402
-from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget  # noqa: E402
+from fibsem.ui.FibsemMovementWidget import (  # noqa: E402
+    ACQUIRING_IMAGES,
+    FibsemMovementWidget,
+)
 
 
 def _pump(ms: int = 150) -> None:
@@ -97,10 +96,12 @@ def dispatched(movement, monkeypatch):
 
 
 def _click(movement, beam=BeamType.ELECTRON, x=100.0, y=100.0, modifiers=frozenset()):
-    """Run the worker body on this thread -- `@thread_worker` would hide the outcome."""
-    FibsemMovementWidget._canvas_double_click_worker.__wrapped__(
-        movement, beam, x, y, set(modifiers)
-    )
+    """A double-click. Every guard resolves synchronously on this thread now."""
+    movement._on_canvas_double_click(beam, x, y, set(modifiers))
+
+
+def _explode(*args, **kwargs):
+    raise RuntimeError("the stage did not get there")
 
 
 def _centre(movement, beam=BeamType.ELECTRON):
@@ -271,48 +272,106 @@ def test_the_far_edge_is_outside_and_the_near_edge_is_inside(movement, dispatche
 # --- what the widget does around a refusal (expected to change) --------------
 
 
-def test_a_refused_click_still_toggles_the_buttons(movement, toasts):
-    """CURRENT BEHAVIOUR, pinned so that changing it is visible.
+def test_a_refused_click_leaves_the_buttons_alone(movement, toasts):
+    """A gesture that was never going to move the stage must not flicker the buttons.
 
-    `_on_canvas_double_click` disables the buttons before starting the worker, and the
-    worker is where the refusal is decided -- so a Shift-click spawns a thread, disables
-    the buttons, decides to do nothing, and re-enables them. The operator sees a flicker
-    for a gesture that was never going to move the stage.
-
-    Moving the guards onto the GUI thread removes this; when it does, this test should
-    be updated to assert the buttons never moved, not deleted.
+    The refusal is decided before `_execute_stage_move` disables anything, so nothing is
+    toggled at all -- where this used to disable, spawn a thread to decide, re-enable.
     """
     assert movement.pushButton_move.isEnabled(), "precondition: buttons start enabled"
 
     seen = []
     original = movement._toggle_interactions
     # Each call round-trips (movement -> image widget -> movement, terminated by the
-    # `caller` sentinel), so what is asserted is the transition, not the call count.
+    # `caller` sentinel), so a single toggle would show up here twice.
     movement._toggle_interactions = lambda enable, caller=None: (
         seen.append(enable),
         original(enable, caller),
     )[1]
 
     movement._on_canvas_double_click(BeamType.ELECTRON, 100.0, 100.0, {"Shift"})
-    _run(lambda: movement.pushButton_move.isEnabled() and True in seen)
+    _pump()
 
-    assert False in seen, f"the buttons were never disabled: {seen}"
-    assert seen[0] is False and seen[-1] is True, (
-        f"expected the buttons disabled and then re-enabled around a refusal: {seen}"
-    )
+    assert seen == [], f"a refused click toggled the buttons: {seen}"
+    assert movement.pushButton_move.isEnabled()
 
 
-def test_a_refused_click_still_reports_finished(movement, toasts):
-    """CURRENT BEHAVIOUR, pinned so that changing it is visible.
+def test_a_refused_click_reports_nothing(movement, toasts):
+    """No worker is started, so nothing hangs off `finished`.
 
-    `move_stage_finished` hangs off the worker's `finished`, which fires whether or not
-    the body did anything -- so a refused click emits `{"finished": True}` and refreshes
-    the stage readout for a move that never happened.
+    A refused click used to emit `{"finished": True}` and refresh the stage readout for
+    a move that never happened, because `move_stage_finished` was already connected by
+    the time the worker decided to do nothing.
     """
     reports = []
     movement.movement_progress_signal.connect(lambda d: reports.append(dict(d)))
 
     movement._on_canvas_double_click(BeamType.ELECTRON, 100.0, 100.0, {"Shift"})
-    _run(lambda: reports)
+    _pump()
 
-    assert reports == [{"finished": True}], reports
+    assert reports == [], reports
+
+
+# --- what the move itself does, once a click has survived the guards ---------
+
+
+def _move_trace(movement, monkeypatch) -> list:
+    """Every reported effect of the move, in order."""
+    seen = []
+
+    def _reported(ddict: dict) -> None:
+        if ddict.get("msg") is not None:
+            seen.append(("msg", ddict["msg"]))
+
+    movement.movement_progress_signal.connect(_reported)
+    monkeypatch.setattr(
+        movement.microscope,
+        "stable_move",
+        lambda dx, dy, beam_type: seen.append(("move", beam_type)),
+    )
+    monkeypatch.setattr(
+        movement,
+        "update_ui_after_movement",
+        lambda *a, **k: seen.append(("refresh", None)),
+    )
+    return seen
+
+
+def test_the_worker_body_only_moves(movement, monkeypatch):
+    """No message, no refresh -- one call to the microscope.
+
+    The same rule the absolute and orientation workers follow. Anything else in here is
+    a widget touched from a worker thread.
+    """
+    seen = _move_trace(movement, monkeypatch)
+    FibsemMovementWidget._stage_move_worker.__wrapped__(
+        movement, BeamType.ELECTRON, Point(x=1e-6, y=1e-6), False
+    )
+    assert [kind for kind, _ in seen] == ["move"], seen
+
+
+def test_a_click_move_is_bracketed_by_its_two_messages(movement, monkeypatch):
+    """Says it is moving, moves, says it is retaking the images, retakes them."""
+    seen = _move_trace(movement, monkeypatch)
+    x, y = _centre(movement)
+    _click(movement, BeamType.ELECTRON, x, y)
+    _run(lambda: [kind for kind, _ in seen] == ["msg", "move", "msg", "refresh"])
+
+    assert [kind for kind, _ in seen] == ["msg", "move", "msg", "refresh"], seen
+    assert seen[0][1] == "Moving the stage…"
+    assert seen[2][1] == ACQUIRING_IMAGES
+
+
+def test_a_failed_click_move_reports_nothing_further(movement, monkeypatch):
+    """The reporting hangs off `returned`, so a move that raised skips it -- the widget
+    never claims to be retaking images for a move that did not happen."""
+    seen = _move_trace(movement, monkeypatch)
+    monkeypatch.setattr(movement.microscope, "stable_move", _explode)
+
+    x, y = _centre(movement)
+    _click(movement, BeamType.ELECTRON, x, y)
+    _run(lambda: movement.pushButton_move.isEnabled())
+
+    assert [kind for kind, _ in seen] == ["msg"], seen
+    assert ACQUIRING_IMAGES not in [value for _, value in seen]
+    assert movement.pushButton_move.isEnabled(), "a failed click move left it disabled"

--- a/tests/ui/test_viewer_less_widgets.py
+++ b/tests/ui/test_viewer_less_widgets.py
@@ -11,6 +11,7 @@ widget constructs, acquires, and simply draws nothing.
 Run directly (no display needed):
     QT_QPA_PLATFORM=offscreen python tests/ui/test_viewer_less_widgets.py
 """
+
 from __future__ import annotations
 
 import os
@@ -50,7 +51,9 @@ def _session():
 
 
 def _image(beam: BeamType = BeamType.ELECTRON) -> FibsemImage:
-    image = FibsemImage.generate_blank_image(resolution=_RESOLUTION, hfw=_HFW, random=True)
+    image = FibsemImage.generate_blank_image(
+        resolution=_RESOLUTION, hfw=_HFW, random=True
+    )
     image.metadata.image_settings.beam_type = beam
     return image
 
@@ -123,11 +126,15 @@ def test_acquired_image_lands_on_its_own_beam_canvas():
     assert sem_canvas._content_extent() is None, "canvas should start empty"
 
     widget._on_acquire(_image(BeamType.ELECTRON))
-    assert sem_canvas._content_extent() is not None, "SEM image did not reach the canvas"
+    assert sem_canvas._content_extent() is not None, (
+        "SEM image did not reach the canvas"
+    )
     assert fib_canvas._content_extent() is None, "SEM image leaked onto the FIB canvas"
 
     widget._on_acquire(_image(BeamType.ION))
-    assert fib_canvas._content_extent() is not None, "FIB image did not reach the canvas"
+    assert fib_canvas._content_extent() is not None, (
+        "FIB image did not reach the canvas"
+    )
 
 
 def test_no_blank_placeholder_is_seeded():
@@ -193,7 +200,9 @@ def _sem_beam_settings(widget):
 def test_shift_scroll_nudges_working_distance_and_plain_scroll_does_not():
     host = _CanvasHost()
     widget = _image_widget(host)
-    assert len(widget._wd_scroll_connections) == 2, "WD scroll not wired to both canvases"
+    assert len(widget._wd_scroll_connections) == 2, (
+        "WD scroll not wired to both canvases"
+    )
 
     settings_widget = _sem_beam_settings(widget)
     spinbox = settings_widget.working_distance_spinbox
@@ -212,8 +221,8 @@ def test_working_distance_spinbox_resolves_the_scroll_step():
 
     widget = _image_widget(_CanvasHost())
     decimals = _sem_beam_settings(widget).working_distance_spinbox.decimals()
-    assert 10 ** -decimals <= WD_WHEEL_STEP_MM, (
-        f"spinbox resolves {10 ** -decimals} mm but the scroll step is {WD_WHEEL_STEP_MM} mm"
+    assert 10**-decimals <= WD_WHEEL_STEP_MM, (
+        f"spinbox resolves {10**-decimals} mm but the scroll step is {WD_WHEEL_STEP_MM} mm"
     )
 
 
@@ -245,7 +254,9 @@ def test_selecting_the_fm_view_leaves_the_beam_radios_alone():
     widget = _image_widget(host)
     widget.dual_beam_widget.fib_radio.setChecked(True)
     widget._on_view_selected("fm")
-    assert widget.dual_beam_widget.fib_radio.isChecked(), "FM selection moved the beam radio"
+    assert widget.dual_beam_widget.fib_radio.isChecked(), (
+        "FM selection moved the beam radio"
+    )
 
 
 # --- movement: double-click input --------------------------------------------
@@ -271,7 +282,7 @@ def test_a_second_double_click_during_a_move_is_ignored():
     movement = _movement_widget(host)
 
     started = []
-    movement._canvas_double_click_worker = lambda *a, **k: started.append(a) or _NoopWorker()
+    movement._stage_move_worker = lambda *a, **k: started.append(a) or _NoopWorker()
 
     assert movement._click_to_move_available()
     movement._on_canvas_double_click(BeamType.ION, 10.0, 10.0, set())
@@ -303,6 +314,8 @@ class _NoopWorker:
     """Stands in for a FunctionWorker without starting a thread."""
 
     finished = property(lambda self: self)
+    returned = property(lambda self: self)
+    errored = property(lambda self: self)
 
     def connect(self, *a, **k):
         pass
@@ -343,7 +356,9 @@ def test_image_widget_teardown_stops_scroll_reaching_a_dead_widget():
     widget._teardown_connections()
     before = spinbox.value()
     host.view_controller.sem_canvas.canvas_scrolled.emit(0.0, 0.0, 1, {"Shift"})
-    assert spinbox.value() == before, "WD scroll still reached the widget after teardown"
+    assert spinbox.value() == before, (
+        "WD scroll still reached the widget after teardown"
+    )
 
 
 def test_teardown_is_idempotent():
@@ -399,8 +414,12 @@ def test_setup_connections_wires_the_whole_widget():
     # early: the instructions label
     assert movement.label_movement_instructions.text() == INSTRUCTIONS_TEXT
     # middle: stage limits pushed onto the spinboxes, and the acquisition hook
-    assert movement.doubleSpinBox_movement_stage_x.maximum() != 99.99, "stage limits unset"
-    assert movement.saved_positions_widget.microscope is not None, "saved positions unwired"
+    assert movement.doubleSpinBox_movement_stage_x.maximum() != 99.99, (
+        "stage limits unset"
+    )
+    assert movement.saved_positions_widget.microscope is not None, (
+        "saved positions unwired"
+    )
     # late: milling-angle controls
     assert movement.doubleSpinBox_milling_angle.maximum() == 45
     assert movement.doubleSpinBox_milling_angle.suffix(), "milling angle suffix unset"
@@ -435,10 +454,8 @@ def test_double_click_to_move_survives_a_host_that_owns_a_milling_widget():
     image_widget._on_acquire(_image(BeamType.ELECTRON))
     moves = []
     movement._execute_stage_move = lambda *a, **k: moves.append((a, k))
-    # call the worker body directly — @thread_worker would swallow the raise onto a thread
-    movement._canvas_double_click_worker.__wrapped__(
-        movement, BeamType.ELECTRON, 100.0, 100.0, set()
-    )
+    # the handler resolves every guard synchronously, so no thread is involved
+    movement._on_canvas_double_click(BeamType.ELECTRON, 100.0, 100.0, set())
     assert moves, "double-click did not dispatch a stage move"
 
 


### PR DESCRIPTION
Stacks on #615 (the characterisation tests) — the top commit is the one under review, and the diff collapses once #615 merges. Base is `main` so this gets CI.

## What was wrong

Four of the five guards between a double-click and a stage move were evaluated *inside the worker*: the Shift modifier, milling in progress, no image acquired yet, and a click landing outside the image. The fifth — a SEM-view vertical move on a backend that cannot do one — sat a level further down. All of them ran **after** `_on_canvas_double_click` had already disabled the buttons in anticipation of a move.

So a click that was never going to move the stage would: disable the buttons, spawn a thread to decide that, re-enable them, and emit `{"finished": True}` — refreshing the stage readout for a move that never happened. Four of the five guards did this; only the capability one is rare.

## What changed

The guards answer in `_on_canvas_double_click` now, on the GUI thread, and nothing is committed until they have. Beyond removing the flicker this makes them **atomic with respect to the event loop** — the whole decision is one handler, so nothing can change `is_milling` or swap the image out between the check and the dispatch. The check-to-act window shrinks rather than grows.

The capability refusal moves the same way into `_execute_stage_move`, which is now the GUI-thread half: it either declines, or starts a worker.

What is left is `_stage_move_worker` — the three microscope calls, chosen from arguments rather than from widget state, with the reporting on either side in the `returned` slot the absolute and orientation paths already share (#612). That completes the movement side of the worker/UI split.

## Behaviour changes, pinned in advance

Both were recorded in #615 as CURRENT BEHAVIOUR, so they show up here as tests flipping rather than as silent drift:

- a refused click no longer toggles the buttons
- a refused click no longer reports `finished`

## Verification

Mutation-checked. My first pass caught only one of three, so I added worker-body, ordering and failure tests for the click path to match what the other two movement paths got:

| mutation | caught by |
| --- | --- |
| toggle the buttons before the guards (restore the flicker) | buttons-alone test |
| report from inside the worker body again | worker-body + ordering tests |
| hang the click path's reporting off `finished` | failure test |

92 passed across `test_canvas_double_click_guards.py`, `test_viewer_less_widgets.py`, `test_movement_worker_bodies.py`, `test_movement_progress.py`, `test_click_to_move_says_so.py`, `test_movement_widget_vertical_gate.py` and `test_milling_lockout.py`. `ruff check` / `ruff format --check` clean; all four files parse under 3.8.

## Notes for review

- **`test_viewer_less_widgets.py` carries unrelated `ruff format` hunks.** The file had pre-existing formatting debt and the lint gate checks changed files, so touching it pulls the debt in. The substantive edits are three: the worker rename, `_NoopWorker` gaining `returned`/`errored`, and one test moving from the worker body to the handler. Everything else in that file's diff is whitespace.
- `tests/test_movement_widget_vertical_gate.py` is retargeted rather than rewritten: the refusal is now asserted on `_execute_stage_move` and the three dispatch branches on `_stage_move_worker.__wrapped__`. That half needs no Qt at all now, which is simpler than what it did before.
- The dead `image is None` guard found in #615 is **still dead** and still pinned as such. Fixing it is a behaviour change on its own and does not belong here.
