### PR TITLE
[refactor] Add StagePositionWidget, not yet wired in (FIB-783)

### DIFF
--- a/fibsem/ui/widgets/stage_position_widget.py
+++ b/fibsem/ui/widgets/stage_position_widget.py
@@ -1,0 +1,189 @@
+"""The stage position readout and entry form.
+
+Five spin boxes and a refresh button. It says where the stage is, in the units an
+operator types in, and it hands back what has been typed. It does not move the stage,
+and it has no opinion about who does -- pressing refresh emits a signal and stops there,
+so the host decides what a refresh costs.
+
+Extracted from ``FibsemMovementWidget`` (FIB-783), which does this alongside the
+movement actions, their workers, the canvas double-click registration and the progress
+reporting. Nothing in this file needs a parent contract, a view controller or an image
+widget; all of that belongs to the half that moves.
+
+**Units.** The stage speaks metres and radians. The form shows millimetres and degrees,
+except the tilt *limits*, which the stage already reports in degrees -- so x, y and z
+are converted on the way through and t is not. That asymmetry is the one thing here
+worth reading twice.
+
+**Device reads.** Exactly one, at construction, for the ranges and the stage kind. Both
+are configuration rather than state: they change when someone reconfigures the
+microscope, not while it is running. Nothing on a UI event path touches the device.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import numpy as np
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import QDoubleSpinBox, QGridLayout, QLabel, QWidget
+from superqt import ensure_main_thread
+
+from fibsem import constants
+from fibsem.microscope import FibsemMicroscope
+from fibsem.structures import FibsemStagePosition
+from fibsem.ui.utils import install_wheel_blocker
+from fibsem.ui.widgets.custom_widgets import IconToolButton
+
+# Five decimals of a millimetre -- ten nanometres. A stage move smaller than that
+# rounds to nothing in the box, and stable_move routinely asks for less.
+_TRANSLATION_DECIMALS = 5
+
+# The default arrow step, in millimetres. A compustage overrides it: see
+# _apply_stage_configuration.
+_TRANSLATION_STEP_MM = 0.001
+_COMPUSTAGE_STEP_MM = 1e-6 * constants.SI_TO_MILLI
+
+
+class StagePositionWidget(QWidget):
+    """Where the stage is, and where the operator would like it to be.
+
+    Parameters
+    ----------
+    microscope:
+        Read once, during construction, for the axis ranges and whether this is a
+        compustage. Never read again.
+    """
+
+    #: The refresh button was pressed. The host owns what happens next -- reading the
+    #: stage is a device call, and this widget does not make those.
+    refresh_requested = pyqtSignal()
+
+    def __init__(
+        self, microscope: FibsemMicroscope, parent: Optional[QWidget] = None
+    ) -> None:
+        super().__init__(parent)
+        self.microscope = microscope
+        self._setup_ui()
+        self._apply_stage_configuration()
+
+    # --- construction --------------------------------------------------------
+
+    def _setup_ui(self) -> None:
+        layout = QGridLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.label_x = QLabel("X Coordinate")
+        self.spinbox_x = QDoubleSpinBox()
+        self.label_y = QLabel("Y Coordinate")
+        self.spinbox_y = QDoubleSpinBox()
+        self.label_z = QLabel("Z Coordinate")
+        self.spinbox_z = QDoubleSpinBox()
+        self.label_rotation = QLabel("Rotation")
+        self.spinbox_rotation = QDoubleSpinBox()
+        self.label_tilt = QLabel("Tilt")
+        self.spinbox_tilt = QDoubleSpinBox()
+
+        for row, (label, spinbox) in enumerate(
+            (
+                (self.label_x, self.spinbox_x),
+                (self.label_y, self.spinbox_y),
+                (self.label_z, self.spinbox_z),
+                (self.label_rotation, self.spinbox_rotation),
+                (self.label_tilt, self.spinbox_tilt),
+            )
+        ):
+            layout.addWidget(label, row, 0)
+            layout.addWidget(spinbox, row, 1)
+
+        for spinbox in (self.spinbox_x, self.spinbox_y, self.spinbox_z):
+            spinbox.setDecimals(_TRANSLATION_DECIMALS)
+            spinbox.setSingleStep(_TRANSLATION_STEP_MM)
+            spinbox.setSuffix(" mm")
+
+        for spinbox in (self.spinbox_rotation, self.spinbox_tilt):
+            spinbox.setSuffix(constants.DEGREE_SYMBOL)
+
+        self.spinbox_rotation.setMinimum(-360.0)
+        self.spinbox_rotation.setMaximum(360.0)
+
+        # Guard every box against accidental scroll-to-change: the panel scrolls, and a
+        # spinbox under the pointer would otherwise retype itself on the way past.
+        for spinbox in self._spinboxes().values():
+            install_wheel_blocker(spinbox)
+
+        # Belongs to this widget, but lives in the host's panel header rather than in
+        # the grid, so the host positions it. Kept here because refreshing the readout
+        # is this widget's job to ask for.
+        self.btn_refresh = IconToolButton(
+            icon="mdi:refresh", tooltip="Refresh stage position"
+        )
+        self.btn_refresh.clicked.connect(self.refresh_requested)
+
+    def _apply_stage_configuration(self) -> None:
+        """The one device read: axis ranges, and whether this stage rotates."""
+        limits = self.microscope._stage.limits
+
+        for axis, spinbox in (
+            ("x", self.spinbox_x),
+            ("y", self.spinbox_y),
+            ("z", self.spinbox_z),
+        ):
+            spinbox.setMinimum(limits[axis].min * constants.SI_TO_MILLI)
+            spinbox.setMaximum(limits[axis].max * constants.SI_TO_MILLI)
+
+        # Not converted: the stage reports x/y/z in metres but t in degrees, which is
+        # already the unit on the box.
+        self.spinbox_tilt.setMinimum(limits["t"].min)
+        self.spinbox_tilt.setMaximum(limits["t"].max)
+
+        if self.microscope.stage_is_compustage:
+            # A compustage is driven in micrometres, so a whole-millimetre arrow step
+            # is a thousand times too coarse to be useful.
+            for spinbox in (self.spinbox_x, self.spinbox_y, self.spinbox_z):
+                spinbox.setSingleStep(_COMPUSTAGE_STEP_MM)
+
+            # It does not rotate. The label goes with the box -- hiding only the box
+            # leaves a caption over the tilt row.
+            self.label_rotation.setVisible(False)
+            self.spinbox_rotation.setVisible(False)
+
+    def _spinboxes(self) -> Dict[str, QDoubleSpinBox]:
+        return {
+            "x": self.spinbox_x,
+            "y": self.spinbox_y,
+            "z": self.spinbox_z,
+            "r": self.spinbox_rotation,
+            "t": self.spinbox_tilt,
+        }
+
+    # --- the readout ---------------------------------------------------------
+
+    @ensure_main_thread
+    def set_position(self, stage_position: FibsemStagePosition) -> None:
+        """Show *stage_position*, converting into the units on the boxes.
+
+        Marshalled: a stage move reports where it landed from a worker thread, and Qt
+        widgets may only be written from the GUI thread. Already on it, this is a
+        direct call.
+        """
+        self.spinbox_x.setValue(stage_position.x * constants.SI_TO_MILLI)
+        self.spinbox_y.setValue(stage_position.y * constants.SI_TO_MILLI)
+        self.spinbox_z.setValue(stage_position.z * constants.SI_TO_MILLI)
+        self.spinbox_rotation.setValue(np.degrees(stage_position.r))
+        self.spinbox_tilt.setValue(np.degrees(stage_position.t))
+
+    def get_position(self) -> FibsemStagePosition:
+        """What is currently typed in, in the units the stage takes.
+
+        ``RAW`` because the boxes are labelled with stage axes: what the operator reads
+        off the box is the raw axis value, not one re-expressed in a linked frame.
+        """
+        return FibsemStagePosition(
+            x=self.spinbox_x.value() * constants.MILLI_TO_SI,
+            y=self.spinbox_y.value() * constants.MILLI_TO_SI,
+            z=self.spinbox_z.value() * constants.MILLI_TO_SI,
+            r=np.radians(self.spinbox_rotation.value()),
+            t=np.radians(self.spinbox_tilt.value()),
+            coordinate_system="RAW",
+        )

--- a/tests/ui/test_stage_position_widget.py
+++ b/tests/ui/test_stage_position_widget.py
@@ -1,0 +1,257 @@
+"""``StagePositionWidget`` -- the stage readout and entry form, on its own.
+
+The widget is cheap to build: a microscope and nothing else. No host, no view
+controller, no image widget. That is most of the point of extracting it, and it is what
+lets these tests do something ``tests/ui/test_stage_position_readout.py`` cannot --
+build the form against a *chosen* microscope configuration and pin both sides of the
+compustage branch, rather than branching on whichever configuration the machine
+happens to default to.
+
+Two configurations, both shipped in ``fibsem/config``:
+
+* ``microscope-configuration.yaml`` -- not a compustage. Rotation offered, millimetre
+  arrow steps, tilt range -10 to 90 degrees.
+* ``sim-arctis-configuration.yaml`` -- a compustage. Rotation hidden, micrometre arrow
+  steps, tilt range -195 to 15 degrees.
+
+The tilt ranges differ between them, which is what makes the range tests worth running
+twice: a form that ignored the stage and hard-coded a range would still pass against
+one configuration.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_stage_position_widget.py
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtCore import QPoint, QPointF, Qt  # noqa: E402
+from PyQt5.QtGui import QWheelEvent  # noqa: E402
+
+from fibsem import config as cfg  # noqa: E402
+from fibsem import constants, utils  # noqa: E402
+from fibsem.structures import FibsemStagePosition  # noqa: E402
+from fibsem.ui.widgets.stage_position_widget import StagePositionWidget  # noqa: E402
+
+FLAT_STAGE = "microscope-configuration.yaml"
+COMPUSTAGE = "sim-arctis-configuration.yaml"
+
+# Off-origin on every axis, and asymmetric, so a transposed pair or a dropped
+# conversion cannot coincide with the right answer. Inside both stages' limits.
+SAMPLE = FibsemStagePosition(
+    x=120e-6,
+    y=-45e-6,
+    z=310e-6,
+    r=np.radians(37.0),
+    t=np.radians(-8.0),
+    coordinate_system="RAW",
+)
+
+_sessions = {}
+
+
+def _microscope(configuration: str):
+    """One Demo microscope per configuration for the whole file -- setup_session is
+    slow, and neither of these tests mutates the stage."""
+    if configuration not in _sessions:
+        _sessions[configuration] = utils.setup_session(
+            config_path=os.path.join(cfg.CONFIG_PATH, configuration),
+            setup_logging=False,
+        )[0]
+    return _sessions[configuration]
+
+
+@pytest.fixture(params=[FLAT_STAGE, COMPUSTAGE], ids=["flat-stage", "compustage"])
+def widget(request, qapp):
+    """The form, against each shipped stage kind in turn."""
+    microscope = _microscope(request.param)
+    form = StagePositionWidget(microscope=microscope)
+    yield form
+    form.deleteLater()
+
+
+@pytest.fixture
+def compustage_widget(qapp):
+    microscope = _microscope(COMPUSTAGE)
+    form = StagePositionWidget(microscope=microscope)
+    yield form
+    form.deleteLater()
+
+
+@pytest.fixture
+def flat_widget(qapp):
+    microscope = _microscope(FLAT_STAGE)
+    form = StagePositionWidget(microscope=microscope)
+    yield form
+    form.deleteLater()
+
+
+def _wheel(delta: int = 120) -> QWheelEvent:
+    return QWheelEvent(
+        QPointF(5.0, 5.0),
+        QPointF(5.0, 5.0),
+        QPoint(0, delta),
+        QPoint(0, delta),
+        Qt.NoButton,
+        Qt.NoModifier,
+        Qt.NoScrollPhase,
+        False,
+    )
+
+
+# --- the conversions, on both stage kinds ------------------------------------
+
+
+def test_it_shows_millimetres_and_degrees(widget):
+    widget.set_position(SAMPLE)
+
+    assert widget.spinbox_x.value() == pytest.approx(0.12, abs=1e-9)
+    assert widget.spinbox_y.value() == pytest.approx(-0.045, abs=1e-9)
+    assert widget.spinbox_z.value() == pytest.approx(0.31, abs=1e-9)
+    assert widget.spinbox_rotation.value() == pytest.approx(37.0, abs=1e-3)
+    assert widget.spinbox_tilt.value() == pytest.approx(-8.0, abs=1e-3)
+
+
+def test_it_reads_back_in_si_units(widget):
+    """The way out undoes the way in. A conversion applied on one side only survives
+    each half being checked alone, but not this."""
+    widget.set_position(SAMPLE)
+    read = widget.get_position()
+
+    assert read.x == pytest.approx(SAMPLE.x, abs=1e-9)
+    assert read.y == pytest.approx(SAMPLE.y, abs=1e-9)
+    assert read.z == pytest.approx(SAMPLE.z, abs=1e-9)
+    assert read.r == pytest.approx(SAMPLE.r, abs=1e-5)
+    assert read.t == pytest.approx(SAMPLE.t, abs=1e-5)
+
+
+def test_it_reads_raw_coordinates(widget):
+    assert widget.get_position().coordinate_system == "RAW"
+
+
+def test_the_units_are_on_the_boxes(widget):
+    """The suffix is the only thing telling the operator which unit to type in."""
+    assert widget.spinbox_x.suffix() == " mm"
+    assert widget.spinbox_y.suffix() == " mm"
+    assert widget.spinbox_z.suffix() == " mm"
+    assert widget.spinbox_rotation.suffix() == constants.DEGREE_SYMBOL
+    assert widget.spinbox_tilt.suffix() == constants.DEGREE_SYMBOL
+
+
+def test_translation_is_shown_to_ten_nanometres(widget):
+    for spinbox in (widget.spinbox_x, widget.spinbox_y, widget.spinbox_z):
+        assert spinbox.decimals() == 5
+
+
+# --- the ranges come from the stage ------------------------------------------
+
+
+def test_translation_ranges_are_the_stage_limits_in_millimetres(widget):
+    limits = widget.microscope._stage.limits
+
+    for axis, spinbox in (
+        ("x", widget.spinbox_x),
+        ("y", widget.spinbox_y),
+        ("z", widget.spinbox_z),
+    ):
+        assert spinbox.minimum() == pytest.approx(
+            limits[axis].min * constants.SI_TO_MILLI
+        )
+        assert spinbox.maximum() == pytest.approx(
+            limits[axis].max * constants.SI_TO_MILLI
+        )
+
+
+def test_the_tilt_range_is_taken_in_degrees_already(widget):
+    """The stage reports x/y/z in metres but t in degrees, and the form must not
+    convert the one that needs no converting."""
+    tilt = widget.microscope._stage.limits["t"]
+
+    assert widget.spinbox_tilt.minimum() == pytest.approx(tilt.min)
+    assert widget.spinbox_tilt.maximum() == pytest.approx(tilt.max)
+
+
+def test_the_two_stages_really_do_disagree_about_tilt():
+    """Guards the two tests above from being run twice against the same numbers -- if
+    the fixtures ever resolved to one configuration, the range tests would still pass
+    and prove nothing."""
+    flat = _microscope(FLAT_STAGE)._stage.limits["t"]
+    compu = _microscope(COMPUSTAGE)._stage.limits["t"]
+
+    assert (flat.min, flat.max) != (compu.min, compu.max)
+
+
+# --- the compustage branch, both sides ---------------------------------------
+
+
+def test_a_compustage_steps_in_micrometres(compustage_widget):
+    for spinbox in (
+        compustage_widget.spinbox_x,
+        compustage_widget.spinbox_y,
+        compustage_widget.spinbox_z,
+    ):
+        assert spinbox.singleStep() == pytest.approx(1e-6 * constants.SI_TO_MILLI)
+
+
+def test_any_other_stage_steps_in_millimetres(flat_widget):
+    for spinbox in (
+        flat_widget.spinbox_x,
+        flat_widget.spinbox_y,
+        flat_widget.spinbox_z,
+    ):
+        assert spinbox.singleStep() == pytest.approx(0.001)
+
+
+def test_a_compustage_is_not_offered_rotation(compustage_widget):
+    """Label as well as box -- hiding only the box leaves a caption over the tilt row."""
+    assert not compustage_widget.spinbox_rotation.isVisibleTo(compustage_widget)
+    assert not compustage_widget.label_rotation.isVisibleTo(compustage_widget)
+
+
+def test_any_other_stage_is(flat_widget):
+    assert flat_widget.spinbox_rotation.isVisibleTo(flat_widget)
+    assert flat_widget.label_rotation.isVisibleTo(flat_widget)
+
+
+# --- the guards --------------------------------------------------------------
+
+
+def test_a_passing_scroll_does_not_retype_a_box(qapp, widget):
+    """Scrolling the panel used to change whichever box the pointer crossed."""
+    widget.set_position(SAMPLE)
+
+    for axis, spinbox in widget._spinboxes().items():
+        before = spinbox.value()
+        # sendEvent, not spinbox.wheelEvent: the guard is an event filter, so it only
+        # sees the event on the way through dispatch. Calling the handler direct walks
+        # past it and would pass with the guard removed.
+        qapp.sendEvent(spinbox, _wheel())
+        assert spinbox.value() == before, f"{axis} changed on a wheel event"
+
+
+# --- it asks, it does not read -----------------------------------------------
+
+
+def test_refresh_asks_the_host_rather_than_the_stage(widget, monkeypatch):
+    """The form never calls the microscope on a UI event. Reading the stage is a device
+    call and the host owns those, so the button emits and stops."""
+    asked = []
+    reads = []
+    widget.refresh_requested.connect(lambda: asked.append(True))
+    monkeypatch.setattr(
+        widget.microscope,
+        "get_stage_position",
+        lambda *a, **k: reads.append(True),
+        raising=False,
+    )
+
+    widget.btn_refresh.click()
+
+    assert asked == [True]
+    assert reads == [], "the form read the stage instead of asking for a refresh"


