### PR TITLE
[refactor] Let a position be relocated without being re-posed (FIB-854)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1566,25 +1566,39 @@ class FibsemMicroscope(ABC):
     def get_target_position(
         self,
         stage_position: FibsemStagePosition,
-        target_orientation: str,
+        target_orientation: Optional[str] = None,
         target_device: Optional[str] = None,
     ) -> FibsemStagePosition:
-        """Convert the stage position to the target position for the given orientation.
+        """Convert a stage position across the orientation axis, the device axis, or both.
 
-        `target_device` converts across the *device* axis as well. Where the objective
-        is offset the two are independent -- the device is a place the stage travels
-        to, the orientation is the pose it is held in once there -- so a caller may
-        ask for either or both. `FM-MILLING` is not a fifth orientation; it is
-        `("MILLING", device="FM")`.
+        Where the objective is offset the two are independent -- the device is a place
+        the stage travels to, the orientation is the pose it is held in once there --
+        so either may be asked for alone:
 
-        Returns the canonical r and t of the target orientation, so a position a
-        degree or two off its nominal pose is snapped rather than carried across.
+            (p, "FIB")                        re-pose, stay put
+            (p, target_device="FM")           relocate, keep the pose
+            (p, "MILLING", target_device="FM") both -- this is FM-MILLING, which is
+                                              a pair rather than a fifth orientation
+
+        **Asking for an orientation snaps the pose.** An orientation *is* a canonical
+        r and t, so a position a degree or two off nominal is written to nominal
+        rather than carried across. That is right for a conversion and wrong for a
+        relocation, which is why the second form exists: the traverse must not discard
+        a milling angle somebody dialled in on the way to the FM.
+
+        Note `target_orientation="FM"` means something on a compustage, where the FM
+        really is an orientation -- a flip to `t = -180`. On an offset mount it is
+        refused: the FM is a device there, and `orientations["FM"]` is a copy of the
+        FIB entry carrying no positional term.
         """
 
         currrent_orientation = self.get_stage_orientation(stage_position)
         logging.info(
             f"Getting target position for {target_orientation} from {currrent_orientation}"
         )
+
+        if target_orientation is None and target_device is None:
+            return stage_position
 
         if currrent_orientation == target_orientation and target_device is None:
             return stage_position
@@ -1615,7 +1629,11 @@ class FibsemMicroscope(ABC):
             )
 
         stage_position = deepcopy(stage_position)
-        orientation = self.get_orientation(target_orientation)
+        orientation = (
+            self.get_orientation(target_orientation)
+            if target_orientation is not None
+            else None
+        )
 
         # The device legs **bracket** the orientation leg rather than following it,
         # so that the re-pose always happens at the beams. Written out, that is the
@@ -1694,19 +1712,26 @@ class FibsemMicroscope(ABC):
         # and this rule is keyed on that classifier's answer, so the two share one
         # definition rather than agreeing by coincidence. Same 5 degree tolerance, for
         # the same reason.
-        from fibsem import movement
+        # Only when a pose was asked for. Relocating alone changes no rotation, so
+        # there is nothing for the compucentric correction to correct and nothing to
+        # write to r and t -- the bracket below collapses to a plain translation from
+        # one device to the other, which is exactly what a traverse is.
+        if orientation is not None:
+            from fibsem import movement
 
-        rotation = movement.angle_difference(
-            self.get_orientation(currrent_orientation).r, orientation.r
-        )
-        rotation_is_half_turn = movement.rotation_angle_is_smaller(
-            rotation, np.pi, atol=5
-        )
-        if rotation_is_half_turn:
-            stage_position = self._get_compucentric_rotation_position(stage_position)
+            rotation = movement.angle_difference(
+                self.get_orientation(currrent_orientation).r, orientation.r
+            )
+            rotation_is_half_turn = movement.rotation_angle_is_smaller(
+                rotation, np.pi, atol=5
+            )
+            if rotation_is_half_turn:
+                stage_position = self._get_compucentric_rotation_position(
+                    stage_position
+                )
 
-        stage_position.r = orientation.r
-        stage_position.t = orientation.t
+            stage_position.r = orientation.r
+            stage_position.t = orientation.t
 
         # ... and back out, to whichever device was asked for. `target_device` of None
         # means the one it started at, so an orientation-only conversion at the FM is
@@ -2272,8 +2297,11 @@ class FibsemMicroscope(ABC):
                 f"Configured devices: {sorted(self.system.stage.devices)}."
             ) from None
 
-    def get_device_position(self, device: str) -> FibsemStagePosition:
+    def get_device_origin(self, device: str) -> FibsemStagePosition:
         """Where the stage travels for `device` to see the sample.
