### PR TITLE
[refactor] One vertical_move, parameterised by the view (FIB-785)

### DIFF
--- a/fibsem/alignment/__init__.py
+++ b/fibsem/alignment/__init__.py
@@ -355,10 +355,11 @@ def _apply_shift(
             beam_type=beam_type,
         )
     elif subsystem is AlignmentSubsystem.STAGE_VERTICAL:
-        if beam_type is BeamType.ELECTRON and hasattr(microscope, "move_coincident_from_sem"):
-            microscope.move_coincident_from_sem(dx=dx, dy=-dy)  # type: ignore
-            return
-        microscope.vertical_move(dy=-dy, dx=dx)
+        # the shift was measured in beam_type's view, so the correction is too.
+        # A backend that cannot correct from that view raises rather than falling
+        # back to the other view's geometry, which used to apply the FIB's
+        # 1/sin(column_tilt) to an SEM-measured shift.
+        microscope.vertical_move(dy=-dy, dx=dx, beam_type=beam_type)
 
 
 def align_with_reference_image(

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -174,6 +174,11 @@ class FibsemMicroscope(ABC):
     stage_is_compustage: bool = False
     milling_channel: BeamType = BeamType.ION
 
+    # The views a coincidence correction can be measured in -- the beam_type
+    # values vertical_move accepts. The FIB view is universal; the SEM view
+    # needs a backend that knows how to slide along the FIB line of sight.
+    vertical_move_views: Tuple[BeamType, ...] = (BeamType.ION,)
+
     # live acquisition
     sem_acquisition_signal = Signal(FibsemImage)
     fib_acquisition_signal = Signal(FibsemImage)
@@ -332,8 +337,35 @@ class FibsemMicroscope(ABC):
         pass
 
     @abstractmethod
-    def vertical_move(self, dy: float, dx: float = 0) -> FibsemStagePosition:
+    def vertical_move(
+        self, dy: float, dx: float = 0, beam_type: BeamType = BeamType.ION
+    ) -> FibsemStagePosition:
+        """Restore coincidence from an offset measured in one of the beam views.
+
+        Args:
+            dy: offset along the image y-axis, in the view named by beam_type.
+            dx: offset along the image x-axis, in the same view.
+            beam_type: the view the offset was measured in. ION (the default, and
+                the historical behaviour) corrects a feature already centred in the
+                SEM; ELECTRON corrects one already centred in the FIB.
+
+        Raises:
+            NotImplementedError: if this backend cannot correct from that view.
+                Ask supports_vertical_move first rather than catching this.
+        """
         pass
+
+    def supports_vertical_move(self, beam_type: BeamType = BeamType.ION) -> bool:
+        """Whether coincidence can be restored from the given view on this system."""
+        return beam_type in self.vertical_move_views
+
+    def _check_vertical_move_supported(self, beam_type: BeamType) -> None:
+        """Guard for a vertical_move implementation -- one message, one source of truth."""
+        if not self.supports_vertical_move(beam_type):
+            raise NotImplementedError(
+                f"{type(self).__name__} cannot restore coincidence from the "
+                f"{beam_type.name} view."
+            )
 
     @abstractmethod
     def project_stable_move(
@@ -2236,8 +2268,8 @@ class ThermoMicroscope(FibsemMicroscope):
         stable_move(self, dx: float, dy: float, beam_type: BeamType,) -> None:
             Calculate the corrected stage movements based on the beam_type, and then move the stage relatively.
 
-        vertical_move(self,  dy: float, dx: float = 0) -> None:
-            Move the stage vertically to correct eucentric point
+        vertical_move(self, dy: float, dx: float = 0, beam_type: BeamType = BeamType.ION) -> None:
+            Move the stage to correct the coincidence point, from either beam view.
 
         get_manipulator_position(self) -> FibsemManipulatorPosition:
             Get the current manipulator position.
@@ -2300,6 +2332,8 @@ class ThermoMicroscope(FibsemMicroscope):
         _y_corrected_stage_movement(self, expected_y: float, beam_type: BeamType = BeamType.ELECTRON) -> FibsemStagePosition:
             Calculate the y corrected stage movement, corrected for the additional tilt of the sample holder (pre-tilt angle).
     """
+
+    vertical_move_views = (BeamType.ION, BeamType.ELECTRON)
 
     def __init__(self, system_settings: SystemSettings):
         if not THERMO_API_AVAILABLE:
@@ -3038,8 +3072,30 @@ class ThermoMicroscope(FibsemMicroscope):
         self,
         dy: float,
         dx: float = 0.0,
+        beam_type: BeamType = BeamType.ION,
+    ) -> FibsemStagePosition:
+        """Restore the coincidence point from an offset measured in one beam view.
+
+        Args:
+            dy (float): distance along the y-axis (image coordinates)
+            dx (float, optional): distance along the x-axis (image coordinates). Defaults to 0.0.
+            beam_type (BeamType, optional): the view the offset was measured in.
+                Defaults to ION.
+        """
+        self._check_vertical_move_supported(beam_type)
+        if beam_type is BeamType.ELECTRON:
+            return self._vertical_move_from_sem(dx=dx, dy=dy)
+        return self._vertical_move_from_fib(dx=dx, dy=dy)
+
+    def _vertical_move_from_fib(
+        self,
+        dy: float,
+        dx: float = 0.0,
     ) -> FibsemStagePosition:
         """Move the stage vertically to correct coincidence point
+
+        The offset is measured in the FIB view: the feature is already centred in
+        the SEM, and a chamber-vertical move is invisible to the electron beam.
 
         Args:
             dy (float): distance along the y-axis (image coordinates)
@@ -3109,7 +3165,24 @@ class ThermoMicroscope(FibsemMicroscope):
         return self.get_stage_position()
 
     def move_coincident_from_sem(self, dx: float, dy: float) -> FibsemStagePosition:
-        """Correct coincident point from SEM to FIB stage position."""
+        """Correct coincident point from SEM to FIB stage position.
+
+        Deprecated: call ``vertical_move(dy, dx, beam_type=BeamType.ELECTRON)``.
+        Kept for one release because custom scripts may call it.
+        """
+        return self.vertical_move(dy=dy, dx=dx, beam_type=BeamType.ELECTRON)
+
+    def _vertical_move_from_sem(self, dx: float, dy: float) -> FibsemStagePosition:
+        """Correct the coincidence point from an offset measured in the SEM view.
+
+        Not the mirror image of the FIB path but a superset: a stable move first
+        brings the feature to the centre of the SEM, and the height correction
+        that follows puts the FIB back.
+
+        NOTE: the geometry here is known to be wrong away from the flat pose, and
+        the two constants below cancel each other -- see FIB-773. Moved verbatim
+        from ``move_coincident_from_sem``; correcting it needs bench time.
+        """
 
         # NOTE:
         # inaccurate over longer distances, but works for small movements
@@ -3136,7 +3209,7 @@ class ThermoMicroscope(FibsemMicroscope):
             dy *= -1.0
 
         # apply the vertical move to correct the position
-        self.vertical_move(
+        self._vertical_move_from_fib(
             dx=0, dy=dy * 1.11
         )  # TODO: MAGIC_NUMBER To correct for perspective correction...
 

--- a/fibsem/microscopes/_stage.py
+++ b/fibsem/microscopes/_stage.py
@@ -289,8 +289,10 @@ class Stage:
     ) -> FibsemStagePosition:
         return self.parent.stable_move(dx, dy, beam_type)
 
-    def vertical_move(self, dy: float, dx: float = 0.0) -> FibsemStagePosition:
-        return self.parent.vertical_move(dy, dx)
+    def vertical_move(
+        self, dy: float, dx: float = 0.0, beam_type: BeamType = BeamType.ION
+    ) -> FibsemStagePosition:
+        return self.parent.vertical_move(dy, dx, beam_type)
 
     def move_to_milling_angle(self, milling_angle: float) -> bool:
         return self.parent.move_to_milling_angle(milling_angle)

--- a/fibsem/microscopes/odemis_microscope.py
+++ b/fibsem/microscopes/odemis_microscope.py
@@ -241,6 +241,7 @@ class OdemisThermoMicroscope(FibsemMicroscope):
 
     milling_progress_signal = Signal(MillingProgress)
     _last_imaging_settings: ImageSettings
+    vertical_move_views = (BeamType.ION, BeamType.ELECTRON)
 
     def __init__(self, system_settings: SystemSettings):
         self.system: SystemSettings = system_settings
@@ -853,13 +854,26 @@ class OdemisThermoMicroscope(FibsemMicroscope):
             self, dx=dx, dy=dy, beam_type=beam_type, static_wd=static_wd
         )
 
-    def vertical_move(self, dy: float, dx: float = 0.0) -> FibsemStagePosition:
-        """Move the stage vertically by the specified amount."""
-        return ThermoMicroscope.vertical_move(self, dy=dy, dx=dx)
+    def vertical_move(
+        self, dy: float, dx: float = 0.0, beam_type: BeamType = BeamType.ION
+    ) -> FibsemStagePosition:
+        """Restore the coincidence point from an offset measured in one beam view."""
+        return ThermoMicroscope.vertical_move(self, dy=dy, dx=dx, beam_type=beam_type)
+
+    def _vertical_move_from_fib(
+        self, dy: float, dx: float = 0.0
+    ) -> FibsemStagePosition:
+        return ThermoMicroscope._vertical_move_from_fib(self, dy=dy, dx=dx)
+
+    def _vertical_move_from_sem(self, dx: float, dy: float) -> FibsemStagePosition:
+        return ThermoMicroscope._vertical_move_from_sem(self, dx=dx, dy=dy)
 
     def move_coincident_from_sem(self, dx: float, dy: float) -> FibsemStagePosition:
-        """Correct coincident point from SEM to FIB stage position."""
-        return ThermoMicroscope.move_coincident_from_sem(self, dx=dx, dy=dy)
+        """Correct coincident point from SEM to FIB stage position.
+
+        Deprecated: call ``vertical_move(dy, dx, beam_type=BeamType.ELECTRON)``.
+        """
+        return self.vertical_move(dy=dy, dx=dx, beam_type=BeamType.ELECTRON)
 
     def _y_corrected_stage_movement(
         self, expected_y: float, beam_type: BeamType

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -367,6 +367,8 @@ class SimulatedFluorescenceMicroscope(FluorescenceMicroscope):
 class DemoMicroscope(FibsemMicroscope):
     """Simulator microscope client based on TFS microscopes"""
 
+    vertical_move_views = (BeamType.ION, BeamType.ELECTRON)
+
     def __init__(self, system_settings: SystemSettings):
 
         # initialise system
@@ -1026,9 +1028,19 @@ class DemoMicroscope(FibsemMicroscope):
     ) -> FibsemStagePosition:
         return ThermoMicroscope.stable_move(self, dx, dy, beam_type, static_wd)
 
-    def vertical_move(self, dy: float, dx: float = 0.0) -> FibsemStagePosition:
-        """Move the stage vertically by the specified amount."""
-        return ThermoMicroscope.vertical_move(self, dy, dx)
+    def vertical_move(
+        self, dy: float, dx: float = 0.0, beam_type: BeamType = BeamType.ION
+    ) -> FibsemStagePosition:
+        """Restore the coincidence point from an offset measured in one beam view."""
+        return ThermoMicroscope.vertical_move(self, dy, dx, beam_type)
+
+    def _vertical_move_from_fib(
+        self, dy: float, dx: float = 0.0
+    ) -> FibsemStagePosition:
+        return ThermoMicroscope._vertical_move_from_fib(self, dy=dy, dx=dx)
+
+    def _vertical_move_from_sem(self, dx: float, dy: float) -> FibsemStagePosition:
+        return ThermoMicroscope._vertical_move_from_sem(self, dx=dx, dy=dy)
 
     def _y_corrected_stage_movement(
         self, expected_y: float, beam_type: BeamType

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -293,6 +293,8 @@ class TescanMicroscope(FibsemMicroscope):
     to the TESCAN FIB-SEM microscope.
     """
 
+    vertical_move_views = (BeamType.ION, BeamType.ELECTRON)
+
     def __init__(self, system_settings: SystemSettings):
         if not TESCAN_API_AVAILABLE:
             raise ImportError(
@@ -814,7 +816,26 @@ class TescanMicroscope(FibsemMicroscope):
         self,
         dy: float,
         dx: float = 0.0,
-    ) -> None:
+        beam_type: BeamType = BeamType.ION,
+    ) -> FibsemStagePosition:
+        """Restore the coincidence point from an offset measured in one beam view.
+
+        Args:
+            dy (float): distance in y-axis (image coordinates)
+            dx (float, optional): distance in x-axis (image coordinates)
+            beam_type (BeamType, optional): the view the offset was measured in.
+                Defaults to ION.
+        """
+        self._check_vertical_move_supported(beam_type)
+        if beam_type is BeamType.ELECTRON:
+            return self._vertical_move_from_sem(dx=dx, dy=dy)
+        return self._vertical_move_from_fib(dx=dx, dy=dy)
+
+    def _vertical_move_from_fib(
+        self,
+        dy: float,
+        dx: float = 0.0,
+    ) -> FibsemStagePosition:
         """
         Move the stage vertically to correct coincidence point
 
@@ -846,10 +867,20 @@ class TescanMicroscope(FibsemMicroscope):
         logging.info(f"vertical movement: {z_move}")
         self.move_stage_relative(z_move)
 
+        return self.get_stage_position()
+
     def move_coincident_from_sem(self, dx: float, dy: float) -> FibsemStagePosition:
         """Correct the coincidence point from the SEM view.
 
-        The SEM-view mirror of vertical_move: the stage slides along the FIB
+        Deprecated: call ``vertical_move(dy, dx, beam_type=BeamType.ELECTRON)``.
+        Kept for one release because custom scripts may call it.
+        """
+        return self.vertical_move(dy=dy, dx=dx, beam_type=BeamType.ELECTRON)
+
+    def _vertical_move_from_sem(self, dx: float, dy: float) -> FibsemStagePosition:
+        """Correct the coincidence point from the SEM view.
+
+        The mirror of the FIB branch above: the stage slides along the FIB
         line of sight, which is invisible in the FIB image, until the clicked
         feature is centred in the SEM. A feature already positioned in the FIB
         view (e.g. just milled, or just corrected with vertical_move) therefore

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -593,19 +593,16 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             }
         )
 
-        # refuse rather than silently fall through to stable_move below: on backends
-        # without move_coincident_from_sem (e.g. the simulator) the operator would
-        # ask to restore coincidence and get a sample-plane move instead
-        if (
-            beam_type is BeamType.ELECTRON
-            and vertical_move
-            and not hasattr(self.microscope, "move_coincident_from_sem")
-        ):
+        # refuse rather than silently fall through to stable_move below: on a backend
+        # that cannot correct coincidence from this view, the operator would ask to
+        # restore coincidence and get a sample-plane move instead
+        if vertical_move and not self.microscope.supports_vertical_move(beam_type):
+            view = "SEM" if beam_type is BeamType.ELECTRON else "FIB"
             logging.warning(
-                "Vertical move from the SEM view is not supported on this system."
+                f"Vertical move from the {view} view is not supported on this system."
             )
             notification_service.show_toast(
-                "Vertical move from the SEM view is not supported on this system - use the FIB view.",
+                f"Vertical move from the {view} view is not supported on this system - use the other view.",
                 "warning",
             )
             return
@@ -630,18 +627,14 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     ) -> None:
         """Move the stage. Runs off the GUI thread — only signals may cross back.
 
-        Which of the three calls applies is decided from arguments, not from widget
+        Which of the two calls applies is decided from arguments, not from widget
         state: the beam and the modifier were resolved by the caller while it was still
         on the GUI thread.
         """
-        # eucentric is only supported for ION beam
-        if beam_type is BeamType.ION and vertical_move:
-            self.microscope.vertical_move(dx=point.x, dy=point.y)
-        elif beam_type is BeamType.ELECTRON and vertical_move:
-            # move coincident from SEM
-            self.microscope.move_coincident_from_sem(
-                dx=0, dy=point.y
-            )  # TMP: disable dx for now
+        if vertical_move:
+            # TMP: an x offset measured in the SEM view is still discarded
+            dx = point.x if beam_type is BeamType.ION else 0
+            self.microscope.vertical_move(dx=dx, dy=point.y, beam_type=beam_type)
         else:
             # corrected stage movement
             self.microscope.stable_move(

--- a/tests/test_movement_widget_vertical_gate.py
+++ b/tests/test_movement_widget_vertical_gate.py
@@ -1,19 +1,21 @@
-"""The SEM-view vertical-move gate (FIB-507 T4a).
+"""The vertical-move capability gate (FIB-507 T4a, FIB-785).
 
-An Alt-click vertical move dispatches to ``move_coincident_from_sem`` for the
-ELECTRON view -- a method only some backends implement (ThermoFisher, Odemis).
-Backends without it (e.g. TESCAN) used to fall through to ``stable_move``
-silently: the operator asked to restore coincidence and got a sample-plane move
-instead. The widget must refuse with a toast, and leave every other dispatch
-branch untouched.
+An Alt-click vertical move dispatches to ``microscope.vertical_move(..., beam_type=...)``,
+where ``beam_type`` names the view the offset was measured in. Not every backend can
+correct from every view, so the widget asks ``supports_vertical_move`` first: a backend
+that cannot used to fall through to ``stable_move`` silently, and the operator asked to
+restore coincidence and got a sample-plane move instead. The widget must refuse with a
+toast, and leave every other dispatch branch untouched.
 
-The refusal and the dispatch now live either side of a thread. ``_execute_stage_move``
+The refusal and the dispatch live either side of a thread. ``_execute_stage_move``
 decides, on the GUI thread, whether the move may go ahead at all; ``_stage_move_worker``
-performs whichever of the three calls applies. So the refusal is asserted on the former
-and the three branches on the latter, called through ``__wrapped__``.
+performs whichever of the two calls applies. So the refusal is asserted on the former
+and the branches on the latter, called through ``__wrapped__``.
 
-No Qt event loop or microscope required: the widget is created without __init__
-and only the attributes each function touches are provided.
+No Qt event loop or microscope required: the widget is created without __init__ and
+only the attributes each function touches are provided. The recorders below borrow the
+real ``supports_vertical_move`` rather than reimplementing it, so they cannot drift from
+the contract the widget is being tested against.
 """
 
 from unittest.mock import Mock
@@ -28,6 +30,7 @@ try:
 except ImportError as e:  # pragma: no cover - exercised only on UI-less CI
     _MISSING_UI_DEPS = str(e)
 
+from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, Point
 
 pytestmark = pytest.mark.skipif(
@@ -36,7 +39,10 @@ pytestmark = pytest.mark.skipif(
 
 
 class RecordingMicroscope:
-    """Records move calls; has no move_coincident_from_sem (the TESCAN case)."""
+    """Records move calls. Corrects coincidence from either view (Thermo/Tescan)."""
+
+    vertical_move_views = (BeamType.ION, BeamType.ELECTRON)
+    supports_vertical_move = FibsemMicroscope.supports_vertical_move
 
     def __init__(self):
         self.calls = []
@@ -44,15 +50,14 @@ class RecordingMicroscope:
     def stable_move(self, dx, dy, beam_type):
         self.calls.append(("stable_move", dx, dy, beam_type))
 
-    def vertical_move(self, dx, dy):
-        self.calls.append(("vertical_move", dx, dy))
+    def vertical_move(self, dy, dx=0.0, beam_type=BeamType.ION):
+        self.calls.append(("vertical_move", dx, dy, beam_type))
 
 
-class SemCoincidentMicroscope(RecordingMicroscope):
-    """A backend that implements the SEM-view coincidence move (Thermo/Odemis)."""
+class FibOnlyMicroscope(RecordingMicroscope):
+    """A backend that can only correct coincidence from the FIB view."""
 
-    def move_coincident_from_sem(self, dx, dy):
-        self.calls.append(("move_coincident_from_sem", dx, dy))
+    vertical_move_views = (BeamType.ION,)
 
 
 @pytest.fixture
@@ -90,36 +95,68 @@ def dispatch(widget, beam_type, vertical):
     )
 
 
-def test_sem_vertical_without_backend_support_refuses_with_a_toast(toasts):
-    m = RecordingMicroscope()
+def test_an_unsupported_view_refuses_with_a_toast(toasts):
+    m = FibOnlyMicroscope()
     refuse_or_start(make_widget(m), BeamType.ELECTRON, vertical=True)
 
     assert m.calls == []  # no silent stable_move fallback
     assert len(toasts) == 1
     msg, level = toasts[0]
-    assert "not supported" in msg and "FIB view" in msg
+    assert "not supported" in msg and "SEM view" in msg
     assert level == "warning"
 
 
-def test_sem_vertical_with_backend_support_moves_coincident(toasts):
-    m = SemCoincidentMicroscope()
+def test_the_sem_view_is_passed_through_as_the_beam_type(toasts):
+    m = RecordingMicroscope()
     dispatch(make_widget(m), BeamType.ELECTRON, vertical=True)
 
-    assert [c[0] for c in m.calls] == ["move_coincident_from_sem"]
+    # dx is still discarded on this path -- see FIB-773
+    assert m.calls == [("vertical_move", 0, 2e-6, BeamType.ELECTRON)]
     assert toasts == []
 
 
-def test_fib_vertical_is_unaffected(toasts):
+def test_the_fib_view_still_carries_dx(toasts):
     m = RecordingMicroscope()
     dispatch(make_widget(m), BeamType.ION, vertical=True)
 
-    assert [c[0] for c in m.calls] == ["vertical_move"]
+    assert m.calls == [("vertical_move", 1e-6, 2e-6, BeamType.ION)]
     assert toasts == []
 
 
-def test_sem_stable_move_is_unaffected(toasts):
-    m = RecordingMicroscope()
+def test_a_stable_move_is_unaffected(toasts):
+    """The gate only ever applies to a vertical move, so a backend that declares
+    no SEM view still gets a plain stable move from the SEM canvas."""
+    m = FibOnlyMicroscope()
     dispatch(make_widget(m), BeamType.ELECTRON, vertical=False)
 
     assert [c[0] for c in m.calls] == ["stable_move"]
     assert toasts == []
+
+
+def test_a_real_backend_satisfies_the_widget(toasts):
+    """The wiring, against a real DemoMicroscope rather than a recorder: the widget
+    asks the capability query and then calls vertical_move with the view. The
+    simulator answers yes to both views, so neither Alt-click is refused."""
+    import os
+
+    import fibsem.config as fibsem_config
+    from fibsem import utils
+
+    scope, _ = utils.setup_session(
+        manufacturer="Demo",
+        config_path=os.path.join(
+            os.path.dirname(fibsem_config.__file__),
+            "config",
+            "microscope-configuration.yaml",
+        ),
+    )
+    widget = make_widget(scope)
+    start = scope.get_stage_position()
+
+    # the GUI-thread half asks the query, and a real simulator answers yes
+    assert scope.supports_vertical_move(BeamType.ELECTRON)
+    # the worker half then reaches the backend's SEM branch and moves the stage
+    dispatch(widget, BeamType.ELECTRON, vertical=True)
+
+    assert toasts == []
+    assert not scope.get_stage_position().is_close2(start, tol=1e-9)

--- a/tests/test_tescan_movement.py
+++ b/tests/test_tescan_movement.py
@@ -480,10 +480,41 @@ def test_reprojection_round_trip_scan_rotation_180(beam_type):
 # ---------------------------------------------------------------------------
 
 
-def test_tescan_has_move_coincident_from_sem():
-    """The movement widget's SEM-vertical gate and the alignment STAGE_VERTICAL
-    path both dispatch on hasattr; adding the method is what lights them up."""
-    assert hasattr(TescanMicroscope, "move_coincident_from_sem")
+def test_tescan_declares_the_sem_view_as_supported():
+    """The movement widget's vertical gate and the alignment STAGE_VERTICAL path both
+    ask supports_vertical_move; declaring the view is what lights them up (FIB-785)."""
+    m = make_microscope()
+
+    assert m.supports_vertical_move(BeamType.ELECTRON)
+    assert m.supports_vertical_move(BeamType.ION)
+
+
+def test_the_deprecated_name_is_the_electron_branch():
+    """``move_coincident_from_sem`` is kept for one release for custom scripts. It must
+    stay exactly the ELECTRON branch, not a second implementation of it."""
+    dx, dy = 1e-6, 10e-6
+
+    m_new = make_microscope(stage_position=stage_at(-15.0))
+    m_new.vertical_move(dy=dy, dx=dx, beam_type=BeamType.ELECTRON)
+
+    m_old = make_microscope(stage_position=stage_at(-15.0))
+    m_old.move_coincident_from_sem(dx=dx, dy=dy)
+
+    assert len(m_new._recorded_moves) == 1
+    assert m_new._recorded_moves[0].is_close2(m_old._recorded_moves[0], tol=1e-12)
+
+
+def test_the_fib_view_is_the_default():
+    """Every existing caller passes no beam_type and must keep the FIB geometry."""
+    dy = 10e-6
+
+    m_default = make_microscope(stage_position=stage_at(-15.0))
+    m_default.vertical_move(dy=dy)
+
+    m_ion = make_microscope(stage_position=stage_at(-15.0))
+    m_ion.vertical_move(dy=dy, beam_type=BeamType.ION)
+
+    assert m_default._recorded_moves[0].is_close2(m_ion._recorded_moves[0], tol=1e-12)
 
 
 def test_coincident_from_sem_explicit_values_flat():

--- a/tests/test_vertical_move_views.py
+++ b/tests/test_vertical_move_views.py
@@ -1,0 +1,116 @@
+"""``vertical_move`` is parameterised by the view the offset was measured in (FIB-785).
+
+One method, not two: ``beam_type`` names the view, ION (the FIB) being the default
+and the historical behaviour. ``supports_vertical_move`` is the capability query
+callers gate on, so nothing has to dispatch on ``hasattr`` to find out whether a
+backend can correct from the SEM view.
+
+These run against a real ``DemoMicroscope`` rather than a stand-in: the simulator
+reaches the ThermoFisher bodies by delegation, which is exactly the wiring that
+would break silently.
+"""
+
+import inspect
+import os
+
+import pytest
+
+import fibsem.config as fibsem_config
+from fibsem import utils
+from fibsem.microscope import FibsemMicroscope, ThermoMicroscope
+from fibsem.microscopes.simulator import DemoMicroscope
+from fibsem.microscopes.tescan import TescanMicroscope
+from fibsem.structures import BeamType
+
+CONFIG_PATH = os.path.join(
+    os.path.dirname(fibsem_config.__file__), "config", "microscope-configuration.yaml"
+)
+
+
+@pytest.fixture
+def microscope():
+    scope, _ = utils.setup_session(manufacturer="Demo", config_path=CONFIG_PATH)
+    return scope
+
+
+# ---------------------------------------------------------------------------
+# the capability query
+# ---------------------------------------------------------------------------
+
+
+def test_the_simulator_corrects_from_both_views(microscope):
+    """The simulator delegates to the ThermoFisher bodies, so it has both views.
+
+    Before FIB-785 it had only the FIB one, and the movement widget refused the
+    SEM-view Alt-click in demo mode -- the feature could not be exercised at all
+    away from hardware.
+    """
+    assert microscope.supports_vertical_move(BeamType.ION)
+    assert microscope.supports_vertical_move(BeamType.ELECTRON)
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [ThermoMicroscope, TescanMicroscope, DemoMicroscope],
+    ids=lambda c: c.__name__,
+)
+def test_every_backend_declares_the_views_it_supports(cls):
+    assert set(cls.vertical_move_views) == {BeamType.ION, BeamType.ELECTRON}
+
+
+def test_the_fib_view_is_the_universal_default():
+    """A backend that declares nothing still corrects from the FIB view."""
+    assert FibsemMicroscope.vertical_move_views == (BeamType.ION,)
+    assert (
+        inspect.signature(FibsemMicroscope.vertical_move)
+        .parameters["beam_type"]
+        .default
+        is BeamType.ION
+    )
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [ThermoMicroscope, TescanMicroscope, DemoMicroscope],
+    ids=lambda c: c.__name__,
+)
+def test_every_backend_takes_the_view_as_a_parameter(cls):
+    """The signature drift FIB-269 warns about: an override that quietly lost beam_type
+    would send every SEM-view correction down the FIB geometry."""
+    assert "beam_type" in inspect.signature(cls.vertical_move).parameters
+
+
+def test_an_unsupported_view_raises_instead_of_moving(microscope):
+    """The failure mode being designed out: correcting a SEM-measured offset with the
+    FIB's geometry, which is what the old fallbacks did."""
+    microscope.vertical_move_views = (BeamType.ION,)
+    before = microscope.get_stage_position()
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        microscope.vertical_move(dy=5e-6, beam_type=BeamType.ELECTRON)
+
+    assert "DemoMicroscope" in str(excinfo.value)
+    assert "ELECTRON" in str(excinfo.value)
+    assert microscope.get_stage_position().is_close2(before, tol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# the two views are two different moves
+# ---------------------------------------------------------------------------
+
+
+def test_the_two_views_move_the_stage_differently(microscope):
+    """The SEM view is not the FIB view's mirror image but a superset -- a stable move
+    to centre in the SEM, then a height correction to bring the FIB back."""
+    start = microscope.get_stage_position()
+
+    microscope.vertical_move(dy=5e-6, beam_type=BeamType.ION)
+    from_fib = microscope.get_stage_position()
+
+    microscope.move_stage_absolute(start)
+    microscope.vertical_move(dy=5e-6, beam_type=BeamType.ELECTRON)
+    from_sem = microscope.get_stage_position()
+
+    assert not from_fib.is_close2(from_sem, tol=1e-9)
+    assert not from_fib.is_close2(start, tol=1e-9)
+    assert not from_sem.is_close2(start, tol=1e-9)


### PR DESCRIPTION
Two methods existed for one concept — "restore coincidence from the view the offset was measured in":

* `vertical_move(dy, dx=0)` — on every backend, implicitly **the FIB view**
* `move_coincident_from_sem(dx, dy)` — **the SEM view**, on some backends only

Because the second was not part of the base API, both call sites dispatched on `hasattr`, and each invented a different fallback for the backends without it.

## The API

```python
def vertical_move(self, dy, dx=0, beam_type: BeamType = BeamType.ION) -> FibsemStagePosition
def supports_vertical_move(self, beam_type=BeamType.ION) -> bool
```

`beam_type` names the view the offset was measured in; ION is the default, so every existing caller is unchanged. The capability query is backed by a `vertical_move_views` class attribute — the base declares the FIB view only, and a backend opts into the SEM view by declaring it. `supports_vertical_move` and the `NotImplementedError` share one guard, so they cannot disagree.

Each backend keeps its own two bodies, now private (`_vertical_move_from_fib` / `_vertical_move_from_sem`) behind one dispatching `vertical_move`. **They are moved verbatim** — no geometry is touched, and both magic constants stay exactly as they were, with a note pointing at FIB-773. That issue keeps the bench time it needs.

## The call sites

* `FibsemMovementWidget._execute_stage_move` — the three-way branch becomes one call, and the refusal toast keys off the capability query rather than `hasattr`. The SEM path still discards `dx`, deliberately: that is FIB-773's to change.
* `alignment._apply_shift` — five lines become one. The `STAGE_VERTICAL` fallback disappears by construction: correcting a SEM-measured shift with the FIB's `1/sin(column_tilt)` is no longer reachable, because an unsupported view raises rather than falling through to the other view's geometry.

## The simulator

It reaches the ThermoFisher bodies by delegation, so it gets the SEM view for free — the Alt + double-click demo mode used to refuse. That is also what makes the path testable away from hardware at all.

## Also fixed

`TescanMicroscope.vertical_move` was declared `-> None` and returned nothing, against a base class returning `FibsemStagePosition` — the signature drift FIB-269 describes.

## Deliberately not in this PR

`move_coincident_from_sem` stays as a thin deprecated wrapper for one release, since custom scripts may call it; removing it is a follow-up. `FibsemClient.vertical_move` still takes `(dy, dx)` and the server has no coincidence endpoint at all, so a client-backed session cannot reach the SEM view — also a follow-up, and pre-existing.

## Verification

Beyond the suites (`tests/` 4082 passed, `tests/ui` 2327 passed, ruff clean), this was **driven in the running application** on the Demo backend, because widget tests do not cover the canvas wiring:

```
{'movement_mode': 'Vertical', 'beam_type': 'ELECTRON'}
  move_stage_relative      y=+2.342e-05  z=-1.640e-05   <- stable move, centres it in the SEM
  _vertical_move_from_fib  z=-1.554e-06                 <- the height correction that follows

{'movement_mode': 'Vertical', 'beam_type': 'ION'}
  _vertical_move_from_fib  x=1.763e-06  z=+2.344e-05    <- one move, dx still carried
```

Plain double-clicks still logged `movement_mode: 'Stable'` on both canvases.

New tests: `tests/test_vertical_move_views.py` drives a real `DemoMicroscope` through the capability contract and both branches; the movement-widget gate tests borrow the real `supports_vertical_move` so the recorders cannot drift from it; the Tescan `hasattr` assertion is replaced by a capability check plus an equivalence test pinning the deprecated name to the ELECTRON branch.

Release-Note: Alt + double-click in the SEM view now restores coincidence on the simulator, instead of being refused as unsupported.
