### PR TITLE
[refactor] Retire the stage-position aliases (FIB-783)

### DIFF
--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -126,24 +126,6 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.stage_panel.add_header_widget(self.position_widget.btn_refresh)
         self.gridLayout_2.addWidget(self.stage_panel, 0, 0)
 
-        # The names the form's controls had while they were built here. Same objects,
-        # so hosts and tests that reach for them still resolve and the extraction is
-        # invisible from outside. A follow-up moves those callers onto
-        # `position_widget` and drops these.
-        self.doubleSpinBox_movement_stage_x = self.position_widget.spinbox_x
-        self.doubleSpinBox_movement_stage_y = self.position_widget.spinbox_y
-        self.doubleSpinBox_movement_stage_z = self.position_widget.spinbox_z
-        self.doubleSpinBox_movement_stage_rotation = (
-            self.position_widget.spinbox_rotation
-        )
-        self.doubleSpinBox_movement_stage_tilt = self.position_widget.spinbox_tilt
-        self.label_movement_stage_x = self.position_widget.label_x
-        self.label_movement_stage_y = self.position_widget.label_y
-        self.label_movement_stage_z = self.position_widget.label_z
-        self.label_movement_stage_rotation = self.position_widget.label_rotation
-        self.label_movement_stage_tilt = self.position_widget.label_tilt
-        self.btn_refresh_stage = self.position_widget.btn_refresh
-
         # Options panel removed — movement acquisition prefs are now in Edit > Preferences
 
         # --- Panel: Saved Positions ---
@@ -215,9 +197,6 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.image_widget.acquisition_progress_signal.connect(
             self.handle_acquisition_update
         )
-
-        # The axis ranges and the compustage adjustments were applied here. They belong
-        # to the form and are applied by it, at construction, from the same stage.
 
         # stylesheets
         self.pushButton_move.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)

--- a/tests/ui/test_stage_position_readout.py
+++ b/tests/ui/test_stage_position_readout.py
@@ -1,16 +1,20 @@
 """What the stage position form on the Movement tab does, before it is extracted.
 
-The form is the five spin boxes in rows 0-4 of ``FibsemMovementWidget``'s stage panel
-plus the refresh button in the panel header. It converts in both directions -- metres to
-millimetres, radians to degrees on the way in, and back again on the way out -- and takes
-its ranges from the stage rather than from the widget. None of that is asserted anywhere
-today: the existing movement tests all drive the half that *moves*.
+The form is the five spin boxes and the refresh button that make up
+``StagePositionWidget``, reached through the Movement tab that hosts it. It converts in
+both directions -- metres to millimetres, radians to degrees on the way in, and back
+again on the way out -- and takes its ranges from the stage rather than from the widget.
 
-These pin the conversions, the ranges and the two compustage adjustments so that
-splitting the form out of the widget is a refactor with a net under it rather than a
-rewrite that happens to still construct. They are deliberately written against the
-public surface a host uses -- ``update_ui`` and ``get_position_from_ui`` -- so they keep
-their meaning when the form moves behind a delegating facade.
+**These are the equivalence tests for the extraction.** They were written against the
+monolithic widget, before the form was a separate class, and they still drive the tab's
+own surface -- ``update_ui`` and ``get_position_from_ui``, which is what a host calls --
+rather than the form directly. That is what makes them evidence that composing the form
+changed nothing, and it is why they stay here rather than being folded into
+``tests/ui/test_stage_position_widget.py``, which tests the form on its own terms.
+
+Where a test needs a control rather than a value it reaches through
+``movement.position_widget``. It used to reach for aliases the tab kept during the swap;
+those are gone.
 
 **The default microscope configuration is user state and is not the same on every
 machine**, and it reaches these tests twice over.
@@ -87,11 +91,11 @@ def movement(qapp):
 
 def _boxes(movement) -> dict:
     return {
-        "x": movement.doubleSpinBox_movement_stage_x,
-        "y": movement.doubleSpinBox_movement_stage_y,
-        "z": movement.doubleSpinBox_movement_stage_z,
-        "r": movement.doubleSpinBox_movement_stage_rotation,
-        "t": movement.doubleSpinBox_movement_stage_tilt,
+        "x": movement.position_widget.spinbox_x,
+        "y": movement.position_widget.spinbox_y,
+        "z": movement.position_widget.spinbox_z,
+        "r": movement.position_widget.spinbox_rotation,
+        "t": movement.position_widget.spinbox_tilt,
     }
 
 
@@ -237,8 +241,9 @@ def test_rotation_is_offered_only_where_it_exists(movement):
     box, which would leave a stranded caption."""
     shown = not movement.microscope.stage_is_compustage
 