### PR DESCRIPTION
Second of three for [FIB-783](https://linear.app/fibsemos/issue/FIB-783/refactor-fibsemmovementwidget-into-modular-components). This adds the readout half as a widget of its own. **Nothing in production imports it**, so the Movement tab is byte-for-byte unchanged by this PR — the swap is the next one, and landing the new thing inert first is what keeps that swap a one-file diff to read.

Independent of [#619](https://github.com/fibsem-os/fibsem-os/pull/619); both are off `main` and merge in either order.

## What it is

`fibsem/ui/widgets/stage_position_widget.py` — five spin boxes and a refresh button. It says where the stage is, in the units an operator types in, and hands back what has been typed. It does not move the stage, and it has no opinion about who does: pressing refresh emits `refresh_requested` and stops there, so the host decides what a refresh costs.

Two properties are the reason the split is worth making at all:

- **No parent contract.** `FibsemMovementWidget` raises unless its parent carries a `FibsemImageSettingsWidget`, and beyond that reaches for a view controller, the live image and a milling widget. None of that is the readout's business, and none of it is here — the widget takes a microscope and an optional parent.
- **One device read, at construction**, for the axis ranges and the stage kind. Both are configuration rather than state: they change when someone reconfigures the microscope, not while it runs. Nothing on a UI event path touches the device, which is the rule the refresh signal exists to keep.

## Carried across unchanged

The conversions, the ranges, the five decimals, the wheel guards, and both compustage adjustments (1 µm arrow steps; rotation hidden — label as well as box).

Including the asymmetry worth reading twice: x, y and z are converted metres → millimetres, but the tilt **limits** are taken as they come, because the stage already reports those in degrees. It is the easiest thing here to "fix" wrongly.

## One thing tidied rather than copied

The rotation and tilt suffixes were written twice during construction — `f" {DEGREE_SYMBOL}"` in `_setup_ui`, then `DEGREE_SYMBOL` in `setup_connections`. Only the second survived, so the leading space never reached the screen. Set once now, to the value that was already winning. [#619](https://github.com/fibsem-os/fibsem-os/pull/619) pins the current behaviour, so if that lands first this stays green.

## Verification

**23 tests**, run against both shipped stage kinds:

| configuration | rotation | arrow step | tilt range |
| -- | -- | -- | -- |
| `microscope-configuration.yaml` | offered | 1 mm | −10…90° |
| `sim-arctis-configuration.yaml` | hidden | 1 µm | −195…15° |

The tilt ranges differ, and one test asserts that they differ — otherwise, if both fixtures ever resolved to the same configuration, the range assertions would still pass and prove nothing.

This is what the standalone widget buys over [#619](https://github.com/fibsem-os/fibsem-os/pull/619)'s tests, which have to branch on whatever configuration the machine defaults to: here the form is cheap enough to build twice, so both sides of the compustage branch are pinned deterministically.

Mutation-checked:

| mutation | result |
| -- | -- |
| convert the tilt limits as if they were metres | 2 failed |
| apply the compustage step to every stage | 1 failed |
| hide the rotation box but not its label | 1 failed |
| drop the wheel guard | 2 failed |
| have refresh read the stage instead of emitting | 2 failed |
| forget the millimetre conversion on the way out | 2 failed |

**Layout** checked with an offscreen render of the widget inside a `TitledPanel`, for both stage kinds — five rows and the refresh button in the panel header on one, four rows and no stranded rotation caption on the other.

`ruff check` and `ruff format --check` clean on both files. Static 3.8 scan clean (no builtin generics, no PEP 604 unions, no 3.9+ string methods).

I have not run the application on this branch — there is nothing to see yet, since no host constructs the widget. That check belongs to the swap PR, and I will do it there.

## Not in scope

Pointing `FibsemMovementWidget` at it, and removing the inline rows. Next PR.

Note: merging this will auto-complete FIB-783 via the Linear attachment, even though it is one of three. Reopen it.