### PR TITLE
[refactor] Extract StageControlWidget from the Movement tab (FIB-783)

### DIFF
--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -1,39 +1,43 @@
-import logging
-from functools import partial
+"""The Movement tab: the panels an operator moves the stage from.
+
+A container. It lays out four things -- the position readout, the move actions, the
+saved-position list and, when the flag is on, the sample holder -- and forwards the
+handful of calls other windows make on the tab.
+
+The two halves it composes are separately owned (FIB-783):
+
+* ``StagePositionWidget`` says where the stage is and reads back what has been typed.
+  It has no host contract at all.
+* ``StageControlWidget`` moves the stage, and carries every coupling that requires:
+  the image widget, the milling widget and the quad-view controller.
+
+**The forwarding surface is not decoration.** Six call sites in four files reach a
+Movement tab, and they reach it as ``movement_widget`` -- ``move_to_position`` from both
+minimaps, the lamella list and AutoLamella's pose move; ``update_ui`` from
+AutoLamella's stage-position signal; ``_teardown_connections`` from both windows'
+disconnect paths; and ``_toggle_interactions`` from ``FibsemImageSettingsWidget``, which
+reaches back through the same attribute. Those names stay here.
+"""
+
 from typing import Optional
 
 from PyQt5 import QtWidgets
-from superqt import ensure_main_thread
 
 from fibsem import config as cfg
-from fibsem import constants, conversions
 from fibsem.microscope import FibsemMicroscope
-from fibsem.structures import (
-    BeamType,
-    FibsemStagePosition,
-    Point,
-)
-from fibsem.ui import notification_service
+from fibsem.structures import FibsemStagePosition
 from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
-from fibsem.ui.qt.threading import thread_worker
-from fibsem.ui.stylesheets import (
-    LABEL_INSTRUCTIONS_STYLE,
-    PRIMARY_BUTTON_STYLESHEET,
-    SECONDARY_BUTTON_STYLESHEET,
-)
-from fibsem.ui.utils import install_wheel_blocker
 from fibsem.ui.widgets.custom_widgets import TitledPanel
-from fibsem.ui.widgets.stage_position_widget import StagePositionWidget
 
-INSTRUCTIONS_TEXT = (
-    """Instructions: Double Click to Move. Alt + Double Click to Move Vertically"""
+# ACQUIRING_IMAGES and INSTRUCTIONS_TEXT are re-exported: they read as the Movement
+# tab's vocabulary rather than one widget's internals, and callers already import them
+# from here.
+from fibsem.ui.widgets.stage_control_widget import (  # noqa: F401  (re-export)
+    ACQUIRING_IMAGES,
+    INSTRUCTIONS_TEXT,
+    StageControlWidget,
 )
-
-# What every path says once the stage has arrived and the images are being retaken.
-# A constant rather than three string literals: the three movement paths had drifted
-# to "updating images", "taking new images" and, on the orientation path, nothing at
-# all -- so the same phase looked different depending on how the move was started.
-ACQUIRING_IMAGES = "Acquiring images…"
+from fibsem.ui.widgets.stage_position_widget import StagePositionWidget
 
 
 class FibsemMovementWidget(QtWidgets.QWidget):
@@ -43,11 +47,6 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         parent: QtWidgets.QWidget,
     ):
         super().__init__(parent=parent)
-        # Set before _setup_ui: the position form takes its axis ranges from the stage
-        # while it is being built, so it needs the microscope one step earlier than the
-        # rest of this widget did.
-        self.microscope = microscope
-        self._setup_ui()
         self.parent = parent
 
         if not hasattr(parent, "image_widget") or not isinstance(
@@ -57,20 +56,10 @@ class FibsemMovementWidget(QtWidgets.QWidget):
                 "Parent must have an 'image_widget' attribute of type FibsemImageSettingsWidget"
             )
 
+        self.microscope = microscope
         self.image_widget: FibsemImageSettingsWidget = parent.image_widget
+        self._setup_ui()
         self.setup_connections()
-
-    def _view_controller(self):
-        """Return the quad-view MicroscopeViewController, or None if unavailable.
-
-        Resolved like the image widget: the direct parent (standalone ``FibsemUI``) or
-        parent -> ``parent_widget`` (AutoLamella) holds ``view_controller``.
-        """
-        controller = getattr(self.parent, "view_controller", None)
-        if controller is not None:
-            return controller
-        parent_ui = getattr(self.parent, "parent_widget", None)
-        return getattr(parent_ui, "view_controller", None)
 
     def _setup_ui(self):
         # Outer layout
@@ -85,41 +74,22 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.gridLayout.addWidget(self.scrollArea, 0, 0, 1, 2)
 
         # --- Panel: Stage Movement ---
+        # The readout above the actions, in one panel, as they have always been shown.
         stage_content = QtWidgets.QWidget()
         self.gridLayout_3 = QtWidgets.QGridLayout(stage_content)
         self.gridLayout_3.setContentsMargins(0, 0, 0, 0)
 
-        # The readout and entry form: rows 0-4 of this grid used to be five spin boxes
-        # built here. It owns the units, the ranges and the compustage adjustments, and
-        # moves nothing (FIB-783).
         self.position_widget = StagePositionWidget(microscope=self.microscope)
-        self.gridLayout_3.addWidget(self.position_widget, 0, 0, 1, 2)
-
-        self.pushButton_move = QtWidgets.QPushButton("Move to Position")
-        self.gridLayout_3.addWidget(self.pushButton_move, 1, 0, 1, 2)
-
-        self.pushButton_move_to_sem_orientation = QtWidgets.QPushButton(
-            "Move Flat to ELECTRON Beam"
+        self.control_widget = StageControlWidget(
+            microscope=self.microscope,
+            position_widget=self.position_widget,
+            host=self.parent,
         )
-        self.pushButton_move_to_fib_orientation = QtWidgets.QPushButton(
-            "Move Flat to ION Beam"
-        )
-        self.gridLayout_3.addWidget(self.pushButton_move_to_sem_orientation, 2, 0)
-        self.gridLayout_3.addWidget(self.pushButton_move_to_fib_orientation, 2, 1)
-
-        self.doubleSpinBox_milling_angle = QtWidgets.QDoubleSpinBox()
-        self.pushButton_move_to_milling_angle = QtWidgets.QPushButton(
-            "Move to Milling Angle"
-        )
-        self.gridLayout_3.addWidget(self.doubleSpinBox_milling_angle, 3, 0)
-        self.gridLayout_3.addWidget(self.pushButton_move_to_milling_angle, 3, 1)
-
-        self.label_movement_instructions = QtWidgets.QLabel()
-        self.label_movement_instructions.setWordWrap(True)
-        self.gridLayout_3.addWidget(self.label_movement_instructions, 4, 0, 1, 2)
+        self.gridLayout_3.addWidget(self.position_widget, 0, 0)
+        self.gridLayout_3.addWidget(self.control_widget, 1, 0)
 
         # The form's button, in this panel's header rather than in the form's own grid
-        # -- the panel chrome is the host's.
+        # -- the panel chrome is the container's.
         self.stage_panel = TitledPanel(
             "Stage Movement", content=stage_content, collapsible=False
         )
@@ -137,13 +107,6 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         )
         self.gridLayout_2.addWidget(self.saved_positions_panel, 2, 0)
 
