### PR TITLE
[fix] Find the milling widget wherever the host keeps it (FIB-855)

### DIFF
--- a/fibsem/ui/widgets/stage_control_widget.py
+++ b/fibsem/ui/widgets/stage_control_widget.py
@@ -12,8 +12,9 @@ them is optional decoration:
 * ``host.image_widget`` -- the interaction handshake (the buttons stay down through the
   acquisition that follows a move, and the image widget brings them back), the live
   image a canvas click is resolved against, and the acquisition-finished signal.
-* ``host.milling_widget`` -- refuses a click-to-move while milling. Optional, so it is
-  reached through ``hasattr``.
+* the milling widget -- refuses a click-to-move while milling. Optional, and the hosts
+  keep it under different names, so it is found by ``_milling_widget`` rather than read
+  off a fixed attribute (FIB-855).
 * the quad-view controller -- where move status and the position readout are written.
 
 ``StagePositionWidget`` needs none of that, which is why it came out first and needs no
@@ -229,6 +230,40 @@ class StageControlWidget(QWidget):
             return controller
         parent_ui = getattr(self.host, "parent_widget", None)
         return getattr(parent_ui, "view_controller", None)
+
+    def _milling_widget(self):
+        """Return whatever can answer ``is_milling``, or None if nothing can.
+
+        The hosts disagree about where the milling widget lives -- ``FibsemUI``
+        publishes it as ``milling_widget``, ``AutoLamellaUI`` keeps the same
+        ``MillingTaskViewerWidget`` as ``milling_task_config_widget``. This looked at
+        the first name only, so in AutoLamella the guard below found nothing and
+        click-to-move went unguarded through every mill (FIB-855).
+
+        **Selected by capability, not by name.** A candidate counts only if it actually
+        carries ``is_milling``; the names are where to look, not what makes it the right
+        object. That is what stops this going quiet again the next time the widget is
+        renamed or re-parented -- a name that stops resolving falls through to the next
+        one instead of silently disabling the guard.
+        """
+        for holder in (self.host, getattr(self.host, "parent_widget", None)):
+            if holder is None:
+                continue
+            for name in ("milling_widget", "milling_task_config_widget"):
+                candidate = getattr(holder, name, None)
+                if candidate is not None and hasattr(candidate, "is_milling"):
+                    return candidate
+        return None
+
+    def _is_milling(self) -> bool:
+        """Whether a mill is running right now.
+
+        False when no milling widget can be found at all -- a host without one cannot
+        be milling. That is the same fail-open the old ``hasattr`` had, but it is now
+        the answer to a question rather than the side effect of looking in one place.
+        """
+        widget = self._milling_widget()
+        return bool(widget is not None and widget.is_milling)
 
     def _toggle_interactions(self, enable: bool, caller: Optional[str] = None):
         """Toggle the interactions in the widget depending on microscope state"""
@@ -525,7 +560,7 @@ class StageControlWidget(QWidget):
             return
         if "Shift" in modifiers:
             return
-        if hasattr(self.host, "milling_widget") and self.host.milling_widget.is_milling:
+        if self._is_milling():
             notification_service.show_toast(
                 "Cannot move stage while milling is in progress."
             )

--- a/tests/ui/test_canvas_double_click_guards.py
+++ b/tests/ui/test_canvas_double_click_guards.py
@@ -24,6 +24,7 @@ import pytest
 pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
 
 from PyQt5.QtCore import QEventLoop, QTimer
+from PyQt5.QtWidgets import QWidget
 
 # The real construction seam: a host with a view controller, a real image widget and a
 # Demo microscope. The guards read `image_widget.eb_image` and `parent.milling_widget`,