-    assert movement.doubleSpinBox_movement_stage_rotation.isVisibleTo(movement) is shown
-    assert movement.label_movement_stage_rotation.isVisibleTo(movement) is shown
+    form = movement.position_widget
+    assert form.spinbox_rotation.isVisibleTo(form) is shown
+    assert form.label_rotation.isVisibleTo(form) is shown
 
 
 # --- the guards --------------------------------------------------------------
@@ -270,7 +275,7 @@ def test_the_refresh_button_asks_the_stage_where_it_is(movement, monkeypatch):
     monkeypatch.setattr(
         movement.microscope, "get_stage_position", _get_stage_position, raising=False
     )
-    movement.btn_refresh_stage.click()
+    movement.position_widget.btn_refresh.click()
 
     assert asked, "refresh did not read the stage"
     assert _boxes(movement)["x"].value() == pytest.approx(0.12, abs=1e-9)

--- a/tests/ui/test_viewer_less_widgets.py
+++ b/tests/ui/test_viewer_less_widgets.py
@@ -413,13 +413,14 @@ def test_setup_connections_wires_the_whole_widget():
 
     # early: the instructions label
     assert movement.label_movement_instructions.text() == INSTRUCTIONS_TEXT
-    # middle: stage limits pushed onto the spinboxes, and the acquisition hook
-    assert movement.doubleSpinBox_movement_stage_x.maximum() != 99.99, (
-        "stage limits unset"
-    )
+    # middle: the saved positions hand-off, and the orientation button text, which is
+    # rewritten from its constructed label a little further down
     assert movement.saved_positions_widget.microscope is not None, (
         "saved positions unwired"
     )
+    assert movement.pushButton_move_to_sem_orientation.text() == (
+        "Move to SEM Orientation"
+    ), "orientation button text unset"
     # late: milling-angle controls
     assert movement.doubleSpinBox_milling_angle.maximum() == 45
     assert movement.doubleSpinBox_milling_angle.suffix(), "milling angle suffix unset"


### PR DESCRIPTION
The follow-up [#624](https://github.com/fibsem-os/fibsem-os/pull/624) promised. Three files, all deletions and re-pointing — no behaviour change.

## The aliases

#624 kept eleven names on `FibsemMovementWidget` pointing at the extracted form's widgets — `doubleSpinBox_movement_stage_*`, `label_movement_stage_*`, `btn_refresh_stage`. They existed so the swap needed no host or test edits in the same PR, which is what kept that one to a single file.

Nothing outside the widget ever used them. The two test files that did now reach through `position_widget`, and a repo-wide grep for all three prefixes comes back empty.

Also drops the comment marking where the axis ranges *used* to be applied — the form says so in its own docstring now.

## The part that isn't bookkeeping: a wiring guard had gone dead

`test_setup_connections_wires_the_whole_widget` exists to catch a `setup_connections` truncated part-way through — it checks an early, a middle and a late point, so a cut anywhere shows up. Its middle assertion was *"stage limits pushed onto the spinboxes"*.

#624 moved the limits into `StagePositionWidget.__init__`, which runs during `_setup_ui`. So that assertion stopped testing `setup_connections` at all, and nobody noticed because it kept passing.

Demonstrated rather than argued — with `setup_connections` replaced by `return` on its first line:

```
setup_connections is a no-op, yet spinbox_x.maximum() = 0.9999
the OLD assertion (maximum() != 99.99) would be: True
```

Replaced with the orientation button's text, which `setup_connections` rewrites from its constructed label partway down. Verified the restored guard fails on a cut at each of three points:

| truncation point | result |
| -- | -- |
| before the saved-positions block | 1 failed |
| before the orientation button text | 1 failed |
| before the milling-angle block | 1 failed |
| (baseline) | 1 passed |

That is the one thing here worth reviewing carefully; the rest is renaming.

## What I deliberately did not do

**`AutoLamellaUI:410` stays on `movement_widget.update_ui`.** I had listed moving it onto `position_widget` as part of this cleanup. It isn't a cleanup — `update_ui` sets the spin boxes *and* calls `_update_position_readout`, which refreshes the canvas info bar. Pointing that caller at `position_widget.set_position` would silently drop the second half on every stage-position signal, on a path that fires throughout a move. `update_ui` is the correct surface for a host and it stays.

## Verification

105 tests green across `test_stage_position_readout`, `test_stage_position_widget`, `test_viewer_less_widgets`, `test_movement_progress`, `test_movement_worker_bodies`, `test_canvas_double_click_guards` and `test_movement_widget_vertical_gate`.

`ruff check` and `ruff format --check` clean on all three files.

Not run: the application. This PR deletes attribute aliases and re-points tests; there is no wiring change to see. #624's own launch covered the composed widget.

Note: merging this will auto-complete FIB-783 through the Linear attachment. The control half (`StageControlWidget`) is still outstanding, so reopen it.