### PR TITLE
[refactor] Point the Movement tab at StagePositionWidget (FIB-783)

### DIFF
--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -2,7 +2,6 @@ import logging
 from functools import partial
 from typing import Optional
 
-import numpy as np
 from PyQt5 import QtWidgets
 from superqt import ensure_main_thread
 
@@ -23,7 +22,8 @@ from fibsem.ui.stylesheets import (
     SECONDARY_BUTTON_STYLESHEET,
 )
 from fibsem.ui.utils import install_wheel_blocker
-from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel
+from fibsem.ui.widgets.custom_widgets import TitledPanel
+from fibsem.ui.widgets.stage_position_widget import StagePositionWidget
 
 INSTRUCTIONS_TEXT = (
     """Instructions: Double Click to Move. Alt + Double Click to Move Vertically"""
@@ -43,6 +43,10 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         parent: QtWidgets.QWidget,
     ):
         super().__init__(parent=parent)
+        # Set before _setup_ui: the position form takes its axis ranges from the stage
+        # while it is being built, so it needs the microscope one step earlier than the
+        # rest of this widget did.
+        self.microscope = microscope
         self._setup_ui()
         self.parent = parent
 
@@ -53,7 +57,6 @@ class FibsemMovementWidget(QtWidgets.QWidget):
                 "Parent must have an 'image_widget' attribute of type FibsemImageSettingsWidget"
             )
 
-        self.microscope = microscope
         self.image_widget: FibsemImageSettingsWidget = parent.image_widget
         self.setup_connections()
 
@@ -86,54 +89,14 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.gridLayout_3 = QtWidgets.QGridLayout(stage_content)
         self.gridLayout_3.setContentsMargins(0, 0, 0, 0)
 
-        self.label_movement_stage_x = QtWidgets.QLabel("X Coordinate")
-        self.doubleSpinBox_movement_stage_x = QtWidgets.QDoubleSpinBox()
-        self.doubleSpinBox_movement_stage_x.setDecimals(5)
-        self.doubleSpinBox_movement_stage_x.setMinimum(-1e10)
-        self.doubleSpinBox_movement_stage_x.setMaximum(1e17)
-        self.doubleSpinBox_movement_stage_x.setSingleStep(0.001)
-        self.doubleSpinBox_movement_stage_x.setSuffix(" mm")
-        self.gridLayout_3.addWidget(self.label_movement_stage_x, 0, 0)
-        self.gridLayout_3.addWidget(self.doubleSpinBox_movement_stage_x, 0, 1)
-
-        self.label_movement_stage_y = QtWidgets.QLabel("Y Coordinate")
-        self.doubleSpinBox_movement_stage_y = QtWidgets.QDoubleSpinBox()
-        self.doubleSpinBox_movement_stage_y.setDecimals(5)
-        self.doubleSpinBox_movement_stage_y.setMinimum(-1e20)
-        self.doubleSpinBox_movement_stage_y.setMaximum(1e25)
-        self.doubleSpinBox_movement_stage_y.setSingleStep(0.001)
-        self.doubleSpinBox_movement_stage_y.setSuffix(" mm")
-        self.gridLayout_3.addWidget(self.label_movement_stage_y, 1, 0)
-        self.gridLayout_3.addWidget(self.doubleSpinBox_movement_stage_y, 1, 1)
-
-        self.label_movement_stage_z = QtWidgets.QLabel("Z Coordinate")
-        self.doubleSpinBox_movement_stage_z = QtWidgets.QDoubleSpinBox()
-        self.doubleSpinBox_movement_stage_z.setDecimals(5)
-        self.doubleSpinBox_movement_stage_z.setMinimum(-1e17)
-        self.doubleSpinBox_movement_stage_z.setMaximum(1e23)
-        self.doubleSpinBox_movement_stage_z.setSingleStep(0.001)
-        self.doubleSpinBox_movement_stage_z.setSuffix(" mm")
-        self.gridLayout_3.addWidget(self.label_movement_stage_z, 2, 0)
-        self.gridLayout_3.addWidget(self.doubleSpinBox_movement_stage_z, 2, 1)
-
-        self.label_movement_stage_rotation = QtWidgets.QLabel("Rotation")
-        self.doubleSpinBox_movement_stage_rotation = QtWidgets.QDoubleSpinBox()
-        self.doubleSpinBox_movement_stage_rotation.setMinimum(-360.0)
-        self.doubleSpinBox_movement_stage_rotation.setMaximum(360.0)
-        self.doubleSpinBox_movement_stage_rotation.setSuffix(
-            f" {constants.DEGREE_SYMBOL}"
-        )
-        self.gridLayout_3.addWidget(self.label_movement_stage_rotation, 3, 0)
-        self.gridLayout_3.addWidget(self.doubleSpinBox_movement_stage_rotation, 3, 1)
-
-        self.label_movement_stage_tilt = QtWidgets.QLabel("Tilt")
-        self.doubleSpinBox_movement_stage_tilt = QtWidgets.QDoubleSpinBox()
-        self.doubleSpinBox_movement_stage_tilt.setSuffix(f" {constants.DEGREE_SYMBOL}")
-        self.gridLayout_3.addWidget(self.label_movement_stage_tilt, 4, 0)
-        self.gridLayout_3.addWidget(self.doubleSpinBox_movement_stage_tilt, 4, 1)
+        # The readout and entry form: rows 0-4 of this grid used to be five spin boxes
+        # built here. It owns the units, the ranges and the compustage adjustments, and
+        # moves nothing (FIB-783).
+        self.position_widget = StagePositionWidget(microscope=self.microscope)
+        self.gridLayout_3.addWidget(self.position_widget, 0, 0, 1, 2)
 
         self.pushButton_move = QtWidgets.QPushButton("Move to Position")
