### PR TITLE
[refactor] Delete movement_progress_signal, a widget signalling itself (FIB-825)

### DIFF
--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -3,7 +3,7 @@ from functools import partial
 from typing import Optional
 
 import numpy as np
-from PyQt5 import QtCore, QtWidgets
+from PyQt5 import QtWidgets
 from superqt import ensure_main_thread
 
 from fibsem import config as cfg
@@ -37,8 +37,6 @@ ACQUIRING_IMAGES = "Acquiring images…"
 
 
 class FibsemMovementWidget(QtWidgets.QWidget):
-    movement_progress_signal = QtCore.pyqtSignal(dict)
-
     def __init__(
         self,
         microscope: FibsemMicroscope,
@@ -233,7 +231,6 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.saved_positions_widget.move_to_requested.connect(self.move_to_position)
 
         # signals
-        self.movement_progress_signal.connect(self.handle_movement_progress_update)
         self.image_widget.acquisition_progress_signal.connect(
             self.handle_acquisition_update
         )
@@ -372,39 +369,20 @@ class FibsemMovementWidget(QtWidgets.QWidget):
                 else SECONDARY_BUTTON_STYLESHEET
             )
 
-    def handle_movement_progress_update(self, ddict: dict) -> None:
-        """Handle movement progress updates from the microscope.
+    def _report_move(self, msg: str) -> None:
+        """Say what the stage is doing, on the canvas info bar.
 
-        Written to the canvas info bar rather than shown as toasts. These messages
-        bracket a blocking move -- one click-to-move emits four of them inside ~45 ms
-        -- so as popups they stack into a wall that says nothing the moving stage and
-        the refreshing images do not already show. On the info bar the same words stay
-        put for the duration of the move, which is when they are worth reading.
+        Written there rather than shown as toasts. These messages bracket a blocking
+        move -- one click-to-move produces four of them inside ~45 ms -- so as popups
+        they stack into a wall that says nothing the moving stage and the refreshing
+        images do not already show. On the info bar the same words stay put for the
+        duration of the move, which is when they are worth reading.
 
         Toasts show unconditionally (FIB-781), so that wall of popups is what these
         messages would actually produce rather than a thing to worry about later.
         """
-        msg = ddict.get("msg", None)
-        if msg is not None:
-            logging.debug(msg)
-            self._set_move_status(msg)
-
-        is_finished = ddict.get("finished", False)
-        if is_finished:
-            # Cleared, or the last line sits there afterwards as though the stage were
-            # still moving. Every path reaches here: each worker connects `finished` to
-            # `move_stage_finished`, which emits this.
-            #
-            # Except while the images are still being retaken -- which is the usual
-            # case, because `update_ui_after_movement` only *queues* the acquisition
-            # before the worker returns. `move_stage_finished` already declines to
-            # re-enable the buttons in that window; the status has to keep the same
-            # counsel or it says "done" over a second of acquisition, and offers a
-            # double-click that is still disabled. `handle_acquisition_update` clears
-            # it when the images actually land.
-            if not self.image_widget.is_acquiring:
-                self._set_move_status(None)
-            self._update_position_readout()
+        logging.debug(msg)
+        self._set_move_status(msg)
 
     def _set_move_status(self, msg: Optional[str]) -> None:
         """Put *msg* on the info bar of every canvas, or clear it when None.
@@ -513,9 +491,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         # Said here rather than from inside the worker: this is the GUI thread, so the
         # status is on the info bar before the stage starts moving instead of racing the
         # move through the event loop.
-        self.movement_progress_signal.emit(
-            {"msg": f"Moving to {stage_position.pretty}…"}
-        )
+        self._report_move(f"Moving to {stage_position.pretty}…")
         worker = self.absolute_movement_worker(stage_position=stage_position)
         worker.returned.connect(self._on_stage_move_returned)
         worker.finished.connect(self.move_stage_finished)
