### PR TITLE
[chore] Ignore the autofocus plot directory a sweep writes into the checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,9 @@ tests/data/
 # into it. 11 MB of them reached a commit once.
 overview-image-*.tif
 overview-image-*/
+
+# Autofocus sweep plots default to a relative path when no save_path is given
+# (`fibsem/autofunctions/plotting.py:224` does os.makedirs("autofocus")), so running
+# the app or a sweep from a checkout writes them into it. Same shape as the overview
+# tilesets above.
+autofocus/


### PR DESCRIPTION
One line of pattern, four of comment.

`fibsem/autofunctions/plotting.py:224` falls back to a **relative** path when no `save_path` is given:

```python
os.makedirs("autofocus", exist_ok=True)
save_path = os.path.join("autofocus", f"autofocus_{datetime.now().strftime('%Y%m%d_%H%M%S')}.png")
```

So running the app or a sweep from a checkout drops plots into the working tree, where they sit untracked waiting to be swept into an unrelated commit by a `git add -A`. That has now been caught twice in review of other PRs.

Exactly the same shape as the `overview-image-*` entry directly above it, which was added after 11 MB of tifs reached a commit.

**It hides no source.** The pattern has no leading slash, so it matches a directory of that name at any depth — worth checking rather than assuming. Nothing tracked lives under a directory named `autofocus/`, and the trailing slash means the ten tracked files merely *named* `autofocus*` are unaffected, `fibsem/autofunctions/autofocus.py` among them.

Not fixed here: the relative-path fallback itself. Writing into the current working directory is the underlying problem, and the overview entry above shows this is the second component to do it — but changing where a sweep saves is a behaviour change, not a chore.
