### PR TITLE
[test] Pin the fire-and-forget status display path before it moves

### DIFF
--- a/tests/ui/test_mainui_workflow_status.py
+++ b/tests/ui/test_mainui_workflow_status.py
@@ -1,0 +1,109 @@
+"""What the main window does with a fire-and-forget status payload, pinned pre-move.
+
+`AutoLamellaSingleWindowUI._on_workflow_update` is the main-window consumer of
+`workflow_update_signal`: transient status-bar text, and the task manager's
+lifecycle reports (timeline feed, the "Workflow: ..." message, run/stop buttons).
+Status is about to move to its own signal, so this pins the observable behaviour
+the move must preserve.
+
+This is the first test to construct the real main window offscreen. The only
+thing that ever prevented it is `add_minimap_tab`, which builds a `napari.Viewer`
+whose vispy canvas calls `glGetIntegerv` with no GL context and takes the process
+down with SIGSEGV — so the fixture stubs that one method out. Nothing here goes
+near the minimap; every other tab is real. When the minimap tab is deleted
+(#585/#586) the stub can go.
+
+Latent init gap, found by these tests: `_border_state` is first assigned on the
+Run-workflow click, never in `__init__`, and `_on_workflow_update` reads it
+unconditionally — so a status payload arriving without a prior Run click is an
+AttributeError inside a queued slot, which PyQt5 turns into a process abort
+(FIB-329). Production is protected by flow order only; the fixture supplies the
+same precondition explicitly.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+from fibsem.applications.autolamella.workflows.tasks.status import (
+    WorkflowStatusUpdate,
+)
+
+
+@pytest.fixture(scope="module")
+def main_ui(qapp):
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
+    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
+    try:
+        window = module.AutoLamellaSingleWindowUI()
+    finally:
+        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    # First connect builds the protocol editor's full UI (its lock path runs on
+    # every lifecycle report); Demo, so no hardware.
+    window.autolamella_ui.system_widget.connect_to_microscope()
+    # What _on_run_workflow_clicked does before any status can arrive: the
+    # border state exists only from the Run click onward, and the handler under
+    # test reads it unconditionally. A bare window never receives status in
+    # production -- see the latent-init note in the module docstring.
+    window._set_border_state("idle")
+    yield window
+    if window.autolamella_ui.microscope is not None:
+        window.autolamella_ui.microscope.disconnect()
+    window.close()
+
+
+def test_a_transient_status_bar_message_is_shown(main_ui):
+    main_ui._on_workflow_update({"status_bar": "Scheduled start in 5 s"})
+
+    assert main_ui.status_bar.currentMessage() == "Scheduled start in 5 s"
+
+
+def test_a_payload_without_status_bar_text_leaves_the_bar_alone(main_ui):
+    main_ui.status_bar.showMessage("previous message")
+
+    main_ui._on_workflow_update({"msg": "not for the status bar"})
+
+    assert main_ui.status_bar.currentMessage() == "previous message"
+
+
+def test_a_lifecycle_report_shows_the_run_on_the_status_bar(main_ui):
+    # queue_items=None on purpose: "no snapshot" leaves the timeline rows alone,
+    # so this exercises the status-bar half without building a queue. The
+    # timeline half is characterised in test_workflow_timeline_sync.
+    report = WorkflowStatusUpdate(
+        task_name="Rough Milling",
+        item_name="lamella-01",
+        status=AutoLamellaTaskStatus.InProgress,
+        queue_position=2,
+        queue_total=5,
+        queue_items=None,
+    )
+
+    main_ui._on_workflow_update({"msg": "", "status": report})
+
+    assert (
+        main_ui.status_bar.currentMessage()
+        == "Workflow: Rough Milling | lamella-01 | 2/5"
+    )
+
+
+def test_a_lifecycle_report_flips_the_run_button_to_stop(main_ui):
+    main_ui.hide_workflow_running()
+    assert not main_ui.stop_workflow_btn.isVisibleTo(main_ui)
+
+    report = WorkflowStatusUpdate(
+        task_name="Rough Milling",
+        item_name="lamella-01",
+        status=AutoLamellaTaskStatus.InProgress,
+    )
+    main_ui._on_workflow_update({"msg": "", "status": report})
+
+    assert main_ui.stop_workflow_btn.isVisibleTo(main_ui)
+    assert not main_ui.run_workflow_btn.isVisibleTo(main_ui)

--- a/tests/ui/test_mainui_workflow_status.py
+++ b/tests/ui/test_mainui_workflow_status.py
@@ -56,7 +56,17 @@ def main_ui(qapp):
     yield window
     if window.autolamella_ui.microscope is not None:
         window.autolamella_ui.microscope.disconnect()
-    window.close()
+    # closeEvent ends in app.quit() — the shipped quit-freeze workaround. On the
+    # shared test QApplication that latches an interrupt (no event loop is running
+    # to consume it), and every later QEventLoop.exec_() in the pytest process
+    # then returns immediately — which silently broke every worker test that ran
+    # after this module. Run the real close cleanup with quit stubbed out.
+    original_quit = qapp.quit
+    qapp.quit = lambda: None
+    try:
+        window.close()
+    finally:
+        qapp.quit = original_quit
 
 
 def test_a_transient_status_bar_message_is_shown(main_ui):

--- a/tests/ui/test_workflow_status_display.py
+++ b/tests/ui/test_workflow_status_display.py
@@ -1,0 +1,107 @@
+"""What a fire-and-forget status update does to the interaction UI, pinned pre-move.
+
+Three of ``workflow_update_signal``'s emit families are fire-and-forget status:
+``update_status_ui`` (message / workflow-info / status-bar text), the task manager's
+lifecycle reports, and ``ask_user``'s trailing prompt-clear. They are about to move to
+their own signal — continuing the split ``queue_changed_signal`` started — so this
+pins what the display half does today, before the channel moves under it.
+
+The payloads here are built by hand to match the emit sites (``update_status_ui`` at
+``workflows/ui.py`` and ``TaskManager._emit_status``), and the handler is called
+directly rather than through the signal: an exception escaping a queued slot is a
+process abort (FIB-329), which would take the pytest summary with it.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+
+
+@pytest.fixture
+def ui(qapp):
+    """A real AutoLamellaUI, connected, without the main window that hosts it.
+
+    Connected because the handler needs ``image_widget`` and
+    ``milling_task_config_widget``, which ``update_microscope_ui()`` builds. The
+    shipped default configuration is Demo, so this touches no hardware.
+    """
+    widget = AutoLamellaUI(parent_ui=None)
+    widget.system_widget.connect_to_microscope()
+    yield widget
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+
+
+def _status_payload(msg, workflow_info=None, status_bar=None):
+    """The dict ``update_status_ui`` puts on the wire, byte for byte."""
+    return {"msg": msg, "workflow_info": workflow_info, "status_bar": status_bar}
+
+
+def test_a_status_message_writes_the_instruction_label(ui):
+    ui.handle_workflow_update(_status_payload("Milling: Preparing..."))
+
+    assert ui.label_instructions.text() == "Milling: Preparing..."
+    assert ui.label_instructions.isVisibleTo(ui)
+
+
+def test_a_status_message_carries_no_question_so_the_buttons_hide(ui):
+    # A question showed its buttons first; a plain status update must take them
+    # down — status payloads carry no pos/neg, and absent means "no question".
+    ui.set_instructions_msg("Continue?", pos="Continue", neg="Exit")
+    assert ui.pushButton_yes.isVisibleTo(ui)
+
+    ui.handle_workflow_update(_status_payload("Milling: Preparing..."))
+
+    assert not ui.pushButton_yes.isVisibleTo(ui)
+    assert not ui.pushButton_no.isVisibleTo(ui)
+
+
+def test_an_empty_message_clears_the_prompt(ui):
+    # ask_user's trailing emit: {"msg": ""} takes the answered question down.
+    ui.set_instructions_msg("Continue?", pos="Continue", neg="Exit")
+
+    ui.handle_workflow_update({"msg": ""})
+
+    assert ui.label_instructions.text() == ""
+    assert not ui.label_instructions.isVisibleTo(ui)
+
+
+def test_workflow_info_writes_the_workflow_information_label(ui):
+    ui.handle_workflow_update(
+        _status_payload("", workflow_info="Task 2/5: Rough Milling")
+    )
+
+    assert ui.label_workflow_information.text() == "Task 2/5: Rough Milling"
+    assert ui.label_workflow_information.isVisibleTo(ui)
+
+
+def test_absent_workflow_info_shows_the_label_without_rewriting_it(ui):
+    # Today's behaviour, deliberate or not: set_current_workflow_message(None)
+    # leaves the text alone but still makes the label visible. The channel move
+    # must not silently change it either way.
+    ui.set_current_workflow_message("Task 2/5: Rough Milling", show=False)
+    assert not ui.label_workflow_information.isVisibleTo(ui)
+
+    ui.handle_workflow_update(_status_payload("Moving stage..."))
+
+    assert ui.label_workflow_information.text() == "Task 2/5: Rough Milling"
+    assert ui.label_workflow_information.isVisibleTo(ui)
+
+
+def test_a_status_update_releases_a_pending_ui_update_wait(ui):
+    # The defect the move removes, pinned as it stands: the flag is scoped to the
+    # signal, not to a request, so a mere status emit releases whoever is blocked
+    # in a `while WAITING_FOR_UI_UPDATE` loop. Once status moves off this signal,
+    # this inverts: a status update must leave a pending wait alone.
+    ui.WAITING_FOR_UI_UPDATE = True
+
+    ui.handle_workflow_update(_status_payload("Moving stage..."))
+
+    assert ui.WAITING_FOR_UI_UPDATE is False


