### PR TITLE
[refactor] Rename MillingStatus to MillingProgressStatus (FIB-797)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -81,7 +81,7 @@ from fibsem.imaging.tiling.progress import TiledProgress, TiledStatus
 from fibsem.milling.progress import (
     MillingMessageTracker,
     MillingProgress,
-    MillingStatus,
+    MillingProgressStatus,
 )
 from fibsem.structures import BeamType
 from fibsem.ui import notification_service
@@ -1568,7 +1568,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         label = self._milling_label.label(report)
 
-        if report.status is MillingStatus.STAGE_STARTED:
+        if report.status is MillingProgressStatus.STAGE_STARTED:
             # `or 1` rather than a `.get` default: a producer that sends 0 total stages
             # is as much a division by zero as one that sends nothing.
             total_stages = report.total_stages or 1
@@ -1581,7 +1581,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
                 f"Milling Stage: {stage}/{total_stages} - {stage_name}"
             )
 
-        elif report.status is MillingStatus.STAGE_UPDATE:
+        elif report.status is MillingProgressStatus.STAGE_UPDATE:
             remaining_time = report.remaining_time
             if remaining_time is not None and report.estimated_time:
                 percent_complete = int(

--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -70,7 +70,7 @@ from fibsem.fm.structures import FluorescenceImage
 from fibsem.milling.progress import (
     MillingMessageTracker,
     MillingProgress,
-    MillingStatus,
+    MillingProgressStatus,
 )
 from fibsem.milling.strategy.coincidence import CoincidenceMillingStrategy
 from fibsem.structures import BeamType, FibsemImage, Point
@@ -2105,7 +2105,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         report = MillingProgress.from_payload(payload)
         label = self._milling_label.label(report)
 
-        if report.status is MillingStatus.STAGE_STARTED:
+        if report.status is MillingProgressStatus.STAGE_STARTED:
             self._set_border_state("supervised" if self._supervised else "automated")
             # `or 1` rather than a `.get` default: a producer that sends 0 total stages
             # is as much a division by zero as one that sends nothing.
@@ -2138,7 +2138,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             )
             self.label_threshold_chip.setVisible(True)
 
-        elif report.status is MillingStatus.STAGE_UPDATE:
+        elif report.status is MillingProgressStatus.STAGE_UPDATE:
             remaining = report.remaining_time
             if remaining is not None and report.estimated_time:
                 pct = int((1 - remaining / report.estimated_time) * 100)

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -111,7 +111,7 @@ from fibsem.microscopes.autoscript import (
     stage_position_from_autoscript,
     stage_position_to_autoscript,
 )
