### PR TITLE
[fix] Restore the space in the missing-reference-image warning

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -488,8 +488,7 @@ class AutoLamellaTask(ABC):
         # validate reference image exists
         if not os.path.exists(full_filename):
             logging.warning(
-                f"Reference image {full_filename} for alignment does not exist"
-                ""
+                f"Reference image {full_filename} for alignment does not exist, "
                 f"but was requested by {self.task_name}. Skipping alignment."
             )
             return


### PR DESCRIPTION
Spotted in the logs while running a workflow against the simulator:

```
Reference image /…/02-helped-osprey/ref_alignment_ib.tif for alignment does not existbut was requested by Mill Fiducial. Skipping alignment.
```

The cause is a stray empty string literal sitting exactly where the space should be, implicitly concatenated between the two f-string fragments:

```python
f"Reference image {full_filename} for alignment does not exist"
""
f"but was requested by {self.task_name}. Skipping alignment."
```

A comma comes with the space, since the clause reads as a contrast.

## Only one site, and worth saying how that was established

**An AST scan cannot find this.** Python folds adjacent string constants inside a single `JoinedStr`, so by parse time the empty literal is gone and `exist`/`but` are already one merged string with nothing suspicious between them — a scan for adjacent constants with a missing space returns zero, which reads as "clean" and is not.

The detector that works is a source-level grep for a bare `""` on its own line. That finds four hits: this one, and three legitimate `"" if cond else …` ternaries in `beam_settings_widget.py`, `guided_setup_dialog.py` and `autolamella_lamella_protocol_editor.py`, which are not this bug.

`592 passed` in `tests/autolamella`; `ruff check` and `ruff format --check` clean.