-        self.gridLayout_3.addWidget(self.pushButton_move, 5, 0, 1, 2)
+        self.gridLayout_3.addWidget(self.pushButton_move, 1, 0, 1, 2)
 
         self.pushButton_move_to_sem_orientation = QtWidgets.QPushButton(
             "Move Flat to ELECTRON Beam"
@@ -141,28 +104,45 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.pushButton_move_to_fib_orientation = QtWidgets.QPushButton(
             "Move Flat to ION Beam"
         )
-        self.gridLayout_3.addWidget(self.pushButton_move_to_sem_orientation, 6, 0)
-        self.gridLayout_3.addWidget(self.pushButton_move_to_fib_orientation, 6, 1)
+        self.gridLayout_3.addWidget(self.pushButton_move_to_sem_orientation, 2, 0)
+        self.gridLayout_3.addWidget(self.pushButton_move_to_fib_orientation, 2, 1)
 
         self.doubleSpinBox_milling_angle = QtWidgets.QDoubleSpinBox()
         self.pushButton_move_to_milling_angle = QtWidgets.QPushButton(
             "Move to Milling Angle"
         )
-        self.gridLayout_3.addWidget(self.doubleSpinBox_milling_angle, 7, 0)
-        self.gridLayout_3.addWidget(self.pushButton_move_to_milling_angle, 7, 1)
+        self.gridLayout_3.addWidget(self.doubleSpinBox_milling_angle, 3, 0)
+        self.gridLayout_3.addWidget(self.pushButton_move_to_milling_angle, 3, 1)
 
         self.label_movement_instructions = QtWidgets.QLabel()
         self.label_movement_instructions.setWordWrap(True)
-        self.gridLayout_3.addWidget(self.label_movement_instructions, 8, 0, 1, 2)
+        self.gridLayout_3.addWidget(self.label_movement_instructions, 4, 0, 1, 2)
 
-        self.btn_refresh_stage = IconToolButton(
-            icon="mdi:refresh", tooltip="Refresh stage position"
-        )
+        # The form's button, in this panel's header rather than in the form's own grid
+        # -- the panel chrome is the host's.
         self.stage_panel = TitledPanel(
             "Stage Movement", content=stage_content, collapsible=False
         )
-        self.stage_panel.add_header_widget(self.btn_refresh_stage)
+        self.stage_panel.add_header_widget(self.position_widget.btn_refresh)
         self.gridLayout_2.addWidget(self.stage_panel, 0, 0)
+
+        # The names the form's controls had while they were built here. Same objects,
+        # so hosts and tests that reach for them still resolve and the extraction is
+        # invisible from outside. A follow-up moves those callers onto
+        # `position_widget` and drops these.
+        self.doubleSpinBox_movement_stage_x = self.position_widget.spinbox_x
+        self.doubleSpinBox_movement_stage_y = self.position_widget.spinbox_y
+        self.doubleSpinBox_movement_stage_z = self.position_widget.spinbox_z
+        self.doubleSpinBox_movement_stage_rotation = (
+            self.position_widget.spinbox_rotation
+        )
+        self.doubleSpinBox_movement_stage_tilt = self.position_widget.spinbox_tilt
+        self.label_movement_stage_x = self.position_widget.label_x
+        self.label_movement_stage_y = self.position_widget.label_y
+        self.label_movement_stage_z = self.position_widget.label_z
+        self.label_movement_stage_rotation = self.position_widget.label_rotation
+        self.label_movement_stage_tilt = self.position_widget.label_tilt
+        self.btn_refresh_stage = self.position_widget.btn_refresh
 
         # Options panel removed — movement acquisition prefs are now in Edit > Preferences
 
@@ -201,7 +181,8 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.pushButton_move_to_sem_orientation.clicked.connect(
             lambda: self.move_to_orientation("SEM")
         )
-        self.btn_refresh_stage.clicked.connect(lambda: self.update_ui(None))
+        # The form asks; this widget is the one allowed to read the device.
+        self.position_widget.refresh_requested.connect(lambda: self.update_ui(None))
 
         # register mouse callbacks — one canvas per beam. The canvases are app-lifetime
         # (owned by the controller), so store each (canvas, slot) pair and disconnect it in
@@ -235,50 +216,8 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             self.handle_acquisition_update
         )
 