+
+        The device's *origin*, not a position expressed at it -- for that, ask
+        `get_target_position(position, target_device=...)`.
 
         Partial: an offset fluorescence microscope is an x location and leaves y, z, r
         and t free, so the axes it does not constrain come back `None`.
@@ -2385,6 +2413,11 @@ class FibsemMicroscope(ABC):
             # found it rather than pulling it out of the sample for nothing.
             logging.info(f"Moving to {target} position...")
             self.fm.objective.retract()
+
+            # No orientation asked for, so the pose comes across untouched. That is
+            # the whole point of the traverse, and the reason this cannot pass the
+            # current orientation's name instead: doing so would snap r and t to
+            # nominal and quietly discard a milling angle somebody dialled in.
             self.move_stage_relative(self._device_translation(source, target))
 
         # Unconditional, so that the postcondition is the device *and* the objective

--- a/tests/test_device_orientation_composition.py
+++ b/tests/test_device_orientation_composition.py
@@ -213,3 +213,80 @@ def test_converting_from_between_the_devices_is_refused():
 
     with pytest.raises(ValueError, match="not at any configured device"):
         microscope.get_target_position(stranded, "FIB", target_device="FM")
+
+
+# ── one axis at a time ───────────────────────────────────────────────
+
+# Three degrees off nominal, which is what makes a snap visible. Inside the 5 degree
+# band `get_stage_orientation` classifies within, so the position still reads as the
+# orientation it is at -- and at the nominal pose these tests would pass against a
+# transform that snapped, which is the whole thing they exist to catch.
+OFF_NOMINAL_DEG = 3.0
+
+
+def _off_nominal(microscope, orientation: str, x_mm: float = 7.0):
+    position = _at(microscope, orientation, x_mm)
+    position.t = position.t + np.radians(OFF_NOMINAL_DEG)
+    return position
+
+
+def test_asking_for_a_device_alone_keeps_the_pose():
+    """The operation the traverse performs, and the one the signature used to refuse.
+
+    An orientation *is* a canonical r and t, so naming one snaps the pose. There was
+    no way to say "somewhere else, same pose" -- the nearest thing was passing the
+    current orientation's name, which is exactly what snaps.
+    """
+    microscope = _microscope()
+    start = _off_nominal(microscope, "FIB")
+
+    target = microscope.get_target_position(start, target_device="FM")
+
+    assert target.x == pytest.approx(start.x + TRAVERSE)
+    assert np.isclose(target.r, start.r)
+    assert np.isclose(target.t, start.t)  # not snapped to the nominal FIB tilt
+    assert not np.isclose(target.t, microscope.get_orientation("FIB").t)
+
+
+def test_asking_for_an_orientation_alone_still_snaps():
+    """Unchanged, and correct: a conversion answers "what pose is orientation X"."""
+    microscope = _microscope()
+    start = _off_nominal(microscope, "FIB")
+
+    target = microscope.get_target_position(start, "MILLING")
+
+    assert np.isclose(target.t, microscope.get_orientation("MILLING").t)
+    assert microscope.get_current_device(target) == "FIBSEM"
+
+
+def test_asking_for_both_snaps_and_relocates():
+    """FM-MILLING: a pair, not a fifth orientation."""
+    microscope = _microscope()
+    start = _off_nominal(microscope, "FIB")
+
+    target = microscope.get_target_position(start, "MILLING", target_device="FM")
+
+    assert microscope.get_current_device(target) == "FM"
+    assert microscope.get_stage_orientation(target) == "MILLING"
+    assert np.isclose(target.t, microscope.get_orientation("MILLING").t)
+
+
+def test_asking_for_neither_is_not_a_conversion():
+    """Returns the argument itself, the way asking for the orientation it is at does."""
+    microscope = _microscope()
+    start = _at(microscope, "FIB", 7.0)
+
+    assert microscope.get_target_position(start) is start
+
+
+def test_relocating_alone_round_trips():
+    """No rotation, so the compucentric leg never runs and the bracket is a plain
+    translation -- out and back has to land exactly where it started."""
+    microscope = _microscope()
+    start = _off_nominal(microscope, "FIB")
+
+    away = microscope.get_target_position(start, target_device="FM")
+    returned = microscope.get_target_position(away, target_device="FIBSEM")
+
+    assert returned.x == pytest.approx(start.x, abs=1e-12)
+    assert np.isclose(returned.t, start.t)

