### PR TITLE
[feat] Add the typed request/answer primitive for workflow-UI interaction

### DIFF
--- a/fibsem/applications/autolamella/workflows/interaction.py
+++ b/fibsem/applications/autolamella/workflows/interaction.py
@@ -1,0 +1,252 @@
+"""Typed requests from the workflow thread to whoever is supervising it.
+
+``workflow_update_signal`` is one ``pyqtSignal(dict)`` carrying three different
+mechanisms: fire-and-forget status, one-way instructions the workflow waits on, and
+questions that need a value back. The waiting is a hand-rolled RPC — a shared mutable
+flag plus a ``time.sleep`` poll — and the answers come back through unsynchronised
+attributes on the main window, or by reaching directly into its widgets.
+
+This module is the replacement's foundation, deliberately unwired: nothing imports it
+yet, and each call site converts on its own.
+
+* **Payload types** — one dataclass per interaction, split by mechanism. A question
+  declares its answer type through ``Request[R]``; an instruction is ``Request[None]``,
+  completed with a bare acknowledgement. One type per question rather than one type
+  with optional fields: which-field-is-set dispatch is the shape being removed.
+* **:class:`Responder`** — the transport is a protocol with one method, not a Qt
+  signal. The workflow layer needs no Qt, a test needs no window, and headless mode
+  stops being ``if parent_ui is None`` at the top of every helper and becomes just
+  another implementation.
+* **:func:`ask` / :func:`wait_for`** — a ``concurrent.futures.Future`` per call
+  carries the answer, the error and the fact of completion. It belongs to one caller,
+  so no other emitter can release it — unlike ``WAITING_FOR_UI_UPDATE``, which any
+  emission clears for every waiter. The wait polls in 0.1 s slices; that bounds how
+  fast an abort is noticed, not how fast an answer arrives.
+
+Two rules keep the types honest, one in each direction:
+
+* **A request carries its context.** A responder must be able to answer from the
+  request alone. If a request only works because one particular responder can see
+  what happens to be on screen, it is under-specified.
+* **A response carries the value.** Never a pointer into the UI for the caller to
+  read back afterwards.
+
+Timeouts scale with who answers. Instructions are answered by a machine, so silence
+means something is broken: pass a ``timeout``. Questions are answered by a human, so
+silence means thinking: no timeout, but pass ``abort`` so Stop still works while the
+prompt is up. Cancellation raises ``InterruptedError`` — the same exception the
+workflow abort path already raises — so a cancelled request unwinds through the one
+path call sites already have, rather than adding a second.
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import Future
+from concurrent.futures import TimeoutError as _FutureTimeoutError
+from dataclasses import dataclass
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Generic,
+    Optional,
+    Protocol,
+    Sequence,
+    TypeVar,
+)
+
+if TYPE_CHECKING:
+    from fibsem.detection.detection import DetectedFeatures
+    from fibsem.fm.structures import ChannelSettings
+    from fibsem.imaging.spot import SpotBurnSettings
+    from fibsem.milling.tasks import FibsemMillingTaskConfig
+    from fibsem.structures import FibsemImage, FibsemRectangle, Point
+
+__all__ = [
+    "Request",
+    "Confirm",
+    "ConfirmDetection",
+    "EditAlignmentArea",
+    "PickPOI",
+    "RunMillingTask",
+    "SetImages",
+    "SetMillingConfig",
+    "ClearMillingConfig",
+    "SetFluorescenceChannels",
+    "SetSpotBurnSettings",
+    "ClearSpotBurn",
+    "Responder",
+    "ask",
+    "wait_for",
+]
+
+R = TypeVar("R")
+
+# How often the wait re-checks ``abort`` and the deadline. An answer that is already
+# set returns immediately regardless; this only bounds how stale a cancel can be.
+_POLL_INTERVAL_S = 0.1
+
+
+class Request(Generic[R]):
+    """A single interaction with the supervisor; ``R`` is the type of the answer.
+
+    Subclasses are frozen dataclasses. A question's answer is a value (never a
+    widget to read); an instruction subclasses ``Request[None]`` and its "answer"
+    is the acknowledgement that the responder has finished acting on it.
+    """
+
+
+# --- questions: the workflow needs a value back -----------------------------------
+
+
+@dataclass(frozen=True)
+class Confirm(Request[bool]):
+    """A yes/no prompt. ``True`` means the positive choice was taken."""
+
+    message: str
+    positive: str = "Continue"
+    negative: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ConfirmDetection(Request["DetectedFeatures"]):
+    """Show detected features for correction; answer with the (possibly moved) set."""
+
+    detection: "DetectedFeatures"
+
+
+@dataclass(frozen=True)
+class EditAlignmentArea(Request["FibsemRectangle"]):
+    """Let the supervisor adjust an alignment area; answer with the final area."""
+
+    initial: "FibsemRectangle"
+
+
+@dataclass(frozen=True)
+class PickPOI(Request[Optional["Point"]]):
+    """Ask for a point of interest on ``image``, in microscope image coordinates.
+
+    The image travels in the request — in-process that is a reference, not a copy —
+    so the responder is never answering about whatever happens to be on screen.
+    """
+
+    image: "FibsemImage"
+    initial: Optional["Point"] = None
+
+
+@dataclass(frozen=True)
+class RunMillingTask(Request["FibsemMillingTaskConfig"]):
+    """Hand over a milling config to edit and (if ``enabled``) run; answer with the
+    config as actually used. Absorbs today's ``start_milling_signal`` sibling poll:
+    running the mill is the responder's job, not a second channel's.
+    """
+
+    config: "FibsemMillingTaskConfig"
+    enabled: bool = True
+
+
+# --- instructions: one-way, answered with a bare acknowledgement ------------------
+
+
+@dataclass(frozen=True)
+class SetImages(Request[None]):
+    """Display these acquisition images."""
+
+    sem_image: Optional["FibsemImage"] = None
+    fib_image: Optional["FibsemImage"] = None
+
+
+@dataclass(frozen=True)
+class SetMillingConfig(Request[None]):
+    """Load this config into the milling editor."""
+
+    config: "FibsemMillingTaskConfig"
+
+
+@dataclass(frozen=True)
+class ClearMillingConfig(Request[None]):
+    """Clear the milling editor."""
+
+
+@dataclass(frozen=True)
+class SetFluorescenceChannels(Request[None]):
+    """Load these channel settings into the fluorescence widget."""
+
+    channels: Sequence["ChannelSettings"]
+
+
+@dataclass(frozen=True)
+class SetSpotBurnSettings(Request[None]):
+    """Load these spot-burn settings into the spot-burn widget."""
+
+    settings: "SpotBurnSettings"
+
+
+@dataclass(frozen=True)
+class ClearSpotBurn(Request[None]):
+    """Clear the spot-burn widget."""
+
+
+# --- transport --------------------------------------------------------------------
+
+
+class Responder(Protocol):
+    """Whoever answers requests: the Qt window when supervised, a stub in tests.
+
+    ``submit`` is called on the workflow thread and must not block — hand the request
+    off (to the GUI thread, to a queue) and return. Every accepted future must
+    eventually be completed: ``set_result`` with the answer, or ``set_exception`` if
+    acting on the request failed. An exception set here re-raises on the workflow
+    thread inside :func:`wait_for`, where a real handler exists — instead of escaping
+    a Qt slot and taking the process down.
+    """
+
+    def submit(self, request: Request[R], future: "Future[R]") -> None:
+        """Deliver ``request``, later completing ``future`` with its answer."""
+        ...
+
+
+def wait_for(
+    future: "Future[R]",
+    *,
+    abort: Optional[Callable[[], bool]] = None,
+    timeout: Optional[float] = None,
+    description: str = "UI request",
+) -> R:
+    """Block until ``future`` completes, staying responsive to cancellation.
+
+    Returns the answer, or re-raises whatever the responder set. Raises
+    ``InterruptedError`` once ``abort()`` goes true, and ``TimeoutError`` once
+    ``timeout`` seconds pass — an answer that is already set always wins over both.
+    ``abort`` is a predicate rather than an event because the real source is
+    ``task_manager.should_abort``, a property.
+    """
+    deadline = None if timeout is None else time.monotonic() + timeout
+    while True:
+        try:
+            return future.result(timeout=_POLL_INTERVAL_S)
+        except _FutureTimeoutError:
+            if abort is not None and abort():
+                raise InterruptedError(f"{description} cancelled")
+            if deadline is not None and time.monotonic() >= deadline:
+                raise TimeoutError(f"No response to {description} within {timeout} s")
+
+
+def ask(
+    responder: Responder,
+    request: Request[R],
+    *,
+    abort: Optional[Callable[[], bool]] = None,
+    timeout: Optional[float] = None,
+) -> R:
+    """Submit ``request`` to ``responder`` and wait for the answer.
+
+    The one call sites use, for questions and instructions alike — an instruction is
+    simply asked for its acknowledgement. The future is created here and shared with
+    nobody else, so only this request's responder can complete it.
+    """
+    future: "Future[R]" = Future()
+    responder.submit(request, future)
+    return wait_for(
+        future, abort=abort, timeout=timeout, description=type(request).__name__
+    )

--- a/tests/test_workflow_interaction.py
+++ b/tests/test_workflow_interaction.py
@@ -1,0 +1,115 @@
+"""The request/answer primitive is headless: no Qt, no window, no microscope.
+
+These tests pin the properties the design leans on — the latch, exception
+propagation, the abort predicate, the timeout, and answer-beats-abort — so the
+first safety net for this subsystem runs in plain ``tests/``, which CI has always
+run, rather than only in ``tests/ui``.
+"""
+
+import dataclasses
+import threading
+import time
+
+import pytest
+
+from fibsem.applications.autolamella.workflows.interaction import (
+    Confirm,
+    SetImages,
+    ask,
+)
+
+
+class InlineResponder:
+    """Answers on the calling thread, inside ``submit`` — before the wait begins."""
+
+    def __init__(self, answer=None, error=None):
+        self.requests = []
+        self._answer = answer
+        self._error = error
+
+    def submit(self, request, future):
+        self.requests.append(request)
+        if self._error is not None:
+            future.set_exception(self._error)
+        else:
+            future.set_result(self._answer)
+
+
+class ThreadResponder:
+    """Answers from another thread after a delay — the wait must actually wait."""
+
+    def __init__(self, answer, delay_s):
+        self._answer = answer
+        self._delay_s = delay_s
+
+    def submit(self, request, future):
+        def _answer_later():
+            time.sleep(self._delay_s)
+            future.set_result(self._answer)
+
+        threading.Thread(target=_answer_later, daemon=True).start()
+
+
+class SilentResponder:
+    """Accepts the request and never completes the future."""
+
+    def submit(self, request, future):
+        pass
+
+
+def test_an_inline_answer_comes_straight_back():
+    responder = InlineResponder(answer=True)
+    request = Confirm("Continue?")
+
+    assert ask(responder, request) is True
+    assert responder.requests == [request]
+
+
+def test_a_deferred_answer_is_waited_for():
+    # The delay spans more than one 0.1 s poll slice, so a pass proves the loop
+    # re-polls rather than answering only when the result is already set.
+    responder = ThreadResponder(answer="landed", delay_s=0.25)
+    started = time.monotonic()
+
+    assert ask(responder, Confirm("Continue?")) == "landed"
+    assert time.monotonic() - started >= 0.2
+
+
+def test_a_responder_failure_reraises_on_the_caller():
+    boom = RuntimeError("widget fell over")
+    responder = InlineResponder(error=boom)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        ask(responder, SetImages())
+    assert excinfo.value is boom
+
+
+def test_silence_times_out_with_the_request_named():
+    started = time.monotonic()
+
+    with pytest.raises(TimeoutError, match="SetImages"):
+        ask(SilentResponder(), SetImages(), timeout=0.3)
+    assert time.monotonic() - started < 3
+
+
+def test_abort_interrupts_the_wait():
+    started = time.monotonic()
+
+    with pytest.raises(InterruptedError):
+        ask(SilentResponder(), Confirm("Continue?"), abort=lambda: True)
+    assert time.monotonic() - started < 3
+
+
+def test_an_answer_already_set_beats_abort():
+    # Both an answer and an abort are available on the first poll; the answer wins,
+    # so a Stop pressed just as the operator answers cannot eat the answer.
+    responder = InlineResponder(answer=False)
+
+    assert ask(responder, Confirm("Continue?"), abort=lambda: True) is False
+
+
+def test_requests_are_immutable():
+    request = Confirm("Continue?")
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        request.message = "changed"


### PR DESCRIPTION
`workflow_update_signal` is one `pyqtSignal(dict)` carrying three different mechanisms: fire-and-forget status, one-way instructions the workflow blocks on, and questions that need a value back. Ten of its thirteen emits are blocking calls built from a Qt signal, a shared mutable flag (`WAITING_FOR_UI_UPDATE` / `WAITING_FOR_USER_INTERACTION`) and a `time.sleep` poll — and the answers come back through unsynchronised attributes on the main window (`USER_RESPONSE`, `SELECTED_POI`) or by reaching directly into widgets (`get_alignment_area()`, `get_config()`, `_get_detected_features()`).

This PR lands the replacement's foundation, **deliberately unwired** — nothing imports the new module yet. Each call site converts in its own later PR; both mechanisms coexist until the last site moves and the flags delete.

## What's in it

**`fibsem/applications/autolamella/workflows/interaction.py`** — no Qt, no heavy imports (verified: importing it pulls neither PyQt5 nor torch):

- **One frozen dataclass per interaction** under a generic `Request[R]`, so each question statically declares its answer type — five questions (`Confirm → bool`, `ConfirmDetection → DetectedFeatures`, `EditAlignmentArea → FibsemRectangle`, `PickPOI → Optional[Point]`, `RunMillingTask → FibsemMillingTaskConfig`) and six ack-only instructions (`SetImages`, `SetMillingConfig` / `ClearMillingConfig`, `SetFluorescenceChannels`, `SetSpotBurnSettings` / `ClearSpotBurn`). Distinct types per question rather than one type with optional fields: which-field-is-set dispatch is the shape being removed.
- **`Responder`** — the transport is a protocol with one method, `submit(request, future)`, not a Qt signal. The workflow layer needs no Qt; a test needs no window; `if parent_ui is None` becomes just another implementation.
- **`ask` / `wait_for`** — a `concurrent.futures.Future` per call carries the answer, the error and the fact of completion. The future belongs to one caller, so no other emitter can release it (today `handle_workflow_update` clears `WAITING_FOR_UI_UPDATE` unconditionally on *every* emission — any emitter releases every waiter, which is why `queue_changed_signal` had to be split out already). The wait polls in 0.1 s slices and stays responsive to an `abort` predicate; a responder-side failure is `set_exception`ed and re-raises on the workflow thread inside `wait_for`, where a real handler exists, instead of escaping a Qt slot.

Two calls that differ from the earlier design sketch:

- **Cancellation raises `InterruptedError`, not a new exception type.** `_check_for_abort` already raises `InterruptedError` and the task manager already treats it as a user stop, so a cancelled request unwinds through the one path call sites already have.
- **`abort` is a callable predicate, not a `threading.Event`** — the real source is `task_manager.should_abort`, a property, so a predicate matches what callers actually hold with no adapter.

**`tests/test_workflow_interaction.py`** — 7 tests, deliberately in plain `tests/` (headless, no Qt) so the main CI job runs them. They pin: inline answer round-trip, a deferred answer across a real poll cycle, `set_exception` re-raising the same instance on the caller, timeout naming the request type, abort interrupting the wait, answer-beats-abort (a Stop pressed just as the operator answers cannot eat the answer), and payload immutability.

## Verification

- `pytest tests/test_workflow_interaction.py` — 7 passed, 0.8 s.
- `ruff check` and `ruff format --check` clean on both files.
- Import smoke: the module pulls no Qt and no ML deps at import time.
- 3.8 note: the `Request[Optional["Point"]]`-style forward refs are 3.8-valid by spec but unverifiable locally (no 3.8 interpreter here) — the CI matrix is the real check.