-        stage_limits = self.microscope._stage.limits
-        xlimits = stage_limits["x"]
-        ylimits = stage_limits["y"]
-        zlimits = stage_limits["z"]
-        tlimits = stage_limits["t"]
-
-        self.doubleSpinBox_movement_stage_tilt.setMinimum(tlimits.min)
-        self.doubleSpinBox_movement_stage_tilt.setMaximum(tlimits.max)
-        self.doubleSpinBox_movement_stage_x.setMinimum(
-            xlimits.min * constants.SI_TO_MILLI
-        )
-        self.doubleSpinBox_movement_stage_x.setMaximum(
-            xlimits.max * constants.SI_TO_MILLI
-        )
-        self.doubleSpinBox_movement_stage_y.setMinimum(
-            ylimits.min * constants.SI_TO_MILLI
-        )
-        self.doubleSpinBox_movement_stage_y.setMaximum(
-            ylimits.max * constants.SI_TO_MILLI
-        )
-        self.doubleSpinBox_movement_stage_z.setMinimum(
-            zlimits.min * constants.SI_TO_MILLI
-        )
-        self.doubleSpinBox_movement_stage_z.setMaximum(
-            zlimits.max * constants.SI_TO_MILLI
-        )
-
-        # set custom tilt limits for the compustage
-        if self.microscope.stage_is_compustage:
-            # NOTE: these values are expressed in mm in the UI, hence the conversion
-            # set x, y, z step sizes to be 1 um
-            self.doubleSpinBox_movement_stage_x.setSingleStep(
-                1e-6 * constants.SI_TO_MILLI
-            )
-            self.doubleSpinBox_movement_stage_y.setSingleStep(
-                1e-6 * constants.SI_TO_MILLI
-            )
-            self.doubleSpinBox_movement_stage_z.setSingleStep(
-                1e-6 * constants.SI_TO_MILLI
-            )
-
-            # hide rotation control for compustage
-            self.label_movement_stage_rotation.setVisible(False)
-            self.doubleSpinBox_movement_stage_rotation.setVisible(False)
+        # The axis ranges and the compustage adjustments were applied here. They belong
+        # to the form and are applied by it, at construction, from the same stage.
 
         # stylesheets
         self.pushButton_move.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
