### PR TITLE
[refactor] Take the button update out of the milling worker body (FIB-828)

### DIFF
--- a/fibsem/ui/widgets/milling_widget.py
+++ b/fibsem/ui/widgets/milling_widget.py
@@ -185,6 +185,12 @@ class FibsemMillingWidget2(QWidget):
         self._milling_thread = FunctionWorker(
             self._milling_worker, self.microscope, config
         )
+        # Both of these used to run from inside the worker's `finally`, which put the
+        # widget update on the worker thread. Connected here in the order they used to
+        # happen in: the controls have to be unlocked before anything acts on
+        # `finished_milling_signal`, which listeners take to mean "fully complete".
+        self._milling_thread.finished.connect(self._update_button_states)
+        self._milling_thread.finished.connect(self.finished_milling_signal.emit)
 
         self._milling_thread.start()
 
@@ -197,7 +203,13 @@ class FibsemMillingWidget2(QWidget):
     def _milling_worker(
         self, microscope: FibsemMicroscope, milling_task_config: FibsemMillingTaskConfig
     ):
-        """Worker function to run the milling task in a separate thread."""
+        """Run the milling task. Runs off the GUI thread — only signals may cross back.
+
+        Clearing ``_milling_thread`` stays here. ``is_milling`` would answer correctly
+        without it — it also asks ``is_alive()``, and the thread has normally exited by
+        the time the queued ``finished`` is processed — but that makes the button state
+        depend on a race the clear settles outright, and it drops the reference.
+        """
         try:
             if not milling_task_config.enabled_stages:
                 raise ValueError("No milling stages defined in the configuration.")
@@ -213,8 +225,6 @@ class FibsemMillingWidget2(QWidget):
 
         finally:
             self._milling_thread = None
-            self._update_button_states()
-            self.finished_milling_signal.emit()
 
     def stop_milling(self):
         if self.is_milling:

--- a/tests/ui/test_milling_lockout.py
+++ b/tests/ui/test_milling_lockout.py
@@ -13,6 +13,7 @@ the protocol as the position that was milled, when it is not.
 Every test here has a not-milling counterpart. A lock test that only ever asserts "this
 did nothing" passes just as well against a widget that does nothing at all.
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -85,7 +86,11 @@ def _start_milling(widget) -> None:
 
 
 def _finish_milling(widget) -> None:
-    """What `_milling_worker`'s finally block does."""
+    """The state a finished mill leaves behind.
+
+    The widget reaches it through the worker's `finished` signal; what matters to the
+    tests below is the state, not the route.
+    """
     widget.milling_widget._milling_thread = None
     widget.milling_widget._update_button_states()
 
