### PR TITLE
[ci] Run the tests on stacked pull requests, not only on those based on main

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,8 +11,15 @@ on:
   # whole of what has to change.
   push:
     branches: [ "main", "release/**" ]
+  # No `branches:` filter: it matches the *base* branch, so scoping it to main gave a
+  # stacked PR -- one based on another feature branch -- no checks at all.
   pull_request:
-    branches: [ "main", "release/**" ]
+
+# Cancel superseded PR runs, but not `push` runs: each of those is the record of one
+# commit on main, and two quick merges would leave the first permanently untested.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:


### PR DESCRIPTION
A `branches:` filter under `pull_request` matches the **base** branch, so scoping it to main meant a stacked pull request -- one opened against another feature branch -- ran nothing at all. That never surfaced as a failure: `gh pr checks` reports *"no checks reported on the branch"*, which reads as "still queued" rather than "never ran".

Only the bottom of a stack was ever tested. Each PR above it got its first real run when it retargeted main after the one below merged, so a break was found at merge time, one PR at a time. The jobs that matter most here are exactly the ones a stacked PR skipped: the 3.8 and 3.9 matrix entries are what catch import-time breakage, and a single `@dataclass(kw_only=True)` has taken the whole suite down on ubuntu 3.8 before (#531).

Worth being clear about what a green stacked run means. `pull_request` builds the merge of head into *its own base*, not into main, so it says the PR is sound given the one below it lands first -- which is the question actually being asked of it.

The concurrency block comes with it rather than separately, because unfiltered PR runs are what make it necessary: a stacked branch is force-pushed every time the branch below it is rebased, and each of those pushes would otherwise start a fresh eight-job matrix while the superseded run continued to completion. Cancelling is limited to pull requests by the expression on `cancel-in-progress` -- a `push` run is the record of one particular commit on main or a release branch, and two merges in quick succession would leave the first commit permanently untested.

Drafts still run, deliberately. A draft is where a break is cheapest to find, and the guard that would skip them has a trap: `ready_for_review` is not in the default event types, so a job-level `draft == false` check leaves a PR that was just marked ready with no run until its next push -- mergeable, having tested nothing.

## Notes for review

- Existing stacks do not pick this up until it is merged down into them. For `pull_request`, the workflow file used is the one on the head-into-base merge commit, so a stack cut before this change carries the old file in both branches.
- Not changed here: the lint job scopes its format check with `git merge-base origin/main HEAD`, which on a stacked PR is still the fork point from main, so it format-checks every file the whole stack touched rather than just this PR's. Noisier, not wrong.