@@ -537,13 +513,27 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         under way by the time ``move_stage_finished`` asks whether it is, and the
         buttons stay disabled until the images actually land.
         """
-        self.movement_progress_signal.emit({"msg": ACQUIRING_IMAGES})
+        self._report_move(ACQUIRING_IMAGES)
         self.update_ui_after_movement()
 
     def move_stage_finished(self):
-        """Handle the completion of a stage movement"""
-        self.movement_progress_signal.emit({"finished": True})
-        if self.image_widget.is_acquiring:
+        """Handle the completion of a stage movement.
+
+        Every path reaches here: each worker connects ``finished`` to this.
+        """
+        is_acquiring = self.image_widget.is_acquiring
+        if not is_acquiring:
+            # Cleared, or the last line sits there afterwards as though the stage were
+            # still moving.
+            self._set_move_status(None)
+        # The usual case is that it *is* still acquiring, because
+        # `update_ui_after_movement` only queues the acquisition before the worker
+        # returns. Neither the status nor the buttons come back in that window: the
+        # status would say "done" over a second of acquisition, and offer a
+        # double-click that is still disabled. `handle_acquisition_update` clears it
+        # when the images actually land.
+        self._update_position_readout()
+        if is_acquiring:
             return
         self._toggle_interactions(enable=True)
 
@@ -626,12 +616,8 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         # along the beam axis to hold eucentricity. "Vertically" rather than
         # "eucentric" so the message matches the words already on screen in
         # INSTRUCTIONS_TEXT.
-        self.movement_progress_signal.emit(
-            {
-                "msg": "Moving the stage vertically…"
-                if vertical_move
-                else "Moving the stage…"
-            }
+        self._report_move(
+            "Moving the stage vertically…" if vertical_move else "Moving the stage…"
         )
         worker = self._stage_move_worker(beam_type, point, vertical_move)
         worker.returned.connect(self._on_stage_move_returned)
@@ -719,9 +705,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         if orientation not in ["SEM", "FIB", "MILLING"]:
             raise ValueError(f"Invalid orientation: {orientation}")
         self._toggle_interactions(False)
-        self.movement_progress_signal.emit(
-            {"msg": f"Moving to the {orientation} orientation…"}
-        )
+        self._report_move(f"Moving to the {orientation} orientation…")
         worker = self.move_to_orientation_worker(orientation)
         # The orientation path never reported the acquisition, so the label sat on
         # "Moving to the SEM orientation…" while the move had finished and the images

--- a/tests/test_movement_widget_vertical_gate.py
+++ b/tests/test_movement_widget_vertical_gate.py
@@ -71,7 +71,7 @@ def make_widget(microscope):
     # allocates just the Python wrapper (no QApplication / C++ widget needed)
     widget = FibsemMovementWidget.__new__(FibsemMovementWidget)
     widget.microscope = microscope
-    widget.movement_progress_signal = Mock()
+    widget._report_move = Mock()
     widget.update_ui_after_movement = Mock()
     return widget
 

--- a/tests/ui/test_canvas_double_click_guards.py
+++ b/tests/ui/test_canvas_double_click_guards.py
@@ -304,7 +304,7 @@ def test_a_refused_click_reports_nothing(movement, toasts):
     the time the worker decided to do nothing.
     """
     reports = []
-    movement.movement_progress_signal.connect(lambda d: reports.append(dict(d)))
+    movement._set_move_status = reports.append
 
     movement._on_canvas_double_click(BeamType.ELECTRON, 100.0, 100.0, {"Shift"})
     _pump()
@@ -318,12 +318,14 @@ def test_a_refused_click_reports_nothing(movement, toasts):
 def _move_trace(movement, monkeypatch) -> list:
     """Every reported effect of the move, in order."""
     seen = []
+    original_status = movement._set_move_status
 
-    def _reported(ddict: dict) -> None:
-        if ddict.get("msg") is not None:
-            seen.append(("msg", ddict["msg"]))
+    def _reported(msg):
+        if msg is not None:
+            seen.append(("msg", msg))
+        original_status(msg)
 