@@ -122,7 +127,14 @@ def test_the_lock_lands_at_start_not_at_the_first_progress_signal(widget, monkey
     import fibsem.ui.widgets.milling_widget as milling_widget_module
 
     class _StubWorker:
+        # `finished` carries the end-of-mill wiring now, so the stub has to offer
+        # something to connect to -- it just never fires, because it never mills.
+        finished = property(lambda self: self)
+
         def __init__(self, *args, **kwargs):
+            pass
+
+        def connect(self, *args, **kwargs):
             pass
 
         def start(self):
@@ -149,7 +161,9 @@ def _record_menu(widget, monkeypatch) -> list:
     return opened
 
 
-def test_the_reposition_menu_opens_when_nothing_is_milling(widget, monkeypatch, fib_image):
+def test_the_reposition_menu_opens_when_nothing_is_milling(
+    widget, monkeypatch, fib_image
+):
     """The control: without this, the milling case below proves nothing."""
     widget.set_fib_image(fib_image)
     opened = _record_menu(widget, monkeypatch)
@@ -181,7 +195,9 @@ def test_moving_patterns_is_refused_while_milling(widget, fib_image):
 
     widget._move_patterns(Point(x=1e-6, y=1e-6), move_all=True)
 
-    after = widget.config_widget.milling_stages_widget.get_enabled_stages()[0].pattern.point
+    after = widget.config_widget.milling_stages_widget.get_enabled_stages()[
+        0
+    ].pattern.point
     assert (after.x, after.y) == (before.x, before.y)
 
 
@@ -194,7 +210,9 @@ def test_moving_patterns_still_works_when_idle(widget, fib_image):
 
     widget._move_patterns(Point(x=before.x + 5e-6, y=before.y + 5e-6), move_all=True)
 
-    after = widget.config_widget.milling_stages_widget.get_enabled_stages()[0].pattern.point
+    after = widget.config_widget.milling_stages_widget.get_enabled_stages()[
+        0
+    ].pattern.point
     assert (after.x, after.y) != (before.x, before.y)
 
 

--- a/tests/ui/test_milling_worker_boundary.py
+++ b/tests/ui/test_milling_worker_boundary.py
@@ -1,0 +1,220 @@
+"""Where the milling worker stops and the widget starts.
+
+``_milling_worker`` runs a milling task off the GUI thread and then, in its ``finally``,
+reaches back for the widget to re-enable its own controls. The call is marshalled --
+``_update_button_states`` carries ``@ensure_main_thread`` -- so this is not a threading
+bug. It is the operation and the UI update sharing a function, the same shape the
+movement workers were split out of.
+
+Two orderings are load-bearing and easy to lose when the call moves, so they are pinned
+here rather than discovered later:
+
+* the buttons unlock only once the mill is genuinely over, and
+* they unlock *before* ``finished_milling_signal`` reaches its listeners. The
+  coincidence viewer hangs ``_finalize_milling_ui`` off that signal precisely because it
+  means "fully complete", and it should not run while the controls still say otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtCore import QEventLoop, QTimer
+
+sys.path.insert(0, os.path.dirname(__file__))  # not str.rsplit: Windows paths
+from test_milling_lockout import _config_with_a_stage  # noqa: E402
+
+from fibsem import utils  # noqa: E402
+from fibsem.ui.widgets import milling_widget as milling_widget_module  # noqa: E402
+from fibsem.ui.widgets.milling_task_viewer_widget import (  # noqa: E402
+    MillingTaskViewerWidget,
+)
+
+_microscope = None
+
+
+def _session():
+    global _microscope
+    if _microscope is None:
+        _microscope, _ = utils.setup_session(manufacturer="Demo")
+    return _microscope
+
+
+def _pump(ms: int = 100) -> None:
+    loop = QEventLoop()
+    QTimer.singleShot(ms, loop.quit)
+    loop.exec_()
+
+
+def _run(condition, tries: int = 30) -> None:
+    for _ in range(tries):
+        _pump()
+        if condition():
+            return
+
+
+@pytest.fixture
+def milling(qapp):
+    viewer = MillingTaskViewerWidget(
+        microscope=_session(),
+        milling_task_config=_config_with_a_stage(),
+        milling_enabled=True,
+    )
+    yield viewer.milling_widget
+    viewer.deleteLater()
+
+
+class _Mill:
+    """A milling task the test starts and ends on purpose.
+
+    `run_milling_task` is replaced by something that blocks until `finish()`. A stub
+    that returned immediately would be worse than useless here: the worker would be over
+    before `run_milling` reached its own closing `_update_button_states()`, so that call
+    would find `is_milling` already False and unlock the controls itself. Every
+    assertion about the end-of-mill hand-off would then pass without the hand-off
+    existing -- which is exactly what happened before this was written.
+    """
+
+    def __init__(self):
+        self.calls = []
+        self.started = threading.Event()
+        self._release = threading.Event()
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        self.started.set()
+        self._release.wait(timeout=10)
+
+    def begin(self, milling, config):
+        milling.run_milling(config)
+        assert self.started.wait(timeout=10), "the milling task never started"
+
+    def finish(self):
+        self._release.set()
+
+
+@pytest.fixture
+def mill(monkeypatch):
+    gate = _Mill()
+    monkeypatch.setattr(milling_widget_module, "run_milling_task", gate)
+    yield gate
+    gate.finish()
+
+
+def _watch(milling, order=None) -> list:
+    """Record each button update: the thread, `is_milling` at the time, and the value.
+
+    Wraps the button's own `setEnabled` rather than `_update_button_states`. Replacing
+    the method on the instance would shadow its `@ensure_main_thread`, so the recorder
+    would run wherever the *caller* is -- which is exactly the thing under test, and the
+    test would report the marshalling it removed.
+    """
+    seen = []
+    button = milling.pushButton_run_milling
+    original = button.setEnabled
+
+    def _record(enabled):
+        seen.append((threading.current_thread().name, milling.is_milling, enabled))
+        if order is not None:
+            order.append("buttons")
+        original(enabled)
+
+    button.setEnabled = _record
+    return seen
+
+
+# --- the hand-off at the end of a mill ---------------------------------------
+
+
+def test_a_finished_mill_unlocks_the_controls(milling, mill):
+    """The control for everything else here: a mill that ran leaves the widget usable."""
+    mill.begin(milling, _config_with_a_stage())
+    assert not milling.pushButton_run_milling.isEnabled(), (
+        "precondition: the controls lock while milling"
+    )
+
+    mill.finish()
+    _run(lambda: not milling.is_milling and milling.pushButton_run_milling.isEnabled())
+
+    assert mill.calls, "the milling task never ran"
+    assert not milling.is_milling
+    assert milling.pushButton_run_milling.isEnabled(), "the controls stayed locked"
+
+
+def test_the_controls_unlock_before_the_finished_signal_is_delivered(milling, mill):
+    """`finished_milling_signal` means "fully complete" to its listeners.
+
+    The coincidence viewer resets its whole panel on it. Delivering it while the
+    controls still read "milling" would have the two halves of the UI disagreeing.
+    """
+    order = []
+    seen = _watch(milling, order)
+    milling.finished_milling_signal.connect(lambda: order.append("finished"))
+
+    mill.begin(milling, _config_with_a_stage())
+    mill.finish()
+    _run(lambda: "finished" in order and milling.pushButton_run_milling.isEnabled())
+
+    assert order.count("finished") == 1, order
+    # `run_milling` locks the controls on the way in, so the first "buttons" entry is
+    # that lock. What has to precede the signal is the *unlock*.
+    unlocked = next(i for i, (_, _, enabled) in enumerate(seen) if enabled)
+    assert (
+        order.index("finished")
+        > [i for i, label in enumerate(order) if label == "buttons"][unlocked]
+    ), order
+
+
+def test_the_buttons_are_updated_on_the_gui_thread(milling, mill):
+    """Touching a widget off the GUI thread is a Qt violation.
+
+    True today because `@ensure_main_thread` marshals the worker's call. It has to stay
+    true however the call is arranged.
+    """
+    seen = _watch(milling)
+
+    mill.begin(milling, _config_with_a_stage())
+    mill.finish()
+    _run(lambda: milling.pushButton_run_milling.isEnabled())
+
+    assert seen, "the buttons were never updated"
+    assert {thread for thread, _, _ in seen} == {"MainThread"}, seen
+
+
+def test_the_mill_is_over_by_the_time_the_buttons_are_updated(milling, mill):
+    """`_update_button_states` reads `is_milling`, so it has to run after the worker
+    has let go of its thread -- otherwise it re-locks the controls it came to free."""
+    seen = _watch(milling)
+
+    mill.begin(milling, _config_with_a_stage())
+    mill.finish()
+    _run(lambda: milling.pushButton_run_milling.isEnabled())
+
+    assert seen[-1][1] is False, f"the buttons were updated while still milling: {seen}"
+    assert seen[-1][2] is True, f"the last update did not unlock the controls: {seen}"
+
+
+# --- the rule the split establishes ------------------------------------------
+
+
+def test_the_worker_body_does_not_touch_the_widget(milling, mill):
+    """The body runs the task and nothing else.
+
+    `@ensure_main_thread` makes the old direct call safe, so this is about coupling
+    rather than correctness -- but it is the rule the movement workers now follow, and
+    the reason this one is worth moving too.
+    """
+    touched = []
+    milling._update_button_states = lambda: touched.append(True)
+
+    mill.finish()  # the body runs in place here, so let it through
+    milling._milling_worker(_session(), _config_with_a_stage())
+
+    assert mill.calls, "the milling task never ran"
+    assert touched == [], "the worker body updated the widget's buttons"


### PR DESCRIPTION
The last shape-3 site. Closes FIB-828.

## What changed

`_milling_worker`'s `finally` called `_update_button_states()` and emitted `finished_milling_signal` from the worker thread. The button update carries `@ensure_main_thread`, so it was marshalled and safe; the signal is a signal. Neither is a threading bug — it is the operation and the UI update sharing a function, the same shape #612 and #616 split out of the movement paths.

Both move to `finished` on the worker, connected **in the order they used to happen in**. That order is load-bearing: the coincidence viewer resets its whole panel on `finished_milling_signal`, which it explicitly takes to mean "fully complete" (`_finalize_milling_ui`), so delivering it while the controls still read "milling" would have the two halves of the UI disagreeing.

Clearing `_milling_thread` stays in the `finally`. `is_milling` would answer correctly without it — it also asks `is_alive()`, and the thread has normally exited by the time the queued `finished` is processed — but that makes the button state depend on a race the clear settles outright. **Not covered by a test**, since it is a race; stated in the docstring instead.

`run_milling_task(parent_ui=self)` is **untouched**. That is the other shape and belongs with FIB-826's request-protocol work.

## Two traps found while writing the tests

Both are recorded in the test file, because both make a test pass while proving nothing:

**1. Wrapping `_update_button_states` on the instance shadows its `@ensure_main_thread`.** A thread-affinity test built that way records the caller's thread — reporting the absence of the marshalling it just removed. The tests watch the button's own `setEnabled` instead.

**2. A `run_milling_task` stub that returns immediately is worse than useless here.** The worker finishes before `run_milling` reaches its own closing `_update_button_states()`, so *that* call finds `is_milling` already False and unlocks the controls itself. Every assertion about the end-of-mill hand-off then passes without the hand-off existing.

That is not hypothetical — it is what my first attempt did, and **three of four mutations went undetected**. The stub now blocks until the test ends the mill.

## Verification

After fixing the fixture:

| mutation | caught by |
| --- | --- |
| reverse the connection order | unlock-before-signal test |
| drop the button update entirely | 3 tests |
| put the widget call back in the worker body | worker-body test |
| never clear `_milling_thread` | **not caught** — and it turns out not to be a defect, see above |

227 passed across `test_milling_worker_boundary.py`, `test_milling_lockout.py`, `test_viewer_less_widgets.py`, `test_canvas_double_click_guards.py` and `tests/milling/`. `ruff check` / `ruff format --check` clean; all three files parse under 3.8.

## Note for review

`test_milling_lockout.py` carries unrelated `ruff format` hunks — pre-existing debt in a file the lint gate now checks because this PR touches it. The substantive edits there are two: `_StubWorker` gains a `finished` to connect to, and `_finish_milling`'s docstring no longer claims to describe a `finally` block that no longer does that.
