### PR TITLE
[server] Rebuild FibsemServer around a factory with auth, scopes, and a command lock

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1913,7 +1913,8 @@ class FibsemMicroscope(ABC):
         stage_position = FibsemStagePosition(t=stage_tilt, r=rotation)
         self.safe_absolute_stage_movement(stage_position)
 
-        return self.is_close_to_milling_angle(milling_angle)
+        # milling_angle is radians here; is_close_to_milling_angle compares degrees (FIB-853)
+        return self.is_close_to_milling_angle(np.degrees(milling_angle))
 
     def _beam_view_tilt(self, beam_type: BeamType) -> float:
         """Tilt of a beam column's viewing axis from the electron column, in radians."""

--- a/fibsem/server/README.md
+++ b/fibsem/server/README.md
@@ -16,16 +16,32 @@ On the machine connected to the microscope:
 from fibsem.server import FibsemServer
 
 server = FibsemServer.from_session(manufacturer="ThermoFisher", ip_address="192.168.1.1", port=8001)
-server.run()
+server.run()   # logs the bearer token; read-only unless scopes are armed
 ```
 
 Or with the Demo microscope for development:
 
 ```bash
-python -m fibsem.server.server --manufacturer Demo --ip-address localhost --port 8001
+python -m fibsem.server.server --manufacturer Demo --arm-hardware
 ```
 
 The Swagger UI is available at `http://<host>:8001/docs`.
+
+### Authentication and scopes
+
+Every request needs the server's bearer token (generated at startup and logged,
+or supplied with `--token`), sent as an `Authorization: Bearer <token>` header.
+A valid token grants the `read` scope (observation). The `hardware` scope —
+moves, acquisition, milling — must be armed explicitly (`--arm-hardware`);
+unarmed hardware calls are refused with a structured `403 scope_not_armed`.
+Hardware commands are serialized: a second concurrent command gets `409 busy`.
+`POST /stop_milling` is deliberately read-scope and lock-exempt — stopping is
+always allowed. `GET /capabilities` reports the armed scopes.
+
+The server binds `127.0.0.1` by default. Exposing it on the LAN
+(`--host 0.0.0.0`) is an explicit choice: the token then travels in cleartext
+HTTP, which keeps strangers out but is not sniff-proof — see the AutoLamella
+Agent Server design doc for the trust model.
 
 ---
 
@@ -34,7 +50,7 @@ The Swagger UI is available at `http://<host>:8001/docs`.
 ```python
 from fibsem.server import FibsemClient
 
-microscope = FibsemClient(host="192.168.1.100", port=8001)
+microscope = FibsemClient(host="192.168.1.100", port=8001, token="<token from the server log>")
 ```
 
 ### Image Acquisition

--- a/fibsem/server/__init__.py
+++ b/fibsem/server/__init__.py
@@ -1,4 +1,5 @@
+from fibsem.server.auth import AuthConfig, Scope
 from fibsem.server.client import FibsemClient
-from fibsem.server.server import FibsemServer
+from fibsem.server.server import FibsemServer, build_server
 
-__all__ = ["FibsemServer", "FibsemClient"]
+__all__ = ["AuthConfig", "FibsemClient", "FibsemServer", "Scope", "build_server"]

--- a/fibsem/server/auth.py
+++ b/fibsem/server/auth.py
@@ -1,0 +1,115 @@
+"""Authentication and scope gating for the fibsem server (FIB-852).
+
+One bearer token per server instance, three scopes:
+
+- ``read``: granted to every valid token. Observation only.
+- ``control``: app-level workflow control. Armed by the hosting (GUI toggle in
+  the embedded app; unused in bench hosting until an app router exists).
+- ``hardware``: anything that commands or mutates the microscope. Armed
+  explicitly by the hosting (GUI toggle, or ``--arm-hardware`` on the CLI).
+
+Fail closed: a server always has a token (generated when the hosting does not
+supply one), and only ``read`` is armed unless the hosting says otherwise.
+"""
+
+import hmac
+import secrets
+import threading
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import FrozenSet, Iterable, Optional
+
+from fastapi import HTTPException, Request
+
+
+class Scope(str, Enum):
+    READ = "read"
+    CONTROL = "control"
+    HARDWARE = "hardware"
+
+
+@dataclass(frozen=True)
+class AuthConfig:
+    """Token + armed scopes for one server instance.
+
+    ``read`` is implicitly armed for any valid token and need not be listed.
+    """
+
+    token: str
+    armed: FrozenSet[Scope] = field(default_factory=frozenset)
+
+    @classmethod
+    def generate(
+        cls,
+        arm_control: bool = False,
+        arm_hardware: bool = False,
+        token: Optional[str] = None,
+    ) -> "AuthConfig":
+        armed = set()
+        if arm_control:
+            armed.add(Scope.CONTROL)
+        if arm_hardware:
+            armed.add(Scope.HARDWARE)
+        return cls(token=token or secrets.token_urlsafe(32), armed=frozenset(armed))
+
+    def is_armed(self, scope: Scope) -> bool:
+        return scope is Scope.READ or scope in self.armed
+
+    def armed_scopes(self) -> Iterable[Scope]:
+        return (s for s in Scope if self.is_armed(s))
+
+
+def _bearer_token(request: Request) -> Optional[str]:
+    header = request.headers.get("Authorization")
+    if header is None or not header.startswith("Bearer "):
+        return None
+    return header[len("Bearer ") :]
+
+
+def require_scope(scope: Scope):
+    """Build a FastAPI dependency enforcing a valid token + an armed scope."""
+
+    def dependency(request: Request) -> None:
+        auth: AuthConfig = request.app.state.auth
+        token = _bearer_token(request)
+        if token is None or not hmac.compare_digest(token, auth.token):
+            raise HTTPException(
+                status_code=401,
+                detail={
+                    "error_type": "unauthorized",
+                    "message": "Missing or invalid bearer token.",
+                },
+            )
+        if not auth.is_armed(scope):
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error_type": "scope_not_armed",
+                    "scope": scope.value,
+                    "message": f"The '{scope.value}' scope is not armed on this server.",
+                },
+            )
+
+    return dependency
+
+
+def command_slot(request: Request):
+    """Serialize hardware commands: one in flight per microscope, 409 otherwise.
+
+    Concurrent requests on the threadpool would interleave multi-call vendor
+    operations (the FIB-517/542/569 incident class). A structured refusal beats
+    queueing: a caller blocked behind an hour-long mill should be told, not held.
+    """
+    lock: threading.Lock = request.app.state.command_lock
+    if not lock.acquire(blocking=False):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error_type": "busy",
+                "message": "Another hardware command is in progress on this microscope.",
+            },
+        )
+    try:
+        yield
+    finally:
+        lock.release()

--- a/fibsem/server/client.py
+++ b/fibsem/server/client.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 import io
+import math
 from typing import List, Optional, Tuple
 
 import requests