@@ -196,6 +197,10 @@ def test_a_click_during_milling_is_refused_out_loud(movement, dispatched, toasts
     """
     from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 
+    # `milling_widget` is the name FibsemUI uses. AutoLamella's name is covered by
+    # test_the_guard_finds_the_real_milling_widget_on_a_real_host, which builds the
+    # host rather than naming the attribute -- this one only needs *a* host that has
+    # one, to exercise the refusal itself.
     viewer = MillingTaskViewerWidget(microscope=_session()[0])
     movement.host.milling_widget = viewer
 
@@ -245,6 +250,93 @@ def test_the_no_image_guard_never_fires(qapp, toasts):
     assert len(calls) == 1, "the guard fired -- if this changed, the finding is fixed"
     assert toasts == [], toasts
     host.deleteLater()
+
+
+def test_the_guard_finds_the_real_milling_widget_on_a_real_host(qapp):
+    """FIB-855. The guard above passes against any host that happens to carry
+    ``milling_widget`` -- including one the test itself gave the attribute to. This one
+    builds the host the operator actually mills from and asks whether the guard can
+    find anything at all.
+
+    It is the check that was missing: click-to-move went unguarded through every mill in
+    AutoLamella, because `FibsemUI` publishes the `MillingTaskViewerWidget` as
+    `milling_widget` and `AutoLamellaUI` keeps the same widget as
+    `milling_task_config_widget`. The old lookup read the first name only and the
+    `hasattr` turned the miss into a silent skip.
+
+    Deliberately asserts on the *resolved object*, not on an attribute name. Naming the
+    attribute here would re-create the original bug the moment the widget moves again.
+    """
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+
+    ui = AutoLamellaUI(parent_ui=None)
+    ui.system_widget.connect_to_microscope()
+    qapp.processEvents()
+    try:
+        control = ui.movement_widget.control_widget
+        found = control._milling_widget()
+
+        assert found is not None, (
+            "the guard cannot see a milling widget on AutoLamellaUI, so click-to-move "
+            "is unguarded during a mill"
+        )
+        assert found.is_milling is False, "precondition: nothing should be milling"
+
+        # Now drive the click itself, with that widget really reporting a mill. Asserting
+        # on `_milling_widget()` alone would not do: it passes with the guard still
+        # reading `host.milling_widget` directly and never calling the resolver, which
+        # is exactly the bug. The refusal has to be observed end to end.
+        image_widget = ui.image_widget
+        image_widget._on_acquire(_image(BeamType.ELECTRON))
+        dispatched = []
+        control._execute_stage_move = lambda *a, **k: dispatched.append(a)
+
+        release = threading.Event()
+        thread = threading.Thread(target=release.wait, daemon=True)
+        thread.start()
+        found.milling_widget._milling_thread = thread
+        try:
+            assert found.is_milling, "precondition: the widget should report milling"
+            assert control._is_milling(), "the guard cannot tell that a mill is running"
+            control._on_canvas_double_click(BeamType.ELECTRON, 100.0, 100.0, set())
+        finally:
+            release.set()
+            thread.join(timeout=5)
+
+        assert dispatched == [], "the stage was moved during a mill"
+    finally:
+        ui.movement_widget._teardown_connections()
+        ui.microscope.disconnect()
+        ui.deleteLater()
+
+
+def test_a_host_with_no_milling_widget_is_not_milling(movement):
+    """Nothing to ask means nothing is milling. The resolver fails open, as the old
+    ``hasattr`` did -- a host without a milling widget cannot be running a mill."""
+    assert movement._milling_widget() is None
+    assert movement._is_milling() is False
+
+
+def test_a_name_that_is_not_a_milling_widget_is_skipped(movement):
+    """The resolver picks by capability, not by name -- so a host where the first name
+    resolves to something else keeps working instead of silently losing the guard.
+
+    This is what the original bug cost: a lookup that trusted one name, and a
+    ``hasattr`` that turned the miss into a skip. Making the *name* the search order and
+    ``is_milling`` the test means a rename degrades to "look in the next place" rather
+    than to "no guard".
+    """
+    from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
+
+    decoy = QWidget()  # carries the name, cannot answer the question
+    real = MillingTaskViewerWidget(microscope=_session()[0])
+    movement.host.milling_widget = decoy
+    movement.host.milling_task_config_widget = real
+
+    assert movement._milling_widget() is real, (
+        "the resolver stopped at a name instead of finding what can answer"
+    )
+    assert movement._is_milling() is False
 
 
 def test_a_click_outside_the_image_is_ignored(movement, dispatched, toasts):


### PR DESCRIPTION
Fixes [FIB-855](https://linear.app/fibsemos/issue/FIB-855/click-to-move-is-unguarded-during-milling-in-autolamella-the-milling). Two files.

## The bug

Double-clicking a beam canvas during a mill **moved the stage** in AutoLamella. The guard was present and was reached — it just looked in one place:

```python
hasattr(self.host, "milling_widget") and self.host.milling_widget.is_milling
```

`FibsemUI` publishes the `MillingTaskViewerWidget` as `milling_widget`. `AutoLamellaUI` keeps the same widget as `milling_task_config_widget`. So on the application operators actually mill from, the attribute was absent, and the `hasattr` turned the miss into a silent skip.

From the session log that found it:

```
18:25:08,958  milling_state=MillingState.RUNNING, remaining_time=4
18:25:09,536  _execute_stage_move  {'movement_mode': 'Stable', ...}
18:25:10,863  stable_move          {'dx': 1.0096e-05, 'dy': -2.0785e-05, ...}
18:25:11,974  milling_state=MillingState.RUNNING, remaining_time=1
```

**Pre-existing**, not fallout from the FIB-783 split — verified against `ff7f834d`, where the same expression resolves to the same `AutoLamellaUI` instance. The split renamed `self.parent` to `self.host` and nothing else.

## The fix

`_milling_widget()` searches the host and its `parent_widget` under both names, and returns the first candidate that actually carries `is_milling`.

**Picking by capability rather than by name is the point.** The names are the search order; `is_milling` is what makes something the right object. A rename now degrades to "look in the next place" instead of to "no guard".

## The test I got wrong first, which is the interesting part

My first test asserted that `_milling_widget()` finds something on a real `AutoLamellaUI`. It passed — **and it still passed when I restored the original buggy lookup**, because the guard can read `host.milling_widget` directly and never call the resolver. That is the same shape as the bug itself: checking a component rather than checking that the thing using it works.

The test now builds a real `AutoLamellaUI`, connects a Demo microscope, puts a real blocked thread behind `is_milling`, and drives the double-click — asserting no move was dispatched. A second test hands a host a decoy `QWidget` under the first name, so the capability filter is falsifiable rather than decorative.

This also explains why the existing suite said the guard worked. `test_a_click_during_milling_is_refused_out_loud` assigns `movement.host.milling_widget = viewer` — creating the attribute the real host lacks. It proves the guard's *body* works and says nothing about whether it is reached. It stays, with a comment saying which half it covers.

## Verification

| mutation | result |
| -- | -- |
| restore the original `host.milling_widget` lookup | 1 failed |
| drop the capability filter | 1 failed |
| search only FibsemUI's name | 2 failed |
| remove the guard entirely | 2 failed |

134 tests green across the nine movement-related files.

**In the running application**, with a mill live:

```
resolver found          : MillingTaskViewerWidget
app reports milling     : True
stage moved during mill : False
operator was told       : ['Cannot move stage while milling is in progress.']
moves once mill is over : True
```

`ruff check` and `ruff format --check` clean.

## Noted, not fixed

`_toggle_interactions` carries a commented-out line reaching for `self.parent.milling_widget` on the same wrong path. Left alone — it is inert, and re-enabling it is a behaviour change that belongs in its own PR. It would now have `_milling_widget()` to use.