### PR TITLE
[fix] Refuse a stage rotation while parked at the FM (FIB-841)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -442,6 +442,63 @@ class FibsemMicroscope(ABC):
         else:
             self.move_stage_absolute(stage_position)
 
+    def _refuse_rotation_at_the_fluorescence_microscope(
+        self, stage_position: FibsemStagePosition
+    ) -> None:
+        """Refuse a stage rotation while the stage is parked at the FM.
+
+        The objective is inserted over the sample there, and the rotation is
+        compucentric about a centre back at the beams -- some 48.8 mm away -- so a half
+        turn swings the sample most of the width of the chamber, under the objective.
+
+        The route to another pose at the FM is the one `get_target_position` computes:
+        traverse back to the beams, re-pose there, traverse out again. This refuses the
+        shortcut. It is a refusal rather than a silent correction because a caller
+        asking for the shortcut has a wrong idea of where the stage is going, and
+        quietly sending it somewhere else would leave that idea intact.
+
+        **Rotation only.** A tilt pivots about an axis through the sample instead of
+        swinging it, and where the objective does restrict tilt the microscope refuses
+        it itself -- FIB-640 measured z and t. This does not duplicate that.
+
+        Not a restriction on FM-MILLING. That pose is a half turn from the FM's own
+        orientation (measured: FM sits at r=180, MILLING at r=0), so it was never
+        reachable by rotating in place -- it is reached the way everything else at the
+        FM is, via the beams.
+
+        Dormant until the connection gate opens: `microscope.fm` is `None` on every
+        non-compustage system today, so nothing can park at the FM to begin with.
+        """
+        # A compustage reaches the FM by flipping, and its devices are the same place,
+        # so "parked at the FM" is not a state it can be in -- and it has no rotation
+        # axis to be compucentric about either.
+        if self.stage_is_compustage or self.fm is None:
+            return
+
+        if stage_position.r is None:
+            return
+
+        current_position = self.get_stage_position()
+        if self.get_current_device(current_position) != "FM":
+            return
+
+        from fibsem import movement
+
+        # The same 5 degrees `get_stage_orientation` classifies within, so a caller
+        # asking for the pose the stage is already in does not trip this on the slop a
+        # real stage always carries.
+        if movement.rotation_angle_is_smaller(
+            stage_position.r, current_position.r, atol=5
+        ):
+            return
+
+        raise ValueError(
+            "Cannot rotate the stage while it is at the fluorescence microscope: the "
+            "rotation is compucentric about a centre at the beams, so it would swing "
+            "the sample across the chamber under the objective. Move to the beams "
+            "first (move_to_microscope('FIBSEM')), re-pose there, and travel back."
+        )
+
     def move_to_orientation(self, orientation: str) -> FibsemStagePosition:
         """Move the stage to the given named orientation (e.g. 'SEM', 'FIB', 'MILLING').
         Args:
@@ -3493,6 +3550,11 @@ class ThermoMicroscope(FibsemMicroscope):
         """Move the stage to the desired position in a safe manner, using compucentric rotation.
         Supports movements in the stage_position coordinate system
         """
+        # Before anything moves. The staged move below rotates the stage where it
+        # stands, which is the correct order leaving the beams and the wrong one
+        # coming back from the FM -- see FIB-841.
+        self._refuse_rotation_at_the_fluorescence_microscope(stage_position)
+
         # safe movements are not required on the compustage, because it doesn't rotate
         if not self.stage_is_compustage:
             # tilt flat for large rotations to prevent collisions

--- a/fibsem/microscopes/tescan.py
+++ b/fibsem/microscopes/tescan.py
@@ -684,6 +684,10 @@ class TescanMicroscope(FibsemMicroscope):
         )
 
     def safe_absolute_stage_movement(self, stage_position: FibsemStagePosition) -> None:
+        # Inert until Tescan has a fluorescence microscope at all -- `self.fm` is set
+        # to None unconditionally here (FIB-836) -- but the guard belongs on every
+        # re-pose path, not only the ones that can reach it today.
+        self._refuse_rotation_at_the_fluorescence_microscope(stage_position)
 
         # TODO: implement if required.
         self.move_stage_absolute(stage_position)

--- a/tests/test_no_repose_at_fm.py
+++ b/tests/test_no_repose_at_fm.py
@@ -1,0 +1,176 @@
+"""Rotating the stage while it is parked at the fluorescence microscope.
+
+The objective is inserted over the sample there, and the rotation is compucentric
+about a centre back at the beams -- some 48.8 mm away -- so a half turn swings the
+sample most of the width of the chamber, underneath the objective.
+
+`get_target_position` already computes targets that keep the re-pose at the beams: the
+device legs bracket the orientation leg. But it computes a target, it does not order
+the moves, and `safe_absolute_stage_movement` rotates the stage *where it stands* --
+the right order leaving the beams and the wrong one coming back. This file is the
+refusal that closes that.
+
+See FIB-841.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.structures import FibsemStagePosition
+
+IFLM_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-iflm-configuration.yaml")
+ARCTIS_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
+
+
+def _microscope(config_path: str = IFLM_CONFIG):
+    microscope, _ = utils.setup_session(config_path=config_path)
+    return microscope
+
+
+def _parked_at_the_fm():
+    """An offset system at the FM. `move_to_microscope` accepts only FIB (FIB-832)."""
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+    microscope.move_to_microscope("FM")
+    assert microscope.get_current_device() == "FM"
+    return microscope
+
+
+# ── the refusal ──────────────────────────────────────────────────────
+
+
+def test_rotating_at_the_fm_is_refused():
+    """MILLING is the case that matters: it is a half turn from where the FM sits.
+
+    Measured on the offset simulator -- FM at r = 180, MILLING at r = 0 -- so this is
+    not an exotic request, it is the pose FM-MILLING wants (FIB-833).
+    """
+    microscope = _parked_at_the_fm()
+
+    with pytest.raises(ValueError, match="Cannot rotate the stage while it is at the"):
+        microscope.move_to_orientation("MILLING")
+
+
+def test_the_refusal_happens_before_anything_moves():
+    """A guard that fires after the first leg would leave the stage mid-manoeuvre.
+
+    `safe_absolute_stage_movement` tilts flat and then rotates, both real moves, so
+    the check has to come ahead of them rather than anywhere inside.
+    """
+    microscope = _parked_at_the_fm()
+    before = microscope.get_stage_position()
+
+    with pytest.raises(ValueError):
+        microscope.move_to_orientation("MILLING")
+
+    after = microscope.get_stage_position()
+    assert after.x == pytest.approx(before.x)
+    assert np.isclose(after.r, before.r)
+    assert np.isclose(after.t, before.t)
+
+
+def test_the_refusal_names_the_way_out():
+    """The route exists; a caller that hits this needs to be told it, not just stopped."""
+    microscope = _parked_at_the_fm()
+
+    with pytest.raises(ValueError, match=r"move_to_microscope\('FIBSEM'\)"):
+        microscope.move_to_orientation("MILLING")
+
+
+def test_the_way_out_actually_works():
+    """Traverse back to the beams, re-pose there. What the refusal tells you to do."""
+    microscope = _parked_at_the_fm()
+
+    microscope.move_to_microscope("FIBSEM")
+    microscope.move_to_orientation("MILLING")
+
+    assert microscope.get_current_device() == "FIBSEM"
+    assert microscope.get_stage_orientation() == "MILLING"
+
+
+def test_the_guard_is_on_the_movement_path_not_just_the_named_one():
+    """`move_to_orientation` is one caller of ten; the guard sits under all of them."""
+    microscope = _parked_at_the_fm()
+    milling = microscope.get_orientation("MILLING")
+
+    with pytest.raises(ValueError, match="Cannot rotate the stage"):
+        microscope.safe_absolute_stage_movement(milling)
+
+
+# ── what it does not refuse ──────────────────────────────────────────
+
+
+def test_the_pose_it_is_already_in_is_not_a_rotation():
+    """A real stage never sits at exactly 180.000, so the check has a tolerance.
+
+    The same five degrees `get_stage_orientation` classifies within, so "the pose I am
+    already in" and "the pose this position reads as" cannot disagree.
+    """
+    microscope = _parked_at_the_fm()
+
+    microscope.move_to_orientation("FIB")  # where it already is
+
+    assert microscope.get_current_device() == "FM"
+
+
+def test_a_tilt_alone_is_not_refused():
+    """A tilt pivots about an axis through the sample; it does not swing it.
+
+    Where the objective does restrict tilt, the microscope refuses it itself -- FIB-640
+    measured z and t. This guard does not duplicate that, and must not, or it would be
+    stricter than the hazard.
+    """
+    microscope = _parked_at_the_fm()
+    position = microscope.get_stage_position()
+    position.t = position.t + np.radians(3)
+
+    microscope.safe_absolute_stage_movement(position)
+
+    assert microscope.get_current_device() == "FM"
+
+
+def test_re_posing_at_the_beams_is_untouched():
+    """Every existing caller is at the beams, and none of them changes behaviour."""
+    microscope = _microscope()
+
+    for orientation in ("SEM", "FIB", "MILLING", "SEM"):
+        microscope.move_to_orientation(orientation)
+        assert microscope.get_stage_orientation() == orientation
+
+    assert microscope.get_current_device() == "FIBSEM"
+
+
+def test_a_compustage_is_not_affected():
+    """Its objective is under the grid: it reaches the FM by flipping, so "parked at
+    the FM" is not a state it can be in -- and it has no rotation axis to swing about."""
+    microscope = _microscope(ARCTIS_CONFIG)
+
+    microscope.move_to_microscope("FM")
+    microscope.move_to_orientation("SEM")
+
+    assert microscope.get_stage_orientation() == "SEM"
+
+
+def test_a_system_with_no_fluorescence_microscope_is_not_affected():
+    """Dormant until the connection gate opens.
+
+    `microscope.fm` is `None` on every non-compustage system today, so nothing can be
+    parked at the FM to begin with -- and a beam-only system must not be told it
+    cannot rotate somewhere it has every right to be.
+    """
+    microscope = _microscope(cfg.MICROSCOPE_CONFIGURATION_PATH)
+    assert microscope.fm is None
+
+    microscope.move_to_orientation("FIB")
+    microscope.move_stage_relative(
+        FibsemStagePosition(x=48.8e-3, y=0.0, z=0.0, r=0.0, t=0.0)
+    )
+    assert microscope.get_current_device() == "FM"
+
+    microscope.move_to_orientation("MILLING")
+
+    assert microscope.get_stage_orientation() == "MILLING"