### PR DESCRIPTION
Three of `workflow_update_signal`'s emit families are fire-and-forget status: `update_status_ui` (message / workflow-info / status-bar text), the task manager's lifecycle reports, and `ask_user`'s trailing prompt-clear. They are about to move to their own signal — continuing the split `queue_changed_signal` started — so this pins what the display half does today, on both windows, before the channel moves under it. Tests only; no behaviour change.

## `tests/ui/test_workflow_status_display.py` — the AutoLamellaUI side (6 tests)

Payloads built by hand to match the emit sites byte for byte, handler called directly (an exception escaping a queued slot is a process abort, which would take the pytest summary with it — same convention as `test_workflow_update_payload.py`). Pins:

- a status message writes the instruction label
- a status payload carries no question, so the yes/no buttons come down
- `{"msg": ""}` (the `ask_user` trailing emit) clears the prompt
- `workflow_info` writes the workflow-information label
- an absent `workflow_info` still shows the label **without rewriting it** — today's oddity, pinned so the move can't change it silently either way
- **a status update releases a pending `WAITING_FOR_UI_UPDATE` wait** — the flag is scoped to the signal, not to a request, so any emitter releases every waiter. Pinned as it stands; the move inverts this one to "leaves the wait alone".

## `tests/ui/test_mainui_workflow_status.py` — the main-window side (4 tests)

