### PR TITLE
[docs] Five files is a target, not a cap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 **Read [CONTRIBUTING.md](CONTRIBUTING.md) first.** Everything in it applies to you: the
-five-file cap on pull requests, the `Release-Note:` commit trailer and where it must sit,
+five-file target for pull requests, the `Release-Note:` commit trailer and where it must sit,
 the Python 3.8 floor in signatures, format-on-touch, `QT_QPA_PLATFORM=offscreen`, the
 palette tokens, and the rule that nothing reaches the network unless a user asked it to.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,21 @@ late or not at all.
 
 ## Pull requests
 
-**Cap a pull request at about five files.** Reviewability is set by what a person can
-hold in their head, not by how well the change is verified — a machine-generated sweep
-with an AST-level safety check and a green suite is still too large to review at twenty
-files. For a mechanical change across many files, slice by directory or module so each
-pull request is one coherent area, and open them independently off `main` rather than
+**Aim for about five files in a pull request.** A target to design toward, not a limit
+to obey: the constraint is reviewability, which is set by what a person can hold in
+their head rather than by a file count. A machine-generated sweep with an AST-level
+safety check and a green suite is still too large to review at twenty files — verifying
+it well does not buy back the size of the thing someone has to read.
+
+Go over five when the extra files are **cohesive** — one change rather than a sweep —
+and **unavoidable**, in the sense that they break without it. Say so in the pull request
+body, and say what they contain: "six test files, four of them a one-line fixture
+change" is the sentence that makes eight files readable. Do not contort the design to
+hit the number; a forwarding shim that exists only to keep the count down is worse than
+the extra file.
+
+For a mechanical change across many files, slice by directory or module so each pull
+request is one coherent area, and open them independently off `main` rather than
 stacking. More pull requests is the accepted cost.
 
 This bites hardest under format-on-touch (below), where editing a file forces a full


### PR DESCRIPTION
Two documentation files. No code.

## Why

The rule read as a hard limit, and it was written from the case that motivated it — [#496](https://github.com/fibsem-os/fibsem-os/pull/496), twenty-one files of machine-generated sweep that no amount of verification could make readable. **That case is still right, and the wording for it is unchanged.**

What it did not cover is a single cohesive change whose extra files are mechanical and cannot be separated from it. [#634](https://github.com/fibsem-os/fibsem-os/pull/634) touched eight: two production files and six test files, four of those a one-line fixture change each. The extraction is what makes those test names move, so re-pointing them is not a separable pull request.

Read as a hard cap it also pushes the wrong way on design. On that change I nearly landed a forty-line forwarding shim purely to keep the file count at two — it did not even work, and deleting it was right. A rule that makes the code worse to satisfy a count is being applied past its purpose.

## What changes

`CONTRIBUTING.md` — "Cap a pull request at about five files" becomes "Aim for about five files", with the condition for going over spelled out: the extra files must be **cohesive** (one change, not a sweep) and **unavoidable** (they break without it), and the pull request body should say what they are. The mechanical-sweep guidance underneath is untouched.

`AGENTS.md` — one word, "cap" → "target", so the two files agree.

## What does not change

The reason for the rule. Reviewability is still the constraint, verification quality still does not buy a size exemption, and a twenty-file sweep is still too big. Only the proxy gives way when it disagrees with the thing it stands for.