-from fibsem.milling.progress import MillingProgress, MillingStatus
+from fibsem.milling.progress import MillingProgress, MillingProgressStatus
 from fibsem.structures import (
     ACTIVE_MILLING_STATES,
     BeamSettings,
@@ -3621,7 +3621,7 @@ class ThermoMicroscope(FibsemMicroscope):
             # update milling progress via signal
             self.milling_progress_signal.emit(
                 MillingProgress(
-                    status=MillingStatus.STAGE_UPDATE,
+                    status=MillingProgressStatus.STAGE_UPDATE,
                     start_time=start_time,
                     milling_state=self.get_milling_state(),
                     estimated_time=estimated_time,

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -22,7 +22,7 @@ from fibsem.microscope import (
     FibsemMicroscope,
     ThermoMicroscope,
 )
-from fibsem.milling.progress import MillingProgress, MillingStatus
+from fibsem.milling.progress import MillingProgress, MillingProgressStatus
 from fibsem.structures import (
     ACTIVE_MILLING_STATES,
     BeamSettings,
@@ -1185,7 +1185,7 @@ class DemoMicroscope(FibsemMicroscope):
             # update milling progress via signal
             self.milling_progress_signal.emit(
                 MillingProgress(
-                    status=MillingStatus.STAGE_UPDATE,
+                    status=MillingProgressStatus.STAGE_UPDATE,
                     start_time=start_time,
                     milling_state=self.get_milling_state(),
                     estimated_time=estimated_time,

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -59,7 +59,7 @@ from fibsem.imaging.spot import (
     SpotBurnStatus,
 )
 from fibsem.milling.base import set_preset_driven_estimation
-from fibsem.milling.progress import MillingProgress, MillingStatus
+from fibsem.milling.progress import MillingProgress, MillingProgressStatus
 from fibsem.structures import (  # noqa
     ACTIVE_MILLING_STATES,
     BeamSettings,
@@ -1377,7 +1377,7 @@ class TescanMicroscope(FibsemMicroscope):
                 # update milling progress via signal
                 self.milling_progress_signal.emit(
                     MillingProgress(
-                        status=MillingStatus.STAGE_UPDATE,
+                        status=MillingProgressStatus.STAGE_UPDATE,
                         milling_state=self.get_milling_state(),
                         start_time=start_time,
                         estimated_time=estimated_time,

--- a/fibsem/milling/progress.py
+++ b/fibsem/milling/progress.py
@@ -6,7 +6,7 @@ with a `.get("progress")`, a `None` guard, and then a second level of `.get` bef
 could read anything. Four payload shapes were in flight, one of which matched no branch
 in any consumer and therefore rendered nowhere.
 
-`MillingProgress` is the whole contract, and `MillingStatus` is the whole vocabulary.
+`MillingProgress` is the whole contract, and `MillingProgressStatus` is the whole vocabulary.
 
 # One flat record, not a union -- but it is the closest call of the three
 
@@ -69,13 +69,13 @@ from typing import Dict, Optional
 from fibsem.structures import MillingState
 
 __all__ = [
-    "MillingStatus",
+    "MillingProgressStatus",
     "MillingProgress",
     "MillingMessageTracker",
 ]
 
 
-class MillingStatus(str, Enum):
+class MillingProgressStatus(str, Enum):
     """Where a milling task has got to.
 
     Seven members across **two scales**, and the prefixes are the whole point: `TASK_*`
@@ -85,7 +85,7 @@ class MillingStatus(str, Enum):
 
     A `str` mixin so a member compares equal to its own value: these are persisted
     nowhere, but they reach log lines, and `"stage-update"` reads better than
-    `MillingStatus.STAGE_UPDATE`.
+    `MillingProgressStatus.STAGE_UPDATE`.
     """
 
     # The task is beginning, before any stage has started. No producer emitted an
@@ -129,9 +129,9 @@ class MillingStatus(str, Enum):
 
 _TERMINAL_STATUSES = frozenset(
     {
-        MillingStatus.TASK_FINISHED,
-        MillingStatus.TASK_CANCELLED,
-        MillingStatus.TASK_FAILED,
+        MillingProgressStatus.TASK_FINISHED,
+        MillingProgressStatus.TASK_CANCELLED,
+        MillingProgressStatus.TASK_FAILED,
     }
 )
 
@@ -144,14 +144,14 @@ _TERMINAL_STATUSES = frozenset(
 # `{stage}` and `{task}` are filled by `display_message` when the report carries a name,
 # and the whole clause is dropped when it does not. A label reading "Preparing: None" is
 # worse than one reading "Preparing...".
-_DEFAULT_MESSAGES: Dict[MillingStatus, str] = {
-    MillingStatus.TASK_STARTED: "Preparing milling task...",
-    MillingStatus.STAGE_STARTED: "Preparing...",
-    MillingStatus.STAGE_UPDATE: "Milling...",
-    MillingStatus.STAGE_FINISHED: "Finished stage",
-    MillingStatus.TASK_FINISHED: "Finished milling task",
-    MillingStatus.TASK_CANCELLED: "Milling cancelled",
-    MillingStatus.TASK_FAILED: "Milling failed",
+_DEFAULT_MESSAGES: Dict[MillingProgressStatus, str] = {
+    MillingProgressStatus.TASK_STARTED: "Preparing milling task...",
+    MillingProgressStatus.STAGE_STARTED: "Preparing...",
+    MillingProgressStatus.STAGE_UPDATE: "Milling...",
+    MillingProgressStatus.STAGE_FINISHED: "Finished stage",
+    MillingProgressStatus.TASK_FINISHED: "Finished milling task",
+    MillingProgressStatus.TASK_CANCELLED: "Milling cancelled",
+    MillingProgressStatus.TASK_FAILED: "Milling failed",
 }
 
 # Which name each default is qualified by, when the report carries one -- a stage report
@@ -160,12 +160,14 @@ _DEFAULT_MESSAGES: Dict[MillingStatus, str] = {
 # cancelled, which is the two-scale confusion the status vocabulary exists to remove.
 _STAGE_QUALIFIED = frozenset(
     {
-        MillingStatus.STAGE_STARTED,
-        MillingStatus.STAGE_UPDATE,
-        MillingStatus.STAGE_FINISHED,
+        MillingProgressStatus.STAGE_STARTED,
+        MillingProgressStatus.STAGE_UPDATE,
+        MillingProgressStatus.STAGE_FINISHED,
     }
 )
-_TASK_QUALIFIED = frozenset({MillingStatus.TASK_STARTED, MillingStatus.TASK_FINISHED})
+_TASK_QUALIFIED = frozenset(
+    {MillingProgressStatus.TASK_STARTED, MillingProgressStatus.TASK_FINISHED}
+)
 
 
 @dataclass(frozen=True)
@@ -186,7 +188,7 @@ class MillingProgress:
     makes these usable in `assert emitted == [...]` and in a set.
     """
 
-    status: MillingStatus
+    status: MillingProgressStatus
     # The producer's own wording, and the one free field on this record. `None` means
     # "no opinion, use the default"; see the module docstring for why it is sticky and
     # why it is tested falsy rather than `is not None`.
@@ -272,7 +274,7 @@ class MillingProgress:
         if isinstance(payload, cls):
             return payload
         if not isinstance(payload, dict):
-            return cls(MillingStatus.STAGE_UPDATE)
+            return cls(MillingProgressStatus.STAGE_UPDATE)
 
         inner = payload.get("progress")
         if not isinstance(inner, dict):
@@ -281,16 +283,16 @@ class MillingProgress:
 
         state = inner.get("state")
         if state == "start":
-            status = MillingStatus.STAGE_STARTED
+            status = MillingProgressStatus.STAGE_STARTED
         elif state == "finished":
-            status = MillingStatus.TASK_FINISHED
+            status = MillingProgressStatus.TASK_FINISHED
         else:
             # `"update"`, and also the shape that carries no `state` at all -- a
             # delegating strategy's own report, whose content is its `msg` plus a
             # countdown. That shape matched no branch in any consumer under the old
             # vocabulary, so its words rendered nowhere; decoding it as an update is
             # what finally puts them on the screen.
-            status = MillingStatus.STAGE_UPDATE
+            status = MillingProgressStatus.STAGE_UPDATE
 
         return cls(
             status=status,
@@ -356,6 +358,6 @@ class MillingMessageTracker:
         """What to show for *report*, given everything before it."""
         if report.message:
             self._message = report.message
-        elif report.status is not MillingStatus.STAGE_UPDATE:
+        elif report.status is not MillingProgressStatus.STAGE_UPDATE:
             self._message = ""
         return self._message or report.display_message

--- a/fibsem/milling/strategy/coincidence.py
+++ b/fibsem/milling/strategy/coincidence.py
@@ -20,7 +20,7 @@ from fibsem.milling import (
     MillingStrategyConfig,
     setup_milling,
 )
-from fibsem.milling.progress import MillingProgress, MillingStatus
+from fibsem.milling.progress import MillingProgress, MillingProgressStatus
 from fibsem.structures import (
     BeamType,
     FibsemImage,
@@ -380,7 +380,7 @@ class CoincidenceMillingStrategy(MillingStrategy[CoincidenceMillingStrategyConfi
             remaining_time = max(0.0, max_end_time - time.time())
             self.microscope.milling_progress_signal.emit(
                 MillingProgress(
-                    status=MillingStatus.STAGE_UPDATE,
+                    status=MillingProgressStatus.STAGE_UPDATE,
                     message=f"Coincidence milling: {self.stage.name}",
                     stage_name=self.stage.name,
                     start_time=start_time,

--- a/fibsem/milling/strategy/standard.py
+++ b/fibsem/milling/strategy/standard.py
@@ -12,7 +12,7 @@ from fibsem.milling.base import (
     MillingStrategy,
     MillingStrategyConfig,
 )
-from fibsem.milling.progress import MillingProgress, MillingStatus
+from fibsem.milling.progress import MillingProgress, MillingProgressStatus
 
 
 @dataclass
@@ -53,7 +53,7 @@ class StandardMillingStrategy(MillingStrategy[StandardMillingConfig]):
         # that has no idea what this strategy calls itself.
         microscope.milling_progress_signal.emit(
             MillingProgress(
-                status=MillingStatus.STAGE_UPDATE,
+                status=MillingProgressStatus.STAGE_UPDATE,
                 message=f"Running {stage.name}...",
                 stage_name=stage.name,
                 start_time=time.time(),

--- a/fibsem/milling/tasks.py
+++ b/fibsem/milling/tasks.py
@@ -15,7 +15,7 @@ from fibsem import config as fcfg
 from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
 from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.base import FibsemMillingStage
-from fibsem.milling.progress import MillingProgress, MillingStatus
+from fibsem.milling.progress import MillingProgress, MillingProgressStatus
 from fibsem.structures import (
     BeamType,
     FibsemImage,
@@ -244,7 +244,7 @@ class FibsemMillingTask:
         """Return the list of milling stages."""
         return self.config.enabled_stages
 
-    def _emit(self, status: MillingStatus, **fields) -> None:
+    def _emit(self, status: MillingProgressStatus, **fields) -> None:
         """Report where this task has got to.
 
         Replaces `_handle_progress`, which was a pass-through: it emitted whatever it
@@ -310,10 +310,10 @@ class FibsemMillingTask:
         # with the failure case because `except Exception` does not catch everything:
         # a KeyboardInterrupt unwinds straight through to the `finally`, and reporting
         # that as a completed mill is the defect this whole block exists to fix.
-        outcome = MillingStatus.TASK_FAILED
+        outcome = MillingProgressStatus.TASK_FAILED
         error: Optional[str] = None
 
-        self._emit(MillingStatus.TASK_STARTED, total_stages=len(self.stages))
+        self._emit(MillingProgressStatus.TASK_STARTED, total_stages=len(self.stages))
 
         try:
             self.initial_beam_shift = self.microscope.get_beam_shift(
@@ -342,13 +342,13 @@ class FibsemMillingTask:
             for idx, stage in enumerate(self.stages):
                 self._mill_stage(stage, idx)
 
-            outcome = MillingStatus.TASK_FINISHED
+            outcome = MillingProgressStatus.TASK_FINISHED
         except OperationCancelledError as e:
             logging.info(f"Milling task '{self.name}' cancelled by user: {e}")
-            outcome = MillingStatus.TASK_CANCELLED
+            outcome = MillingProgressStatus.TASK_CANCELLED
         except Exception as e:
             logging.error(e)
-            outcome = MillingStatus.TASK_FAILED
+            outcome = MillingProgressStatus.TASK_FAILED
             error = str(e)
         finally:
             # The outcome, not just "it stopped". Both `except` blocks used to log and
@@ -400,7 +400,7 @@ class FibsemMillingTask:
         raise_if_cancelled(self._stop_event)
 
         self._emit(
-            MillingStatus.STAGE_STARTED,
+            MillingProgressStatus.STAGE_STARTED,
             start_time=start_time,
             current_stage=idx,
             total_stages=len(self.stages),
@@ -447,7 +447,7 @@ class FibsemMillingTask:
                 )
 
             self._emit(
-                MillingStatus.STAGE_FINISHED,
+                MillingProgressStatus.STAGE_FINISHED,
                 start_time=start_time,
                 current_stage=idx,
                 total_stages=len(self.stages),

--- a/fibsem/ui/widgets/milling_widget.py
+++ b/fibsem/ui/widgets/milling_widget.py
@@ -15,7 +15,7 @@ from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.progress import (
     MillingMessageTracker,
     MillingProgress,
-    MillingStatus,
+    MillingProgressStatus,
 )
 from fibsem.milling.tasks import FibsemMillingTaskConfig, run_milling_task
 from fibsem.structures import MillingState
@@ -126,7 +126,7 @@ class FibsemMillingWidget2(QWidget):
 
         label = self._milling_label.label(report)
 
-        if report.status is MillingStatus.STAGE_STARTED:
+        if report.status is MillingProgressStatus.STAGE_STARTED:
             # `or 1` rather than a `.get` default: a producer that sends 0 total stages
             # is as much a division by zero as one that sends nothing.
             total_stages = report.total_stages or 1
@@ -143,7 +143,7 @@ class FibsemMillingWidget2(QWidget):
                 f"Milling Stage: {stage}/{total_stages} - {stage_name}"
             )
 
-        elif report.status is MillingStatus.STAGE_UPDATE:
+        elif report.status is MillingProgressStatus.STAGE_UPDATE:
             remaining_time = report.remaining_time
             # Falsy rather than `is None`, so an estimate of zero takes this branch
             # instead of dividing by it. That division runs inside a queued Qt slot, and

--- a/tests/milling/test_progress.py
+++ b/tests/milling/test_progress.py
@@ -20,7 +20,7 @@ from fibsem.milling.progress import (
     _DEFAULT_MESSAGES,
     MillingMessageTracker,
     MillingProgress,
-    MillingStatus,
+    MillingProgressStatus,
 )
 from fibsem.structures import ACTIVE_MILLING_STATES, MillingState
 
@@ -31,36 +31,48 @@ class TestTheStatusVocabulary:
         times) sitting beside `state: "finished"` (emitted once, from the task's
         `finally`). They read like a matched pair and were not one, so a consumer
         bracketing them was wrong N-1 times."""
-        assert MillingStatus.STAGE_FINISHED is not MillingStatus.TASK_FINISHED
-        assert MillingStatus.STAGE_STARTED is not MillingStatus.TASK_STARTED
+        assert (
+            MillingProgressStatus.STAGE_FINISHED
+            is not MillingProgressStatus.TASK_FINISHED
+        )
+        assert (
+            MillingProgressStatus.STAGE_STARTED
+            is not MillingProgressStatus.TASK_STARTED
+        )
 
     def test_only_the_task_outcomes_are_terminal(self):
         """`STAGE_FINISHED` is not the end of anything. A consumer that hides its
         progress bar on it hides it after the first stage of an N-stage task."""
-        terminal = {s for s in MillingStatus if s.is_terminal}
+        terminal = {s for s in MillingProgressStatus if s.is_terminal}
         assert terminal == {
-            MillingStatus.TASK_FINISHED,
-            MillingStatus.TASK_CANCELLED,
-            MillingStatus.TASK_FAILED,
+            MillingProgressStatus.TASK_FINISHED,
+            MillingProgressStatus.TASK_CANCELLED,
+            MillingProgressStatus.TASK_FAILED,
         }
-        assert not MillingStatus.STAGE_FINISHED.is_terminal
+        assert not MillingProgressStatus.STAGE_FINISHED.is_terminal
 
     def test_a_cancelled_task_is_not_a_failed_one(self):
         """A cancel is someone getting what they asked for. Today both land in the same
         `finally` and report as *finished*; keeping them apart in the vocabulary is what
         lets a consumer paint one neutrally and the other red."""
-        assert MillingStatus.TASK_CANCELLED is not MillingStatus.TASK_FAILED
-        assert MillingStatus.TASK_CANCELLED is not MillingStatus.TASK_FINISHED
+        assert (
+            MillingProgressStatus.TASK_CANCELLED
+            is not MillingProgressStatus.TASK_FAILED
+        )
+        assert (
+            MillingProgressStatus.TASK_CANCELLED
+            is not MillingProgressStatus.TASK_FINISHED
+        )
 
     def test_a_member_compares_equal_to_its_own_value(self):
         """The `str` mixin, so these read as themselves in a log line."""
-        assert MillingStatus.STAGE_UPDATE == "stage-update"
+        assert MillingProgressStatus.STAGE_UPDATE == "stage-update"
 
     def test_every_status_has_a_default_message(self):
         """`display_message` indexes `_DEFAULT_MESSAGES` directly. A status added
         without one is a `KeyError` raised inside a queued Qt slot, which on PyQt5 is
         `qFatal` -- the process aborts with nothing in the logfile (FIB-329)."""
-        assert set(_DEFAULT_MESSAGES) == set(MillingStatus)
+        assert set(_DEFAULT_MESSAGES) == set(MillingProgressStatus)
 
 
 class TestDisplayStage:
@@ -68,15 +80,17 @@ class TestDisplayStage:
         """`current_stage` is 0-based on the wire, like every other index in the
         codebase. The `+ 1` was written out by hand at seven call sites across three
         widgets before this property existed."""
-        first = MillingProgress(MillingStatus.STAGE_STARTED, current_stage=0)
-        fourth = MillingProgress(MillingStatus.STAGE_STARTED, current_stage=3)
+        first = MillingProgress(MillingProgressStatus.STAGE_STARTED, current_stage=0)
+        fourth = MillingProgress(MillingProgressStatus.STAGE_STARTED, current_stage=3)
         assert first.display_stage == 1
         assert fourth.display_stage == 4
 
     def test_a_report_with_no_stage_index_has_no_display_stage(self):
         """Rather than defaulting to 0 and rendering "Stage 1" for a task-level report
         that is about no stage at all."""
-        assert MillingProgress(MillingStatus.TASK_FINISHED).display_stage is None
+        assert (
+            MillingProgress(MillingProgressStatus.TASK_FINISHED).display_stage is None
+        )
 
 
 class TestDisplayMessage:
@@ -84,38 +98,47 @@ class TestDisplayMessage:
         """The point of keeping `message` at all: milling strategies are plugin-loadable
         and users asked to customise the text a strategy shows while it runs."""
         words = "Polishing at 30 pA"
-        report = MillingProgress(MillingStatus.STAGE_UPDATE, message=words)
+        report = MillingProgress(MillingProgressStatus.STAGE_UPDATE, message=words)
         assert report.display_message == words
 
     def test_an_empty_message_falls_back_to_the_default(self):
         """Falsy, not `is not None`. A plugin returning `""` is a bug, not a request for
         a blank label -- FIB-401 hit this exactly, where an empty channel rendered
         "Acquiring  (1/1)..."."""
-        report = MillingProgress(MillingStatus.STAGE_UPDATE, message="")
-        assert report.display_message == _DEFAULT_MESSAGES[MillingStatus.STAGE_UPDATE]
+        report = MillingProgress(MillingProgressStatus.STAGE_UPDATE, message="")
+        assert (
+            report.display_message
+            == _DEFAULT_MESSAGES[MillingProgressStatus.STAGE_UPDATE]
+        )
 
     def test_the_default_says_which_stage_when_the_report_names_one(self):
         """One home for the wording. The three consumers defaulted three different ways
         for the same report -- "Preparing Milling Conditions...", "Preparing...",
         "Milling..." -- which is the drift a single table removes."""
-        report = MillingProgress(MillingStatus.STAGE_STARTED, stage_name="Rough Mill")
+        report = MillingProgress(
+            MillingProgressStatus.STAGE_STARTED, stage_name="Rough Mill"
+        )
         assert report.display_message == "Preparing: Rough Mill"
 
     def test_the_default_says_which_task_when_the_report_names_one(self):
-        report = MillingProgress(MillingStatus.TASK_FINISHED, task_name="Trench")
+        report = MillingProgress(
+            MillingProgressStatus.TASK_FINISHED, task_name="Trench"
+        )
         assert report.display_message == "Finished milling task: Trench"
 
     def test_an_outcome_is_not_qualified_by_a_stage_name(self):
         """A label reading "Milling cancelled: Rough Mill" invites the reading that one
         *stage* was cancelled. The outcomes are task-level; that is the whole reason the
         vocabulary has two scales."""
-        report = MillingProgress(MillingStatus.TASK_CANCELLED, stage_name="Rough Mill")
+        report = MillingProgress(
+            MillingProgressStatus.TASK_CANCELLED, stage_name="Rough Mill"
+        )
         assert report.display_message == "Milling cancelled"
 
     def test_a_report_naming_nothing_still_renders(self):
         """Every status, with no fields at all. A label reading "Preparing: None" is
         worse than one reading "Preparing..."."""
-        for status in MillingStatus:
+        for status in MillingProgressStatus:
             message = MillingProgress(status).display_message
             assert message
             assert "None" not in message
@@ -123,7 +146,9 @@ class TestDisplayMessage:
     def test_a_qualified_label_does_not_keep_its_ellipsis(self):
         """It reads as a pause rather than as "and then the name" once something
         follows it."""
-        report = MillingProgress(MillingStatus.STAGE_UPDATE, stage_name="Polish")
+        report = MillingProgress(
+            MillingProgressStatus.STAGE_UPDATE, stage_name="Polish"
+        )
         assert report.display_message == "Milling: Polish"
 
 
@@ -131,13 +156,13 @@ class TestTheRecord:
     def test_status_is_the_only_required_field(self):
         """Which is also what keeps this constructible on the 3.8 CI jobs, where
         `dataclass(kw_only=...)` does not exist and required fields must come first."""
-        report = MillingProgress(MillingStatus.TASK_STARTED)
-        assert report.status is MillingStatus.TASK_STARTED
+        report = MillingProgress(MillingProgressStatus.TASK_STARTED)
+        assert report.status is MillingProgressStatus.TASK_STARTED
         assert report.message is None
         assert report.error is None
 
     def test_a_report_is_frozen(self):
-        report = MillingProgress(MillingStatus.STAGE_UPDATE)
+        report = MillingProgress(MillingProgressStatus.STAGE_UPDATE)
         with pytest.raises(dataclasses.FrozenInstanceError):
             report.remaining_time = 1.0  # type: ignore[misc]
 
@@ -145,8 +170,8 @@ class TestTheRecord:
         """Equality is left generated, unlike `TiledProgress` -- nothing here holds a
         numpy array whose `__eq__` returns an array. That is what makes these usable in
         `assert emitted == [...]`, which every consumer test in this stack relies on."""
-        a = MillingProgress(MillingStatus.STAGE_UPDATE, remaining_time=12.0)
-        b = MillingProgress(MillingStatus.STAGE_UPDATE, remaining_time=12.0)
+        a = MillingProgress(MillingProgressStatus.STAGE_UPDATE, remaining_time=12.0)
+        b = MillingProgress(MillingProgressStatus.STAGE_UPDATE, remaining_time=12.0)
         assert a == b
         assert len({a, b}) == 1
 
@@ -155,7 +180,7 @@ class TestTheRecord:
         free: on ThermoFisher `get_milling_state()` sets the active view as a side
         effect."""
         report = MillingProgress(
-            MillingStatus.STAGE_UPDATE, milling_state=MillingState.RUNNING
+            MillingProgressStatus.STAGE_UPDATE, milling_state=MillingState.RUNNING
         )
         assert report.milling_state is MillingState.RUNNING
 
@@ -209,7 +234,7 @@ class TestTheTotalityGuard:
                 },
             }
         )
-        assert report.status is MillingStatus.STAGE_STARTED
+        assert report.status is MillingProgressStatus.STAGE_STARTED
         assert report.display_stage == 1
         assert report.total_stages == 3
         assert report.stage_name == "Rough Mill"
@@ -227,7 +252,7 @@ class TestTheTotalityGuard:
                 }
             }
         )
-        assert report.status is MillingStatus.STAGE_UPDATE
+        assert report.status is MillingProgressStatus.STAGE_UPDATE
         assert report.remaining_time == 12.0
         assert report.milling_state is MillingState.RUNNING
 
@@ -242,7 +267,7 @@ class TestTheTotalityGuard:
                 },
             }
         )
-        assert report.status is MillingStatus.TASK_FINISHED
+        assert report.status is MillingProgressStatus.TASK_FINISHED
         assert report.status.is_terminal
 
     def test_a_delegating_strategys_shape_decodes_to_something(self):
@@ -265,7 +290,7 @@ class TestTheTotalityGuard:
                 },
             }
         )