**The first test ever to construct the real `AutoLamellaSingleWindowUI` offscreen.** The only thing that ever prevented it is `add_minimap_tab`, which builds a `napari.Viewer` whose vispy canvas calls `glGetIntegerv` with no GL context and takes the process down with SIGSEGV (measured via faulthandler). The fixture stubs that one method; everything else — status bar, timeline, embedded AutoLamellaUI, protocol editor — is real, with a real Demo connect. The drafts that delete the tab outright (#585/#586) are held pending user testing of the replacement Overview tab; when they land, the stub goes.

Pins: transient status-bar text is shown; a payload without `status_bar` leaves the bar alone; a lifecycle report renders `Workflow: <task> | <lamella> | 2/5` on the bar; a report flips Run→Stop.

### Latent init gap, found doing it

`_border_state` is first assigned on the Run-workflow click (`_on_run_workflow_clicked`), never in `__init__`, and `_on_workflow_update` reads it unconditionally at the end — so any status payload arriving without a prior Run click is an `AttributeError` inside a queued slot, i.e. a process abort, not a blank label. Production is protected by flow order only. The fixture supplies the same precondition explicitly (`_set_border_state("idle")`, documented); the follow-up PR that moves the handler initialises it properly.

Also confirmed while building the fixture: the protocol editor builds its full UI on **first microscope connect** (not experiment load), which is why the fixture connects to Demo — the editor's lock path runs on every lifecycle report.

## Verification

- `pytest tests/ui/test_workflow_status_display.py tests/ui/test_mainui_workflow_status.py` — 10 passed, ~4 s, offscreen.
- `ruff check` / `ruff format --check` clean on both files.
