### PR TITLE
[test] Pin that travelling to a device does not re-pose the sample

### DIFF
--- a/tests/test_fm_device_position.py
+++ b/tests/test_fm_device_position.py
@@ -17,6 +17,7 @@ See FIB-830.
 import os
 from copy import deepcopy
 
+import numpy as np
 import pytest
 
 import fibsem.config as cfg
@@ -448,3 +449,34 @@ def test_devices_are_allowed_to_overlap():
 
     assert microscope.is_at_device("FIBSEM") is True
     assert microscope.is_at_device("FM") is True
+
+
+# ── what the traverse does not do ────────────────────────────────────
+
+
+def test_the_traverse_commands_only_the_axes_the_devices_differ_along():
+    """A device change is a translation, not a re-pose.
+
+    Worth pinning because the obvious refactor breaks it: `get_target_position` also
+    answers "where should the stage go", but it snaps r and t to the target
+    orientation's canonical pose. Reaching for it here would quietly discard a milling
+    angle an operator had dialled in. It converts a pose; the traverse relocates one.
+    """
+    microscope = _at_beam_x(_microscope(), 7.0)
+    # Three degrees off the nominal FIB tilt -- still inside the 5 degree band that
+    # `get_stage_orientation` calls FIB, so the traverse accepts it. Off-nominal is
+    # the whole point: at the canonical pose a snap is invisible, and this test would
+    # pass against the very refactor it exists to refuse.
+    microscope.move_stage_relative(
+        FibsemStagePosition(x=0.0, y=3.0e-3, z=1.0e-3, r=0.0, t=np.radians(3))
+    )
+    before = deepcopy(microscope.get_stage_position())
+
+    microscope.move_to_microscope("FM")
+    after = microscope.get_stage_position()
+
+    assert after.x == pytest.approx(before.x + 48.8e-3)
+    assert after.y == pytest.approx(before.y)
+    assert after.z == pytest.approx(before.z)
+    assert after.r == pytest.approx(before.r)
+    assert after.t == pytest.approx(before.t)


### PR DESCRIPTION
`move_to_microscope` translates the stage between devices. Nothing said it must leave the pose alone, and the obvious refactor breaks that quietly.

`get_target_position` also answers "where should the stage go", and now takes a `target_device`, so it reads as a drop-in replacement for the traverse's delta. It is not. It ends by writing the target orientation's canonical `r` and `t` — because it answers a *different* question, *what position corresponds to being in orientation X*, and an orientation is a canonical pose. Right for a conversion; wrong for a relocation.

Measured on the offset simulator, with the stage 3° off the nominal FIB tilt:

```
stage now           x =  7.00 mm   t = 20.00°     (nominal FIB is 17.00°)
get_target_position x = 55.80 mm   t = 17.00°   <- snapped
the traverse        x = 55.80 mm   t = 20.00°   <- preserved
```

Same x, different tilt. At MILLING those 3° are a milling angle somebody chose, and the traverse would have discarded them on the way to the FM.

## The off-nominal tilt is the test, not decoration

`get_stage_orientation` classifies within 5°, so a stage a few degrees out still reads as FIB and the traverse accepts it. Start the stage exactly on nominal and both functions agree, the snap becomes invisible, and the test passes against the very refactor it exists to refuse.

Verified by mutation rather than by argument: swapping the delta for `get_target_position` **fails** this test — and **failed to fail** an earlier version that started from the canonical pose. That earlier version was what I first wrote, and it was green.

## Scope

Test only, one file. No production change. This is what is left of a refactor that turned out to buy nothing — the traverse stays a relative move, which is also the more robust primitive here, since it depends on nothing that can go stale between the position read and the command.