-        assert report.status is MillingStatus.STAGE_UPDATE
+        assert report.status is MillingProgressStatus.STAGE_UPDATE
         assert report.display_message == "Running Rough Mill..."
         # `name` is the older spelling of `stage_name`.
         assert report.stage_name == "Rough Mill"
@@ -282,7 +307,7 @@ class TestTheTotalityGuard:
     def test_a_typed_report_passes_straight_through(self):
         """The in-tree path, which is every producer in this repo. Identity, not a
         rebuild -- the guard must cost nothing on the path that is always taken."""
-        original = MillingProgress(MillingStatus.TASK_CANCELLED, error=None)
+        original = MillingProgress(MillingProgressStatus.TASK_CANCELLED, error=None)
         assert MillingProgress.from_payload(original) is original
 
     @pytest.mark.parametrize(
@@ -326,23 +351,31 @@ class TestTheStickyMessage:
 
     def test_a_message_survives_the_ticks_that_follow_it(self):
         tracker = MillingMessageTracker()
-        tracker.label(MillingProgress(MillingStatus.STAGE_UPDATE, message="Polishing"))
-        plain = MillingProgress(MillingStatus.STAGE_UPDATE, remaining_time=4.0)
+        tracker.label(
+            MillingProgress(MillingProgressStatus.STAGE_UPDATE, message="Polishing")
+        )
+        plain = MillingProgress(MillingProgressStatus.STAGE_UPDATE, remaining_time=4.0)
         assert tracker.label(plain) == "Polishing"
 
     def test_a_new_stage_drops_the_previous_stages_words(self):
         """Only `STAGE_UPDATE` inherits. Every other status is its own moment: a stage
         that has just started is not still "Polishing" the one before it."""
         tracker = MillingMessageTracker()
-        tracker.label(MillingProgress(MillingStatus.STAGE_UPDATE, message="Polishing"))
-        started = MillingProgress(MillingStatus.STAGE_STARTED, stage_name="Rough Mill")
+        tracker.label(
+            MillingProgress(MillingProgressStatus.STAGE_UPDATE, message="Polishing")
+        )
+        started = MillingProgress(
+            MillingProgressStatus.STAGE_STARTED, stage_name="Rough Mill"
+        )
         assert tracker.label(started) == "Preparing: Rough Mill"
 
     def test_a_finished_task_is_not_captioned_with_what_it_was_doing(self):
         tracker = MillingMessageTracker()
-        tracker.label(MillingProgress(MillingStatus.STAGE_UPDATE, message="Polishing"))
+        tracker.label(
+            MillingProgress(MillingProgressStatus.STAGE_UPDATE, message="Polishing")
+        )
         assert (
-            tracker.label(MillingProgress(MillingStatus.TASK_FINISHED))
+            tracker.label(MillingProgress(MillingProgressStatus.TASK_FINISHED))
             == "Finished milling task"
         )
 
@@ -350,12 +383,15 @@ class TestTheStickyMessage:
         """Falsy, not `is not None`: a plugin returning `""` is a bug, not a request for
         a blank label."""
         tracker = MillingMessageTracker()
-        tracker.label(MillingProgress(MillingStatus.STAGE_UPDATE, message="Polishing"))
-        blank = MillingProgress(MillingStatus.STAGE_UPDATE, message="")
+        tracker.label(
+            MillingProgress(MillingProgressStatus.STAGE_UPDATE, message="Polishing")
+        )
+        blank = MillingProgress(MillingProgressStatus.STAGE_UPDATE, message="")
         assert tracker.label(blank) == "Polishing"
 
     def test_a_tracker_that_has_seen_nothing_still_renders(self):
         tracker = MillingMessageTracker()
         assert (
-            tracker.label(MillingProgress(MillingStatus.STAGE_UPDATE)) == "Milling..."
+            tracker.label(MillingProgress(MillingProgressStatus.STAGE_UPDATE))
+            == "Milling..."
         )

--- a/tests/milling/test_progress_producers.py
+++ b/tests/milling/test_progress_producers.py
@@ -20,7 +20,7 @@ import pytest
 import fibsem
 from fibsem import utils
 from fibsem.milling import FibsemMillingStage
-from fibsem.milling.progress import MillingProgress, MillingStatus
+from fibsem.milling.progress import MillingProgress, MillingProgressStatus
 from fibsem.milling.strategy.coincidence import (
     CoincidenceMillingStrategy,
     CoincidenceMillingStrategyConfig,
@@ -66,7 +66,7 @@ class TestADelegatingStrategy:
         assert first.message == "Running Rough Mill..."
         assert first.stage_name == "Rough Mill"
         # A status a consumer actually renders, which is what makes the message visible.
-        assert first.status is MillingStatus.STAGE_UPDATE
+        assert first.status is MillingProgressStatus.STAGE_UPDATE
 
     def test_the_backends_ticks_carry_the_countdown_and_the_instrument_state(
         self, microscope
@@ -76,7 +76,7 @@ class TestADelegatingStrategy:
 
         ticks = [r for r in emitted if r.remaining_time is not None]
         assert ticks, "the backend poll loop reported no countdown"
-        assert all(t.status is MillingStatus.STAGE_UPDATE for t in ticks)
+        assert all(t.status is MillingProgressStatus.STAGE_UPDATE for t in ticks)
         # Carried on the report so a consumer does not have to poll for it -- and on
         # ThermoFisher that poll sets the active view as a side effect.
         assert all(isinstance(t.milling_state, MillingState) for t in ticks)
@@ -144,7 +144,7 @@ class TestTheCoincidenceStrategy:
         assert all(
             r.message == "Coincidence milling: Coincidence Mill" for r in emitted
         )
-        assert all(r.status is MillingStatus.STAGE_UPDATE for r in emitted)
+        assert all(r.status is MillingProgressStatus.STAGE_UPDATE for r in emitted)
 
 
 # --------------------------------------------------------------------------------------
@@ -234,7 +234,7 @@ def test_the_scan_sees_through_the_relay(tmp_path):
         "    def relayed(self):\n"
         "        self._handle_progress({'progress': {}})\n"
         "    def typed(self):\n"
-        "        self._handle_progress(MillingProgress(MillingStatus.TASK_FINISHED))\n",
+        "        self._handle_progress(MillingProgress(MillingProgressStatus.TASK_FINISHED))\n",
         encoding="utf-8",
     )
     assert _dict_emits(probe) == [3, 5]
@@ -281,7 +281,7 @@ class TestHowATaskEnds:
         emitted = _collect(microscope)
         task.run()
 
-        assert emitted[-1].status is MillingStatus.TASK_FINISHED
+        assert emitted[-1].status is MillingProgressStatus.TASK_FINISHED
         assert emitted[-1].error is None
 
     def test_a_cancelled_task_does_not_claim_to_have_finished(self, microscope):
@@ -291,7 +291,7 @@ class TestHowATaskEnds:
         emitted = _collect(microscope)
         task.run()
 
-        assert emitted[-1].status is MillingStatus.TASK_CANCELLED
+        assert emitted[-1].status is MillingProgressStatus.TASK_CANCELLED
 
     def test_a_cancelled_task_is_not_painted_as_a_failure(self, microscope):
         """A cancel is someone getting what they asked for, so it is a distinct status
@@ -302,7 +302,7 @@ class TestHowATaskEnds:
         emitted = _collect(microscope)
         task.run()
 
-        assert emitted[-1].status is not MillingStatus.TASK_FAILED
+        assert emitted[-1].status is not MillingProgressStatus.TASK_FAILED
         assert emitted[-1].error is None
 
     def test_a_failed_task_carries_why(self, microscope):
@@ -315,7 +315,7 @@ class TestHowATaskEnds:
         emitted = _collect(microscope)
         task.run()
 
-        assert emitted[-1].status is MillingStatus.TASK_FAILED
+        assert emitted[-1].status is MillingProgressStatus.TASK_FAILED
         assert emitted[-1].error == "the column tripped"
 
     def test_the_terminal_is_the_last_thing_the_task_says(self, microscope):
@@ -339,15 +339,19 @@ class TestTheTwoScales:
         emitted = _collect(microscope)
         task.run()
 
-        assert [r.status for r in emitted].count(MillingStatus.TASK_STARTED) == 1
-        assert [r.status for r in emitted].count(MillingStatus.STAGE_STARTED) == 2
+        assert [r.status for r in emitted].count(
+            MillingProgressStatus.TASK_STARTED
+        ) == 1
+        assert [r.status for r in emitted].count(
+            MillingProgressStatus.STAGE_STARTED
+        ) == 2
 
     def test_each_stage_reports_its_own_index_zero_based(self, microscope):
         task = _task(microscope, [_stage("Rough Mill"), _stage("Polish")])
         emitted = _collect(microscope)
         task.run()
 
-        starts = [r for r in emitted if r.status is MillingStatus.STAGE_STARTED]
+        starts = [r for r in emitted if r.status is MillingProgressStatus.STAGE_STARTED]
         assert [r.current_stage for r in starts] == [0, 1]
         assert [r.display_stage for r in starts] == [1, 2]
         assert [r.stage_name for r in starts] == ["Rough Mill", "Polish"]
@@ -358,7 +362,9 @@ class TestTheTwoScales:
         emitted = _collect(microscope)
         task.run()
 
-        finishes = [r for r in emitted if r.status is MillingStatus.STAGE_FINISHED]
+        finishes = [
+            r for r in emitted if r.status is MillingProgressStatus.STAGE_FINISHED
+        ]
         assert len(finishes) == 2
         assert not any(r.status.is_terminal for r in finishes)
 

--- a/tests/ui/test_milling_progress_rendering.py
+++ b/tests/ui/test_milling_progress_rendering.py
@@ -32,7 +32,7 @@ from fibsem.applications.autolamella.ui.fluorescence_coincidence_viewer_widget i
 from fibsem.milling.progress import (  # noqa: E402
     MillingMessageTracker,
     MillingProgress,
-    MillingStatus,
+    MillingProgressStatus,
 )
 from fibsem.ui.widgets.milling_widget import FibsemMillingWidget2  # noqa: E402
 
@@ -47,7 +47,7 @@ from fibsem.ui.widgets.milling_widget import FibsemMillingWidget2  # noqa: E402
 def stage_start(stage_name="Rough Mill", current_stage=0, total_stages=3):
     """`MillingTask._mill_stage`, once per stage."""
     return MillingProgress(
-        status=MillingStatus.STAGE_STARTED,
+        status=MillingProgressStatus.STAGE_STARTED,
         message=None,
         task_id="task-1",
         task_name="Trench",
@@ -62,7 +62,7 @@ def backend_tick(remaining_time=30.0, estimated_time=60.0):
     """A backend's poll loop -- `microscope.py`, `simulator.py`, `tescan.py`. Carries no
     message: the backend has no idea what the strategy driving it calls itself."""
     return MillingProgress(
-        status=MillingStatus.STAGE_UPDATE,
+        status=MillingProgressStatus.STAGE_UPDATE,
         start_time=100.0,
         estimated_time=estimated_time,
         remaining_time=remaining_time,
@@ -73,7 +73,7 @@ def strategy_message(stage_name="Rough Mill"):
     """`strategy/standard.py`. This is the report that used to carry no `state` at all,
     so it matched no branch in any of the three consumers and rendered nowhere."""
     return MillingProgress(
-        status=MillingStatus.STAGE_UPDATE,
+        status=MillingProgressStatus.STAGE_UPDATE,
         message=f"Running {stage_name}...",
         stage_name=stage_name,
         start_time=100.0,
@@ -84,7 +84,7 @@ def strategy_message(stage_name="Rough Mill"):
 def task_finished():
     """`MillingTask.run`'s `finally`, once per task."""
     return MillingProgress(
-        status=MillingStatus.TASK_FINISHED,
+        status=MillingProgressStatus.TASK_FINISHED,
         task_id="task-1",
         task_name="Trench",
     )
@@ -419,7 +419,9 @@ class TestATaskEnding:
         milling_widget._on_milling_progress(stage_start())
         milling_widget.progressBar_milling.setVisible(True)
         milling_widget._on_milling_progress(
-            MillingProgress(MillingStatus.STAGE_FINISHED, stage_name="Rough Mill")
+            MillingProgress(
+                MillingProgressStatus.STAGE_FINISHED, stage_name="Rough Mill"
+            )
         )
         assert milling_widget.progressBar_milling.isVisible()
 
@@ -428,7 +430,9 @@ class TestATaskEnding:
         but the consumer has to be ready before they do, or a cancelled mill leaves the
         bar up for the rest of the session."""
         main_window._on_milling_progress(stage_start())
-        main_window._on_milling_progress(MillingProgress(MillingStatus.TASK_CANCELLED))
+        main_window._on_milling_progress(
+            MillingProgress(MillingProgressStatus.TASK_CANCELLED)
+        )
         assert not main_window.milling_progress_bar.isVisible()
 
 
@@ -448,21 +452,25 @@ class TestNothingTakesTheProcessDown:
     """
 
     DEGENERATE = [
-        MillingProgress(MillingStatus.STAGE_STARTED),
-        MillingProgress(MillingStatus.STAGE_STARTED, total_stages=0, current_stage=0),
-        MillingProgress(MillingStatus.STAGE_STARTED, current_stage=7, total_stages=2),
-        MillingProgress(MillingStatus.STAGE_UPDATE),
+        MillingProgress(MillingProgressStatus.STAGE_STARTED),
         MillingProgress(
-            MillingStatus.STAGE_UPDATE, remaining_time=1.0, estimated_time=0.0
+            MillingProgressStatus.STAGE_STARTED, total_stages=0, current_stage=0
         ),
-        MillingProgress(MillingStatus.STAGE_UPDATE, estimated_time=60.0),
         MillingProgress(
-            MillingStatus.STAGE_UPDATE, remaining_time=99.0, estimated_time=1.0
+            MillingProgressStatus.STAGE_STARTED, current_stage=7, total_stages=2
         ),
-        MillingProgress(MillingStatus.STAGE_FINISHED),
-        MillingProgress(MillingStatus.TASK_STARTED),
-        MillingProgress(MillingStatus.TASK_CANCELLED, stage_name="Rough Mill"),
-        MillingProgress(MillingStatus.TASK_FAILED, error="the column tripped"),
+        MillingProgress(MillingProgressStatus.STAGE_UPDATE),
+        MillingProgress(
+            MillingProgressStatus.STAGE_UPDATE, remaining_time=1.0, estimated_time=0.0
+        ),
+        MillingProgress(MillingProgressStatus.STAGE_UPDATE, estimated_time=60.0),
+        MillingProgress(
+            MillingProgressStatus.STAGE_UPDATE, remaining_time=99.0, estimated_time=1.0
+        ),
+        MillingProgress(MillingProgressStatus.STAGE_FINISHED),
+        MillingProgress(MillingProgressStatus.TASK_STARTED),
+        MillingProgress(MillingProgressStatus.TASK_CANCELLED, stage_name="Rough Mill"),
+        MillingProgress(MillingProgressStatus.TASK_FAILED, error="the column tripped"),
     ]
 
     @pytest.mark.parametrize("report", DEGENERATE, ids=lambda r: r.status.value)


### PR DESCRIPTION
Follow-up to the FIB-797 stack, deliberately kept out of it.

## Why

`MillingState` already exists — `IDLE`/`RUNNING`/`STOPPING`/`PAUSED`/`ERROR`/`UNKNOWN`, in `fibsem/structures.py`, and it goes over the wire to the server client. It and the progress vocabulary land as fields on the **same record**, one letter apart:

```python
status: MillingStatus                    # task-started / stage-update / ...
milling_state: Optional[MillingState]    # IDLE / RUNNING / PAUSED / ERROR
```

Renaming `MillingState` instead was not an option — it predates this work and is part of the wire format.

## The cost, taken knowingly

The three sibling contracts are `TiledStatus`, `SpotBurnStatus` and `FluorescenceAcquisitionStatus` — all `<Domain>Status`, none carrying "Progress" — so this becomes the odd one out of four. The collision wins anyway, because none of those three has a `<Domain>State` sitting beside it. The record itself stays `MillingProgress`, matching `TiledProgress` and `FluorescenceAcquisitionProgress`.

## Why it is safe

`MillingStatus` was the **only** identifier anywhere in `fibsem/` or `tests/` containing that substring, and `MillingProgressStatus` was unused — so a plain substitution could not have caught a near-miss. Nothing outside `.py` mentions either name.

## But it is not a pure token substitution, and the diff shows it

The new name is seven characters longer, which pushes four files past the formatter's width, so `ruff format` rewraps them: `progress.py` and the three test files. That rewrapping is **caused** by the rename, so unlike the FIB-797 stack it cannot be split into a format-prep PR — it has to ride along.

The other nine files are the token and nothing else. Verified rather than asserted: reversing the substitution on each of the thirteen files reproduces `main` **byte-for-byte** for those nine, which is what isolates the rewrapping to exactly four.

## Verification

- `tests/milling/ tests/autolamella/ tests/test_import_cycles.py tests/test_microscope.py tests/test_structures.py tests/test_milling_time_estimates.py` → **853 passed**; `tests/ui/test_milling_progress_rendering.py` → **58 passed**.
- `ruff check` and `ruff format --check` clean on all 13 files.
- No 3.8-incompatible syntax introduced (the diff adds no new constructs at all — it is a rename plus rewrapping).