@@ -39,9 +40,13 @@ class FibsemClient:
     so they are available as direct attributes, matching the FibsemMicroscope interface.
     """
 
-    def __init__(self, host: str = "localhost", port: int = 8001):
+    def __init__(
+        self, host: str = "localhost", port: int = 8001, token: Optional[str] = None
+    ):
         self.base_url = f"http://{host}:{port}"
         self._session = requests.Session()
+        if token is not None:
+            self._session.headers["Authorization"] = f"Bearer {token}"
         self._fetch_system()
 
     def _fetch_system(self) -> None:
@@ -56,12 +61,18 @@ class FibsemClient:
         return resp.json()
 
     def _post(self, endpoint: str, body: dict = None, timeout: int = 30) -> dict:
-        resp = self._session.post(f"{self.base_url}/{endpoint}", json=body or {}, timeout=timeout)
+        resp = self._session.post(
+            f"{self.base_url}/{endpoint}", json=body or {}, timeout=timeout
+        )
         resp.raise_for_status()
         return resp.json()
 
-    def _post_image(self, endpoint: str, body: dict = None, timeout: int = 60) -> FibsemImage:
-        resp = self._session.post(f"{self.base_url}/{endpoint}", json=body or {}, timeout=timeout)
+    def _post_image(
+        self, endpoint: str, body: dict = None, timeout: int = 60
+    ) -> FibsemImage:
+        resp = self._session.post(
+            f"{self.base_url}/{endpoint}", json=body or {}, timeout=timeout
+        )
         resp.raise_for_status()
         return FibsemImage.load(io.BytesIO(resp.content))
 
@@ -72,7 +83,11 @@ class FibsemClient:
 
     # --- Image acquisition ---
 
-    def acquire_image(self, beam_type: BeamType = BeamType.ELECTRON, image_settings: Optional[ImageSettings] = None) -> FibsemImage:
+    def acquire_image(
+        self,
+        beam_type: BeamType = BeamType.ELECTRON,
+        image_settings: Optional[ImageSettings] = None,
+    ) -> FibsemImage:
         """Acquire a fresh image. Pass image_settings to override current microscope settings."""
         body = {"beam_type": beam_type.name}
         if image_settings is not None:
@@ -107,16 +122,30 @@ class FibsemClient:
         result = self._post("move_stage_relative", {"position": position.to_dict()})
         return FibsemStagePosition.from_dict(result["position"])
 
-    def stable_move(self, dx: float, dy: float, beam_type: BeamType) -> FibsemStagePosition:
-        result = self._post("stable_move", {"dx": dx, "dy": dy, "beam_type": beam_type.name})
+    def stable_move(
+        self, dx: float, dy: float, beam_type: BeamType
+    ) -> FibsemStagePosition:
+        result = self._post(
+            "stable_move", {"dx": dx, "dy": dy, "beam_type": beam_type.name}
+        )
         return FibsemStagePosition.from_dict(result["position"])
 
-    def project_stable_move(self, dx: float, dy: float, beam_type: BeamType, base_position: FibsemStagePosition) -> FibsemStagePosition:
-        result = self._post("project_stable_move", {
-            "dx": dx, "dy": dy,
-            "beam_type": beam_type.name,
-            "base_position": base_position.to_dict(),
-        })
+    def project_stable_move(
+        self,
+        dx: float,
+        dy: float,
+        beam_type: BeamType,
+        base_position: FibsemStagePosition,
+    ) -> FibsemStagePosition:
+        result = self._post(
+            "project_stable_move",
+            {
+                "dx": dx,
+                "dy": dy,
+                "beam_type": beam_type.name,
+                "base_position": base_position.to_dict(),
+            },
+        )
         return FibsemStagePosition.from_dict(result["position"])
 
     def vertical_move(self, dy: float, dx: float = 0.0) -> FibsemStagePosition:
@@ -132,7 +161,9 @@ class FibsemClient:
     # --- Microscope state ---
 
     def get_microscope_state(self) -> MicroscopeState:
-        return MicroscopeState.from_dict(self._get("microscope_state")["microscope_state"])
+        return MicroscopeState.from_dict(
+            self._get("microscope_state")["microscope_state"]
+        )
 
     def set_microscope_state(self, microscope_state: MicroscopeState) -> None:
         self._post("microscope_state", {"microscope_state": microscope_state.to_dict()})
@@ -160,7 +191,9 @@ class FibsemClient:
         return BeamSystemSettings.from_dict(result["beam_system_settings"])
 
     def set_beam_system_settings(self, settings: BeamSystemSettings) -> None:
-        self._post("beam_system_settings/set", {"beam_system_settings": settings.to_dict()})
+        self._post(
+            "beam_system_settings/set", {"beam_system_settings": settings.to_dict()}
+        )
 
     # --- Detector settings ---
 
@@ -168,11 +201,16 @@ class FibsemClient:
         result = self._post("detector_settings/get", {"beam_type": beam_type.name})
         return FibsemDetectorSettings.from_dict(result["detector_settings"])
 
-    def set_detector_settings(self, detector_settings: FibsemDetectorSettings, beam_type: BeamType) -> None:
-        self._post("detector_settings/set", {
-            "detector_settings": detector_settings.to_dict(),
-            "beam_type": beam_type.name,
-        })
+    def set_detector_settings(
+        self, detector_settings: FibsemDetectorSettings, beam_type: BeamType
+    ) -> None:
+        self._post(
+            "detector_settings/set",
+            {
+                "detector_settings": detector_settings.to_dict(),
+                "beam_type": beam_type.name,
+            },
+        )
 
     # --- Individual beam getters / setters ---
 
@@ -180,55 +218,92 @@ class FibsemClient:
         return self._post("beam_current/get", {"beam_type": beam_type.name})["value"]
 
     def set_beam_current(self, current: float, beam_type: BeamType) -> float:
-        return self._post("beam_current/set", {"value": current, "beam_type": beam_type.name})["value"]
+        return self._post(
+            "beam_current/set", {"value": current, "beam_type": beam_type.name}
+        )["value"]
 
     def get_beam_voltage(self, beam_type: BeamType) -> float:
         return self._post("beam_voltage/get", {"beam_type": beam_type.name})["value"]
 
     def set_beam_voltage(self, voltage: float, beam_type: BeamType) -> float:
-        return self._post("beam_voltage/set", {"value": voltage, "beam_type": beam_type.name})["value"]
+        return self._post(
+            "beam_voltage/set", {"value": voltage, "beam_type": beam_type.name}
+        )["value"]
 
     def get_field_of_view(self, beam_type: BeamType) -> float:
         return self._post("field_of_view/get", {"beam_type": beam_type.name})["value"]
 
     def set_field_of_view(self, hfw: float, beam_type: BeamType) -> float:
-        return self._post("field_of_view/set", {"value": hfw, "beam_type": beam_type.name})["value"]
+        return self._post(
+            "field_of_view/set", {"value": hfw, "beam_type": beam_type.name}
+        )["value"]
 
     def get_working_distance(self, beam_type: BeamType) -> float:
-        return self._post("working_distance/get", {"beam_type": beam_type.name})["value"]
+        return self._post("working_distance/get", {"beam_type": beam_type.name})[
+            "value"
+        ]
 
     def set_working_distance(self, wd: float, beam_type: BeamType) -> float:
-        return self._post("working_distance/set", {"value": wd, "beam_type": beam_type.name})["value"]
+        return self._post(
+            "working_distance/set", {"value": wd, "beam_type": beam_type.name}
+        )["value"]
 
     def get_dwell_time(self, beam_type: BeamType) -> float:
         return self._post("dwell_time/get", {"beam_type": beam_type.name})["value"]
 
     def set_dwell_time(self, dwell_time: float, beam_type: BeamType) -> float:
-        return self._post("dwell_time/set", {"value": dwell_time, "beam_type": beam_type.name})["value"]
+        return self._post(
+            "dwell_time/set", {"value": dwell_time, "beam_type": beam_type.name}
+        )["value"]
 
     def get_resolution(self, beam_type: BeamType) -> Tuple[int, int]:
-        return tuple(self._post("resolution/get", {"beam_type": beam_type.name})["value"])
+        return tuple(
+            self._post("resolution/get", {"beam_type": beam_type.name})["value"]
+        )
 
-    def set_resolution(self, resolution: Tuple[int, int], beam_type: BeamType) -> Tuple[int, int]:
-        return tuple(self._post("resolution/set", {"value": list(resolution), "beam_type": beam_type.name})["value"])
+    def set_resolution(
+        self, resolution: Tuple[int, int], beam_type: BeamType
+    ) -> Tuple[int, int]:
+        return tuple(
+            self._post(
+                "resolution/set",
+                {"value": list(resolution), "beam_type": beam_type.name},
+            )["value"]
+        )
 
     def get_scan_rotation(self, beam_type: BeamType) -> float:
         return self._post("scan_rotation/get", {"beam_type": beam_type.name})["value"]
 
     def set_scan_rotation(self, rotation: float, beam_type: BeamType) -> float:
-        return self._post("scan_rotation/set", {"value": rotation, "beam_type": beam_type.name})["value"]
+        return self._post(
+            "scan_rotation/set", {"value": rotation, "beam_type": beam_type.name}
+        )["value"]
 
     def get_stigmation(self, beam_type: BeamType) -> Point:
-        return Point.from_dict(self._post("stigmation/get", {"beam_type": beam_type.name})["value"])
+        return Point.from_dict(
+            self._post("stigmation/get", {"beam_type": beam_type.name})["value"]
+        )
 
     def set_stigmation(self, stigmation: Point, beam_type: BeamType) -> Point:
-        return Point.from_dict(self._post("stigmation/set", {"value": stigmation.to_dict(), "beam_type": beam_type.name})["value"])
+        return Point.from_dict(
+            self._post(
+                "stigmation/set",
+                {"value": stigmation.to_dict(), "beam_type": beam_type.name},
+            )["value"]
+        )
 
     def get_beam_shift(self, beam_type: BeamType) -> Point:
-        return Point.from_dict(self._post("beam_shift/get", {"beam_type": beam_type.name})["value"])
+        return Point.from_dict(
+            self._post("beam_shift/get", {"beam_type": beam_type.name})["value"]
+        )
 
     def set_beam_shift(self, shift: Point, beam_type: BeamType) -> Point:
-        return Point.from_dict(self._post("beam_shift/set", {"value": shift.to_dict(), "beam_type": beam_type.name})["value"])
+        return Point.from_dict(
+            self._post(
+                "beam_shift/set",
+                {"value": shift.to_dict(), "beam_type": beam_type.name},
+            )["value"]
+        )
 
     # --- Detector individual getters / setters ---
 
@@ -236,56 +311,81 @@ class FibsemClient:
         return self._post("detector_type/get", {"beam_type": beam_type.name})["value"]
 
     def set_detector_type(self, detector_type: str, beam_type: BeamType) -> str:
-        return self._post("detector_type/set", {"value": detector_type, "beam_type": beam_type.name})["value"]
+        return self._post(
+            "detector_type/set", {"value": detector_type, "beam_type": beam_type.name}
+        )["value"]
 
     def get_detector_mode(self, beam_type: BeamType) -> str:
         return self._post("detector_mode/get", {"beam_type": beam_type.name})["value"]
 
     def set_detector_mode(self, mode: str, beam_type: BeamType) -> str:
-        return self._post("detector_mode/set", {"value": mode, "beam_type": beam_type.name})["value"]
+        return self._post(
+            "detector_mode/set", {"value": mode, "beam_type": beam_type.name}
+        )["value"]
 
     def get_detector_contrast(self, beam_type: BeamType) -> float:
-        return self._post("detector_contrast/get", {"beam_type": beam_type.name})["value"]
+        return self._post("detector_contrast/get", {"beam_type": beam_type.name})[
+            "value"
+        ]
 
     def set_detector_contrast(self, contrast: float, beam_type: BeamType) -> float:
-        return self._post("detector_contrast/set", {"value": contrast, "beam_type": beam_type.name})["value"]
+        return self._post(
+            "detector_contrast/set", {"value": contrast, "beam_type": beam_type.name}
+        )["value"]
 
     def get_detector_brightness(self, beam_type: BeamType) -> float:
-        return self._post("detector_brightness/get", {"beam_type": beam_type.name})["value"]
+        return self._post("detector_brightness/get", {"beam_type": beam_type.name})[
+            "value"
+        ]
 
     def set_detector_brightness(self, brightness: float, beam_type: BeamType) -> float:
-        return self._post("detector_brightness/set", {"value": brightness, "beam_type": beam_type.name})["value"]
+        return self._post(
+            "detector_brightness/set",
+            {"value": brightness, "beam_type": beam_type.name},
+        )["value"]
 
     # --- Available values ---
 
-    def get_available_values(self, key: str, beam_type: Optional[BeamType] = None) -> list:
+    def get_available_values(
+        self, key: str, beam_type: Optional[BeamType] = None
+    ) -> list:
         """Get the list of available values for a given key (e.g. 'detector_type', 'application_file')."""
         body = {"key": key, "beam_type": beam_type.name if beam_type else None}
         return self._post("available_values", body)["values"]
 
     # --- Milling angle ---
 
-    def get_current_milling_angle(self, stage_position: Optional[FibsemStagePosition] = None) -> float:
+    def get_current_milling_angle(
+        self, stage_position: Optional[FibsemStagePosition] = None
+    ) -> float:
         """Get the current milling angle in degrees. Pass a stage_position to calculate from a specific position."""
         if stage_position is None:
-            return self._get("milling_angle")["milling_angle"]
+            return self._get("milling_angle")["milling_angle_deg"]
         body = {"stage_position": stage_position.to_dict()}
-        return self._post("milling_angle/from_position", body)["milling_angle"]
+        return self._post("milling_angle/from_position", body)["milling_angle_deg"]
 
     def set_milling_angle(self, milling_angle: float) -> None:
         """Set the stored milling angle in degrees."""
-        self._post("milling_angle/set", {"milling_angle": milling_angle})
+        self._post("milling_angle/set", {"milling_angle_deg": milling_angle})
 
-    def move_to_milling_angle(self, milling_angle: float, rotation: Optional[float] = None) -> bool:
-        """Move the stage to the specified milling angle (radians). Returns True if the move was successful."""
-        body = {"milling_angle": milling_angle}
+    def move_to_milling_angle(
+        self, milling_angle: float, rotation: Optional[float] = None
+    ) -> bool:
+        """Move the stage to the specified milling angle (RADIANS, matching the
+        FibsemMicroscope ABC — FIB-853). The wire speaks degrees; converted here."""
+        body = {"milling_angle_deg": math.degrees(milling_angle)}
         if rotation is not None:
-            body["rotation"] = rotation
+            body["rotation_deg"] = math.degrees(rotation)
         return self._post("milling_angle/move", body)["success"]
 
-    def is_close_to_milling_angle(self, milling_angle: float, atol: float = 2.0) -> bool:
+    def is_close_to_milling_angle(
+        self, milling_angle: float, atol: float = 2.0
+    ) -> bool:
         """Check if the current milling angle (degrees) is within atol degrees of the target."""
-        return self._post("milling_angle/is_close", {"milling_angle": milling_angle, "atol": atol})["is_close"]
+        return self._post(
+            "milling_angle/is_close",
+            {"milling_angle_deg": milling_angle, "atol_deg": atol},
+        )["is_close"]
 
     # --- Milling ---
 
@@ -300,12 +400,18 @@ class FibsemClient:
             payload.append(d)
         self._post("draw_patterns", {"patterns": payload})
 
-    def run_milling(self, milling_current: float, milling_voltage: float, asynch: bool = False) -> None:
-        self._post("run_milling", {
-            "milling_current": milling_current,
-            "milling_voltage": milling_voltage,
-            "asynch": asynch,
-        }, timeout=3600)
+    def run_milling(
+        self, milling_current: float, milling_voltage: float, asynch: bool = False
+    ) -> None:
+        self._post(
+            "run_milling",
+            {
+                "milling_current": milling_current,
+                "milling_voltage": milling_voltage,
+                "asynch": asynch,
+            },
+            timeout=3600,
+        )
 
     def start_milling(self) -> None:
         self._post("start_milling")
@@ -320,10 +426,13 @@ class FibsemClient:
         self._post("resume_milling")
 
     def finish_milling(self, imaging_current: float, imaging_voltage: float) -> None:
-        self._post("finish_milling", {
-            "imaging_current": imaging_current,
-            "imaging_voltage": imaging_voltage,
-        })
+        self._post(
+            "finish_milling",
+            {
+                "imaging_current": imaging_current,
+                "imaging_voltage": imaging_voltage,
+            },
+        )
 
     def clear_patterns(self) -> None:
         self._post("clear_patterns")

--- a/fibsem/server/models.py
+++ b/fibsem/server/models.py
@@ -4,18 +4,23 @@ from pydantic import BaseModel
 
 # --- Shared ---
 
+
 class BeamTypeRequest(BaseModel):
     beam_type: str  # "ELECTRON" or "ION"
 
 
 # --- Image ---
 
+
 class AcquireImageRequest(BaseModel):
     beam_type: str
-    image_settings: Optional[Dict[str, Any]] = None  # ImageSettings.to_dict(); if None uses current settings
+    image_settings: Optional[Dict[str, Any]] = (
+        None  # ImageSettings.to_dict(); if None uses current settings
+    )
 
 
 # --- Stage ---
+
 
 class StagePositionRequest(BaseModel):
     position: Dict[str, Any]
@@ -48,6 +53,7 @@ class FlatToBeamRequest(BaseModel):
 
 
 # --- Beam / Detector / State ---
+
 
 class BeamSettingsRequest(BaseModel):
     beam_settings: Dict[str, Any]
@@ -92,6 +98,7 @@ class ResolutionBeamRequest(BaseModel):
 
 # --- Milling ---
 
+
 class MillingSettingsRequest(BaseModel):
     mill_settings: Dict[str, Any]
 
@@ -117,16 +124,27 @@ class DrawPatternsRequest(BaseModel):
     patterns: List[Dict[str, Any]]
 
 
+# The HTTP boundary speaks degrees everywhere (fields named *_deg); the server
+# converts for the one ABC method that takes radians (FIB-853).
+
+
 class MillingAngleRequest(BaseModel):
-    milling_angle: float  # degrees
+    milling_angle_deg: float
+
 
 class MillingAngleFromPositionRequest(BaseModel):
-    stage_position: Optional[Dict[str, Any]] = None  # FibsemStagePosition.to_dict(); if None uses current position
+    stage_position: Optional[Dict[str, Any]] = (
+        None  # FibsemStagePosition.to_dict(); if None uses current position
+    )
+
 
 class MoveToMillingAngleRequest(BaseModel):
-    milling_angle: float                # radians (underlying move_to_milling_angle takes radians)
-    rotation: Optional[float] = None   # radians; if None uses rotation_reference from system settings
+    milling_angle_deg: float
+    rotation_deg: Optional[float] = (
+        None  # if None uses rotation_reference from system settings
+    )
+
 
 class IsCloseToMillingAngleRequest(BaseModel):
-    milling_angle: float        # degrees
-    atol: float = 2.0           # degrees
+    milling_angle_deg: float
+    atol_deg: float = 2.0

--- a/fibsem/server/server.py
+++ b/fibsem/server/server.py
@@ -1,24 +1,45 @@
-"""
-FibsemServer: wraps any FibsemMicroscope instance and exposes it over HTTP via FastAPI.
+"""The fibsem server: one server codebase per microscope, hosted two ways (FIB-852).
+
+``build_server`` constructs the FastAPI app around an already-connected
+``FibsemMicroscope``:
+
+- **Bench hosting** (this module's CLI): the server process owns the microscope
+  connection and mounts the microscope router only.
+- **Embedded hosting** (the AutoLamella app): the app passes its live microscope
+  and, once FIB-846 lands, an ``app_context`` that additionally mounts the
+  app-level router.
+
+Every route requires a bearer token. Routes are split into two scopes: ``read``
+(observation; granted to any valid token) and ``hardware`` (commands and
+mutations; armed explicitly by the hosting). Hardware commands are additionally
+serialized by a per-microscope lock — a second concurrent command is refused
+with a structured ``409 busy`` rather than interleaved or queued.
 
 Usage:
-    from fibsem.server.server import FibsemServer
-    server = FibsemServer.from_session(manufacturer="Demo", ip_address="localhost", port=8001)
-    server.run()
+
+    from fibsem.server import FibsemServer
+    server = FibsemServer.from_session(manufacturer="Demo", ip_address="localhost")
+    server.run()   # token is generated and logged; read-only unless armed
 
 Or as a script:
-    python -m fibsem.server.server --manufacturer Demo --host 0.0.0.0 --port 8001
+
+    python -m fibsem.server.server --manufacturer Demo --arm-hardware
 """
 
 import io
