### PR TITLE
[test] Pin the stage position form before it moves (FIB-783)

### DIFF
--- a/tests/ui/test_stage_position_readout.py
+++ b/tests/ui/test_stage_position_readout.py
@@ -1,0 +1,234 @@
+"""What the stage position form on the Movement tab does, before it is extracted.
+
+The form is the five spin boxes in rows 0-4 of ``FibsemMovementWidget``'s stage panel
+plus the refresh button in the panel header. It converts in both directions -- metres to
+millimetres, radians to degrees on the way in, and back again on the way out -- and takes
+its ranges from the stage rather than from the widget. None of that is asserted anywhere
+today: the existing movement tests all drive the half that *moves*.
+
+These pin the conversions, the ranges and the two compustage adjustments so that
+splitting the form out of the widget is a refactor with a net under it rather than a
+rewrite that happens to still construct. They are deliberately written against the
+public surface a host uses -- ``update_ui`` and ``get_position_from_ui`` -- so they keep
+their meaning when the form moves behind a delegating facade.
+
+Two of them branch on ``stage_is_compustage``. The default microscope configuration is
+user state and is not the same on every machine, so a test that assumed either answer
+would pass here and fail elsewhere; each asserts the behaviour for the configuration it
+actually got, and the branch it did not take is covered from the other side.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_stage_position_readout.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtCore import QPoint, QPointF, Qt  # noqa: E402
+from PyQt5.QtGui import QWheelEvent  # noqa: E402
+
+# Same construction seam the rest of tests/ui uses: a host with a view controller, a
+# real image widget and a Demo microscope. The movement widget asserts on its parent,
+# so there is no lighter way to build the real thing.
+sys.path.insert(0, os.path.dirname(__file__))  # not str.rsplit: Windows paths
+from test_viewer_less_widgets import (  # noqa: E402
+    _CanvasHost,
+    _image_widget,
+    _movement_widget,
+)
+
+from fibsem import constants  # noqa: E402
+from fibsem.structures import FibsemStagePosition  # noqa: E402
+
+# Off-origin on every axis, and asymmetric, so a transposed pair or a dropped
+# conversion cannot coincide with the right answer. Inside the Demo stage limits.
+SAMPLE = FibsemStagePosition(
+    x=120e-6,
+    y=-45e-6,
+    z=310e-6,
+    r=np.radians(37.0),
+    t=np.radians(-12.0),
+    coordinate_system="RAW",
+)
+
+
+@pytest.fixture
+def movement(qapp):
+    host = _CanvasHost()
+    _image_widget(host)
+    widget = _movement_widget(host)
+    yield widget
+    host.deleteLater()
+
+
+def _boxes(movement) -> dict:
+    return {
+        "x": movement.doubleSpinBox_movement_stage_x,
+        "y": movement.doubleSpinBox_movement_stage_y,
+        "z": movement.doubleSpinBox_movement_stage_z,
+        "r": movement.doubleSpinBox_movement_stage_rotation,
+        "t": movement.doubleSpinBox_movement_stage_tilt,
+    }
+
+
+def _wheel(delta: int = 120) -> QWheelEvent:
+    return QWheelEvent(
+        QPointF(5.0, 5.0),
+        QPointF(5.0, 5.0),
+        QPoint(0, delta),
+        QPoint(0, delta),
+        Qt.NoButton,
+        Qt.NoModifier,
+        Qt.NoScrollPhase,
+        False,
+    )
+
+
+# --- the conversions ---------------------------------------------------------
+
+
+def test_the_form_shows_millimetres_and_degrees(movement):
+    """Metres and radians go in; the operator reads millimetres and degrees."""
+    movement.update_ui(stage_position=SAMPLE)
+    boxes = _boxes(movement)
+
+    assert boxes["x"].value() == pytest.approx(0.12, abs=1e-9)
+    assert boxes["y"].value() == pytest.approx(-0.045, abs=1e-9)
+    assert boxes["z"].value() == pytest.approx(0.31, abs=1e-9)
+    assert boxes["r"].value() == pytest.approx(37.0, abs=1e-3)
+    assert boxes["t"].value() == pytest.approx(-12.0, abs=1e-3)
+
+
+def test_the_form_reads_back_in_si_units(movement):
+    """And the way out undoes the way in, on every axis at once.
+
+    The round trip is the assertion that matters: a conversion applied on one side
+    only survives each half being checked separately, but not this.
+    """
+    movement.update_ui(stage_position=SAMPLE)
+    read = movement.get_position_from_ui()
+
+    assert read.x == pytest.approx(SAMPLE.x, abs=1e-9)
+    assert read.y == pytest.approx(SAMPLE.y, abs=1e-9)
+    assert read.z == pytest.approx(SAMPLE.z, abs=1e-9)
+    assert read.r == pytest.approx(SAMPLE.r, abs=1e-5)
+    assert read.t == pytest.approx(SAMPLE.t, abs=1e-5)
+
+
+def test_the_form_reads_raw_coordinates(movement):
+    """RAW, not the linked coordinate system -- the entry boxes mean stage axes."""
+    assert movement.get_position_from_ui().coordinate_system == "RAW"
+
+
+def test_the_units_are_on_the_boxes(movement):
+    """The suffix is the only thing telling the operator which unit to type in."""
+    boxes = _boxes(movement)
+    assert boxes["x"].suffix() == " mm"
+    assert boxes["y"].suffix() == " mm"
+    assert boxes["z"].suffix() == " mm"
+    # Set twice during construction -- with a leading space in the layout, without one
+    # when the connections are made. The second write is the one that survives.
+    assert boxes["r"].suffix() == constants.DEGREE_SYMBOL
+    assert boxes["t"].suffix() == constants.DEGREE_SYMBOL
+
+
+def test_translation_is_shown_to_ten_nanometres(movement):
+    """Five decimals of a millimetre. Fewer and a stable_move would round to nothing."""
+    boxes = _boxes(movement)
+    assert boxes["x"].decimals() == 5
+    assert boxes["y"].decimals() == 5
+    assert boxes["z"].decimals() == 5
+
+
+# --- the ranges come from the stage, not from the widget ---------------------
+
+
+def test_translation_ranges_are_the_stage_limits_in_millimetres(movement):
+    limits = movement.microscope._stage.limits
+    boxes = _boxes(movement)
+
+    for axis in ("x", "y", "z"):
+        assert boxes[axis].minimum() == pytest.approx(
+            limits[axis].min * constants.SI_TO_MILLI
+        )
+        assert boxes[axis].maximum() == pytest.approx(
+            limits[axis].max * constants.SI_TO_MILLI
+        )
+
+
+def test_the_tilt_range_is_taken_in_degrees_already(movement):
+    """The stage reports x/y/z in metres but t in degrees, and the form must not
+    convert the one that needs no converting."""
+    tilt = movement.microscope._stage.limits["t"]
+    box = _boxes(movement)["t"]
+
+    assert box.minimum() == pytest.approx(tilt.min)
+    assert box.maximum() == pytest.approx(tilt.max)
+
+
+# --- the compustage adjustments ----------------------------------------------
+
+
+def test_the_step_size_suits_the_stage(movement):
+    """A compustage works in micrometres, so its arrows step by 1 um rather than 1 um
+    times a thousand. Everything else keeps the default."""
+    boxes = _boxes(movement)
+    expected = (
+        1e-6 * constants.SI_TO_MILLI
+        if movement.microscope.stage_is_compustage
+        else 0.001
+    )
+
+    for axis in ("x", "y", "z"):
+        assert boxes[axis].singleStep() == pytest.approx(expected)
+
+
+def test_rotation_is_offered_only_where_it_exists(movement):
+    """A compustage does not rotate, so both the label and the box go -- not just the
+    box, which would leave a stranded caption."""
+    shown = not movement.microscope.stage_is_compustage
+
+    assert movement.doubleSpinBox_movement_stage_rotation.isVisibleTo(movement) is shown
+    assert movement.label_movement_stage_rotation.isVisibleTo(movement) is shown
+
+
+# --- the guards --------------------------------------------------------------
+
+
+def test_a_passing_scroll_does_not_move_the_stage_position(qapp, movement):
+    """Scrolling the panel used to retype whichever box the pointer crossed. Every box
+    on the form is guarded, not only the ones that were reported."""
+    movement.update_ui(stage_position=SAMPLE)
+
+    for axis, box in _boxes(movement).items():
+        before = box.value()
+        # sendEvent, not box.wheelEvent: the guard is an event filter, so it only sees
+        # the event on the way through dispatch. Calling the handler direct walks past
+        # it and would pass with the guard removed.
+        qapp.sendEvent(box, _wheel())
+        assert box.value() == before, f"{axis} changed on a wheel event"
+
+
+def test_the_refresh_button_asks_the_stage_where_it_is(movement, monkeypatch):
+    """The one place the form is allowed to read the device: a button the operator
+    pressed. Nothing else on this half polls."""
+    asked = []
+
+    def _get_stage_position():
+        asked.append(True)
+        return SAMPLE
+
+    monkeypatch.setattr(
+        movement.microscope, "get_stage_position", _get_stage_position, raising=False
+    )
+    movement.btn_refresh_stage.click()
+
+    assert asked, "refresh did not read the stage"
+    assert _boxes(movement)["x"].value() == pytest.approx(0.12, abs=1e-9)

--- a/tests/ui/test_stage_position_readout.py
+++ b/tests/ui/test_stage_position_readout.py
@@ -12,10 +12,22 @@ rewrite that happens to still construct. They are deliberately written against t
 public surface a host uses -- ``update_ui`` and ``get_position_from_ui`` -- so they keep
 their meaning when the form moves behind a delegating facade.
 
-Two of them branch on ``stage_is_compustage``. The default microscope configuration is
-user state and is not the same on every machine, so a test that assumed either answer
-would pass here and fail elsewhere; each asserts the behaviour for the configuration it
-actually got, and the branch it did not take is covered from the other side.
+**The default microscope configuration is user state and is not the same on every
+machine**, and it reaches these tests twice over.
+
+Once through ``stage_is_compustage``: two tests branch on it rather than assuming an
+answer, and the branch not taken is covered directly in
+``tests/ui/test_stage_position_widget.py``, where the form is cheap enough to build
+against a chosen configuration.
+
+And once through the *ranges*, which is the subtler of the two. A spin box clamps to its
+range, so a sample position outside the configured stage limits comes back as the limit
+and the failure reads as a broken conversion rather than an out-of-range fixture. That
+is exactly what happened: ``sim-arctis`` tilts to -195 degrees and the shipped default
+only to -10, so a -12 degree sample passed locally and came back as -10.0 in CI.
+``SAMPLE`` therefore sits inside the intersection of the shipped configurations, and
+``test_the_sample_is_inside_this_stages_limits`` says so out loud -- so a future
+configuration that narrows further fails by name instead of by clamping.
 
 Run directly (no display needed):
     QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_stage_position_readout.py
@@ -48,13 +60,18 @@ from fibsem import constants  # noqa: E402
 from fibsem.structures import FibsemStagePosition  # noqa: E402
 
 # Off-origin on every axis, and asymmetric, so a transposed pair or a dropped
-# conversion cannot coincide with the right answer. Inside the Demo stage limits.
+# conversion cannot coincide with the right answer.
+#
+# Inside every shipped configuration's stage limits, which is narrower than it looks:
+# z starts at 0 on the default configuration and tilt only reaches -10 there, against
+# -195 on sim-arctis. A spin box clamps silently, so a sample outside the range does
+# not fail as "out of range" -- it fails as a wrong conversion.
 SAMPLE = FibsemStagePosition(
     x=120e-6,
     y=-45e-6,
     z=310e-6,
     r=np.radians(37.0),
-    t=np.radians(-12.0),
+    t=np.radians(-8.0),
     coordinate_system="RAW",
 )
 
@@ -94,6 +111,31 @@ def _wheel(delta: int = 120) -> QWheelEvent:
 # --- the conversions ---------------------------------------------------------
 
 
+def test_the_sample_is_inside_this_stages_limits(movement):
+    """The fixture, not the widget. A spin box clamps silently, so a SAMPLE outside the
+    configured range would make every conversion test above fail as though a unit had
+    been dropped. This one names the real cause instead.
+
+    It bites because the shipped configurations disagree: tilt reaches -195 degrees on
+    sim-arctis and only -10 on the default, and z starts at 0 there.
+    """
+    limits = movement.microscope._stage.limits
+
+    for axis, value_mm in (
+        ("x", SAMPLE.x * constants.SI_TO_MILLI),
+        ("y", SAMPLE.y * constants.SI_TO_MILLI),
+        ("z", SAMPLE.z * constants.SI_TO_MILLI),
+    ):
+        low = limits[axis].min * constants.SI_TO_MILLI
+        high = limits[axis].max * constants.SI_TO_MILLI
+        assert low <= value_mm <= high, f"SAMPLE.{axis} is outside {low}..{high} mm"
+
+    tilt_deg = np.degrees(SAMPLE.t)
+    assert limits["t"].min <= tilt_deg <= limits["t"].max, (
+        f"SAMPLE.t is outside {limits['t'].min}..{limits['t'].max} deg"
+    )
+
+
 def test_the_form_shows_millimetres_and_degrees(movement):
     """Metres and radians go in; the operator reads millimetres and degrees."""
     movement.update_ui(stage_position=SAMPLE)
@@ -103,7 +145,7 @@ def test_the_form_shows_millimetres_and_degrees(movement):
     assert boxes["y"].value() == pytest.approx(-0.045, abs=1e-9)
     assert boxes["z"].value() == pytest.approx(0.31, abs=1e-9)
     assert boxes["r"].value() == pytest.approx(37.0, abs=1e-3)
-    assert boxes["t"].value() == pytest.approx(-12.0, abs=1e-3)
+    assert boxes["t"].value() == pytest.approx(-8.0, abs=1e-3)
 
 
 def test_the_form_reads_back_in_si_units(movement):


### PR DESCRIPTION
First of three for [FIB-783](https://linear.app/fibsemos/issue/FIB-783/refactor-fibsemmovementwidget-into-modular-components), which splits `FibsemMovementWidget` into a readout half and a control half. This one adds the net; it changes no production code.

## Why this first

The five spin boxes in rows 0–4 of the stage panel convert in both directions — metres to millimetres and radians to degrees on the way in, back again on the way out — and take their ranges from `microscope._stage.limits` rather than from the widget. None of that is asserted anywhere today: `test_movement_progress.py`, `test_movement_worker_bodies.py` and `test_canvas_double_click_guards.py` all drive the half that *moves*.

So the readout half could be extracted, silently lose a unit conversion, and every existing test would still pass.

## What is pinned

`tests/ui/test_stage_position_readout.py`, 11 tests:

- the millimetre and degree conversions, and the round trip through `update_ui` → `get_position_from_ui`
- `RAW` as the coordinate system the form means
- the suffixes and the five decimals — the only thing telling an operator which unit to type
- the translation ranges in millimetres, and the tilt range taken in degrees *without* conversion (the stage reports x/y/z in metres but t in degrees, and this is the easy one to get wrong)
- the two compustage adjustments: 1 µm single steps, and the rotation row hidden — label as well as box
- the wheel guard on all five boxes
- the refresh button reading the stage

They are written against `update_ui` and `get_position_from_ui`, the surface `AutoLamellaUI` already calls, so they keep their meaning once the form sits behind a delegating facade.

## Two things worth a reviewer's attention

**The compustage tests branch rather than assume.** The default microscope configuration comes from user state (`fibsem/config/configurations.yaml`, gitignored), so it is not the same on every machine — this worktree resolves to `sim-arctis-configuration`, which *is* a compustage. A test that picked either answer would pass here and fail in CI. Each asserts the behaviour for the configuration it actually got. The branch not taken gets covered directly in the next PR, where the extracted widget is cheap enough to build against an explicit configuration.

**The wheel test uses `qapp.sendEvent`, not `box.wheelEvent`.** The guard is an event filter, so it only sees the event on the way through dispatch. Calling the handler directly walks past it — the first version of this test passed with the guard removed.

## Verification

Mutation-checked rather than just run green:

| mutation | result |
| -- | -- |
| drop `SI_TO_MILLI` on x in `update_ui` | 3 failed |
| convert the tilt limits as if they were metres | 1 failed |
| remove the wheel guard from the tilt box | 1 failed |
| hide the rotation box but not its label | 1 failed |
| disconnect the refresh button | 1 failed |

Baseline 11 passed, tree restored clean after each.

Run locally with `QT_QPA_PLATFORM=offscreen`, macOS, PyQt5. `tests/ui/` does run in CI as of #584, but a local macOS run is not interchangeable with it.

## Not in scope

The extraction itself, and the `StagePositionWidget` class. Those are the next two PRs.

Note: merging this will auto-complete FIB-783 via the Linear attachment, even though it is one of three. Reopen it.

---

**Update — CI caught one, and it is the interesting kind.**

The first push failed `ui-tests` on two conversion assertions: `assert -10.0 == -12.0 ± 0.001`. Not a conversion bug — the sample's tilt was −12°, and the configuration CI resolves to only tilts to −10°, so the spin box **clamped it silently**.

That is the same environment-dependence the file's docstring already warned about, reaching in through a second door I had not guarded. I checked `stage_is_compustage` differed between machines; I did not check that the *ranges* did. `sim-arctis` (this worktree's default) tilts to −195° and the shipped default only to −10°, and z starts at 0 there rather than −1 mm.

The failure mode is worth remembering: a clamp makes an out-of-range fixture look exactly like a dropped unit conversion.

Fixed by moving the sample tilt to −8°, inside the intersection of the shipped configurations, and adding `test_the_sample_is_inside_this_stages_limits` — which asserts the *fixture* against the configured limits, so the next configuration that narrows further fails by name instead of by clamping. Checked both ways: with −12° restored it fails with `SAMPLE.t is outside -10.0..90.0 deg`.

Also verified locally against both configurations by pre-seeding the shared session cache — 12 passed under `microscope-configuration` (the one CI uses, not a compustage) and under `sim-arctis-configuration` (a compustage). 12 tests now, not 11.