@@ -319,16 +258,8 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             lambda: self.move_to_orientation("MILLING")
         )
 
-        # set degree symbols for rotation and tilt
-        self.doubleSpinBox_movement_stage_rotation.setSuffix(constants.DEGREE_SYMBOL)
-        self.doubleSpinBox_movement_stage_tilt.setSuffix(constants.DEGREE_SYMBOL)
-
-        # Install wheel blocker on all double spin boxes
-        install_wheel_blocker(self.doubleSpinBox_movement_stage_x)
-        install_wheel_blocker(self.doubleSpinBox_movement_stage_y)
-        install_wheel_blocker(self.doubleSpinBox_movement_stage_z)
-        install_wheel_blocker(self.doubleSpinBox_movement_stage_rotation)
-        install_wheel_blocker(self.doubleSpinBox_movement_stage_tilt)
+        # The form's degree suffixes and wheel guards moved with it. This one is the
+        # milling angle, which stays on this half.
         install_wheel_blocker(self.doubleSpinBox_milling_angle)
 
         if cfg.FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED:
@@ -426,19 +357,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         if stage_position is None:
             stage_position = self.microscope.get_stage_position()
 
-        self.doubleSpinBox_movement_stage_x.setValue(
-            stage_position.x * constants.SI_TO_MILLI
-        )
-        self.doubleSpinBox_movement_stage_y.setValue(
-            stage_position.y * constants.SI_TO_MILLI
-        )
-        self.doubleSpinBox_movement_stage_z.setValue(
-            stage_position.z * constants.SI_TO_MILLI
-        )
-        self.doubleSpinBox_movement_stage_rotation.setValue(
-            np.degrees(stage_position.r)
-        )
-        self.doubleSpinBox_movement_stage_tilt.setValue(np.degrees(stage_position.t))
+        self.position_widget.set_position(stage_position)
 
         # update the current position label
         self._update_position_readout(stage_position=stage_position)
@@ -540,16 +459,7 @@ class FibsemMovementWidget(QtWidgets.QWidget):
     def get_position_from_ui(self):
         """Get the stage position from the UI"""
 