+import logging
+import math
+import threading
+from typing import Optional
 
 import tifffile as tff
 import uvicorn
-from fastapi import FastAPI, HTTPException
-from fastapi.responses import Response
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, Response
 
 from fibsem import utils
 from fibsem.microscope import FibsemMicroscope
+from fibsem.server.auth import AuthConfig, Scope, command_slot, require_scope
 from fibsem.server.models import (
     AcquireImageRequest,
     AvailableValuesRequest,
@@ -65,6 +86,8 @@ from fibsem.structures import (
     Point,
 )
 
+API_VERSION = "0.1.0"
+
 _PATTERN_CLASSES = {
     "Rectangle": FibsemRectangleSettings,
     "Line": FibsemLineSettings,
@@ -77,7 +100,9 @@ _PATTERN_CLASSES = {
 def _pattern_from_dict(d: dict) -> FibsemPatternSettings:
     type_name = d.get("type")
     if type_name not in _PATTERN_CLASSES:
-        raise ValueError(f"Unknown pattern type: {type_name!r}. Available: {list(_PATTERN_CLASSES)}")
+        raise ValueError(
+            f"Unknown pattern type: {type_name!r}. Available: {list(_PATTERN_CLASSES)}"
+        )
     return _PATTERN_CLASSES[type_name].from_dict(d)
 
 
@@ -92,404 +117,623 @@ def _beam_type(value: str) -> BeamType:
     try:
         return BeamType[value.upper()]
     except KeyError:
-        raise HTTPException(status_code=422, detail=f"Unknown beam_type: {value!r}. Use 'ELECTRON' or 'ION'.")
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown beam_type: {value!r}. Use 'ELECTRON' or 'ION'.",
+        )
+
+
+def build_server(
+    microscope: FibsemMicroscope,
+    app_context=None,
+    auth: Optional[AuthConfig] = None,
+) -> FastAPI:
+    """Build the server app around an already-connected microscope.
+
+    ``auth`` defaults to a generated token with only the ``read`` scope armed.
+    ``app_context`` mounts the app-level router (FIB-846); until that lands,
+    passing one is an error rather than a silent no-op.
+    """
+    if app_context is not None:
+        raise NotImplementedError(
+            "The app router lands with FIB-846; app_context is not usable yet."
+        )
+    if auth is None:
+        auth = AuthConfig.generate()
+
+    app = FastAPI(title="fibsem server", version=API_VERSION)
+    app.state.auth = auth
+    app.state.microscope = microscope
+    # One hardware command in flight per microscope; see auth.command_slot.
+    app.state.command_lock = threading.Lock()
+
+    @app.exception_handler(Exception)
+    def _unhandled(request: Request, exc: Exception) -> JSONResponse:
+        # The remote caller must be able to tell a bad request from a fallen-over
+        # microscope; FastAPI's default 500 hides everything.
+        return JSONResponse(
+            status_code=500,
+            content={"detail": {"error_type": type(exc).__name__, "message": str(exc)}},
+        )
+
+    read = APIRouter(dependencies=[Depends(require_scope(Scope.READ))])
+    # Hardware routes also take the command slot, so two commands never interleave.
+    hw = APIRouter(
+        dependencies=[Depends(require_scope(Scope.HARDWARE)), Depends(command_slot)]
+    )
+
+    # --- Health / capabilities ---
+
+    @app.get("/health")
+    def health():
+        # Unauthenticated liveness probe; everything informative lives in /capabilities.
+        return {"status": "ok"}
+
+    @read.get("/capabilities")
+    def capabilities():
+        return {
+            "api_version": API_VERSION,
+            "manufacturer": type(microscope).__name__,
+            "routers": {"microscope": True, "app": False},
+            "scopes": {s.value: auth.is_armed(s) for s in Scope},
+        }
+
+    @read.get("/system")
+    def get_system():
+        return {
+            "system": microscope.system.to_dict(),
+            "stage_is_compustage": microscope.stage_is_compustage,
+        }
+
+    # --- Image acquisition ---
+
+    @hw.post("/acquire_image")
+    def acquire_image(body: AcquireImageRequest) -> Response:
+        bt = _beam_type(body.beam_type)
+        image_settings = (
+            ImageSettings.from_dict(body.image_settings)
+            if body.image_settings
+            else None
+        )
+        return _image_response(
+            microscope.acquire_image(image_settings=image_settings, beam_type=bt)
+        )
+
+    # hardware, not read: on Thermo this switches the active imaging channel
+    # (shared-view state) before pulling the frame from the vendor server.
+    @hw.post("/last_image")
+    def last_image(body: BeamTypeRequest) -> Response:
+        return _image_response(
+            microscope.last_image(beam_type=_beam_type(body.beam_type))
+        )
+
+    @hw.post("/acquire_chamber_image")
+    def acquire_chamber_image() -> Response:
+        return _image_response(microscope.acquire_chamber_image())
+
+    @hw.post("/autocontrast")
+    def autocontrast(body: BeamTypeRequest):
+        microscope.autocontrast(beam_type=_beam_type(body.beam_type))
+        return {"status": "ok"}
+
+    @hw.post("/auto_focus")
+    def auto_focus(body: BeamTypeRequest):
+        microscope.auto_focus(beam_type=_beam_type(body.beam_type))
+        return {"status": "ok"}
+
+    # --- Stage movement ---
+
+    @read.get("/stage_position")
+    def get_stage_position():
+        return {"position": microscope.get_stage_position().to_dict()}
+
+    @read.get("/stage_orientation")
+    def get_stage_orientation():
+        return {"orientation": microscope.get_stage_orientation()}
+
+    @hw.post("/move_stage_absolute", response_model=StagePositionResponse)
+    def move_stage_absolute(body: StagePositionRequest):
+        result = microscope.move_stage_absolute(
+            FibsemStagePosition.from_dict(body.position)
+        )
+        return StagePositionResponse(position=result.to_dict())
+
+    @hw.post("/move_stage_relative", response_model=StagePositionResponse)
+    def move_stage_relative(body: StagePositionRequest):
+        result = microscope.move_stage_relative(
+            FibsemStagePosition.from_dict(body.position)
+        )
+        return StagePositionResponse(position=result.to_dict())
+
+    @hw.post("/stable_move", response_model=StagePositionResponse)
+    def stable_move(body: StableMoveRequest):
+        result = microscope.stable_move(
+            dx=body.dx, dy=body.dy, beam_type=_beam_type(body.beam_type)
+        )
+        return StagePositionResponse(position=result.to_dict())
+
+    # read, not hardware: pure geometry from an explicit base position, no motion.
+    @read.post("/project_stable_move", response_model=StagePositionResponse)
+    def project_stable_move(body: ProjectStableMoveRequest):
+        base_position = FibsemStagePosition.from_dict(body.base_position)
+        result = microscope.project_stable_move(
+            dx=body.dx,
+            dy=body.dy,
+            beam_type=_beam_type(body.beam_type),
+            base_position=base_position,
+        )
+        return StagePositionResponse(position=result.to_dict())
+
+    @hw.post("/vertical_move", response_model=StagePositionResponse)
+    def vertical_move(body: VerticalMoveRequest):
+        result = microscope.vertical_move(dy=body.dy, dx=body.dx)
+        return StagePositionResponse(position=result.to_dict())
+
+    @hw.post("/safe_absolute_stage_movement")
+    def safe_absolute_stage_movement(body: StagePositionRequest):
+        microscope.safe_absolute_stage_movement(
+            FibsemStagePosition.from_dict(body.position)
+        )
+        return {"status": "ok"}
+
+    @hw.post("/move_flat_to_beam")
+    def move_flat_to_beam(body: FlatToBeamRequest):
+        microscope.move_flat_to_beam(beam_type=_beam_type(body.beam_type))
+        return {"status": "ok"}
+
+    # --- Microscope state ---
+
+    @read.get("/microscope_state")
+    def get_microscope_state():
+        return {"microscope_state": microscope.get_microscope_state().to_dict()}
+
+    @hw.post("/microscope_state")
+    def set_microscope_state(body: MicroscopeStateRequest):
+        microscope.set_microscope_state(
+            MicroscopeState.from_dict(body.microscope_state)
+        )
+        return {"status": "ok"}
+
+    # --- Imaging settings ---
+
+    @read.post("/imaging_settings/get")
+    def get_imaging_settings(body: BeamTypeRequest):
+        return {
+            "image_settings": microscope.get_imaging_settings(
+                _beam_type(body.beam_type)
+            ).to_dict()
+        }
+
+    @hw.post("/imaging_settings/set")
+    def set_imaging_settings(body: ImageSettingsRequest):
+        microscope.set_imaging_settings(ImageSettings.from_dict(body.image_settings))
+        return {"status": "ok"}
+
+    # --- Beam settings ---
+
+    @read.post("/beam_settings/get")
+    def get_beam_settings(body: BeamTypeRequest):
+        return {
+            "beam_settings": microscope.get_beam_settings(
+                _beam_type(body.beam_type)
+            ).to_dict()
+        }
+
+    @hw.post("/beam_settings/set")
+    def set_beam_settings(body: BeamSettingsRequest):
+        microscope.set_beam_settings(BeamSettings.from_dict(body.beam_settings))
+        return {"status": "ok"}
+
+    @read.post("/beam_system_settings/get")
+    def get_beam_system_settings(body: BeamTypeRequest):
+        return {
+            "beam_system_settings": microscope.get_beam_system_settings(
+                _beam_type(body.beam_type)
+            ).to_dict()
+        }
+
+    @hw.post("/beam_system_settings/set")
+    def set_beam_system_settings(body: BeamSystemSettingsRequest):
+        microscope.set_beam_system_settings(
+            BeamSystemSettings.from_dict(body.beam_system_settings)
+        )
+        return {"status": "ok"}
+
+    # --- Detector settings ---
+
+    @read.post("/detector_settings/get")
+    def get_detector_settings(body: BeamTypeRequest):
+        return {
+            "detector_settings": microscope.get_detector_settings(
+                _beam_type(body.beam_type)
+            ).to_dict()
+        }
+
+    @hw.post("/detector_settings/set")
+    def set_detector_settings(body: DetectorSettingsRequest):
+        microscope.set_detector_settings(
+            FibsemDetectorSettings.from_dict(body.detector_settings),
+            beam_type=_beam_type(body.beam_type),
+        )
+        return {"status": "ok"}
+
+    # --- Individual beam getters / setters ---
+
+    @read.post("/beam_current/get")
+    def get_beam_current(body: BeamTypeRequest):
+        return {"value": microscope.get_beam_current(_beam_type(body.beam_type))}
+
+    @hw.post("/beam_current/set")
+    def set_beam_current(body: FloatBeamRequest):
+        return {
+            "value": microscope.set_beam_current(body.value, _beam_type(body.beam_type))
+        }
+
+    @read.post("/beam_voltage/get")
+    def get_beam_voltage(body: BeamTypeRequest):
+        return {"value": microscope.get_beam_voltage(_beam_type(body.beam_type))}
+
+    @hw.post("/beam_voltage/set")
+    def set_beam_voltage(body: FloatBeamRequest):
+        return {
+            "value": microscope.set_beam_voltage(body.value, _beam_type(body.beam_type))
+        }
+
+    @read.post("/field_of_view/get")
+    def get_field_of_view(body: BeamTypeRequest):
+        return {"value": microscope.get_field_of_view(_beam_type(body.beam_type))}
+
+    @hw.post("/field_of_view/set")
+    def set_field_of_view(body: FloatBeamRequest):
+        return {
+            "value": microscope.set_field_of_view(
+                body.value, _beam_type(body.beam_type)
+            )
+        }
+
+    @read.post("/working_distance/get")
+    def get_working_distance(body: BeamTypeRequest):
+        return {"value": microscope.get_working_distance(_beam_type(body.beam_type))}
+
+    @hw.post("/working_distance/set")
+    def set_working_distance(body: FloatBeamRequest):
+        return {
+            "value": microscope.set_working_distance(
+                body.value, _beam_type(body.beam_type)
+            )
+        }
+
+    @read.post("/dwell_time/get")
+    def get_dwell_time(body: BeamTypeRequest):
+        return {"value": microscope.get_dwell_time(_beam_type(body.beam_type))}
+
+    @hw.post("/dwell_time/set")
+    def set_dwell_time(body: FloatBeamRequest):
+        return {
+            "value": microscope.set_dwell_time(body.value, _beam_type(body.beam_type))
+        }
+
+    @read.post("/resolution/get")
+    def get_resolution(body: BeamTypeRequest):
+        return {"value": list(microscope.get_resolution(_beam_type(body.beam_type)))}
+
+    @hw.post("/resolution/set")
+    def set_resolution(body: ResolutionBeamRequest):
+        return {
+            "value": list(
+                microscope.set_resolution(body.value, _beam_type(body.beam_type))
+            )
+        }
+
+    @read.post("/scan_rotation/get")
+    def get_scan_rotation(body: BeamTypeRequest):
+        return {"value": microscope.get_scan_rotation(_beam_type(body.beam_type))}
+
+    @hw.post("/scan_rotation/set")
+    def set_scan_rotation(body: FloatBeamRequest):
+        return {
+            "value": microscope.set_scan_rotation(
+                body.value, _beam_type(body.beam_type)
+            )
+        }
+
+    @read.post("/stigmation/get")
+    def get_stigmation(body: BeamTypeRequest):
+        return {
+            "value": microscope.get_stigmation(_beam_type(body.beam_type)).to_dict()
+        }
+
+    @hw.post("/stigmation/set")
+    def set_stigmation(body: PointBeamRequest):
+        result = microscope.set_stigmation(
+            Point.from_dict(body.value), _beam_type(body.beam_type)
+        )
+        return {"value": result.to_dict()}
+
+    @read.post("/beam_shift/get")
+    def get_beam_shift(body: BeamTypeRequest):
+        return {
+            "value": microscope.get_beam_shift(_beam_type(body.beam_type)).to_dict()
+        }
+
+    @hw.post("/beam_shift/set")
+    def set_beam_shift(body: PointBeamRequest):
+        result = microscope.set_beam_shift(
+            Point.from_dict(body.value), _beam_type(body.beam_type)
+        )
+        return {"value": result.to_dict()}
+
+    # --- Detector individual getters / setters ---
+
+    @read.post("/detector_type/get")
+    def get_detector_type(body: BeamTypeRequest):
+        return {"value": microscope.get_detector_type(_beam_type(body.beam_type))}
+
+    @hw.post("/detector_type/set")
+    def set_detector_type(body: StringBeamRequest):
+        return {
+            "value": microscope.set_detector_type(
+                body.value, _beam_type(body.beam_type)
+            )
+        }
+
+    @read.post("/detector_mode/get")
+    def get_detector_mode(body: BeamTypeRequest):
+        return {"value": microscope.get_detector_mode(_beam_type(body.beam_type))}
+
+    @hw.post("/detector_mode/set")
+    def set_detector_mode(body: StringBeamRequest):
+        return {
+            "value": microscope.set_detector_mode(
+                body.value, _beam_type(body.beam_type)
+            )
+        }
+
+    @read.post("/detector_contrast/get")
+    def get_detector_contrast(body: BeamTypeRequest):
+        return {"value": microscope.get_detector_contrast(_beam_type(body.beam_type))}
+
+    @hw.post("/detector_contrast/set")
+    def set_detector_contrast(body: FloatBeamRequest):
+        return {
+            "value": microscope.set_detector_contrast(
+                body.value, _beam_type(body.beam_type)
+            )
+        }
+
+    @read.post("/detector_brightness/get")
+    def get_detector_brightness(body: BeamTypeRequest):
+        return {"value": microscope.get_detector_brightness(_beam_type(body.beam_type))}
+
+    @hw.post("/detector_brightness/set")
+    def set_detector_brightness(body: FloatBeamRequest):
+        return {
+            "value": microscope.set_detector_brightness(
+                body.value, _beam_type(body.beam_type)
+            )
+        }
+
+    # --- Available values ---
+
+    @read.post("/available_values")
+    def get_available_values(body: AvailableValuesRequest):
+        beam_type = _beam_type(body.beam_type) if body.beam_type else None
+        return {
+            "values": microscope.get_available_values(body.key, beam_type=beam_type)
+        }
+
+    # --- Milling angle ---
+    # The HTTP boundary speaks DEGREES everywhere (fields named *_deg).
+    # The ABC's move_to_milling_angle takes radians (FIB-853); converted here.
+
+    @read.get("/milling_angle")
+    def get_milling_angle():
+        return {"milling_angle_deg": microscope.get_current_milling_angle()}
+
+    @read.post("/milling_angle/from_position")
+    def get_milling_angle_from_position(body: MillingAngleFromPositionRequest):
+        position = (
+            FibsemStagePosition.from_dict(body.stage_position)
+            if body.stage_position
+            else None
+        )
+        return {
+            "milling_angle_deg": microscope.get_current_milling_angle(
+                stage_position=position
+            )
+        }
+
+    @hw.post("/milling_angle/set")
+    def set_milling_angle(body: MillingAngleRequest):
+        microscope.set_milling_angle(body.milling_angle_deg)
+        return {"status": "ok"}
+
+    @hw.post("/milling_angle/move")
+    def move_to_milling_angle(body: MoveToMillingAngleRequest):
+        rotation = (
+            math.radians(body.rotation_deg) if body.rotation_deg is not None else None
+        )
+        success = microscope.move_to_milling_angle(
+            math.radians(body.milling_angle_deg), rotation=rotation
+        )
+        return {
+            "success": success,
+            "milling_angle_deg": microscope.get_current_milling_angle(),
+        }
+
+    @read.post("/milling_angle/is_close")
+    def is_close_to_milling_angle(body: IsCloseToMillingAngleRequest):
+        return {
+            "is_close": microscope.is_close_to_milling_angle(
+                body.milling_angle_deg, atol=body.atol_deg
+            )
+        }
+
+    # --- Milling ---
+
+    @hw.post("/setup_milling")
+    def setup_milling(body: MillingSettingsRequest):
+        microscope.setup_milling(
+            mill_settings=FibsemMillingSettings.from_dict(body.mill_settings)
+        )
+        return {"status": "ok"}
+
+    @hw.post("/draw_patterns")
+    def draw_patterns(body: DrawPatternsRequest):
+        try:
+            patterns = [_pattern_from_dict(p) for p in body.patterns]
+        except (KeyError, ValueError) as e:
+            raise HTTPException(status_code=422, detail=str(e))
+        microscope.draw_patterns(patterns)
+        return {"status": "ok"}
+
+    @hw.post("/run_milling")
+    def run_milling(body: RunMillingRequest):
+        microscope.run_milling(
+            milling_current=body.milling_current,
+            milling_voltage=body.milling_voltage,
+            asynch=body.asynch,
+        )
+        return {"status": "ok"}
+
+    @hw.post("/start_milling")
+    def start_milling():
+        microscope.start_milling()
+        return {"status": "ok"}
+
+    # read scope, and no command slot: an emergency stop must never be blocked
+    # by arming or by the in-flight command it exists to interrupt.
+    @read.post("/stop_milling")
+    def stop_milling():
+        microscope.stop_milling()
+        return {"status": "ok"}
+
+    @hw.post("/pause_milling")
+    def pause_milling():
+        microscope.pause_milling()
+        return {"status": "ok"}
+
+    @hw.post("/resume_milling")
+    def resume_milling():
+        microscope.resume_milling()
+        return {"status": "ok"}
+
+    @hw.post("/finish_milling")
+    def finish_milling(body: FinishMillingRequest):
+        microscope.finish_milling(
+            imaging_current=body.imaging_current,
+            imaging_voltage=body.imaging_voltage,
+        )
+        return {"status": "ok"}
+
+    @hw.post("/clear_patterns")
+    def clear_patterns():
+        microscope.clear_patterns()
+        return {"status": "ok"}
+
+    @read.get("/milling_state")
+    def get_milling_state():
+        return {"state": microscope.get_milling_state().name}
+
+    @read.get("/estimate_milling_time")
+    def estimate_milling_time():
+        return {"seconds": microscope.estimate_milling_time()}
+
+    app.include_router(read)
+    app.include_router(hw)
+    return app
 
 
 class FibsemServer:
-    def __init__(self, microscope: FibsemMicroscope, host: str = "0.0.0.0", port: int = 8001):
+    """Bench hosting: own the microscope connection and serve it.
+
+    Binds localhost by default; exposing on the LAN is an explicit choice.
+    """
+
+    def __init__(
+        self,
+        microscope: FibsemMicroscope,
+        host: str = "127.0.0.1",
+        port: int = 8001,
+        auth: Optional[AuthConfig] = None,
+    ):
         self.microscope = microscope
         self.host = host
         self.port = port
-        self.app = self._build_app()
-
-    def _build_app(self) -> FastAPI:
-        app = FastAPI(title="FibsemMicroscope Server")
-        microscope = self.microscope
-
-        # --- Health / System ---
-
-        @app.get("/health")
-        def health():
-            return {"status": "ok", "manufacturer": type(microscope).__name__}
-
-        @app.get("/system")
-        def get_system():
-            return {
-                "system": microscope.system.to_dict(),
-                "stage_is_compustage": microscope.stage_is_compustage,
-            }
-
-        # --- Image acquisition ---
-
-        @app.post("/acquire_image")
-        def acquire_image(body: AcquireImageRequest) -> Response:
-            bt = _beam_type(body.beam_type)
-            image_settings = ImageSettings.from_dict(body.image_settings) if body.image_settings else None
-            return _image_response(microscope.acquire_image(image_settings=image_settings, beam_type=bt))
-
-        @app.post("/last_image")
-        def last_image(body: BeamTypeRequest) -> Response:
-            return _image_response(microscope.last_image(beam_type=_beam_type(body.beam_type)))
-
-        @app.post("/acquire_chamber_image")
-        def acquire_chamber_image() -> Response:
-            return _image_response(microscope.acquire_chamber_image())
-
-        @app.post("/autocontrast")
-        def autocontrast(body: BeamTypeRequest):
-            microscope.autocontrast(beam_type=_beam_type(body.beam_type))
-            return {"status": "ok"}
-
-        @app.post("/auto_focus")
-        def auto_focus(body: BeamTypeRequest):
-            microscope.auto_focus(beam_type=_beam_type(body.beam_type))
-            return {"status": "ok"}
-
-        # --- Stage movement ---
-
-        @app.get("/stage_position")
-        def get_stage_position():
-            return {"position": microscope.get_stage_position().to_dict()}
-
-        @app.get("/stage_orientation")
-        def get_stage_orientation():
-            return {"orientation": microscope.get_stage_orientation()}
-
-        @app.post("/move_stage_absolute", response_model=StagePositionResponse)
-        def move_stage_absolute(body: StagePositionRequest):
-            result = microscope.move_stage_absolute(FibsemStagePosition.from_dict(body.position))
-            return StagePositionResponse(position=result.to_dict())
-
-        @app.post("/move_stage_relative", response_model=StagePositionResponse)
-        def move_stage_relative(body: StagePositionRequest):
-            result = microscope.move_stage_relative(FibsemStagePosition.from_dict(body.position))
-            return StagePositionResponse(position=result.to_dict())
-
-        @app.post("/stable_move", response_model=StagePositionResponse)
-        def stable_move(body: StableMoveRequest):
-            result = microscope.stable_move(dx=body.dx, dy=body.dy, beam_type=_beam_type(body.beam_type))
-            return StagePositionResponse(position=result.to_dict())
-
-        @app.post("/project_stable_move", response_model=StagePositionResponse)
-        def project_stable_move(body: ProjectStableMoveRequest):
-            base_position = FibsemStagePosition.from_dict(body.base_position)
-            result = microscope.project_stable_move(
-                dx=body.dx, dy=body.dy,
-                beam_type=_beam_type(body.beam_type),
-                base_position=base_position,
-            )
-            return StagePositionResponse(position=result.to_dict())
-
-        @app.post("/vertical_move", response_model=StagePositionResponse)
-        def vertical_move(body: VerticalMoveRequest):
-            result = microscope.vertical_move(dy=body.dy, dx=body.dx)
-            return StagePositionResponse(position=result.to_dict())
-
-        @app.post("/safe_absolute_stage_movement")
-        def safe_absolute_stage_movement(body: StagePositionRequest):
-            microscope.safe_absolute_stage_movement(FibsemStagePosition.from_dict(body.position))
-            return {"status": "ok"}
-
-        @app.post("/move_flat_to_beam")
-        def move_flat_to_beam(body: FlatToBeamRequest):
-            microscope.move_flat_to_beam(beam_type=_beam_type(body.beam_type))
-            return {"status": "ok"}
-
-        # --- Microscope state ---
-
-        @app.get("/microscope_state")
-        def get_microscope_state():
-            return {"microscope_state": microscope.get_microscope_state().to_dict()}
-
-        @app.post("/microscope_state")
-        def set_microscope_state(body: MicroscopeStateRequest):
-            microscope.set_microscope_state(MicroscopeState.from_dict(body.microscope_state))
-            return {"status": "ok"}
-
-        # --- Imaging settings ---
-
-        @app.post("/imaging_settings/get")
-        def get_imaging_settings(body: BeamTypeRequest):
-            return {"image_settings": microscope.get_imaging_settings(_beam_type(body.beam_type)).to_dict()}
-
-        @app.post("/imaging_settings/set")
-        def set_imaging_settings(body: ImageSettingsRequest):
-            microscope.set_imaging_settings(ImageSettings.from_dict(body.image_settings))
-            return {"status": "ok"}
-
-        # --- Beam settings ---
-
-        @app.post("/beam_settings/get")
-        def get_beam_settings(body: BeamTypeRequest):
-            return {"beam_settings": microscope.get_beam_settings(_beam_type(body.beam_type)).to_dict()}
-
-        @app.post("/beam_settings/set")
-        def set_beam_settings(body: BeamSettingsRequest):
-            microscope.set_beam_settings(BeamSettings.from_dict(body.beam_settings))
-            return {"status": "ok"}
-
-        @app.post("/beam_system_settings/get")
-        def get_beam_system_settings(body: BeamTypeRequest):
-            return {"beam_system_settings": microscope.get_beam_system_settings(_beam_type(body.beam_type)).to_dict()}
-
-        @app.post("/beam_system_settings/set")
-        def set_beam_system_settings(body: BeamSystemSettingsRequest):
-            microscope.set_beam_system_settings(BeamSystemSettings.from_dict(body.beam_system_settings))
-            return {"status": "ok"}
-
-        # --- Detector settings ---
-
-        @app.post("/detector_settings/get")
-        def get_detector_settings(body: BeamTypeRequest):
-            return {"detector_settings": microscope.get_detector_settings(_beam_type(body.beam_type)).to_dict()}
-
-        @app.post("/detector_settings/set")
-        def set_detector_settings(body: DetectorSettingsRequest):
-            microscope.set_detector_settings(
-                FibsemDetectorSettings.from_dict(body.detector_settings),
-                beam_type=_beam_type(body.beam_type),
-            )
-            return {"status": "ok"}
-
-        # --- Individual beam getters / setters ---
-
-        @app.post("/beam_current/get")
-        def get_beam_current(body: BeamTypeRequest):
-            return {"value": microscope.get_beam_current(_beam_type(body.beam_type))}
-
-        @app.post("/beam_current/set")
-        def set_beam_current(body: FloatBeamRequest):
-            return {"value": microscope.set_beam_current(body.value, _beam_type(body.beam_type))}
-
-        @app.post("/beam_voltage/get")
-        def get_beam_voltage(body: BeamTypeRequest):
-            return {"value": microscope.get_beam_voltage(_beam_type(body.beam_type))}
-
-        @app.post("/beam_voltage/set")
-        def set_beam_voltage(body: FloatBeamRequest):
-            return {"value": microscope.set_beam_voltage(body.value, _beam_type(body.beam_type))}
-
-        @app.post("/field_of_view/get")
-        def get_field_of_view(body: BeamTypeRequest):
-            return {"value": microscope.get_field_of_view(_beam_type(body.beam_type))}
-
-        @app.post("/field_of_view/set")
-        def set_field_of_view(body: FloatBeamRequest):
-            return {"value": microscope.set_field_of_view(body.value, _beam_type(body.beam_type))}
-
-        @app.post("/working_distance/get")
-        def get_working_distance(body: BeamTypeRequest):
-            return {"value": microscope.get_working_distance(_beam_type(body.beam_type))}
-
-        @app.post("/working_distance/set")
-        def set_working_distance(body: FloatBeamRequest):
-            return {"value": microscope.set_working_distance(body.value, _beam_type(body.beam_type))}
-
-        @app.post("/dwell_time/get")
-        def get_dwell_time(body: BeamTypeRequest):
-            return {"value": microscope.get_dwell_time(_beam_type(body.beam_type))}
-
-        @app.post("/dwell_time/set")
-        def set_dwell_time(body: FloatBeamRequest):
-            return {"value": microscope.set_dwell_time(body.value, _beam_type(body.beam_type))}
-
-        @app.post("/resolution/get")
-        def get_resolution(body: BeamTypeRequest):
-            return {"value": list(microscope.get_resolution(_beam_type(body.beam_type)))}
-
-        @app.post("/resolution/set")
-        def set_resolution(body: ResolutionBeamRequest):
-            return {"value": list(microscope.set_resolution(body.value, _beam_type(body.beam_type)))}
-
-        @app.post("/scan_rotation/get")
-        def get_scan_rotation(body: BeamTypeRequest):
-            return {"value": microscope.get_scan_rotation(_beam_type(body.beam_type))}
-
-        @app.post("/scan_rotation/set")
-        def set_scan_rotation(body: FloatBeamRequest):
-            return {"value": microscope.set_scan_rotation(body.value, _beam_type(body.beam_type))}
-
-        @app.post("/stigmation/get")
-        def get_stigmation(body: BeamTypeRequest):
-            return {"value": microscope.get_stigmation(_beam_type(body.beam_type)).to_dict()}
-
-        @app.post("/stigmation/set")
-        def set_stigmation(body: PointBeamRequest):
-            result = microscope.set_stigmation(Point.from_dict(body.value), _beam_type(body.beam_type))
-            return {"value": result.to_dict()}
-
-        @app.post("/beam_shift/get")
-        def get_beam_shift(body: BeamTypeRequest):
-            return {"value": microscope.get_beam_shift(_beam_type(body.beam_type)).to_dict()}
-
-        @app.post("/beam_shift/set")
-        def set_beam_shift(body: PointBeamRequest):
-            result = microscope.set_beam_shift(Point.from_dict(body.value), _beam_type(body.beam_type))
-            return {"value": result.to_dict()}
-
-        # --- Detector individual getters / setters ---
-
-        @app.post("/detector_type/get")
-        def get_detector_type(body: BeamTypeRequest):
-            return {"value": microscope.get_detector_type(_beam_type(body.beam_type))}
-
-        @app.post("/detector_type/set")
-        def set_detector_type(body: StringBeamRequest):
-            return {"value": microscope.set_detector_type(body.value, _beam_type(body.beam_type))}
-
-        @app.post("/detector_mode/get")
-        def get_detector_mode(body: BeamTypeRequest):
-            return {"value": microscope.get_detector_mode(_beam_type(body.beam_type))}
-
-        @app.post("/detector_mode/set")
-        def set_detector_mode(body: StringBeamRequest):
-            return {"value": microscope.set_detector_mode(body.value, _beam_type(body.beam_type))}
-
-        @app.post("/detector_contrast/get")
-        def get_detector_contrast(body: BeamTypeRequest):
-            return {"value": microscope.get_detector_contrast(_beam_type(body.beam_type))}
-
-        @app.post("/detector_contrast/set")
-        def set_detector_contrast(body: FloatBeamRequest):
-            return {"value": microscope.set_detector_contrast(body.value, _beam_type(body.beam_type))}
-
-        @app.post("/detector_brightness/get")
-        def get_detector_brightness(body: BeamTypeRequest):
-            return {"value": microscope.get_detector_brightness(_beam_type(body.beam_type))}
-
-        @app.post("/detector_brightness/set")
-        def set_detector_brightness(body: FloatBeamRequest):
-            return {"value": microscope.set_detector_brightness(body.value, _beam_type(body.beam_type))}
-
-        # --- Available values ---
-
-        @app.post("/available_values")
-        def get_available_values(body: AvailableValuesRequest):
-            beam_type = _beam_type(body.beam_type) if body.beam_type else None
-            return {"values": microscope.get_available_values(body.key, beam_type=beam_type)}
-
-        # --- Milling angle ---
-
-        @app.get("/milling_angle")
-        def get_milling_angle():
-            return {"milling_angle": microscope.get_current_milling_angle()}
-
-        @app.post("/milling_angle/from_position")
-        def get_milling_angle_from_position(body: MillingAngleFromPositionRequest):
-            position = FibsemStagePosition.from_dict(body.stage_position) if body.stage_position else None
-            return {"milling_angle": microscope.get_current_milling_angle(stage_position=position)}
-
-        @app.post("/milling_angle/set")
-        def set_milling_angle(body: MillingAngleRequest):
-            microscope.set_milling_angle(body.milling_angle)
-            return {"status": "ok"}
-
-        @app.post("/milling_angle/move")
-        def move_to_milling_angle(body: MoveToMillingAngleRequest):
-            success = microscope.move_to_milling_angle(body.milling_angle, rotation=body.rotation)
-            return {"success": success, "milling_angle": microscope.get_current_milling_angle()}
-
-        @app.post("/milling_angle/is_close")
-        def is_close_to_milling_angle(body: IsCloseToMillingAngleRequest):
-            return {"is_close": microscope.is_close_to_milling_angle(body.milling_angle, atol=body.atol)}
-
-        # --- Milling ---
-
-        @app.post("/setup_milling")
-        def setup_milling(body: MillingSettingsRequest):
-            microscope.setup_milling(mill_settings=FibsemMillingSettings.from_dict(body.mill_settings))
-            return {"status": "ok"}
-
-        @app.post("/draw_patterns")
-        def draw_patterns(body: DrawPatternsRequest):
-            try:
-                patterns = [_pattern_from_dict(p) for p in body.patterns]
-            except (KeyError, ValueError) as e:
-                raise HTTPException(status_code=422, detail=str(e))
-            microscope.draw_patterns(patterns)
-            return {"status": "ok"}
-
-        @app.post("/run_milling")
-        def run_milling(body: RunMillingRequest):
-            microscope.run_milling(
-                milling_current=body.milling_current,
-                milling_voltage=body.milling_voltage,
-                asynch=body.asynch,
-            )
-            return {"status": "ok"}
-
-        @app.post("/start_milling")
-        def start_milling():
-            microscope.start_milling()
-            return {"status": "ok"}
-
-        @app.post("/stop_milling")
-        def stop_milling():
-            microscope.stop_milling()
-            return {"status": "ok"}
-
-        @app.post("/pause_milling")
-        def pause_milling():
-            microscope.pause_milling()
-            return {"status": "ok"}
-
-        @app.post("/resume_milling")
-        def resume_milling():
-            microscope.resume_milling()
-            return {"status": "ok"}
-
-        @app.post("/finish_milling")
-        def finish_milling(body: FinishMillingRequest):
-            microscope.finish_milling(
-                imaging_current=body.imaging_current,
-                imaging_voltage=body.imaging_voltage,
-            )
-            return {"status": "ok"}
-
-        @app.post("/clear_patterns")
-        def clear_patterns():
-            microscope.clear_patterns()
-            return {"status": "ok"}
-
-        @app.get("/milling_state")
-        def get_milling_state():
-            return {"state": microscope.get_milling_state().name}
-
-        @app.get("/estimate_milling_time")
-        def estimate_milling_time():
-            return {"seconds": microscope.estimate_milling_time()}
-
-        return app
+        self.auth = auth or AuthConfig.generate()
+        self.app = build_server(microscope, auth=self.auth)
 
     def run(self):
+        armed = ", ".join(s.value for s in self.auth.armed_scopes())
+        logging.info(
+            "fibsem server on http://%s:%s — scopes armed: %s",
+            self.host,
+            self.port,
+            armed,
+        )
+        logging.info("bearer token: %s", self.auth.token)
         uvicorn.run(self.app, host=self.host, port=self.port)
 
     @classmethod
     def from_session(
         cls,
-        manufacturer: str,
-        ip_address: str,
-        host: str = "0.0.0.0",
+        manufacturer: Optional[str] = None,
+        ip_address: Optional[str] = None,
+        config_path: Optional[str] = None,
+        host: str = "127.0.0.1",
         port: int = 8001,
+        auth: Optional[AuthConfig] = None,
     ) -> "FibsemServer":
-        microscope, _ = utils.setup_session(manufacturer=manufacturer, ip_address=ip_address)
-        return cls(microscope, host=host, port=port)
+        microscope, _ = utils.setup_session(
+            manufacturer=manufacturer, ip_address=ip_address, config_path=config_path
+        )
+        return cls(microscope, host=host, port=port, auth=auth)
 
 
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Start a FibsemMicroscope HTTP server")
-    parser.add_argument("--manufacturer", default="Demo", help="Microscope manufacturer (default: Demo)")
-    parser.add_argument("--ip-address", default="localhost", help="Microscope IP address")
-    parser.add_argument("--host", default="0.0.0.0", help="Server host (default: 0.0.0.0)")
-    parser.add_argument("--port", type=int, default=8001, help="Server port (default: 8001)")
+    parser = argparse.ArgumentParser(
+        description="Start a fibsem microscope server (bench hosting)"
+    )
+    parser.add_argument(
+        "--manufacturer",
+        default=None,
+        help="Microscope manufacturer (default: from config)",
+    )
+    parser.add_argument(
+        "--ip-address",
+        default=None,
+        help="Microscope IP address (default: from config)",
+    )
+    parser.add_argument(
+        "--config", default=None, help="Path to a microscope configuration file"
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Bind address (default: 127.0.0.1; use 0.0.0.0 to expose on the LAN)",
+    )
+    parser.add_argument(
+        "--port", type=int, default=8001, help="Server port (default: 8001)"
+    )
+    parser.add_argument(
+        "--token", default=None, help="Bearer token (default: generated and logged)"
+    )
+    parser.add_argument(
+        "--arm-hardware",
+        action="store_true",
+        help="Arm the hardware scope (moves, acquisition, milling)",
+    )
     args = parser.parse_args()
 
+    logging.basicConfig(level=logging.INFO)
     server = FibsemServer.from_session(
         manufacturer=args.manufacturer,
         ip_address=args.ip_address,
+        config_path=args.config,
         host=args.host,
         port=args.port,
+        auth=AuthConfig.generate(arm_hardware=args.arm_hardware, token=args.token),
     )
     server.run()

--- a/tests/server/test_server_factory.py
+++ b/tests/server/test_server_factory.py
@@ -1,0 +1,192 @@
+"""Tests for the fibsem server factory: auth, scopes, the command lock, and the
+degree-normalized milling-angle boundary (FIB-852).
+
+Skipped when the [server] extra is not installed (CI installs [test] only until
+the FIB-849 leg lands).
+"""
+
+import os
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")  # TestClient transport
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from fibsem import utils  # noqa: E402
+from fibsem.server import AuthConfig, FibsemServer, Scope, build_server  # noqa: E402
+
+TOKEN = "test-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+
+def _pos(x=0.0, y=0.0, z=0.0, r=0.0, t=0.0):
+    # FibsemStagePosition.from_dict requires every axis key.
+    return {
+        "name": None,
+        "x": x,
+        "y": y,
+        "z": z,
+        "r": r,
+        "t": t,
+        "coordinate_system": "RAW",
+    }
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    previous = os.environ.get("FIBSEM_SIM_NO_DELAY")
+    os.environ["FIBSEM_SIM_NO_DELAY"] = "1"
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    yield microscope
+    if previous is None:
+        os.environ.pop("FIBSEM_SIM_NO_DELAY", None)
+    else:
+        os.environ["FIBSEM_SIM_NO_DELAY"] = previous
+
+
+@pytest.fixture(scope="module")
+def read_client(microscope):
+    app = build_server(microscope, auth=AuthConfig(token=TOKEN))
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+
+
+@pytest.fixture(scope="module")
+def armed_client(microscope):
+    app = build_server(
+        microscope, auth=AuthConfig.generate(arm_hardware=True, token=TOKEN)
+    )
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+
+
+def test_health_is_open(read_client):
+    resp = read_client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_missing_token_is_401(read_client):
+    resp = read_client.get("/capabilities")
+    assert resp.status_code == 401
+    assert resp.json()["detail"]["error_type"] == "unauthorized"
+
+
+def test_wrong_token_is_401(read_client):
+    resp = read_client.get("/capabilities", headers={"Authorization": "Bearer wrong"})
+    assert resp.status_code == 401
+
+
+def test_capabilities_reports_scopes_and_routers(read_client):
+    resp = read_client.get("/capabilities", headers=AUTH)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["routers"] == {"microscope": True, "app": False}
+    assert body["scopes"] == {"read": True, "control": False, "hardware": False}
+    assert body["manufacturer"] == "DemoMicroscope"
+
+
+def test_read_route_with_token(read_client):
+    resp = read_client.get("/stage_position", headers=AUTH)
+    assert resp.status_code == 200
+    assert "x" in resp.json()["position"]
+
+
+def test_hardware_route_refused_when_not_armed(read_client):
+    resp = read_client.post(
+        "/move_stage_relative", headers=AUTH, json={"position": _pos(0)}
+    )
+    assert resp.status_code == 403
+    detail = resp.json()["detail"]
+    assert detail["error_type"] == "scope_not_armed"
+    assert detail["scope"] == "hardware"
+
+
+def test_last_image_is_hardware_scope(read_client):
+    # ThermoMicroscope.last_image switches the active imaging channel, so it is
+    # a command, not a read (see the FIB-852 review).
+    resp = read_client.post("/last_image", headers=AUTH, json={"beam_type": "ION"})
+    assert resp.status_code == 403
+
+
+def test_stop_milling_allowed_with_read_scope(read_client):
+    # Emergency stop is deliberately never gated behind arming.
+    resp = read_client.post("/stop_milling", headers=AUTH)
+    assert resp.status_code == 200
+
+
+def test_hardware_route_works_when_armed(armed_client):
+    resp = armed_client.get("/stage_position", headers=AUTH)
+    start = resp.json()["position"]
+    resp = armed_client.post(
+        "/move_stage_relative", headers=AUTH, json={"position": _pos(x=10e-6)}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["position"]["x"] == pytest.approx(start["x"] + 10e-6, abs=1e-9)
+
+
+def test_concurrent_hardware_command_is_409(armed_client):
+    lock = armed_client.app.state.command_lock
+    assert lock.acquire(blocking=False)
+    try:
+        resp = armed_client.post(
+            "/move_stage_relative", headers=AUTH, json={"position": _pos(x=1e-6)}
+        )
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["error_type"] == "busy"
+    finally:
+        lock.release()
+
+
+def test_stop_milling_bypasses_command_lock(armed_client):
+    # The stop must interrupt an in-flight command, so it cannot wait on the slot.
+    lock = armed_client.app.state.command_lock
+    assert lock.acquire(blocking=False)
+    try:
+        resp = armed_client.post("/stop_milling", headers=AUTH)
+        assert resp.status_code == 200
+    finally:
+        lock.release()
+
+
+def test_microscope_exception_becomes_structured_500(microscope, monkeypatch):
+    app = build_server(microscope, auth=AuthConfig(token=TOKEN))
+    monkeypatch.setattr(
+        type(microscope),
+        "get_stage_orientation",
+        lambda self, stage_position=None: (_ for _ in ()).throw(
+            RuntimeError("vendor fell over")
+        ),
+    )
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/stage_orientation", headers=AUTH)
+    assert resp.status_code == 500
+    detail = resp.json()["detail"]
+    assert detail["error_type"] == "RuntimeError"
+    assert "vendor fell over" in detail["message"]
+
+
+def test_milling_angle_boundary_is_degrees(armed_client):
+    # The wire speaks degrees; the server converts for the radians-taking ABC
+    # method (FIB-853). Moving to 15 deg must read back as ~15 deg, not ~859.
+    resp = armed_client.post(
+        "/milling_angle/move", headers=AUTH, json={"milling_angle_deg": 15.0}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["milling_angle_deg"] == pytest.approx(15.0, abs=0.5)
+
+
+def test_app_context_not_implemented_yet(microscope):
+    with pytest.raises(NotImplementedError):
+        build_server(microscope, app_context=object())
+
+
+def test_fibsem_server_defaults_to_localhost(microscope):
+    server = FibsemServer(microscope)
+    assert server.host == "127.0.0.1"
+    assert server.auth.is_armed(Scope.READ)
+    assert not server.auth.is_armed(Scope.HARDWARE)


### PR DESCRIPTION
First slice of the agent-server work (Linear: AutoLamella Agent Server project): the shared server core both hostings will use.

## What

- `build_server(microscope, app_context=None, auth=None)` factory; `FibsemServer` becomes the bench hosting of it
- Bearer-token auth on every route; `read` scope for observation, `hardware` scope armed explicitly (`--arm-hardware`); structured `403 scope_not_armed` refusals
- Per-microscope command lock on hardware routes: concurrent commands get `409 busy` instead of interleaving on the vendor connection
- Structured `500 {error_type, message}` envelope instead of FastAPI's hidden default
- Default bind flips `0.0.0.0` → `127.0.0.1`; LAN exposure is now an explicit choice
- Milling-angle HTTP boundary normalized to degrees (`*_deg` fields), converted server-side; the client keeps ABC radians semantics and converts at the wire
- Deliberate scope placements: `last_image` is hardware (switches the active imaging channel on Thermo); `stop_milling` is read-scope and lock-exempt (an emergency stop must never be blocked by arming or by the command it interrupts)

## Bug found by the new tests

`move_to_milling_angle` returned `False` on every successful move — its final check fed its radians argument into the degrees comparison. Verified on Demo (move to 15°, readback 15.000°, return False); `fibsem-cli mill-angle` printed its not-at-target warning on every success because of it. One-line fix + regression test.

## Verification

15 new tests in `tests/server/` (the package's first), TestClient against DemoMicroscope with `FIBSEM_SIM_NO_DELAY=1`: auth failures, scope refusal shapes, the 409, stop-milling bypass, the error envelope, and the degree round-trip. Skips cleanly where the `[server]` extra isn't installed (current CI); a dedicated CI leg comes with the sidecar PR. Ruff check + format clean.