--- a/tests/test_fm_device_position.py
+++ b/tests/test_fm_device_position.py
@@ -59,8 +59,8 @@ def test_the_devices_come_from_the_configuration_file():
     """
     microscope = _microscope()
 
-    assert microscope.get_device_position("FIBSEM").x == pytest.approx(0.0)
-    assert microscope.get_device_position("FM").x == pytest.approx(48.8e-3)
+    assert microscope.get_device_origin("FIBSEM").x == pytest.approx(0.0)
+    assert microscope.get_device_origin("FM").x == pytest.approx(48.8e-3)
     assert microscope.system.stage.device_range.x == pytest.approx(20.0e-3)
 
 
@@ -83,7 +83,7 @@ def test_a_device_is_a_place_and_leaves_the_pose_alone():
     A device that also fixed r or t would be the same conflation this is undoing, so
     the configuration refuses to express one.
     """
-    position = _microscope().get_device_position("FM")
+    position = _microscope().get_device_origin("FM")
 
     assert position.x is not None
     assert (position.y, position.z, position.r, position.t) == (None, None, None, None)


### PR DESCRIPTION
The device and the orientation are independent axes on an offset mount, and `get_target_position` models that — it takes both. Its signature did not admit changing only one of them: `target_orientation` was required, and naming an orientation writes that orientation's canonical `r` and `t`.

So there was no public way to say *this position, at the other device, same pose* — the operation the traverse performs. The only public function that looked like it did that snapped the pose instead:

```
stage 3 degrees off the nominal FIB tilt, offset simulator

stage now              x =  7.00 mm   t = 20.00°   (nominal FIB is 17.00°)
(p, "FIB", device=FM)  x = 55.80 mm   t = 17.00°   <- snapped
(p, device=FM)         x = 55.80 mm   t = 20.00°   <- the new mode
```

`get_stage_orientation` classifies within 5°, so a stage that far off still reads as FIB and the call is accepted — it just quietly re-poses. At MILLING those 3° are a milling angle somebody chose.

## Three modes, one per combination

| call | meaning |
| -- | -- |
| `(p, "FIB")` | re-pose, stay put — unchanged |
| `(p, target_device="FM")` | **relocate, keep the pose** — new |
| `(p, "MILLING", target_device="FM")` | both — FM-MILLING, a pair rather than a fifth orientation |

With no re-pose asked for there is no rotation, so the compucentric leg does not run and the bracketing collapses to a plain translation from one device to the other. That is what a traverse is.

## `get_device_position` → `get_device_origin`

It returns the device's origin — `x=0.0488` with every other axis `None` — not a position expressed at it. The old name misled twice in one sitting, both times someone reaching for it meaning the relocation above. One day old (#618), so the rename is cheapest now. Three call sites, all in tests.

## Mutation-checked, not assumed

Six new tests. Making the device-only mode snap the pose anyway kills two of them; dropping the ask-for-nothing early return kills a third.

They all start **3° off nominal**, and that is the test rather than decoration — at the canonical pose a snap is invisible and every one of them would pass against the transform it exists to refuse. An earlier pin in this area did exactly that: it was green against its own mutant.

## Not included

The issue also proposed rewiring `move_to_microscope` to call this. Struck while building — that repeats the mistake that cancelled FIB-844. Its line today is already `move_stage_relative(self._device_translation(source, target))`: one line, shared helper, pose preserved, relative. Routing it through `get_target_position` hands back an *absolute* target and forces an absolute move, which measured as buying nothing and being less robust to drift between the position read and the command.

## Verification

`6684 passed, 23 skipped` on the full suite.
