### PR TITLE
[server] Add preview renditions: agent-sized JPEG endpoints beside the TIFF transport

### DIFF
--- a/fibsem/server/images.py
+++ b/fibsem/server/images.py
@@ -1,0 +1,74 @@
+"""Preview renditions of microscope images for agent and browser clients.
+
+Full-resolution 16-bit TIFF is the right transport for a drop-in client; an
+agent inspecting a milling result needs a small 8-bit JPEG it can actually
+look at. Harvested from the feat-mcp-server prototype, which proved that a
+768 px JPEG is enough for Claude to assess milling quality.
+
+`PIL.Resampling.LANCZOS` requires Pillow >= 9.1; Pillow arrives transitively
+with the core matplotlib dependency, so it is imported lazily and reported
+clearly if absent.
+"""
+
+import base64
+import io
+from typing import Optional, Tuple
+
+import numpy as np
+
+
+def preview_jpeg_bytes(
+    data: "np.ndarray", max_width: int = 768, quality: int = 70
+) -> Tuple[bytes, int, int]:
+    """Min-max normalize to uint8, downscale to max_width, encode JPEG.
+
+    Returns (jpeg_bytes, width, height) of the encoded rendition.
+    """
+    try:
+        from PIL import Image as PILImage
+    except ImportError as e:
+        raise RuntimeError(
+            "Pillow is required for image previews (pip install pillow)."
+        ) from e
+
+    if data.dtype != np.uint8:
+        d_min, d_max = float(data.min()), float(data.max())
+        if d_max > d_min:
+            data = ((data.astype(np.float32) - d_min) / (d_max - d_min) * 255).astype(
+                np.uint8
+            )
+        else:
+            data = np.zeros_like(data, dtype=np.uint8)
+    pil = PILImage.fromarray(data, mode="L" if data.ndim == 2 else "RGB")
+    if pil.width > max_width:
+        scale = max_width / pil.width
+        pil = pil.resize(
+            (max_width, max(1, int(pil.height * scale))), PILImage.Resampling.LANCZOS
+        )
+    buf = io.BytesIO()
+    pil.save(buf, format="JPEG", quality=quality)
+    return buf.getvalue(), pil.width, pil.height
+
+
+def preview_payload(image, max_width: int = 768) -> dict:
+    """Build the JSON payload for a preview endpoint from a FibsemImage."""
+    jpeg, width, height = preview_jpeg_bytes(image.data, max_width=max_width)
+    payload = {
+        "image_b64_jpeg": base64.b64encode(jpeg).decode(),
+        "width": width,
+        "height": height,
+        "full_width": int(image.data.shape[1]),
+        "full_height": int(image.data.shape[0]),
+        "beam_type": None,
+        "hfw": None,
+    }
+    md = image.metadata
+    if md is not None and md.image_settings is not None:
+        payload["hfw"] = _maybe_float(md.image_settings.hfw)
+        beam_type = md.image_settings.beam_type
+        payload["beam_type"] = beam_type.name if beam_type is not None else None
+    return payload
+
+
+def _maybe_float(value) -> Optional[float]:
+    return float(value) if value is not None else None

--- a/fibsem/server/server.py
+++ b/fibsem/server/server.py
@@ -40,6 +40,7 @@ from fastapi.responses import JSONResponse, Response
 from fibsem import utils
 from fibsem.microscope import FibsemMicroscope
 from fibsem.server.auth import AuthConfig, Scope, command_slot, require_scope
