### PR TITLE
[refactor] Make the device a place in configuration, not three constants (FIB-830)

### DIFF
--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -28,6 +28,12 @@ stage:
     rotation_180:               180                         # the reference rotation + 180 degrees                          [DERIVED - rotation-reference]
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
+    device_range:               {x: 20.0e-3}                # the region belonging to each device, from its origin    [metres][SPECIFIED]
+    devices:                                                # where the stage travels for each instrument to see the sample
+        FIBSEM:
+            origin:     {x: 0.0}                            # the beams: the chamber origin                         [metres][SPECIFIED]
+        FM:
+            origin:     {x: 48.8e-3}                        # the FM: offset along x                                [metres][SPECIFIED]
 electron:
     enabled:                    true                        # the electron beam is enabled                                  [USER]
     column_tilt:                0                           # the column tilt of the electron beam                          [DERIVED - manufactuer]

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -114,6 +114,7 @@ from fibsem.microscopes.autoscript import (
 from fibsem.milling.progress import MillingProgress, MillingProgressStatus
 from fibsem.structures import (
     ACTIVE_MILLING_STATES,
+    DEVICE_AXES,
     BeamSettings,
     BeamSystemSettings,
     BeamType,
@@ -141,6 +142,7 @@ from fibsem.structures import (
     MillingState,
     Point,
     RangeLimit,
+    StageDeviceSettings,
     SystemSettings,
 )
 from fibsem.transformations import (
@@ -2111,10 +2113,86 @@ class FibsemMicroscope(ABC):
         )
         pass
 
+    def _get_device(self, device: str) -> StageDeviceSettings:
+        """The configuration for `device`, or a refusal naming the ones there are."""
+        try:
+            return self.system.stage.devices[device]
+        except KeyError:
+            raise ValueError(
+                f"Microscope {device} not supported. "
+                f"Configured devices: {sorted(self.system.stage.devices)}."
+            ) from None
+
+    def get_device_position(self, device: str) -> FibsemStagePosition:
+        """Where the stage travels for `device` to see the sample.
+
+        Partial: an offset fluorescence microscope is an x location and leaves y, z, r
+        and t free, so the axes it does not constrain come back `None`.
+        """
+        return deepcopy(self._get_device(device).origin)
+
+    def is_at_device(
+        self, device: str, stage_position: Optional[FibsemStagePosition] = None
+    ) -> bool:
+        """Is the stage at `device`?
+
+        The question nothing could ask before. `get_stage_orientation` cannot answer
+        it on an offset mount -- the FM orientation there is byte-identical to the FIB
+        one -- because it is not a question about orientation at all.
+
+        Only meaningful for a device the stage *travels to*. A device that comes to
+        the sample instead has no origin, and answers `False` rather than pretending
+        position decides it.
+        """
+        if stage_position is None:
+            stage_position = self.get_stage_position()
+        return self._get_device(device).contains(
+            stage_position, self.system.stage.device_range
+        )
+
+    def get_current_device(
+        self, stage_position: Optional[FibsemStagePosition] = None
+    ) -> Optional[str]:
+        """Which device the stage is at, or `None` if it is at no configured device.
+
+        `None` is a real answer, not a failure to find one: the device ranges
+        deliberately leave a gap between them, so a stage part-way through a traverse
+        -- or left there by one that was aborted -- is at neither.
+
+        Positional, so it is the wrong question on a compustage, where the beams and
+        the FM are the same place reached by flipping and the devices fully overlap.
+        Nothing asks it there: `move_to_microscope` branches to the compustage path
+        first, and the device is decided by orientation instead.
+        """
+        if stage_position is None:
+            stage_position = self.get_stage_position()
+
+        for device in self.system.stage.devices:
+            if self.is_at_device(device, stage_position):
+                return device
+        return None
+
+    def _device_translation(self, source: str, target: str) -> FibsemStagePosition:
+        """The relative stage move from one device to another.
+
+        A difference of two configured places rather than a constant, so the traverse
+        and the "am I already there" windows can no longer drift apart. Relative
+        rather than absolute on purpose: the devices constrain x only, and a relative
+        move carries y, z, r and t across unchanged.
+        """
+        source_origin = self._get_device(source).origin
+        target_origin = self._get_device(target).origin
+
+        translation = FibsemStagePosition()
+        for axis in DEVICE_AXES:
+            start, end = getattr(source_origin, axis), getattr(target_origin, axis)
+            if start is not None and end is not None:
+                setattr(translation, axis, end - start)
+        return translation
+
     def move_to_microscope(self, target: str) -> None:
         """Move the stage to the specified microscope (FIBSEM <-> FM)"""
-        if target not in ["FIBSEM", "FM"]:
-            raise ValueError(f"Microscope {target} not supported.")
+        self._get_device(target)  # refuses by name if it is not a configured device
 
         if self.stage_is_compustage:
             self.move_to_microscope_compustage(target)
@@ -2130,38 +2208,30 @@ class FibsemMicroscope(ABC):
                 "Cannot move to FM from SEM or MILLING orientation. Please switch to FIB orientation first."
             )
 
-        # check if we are already at the target position
-        # this is for TFS SDB chamber: e.g. piescope, meteor, iflm
-        # arctis has same range for FIBSEM/FM (stage is flipped upside down)
-        FM_RANGE = (40e-3, 60e-3)  # 40 mm to 60 mm
-        FIBSEM_RANGE = (-20e-3, 20e-3)  # -20 mm to 20 mm
-        if target == "FM" and (FM_RANGE[0] < stage_position.x < FM_RANGE[1]):
-            logging.info("Already at FM position, no need to move.")
-            return
+        source = self.get_current_device(stage_position)
+        if source is None:
+            raise ValueError(
+                f"The stage is not at any configured device "
+                f"({sorted(self.system.stage.devices)}), so there is nothing to "
+                f"travel from. Position: {stage_position}."
+            )
 
-        if target == "FIBSEM" and (
-            FIBSEM_RANGE[0] < stage_position.x < FIBSEM_RANGE[1]
-        ):
-            logging.info("Already at FIBSEM position, no need to move.")
-            return
+        if source == target:
+            logging.info(f"Already at {target} position, no need to move.")
+        else:
+            # Retracted immediately before the stage travels, and only then. The
+            # objective must not be out over the sample while the stage moves, but
+            # every reason to retract it is the move itself -- so a call that refuses,
+            # or that finds it has nowhere to go, leaves the objective exactly as it
+            # found it rather than pulling it out of the sample for nothing.
+            logging.info(f"Moving to {target} position...")
+            self.fm.objective.retract()
+            self.move_stage_relative(self._device_translation(source, target))
 
-        logging.info(f"Moving to {target} position...")
-
-        # retract objective (safety precaution)
-        self.fm.objective.retract()
-
-        TRANSLATION_DX = (
-            48.8e-3  # 48.8 mm # THIS needs to be configurable for different microscopes
-        )
-        transf = FibsemStagePosition(x=TRANSLATION_DX)
-
-        # move to FIBSEM
-        if target == "FIBSEM":
-            transf.x *= -1
-            self.move_stage_relative(transf)
-        # move to FM
+        # Unconditional, so that the postcondition is the device *and* the objective
+        # state together: asking again for a device the stage is already at cannot
+        # leave the FM blind.
         if target == "FM":
-            self.move_stage_relative(transf)
             self.fm.objective.insert()
 
     def move_to_microscope_compustage(self, target: str) -> None:

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -6,6 +6,7 @@ import logging
 import os
 import sys
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from dataclasses import InitVar, asdict, dataclass, field, fields
 from datetime import datetime
 from enum import Enum, auto
@@ -1962,6 +1963,134 @@ class FibsemMillingSettings:
         return "\n".join(lines)
 
 
+# The axes a device is allowed to constrain.
+#
+# Linear only, and that is the model rather than a shortcut: a device is a *place*,
+# and the pose the sample is held in once the stage is there is the orientation, which
+# is the other axis of this model entirely. A device that also fixed r or t would be
+# the same conflation this is here to undo. It also sidesteps a units question --
+# x/y/z are metres in the configuration, while `rotation_reference` and
+# `shuttle_pre_tilt` are degrees, converted at use.
+DEVICE_AXES = ("x", "y", "z")
+
+
+def device_axes_to_dict(position: FibsemStagePosition) -> dict:
+    """The device axes a partial position sets, as a plain dict. Absent axes are absent."""
+    return {
+        axis: getattr(position, axis)
+        for axis in DEVICE_AXES
+        if getattr(position, axis) is not None
+    }
+
+
+def device_axes_from_dict(axes: dict, what: str) -> FibsemStagePosition:
+    """A partial position from device axes, refusing anything that is not one."""
+    axes = axes or {}
+    unknown = set(axes) - set(DEVICE_AXES)
+    if unknown:
+        raise ValueError(
+            f"Unsupported {what} axes: {sorted(unknown)}. Supported: {list(DEVICE_AXES)}."
+        )
+    return FibsemStagePosition(**{axis: float(value) for axis, value in axes.items()})
+
+
+@dataclass
+class StageDeviceSettings:
+    """Where the stage travels for one instrument to see the sample.
+
+    An offset fluorescence microscope is not under the grid; the stage travels to it.
+    So the FM is a *place* on the stage rather than a pose the stage is held in, and
+    `origin` is that place, in stage coordinates.
+
+    It is a reference point, not a destination. The stage does not land on it: it
+    travels by the difference between two origins and arrives wherever that puts it.
+    Partial, too -- an offset FM is an x location and leaves y, z, r and t free, so an
+    axis that is absent does not decide anything.
+    """
+
+    origin: FibsemStagePosition
+
+    def contains(
+        self, stage_position: FibsemStagePosition, device_range: FibsemStagePosition
+    ) -> bool:
+        """Is `stage_position` within `device_range` of this device's origin?
+
+        `device_range` is the region belonging to a device, as a half-width per axis
+        from its origin. One value shared by every device, and it has to be shared.
+        The stage travels by the *difference* between two origins, so it keeps its
+        offset: a grid position 15 mm along at the beams arrives 15 mm along at the
+        FM. If the destination's range were the smaller of the two, the traverse could
+        legally produce a position the destination refuses to recognise -- the stage
+        would arrive somewhere it reports it has not arrived, ask again and traverse a
+        second time, and be unable to go back either. That is not hypothetical: the
+        two windows this replaces were 20 mm at the beams and about 10 mm at the FM,
+        written out separately, and that is exactly what they did.
+
+        Sharing it makes the mapping invertible, and makes a destination check
+        unnecessary rather than merely omitted: `|arrival - target| = |start -
+        source|`, so a traverse that starts inside a range always ends inside one.
+        What has to be checked is the *start*, which
+        `FibsemMicroscope.move_to_microscope` does.
+
+        Not the same question as whether the device usefully *covers* the sample
+        here -- an objective's field, a knife's approach -- which genuinely does vary
+        per device. Nothing needs that yet; see FIB-839.
+
+        Devices may overlap, and on a compustage they fully do: the objective is under
+        the grid, so the beams and the FM are the same place reached by flipping. The
+        device axis is degenerate there and this question is not the one to ask -- see
+        `FibsemMicroscope.get_current_device`.
+
+        A device whose origin constrains an axis that `device_range` says nothing
+        about answers **no**. The caller is "have I already arrived", and the two costs are
+        not symmetric: a wrong `False` costs a move that was not needed, a wrong
+        `True` skips one that was.
+        """
+        constrained = [
+            axis for axis in DEVICE_AXES if getattr(self.origin, axis) is not None
+        ]
+        if not constrained:
+            return False
+
+        for axis in constrained:
+            extent, value = getattr(device_range, axis), getattr(stage_position, axis)
+            if extent is None or value is None:
+                return False
+            if abs(value - getattr(self.origin, axis)) > extent:
+                return False
+        return True
+
+    def to_dict(self) -> dict:
+        return {"origin": device_axes_to_dict(self.origin)}
+
+    @staticmethod
+    def from_dict(ddict: dict) -> "StageDeviceSettings":
+        return StageDeviceSettings(
+            origin=device_axes_from_dict(ddict.get("origin"), "device origin")
+        )
+
+
+# The region belonging to a device, as a half-width from its origin: the grid, give
+# or take. One value for every device, so no device can be given a range inconsistent
+# with the traverse that gets to it -- that inconsistency was a real bug, and
+# per-device windows are how it happened.
+DEFAULT_DEVICE_RANGE = FibsemStagePosition(x=20.0e-3)
+
+# The TFS SDB chamber layout -- piescope, METEOR, iFLM -- which is where every offset
+# fluorescence microscope sits today. The traverse between these two was a constant
+# inlined in `move_to_microscope` (`TRANSLATION_DX`), carrying its own "THIS needs to
+# be configurable" note, with two further constants for the windows it had to agree
+# with. They stay the defaults so that no existing configuration changes behaviour by
+# saying nothing; a site whose chamber differs now has somewhere to say so.
+#
+# A compustage never reaches them: its objective is under the grid, so it takes the
+# `move_to_microscope_compustage` branch and does not travel to the FM at all.
+DEFAULT_STAGE_DEVICES: Dict[str, StageDeviceSettings] = {
+    "FIBSEM": StageDeviceSettings(origin=FibsemStagePosition(x=0.0)),
+    "FM": StageDeviceSettings(origin=FibsemStagePosition(x=48.8e-3)),
+}
+
+
 @dataclass
 class StageSystemSettings:
     rotation_reference: float
@@ -1972,6 +2101,19 @@ class StageSystemSettings:
     rotation: bool = True
     tilt: bool = True
     milling_angle: float = 15
+    # Where the stage travels for each instrument to see the sample. Keyed by device
+    # name -- "FIBSEM" and "FM" today -- and separate from `orientations`, which says
+    # what pose the sample is held in once the stage is there.
+    #
+    # `device_range` is how far from one of them the stage can be and still count as
+    # having travelled to it. Not to be confused with `microscope._stage.limits`,
+    # which is how far the axes can physically move.
+    device_range: FibsemStagePosition = field(
+        default_factory=lambda: deepcopy(DEFAULT_DEVICE_RANGE)
+    )
+    devices: Dict[str, StageDeviceSettings] = field(
+        default_factory=lambda: deepcopy(DEFAULT_STAGE_DEVICES)
+    )
 
     def to_dict(self):
         return {
@@ -1983,10 +2125,16 @@ class StageSystemSettings:
             "rotation": self.rotation,
             "tilt": self.tilt,
             "milling_angle": self.milling_angle,
+            "device_range": device_axes_to_dict(self.device_range),
+            "devices": {
+                name: device.to_dict() for name, device in self.devices.items()
+            },
         }
 
     @staticmethod
     def from_dict(settings: dict):
+        devices = settings.get("devices")
+        device_range = settings.get("device_range")
         return StageSystemSettings(
             rotation_reference=settings["rotation_reference"],
             rotation_180=settings["rotation_180"],
@@ -1996,6 +2144,19 @@ class StageSystemSettings:
             rotation=settings.get("rotation", True),
             tilt=settings.get("tilt", True),
             milling_angle=settings.get("milling_angle", 15.0),
+            device_range=(
+                device_axes_from_dict(device_range, "device range")
+                if device_range
+                else deepcopy(DEFAULT_DEVICE_RANGE)
+            ),
+            devices=(
+                {
+                    name: StageDeviceSettings.from_dict(device)
+                    for name, device in devices.items()
+                }
+                if devices
+                else deepcopy(DEFAULT_STAGE_DEVICES)
+            ),
         )
 
 

--- a/tests/test_fm_device_position.py
+++ b/tests/test_fm_device_position.py
@@ -1,0 +1,450 @@
+"""Where the stage travels for an instrument to see the sample.
+
+A compustage's fluorescence objective sits under the grid: the stage turns over and
+the FM is genuinely an *orientation*. An offset FM -- METEOR, iFLM -- is off to the
+side, and the stage travels ~48.8 mm to reach it while rotation and tilt do not change
+at all. There the FM is a **place**, and a place is not something
+`get_stage_orientation` can report: measured on the offset simulator, the FM
+orientation is byte-identical to the FIB one, so it never comes back.
+
+So the device is its own axis, alongside orientation. This file pins the first half of
+it: the devices are configuration rather than three constants inlined in
+`move_to_microscope`, and `is_at_device` can ask the question that had no asker.
+
+See FIB-830.
+"""
+
+import os
+from copy import deepcopy
+
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.structures import (
+    DEFAULT_DEVICE_RANGE,
+    DEFAULT_STAGE_DEVICES,
+    FibsemStagePosition,
+    StageDeviceSettings,
+)
+
+IFLM_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-iflm-configuration.yaml")
+
+# Between the two windows: past the beams' 20 mm, short of the FM's 28.8 mm.
+# Mid-traverse, and at no device.
+IN_THE_GAP_MM = 24.0
+
+
+def _microscope():
+    microscope, _ = utils.setup_session(config_path=IFLM_CONFIG)
+    return microscope
+
+
+def _at_fib(microscope):
+    """`move_to_microscope("FM")` refuses from any other orientation -- see FIB-832."""
+    microscope.move_to_orientation("FIB")
+    return microscope
+
+
+# ── the devices are configuration ────────────────────────────────────
+
+
+def test_the_devices_come_from_the_configuration_file():
+    """The three numbers that used to be inline in `move_to_microscope`.
+
+    `TRANSLATION_DX` carried its own note -- *"THIS needs to be configurable for
+    different microscopes"* -- and the two windows it had to agree with were separate
+    literals that nothing kept in step with it.
+    """
+    microscope = _microscope()
+
+    assert microscope.get_device_position("FIBSEM").x == pytest.approx(0.0)
+    assert microscope.get_device_position("FM").x == pytest.approx(48.8e-3)
+    assert microscope.system.stage.device_range.x == pytest.approx(20.0e-3)
+
+
+def test_a_configuration_that_says_nothing_gets_the_chamber_it_had_before():
+    """No existing configuration changes behaviour by not mentioning devices.
+
+    The defaults are the TFS SDB chamber layout the constants described, so a site
+    that never had a reason to think about this keeps exactly what it had.
+    """
+    default, _ = utils.setup_session(config_path=cfg.MICROSCOPE_CONFIGURATION_PATH)
+
+    assert "devices" not in utils.load_yaml(cfg.MICROSCOPE_CONFIGURATION_PATH)["stage"]
+    assert default.system.stage.devices == DEFAULT_STAGE_DEVICES
+    assert default.system.stage.device_range == DEFAULT_DEVICE_RANGE
+
+
+def test_a_device_is_a_place_and_leaves_the_pose_alone():
+    """Only x. Rotation and tilt are the *orientation* axis, not the device one.
+
+    A device that also fixed r or t would be the same conflation this is undoing, so
+    the configuration refuses to express one.
+    """
+    position = _microscope().get_device_position("FM")
+
+    assert position.x is not None
+    assert (position.y, position.z, position.r, position.t) == (None, None, None, None)
+
+    with pytest.raises(ValueError, match="Unsupported device"):
+        StageDeviceSettings.from_dict({"origin": {"x": 48.8e-3, "r": 3.14}})
+
+
+def test_the_configuration_survives_a_round_trip():
+    """`system.to_dict()` is served over the API and written into image metadata."""
+    stage = _microscope().system.stage
+    restored = type(stage).from_dict(stage.to_dict())
+
+    assert restored.devices == stage.devices
+    assert restored.device_range == stage.device_range
+
+
+# ── the question nothing could ask ───────────────────────────────────
+
+
+def test_is_at_device_answers_where_get_stage_orientation_cannot():
+    """The stage starts at the beams, which is not where the FM is.
+
+    `get_stage_orientation` cannot make this distinction on an offset mount at all:
+    the FM orientation there is a copy of the FIB one, so it reports "FIB" at both
+    ends of a 48.8 mm traverse.
+    """
+    microscope = _microscope()
+
+    assert microscope.is_at_device("FIBSEM") is True
+    assert microscope.is_at_device("FM") is False
+
+
+def test_the_window_is_wider_than_the_origin():
+    """A stage never lands on the nominal value, so "at" is a window, not a point."""
+    microscope = _microscope()
+    position = FibsemStagePosition(x=10.0e-3, y=0.0, z=0.0, r=0.0, t=0.0)
+
+    assert microscope.is_at_device("FIBSEM", position) is True
+    assert microscope.is_at_device("FM", position) is False
+
+
+def test_between_the_two_devices_is_neither():
+    """The windows do not tile the axis, and that is deliberate.
+
+    The beam window ends at 20 mm and the fluorescence one begins at 28.8 mm, so 8.8
+    mm of travel belongs to neither. A stage there is mid-traverse, which is a real
+    state and not one to guess a device for.
+    """
+    microscope = _microscope()
+    position = FibsemStagePosition(x=IN_THE_GAP_MM * 1e-3, y=0.0, z=0.0, r=0.0, t=0.0)
+
+    assert microscope.is_at_device("FIBSEM", position) is False
+    assert microscope.is_at_device("FM", position) is False
+
+
+def test_the_axes_a_device_does_not_constrain_do_not_decide():
+    """y, z, r and t are free at a device: it is an x location, nothing more."""
+    microscope = _microscope()
+    position = FibsemStagePosition(x=0.0, y=5.0e-3, z=2.0e-3, r=3.14, t=0.3)
+
+    assert microscope.is_at_device("FIBSEM", position) is True
+
+
+def test_a_device_the_range_cannot_decide_is_never_arrived_at():
+    """The asymmetry is the reason: a wrong "no" costs a move, a wrong "yes" skips one.
+
+    Two ways to be unanswerable, and both say no. A device whose origin constrains an
+    axis the range says nothing about cannot be decided; nor can a device with no
+    origin at all, which is what a device that comes to the sample rather than being
+    travelled to looks like -- a needle or a knife inserts, and position is simply not
+    the question for it. See FIB-839.
+    """
+    device = StageDeviceSettings(origin=FibsemStagePosition(x=48.8e-3))
+    here = FibsemStagePosition(x=48.8e-3, y=0.0, z=0.0)
+
+    assert device.contains(here, FibsemStagePosition(y=1.0e-3)) is False
+    assert (
+        StageDeviceSettings(origin=FibsemStagePosition()).contains(
+            here, DEFAULT_DEVICE_RANGE
+        )
+        is False
+    )
+
+
+def test_an_unconfigured_device_is_refused_by_name():
+    microscope = _microscope()
+
+    with pytest.raises(ValueError, match=r"Configured devices: \['FIBSEM', 'FM'\]"):
+        microscope.is_at_device("TEM")
+
+
+# ── the traverse ─────────────────────────────────────────────────────
+
+
+def test_the_traverse_lands_at_the_fm():
+    microscope = _at_fib(_microscope())
+
+    microscope.move_to_microscope("FM")
+
+    assert microscope.get_stage_position().x == pytest.approx(48.8e-3)
+    assert microscope.is_at_device("FM") is True
+    assert microscope.is_at_device("FIBSEM") is False
+
+
+def test_the_traverse_round_trips():
+    microscope = _at_fib(_microscope())
+    start = deepcopy(microscope.get_stage_position())
+
+    microscope.move_to_microscope("FM")
+    microscope.move_to_microscope("FIBSEM")
+
+    assert microscope.get_stage_position().is_close(start, tol=1e-9)
+
+
+def test_the_traverse_leaves_the_orientation_alone():
+    """The point of the model: travelling to a device is not re-posing the sample."""
+    microscope = _at_fib(_microscope())
+    before = deepcopy(microscope.get_stage_position())
+
+    microscope.move_to_microscope("FM")
+    after = microscope.get_stage_position()
+
+    assert (after.r, after.t) == (before.r, before.t)
+
+
+def test_arriving_where_it_already_is_does_not_move():
+    microscope = _at_fib(_microscope())
+    microscope.move_to_microscope("FM")
+
+    microscope.move_to_microscope("FM")
+
+    assert microscope.get_stage_position().x == pytest.approx(48.8e-3)
+
+
+def test_the_traverse_is_the_gap_between_the_devices_not_a_constant():
+    """Move a device in configuration and the traverse follows it.
+
+    This is what the separate `TRANSLATION_DX` could not do: it was a third number
+    that had to be kept consistent with two windows by hand. Now there is one origin
+    to move, and the traverse and the window both follow it.
+    """
+    microscope = _at_fib(_microscope())
+    microscope.system.stage.devices["FM"] = StageDeviceSettings(
+        origin=FibsemStagePosition(x=30.0e-3)
+    )
+
+    microscope.move_to_microscope("FM")
+
+    assert microscope.get_stage_position().x == pytest.approx(30.0e-3)
+    assert microscope.is_at_device("FM") is True
+
+
+# ── the window has to survive the traverse ───────────────────────────
+
+# Every corner of the beam window, because the traverse carries the grid position
+# across rather than discarding it: at beam x the stage arrives at x + 48.8.
+BEAM_WINDOW_MM = [-19.0, -10.0, 0.0, 5.0, 11.0, 15.0, 19.0]
+
+
+def _at_beam_x(microscope, beam_x_mm: float):
+    """Put the stage at the FIB orientation, `beam_x_mm` along the grid."""
+    microscope.move_to_orientation("FIB")
+    microscope.move_stage_relative(
+        FibsemStagePosition(x=beam_x_mm * 1e-3, y=0.0, z=0.0, r=0.0, t=0.0)
+    )
+    assert microscope.is_at_device("FIBSEM") is True
+    return microscope
+
+
+@pytest.mark.parametrize("beam_x_mm", BEAM_WINDOW_MM)
+def test_anywhere_in_the_beam_window_traverses_to_somewhere_in_the_fm_window(
+    beam_x_mm: float,
+):
+    """The property, not the arithmetic: the two ranges must agree with the traverse.
+
+    They did not. The FM window was `(40, 60)` -- about 10 mm around its origin --
+    against the beams' 20 mm, and the traverse carries the offset across unchanged.
+    Above beam x = 11.2 mm the stage arrived at the FM and reported that it had not.
+
+    Now that both ranges come from one value this holds by arithmetic rather than by
+    agreement: `|arrival - target| = |start - source|`. That is why
+    `move_to_microscope` checks where the stage *starts* and never checks where it
+    will land -- a destination check could not fire. This test is what makes that
+    claim checkable instead of asserted.
+    """
+    microscope = _at_beam_x(_microscope(), beam_x_mm)
+
+    microscope.move_to_microscope("FM")
+
+    assert microscope.get_stage_position().x == pytest.approx((beam_x_mm + 48.8) * 1e-3)
+    assert microscope.is_at_device("FM") is True
+
+
+@pytest.mark.parametrize("beam_x_mm", BEAM_WINDOW_MM)
+def test_asking_twice_does_not_traverse_twice(beam_x_mm: float):
+    """What the mismatched window cost: a second request moved the stage again.
+
+    From beam x = 15 mm the old pair landed at 63.8 mm, called it "not at the FM", and
+    a second `move_to_microscope("FM")` translated another 48.8 mm to 112.6 mm.
+    """
+    microscope = _at_beam_x(_microscope(), beam_x_mm)
+    microscope.move_to_microscope("FM")
+    arrived = microscope.get_stage_position().x
+
+    microscope.move_to_microscope("FM")
+
+    assert microscope.get_stage_position().x == pytest.approx(arrived)
+
+
+# ── travelling from where the stage is ───────────────────────────────
+
+
+def test_the_source_is_where_the_stage_is_not_the_other_device():
+    """`get_current_device` reports the device, and `None` between them."""
+    microscope = _microscope()
+
+    assert microscope.get_current_device() == "FIBSEM"
+    assert (
+        microscope.get_current_device(
+            FibsemStagePosition(x=48.8e-3, y=0, z=0, r=0, t=0)
+        )
+        == "FM"
+    )
+    assert (
+        microscope.get_current_device(
+            FibsemStagePosition(x=24.0e-3, y=0, z=0, r=0, t=0)
+        )
+        is None
+    )
+
+
+def test_travelling_from_neither_device_is_refused_rather_than_guessed():
+    """Mid-traverse the old code translated anyway, and landed nowhere in particular.
+
+    It assumed the source was "the other device". A visible refusal the operator can
+    report beats a move that silently ends up 24 mm past the objective -- the same
+    preference FIB-640 argues for.
+    """
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+    microscope.move_stage_relative(
+        FibsemStagePosition(x=IN_THE_GAP_MM * 1e-3, y=0, z=0, r=0, t=0)
+    )
+    assert microscope.get_current_device() is None
+
+    with pytest.raises(ValueError, match="not at any configured device"):
+        microscope.move_to_microscope("FM")
+
+
+# ── the objective is out before the stage moves ──────────────────────
+
+
+def test_the_objective_is_retracted_before_the_stage_travels():
+    microscope = _at_beam_x(_microscope(), 0.0)
+    microscope.fm.objective.insert()
+
+    moved_at = []
+    original = microscope.move_stage_relative
+
+    def record(position):
+        moved_at.append(microscope.fm.objective.state)
+        return original(position)
+
+    microscope.move_stage_relative = record
+    microscope.move_to_microscope("FM")
+
+    assert moved_at == ["Retracted"]
+
+
+def test_no_move_means_no_retraction():
+    """The objective comes out for the move, and there is no move here.
+
+    Retracting anyway would pull the objective off the sample to accomplish nothing,
+    which is a real cost on a call that is otherwise free -- and asking for the device
+    the stage is already at is an ordinary thing for a caller to do.
+    """
+    microscope = _at_beam_x(_microscope(), 0.0)
+    microscope.fm.objective.insert()
+
+    microscope.move_to_microscope("FIBSEM")  # already there
+
+    assert microscope.fm.objective.state == "Inserted"
+
+
+def test_arriving_at_the_fm_leaves_the_objective_inserted_either_way():
+    """The postcondition is the device *and* the objective state, so it holds on the
+    no-move path too -- otherwise a redundant call would leave the FM blind."""
+    microscope = _at_beam_x(_microscope(), 0.0)
+    microscope.move_to_microscope("FM")
+
+    microscope.move_to_microscope("FM")
+
+    assert microscope.fm.objective.state == "Inserted"
+
+
+def test_a_refused_traverse_leaves_the_objective_alone():
+    """A call that refuses changes nothing, the objective included.
+
+    The source is resolved before the objective is touched, so a refusal is inert
+    rather than half-done. Retracting first would mean a rejected request still moved
+    hardware -- and the operator would be left with the objective out and no
+    explanation for it.
+    """
+    microscope = _at_beam_x(_microscope(), 0.0)
+    microscope.move_to_microscope("FM")
+    assert microscope.fm.objective.state == "Inserted"
+
+    microscope.move_stage_relative(
+        FibsemStagePosition(x=(IN_THE_GAP_MM - 48.8) * 1e-3, y=0, z=0, r=0, t=0)
+    )  # into the gap
+
+    with pytest.raises(ValueError, match="not at any configured device"):
+        microscope.move_to_microscope("FIBSEM")
+
+    assert microscope.fm.objective.state == "Inserted"
+
+
+# ── one range, not a window per device ───────────────────────────────
+
+
+def test_the_window_is_the_range_placed_at_each_origin():
+    """The number that used to be written out per device, and drifted.
+
+    Both windows come from one range, so no device can be given a region that
+    disagrees with the traverse that gets to it.
+    """
+    microscope = _microscope()
+    device_range = microscope.system.stage.device_range.x
+
+    for device, origin in (("FIBSEM", 0.0), ("FM", 48.8e-3)):
+        inside = FibsemStagePosition(x=origin + device_range * 0.99, y=0.0, z=0.0)
+        outside = FibsemStagePosition(x=origin + device_range * 1.01, y=0.0, z=0.0)
+
+        assert microscope.is_at_device(device, inside) is True
+        assert microscope.is_at_device(device, outside) is False
+
+
+def test_widening_the_range_widens_every_device_at_once():
+    """One number, so the two windows cannot be changed out of step with each other."""
+    microscope = _microscope()
+    just_past_the_beams = FibsemStagePosition(x=24.0e-3, y=0.0, z=0.0)
+
+    assert microscope.get_current_device(just_past_the_beams) is None
+
+    microscope.system.stage.device_range = FibsemStagePosition(x=25.0e-3)
+
+    assert microscope.get_current_device(just_past_the_beams) == "FIBSEM"
+
+
+def test_devices_are_allowed_to_overlap():
+    """A compustage is exactly that case, and the model has to be able to say it.
+
+    There the objective is under the grid: the beams and the FM are the *same* place,
+    reached by flipping rather than travelling, so the two devices share an origin.
+    Forbidding overlap would make an Arctis unrepresentable. Position stops deciding
+    which device it is -- correctly, because there it is the orientation that does.
+    """
+    microscope = _microscope()
+    microscope.system.stage.devices["FM"] = StageDeviceSettings(
+        origin=FibsemStagePosition(x=0.0)
+    )
+
+    assert microscope.is_at_device("FIBSEM") is True
+    assert microscope.is_at_device("FM") is True


### PR DESCRIPTION
An offset fluorescence microscope is not under the grid; the stage travels ~48.8 mm to reach it. So the FM is a **place**, and a place is not something `get_stage_orientation` can report — on an offset mount the FM orientation is byte-identical to the FIB one, so it never comes back.

This makes the device its own axis, alongside orientation. First half of FIB-830.

## The shape

```yaml
stage:
    device_range:   {x: 20.0e-3}      # the region belonging to each device, from its origin
    devices:
        FIBSEM:
            origin: {x: 0.0}
        FM:
            origin: {x: 48.8e-3}
```

`get_device_position(device)` and `is_at_device(device)` are the queries nothing could make before. `move_to_microscope` had three constants inlined in it — `TRANSLATION_DX`, `FM_RANGE`, `FIBSEM_RANGE` — with the traverse carrying its own *"THIS needs to be configurable"* note. It reads all three from configuration now, and the defaults are the values it had, so a configuration that says nothing keeps exactly what it had.

Device origins constrain **x/y/z only**, never r or t. A device is a place; the pose the sample is held in once the stage is there is the orientation, which is the other axis. A device that also fixed rotation would be the same conflation this is undoing. `from_dict` refuses those axes by name.

## Three fixes fall out of putting the numbers next to each other

**The windows contradicted the traverse.** The stage moves by the *difference* between two origins, so it keeps its offset — a grid position 15 mm along at the beams arrives 15 mm along at the FM. But the windows were 20 mm at the beams and about 10 mm at the FM, written out separately. Measured on the offset simulator, before:

```
beam x=  0 mm  at FIBSEM=True  -> x=  48.8 mm  at FM=True   second call -> x=  48.8 mm
beam x= 11 mm  at FIBSEM=True  -> x=  59.8 mm  at FM=True   second call -> x=  59.8 mm
beam x= 15 mm  at FIBSEM=True  -> x=  63.8 mm  at FM=False  second call -> x= 112.6 mm
beam x= 19 mm  at FIBSEM=True  -> x=  67.8 mm  at FM=False  second call -> x= 116.6 mm
```

The stage arrived at the FM, reported that it had not, and traversed again when asked. Pre-existing — same windows, same relative move — and only visible because the three numbers are now next to each other instead of scattered through one function.

One shared `device_range` makes this unrepresentable rather than merely fixed. Since `|arrival − target| = |start − source|`, a traverse that starts inside a range always ends inside one, so a destination check could not fire. What has to be checked is the *start*.

**The source was assumed, not asked.** It took the source to be "the other device". Mid-traverse that is wrong, and it translated anyway, landing nowhere in particular. It now asks `get_current_device()` and refuses by name if the stage is at neither — a visible error the operator can report, which is the preference FIB-640 argues for.

**The objective retracts on every call**, before anything else, whether or not a move follows. It is a collision guard rather than a step in the traverse, and the check that says no move is needed is exactly the one that was wrong above. The insert is unconditional too, so the postcondition is the device *and* the objective state together — a redundant call to `move_to_microscope("FM")` no longer leaves the FM blind, and a refused traverse leaves the objective retracted.

## Devices may overlap, deliberately

On a compustage the beams and the FM are the *same place*, reached by flipping — the old code said so: *"arctis has same range for FIBSEM/FM (stage is flipped upside down)"*. Forbidding overlap would make an Arctis unrepresentable, so no validation was added. Position stops deciding which device it is there, correctly, because it is the orientation that does:

|  | device decided by | orientation decided by |
| -- | -- | -- |
| offset mount | position | free — FM is byte-identical to FIB |
| compustage | orientation | position — both devices share it |

Nothing asks the wrong one today: `move_to_microscope` branches to the compustage path before any device lookup. FIB-839 records the three different ways "am I at this device" gets answered, and says not to build the dispatch until there is a second non-positional device.

## Not in scope

`microscope.fm` is still refused on every non-compustage system at connection, so none of this is reachable by a user yet. Opening that gate comes last, deliberately: until the device leg exists in the composed transform, `_to_fluorescence`'s currently-safe `None` would become a silently wrong pose ~48 mm from the FM.

## Verification

`6345 passed, 23 skipped` on the full suite. 38 new tests in `tests/test_fm_device_position.py`, including the traverse parametrised across the whole beam window — the property that the two ranges must agree with the traverse, which is what makes the invariant checkable rather than asserted.