-    movement.movement_progress_signal.connect(_reported)
+    monkeypatch.setattr(movement, "_set_move_status", _reported)
     monkeypatch.setattr(
         movement.microscope,
         "stable_move",

--- a/tests/ui/test_movement_progress.py
+++ b/tests/ui/test_movement_progress.py
@@ -26,7 +26,7 @@ from PyQt5.QtCore import QEventLoop, QTimer
 
 # The real construction seam: a host with a view controller, a real image widget and a
 # Demo microscope. Building the widget through `__new__` and hand-injecting a label
-# would let every test here pass with `movement_progress_signal` disconnected.
+# would let every test here pass without the info bar ever being reached.
 sys.path.insert(0, os.path.dirname(__file__))  # not str.rsplit: Windows paths
 from test_viewer_less_widgets import (  # noqa: E402
     _CanvasHost,
@@ -81,9 +81,21 @@ def _status(widget, beam: BeamType = BeamType.ELECTRON):
 
 
 def _record(widget) -> list:
-    """Every status the info bar held, in order, as the move ran."""
+    """Every status the info bar held, in order, as the move ran.
+
+    Sampled by wrapping `_set_move_status`, which is what actually writes the bar. This
+    was a `movement_progress_signal` connection until that signal turned out to be the
+    widget calling itself on one thread; the observation point moved to the method the
+    signal existed to reach.
+    """
     seen = []
-    widget.movement_progress_signal.connect(lambda _d: seen.append(_status(widget)))
+    original = widget._set_move_status
+
+    def _sample(msg):
+        original(msg)
+        seen.append(_status(widget))
+
+    widget._set_move_status = _sample
     return seen
 
 
@@ -144,9 +156,11 @@ def test_the_status_shows_from_another_tab(movement):
 def test_the_instructions_label_is_left_alone(movement):
     """It says what a double-click does, which does not change while the stage moves."""
     seen = []
-    movement.movement_progress_signal.connect(
-        lambda _d: seen.append(movement.label_movement_instructions.text())
-    )
+    original = movement._set_move_status
+    movement._set_move_status = lambda msg: (
+        original(msg),
+        seen.append(movement.label_movement_instructions.text()),
+    )[0]
     movement._move_to_absolute_position(TARGET)
     _run(lambda: seen and _status(movement) is None)
     assert set(seen) == {INSTRUCTIONS_TEXT}, seen
@@ -171,7 +185,8 @@ def test_progress_does_not_toast(movement, monkeypatch):
         lambda *a, **k: shown.append(a[0] if a else ""),
     )
     progress = []
-    movement.movement_progress_signal.connect(lambda d: progress.append(d.get("msg")))
+    original = movement._set_move_status
+    movement._set_move_status = lambda msg: (original(msg), progress.append(msg))[0]
     movement._move_to_absolute_position(TARGET)
     _run(lambda: _status(movement) is None)
 
@@ -189,14 +204,11 @@ def test_it_clears_when_the_images_land_not_before(movement):
     the status cleared there it would read "nothing is happening" over the acquisition
     it just announced, and offer a double-click that is still disabled."""
     at_finished = []
-    movement.movement_progress_signal.connect(
-        lambda d: (
-            d.get("finished")
-            and at_finished.append(
-                (_status(movement), movement.image_widget.is_acquiring)
-            )
-        )
-    )
+    original = movement.move_stage_finished
+    movement.move_stage_finished = lambda: (
+        original(),
+        at_finished.append((_status(movement), movement.image_widget.is_acquiring)),
+    )[0]
     movement._move_to_absolute_position(TARGET)
     _run(lambda: at_finished and not movement.image_widget.is_acquiring)
 
@@ -271,16 +283,21 @@ def test_no_progress_message_says_updating_ui(movement):
 
 
 def test_the_status_is_written_on_the_gui_thread(movement):
-    """`movement_progress_signal` is a `pyqtSignal` on a widget with main-thread
-    affinity, so emitting it from a worker queues delivery onto the GUI thread -- which
-    is why the handler needs no `@ensure_main_thread` (`update_ui_after_movement` does,
-    because a worker calls *that* directly rather than through a signal). Asserted
-    rather than assumed: writing the info bar off-thread would be a Qt violation."""
+    """Writing the info bar off-thread would be a Qt violation, so nothing may.
+
+    This used to hold because the reporting went through a signal, which queued
+    delivery when a worker emitted it. There is no signal and no queueing now: the
+    reporting is a direct call, and it is safe only because every caller is already on
+    the GUI thread. That is a property of where the calls are, so it can be broken by
+    moving one -- which is what this catches. Run over a whole move, worker included.
+    """
     threads = []
-    movement.movement_progress_signal.connect(
-        lambda _d: threads.append(threading.current_thread().name)
-    )
+    original = movement._set_move_status
+    movement._set_move_status = lambda msg: (
+        threads.append(threading.current_thread().name),
+        original(msg),
+    )[1]
     movement._move_to_absolute_position(TARGET)
     _run(lambda: _status(movement) is None)
-    assert threads, "the handler never ran"
+    assert threads, "the status was never written"
     assert set(threads) == {"MainThread"}, threads

--- a/tests/ui/test_movement_worker_bodies.py
+++ b/tests/ui/test_movement_worker_bodies.py
@@ -79,14 +79,18 @@ def _trace(movement, monkeypatch) -> list:
     and it keeps the recorder from being queued behind the assertions.
     """
     seen = []
+    # `_set_move_status` is where the reporting lands on the info bar. It was a
+    # `movement_progress_signal` emit until the signal turned out to be the widget
+    # calling itself; the clear it also receives (None, once a move is done) is pinned
+    # by the buttons-back test instead.
+    original_status = movement._set_move_status
 
-    def _reported(ddict: dict) -> None:
-        # Only the messages. `move_stage_finished` also emits {"finished": True}, which
-        # carries no message and is pinned by the buttons-back test instead.
-        if ddict.get("msg") is not None:
-            seen.append(("msg", ddict["msg"]))
+    def _reported(msg):
+        if msg is not None:
+            seen.append(("msg", msg))
+        original_status(msg)
 
-    movement.movement_progress_signal.connect(_reported)
+    monkeypatch.setattr(movement, "_set_move_status", _reported)
 
     def _moved(stage_position, *args, **kwargs):
         seen.append(("move", stage_position))
@@ -287,19 +291,19 @@ def test_a_real_move_keeps_the_buttons_down_until_the_images_land(movement):
     what ``move_stage_finished`` reads when it decides whether to give the buttons
     back, and the one fact in this file that a stub cannot supply honestly.
 
-    The buttons must be down from the moment the move starts, still down when
-    ``finished`` arrives mid-acquisition, and back only once the images have landed.
+    The buttons must be down from the moment the move starts, stay down through the
+    acquisition that follows it, and come back only once the images have landed --
+    which is also when the status is cleared, by `handle_acquisition_update` rather
+    than by `move_stage_finished`.
     """
     seen = []
-    movement.movement_progress_signal.connect(
-        lambda d: seen.append(
-            (
-                dict(d),
-                movement.pushButton_move.isEnabled(),
-                movement.image_widget.is_acquiring,
-            )
-        )
-    )
+    original_status = movement._set_move_status
+
+    def _sample(msg):
+        seen.append((msg, movement.pushButton_move.isEnabled()))
+        original_status(msg)
+
+    movement._set_move_status = _sample
 
     assert movement.pushButton_move.isEnabled(), "precondition: buttons start enabled"
     movement._move_to_absolute_position(TARGET)
@@ -309,23 +313,18 @@ def test_a_real_move_keeps_the_buttons_down_until_the_images_land(movement):
 
     _run(
         lambda: (
-            len(seen) >= 3
+            None in [msg for msg, _ in seen]
             and movement.pushButton_move.isEnabled()
             and not movement.image_widget.is_acquiring
         ),
         tries=60,
     )
 
-    assert [d.get("msg") for d, _, _ in seen[:2]] == [
-        seen[0][0].get("msg"),
-        ACQUIRING_IMAGES,
-    ], seen
-    assert not any(enabled for _, enabled, _ in seen), (
+    messages = [msg for msg, _ in seen]
+    assert messages[:2] == [messages[0], ACQUIRING_IMAGES], seen
+    assert messages[0] and messages[0].startswith("Moving to"), seen
+    assert None in messages, f"the status was never cleared: {seen}"
+    assert not any(enabled for msg, enabled in seen if msg is not None), (
         f"the buttons came back while the move was still reporting: {seen}"
-    )
-    assert seen[-1][0].get("finished") is True, seen[-1]
-    assert seen[-1][2] is True, (
-        "the acquisition had not started when the move finished -- move_stage_finished "
-        "would have re-enabled the buttons over it"
     )
     assert movement.pushButton_move.isEnabled(), "the buttons never came back"


### PR DESCRIPTION
Replaces #591, which was written against code that no longer exists. Closes FIB-825.

## What it was

The signal carried `{"msg": ...}` and `{"finished": True}` from five places in `FibsemMovementWidget` to one handler on the same widget. Measured on `main` rather than argued:

- **Every delivery is a direct connection** — the handler runs *inside* `emit()`, before it returns, on `MainThread`, for all five emit sites.
- **All five emitters are GUI-thread code**: the two entry points, `_execute_stage_move`, `_on_stage_move_returned`, `move_stage_finished`.
- **One subscriber, itself.** Zero references anywhere outside the widget and its tests.

So it was a method call with a dict wrapper and a trip through Qt's signal machinery.

## What replaces it

The four message emits become `_report_move(msg)`, which keeps the handler's logging and its explanation of why these go to the info bar rather than to toasts. `move_stage_finished` absorbs what the `finished` branch did — which also puts the "clear the status unless the images are still coming" decision next to the *identical* decision about the buttons, instead of in a handler two hundred lines away that reached the same conclusion separately.

Net −20 lines in the widget, and one dead `QtCore` import goes with it (the signal was its only user; `ruff check` did not flag it because F401 is not in the project's rule set).

## The reason changed, and that is worth stating

FIB-825 originally argued this was **a thread hop duplicating `@ensure_main_thread`**. That is no longer true and has not been since #612: the movement workers stopped emitting anything when the reporting moved onto the GUI thread. There is no hop to remove.

What is left is a simpler argument for the same deletion — a widget calling itself, synchronously, through a signal. #591 cannot be rebased onto this (it is `+79 −74` against `absolute_movement_worker` as it stood two rewrites ago), so this supersedes it.

## Tests

They observe `_set_move_status` now — what actually writes the info bar, and what the signal existed to reach. Five connect sites across four files moved.

**One test changes meaning, not just shape.** `test_the_status_is_written_on_the_gui_thread` asserted the handler ran on the main thread; its docstring explained that emitting from a worker queues delivery. Nothing has emitted from a worker since #612, so it had become true by construction and could not fail. It now wraps the whole move including the worker, so it fails if any reporting moves back off the GUI thread — verified by putting a `_report_move` call inside `absolute_movement_worker` and watching it fail, then removing it.

## Verification

92 passed across `test_movement_progress.py`, `test_movement_worker_bodies.py`, `test_canvas_double_click_guards.py`, `test_viewer_less_widgets.py`, `test_click_to_move_says_so.py`, `test_movement_widget_vertical_gate.py`, `test_milling_lockout.py`. `ruff check` (including an explicit F401 pass) and `ruff format --check` clean; all five files parse under 3.8.
