### PR TITLE
[refactor] Compose the device leg with the orientation one (FIB-830)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -159,6 +159,13 @@ if TYPE_CHECKING:
     from fibsem.structures import TFibsemPatternSettings
 
 
+# The device the orientation transform is defined at. `_get_compucentric_rotation_position`
+# is a half turn about a chamber-fixed centre, and the beams are the only place it has
+# ever been applied on any instrument -- so `get_target_position` carries a position
+# into this device's frame before re-posing it, and back out afterwards.
+ROTATION_FRAME_DEVICE = "FIBSEM"
+
+
 class FibsemMicroscope(ABC):
     """Abstract class containing all the core microscope functionalities"""
 
@@ -1481,17 +1488,48 @@ class FibsemMicroscope(ABC):
 
         return target_position
 
-    def get_target_position(
-        self, stage_position: FibsemStagePosition, target_orientation: str
+    def _apply_device_translation(
+        self, stage_position: FibsemStagePosition, source: str, target: str
     ) -> FibsemStagePosition:
-        """Convert the stage position to the target position for the given orientation."""
+        """`stage_position`, moved from one device to another. Mutates and returns it."""
+        translation = self._device_translation(source, target)
+        for axis in DEVICE_AXES:
+            delta = getattr(translation, axis)
+            if delta is None:
+                continue
+            value = getattr(stage_position, axis)
+            if value is None:
+                raise ValueError(
+                    f"Cannot convert between devices {source} and {target}: the "
+                    f"position has no {axis}, and the two differ along it."
+                )
+            setattr(stage_position, axis, value + delta)
+        return stage_position
+
+    def get_target_position(
+        self,
+        stage_position: FibsemStagePosition,
+        target_orientation: str,
+        target_device: Optional[str] = None,
+    ) -> FibsemStagePosition:
+        """Convert the stage position to the target position for the given orientation.
+
+        `target_device` converts across the *device* axis as well. Where the objective
+        is offset the two are independent -- the device is a place the stage travels
+        to, the orientation is the pose it is held in once there -- so a caller may
+        ask for either or both. `FM-MILLING` is not a fifth orientation; it is
+        `("MILLING", device="FM")`.
+
+        Returns the canonical r and t of the target orientation, so a position a
+        degree or two off its nominal pose is snapped rather than carried across.
+        """
 
         currrent_orientation = self.get_stage_orientation(stage_position)
         logging.info(
             f"Getting target position for {target_orientation} from {currrent_orientation}"
         )
 
-        if currrent_orientation == target_orientation:
+        if currrent_orientation == target_orientation and target_device is None:
             return stage_position
 
         if currrent_orientation == "NONE":
@@ -1501,15 +1539,60 @@ class FibsemMicroscope(ABC):
         # offset mount it is a *place*, reached by translating rather than re-posing,
         # and `orientations["FM"]` there is a copy of the FIB entry carrying no
         # positional term -- so converting into it would return a position under the
-        # beam wearing the FM's rotation and tilt. Refused until the device axis
-        # exists (FIB-830).
+        # beam wearing the FM's rotation and tilt. Ask for it as a device instead:
+        # `target_device="FM"`, with whichever orientation the sample should be in.
         if "FM" in (currrent_orientation, target_orientation) and (
             not self.stage_is_compustage
         ):
             raise ValueError("Cannot move to FM position on non-compustage systems.")
 
+        # Which device the stage is at, read *before* either leg runs. The orientation
+        # leg below can move x and y most of the way across the grid, so asking
+        # afterwards would sometimes name a different device, or none.
+        source_device = self.get_current_device(stage_position)
+        if target_device is not None and source_device is None:
+            raise ValueError(
+                f"The stage is not at any configured device "
+                f"({sorted(self.system.stage.devices)}), so there is nothing to "
+                f"convert from. Position: {stage_position}."
+            )
+
         stage_position = deepcopy(stage_position)
         orientation = self.get_orientation(target_orientation)
+
+        # The device legs **bracket** the orientation leg rather than following it,
+        # so that the re-pose always happens at the beams. Written out, that is the
+        # order an operator would use:
+        #
+        #   leaving the beams:  re-pose first, then traverse to the device
+        #   returning:          traverse back to the beams first, then re-pose
+        #
+        # Both come out of one expression, `f(p) = rotate(p - source) + target`.
+        # Leaving, `source` is zero and the rotation happens before the traverse;
+        # returning, `target` is zero and the traverse happens before the rotation.
+        #
+        # **The stage must not be re-posed while it is parked at the FM.** The
+        # objective is inserted over the sample there, and a half turn swings the
+        # sample about a centre ~48.8 mm away. Bracketing is what keeps the rotation
+        # out of that pose; the arrangement that re-poses wherever the stage happens
+        # to be would compute a target that commands exactly that move.
+        #
+        # It is also the only arrangement that round-trips, which is how the wrong one
+        # was caught rather than reasoned about: re-posing at the FM and translating
+        # afterwards sends `(SEM, beams) -> (FIB, FM) -> (SEM, beams)` back to
+        # -97.6 mm instead of 0. `rotate` is an involution, so `f` inverts by swapping
+        # source and target -- which is exactly what the reverse call does.
+        #
+        # This computes a target; it does not order the moves. Nothing yet stops a
+        # caller re-posing while at the FM -- see FIB-841, a prerequisite for opening
+        # the connection gate.
+        #
+        # A compustage brackets with a zero translation, so it takes this path and
+        # gets its old answer untouched.
+        if source_device is not None:
+            stage_position = self._apply_device_translation(
+                stage_position, source_device, ROTATION_FRAME_DEVICE
+            )
 
         # One rule, in place of a branch per ordered pair.
         #
@@ -1567,6 +1650,15 @@ class FibsemMicroscope(ABC):
 
         stage_position.r = orientation.r
         stage_position.t = orientation.t
+
+        # ... and back out, to whichever device was asked for. `target_device` of None
+        # means the one it started at, so an orientation-only conversion at the FM is
+        # still re-posed about the right centre rather than about wherever it is
+        # parked.
+        if source_device is not None:
+            stage_position = self._apply_device_translation(
+                stage_position, ROTATION_FRAME_DEVICE, target_device or source_device
+            )
 
         return stage_position
 
@@ -2179,7 +2271,17 @@ class FibsemMicroscope(ABC):
         and the "am I already there" windows can no longer drift apart. Relative
         rather than absolute on purpose: the devices constrain x only, and a relative
         move carries y, z, r and t across unchanged.
+
+        **Nothing on a compustage.** There the objective is under the grid, so the
+        beams and the FM are the same place and the stage reaches one from the other
+        by flipping, not travelling -- the configured origins describe an offset
+        chamber and do not apply. Answering here rather than at each call site is the
+        same arrangement `_get_compucentric_rotation_position` already uses: the
+        primitive is the no-op, so no caller needs a stage-type branch.
         """
+        if self.stage_is_compustage:
+            return FibsemStagePosition()
+
         source_origin = self._get_device(source).origin
         target_origin = self._get_device(target).origin
 

--- a/tests/test_device_orientation_composition.py
+++ b/tests/test_device_orientation_composition.py
@@ -1,0 +1,215 @@
+"""Converting across both axes at once: the device and the orientation.
+
+On an offset mount these are independent. The device is a *place* the stage travels
+to; the orientation is the pose the sample is held in once it is there. So a target
+position is a pair, and `get_target_position` takes both.
+
+The thing worth reading this file for is the **order**. The two legs do not commute,
+and only one arrangement round-trips -- see
+`test_the_orientation_leg_is_bracketed_by_the_device_legs`, which is where the wrong
+one was caught.
+
+See FIB-830.
+"""
+
+import itertools
+import os
+
+import numpy as np
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.structures import FibsemStagePosition
+
+IFLM_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-iflm-configuration.yaml")
+ARCTIS_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
+
+ORIENTATIONS = ("SEM", "FIB", "MILLING")
+TRAVERSE = 48.8e-3
+
+# Across the beam device's range, which is what the traverse has to carry.
+GRID_X_MM = (-19.0, -12.0, 0.0, 5.0, 15.0, 19.0)
+
+
+def _microscope(config_path: str = IFLM_CONFIG):
+    microscope, _ = utils.setup_session(config_path=config_path)
+    return microscope
+
+
+def _at(microscope, orientation: str, x_mm: float, y_mm: float = 2.0):
+    """A position at `orientation`, `x_mm` along the grid. Constructed, not moved to.
+
+    Relative moves accumulate, and a few of them in a row walk the stage into the gap
+    between the two devices, where the conversion is refused -- correctly, and
+    confusingly if it happens inside a loop.
+    """
+    pose = microscope.get_orientation(orientation)
+    return FibsemStagePosition(
+        x=x_mm * 1e-3,
+        y=y_mm * 1e-3,
+        z=0.0,
+        r=pose.r,
+        t=pose.t,
+        coordinate_system="RAW",
+    )
+
+
+# ── the device leg ───────────────────────────────────────────────────
+
+
+def test_asking_only_for_a_device_is_the_traverse():
+    """No orientation change, so the whole answer is the gap between the origins."""
+    microscope = _microscope()
+    position = _at(microscope, "FIB", 5.0)
+
+    target = microscope.get_target_position(position, "FIB", target_device="FM")
+
+    assert target.x == pytest.approx(position.x + TRAVERSE)
+    assert target.y == pytest.approx(position.y)
+    assert microscope.is_at_device("FM", target) is True
+
+
+def test_fm_milling_is_a_device_and_an_orientation_not_a_fifth_orientation():
+    """The request that settles the design (FIB-833): at the FM, posed for milling.
+
+    Nothing was added to `orientations` for this. It is a pair the model could already
+    express the moment the device became its own axis.
+    """
+    microscope = _microscope()
+
+    target = microscope.get_target_position(
+        _at(microscope, "SEM", 0.0), "MILLING", target_device="FM"
+    )
+
+    assert microscope.get_current_device(target) == "FM"
+    assert microscope.get_stage_orientation(target) == "MILLING"
+    assert target.t == pytest.approx(microscope.get_orientation("MILLING").t)
+
+
+# ── the order of the two legs ────────────────────────────────────────
+
+
+def test_the_orientation_leg_is_bracketed_by_the_device_legs():
+    """The arrangement, stated as the number it produces.
+
+    `_get_compucentric_rotation_position` is a half turn about a chamber-fixed centre,
+    and the beams are the only place it has ever been applied. So a position is
+    carried into that frame, re-posed, and carried back out to the device asked for.
+
+    The alternative -- re-pose wherever the stage is, then translate -- gives the same
+    answer going out and a different one coming back, because the return journey
+    rotates about a centre 48.8 mm away. From the beams at x = 0 it returns
+    **-97.6 mm** rather than 0. That is how this was caught; it is not a stylistic
+    preference between two correct orders.
+    """
+    microscope = _microscope()
+    start = _at(microscope, "SEM", 0.0)
+
+    at_the_fm = microscope.get_target_position(start, "FIB", target_device="FM")
+    returned = microscope.get_target_position(at_the_fm, "SEM", target_device="FIBSEM")
+
+    assert at_the_fm.x == pytest.approx(TRAVERSE)
+    assert returned.x == pytest.approx(0.0, abs=1e-12)
+    assert returned.x != pytest.approx(-2 * TRAVERSE)  # the arrangement that lost
+
+
+@pytest.mark.parametrize("x_mm", GRID_X_MM)
+@pytest.mark.parametrize(
+    ("there", "back"), list(itertools.product(ORIENTATIONS, repeat=2))
+)
+def test_every_pair_round_trips_from_anywhere_on_the_grid(
+    x_mm: float, there: str, back: str
+):
+    """`f(p) = rotate(p - source) + target`, and `rotate` is an involution.
+
+    So swapping source and target inverts it, which is exactly what the return call
+    does. Pinned across the beam device's whole range because the traverse carries the
+    grid offset -- an error in the bracketing shows up as a function of x, and at
+    x = 0 with the simulator's zero compucentric offset it would hide entirely.
+    """
+    microscope = _microscope()
+    start = _at(microscope, back, x_mm)
+
+    away = microscope.get_target_position(start, there, target_device="FM")
+    returned = microscope.get_target_position(away, back, target_device="FIBSEM")
+
+    assert returned.x == pytest.approx(start.x, abs=1e-12)
+    assert returned.y == pytest.approx(start.y, abs=1e-12)
+    assert np.isclose(returned.r, start.r)
+    assert np.isclose(returned.t, start.t)
+
+
+@pytest.mark.parametrize("x_mm", GRID_X_MM)
+def test_the_traverse_lands_inside_the_fm_range_whatever_the_pose(x_mm: float):
+    """A converted position has to be somewhere the device axis recognises.
+
+    Otherwise the caller has a target it cannot then be told it has reached.
+    """
+    microscope = _microscope()
+
+    for orientation in ORIENTATIONS:
+        target = microscope.get_target_position(
+            _at(microscope, "SEM", x_mm), orientation, target_device="FM"
+        )
+        assert microscope.get_current_device(target) == "FM"
+
+
+# ── what did not change ──────────────────────────────────────────────
+
+
+def test_a_compustage_brackets_with_nothing():
+    """Its objective is under the grid: the FM is reached by flipping, not travelling.
+
+    So the device legs are a zero translation there and the compustage takes the same
+    path to the same answer it gave before -- no stage-type branch in the transform.
+    """
+    microscope = _microscope(ARCTIS_CONFIG)
+    start = _at(microscope, "SEM", 0.0)
+
+    with_device = microscope.get_target_position(start, "FM", target_device="FM")
+    orientation_only = microscope.get_target_position(start, "FM")
+
+    assert with_device.x == pytest.approx(orientation_only.x)
+    assert with_device.y == pytest.approx(orientation_only.y)
+
+
+def test_asking_for_no_device_is_the_transform_that_was_already_there():
+    """Every existing caller passes no device, and gets what it always got."""
+    microscope = _microscope()
+    start = _at(microscope, "SEM", 5.0)
+
+    target = microscope.get_target_position(start, "FIB")
+
+    assert target.x == pytest.approx(-start.x)  # the compucentric half turn, alone
+    assert np.isclose(target.r, microscope.get_orientation("FIB").r)
+
+
+def test_converting_to_where_it_already_is_still_returns_the_same_object():
+    """The aliasing early return, which `tests/test_orientation_transform_parity.py`
+    pins. A device argument is what takes the conversion off that path."""
+    microscope = _microscope()
+    start = _at(microscope, "SEM", 0.0)
+
+    assert microscope.get_target_position(start, "SEM") is start
+    assert microscope.get_target_position(start, "SEM", target_device="FM") is not start
+
+
+def test_the_fm_is_still_not_an_orientation_on_an_offset_mount():
+    """`orientations["FM"]` is a copy of the FIB entry there, carrying no positional
+    term. The device argument is how to ask for the FM; the orientation is not."""
+    microscope = _microscope()
+
+    with pytest.raises(ValueError, match="Cannot move to FM position"):
+        microscope.get_target_position(_at(microscope, "SEM", 0.0), "FM")
+
+
+def test_converting_from_between_the_devices_is_refused():
+    """Mid-traverse there is no source frame to convert out of, so it says so."""
+    microscope = _microscope()
+    stranded = _at(microscope, "SEM", 24.0)  # the gap between the two ranges
+
+    assert microscope.get_current_device(stranded) is None
+
+    with pytest.raises(ValueError, match="not at any configured device"):
+        microscope.get_target_position(stranded, "FIB", target_device="FM")


### PR DESCRIPTION
> Stacked on #618. Review that first; this diff is the device leg alone.

`get_target_position` gains `target_device`, so a target position is the pair it physically is: a place the stage travels to, and a pose it is held in once there. `FM-MILLING` (FIB-833) needs nothing added to `orientations` — it is `("MILLING", device="FM")`.

## The two legs bracket the orientation, they do not follow it

Which is the order an operator would use:

```
leaving the beams:  re-pose first, then traverse to the device
returning:          traverse back to the beams first, then re-pose
```

Both fall out of one expression, `f(p) = rotate(p - source) + target`. Leaving, `source` is zero so the rotation comes first; returning, `target` is zero so the traverse does. Measured at a 15 mm grid position, half turn:

| direction | steps | result |
| -- | -- | -- |
| FIBSEM → FM | `rotate(15) = -15`, then `+48.8` | 33.8 |
| FM → FIBSEM | `33.8 - 48.8 = -15`, then `rotate` | 15.0 |

**The reason is safety before arithmetic.** The objective is inserted over the sample at the FM, and `_get_compucentric_rotation_position` is a half turn about a centre ~48.8 mm away — so the stage must not be re-posed while parked there. Bracketing is what keeps the re-pose at the beams. The arrangement that re-poses wherever the stage happens to be would compute a target commanding exactly that move.

It is also the only arrangement that round-trips, which is how the wrong one was caught rather than reasoned about: `(SEM, beams) → (FIB, FM) → (SEM, beams)` came back at **−97.6 mm instead of 0**. `rotate` is an involution, so `f` inverts by swapping source and target, which is exactly what the reverse call does.

## What this does not do

The transform computes a target; it does not order the moves. Nothing yet refuses a re-pose while parked at the FM — `move_to_microscope` traverses and `move_to_orientation` re-poses, and a caller only has to invoke them in the order that looks natural. FIB-841 covers that refusal, as a prerequisite for opening the connection gate.

## Compustage

Brackets with a zero translation: its objective is under the grid, so it reaches the FM by flipping, not travelling. It takes the same path to the answer it gave before, with no stage-type branch in the transform — the same arrangement `_get_compucentric_rotation_position` already uses, where the primitive is the no-op so no caller needs the branch.

## One assumption, for the bench

The order assumes the compucentric centre sits at the beams, which is where the correction has always been applied. Sound rather than derived, and noted in the code: the simulator cannot confirm it, because its compucentric offset is `(0, 0)`.

## Verification

68 new tests. The round trip is pinned across all nine orientation pairs at six positions spanning the beam device's range — at x = 0 with the simulator's zero offset a bracketing error hides entirely, so the range is the point.
