### PR TITLE
[server] Add the tool catalog and same-machine discovery file

### DIFF
--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -1,0 +1,157 @@
+"""The tool catalog: the single source of truth for what agents can do.
+
+The sidecar (``fibsem-mcp``) builds its MCP tool list from this module, and a
+contract test asserts every entry maps onto a real route on the server app —
+so the two surfaces cannot drift apart. Pure data, no dependencies beyond the
+standard library: importable everywhere, including the py3.8 floor.
+
+Scopes mirror the server's enforcement (fibsem/server/auth.py): the sidecar
+registers ``read`` tools for any valid token and ``hardware`` tools only when
+``/capabilities`` reports that scope armed — but the server enforces either
+way; the catalog filter is a courtesy, not the security boundary.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    name: str
+    description: str
+    method: str  # "GET" | "POST"
+    path: str
+    scope: str  # "read" | "hardware"
+    params: Dict[str, str] = field(default_factory=dict)  # name -> description
+
+
+CATALOG: Tuple[ToolSpec, ...] = (
+    # --- read ---
+    ToolSpec(
+        name="get_capabilities",
+        description="Server capabilities: API version, manufacturer, mounted routers, armed scopes.",
+        method="GET",
+        path="/capabilities",
+        scope="read",
+    ),
+    ToolSpec(
+        name="get_system_info",
+        description="Microscope system settings and stage geometry flags.",
+        method="GET",
+        path="/system",
+        scope="read",
+    ),
+    ToolSpec(
+        name="get_stage_position",
+        description="Current stage position (x/y/z in metres, r/t in radians).",
+        method="GET",
+        path="/stage_position",
+        scope="read",
+    ),
+    ToolSpec(
+        name="get_stage_orientation",
+        description="Named stage orientation (e.g. SEM, FIB, MILLING, UNKNOWN).",
+        method="GET",
+        path="/stage_orientation",
+        scope="read",
+    ),
+    ToolSpec(
+        name="get_microscope_state",
+        description="Full microscope state snapshot (beams, detectors, stage).",
+        method="GET",
+        path="/microscope_state",
+        scope="read",
+    ),
+    ToolSpec(
+        name="get_milling_angle",
+        description="Current milling angle in degrees.",
+        method="GET",
+        path="/milling_angle",
+        scope="read",
+    ),
+    ToolSpec(
+        name="get_milling_state",
+        description="Milling state (IDLE, RUNNING, PAUSED, ...).",
+        method="GET",
+        path="/milling_state",
+        scope="read",
+    ),
+    ToolSpec(
+        name="estimate_milling_time",
+        description="Estimated time in seconds for the currently drawn patterns.",
+        method="GET",
+        path="/estimate_milling_time",
+        scope="read",
+    ),
+    ToolSpec(
+        name="stop_milling",
+        description="Emergency stop for an in-progress mill. Always allowed with a valid token.",
+        method="POST",
+        path="/stop_milling",
+        scope="read",  # deliberate: stopping is never gated behind arming
+    ),
+    # --- hardware ---
+    ToolSpec(
+        name="acquire_image_preview",
+        description="Acquire a fresh image and return an agent-sized JPEG preview with metadata.",
+        method="POST",
+        path="/acquire_image_preview",
+        scope="hardware",
+        params={"beam_type": "ELECTRON or ION"},
+    ),
+    ToolSpec(
+        name="last_image_preview",
+        description="JPEG preview of the last acquired image for a beam (switches the active channel).",
+        method="POST",
+        path="/last_image_preview",
+        scope="hardware",
+        params={"beam_type": "ELECTRON or ION"},
+    ),
+    ToolSpec(
+        name="move_stage_relative",
+        description="Move the stage by a relative offset (metres and radians).",
+        method="POST",
+        path="/move_stage_relative",
+        scope="hardware",
+        params={
+            "dx": "relative x in metres",
+            "dy": "relative y in metres",
+            "dz": "relative z in metres",
+        },
+    ),
+    ToolSpec(
+        name="move_stage_absolute",
+        description="Move the stage to an absolute position (metres and radians).",
+        method="POST",
+        path="/move_stage_absolute",
+        scope="hardware",
+        params={
+            "x": "x in metres",
+            "y": "y in metres",
+            "z": "z in metres",
+            "r": "rotation in radians",
+            "t": "tilt in radians",
+        },
+    ),
+    ToolSpec(
+        name="move_to_milling_angle",
+        description="Tilt the stage to a milling angle, in degrees.",
+        method="POST",
+        path="/milling_angle/move",
+        scope="hardware",
+        params={"milling_angle_deg": "target milling angle in degrees"},
+    ),
+    ToolSpec(
+        name="autocontrast",
+        description="Run autocontrast for a beam (changes detector settings).",
+        method="POST",
+        path="/autocontrast",
+        scope="hardware",
+        params={"beam_type": "ELECTRON or ION"},
+    ),
+)
+
+
+def tools_for_scopes(armed: Dict[str, bool]) -> Tuple[ToolSpec, ...]:
+    """The catalog entries usable given the /capabilities scopes payload."""
+    return tuple(t for t in CATALOG if armed.get(t.scope, False))

--- a/fibsem/server/discovery.py
+++ b/fibsem/server/discovery.py
@@ -1,0 +1,77 @@
+"""Same-machine discovery of a running fibsem server.
+
+The server writes ``~/.fibsem/agent-server.json`` while it runs so local
+clients (the ``fibsem-mcp`` sidecar in particular) can connect without the
+user copying a token. The file is written ``0600``; on Windows the mode is
+advisory and the real protection is the user-profile directory's ACLs — do
+not claim more than that.
+
+One file means one server per machine, which doubles as the startup guard
+for the single-commander rule: refuse to start a second server while a live
+one owns the file.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+from fibsem.server.auth import AuthConfig, Scope
+
+DISCOVERY_DIR = Path.home() / ".fibsem"
+DISCOVERY_FILE = DISCOVERY_DIR / "agent-server.json"
+
+
+def _client_host(bind_host: str) -> str:
+    # A 0.0.0.0 bind is not a connectable address; local clients use loopback.
+    return "127.0.0.1" if bind_host in ("0.0.0.0", "::", "") else bind_host
+
+
+def write_discovery_file(
+    host: str, port: int, auth: AuthConfig, path: Optional[Path] = None
+) -> Path:
+    path = Path(path) if path is not None else DISCOVERY_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "url": f"http://{_client_host(host)}:{port}",
+        "token": auth.token,
+        "pid": os.getpid(),
+        "scopes": {s.value: auth.is_armed(s) for s in Scope},
+    }
+    with open(path, "w") as f:
+        json.dump(payload, f, indent=2)
+    os.chmod(path, 0o600)
+    return path
+
+
+def read_discovery_file(path: Optional[Path] = None) -> Optional[dict]:
+    """The running server's connection info, or None if absent/stale/unreadable."""
+    path = Path(path) if path is not None else DISCOVERY_FILE
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict) or "url" not in data or "token" not in data:
+        return None
+    if not _pid_alive(data.get("pid")):
+        return None
+    return data
+
+
+def remove_discovery_file(path: Optional[Path] = None) -> None:
+    path = Path(path) if path is not None else DISCOVERY_FILE
+    try:
+        path.unlink()
+    except OSError:
+        pass
+
+
+def _pid_alive(pid) -> bool:
+    if not isinstance(pid, int):
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True