-        self._move_buttons = [
-            self.pushButton_move,
-            self.pushButton_move_to_fib_orientation,
-            self.pushButton_move_to_sem_orientation,
-            self.pushButton_move_to_milling_angle,
-        ]
-
         # Bottom spacer (row 4 — row 3 reserved for optional sample holder widget)
         self.gridLayout_2.addItem(
             QtWidgets.QSpacerItem(
@@ -154,92 +117,17 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         )
 
     def setup_connections(self):
-
-        # buttons
-        self.pushButton_move.clicked.connect(lambda: self.move_to_position(None))
-        self.pushButton_move_to_fib_orientation.clicked.connect(
-            lambda: self.move_to_orientation("FIB")
+        # The form asks for a refresh; the control half is the one allowed to read the
+        # device for it.
+        self.position_widget.refresh_requested.connect(
+            lambda: self.control_widget.update_ui(None)
         )
-        self.pushButton_move_to_sem_orientation.clicked.connect(
-            lambda: self.move_to_orientation("SEM")
-        )
-        # The form asks; this widget is the one allowed to read the device.
-        self.position_widget.refresh_requested.connect(lambda: self.update_ui(None))
-
-        # register mouse callbacks — one canvas per beam. The canvases are app-lifetime
-        # (owned by the controller), so store each (canvas, slot) pair and disconnect it in
-        # _teardown_connections: this widget is torn down via removeTab + deleteLater
-        # (which fires neither closeEvent nor close), and a stale double-click firing on the
-        # deleted widget makes PyQt call qFatal -> the process aborts (FIB-329).
-        # partial (not lambda) so the exact slot object can be disconnected.
-        self._canvas_dbl_click_conns = []
-        controller = self._view_controller()
-        if controller is not None:
-            for canvas, beam in (
-                (controller.sem_canvas, BeamType.ELECTRON),
-                (controller.fib_canvas, BeamType.ION),
-            ):
-                slot = partial(self._on_canvas_double_click, beam)
-                canvas.canvas_double_clicked.connect(slot)
-                self._canvas_dbl_click_conns.append((canvas, slot))
-
-        # disable ui elements
-        self.label_movement_instructions.setText(INSTRUCTIONS_TEXT)
-        self.label_movement_instructions.setStyleSheet(LABEL_INSTRUCTIONS_STYLE)
 
         # saved positions
         self.saved_positions_widget.microscope = self.microscope
         self.saved_positions_widget._header.btn_add.setEnabled(True)
         self.saved_positions_widget._load_default_positions()
         self.saved_positions_widget.move_to_requested.connect(self.move_to_position)
-
-        # signals
-        self.image_widget.acquisition_progress_signal.connect(
-            self.handle_acquisition_update
-        )
-
-        # stylesheets
-        self.pushButton_move.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
-        self.pushButton_move_to_fib_orientation.setStyleSheet(
-            SECONDARY_BUTTON_STYLESHEET
-        )
-        self.pushButton_move_to_sem_orientation.setStyleSheet(
-            SECONDARY_BUTTON_STYLESHEET
-        )
-        self.pushButton_move_to_milling_angle.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
-
-        # display orientation values on tooltips
-        self.pushButton_move_to_sem_orientation.setText("Move to SEM Orientation")
-        self.pushButton_move_to_fib_orientation.setText("Move to FIB Orientation")
-        sem = self.microscope.get_orientation("SEM")
-        fib = self.microscope.get_orientation("FIB")
-        milling = self.microscope.get_orientation("MILLING")
-        self.pushButton_move_to_sem_orientation.setToolTip(sem.pretty_orientation)
-        self.pushButton_move_to_fib_orientation.setToolTip(fib.pretty_orientation)
-        self.pushButton_move_to_milling_angle.setToolTip(milling.pretty_orientation)
-
-        # milling angle controls
-        self.doubleSpinBox_milling_angle.setValue(
-            self.microscope.system.stage.milling_angle
-        )  # deg
-        self.doubleSpinBox_milling_angle.setSuffix(constants.DEGREE_SYMBOL)
-        self.doubleSpinBox_milling_angle.setSingleStep(1.0)
-        self.doubleSpinBox_milling_angle.setDecimals(1)
-        self.doubleSpinBox_milling_angle.setRange(0, 45)
-        self.doubleSpinBox_milling_angle.setToolTip(
-            "The milling angle is the difference between the stage and the fib viewing angle."
-        )
-        self.doubleSpinBox_milling_angle.setKeyboardTracking(False)
-        self.doubleSpinBox_milling_angle.valueChanged.connect(
-            self._update_milling_angle
-        )
-        self.pushButton_move_to_milling_angle.clicked.connect(
-            lambda: self.move_to_orientation("MILLING")
-        )
-
-        # The form's degree suffixes and wheel guards moved with it. This one is the
-        # milling angle, which stays on this half.
-        install_wheel_blocker(self.doubleSpinBox_milling_angle)
 
         if cfg.FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED:
             from fibsem.ui.widgets.sample_holder_widget import SampleHolderWidget
@@ -248,355 +136,33 @@ class FibsemMovementWidget(QtWidgets.QWidget):
             self.sample_holder_widget.set_holder(self.microscope._stage.holder)
             self.gridLayout_2.addWidget(self.sample_holder_widget, 3, 0)
 
-        self.update_ui()
+        self.control_widget.update_ui()
 
-    def _teardown_connections(self) -> None:
-        """Disconnect from the app-lifetime quad-view canvases before this widget is
-        destroyed. The canvases outlive the per-connection movement widget; without this a
-        stale double-click after teardown fires on a deleted widget and PyQt aborts the
-        process. Idempotent — safe to call more than once."""
-        for canvas, slot in getattr(self, "_canvas_dbl_click_conns", []):
-            try:
-                canvas.canvas_double_clicked.disconnect(slot)
-            except (TypeError, RuntimeError):
-                pass
-        self._canvas_dbl_click_conns = []
+    # --- the surface other windows reach for ---------------------------------
 
-    def _toggle_interactions(self, enable: bool, caller: Optional[str] = None):
-        """Toggle the interactions in the widget depending on microscope state"""
-        for btn in self._move_buttons:
-            btn.setEnabled(enable)
-        self.doubleSpinBox_milling_angle.setEnabled(enable)
-        if caller is None:
-            # self.parent.milling_widget._toggle_interactions(enable, caller="movement")
-            self.parent.image_widget._toggle_interactions(enable, caller="movement")
-        # No disabled branch: both sheets carry a :disabled rule, so setEnabled
-        # above is what greys these out.
-        for btn in self._move_buttons:
-            btn.setStyleSheet(
-                PRIMARY_BUTTON_STYLESHEET
-                if btn is self.pushButton_move
-                else SECONDARY_BUTTON_STYLESHEET
-            )
-
-    def _report_move(self, msg: str) -> None:
-        """Say what the stage is doing, on the canvas info bar.
-
-        Written there rather than shown as toasts. These messages bracket a blocking
-        move -- one click-to-move produces four of them inside ~45 ms -- so as popups
-        they stack into a wall that says nothing the moving stage and the refreshing
-        images do not already show. On the info bar the same words stay put for the
-        duration of the move, which is when they are worth reading.
-
-        Toasts show unconditionally (FIB-781), so that wall of popups is what these
-        messages would actually produce rather than a thing to worry about later.
-        """
-        logging.debug(msg)
-        self._set_move_status(msg)
-
-    def _set_move_status(self, msg: Optional[str]) -> None:
-        """Put *msg* on the info bar of every canvas, or clear it when None.
-
-        Not the instructions label on this tab. Five of the six paths that start a
-        stage move start it from somewhere else -- the canvas beside the tabs (which
-        takes a double-click whatever tab is showing), either minimap, or the lamella
-        list -- so a message on the Movement tab is one the operator is usually not
-        looking at, where a toast could be read from anywhere. The info bar is beside
-        the canvas that was clicked, is visible from every tab, and is already where
-        the stage position this move is changing gets written.
-        """
-        controller = self._view_controller()
-        if controller is None:
-            return
-        controller.set_info(BeamType.ELECTRON, "move", msg)
-        controller.set_info(BeamType.ION, "move", msg)
-        controller.set_fm_info("move", msg)
-
-    def _update_position_readout(
+    def move_to_position(
         self, stage_position: Optional[FibsemStagePosition] = None
     ) -> None:
-        """Refresh the stage/beam readout on the quad-view info bar (debounced render)."""
-        controller = self._view_controller()
-        if controller is not None:
-            controller.update_info(self.microscope, stage_position=stage_position)
+        """Move the stage. ``None`` means the position typed into the form."""
+        self.control_widget.move_to_position(stage_position)
 
-    def handle_acquisition_update(self, ddict: dict):
-        """Handle acquisition updates from the image widget"""
-        is_finished = ddict.get("finished", False)
-        if is_finished:
-            # The other half of the hand-off above: a move's status outlives its
-            # `finished` so it covers the acquisition that follows, and this is what
-            # takes it down. A no-op when no move put anything there.
-            self._set_move_status(None)
-            self.update_ui()
+    def update_ui(self, stage_position: Optional[FibsemStagePosition] = None) -> None:
+        """Show *stage_position*, or read the stage when it is None."""
+        self.control_widget.update_ui(stage_position)
 
-    @ensure_main_thread
-    def update_ui(self, stage_position: Optional[FibsemStagePosition] = None):
-        """Update the UI with the current stage position and saved positions"""
-        if stage_position is None:
-            stage_position = self.microscope.get_stage_position()
-
-        self.position_widget.set_position(stage_position)
-
-        # update the current position label
-        self._update_position_readout(stage_position=stage_position)
-
-    @ensure_main_thread
-    def update_ui_after_movement(self, retake: bool = True):
-        # disable taking images after movement here
-        if (
-            retake is False
-            or self.microscope.is_acquiring
-            or self.microscope.fm is not None
-            and self.microscope.fm.objective.state == "Inserted"
-        ):
-            self.update_ui()
-            return
-        prefs = cfg.load_user_preferences()
-        acquire_sem = prefs.movement.acquire_sem_after_stage_movement
-        acquire_fib = prefs.movement.acquire_fib_after_stage_movement
-        if acquire_sem and acquire_fib:
-            self.image_widget.acquire_reference_images()
-            return
-        if acquire_sem:
-            self.image_widget.acquire_sem_image()
-        elif acquire_fib:
-            self.image_widget.acquire_fib_image()
-        else:
-            self.update_ui()
-
-    def _update_milling_angle(self):
-        """Update the milling angle in the microscope and the UI"""
-        milling_angle = self.doubleSpinBox_milling_angle.value()  # deg
-        self.microscope.set_milling_angle(milling_angle)
-
-        # refresh tooltip and overlay
-        milling = self.microscope.get_orientation("MILLING")
-        self.pushButton_move_to_milling_angle.setToolTip(milling.pretty_orientation)
-        self._update_position_readout()
-
-    #### MOVEMENT
-
-    def move_to_position(self, stage_position: Optional[FibsemStagePosition] = None):
-        """Move the stage to the position specified in the UI"""
-        if stage_position is None:
-            stage_position = self.get_position_from_ui()
-        self._move_to_absolute_position(stage_position)
-
-    def _move_to_absolute_position(self, stage_position: FibsemStagePosition):
-        """Move the stage to the specified position"""
-        self._toggle_interactions(enable=False)
-        # Said here rather than from inside the worker: this is the GUI thread, so the
-        # status is on the info bar before the stage starts moving instead of racing the
-        # move through the event loop.
-        self._report_move(f"Moving to {stage_position.pretty}…")
-        worker = self.absolute_movement_worker(stage_position=stage_position)
-        worker.returned.connect(self._on_stage_move_returned)
-        worker.finished.connect(self.move_stage_finished)
-        worker.start()
-
-    @thread_worker
-    def absolute_movement_worker(self, stage_position: FibsemStagePosition) -> None:
-        """Move the stage. Runs off the GUI thread — only signals may cross back."""
-        self.microscope.safe_absolute_stage_movement(stage_position)
-
-    def _on_stage_move_returned(self, _result: object = None) -> None:
-        """The move landed: say the images are coming, and retake them. GUI thread.
-
-        Hangs off ``returned``, not ``finished``, so a move that raised skips it — the
-        widget never claims to be retaking images for a move that did not happen.
-
-        Ordering matters here and is not incidental. ``FunctionWorker`` emits
-        ``returned`` before ``finished``, so the acquisition this queues is already
-        under way by the time ``move_stage_finished`` asks whether it is, and the
-        buttons stay disabled until the images actually land.
-        """
-        self._report_move(ACQUIRING_IMAGES)
-        self.update_ui_after_movement()
-
-    def move_stage_finished(self):
-        """Handle the completion of a stage movement.
-
-        Every path reaches here: each worker connects ``finished`` to this.
-        """
-        is_acquiring = self.image_widget.is_acquiring
-        if not is_acquiring:
-            # Cleared, or the last line sits there afterwards as though the stage were
-            # still moving.
-            self._set_move_status(None)
-        # The usual case is that it *is* still acquiring, because
-        # `update_ui_after_movement` only queues the acquisition before the worker
-        # returns. Neither the status nor the buttons come back in that window: the
-        # status would say "done" over a second of acquisition, and offer a
-        # double-click that is still disabled. `handle_acquisition_update` clears it
-        # when the images actually land.
-        self._update_position_readout()
-        if is_acquiring:
-            return
-        self._toggle_interactions(enable=True)
-
-    def get_position_from_ui(self):
-        """Get the stage position from the UI"""
-
+    def get_position_from_ui(self) -> FibsemStagePosition:
+        """What is currently typed into the form."""
         return self.position_widget.get_position()
 
-    def _click_to_move_available(self) -> bool:
-        """Whether a click may start a stage move right now.
+    def _toggle_interactions(self, enable: bool, caller: Optional[str] = None) -> None:
+        """Enable or disable the move actions. ``FibsemImageSettingsWidget`` calls this
+        with ``caller="ui"`` to stop the handshake bouncing back."""
+        self.control_widget._toggle_interactions(enable, caller=caller)
 
-        Click-to-move is the same action as the Move button, so it honours the same
-        enabled state — `_toggle_interactions` disables the buttons for the whole move
-        *and* the acquisition that follows it (`move_stage_finished` deliberately returns
-        early while `image_widget.is_acquiring`). Only the buttons were ever gated,
-        though: a click landing in that window started a second, overlapping stage move
-        and a second acquisition on the same microscope, which is how a SEM frame ended
-        up on the FIB canvas.
+    def _teardown_connections(self) -> None:
+        """Drop the canvas double-click registrations before this tab is destroyed.
+
+        The canvases outlive it, and a stale double-click on a deleted widget makes
+        PyQt abort the process (FIB-329). Idempotent.
         """
-        return self.pushButton_move.isEnabled()
-
-    def _execute_stage_move(
-        self,
-        beam_type: BeamType,
-        point: Point,
-        vertical_move: bool,
-        coords: Optional[dict] = None,
-    ) -> None:
-        """Start a stage move from a microscope-space delta (GUI thread).
-
-        ``coords`` is the
-        originating image-space click, carried through purely so the debug log still
-        records where the operator actually clicked when a move goes wrong on hardware.
-
-        The backend-capability refusal below is the last thing that can decline the
-        move, so nothing is committed until it has had its say: the buttons are not
-        disabled, and no worker is started, for a move that is about to be refused.
-        """
-        movement_mode = "Vertical" if vertical_move else "Stable"
-
-        logging.debug(
-            {
-                "msg": "stage_movement",  # message type
-                "movement_mode": movement_mode,  # movement mode
-                "beam_type": beam_type.name,  # beam type
-                "dm": point.to_dict(),  # shift in microscope coordinates
-                "coords": coords,  # coords in image coordinates
-            }
-        )
-
-        # refuse rather than silently fall through to stable_move below: on a backend
-        # that cannot correct coincidence from this view, the operator would ask to
-        # restore coincidence and get a sample-plane move instead
-        if vertical_move and not self.microscope.supports_vertical_move(beam_type):
-            view = "SEM" if beam_type is BeamType.ELECTRON else "FIB"
-            logging.warning(
-                f"Vertical move from the {view} view is not supported on this system."
-            )
-            notification_service.show_toast(
-                f"Vertical move from the {view} view is not supported on this system - use the other view.",
-                "warning",
-            )
-            return
-
-        self._toggle_interactions(enable=False)
-        # Which kind of move, because they are different operations and the user chose
-        # between them: a plain double-click moves laterally, Alt + double-click moves
-        # along the beam axis to hold eucentricity. "Vertically" rather than
-        # "eucentric" so the message matches the words already on screen in
-        # INSTRUCTIONS_TEXT.
-        self._report_move(
-            "Moving the stage vertically…" if vertical_move else "Moving the stage…"
-        )
-        worker = self._stage_move_worker(beam_type, point, vertical_move)
-        worker.returned.connect(self._on_stage_move_returned)
-        worker.finished.connect(self.move_stage_finished)
-        worker.start()
-
-    @thread_worker
-    def _stage_move_worker(
-        self, beam_type: BeamType, point: Point, vertical_move: bool
-    ) -> None:
-        """Move the stage. Runs off the GUI thread — only signals may cross back.
-
-        Which of the two calls applies is decided from arguments, not from widget
-        state: the beam and the modifier were resolved by the caller while it was still
-        on the GUI thread.
-        """
-        if vertical_move:
-            # TMP: an x offset measured in the SEM view is still discarded
-            dx = point.x if beam_type is BeamType.ION else 0
-            self.microscope.vertical_move(dx=dx, dy=point.y, beam_type=beam_type)
-        else:
-            # corrected stage movement
-            self.microscope.stable_move(
-                dx=point.x,
-                dy=point.y,
-                beam_type=beam_type,
-            )
-
-    def _on_canvas_double_click(
-        self, beam_type: BeamType, x: float, y: float, modifiers
-    ) -> None:
-        """Canvas double-click -> move stage.
-
-        Every guard is answered here, on the GUI thread, before anything is committed.
-        They used to run inside the worker, which meant a click that was never going to
-        move the stage still disabled the buttons, spawned a thread to decide that, and
-        re-enabled them — and still reported ``finished``, refreshing the stage readout
-        for a move that never happened.
-
-        Answering them here also makes them atomic with respect to the event loop: the
-        whole decision is one handler, so nothing can change ``is_milling`` or swap the
-        image out between the check and the dispatch.
-
-        ``x, y`` are already beam-local, full-resolution image pixels — the canvas emits
-        data coords, one image per canvas, so there is no side-by-side offset to undo.
-        """
-        if not self._click_to_move_available():
-            return
-        if "Shift" in modifiers:
-            return
-        if (
-            hasattr(self.parent, "milling_widget")
-            and self.parent.milling_widget.is_milling
-        ):
-            notification_service.show_toast(
-                "Cannot move stage while milling is in progress."
-            )
-            return
-        image = (
-            self.image_widget.eb_image
-            if beam_type is BeamType.ELECTRON
-            else self.image_widget.ib_image
-        )
-        if image is None or image.metadata is None:
-            notification_service.show_toast("No image available to move from.")
-            return
-        h, w = image.data.shape[:2]
-        if not (0 <= x < w and 0 <= y < h):
-            return  # click landed outside the image area
-        point = conversions.image_to_microscope_image_coordinates(
-            coord=Point(x=x, y=y),
-            image=image.data,
-            pixelsize=image.metadata.pixel_size.x,
-        )
-        self._execute_stage_move(
-            beam_type, point, "Alt" in modifiers, coords={"x": x, "y": y}
-        )
-
-    def move_to_orientation(self, orientation: str) -> None:
-        """Move to the specifed orientation"""
-        if orientation not in ["SEM", "FIB", "MILLING"]:
-            raise ValueError(f"Invalid orientation: {orientation}")
-        self._toggle_interactions(False)
-        self._report_move(f"Moving to the {orientation} orientation…")
-        worker = self.move_to_orientation_worker(orientation)
-        # The orientation path never reported the acquisition, so the label sat on
-        # "Moving to the SEM orientation…" while the move had finished and the images
-        # were being retaken. Both paths now share the one slot that says it.
-        worker.returned.connect(self._on_stage_move_returned)
-        worker.finished.connect(self.move_stage_finished)
-        worker.start()
-
-    @thread_worker
-    def move_to_orientation_worker(self, orientation: str) -> None:
-        """Move the stage. Runs off the GUI thread — only signals may cross back."""
-        self.microscope.move_to_orientation(orientation)
+        self.control_widget._teardown_connections()

--- a/fibsem/ui/widgets/stage_control_widget.py
+++ b/fibsem/ui/widgets/stage_control_widget.py
@@ -1,0 +1,572 @@
+"""The stage movement actions: the buttons, their workers, and click-to-move.
+
+Everything on the Movement tab that *moves* the stage. The readout it moves is
+``StagePositionWidget``, which this widget writes to but does not otherwise own.
+
+Extracted from ``FibsemMovementWidget`` (FIB-783), which is now the container: it lays
+out the panels and forwards the four calls hosts make.
+
+**Why this half keeps the parent contract.** It reaches three neighbours, and none of
+them is optional decoration:
+
+* ``host.image_widget`` -- the interaction handshake (the buttons stay down through the
+  acquisition that follows a move, and the image widget brings them back), the live
+  image a canvas click is resolved against, and the acquisition-finished signal.
+* ``host.milling_widget`` -- refuses a click-to-move while milling. Optional, so it is
+  reached through ``hasattr``.
+* the quad-view controller -- where move status and the position readout are written.
+
+``StagePositionWidget`` needs none of that, which is why it came out first and needs no
+host at all.
+
+**The teardown is load-bearing.** The canvases are app-lifetime and outlive this widget,
+which is destroyed by ``removeTab`` + ``deleteLater`` -- neither of which fires
+``closeEvent``. A stale double-click arriving after that makes PyQt call ``qFatal`` and
+the process aborts (FIB-329). Whatever else changes here, registration and
+``_teardown_connections`` stay together.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import partial
+from typing import Optional
+
+from PyQt5.QtWidgets import QDoubleSpinBox, QGridLayout, QLabel, QPushButton, QWidget
+from superqt import ensure_main_thread
+
+from fibsem import config as cfg
+from fibsem import constants, conversions
+from fibsem.microscope import FibsemMicroscope
+from fibsem.structures import BeamType, FibsemStagePosition, Point
+from fibsem.ui import notification_service
+from fibsem.ui.qt.threading import thread_worker
+from fibsem.ui.stylesheets import (
+    LABEL_INSTRUCTIONS_STYLE,
+    PRIMARY_BUTTON_STYLESHEET,
+    SECONDARY_BUTTON_STYLESHEET,
+)
+from fibsem.ui.utils import install_wheel_blocker
+from fibsem.ui.widgets.stage_position_widget import StagePositionWidget
+
+INSTRUCTIONS_TEXT = (
+    """Instructions: Double Click to Move. Alt + Double Click to Move Vertically"""
+)
+
+# What every path says once the stage has arrived and the images are being retaken.
+# A constant rather than three string literals: the three movement paths had drifted
+# to "updating images", "taking new images" and, on the orientation path, nothing at
+# all -- so the same phase looked different depending on how the move was started.
+ACQUIRING_IMAGES = "Acquiring images…"
+
+ORIENTATIONS = ("SEM", "FIB", "MILLING")
+
+
+class StageControlWidget(QWidget):
+    """The move actions for one stage, and the state that says whether they may run.
+
+    Parameters
+    ----------
+    microscope:
+        The stage being moved.
+    position_widget:
+        The readout this widget writes after a move, and reads when the Move button is
+        pressed with nothing passed in.
+    host:
+        The window that owns the Movement tab -- ``FibsemUI`` or ``AutoLamellaUI``. Must
+        carry ``image_widget``; ``view_controller`` and ``milling_widget`` are resolved
+        from it when present.
+    """
+
+    def __init__(
+        self,
+        microscope: FibsemMicroscope,
+        position_widget: StagePositionWidget,
+        host: QWidget,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.microscope = microscope
+        self.position_widget = position_widget
+        self.host = host
+        self.image_widget = host.image_widget
+        self._setup_ui()
+        self.setup_connections()
+
+    # --- construction --------------------------------------------------------
+
+    def _setup_ui(self) -> None:
+        layout = QGridLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self.pushButton_move = QPushButton("Move to Position")
+        layout.addWidget(self.pushButton_move, 0, 0, 1, 2)
+
+        self.pushButton_move_to_sem_orientation = QPushButton(
+            "Move Flat to ELECTRON Beam"
+        )
+        self.pushButton_move_to_fib_orientation = QPushButton("Move Flat to ION Beam")
+        layout.addWidget(self.pushButton_move_to_sem_orientation, 1, 0)
+        layout.addWidget(self.pushButton_move_to_fib_orientation, 1, 1)
+
+        self.doubleSpinBox_milling_angle = QDoubleSpinBox()
+        self.pushButton_move_to_milling_angle = QPushButton("Move to Milling Angle")
+        layout.addWidget(self.doubleSpinBox_milling_angle, 2, 0)
+        layout.addWidget(self.pushButton_move_to_milling_angle, 2, 1)
+
+        self.label_movement_instructions = QLabel()
+        self.label_movement_instructions.setWordWrap(True)
+        layout.addWidget(self.label_movement_instructions, 3, 0, 1, 2)
+
+        self._move_buttons = [
+            self.pushButton_move,
+            self.pushButton_move_to_fib_orientation,
+            self.pushButton_move_to_sem_orientation,
+            self.pushButton_move_to_milling_angle,
+        ]
+
+    def setup_connections(self) -> None:
+        # buttons
+        self.pushButton_move.clicked.connect(lambda: self.move_to_position(None))
+        self.pushButton_move_to_fib_orientation.clicked.connect(
+            lambda: self.move_to_orientation("FIB")
+        )
+        self.pushButton_move_to_sem_orientation.clicked.connect(
+            lambda: self.move_to_orientation("SEM")
+        )
+
+        # register mouse callbacks — one canvas per beam. The canvases are app-lifetime
+        # (owned by the controller), so store each (canvas, slot) pair and disconnect it in
+        # _teardown_connections: this widget is torn down via removeTab + deleteLater
+        # (which fires neither closeEvent nor close), and a stale double-click firing on the
+        # deleted widget makes PyQt call qFatal -> the process aborts (FIB-329).
+        # partial (not lambda) so the exact slot object can be disconnected.
+        self._canvas_dbl_click_conns = []
+        controller = self._view_controller()
+        if controller is not None:
+            for canvas, beam in (
+                (controller.sem_canvas, BeamType.ELECTRON),
+                (controller.fib_canvas, BeamType.ION),
+            ):
+                slot = partial(self._on_canvas_double_click, beam)
+                canvas.canvas_double_clicked.connect(slot)
+                self._canvas_dbl_click_conns.append((canvas, slot))
+
+        # disable ui elements
+        self.label_movement_instructions.setText(INSTRUCTIONS_TEXT)
+        self.label_movement_instructions.setStyleSheet(LABEL_INSTRUCTIONS_STYLE)
+
+        # signals
+        self.image_widget.acquisition_progress_signal.connect(
+            self.handle_acquisition_update
+        )
+
+        # stylesheets
+        self.pushButton_move.setStyleSheet(PRIMARY_BUTTON_STYLESHEET)
+        self.pushButton_move_to_fib_orientation.setStyleSheet(
+            SECONDARY_BUTTON_STYLESHEET
+        )
+        self.pushButton_move_to_sem_orientation.setStyleSheet(
+            SECONDARY_BUTTON_STYLESHEET
+        )
+        self.pushButton_move_to_milling_angle.setStyleSheet(SECONDARY_BUTTON_STYLESHEET)
+
+        # display orientation values on tooltips
+        self.pushButton_move_to_sem_orientation.setText("Move to SEM Orientation")
+        self.pushButton_move_to_fib_orientation.setText("Move to FIB Orientation")
+        sem = self.microscope.get_orientation("SEM")
+        fib = self.microscope.get_orientation("FIB")
+        milling = self.microscope.get_orientation("MILLING")
+        self.pushButton_move_to_sem_orientation.setToolTip(sem.pretty_orientation)
+        self.pushButton_move_to_fib_orientation.setToolTip(fib.pretty_orientation)
+        self.pushButton_move_to_milling_angle.setToolTip(milling.pretty_orientation)
+
+        # milling angle controls
+        self.doubleSpinBox_milling_angle.setValue(
+            self.microscope.system.stage.milling_angle
+        )  # deg
+        self.doubleSpinBox_milling_angle.setSuffix(constants.DEGREE_SYMBOL)
+        self.doubleSpinBox_milling_angle.setSingleStep(1.0)
+        self.doubleSpinBox_milling_angle.setDecimals(1)
+        self.doubleSpinBox_milling_angle.setRange(0, 45)
+        self.doubleSpinBox_milling_angle.setToolTip(
+            "The milling angle is the difference between the stage and the fib viewing angle."
+        )
+        self.doubleSpinBox_milling_angle.setKeyboardTracking(False)
+        self.doubleSpinBox_milling_angle.valueChanged.connect(
+            self._update_milling_angle
+        )
+        self.pushButton_move_to_milling_angle.clicked.connect(
+            lambda: self.move_to_orientation("MILLING")
+        )
+
+        # The form's own boxes are guarded where they are built. This one is the milling
+        # angle, which belongs to this half.
+        install_wheel_blocker(self.doubleSpinBox_milling_angle)
+
+    def _teardown_connections(self) -> None:
+        """Disconnect from the app-lifetime quad-view canvases before this widget is
+        destroyed. The canvases outlive the per-connection movement widget; without this a
+        stale double-click after teardown fires on a deleted widget and PyQt aborts the
+        process. Idempotent — safe to call more than once."""
+        for canvas, slot in getattr(self, "_canvas_dbl_click_conns", []):
+            try:
+                canvas.canvas_double_clicked.disconnect(slot)
+            except (TypeError, RuntimeError):
+                pass
+        self._canvas_dbl_click_conns = []
+
+    # --- the neighbours ------------------------------------------------------
+
+    def _view_controller(self):
+        """Return the quad-view MicroscopeViewController, or None if unavailable.
+
+        Resolved like the image widget: the host (standalone ``FibsemUI``) or
+        host -> ``parent_widget`` (AutoLamella) holds ``view_controller``.
+        """
+        controller = getattr(self.host, "view_controller", None)
+        if controller is not None:
+            return controller
+        parent_ui = getattr(self.host, "parent_widget", None)
+        return getattr(parent_ui, "view_controller", None)
+
+    def _toggle_interactions(self, enable: bool, caller: Optional[str] = None):
+        """Toggle the interactions in the widget depending on microscope state"""
+        for btn in self._move_buttons:
+            btn.setEnabled(enable)
+        self.doubleSpinBox_milling_angle.setEnabled(enable)
+        if caller is None:
+            self.host.image_widget._toggle_interactions(enable, caller="movement")
+        # No disabled branch: both sheets carry a :disabled rule, so setEnabled
+        # above is what greys these out.
+        for btn in self._move_buttons:
+            btn.setStyleSheet(
+                PRIMARY_BUTTON_STYLESHEET
+                if btn is self.pushButton_move
+                else SECONDARY_BUTTON_STYLESHEET
+            )
+
+    # --- saying what the stage is doing --------------------------------------
+
+    def _report_move(self, msg: str) -> None:
+        """Say what the stage is doing, on the canvas info bar.
+
+        Written there rather than shown as toasts. These messages bracket a blocking
+        move -- one click-to-move produces four of them inside ~45 ms -- so as popups
+        they stack into a wall that says nothing the moving stage and the refreshing
+        images do not already show. On the info bar the same words stay put for the
+        duration of the move, which is when they are worth reading.
+
+        Toasts show unconditionally (FIB-781), so that wall of popups is what these
+        messages would actually produce rather than a thing to worry about later.
+        """
+        logging.debug(msg)
+        self._set_move_status(msg)
+
+    def _set_move_status(self, msg: Optional[str]) -> None:
+        """Put *msg* on the info bar of every canvas, or clear it when None.
+
+        Not the instructions label on this tab. Five of the six paths that start a
+        stage move start it from somewhere else -- the canvas beside the tabs (which
+        takes a double-click whatever tab is showing), either minimap, or the lamella
+        list -- so a message on the Movement tab is one the operator is usually not
+        looking at, where a toast could be read from anywhere. The info bar is beside
+        the canvas that was clicked, is visible from every tab, and is already where
+        the stage position this move is changing gets written.
+        """
+        controller = self._view_controller()
+        if controller is None:
+            return
+        controller.set_info(BeamType.ELECTRON, "move", msg)
+        controller.set_info(BeamType.ION, "move", msg)
+        controller.set_fm_info("move", msg)
+
+    def _update_position_readout(
+        self, stage_position: Optional[FibsemStagePosition] = None
+    ) -> None:
+        """Refresh the stage/beam readout on the quad-view info bar (debounced render)."""
+        controller = self._view_controller()
+        if controller is not None:
+            controller.update_info(self.microscope, stage_position=stage_position)
+
+    def handle_acquisition_update(self, ddict: dict):
+        """Handle acquisition updates from the image widget"""
+        is_finished = ddict.get("finished", False)
+        if is_finished:
+            # The other half of the hand-off above: a move's status outlives its
+            # `finished` so it covers the acquisition that follows, and this is what
+            # takes it down. A no-op when no move put anything there.
+            self._set_move_status(None)
+            self.update_ui()
+
+    @ensure_main_thread
+    def update_ui(self, stage_position: Optional[FibsemStagePosition] = None):
+        """Update the UI with the current stage position and saved positions"""
+        if stage_position is None:
+            stage_position = self.microscope.get_stage_position()
+
+        self.position_widget.set_position(stage_position)
+
+        # update the current position label
+        self._update_position_readout(stage_position=stage_position)
+
+    @ensure_main_thread
+    def update_ui_after_movement(self, retake: bool = True):
+        # disable taking images after movement here
+        if (
+            retake is False
+            or self.microscope.is_acquiring
+            or self.microscope.fm is not None
+            and self.microscope.fm.objective.state == "Inserted"
+        ):
+            self.update_ui()
+            return
+        prefs = cfg.load_user_preferences()
+        acquire_sem = prefs.movement.acquire_sem_after_stage_movement
+        acquire_fib = prefs.movement.acquire_fib_after_stage_movement
+        if acquire_sem and acquire_fib:
+            self.image_widget.acquire_reference_images()
+            return
+        if acquire_sem:
+            self.image_widget.acquire_sem_image()
+        elif acquire_fib:
+            self.image_widget.acquire_fib_image()
+        else:
+            self.update_ui()
+
+    def _update_milling_angle(self):
+        """Update the milling angle in the microscope and the UI"""
+        milling_angle = self.doubleSpinBox_milling_angle.value()  # deg
+        self.microscope.set_milling_angle(milling_angle)
+
+        # refresh tooltip and overlay
+        milling = self.microscope.get_orientation("MILLING")
+        self.pushButton_move_to_milling_angle.setToolTip(milling.pretty_orientation)
+        self._update_position_readout()
+
+    # --- moving to a position ------------------------------------------------
+
+    def move_to_position(self, stage_position: Optional[FibsemStagePosition] = None):
+        """Move the stage to the position specified in the UI"""
+        if stage_position is None:
+            stage_position = self.get_position_from_ui()
+        self._move_to_absolute_position(stage_position)
+
+    def _move_to_absolute_position(self, stage_position: FibsemStagePosition):
+        """Move the stage to the specified position"""
+        self._toggle_interactions(enable=False)
+        # Said here rather than from inside the worker: this is the GUI thread, so the
+        # status is on the info bar before the stage starts moving instead of racing the
+        # move through the event loop.
+        self._report_move(f"Moving to {stage_position.pretty}…")
+        worker = self.absolute_movement_worker(stage_position=stage_position)
+        worker.returned.connect(self._on_stage_move_returned)
+        worker.finished.connect(self.move_stage_finished)
+        worker.start()
+
+    @thread_worker
+    def absolute_movement_worker(self, stage_position: FibsemStagePosition) -> None:
+        """Move the stage. Runs off the GUI thread — only signals may cross back."""
+        self.microscope.safe_absolute_stage_movement(stage_position)
+
+    def _on_stage_move_returned(self, _result: object = None) -> None:
+        """The move landed: say the images are coming, and retake them. GUI thread.
+
+        Hangs off ``returned``, not ``finished``, so a move that raised skips it — the
+        widget never claims to be retaking images for a move that did not happen.
+
+        Ordering matters here and is not incidental. ``FunctionWorker`` emits
+        ``returned`` before ``finished``, so the acquisition this queues is already
+        under way by the time ``move_stage_finished`` asks whether it is, and the
+        buttons stay disabled until the images actually land.
+        """
+        self._report_move(ACQUIRING_IMAGES)
+        self.update_ui_after_movement()
+
+    def move_stage_finished(self):
+        """Handle the completion of a stage movement.
+
+        Every path reaches here: each worker connects ``finished`` to this.
+        """
+        is_acquiring = self.image_widget.is_acquiring
+        if not is_acquiring:
+            # Cleared, or the last line sits there afterwards as though the stage were
+            # still moving.
+            self._set_move_status(None)
+        # The usual case is that it *is* still acquiring, because
+        # `update_ui_after_movement` only queues the acquisition before the worker
+        # returns. Neither the status nor the buttons come back in that window: the
+        # status would say "done" over a second of acquisition, and offer a
+        # double-click that is still disabled. `handle_acquisition_update` clears it
+        # when the images actually land.
+        self._update_position_readout()
+        if is_acquiring:
+            return
+        self._toggle_interactions(enable=True)
+
+    def get_position_from_ui(self) -> FibsemStagePosition:
+        """Get the stage position from the UI"""
+
+        return self.position_widget.get_position()
+
+    # --- moving from a canvas click ------------------------------------------
+
+    def _click_to_move_available(self) -> bool:
+        """Whether a click may start a stage move right now.
+
+        Click-to-move is the same action as the Move button, so it honours the same
+        enabled state — `_toggle_interactions` disables the buttons for the whole move
+        *and* the acquisition that follows it (`move_stage_finished` deliberately returns
+        early while `image_widget.is_acquiring`). Only the buttons were ever gated,
+        though: a click landing in that window started a second, overlapping stage move
+        and a second acquisition on the same microscope, which is how a SEM frame ended
+        up on the FIB canvas.
+        """
+        return self.pushButton_move.isEnabled()
+
+    def _execute_stage_move(
+        self,
+        beam_type: BeamType,
+        point: Point,
+        vertical_move: bool,
+        coords: Optional[dict] = None,
+    ) -> None:
+        """Start a stage move from a microscope-space delta (GUI thread).
+
+        ``coords`` is the
+        originating image-space click, carried through purely so the debug log still
+        records where the operator actually clicked when a move goes wrong on hardware.
+
+        The backend-capability refusal below is the last thing that can decline the
+        move, so nothing is committed until it has had its say: the buttons are not
+        disabled, and no worker is started, for a move that is about to be refused.
+        """
+        movement_mode = "Vertical" if vertical_move else "Stable"
+
+        logging.debug(
+            {
+                "msg": "stage_movement",  # message type
+                "movement_mode": movement_mode,  # movement mode
+                "beam_type": beam_type.name,  # beam type
+                "dm": point.to_dict(),  # shift in microscope coordinates
+                "coords": coords,  # coords in image coordinates
+            }
+        )
+
+        # refuse rather than silently fall through to stable_move below: on a backend
+        # that cannot correct coincidence from this view, the operator would ask to
+        # restore coincidence and get a sample-plane move instead
+        if vertical_move and not self.microscope.supports_vertical_move(beam_type):
+            view = "SEM" if beam_type is BeamType.ELECTRON else "FIB"
+            logging.warning(
+                f"Vertical move from the {view} view is not supported on this system."
+            )
+            notification_service.show_toast(
+                f"Vertical move from the {view} view is not supported on this system - use the other view.",
+                "warning",
+            )
+            return
+
+        self._toggle_interactions(enable=False)
+        # Which kind of move, because they are different operations and the user chose
+        # between them: a plain double-click moves laterally, Alt + double-click moves
+        # along the beam axis to hold eucentricity. "Vertically" rather than
+        # "eucentric" so the message matches the words already on screen in
+        # INSTRUCTIONS_TEXT.
+        self._report_move(
+            "Moving the stage vertically…" if vertical_move else "Moving the stage…"
+        )
+        worker = self._stage_move_worker(beam_type, point, vertical_move)
+        worker.returned.connect(self._on_stage_move_returned)
+        worker.finished.connect(self.move_stage_finished)
+        worker.start()
+
+    @thread_worker
+    def _stage_move_worker(
+        self, beam_type: BeamType, point: Point, vertical_move: bool
+    ) -> None:
+        """Move the stage. Runs off the GUI thread — only signals may cross back.
+
+        Which of the two calls applies is decided from arguments, not from widget
+        state: the beam and the modifier were resolved by the caller while it was still
+        on the GUI thread.
+        """
+        if vertical_move:
+            # TMP: an x offset measured in the SEM view is still discarded
+            dx = point.x if beam_type is BeamType.ION else 0
+            self.microscope.vertical_move(dx=dx, dy=point.y, beam_type=beam_type)
+        else:
+            # corrected stage movement
+            self.microscope.stable_move(
+                dx=point.x,
+                dy=point.y,
+                beam_type=beam_type,
+            )
+
+    def _on_canvas_double_click(
+        self, beam_type: BeamType, x: float, y: float, modifiers
+    ) -> None:
+        """Canvas double-click -> move stage.
+
+        Every guard is answered here, on the GUI thread, before anything is committed.
+        They used to run inside the worker, which meant a click that was never going to
+        move the stage still disabled the buttons, spawned a thread to decide that, and
+        re-enabled them — and still reported ``finished``, refreshing the stage readout
+        for a move that never happened.
+
+        Answering them here also makes them atomic with respect to the event loop: the
+        whole decision is one handler, so nothing can change ``is_milling`` or swap the
+        image out between the check and the dispatch.
+
+        ``x, y`` are already beam-local, full-resolution image pixels — the canvas emits
+        data coords, one image per canvas, so there is no side-by-side offset to undo.
+        """
+        if not self._click_to_move_available():
+            return
+        if "Shift" in modifiers:
+            return
+        if hasattr(self.host, "milling_widget") and self.host.milling_widget.is_milling:
+            notification_service.show_toast(
+                "Cannot move stage while milling is in progress."
+            )
+            return
+        image = (
+            self.image_widget.eb_image
+            if beam_type is BeamType.ELECTRON
+            else self.image_widget.ib_image
+        )
+        if image is None or image.metadata is None:
+            notification_service.show_toast("No image available to move from.")
+            return
+        h, w = image.data.shape[:2]
+        if not (0 <= x < w and 0 <= y < h):
+            return  # click landed outside the image area
+        point = conversions.image_to_microscope_image_coordinates(
+            coord=Point(x=x, y=y),
+            image=image.data,
+            pixelsize=image.metadata.pixel_size.x,
+        )
+        self._execute_stage_move(
+            beam_type, point, "Alt" in modifiers, coords={"x": x, "y": y}
+        )
+
+    # --- moving to an orientation --------------------------------------------
+
+    def move_to_orientation(self, orientation: str) -> None:
+        """Move to the specifed orientation"""
+        if orientation not in ORIENTATIONS:
+            raise ValueError(f"Invalid orientation: {orientation}")
+        self._toggle_interactions(False)
+        self._report_move(f"Moving to the {orientation} orientation…")
+        worker = self.move_to_orientation_worker(orientation)
+        # The orientation path never reported the acquisition, so the label sat on
+        # "Moving to the SEM orientation…" while the move had finished and the images
+        # were being retaken. Both paths now share the one slot that says it.
+        worker.returned.connect(self._on_stage_move_returned)
+        worker.finished.connect(self.move_stage_finished)
+        worker.start()
+
+    @thread_worker
+    def move_to_orientation_worker(self, orientation: str) -> None:
+        """Move the stage. Runs off the GUI thread — only signals may cross back."""
+        self.microscope.move_to_orientation(orientation)

--- a/tests/test_movement_widget_vertical_gate.py
+++ b/tests/test_movement_widget_vertical_gate.py
@@ -24,7 +24,7 @@ import pytest
 
 try:
     from fibsem.ui import notification_service
-    from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget
+    from fibsem.ui.widgets.stage_control_widget import StageControlWidget
 
     _MISSING_UI_DEPS = None
 except ImportError as e:  # pragma: no cover - exercised only on UI-less CI
@@ -74,7 +74,7 @@ def toasts(monkeypatch):
 def make_widget(microscope):
     # sip forbids object.__new__ on QWidget subclasses; the class's own __new__
     # allocates just the Python wrapper (no QApplication / C++ widget needed)
-    widget = FibsemMovementWidget.__new__(FibsemMovementWidget)
+    widget = StageControlWidget.__new__(StageControlWidget)
     widget.microscope = microscope
     widget._report_move = Mock()
     widget.update_ui_after_movement = Mock()
@@ -90,7 +90,7 @@ def refuse_or_start(widget, beam_type, vertical):
 
 def dispatch(widget, beam_type, vertical):
     """The worker half, run in place -- `@thread_worker` would put it on a thread."""
-    FibsemMovementWidget._stage_move_worker.__wrapped__(
+    StageControlWidget._stage_move_worker.__wrapped__(
         widget, beam_type, Point(1e-6, 2e-6), vertical
     )
 

--- a/tests/ui/test_canvas_double_click_guards.py
+++ b/tests/ui/test_canvas_double_click_guards.py
@@ -31,6 +31,7 @@ from PyQt5.QtCore import QEventLoop, QTimer
 sys.path.insert(0, os.path.dirname(__file__))  # not str.rsplit: Windows paths
 from test_viewer_less_widgets import (  # noqa: E402
     _CanvasHost,
+    _control_widget,
     _image,
     _image_widget,
     _movement_widget,
@@ -39,9 +40,9 @@ from test_viewer_less_widgets import (  # noqa: E402
 
 from fibsem.structures import BeamType, Point  # noqa: E402
 from fibsem.ui import notification_service  # noqa: E402
-from fibsem.ui.FibsemMovementWidget import (  # noqa: E402
-    ACQUIRING_IMAGES,
-    FibsemMovementWidget,
+from fibsem.ui.FibsemMovementWidget import ACQUIRING_IMAGES  # noqa: E402
+from fibsem.ui.widgets.stage_control_widget import (  # noqa: E402
+    StageControlWidget,
 )
 
 
@@ -66,7 +67,7 @@ def movement(qapp):
     image_widget._on_acquire(_image(BeamType.ELECTRON))
     image_widget._on_acquire(_image(BeamType.ION))
     widget = _movement_widget(host)
-    yield widget
+    yield widget.control_widget
     host.deleteLater()
 
 
@@ -196,7 +197,7 @@ def test_a_click_during_milling_is_refused_out_loud(movement, dispatched, toasts
     from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 
     viewer = MillingTaskViewerWidget(microscope=_session()[0])
-    movement.parent.milling_widget = viewer
+    movement.host.milling_widget = viewer
 
     release = threading.Event()
     thread = threading.Thread(target=release.wait, daemon=True)
@@ -232,7 +233,7 @@ def test_the_no_image_guard_never_fires(qapp, toasts):
     """
     host = _CanvasHost()
     image_widget = _image_widget(host)  # deliberately not acquired into
-    movement = _movement_widget(host)
+    movement = _control_widget(host)
     calls = []
     movement._execute_stage_move = lambda *a, **k: calls.append(a)
 
@@ -346,7 +347,7 @@ def test_the_worker_body_only_moves(movement, monkeypatch):
     a widget touched from a worker thread.
     """
     seen = _move_trace(movement, monkeypatch)
-    FibsemMovementWidget._stage_move_worker.__wrapped__(
+    StageControlWidget._stage_move_worker.__wrapped__(
         movement, BeamType.ELECTRON, Point(x=1e-6, y=1e-6), False
     )
     assert [kind for kind, _ in seen] == ["move"], seen

--- a/tests/ui/test_movement_control_surface.py
+++ b/tests/ui/test_movement_control_surface.py
@@ -76,7 +76,7 @@ def movement(qapp):
     host = _CanvasHost()
     _image_widget(host)
     widget = _movement_widget(host)
-    yield widget
+    yield widget.control_widget
     widget._teardown_connections()
     host.deleteLater()
 

--- a/tests/ui/test_movement_progress.py
+++ b/tests/ui/test_movement_progress.py
@@ -63,7 +63,7 @@ def movement(qapp):
     host = _CanvasHost()
     _image_widget(host)
     widget = _movement_widget(host)
-    yield widget
+    yield widget.control_widget
     host.deleteLater()
 
 

--- a/tests/ui/test_movement_worker_bodies.py
+++ b/tests/ui/test_movement_worker_bodies.py
@@ -42,8 +42,8 @@ from test_viewer_less_widgets import (  # noqa: E402
 from fibsem.structures import FibsemStagePosition  # noqa: E402
 from fibsem.ui.FibsemMovementWidget import (  # noqa: E402
     ACQUIRING_IMAGES,
-    FibsemMovementWidget,
 )
+from fibsem.ui.widgets.stage_control_widget import StageControlWidget  # noqa: E402
 
 TARGET = FibsemStagePosition(x=1e-6, y=1e-6, z=1e-6, r=0.0, t=0.0)
 
@@ -67,7 +67,7 @@ def movement(qapp):
     host = _CanvasHost()
     _image_widget(host)
     widget = _movement_widget(host)
-    yield widget
+    yield widget.control_widget
     host.deleteLater()
 
 
@@ -119,7 +119,7 @@ def _kinds(seen) -> list:
 def _body(name):
     """The undecorated worker function -- ``@thread_worker`` would put it on a thread,
     where the raise is swallowed into ``errored`` and nothing is observable in place."""
-    return getattr(FibsemMovementWidget, name).__wrapped__
+    return getattr(StageControlWidget, name).__wrapped__
 
 
 def _explode(*args, **kwargs):

--- a/tests/ui/test_viewer_less_widgets.py
+++ b/tests/ui/test_viewer_less_widgets.py
@@ -32,6 +32,7 @@ from fibsem.structures import BeamType, FibsemImage, FibsemRectangle
 from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
 from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget
 from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+from fibsem.ui.widgets.stage_control_widget import StageControlWidget
 
 _app = QApplication.instance() or QApplication(sys.argv)
 
@@ -95,6 +96,13 @@ def _movement_widget(host) -> FibsemMovementWidget:
     widget = FibsemMovementWidget(microscope=_session()[0], parent=host)
     host.movement_widget = widget
     return widget
+
+
+def _control_widget(host) -> StageControlWidget:
+    """The half that moves the stage (FIB-783). Built through the tab rather than
+    directly, because the tab is what wires it to the form and the saved positions --
+    a hand-built control widget would pass tests the application would fail."""
+    return _movement_widget(host).control_widget
 
 
 # --- the controller is found -------------------------------------------------
@@ -266,7 +274,7 @@ def test_movement_binds_double_click_to_both_canvases():
     host = _CanvasHost()
     _image_widget(host)
     movement = _movement_widget(host)
-    assert len(movement._canvas_dbl_click_conns) == 2
+    assert len(movement.control_widget._canvas_dbl_click_conns) == 2
 
 
 def test_a_second_double_click_during_a_move_is_ignored():
@@ -282,15 +290,17 @@ def test_a_second_double_click_during_a_move_is_ignored():
     movement = _movement_widget(host)
 
     started = []
-    movement._stage_move_worker = lambda *a, **k: started.append(a) or _NoopWorker()
+    movement.control_widget._stage_move_worker = lambda *a, **k: (
+        started.append(a) or _NoopWorker()
+    )
 
-    assert movement._click_to_move_available()
-    movement._on_canvas_double_click(BeamType.ION, 10.0, 10.0, set())
+    assert movement.control_widget._click_to_move_available()
+    movement.control_widget._on_canvas_double_click(BeamType.ION, 10.0, 10.0, set())
     assert len(started) == 1, "first double-click did not start a move"
 
     # the first move is in flight: interactions are off, so a second click must not fire
-    assert not movement._click_to_move_available()
-    movement._on_canvas_double_click(BeamType.ION, 20.0, 20.0, set())
+    assert not movement.control_widget._click_to_move_available()
+    movement.control_widget._on_canvas_double_click(BeamType.ION, 20.0, 20.0, set())
     assert len(started) == 1, "a second move started while the first was still running"
 
 
@@ -303,9 +313,9 @@ def test_click_to_move_is_blocked_while_acquiring_after_a_move():
 
     movement._toggle_interactions(enable=False)
     image_widget.is_acquiring = True
-    movement.move_stage_finished()  # move done, acquisition still running
+    movement.control_widget.move_stage_finished()  # move done, acquisition still running
 
-    assert not movement._click_to_move_available(), (
+    assert not movement.control_widget._click_to_move_available(), (
         "click-to-move re-armed while the post-move acquisition was still running"
     )
 
@@ -371,7 +381,7 @@ def test_teardown_is_idempotent():
         movement._teardown_connections()
     assert widget._wd_scroll_connections == []
     assert widget._view_sync_connections == []
-    assert movement._canvas_dbl_click_conns == []
+    assert movement.control_widget._canvas_dbl_click_conns == []
 
 
 # --- position readout ---------------------------------------------------------
@@ -383,7 +393,7 @@ def test_position_readout_goes_to_the_controller_info_bar():
     movement = _movement_widget(host)
     seen = []
     host.view_controller.update_info = lambda *a, **k: seen.append((a, k))
-    movement._update_position_readout()
+    movement.control_widget._update_position_readout()
     assert seen, "stage readout never reached the quad-view info bar"
 
 
@@ -403,8 +413,13 @@ def test_the_stage_position_shows_without_touching_anything():
 
 def test_setup_connections_wires_the_whole_widget():
     """Guards the shape of the bug above rather than one symptom of it: every one of
-    these is set at a different point in ``setup_connections``, so a method truncated
-    anywhere shows up here."""
+    these is set at a different point in a ``setup_connections``, so a method truncated
+    anywhere shows up here.
+
+    Spans both halves since FIB-783 split them -- the instructions label and the
+    orientation text come from ``StageControlWidget.setup_connections``, the saved
+    positions from the container's. That is deliberate: this is the tab's wiring guard,
+    and a tab is only wired when both are."""
     host = _CanvasHost()
     image_widget = _image_widget(host)
     movement = _movement_widget(host)
@@ -412,18 +427,22 @@ def test_setup_connections_wires_the_whole_widget():
     from fibsem.ui.FibsemMovementWidget import INSTRUCTIONS_TEXT
 
     # early: the instructions label
-    assert movement.label_movement_instructions.text() == INSTRUCTIONS_TEXT
+    assert (
+        movement.control_widget.label_movement_instructions.text() == INSTRUCTIONS_TEXT
+    )
     # middle: the saved positions hand-off, and the orientation button text, which is
     # rewritten from its constructed label a little further down
     assert movement.saved_positions_widget.microscope is not None, (
         "saved positions unwired"
     )
-    assert movement.pushButton_move_to_sem_orientation.text() == (
+    assert movement.control_widget.pushButton_move_to_sem_orientation.text() == (
         "Move to SEM Orientation"
     ), "orientation button text unset"
     # late: milling-angle controls
-    assert movement.doubleSpinBox_milling_angle.maximum() == 45
-    assert movement.doubleSpinBox_milling_angle.suffix(), "milling angle suffix unset"
+    assert movement.control_widget.doubleSpinBox_milling_angle.maximum() == 45
+    assert movement.control_widget.doubleSpinBox_milling_angle.suffix(), (
+        "milling angle suffix unset"
+    )
     # the acquisition signal must reach the widget (drives update_ui after each acquire)
     image_widget.acquisition_progress_signal.emit({"finished": True})
 
@@ -454,9 +473,11 @@ def test_double_click_to_move_survives_a_host_that_owns_a_milling_widget():
 
     image_widget._on_acquire(_image(BeamType.ELECTRON))
     moves = []
-    movement._execute_stage_move = lambda *a, **k: moves.append((a, k))
+    movement.control_widget._execute_stage_move = lambda *a, **k: moves.append((a, k))
     # the handler resolves every guard synchronously, so no thread is involved
-    movement._on_canvas_double_click(BeamType.ELECTRON, 100.0, 100.0, set())
+    movement.control_widget._on_canvas_double_click(
+        BeamType.ELECTRON, 100.0, 100.0, set()
+    )
     assert moves, "double-click did not dispatch a stage move"
 
 


### PR DESCRIPTION
The second half of [FIB-783](https://linear.app/fibsemos/issue/FIB-783/refactor-fibsemmovementwidget-into-modular-components), and the last of it. `FibsemMovementWidget` goes **602 → 168 lines**: it is now a container that lays out the four panels and forwards the calls other windows make on the tab.

**Rebased onto `main` after [#632](https://github.com/fibsem-os/fibsem-os/pull/632) merged**, so it runs CI. It was stacked on #632's branch and got no checks at all before this.

Cherry-picked rather than rebased, because this repo squash-merges and #632's commit is not an ancestor of `main`. Verified first that the squash preserved #632's file byte-for-byte, and afterwards that my eight files are byte-identical to the version I verified. It picked up three commits from `main` in the process — #631 (FIB-841, refusing a stage rotation at the FM), #632 and #633 — none of which touch these files; the 131 tests were re-run on top of them.

## Where the cut falls, and why there

I grouped what was left by job before moving anything:

| job | lines |
| -- | -- |
| canvas double-click (guards, dispatch, worker, teardown) | 137 |
| move actions + workers | 72 |
| progress / status | 47 |
| acquisition policy | 22 |
| host facade + layout | 158 |
| `setup_connections`, spanning all of them | 96 |

A real ~280/320 split rather than a rename.

**I considered pulling the canvas double-click out separately** — at 137 lines it is the largest coherent unit and it carries the FIB-329 teardown. It stays, because `_click_to_move_available` gates on `pushButton_move.isEnabled()`: the enabled state is one thing, owned jointly by the Move button, the orientation buttons and click-to-move. Splitting it would mean sharing that state across two widgets, which is worse than the 137 lines are worth.

## What each side keeps

`StageControlWidget` takes the **host explicitly** rather than reaching through `self.parent`, because it is no longer the widget the host parents. It keeps every coupling the drift audit predicted would follow it:

- `host.image_widget` — the interaction handshake, the live image a canvas click is resolved against, the acquisition-finished signal
- `host.milling_widget` — optional, via `hasattr`
- the quad-view controller — where move status and the position readout are written

The container keeps the parent assert, since it is still what the hosts construct, and the four names hosts reach for: `move_to_position`, `update_ui`, `_toggle_interactions`, `_teardown_connections`.

## The test churn, and why it is 8 files

Six test files. **Four needed only their fixture to yield `widget.control_widget`** — a one-line change each, every test body untouched. That is the equivalence argument: the assertions that pinned the monolith pass unaltered against the composed pair.

`test_viewer_less_widgets` gains a `_control_widget(host)` seam beside `_movement_widget`, and its wiring guard now spans both halves — its docstring says so, because "a method truncated anywhere" now means either `setup_connections`.

Eight files is over the usual five. The extra ones are mechanical and cannot be separated from the move: the extraction *is* what makes those names move. Happy to split the test re-pointing ahead of it if you would rather read it that way.

## Verification

- **131 tests green** across the nine movement-related files.
- **The stage panel renders pixel-identically** before and after — 0 differing pixels at 429×313. The position half shifted a column by 5 px; this one does not, because the control widget's grid spans the full width and the buttons were already the widest things in it.
- **The real application, two ways.** `AutoLamellaUI` built offscreen against a Demo microscope and driven through `update_ui`, the refresh button, `move_to_position` and `_teardown_connections` — correct values, buttons correctly disabled during the move, zero Qt warnings. And the desktop app launched, connected and stayed up with no errors.
- `ruff check` and `ruff format --check` clean on all eight.

## One thing I tried and abandoned

I first landed this behind a forwarding shim, so the container aliased the control widget's internals and no test would change — the trick that worked for the position half. **It only half-works**: forwarding handles calls *in*, but tests that `monkeypatch` the container's attributes never reach the control widget's own `self.` calls, so 32 tests still failed. Deleted rather than shipped, and the tests re-pointed properly instead.

## After this

FIB-783 is done. The remaining follow-up is small: nothing outside the tab reaches the moved names any more, so there is no alias block to retire this time.