-        stage_position = FibsemStagePosition(
-            x=self.doubleSpinBox_movement_stage_x.value() * constants.MILLI_TO_SI,
-            y=self.doubleSpinBox_movement_stage_y.value() * constants.MILLI_TO_SI,
-            z=self.doubleSpinBox_movement_stage_z.value() * constants.MILLI_TO_SI,
-            r=np.radians(self.doubleSpinBox_movement_stage_rotation.value()),
-            t=np.radians(self.doubleSpinBox_movement_stage_tilt.value()),
-            coordinate_system="RAW",
-        )
-
-        return stage_position
+        return self.position_widget.get_position()
 
     def _click_to_move_available(self) -> bool:
         """Whether a click may start a stage move right now.


### PR DESCRIPTION
Third of three for [FIB-783](https://linear.app/fibsemos/issue/FIB-783/refactor-fibsemmovementwidget-into-modular-components). The Movement tab now composes the form added in [#620](https://github.com/fibsem-os/fibsem-os/pull/620) instead of building five spin boxes inline.

**Rebased onto `main` after [#619](https://github.com/fibsem-os/fibsem-os/pull/619) and [#620](https://github.com/fibsem-os/fibsem-os/pull/620) merged**, so it now runs CI. It was stacked on #620's branch and got no checks at all before this.

The rebase was a cherry-pick, not `git rebase`: this repo squash-merges, so #620's commit is not an ancestor of `main` and replaying against it would have conflicted with itself. Verified first that the squash preserved #620's two files byte-for-byte.

It picked up one real change in the process — [#621](https://github.com/fibsem-os/fibsem-os/pull/621) (FIB-785) landed on `main` and touched this same file, replacing the `hasattr(move_coincident_from_sem)` dispatch with `supports_vertical_move(beam_type)`. Different region of the file (the double-click path, ~line 509) from anything here (construction and the two readout methods, all before ~line 462), and it auto-merged cleanly. Both changes verified present after the rebase.

## The diff

`FibsemMovementWidget` drops 720 → 618 lines. `setup_connections` loses the stage limits, the compustage branch, the degree suffixes and five of the six wheel guards — the form applies all of it for itself, at construction, from the same stage. `update_ui` and `get_position_from_ui` become one-line delegations. Nothing that moves the stage is touched.

Three things worth knowing while reading it:

- **`self.microscope` is assigned before `_setup_ui`** rather than after. The form takes its axis ranges from the stage while it is being built, so it needs the microscope one step earlier than this widget did. The parent validation still runs before anything is connected.
- **The old control names are kept as plain aliases** onto the form's widgets — `self.doubleSpinBox_movement_stage_x = self.position_widget.spinbox_x` and so on. Same objects, so the extraction is invisible from outside and no host or test has to move in this PR. A follow-up retires them, which is also what keeps this PR at one file.
- **The refresh button is now the form's**, emitting `refresh_requested`; this widget connects that to `update_ui`. The form never reads the device, which is the point of routing it through a signal rather than handing the form a microscope call.

The stage panel's grid rows renumber 5–8 → 1–4, since rows 0–4 collapse into one spanning widget.

## One deliberate 5px layout change

Not "no visible change" — there is one, and it is measurable:

| | before | after |
| -- | -- | -- |
| label column | 213 px | 208 px |
| spin box | 202 px | 207 px |
| spin box origin x | 223 | 218 |

The label column used to be stretched to the width of *Move to SEM Orientation*, because the labels and the orientation buttons shared `gridLayout_3`. They no longer do, so the label column sizes to the widest label and the spin boxes take the 5 px back.

Every row's vertical position, every button, and the panel's overall size (429×313) are unchanged. Coupling the form's columns back to the button widths to avoid this would reinstate exactly the coupling the split removes, so I left it.

## Verification

**The equivalence argument:** the 11 characterization tests from [#619](https://github.com/fibsem-os/fibsem-os/pull/619) — written against the *pre-split* widget, and not modified — pass unchanged against this one. They reach the form through `update_ui`, `get_position_from_ui` and the old attribute names, so they are checking the composed widget behaves as the monolithic one did.

**104 tests green** across `test_stage_position_widget`, `test_viewer_less_widgets`, `test_movement_progress`, `test_movement_worker_bodies`, `test_canvas_double_click_guards`, `test_movement_widget_vertical_gate` and `test_objective_display_signal`.

**Offscreen render** of the stage panel, before and after, pixel-compared: identical size, identical row origins, differences confined to the 5 px column split above.

**The real application, two ways.** `AutoLamellaUI` built offscreen against a Demo microscope and driven through `update_ui(stage_position=...)` (the `AutoLamellaUI:410` path), the refresh button, `move_to_position` and `_teardown_connections` — correct values in and out, buttons correctly disabled during the move, zero Qt warnings. And the desktop application launched on a real display and connected with no errors; I confirmed a clean startup from the log rather than by inspecting the window.

`ruff check` and `ruff format --check` clean.

## Not in scope

- Retiring the alias block, and moving `AutoLamellaUI:410` onto `position_widget` directly.
- The `StageControlWidget` half. I had flagged that as blocked on [FIB-828](https://linear.app/fibsemos/issue/FIB-828/widget-workers-that-mix-the-operation-with-the-ui-update); it is not. #612 and #616 already reduced all three `@thread_worker` bodies in this file to domain calls only — FIB-828's own "shape 2", the pattern it names as correct — so there are no shape-3 sites left here for it to redo. That half is unblocked; it is just larger, and out of scope for this PR.

Note: merging this will auto-complete FIB-783 via the Linear attachment, even though the control half is still outstanding. Reopen it.