### PR DESCRIPTION
The objective is inserted over the sample at the fluorescence microscope, and the rotation is compucentric about a centre back at the beams — some 48.8 mm away — so a half turn swings the sample most of the width of the chamber, underneath the objective.

## The existing "safe" path picks the hazardous order by itself

`get_target_position` already computes targets that keep the re-pose at the beams (#627). But it computes a target; it does not order the moves. `safe_absolute_stage_movement` stages its own:

```python
self._safe_rotation_movement(stage_position)          # tilt flat
self.move_stage_absolute(FibsemStagePosition(r=...))  # rotate, where it stands
self.move_stage_absolute(stage_position)              # then the rest
```

Rotating where the stage stands is correct leaving the beams and wrong coming back. So this is not only a caller mistake waiting to happen — ten call sites already funnel through a helper that would do it.

The guard sits at the top of that method, ahead of both moves. It **refuses rather than silently rerouting**: a caller asking for the shortcut has a wrong idea of where the stage is going, and quietly sending it elsewhere would leave that idea intact. The error names the way out, and a test walks that route to show it works.

## Rotation only

A tilt pivots about an axis through the sample instead of swinging it. Where the objective *does* restrict tilt, the microscope refuses it itself — FIB-640 measured z and t — so duplicating that here would be stricter than the hazard.

**It does not block FM-MILLING**, and an earlier reading of FIB-841 had this backwards (now corrected there). Measured on the offset simulator:

| orientation | r | t |
| -- | -- | -- |
| FIB / FM | 180° | 17° |
| MILLING | 0° | 12° |

FM-MILLING is a *half turn* from the FM's own orientation, so it was never reachable by rotating in place. The route is the one the transform computes — traverse to the beams, re-pose, traverse out. This refuses the shortcut, not the destination.

## Scope

One guard covers three backends: Demo and Odemis both delegate to `ThermoMicroscope.safe_absolute_stage_movement`. Tescan has its own stub and gets the same call — inert while its `fm` is `None` unconditionally (FIB-836), but the guard belongs on every re-pose path rather than only the ones reachable today.

## What changes, and what does not

**Dormant on every real system.** The guard is conditioned on `self.fm is not None`, and that is `None` on all non-compustage systems until the connection gate opens. A compustage returns early — it reaches the FM by flipping, so "parked at the FM" is not a state it can be in. At the beams the device check exits.

**It does change behaviour on the offset simulator**, which is the point, and it goes live on hardware the moment the gate opens — which is why it is a prerequisite for that rather than a follow-up to it.

The 5° tolerance is the same one `get_stage_orientation` classifies within, so asking for the pose the stage is already in does not trip on the slop a real stage always carries.

## Verification

`6664 passed, 23 skipped` on the full suite. 10 new tests, including that the refusal happens before *anything* moves (the staged move would otherwise leave the stage mid-manoeuvre), that a tilt alone is still allowed, and that the route named in the error message actually works.