--- a/fibsem/server/server.py
+++ b/fibsem/server/server.py
@@ -26,9 +26,11 @@ Or as a script:
     python -m fibsem.server.server --manufacturer Demo --arm-hardware
 """
 
+import atexit
 import io
 import logging
 import math
+import os
 import threading
 from typing import Optional
 
@@ -40,6 +42,12 @@ from fastapi.responses import JSONResponse, Response
 from fibsem import utils
 from fibsem.microscope import FibsemMicroscope
 from fibsem.server.auth import AuthConfig, Scope, command_slot, require_scope
+from fibsem.server.discovery import (
+    DISCOVERY_FILE,
+    read_discovery_file,
+    remove_discovery_file,
+    write_discovery_file,
+)
 from fibsem.server.images import preview_payload
 from fibsem.server.models import (
     AcquireImageRequest,
@@ -683,6 +691,15 @@ class FibsemServer:
         self.app = build_server(microscope, auth=self.auth)
 
     def run(self):
+        # One server per microscope/machine: the discovery file is the guard.
+        existing = read_discovery_file()
+        if existing is not None and existing.get("pid") != os.getpid():
+            raise RuntimeError(
+                f"A fibsem server already appears to be running "
+                f"(pid {existing.get('pid')}, {existing.get('url')}). "
+                "One server per microscope: stop it first, or delete "
+                f"{DISCOVERY_FILE} if it is stale."
+            )
         armed = ", ".join(s.value for s in self.auth.armed_scopes())
         logging.info(
             "fibsem server on http://%s:%s — scopes armed: %s",
@@ -691,7 +708,12 @@ class FibsemServer:
             armed,
         )
         logging.info("bearer token: %s", self.auth.token)
-        uvicorn.run(self.app, host=self.host, port=self.port)
+        write_discovery_file(self.host, self.port, self.auth)
+        atexit.register(remove_discovery_file)
+        try:
+            uvicorn.run(self.app, host=self.host, port=self.port)
+        finally:
+            remove_discovery_file()
 
     @classmethod
     def from_session(

--- a/tests/server/test_catalog_discovery.py
+++ b/tests/server/test_catalog_discovery.py
@@ -27,14 +27,20 @@ def app():
 
 
 def test_every_catalog_entry_is_a_real_route(app):
-    routes = {
-        (method, route.path)
-        for route in app.routes
-        if hasattr(route, "methods")
-        for method in route.methods
-    }
+    # Dispatch a real request per entry instead of introspecting app.routes:
+    # route-object metadata shapes vary across FastAPI/Starlette versions (the
+    # introspection form of this test passed locally and failed on CI's newer
+    # FastAPI), but dispatch is version-proof. Any status except 404/405 proves
+    # the (method, path) pair exists — 401 is the expected answer, since no
+    # token is sent.
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app, raise_server_exceptions=False)
     missing = [
-        (t.name, t.method, t.path) for t in CATALOG if (t.method, t.path) not in routes
+        (t.name, t.method, t.path, resp.status_code)
+        for t in CATALOG
+        for resp in [client.request(t.method, t.path)]
+        if resp.status_code in (404, 405)
     ]
     assert missing == []
 

--- a/tests/server/test_catalog_discovery.py
+++ b/tests/server/test_catalog_discovery.py
@@ -1,0 +1,77 @@
+"""Contract tests: the tool catalog maps onto real routes, and the discovery
+file round-trips."""
+
+import json
+import os
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fibsem import utils  # noqa: E402
+from fibsem.server import AuthConfig, build_server  # noqa: E402
+from fibsem.server.catalog import CATALOG, tools_for_scopes  # noqa: E402
+from fibsem.server.discovery import (  # noqa: E402
+    read_discovery_file,
+    remove_discovery_file,
+    write_discovery_file,
+)
+
+
+@pytest.fixture(scope="module")
+def app():
+    os.environ.setdefault("FIBSEM_SIM_NO_DELAY", "1")
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    return build_server(microscope, auth=AuthConfig(token="t"))
+
+
+def test_every_catalog_entry_is_a_real_route(app):
+    routes = {
+        (method, route.path)
+        for route in app.routes
+        if hasattr(route, "methods")
+        for method in route.methods
+    }
+    missing = [
+        (t.name, t.method, t.path) for t in CATALOG if (t.method, t.path) not in routes
+    ]
+    assert missing == []
+
+
+def test_catalog_names_unique_and_scopes_valid():
+    names = [t.name for t in CATALOG]
+    assert len(names) == len(set(names))
+    assert set(t.scope for t in CATALOG) <= {"read", "hardware"}
+
+
+def test_tools_for_scopes_filters_hardware():
+    read_only = tools_for_scopes({"read": True, "hardware": False})
+    assert all(t.scope == "read" for t in read_only)
+    assert any(t.name == "stop_milling" for t in read_only)
+    armed = tools_for_scopes({"read": True, "hardware": True})
+    assert len(armed) == len(CATALOG)
+
+
+def test_discovery_round_trip(tmp_path):
+    auth = AuthConfig.generate(arm_hardware=True, token="secret")
+    path = tmp_path / "agent-server.json"
+    write_discovery_file("0.0.0.0", 8001, auth, path=path)
+    data = read_discovery_file(path)
+    assert data is not None
+    assert data["url"] == "http://127.0.0.1:8001"  # 0.0.0.0 is not connectable
+    assert data["token"] == "secret"
+    assert data["scopes"]["hardware"] is True
+    if os.name != "nt":
+        assert (path.stat().st_mode & 0o777) == 0o600
+    remove_discovery_file(path)
+    assert read_discovery_file(path) is None
+
+
+def test_discovery_rejects_stale_or_malformed(tmp_path):
+    path = tmp_path / "agent-server.json"
+    path.write_text("not json")
+    assert read_discovery_file(path) is None
+    path.write_text(json.dumps({"url": "http://x", "token": "t"}))  # no pid
+    assert read_discovery_file(path) is None
+    assert read_discovery_file(tmp_path / "absent.json") is None


### PR DESCRIPTION
Stacked on #641. Third slice — the two pieces the sidecar consumes.

## What

- `fibsem/server/catalog.py`: 15 `ToolSpec` entries (9 read, 6 hardware) — the single source the sidecar builds its MCP tools from, with a contract test asserting every entry is a real route+method on the app. `stop_milling` is deliberately read-scope in the catalog exactly as on the server.
- `fibsem/server/discovery.py`: writes `~/.fibsem/agent-server.json` (url, token, pid, armed scopes; `0600`, advisory on Windows) while the server runs; readers reject malformed/stale entries (dead pid). `FibsemServer.run()` writes it, removes it on exit, and refuses to start while another live server owns it — the one-server-per-microscope rule as code rather than convention.

## Verification

5 new tests (catalog↔routes contract, scope filtering, discovery round-trip incl. the 0.0.0.0→127.0.0.1 connect-address rule and permission bits, stale/malformed rejection); 26 total in `tests/server/`, green; ruff clean.