+from fibsem.server.images import preview_payload
 from fibsem.server.models import (
     AcquireImageRequest,
     AvailableValuesRequest,
@@ -210,6 +211,24 @@ def build_server(
     @hw.post("/acquire_chamber_image")
     def acquire_chamber_image() -> Response:
         return _image_response(microscope.acquire_chamber_image())
+
+    # --- Preview renditions (agent/browser-sized JPEG instead of full TIFF) ---
+
+    @hw.post("/acquire_image_preview")
+    def acquire_image_preview(body: AcquireImageRequest):
+        bt = _beam_type(body.beam_type)
+        image_settings = (
+            ImageSettings.from_dict(body.image_settings)
+            if body.image_settings
+            else None
+        )
+        image = microscope.acquire_image(image_settings=image_settings, beam_type=bt)
+        return preview_payload(image)
+
+    @hw.post("/last_image_preview")
+    def last_image_preview(body: BeamTypeRequest):
+        image = microscope.last_image(beam_type=_beam_type(body.beam_type))
+        return preview_payload(image)
 
     @hw.post("/autocontrast")
     def autocontrast(body: BeamTypeRequest):

--- a/tests/server/test_image_previews.py
+++ b/tests/server/test_image_previews.py
@@ -1,0 +1,93 @@
+"""Tests for the preview-rendition endpoints and the downscale helper."""
+
+import base64
+import io
+import os
+
+import numpy as np
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+PILImage = pytest.importorskip("PIL.Image")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from fibsem import utils  # noqa: E402
+from fibsem.server import AuthConfig, build_server  # noqa: E402
+from fibsem.server.images import preview_jpeg_bytes  # noqa: E402
+
+TOKEN = "test-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+
+@pytest.fixture(scope="module")
+def armed_client():
+    previous = os.environ.get("FIBSEM_SIM_NO_DELAY")
+    os.environ["FIBSEM_SIM_NO_DELAY"] = "1"
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    app = build_server(
+        microscope, auth=AuthConfig.generate(arm_hardware=True, token=TOKEN)
+    )
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+    if previous is None:
+        os.environ.pop("FIBSEM_SIM_NO_DELAY", None)
+    else:
+        os.environ["FIBSEM_SIM_NO_DELAY"] = previous
+
+
+def test_preview_downscales_and_normalizes():
+    data = (np.random.rand(1024, 1536) * 65535).astype(np.uint16)
+    jpeg, width, height = preview_jpeg_bytes(data, max_width=768)
+    assert width == 768
+    assert height == 512
+    decoded = PILImage.open(io.BytesIO(jpeg))
+    assert decoded.format == "JPEG"
+    assert decoded.size == (768, 512)
+
+
+def test_preview_flat_image_does_not_divide_by_zero():
+    data = np.full((64, 64), 1234, dtype=np.uint16)
+    jpeg, _, _ = preview_jpeg_bytes(data)
+    assert len(jpeg) > 0
+
+
+def test_small_image_is_not_upscaled():
+    data = np.zeros((100, 200), dtype=np.uint8)
+    _, width, height = preview_jpeg_bytes(data, max_width=768)
+    assert (width, height) == (200, 100)
+
+
+def test_acquire_image_preview_endpoint(armed_client):
+    resp = armed_client.post(
+        "/acquire_image_preview", headers=AUTH, json={"beam_type": "ION"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    jpeg = base64.b64decode(body["image_b64_jpeg"])
+    decoded = PILImage.open(io.BytesIO(jpeg))
+    assert decoded.format == "JPEG"
+    assert body["width"] <= 768
+    assert decoded.size == (body["width"], body["height"])
+    assert body["full_width"] >= body["width"]
+    assert body["beam_type"] == "ION"
+    assert body["hfw"] is not None
+
+
+def test_last_image_preview_endpoint(armed_client):
+    armed_client.post(
+        "/acquire_image_preview", headers=AUTH, json={"beam_type": "ELECTRON"}
+    )
+    resp = armed_client.post(
+        "/last_image_preview", headers=AUTH, json={"beam_type": "ELECTRON"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["image_b64_jpeg"]
+
+
+def test_preview_requires_hardware_scope(armed_client):
+    # Same app, wrong scope story is covered in test_server_factory; here just
+    # assert the endpoint rejects a missing token so it is provably gated.
+    resp = armed_client.post("/acquire_image_preview", json={"beam_type": "ION"})
+    assert resp.status_code == 401


### PR DESCRIPTION
Stacked on #640. Second slice of the agent-server stack.

## What

- `fibsem/server/images.py`: min-max normalize → uint8 → LANCZOS downscale (768 px) → JPEG q70, plus a JSON payload builder carrying the rendition, full-res dimensions, beam type, and hfw
- Two hardware-scope routes: `POST /acquire_image_preview`, `POST /last_image_preview`
- Harvested from the `feat-mcp-server` prototype's `_image_to_b64_jpeg` (which proved a 768 px JPEG is enough for visual milling assessment), with one behavioral change: a failed conversion raises into the structured error envelope rather than silently returning nothing

## Why

Full-res 16-bit TIFF is right for drop-in clients and wrong for agents: MCP image content wants small 8-bit renditions. This is the server-side half of the image story; the sidecar (two PRs up) turns these payloads into MCP `ImageContent`.

## Verification

6 new tests (downscale geometry, flat-image guard, no-upscale, endpoint round-trip decoding the JPEG, auth gating); 21 total in `tests/server/`, all green; ruff clean.