### PR TITLE
[fix] Confine the objective axis-drop to the stage type it has run on

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -442,6 +442,41 @@ class FibsemMicroscope(ABC):
         else:
             self.move_stage_absolute(stage_position)
 
+    def _axis_restrictions_apply(self) -> bool:
+        """Whether the microscope refuses z and rotation, so an absolute move drops them.
+
+        Two halves, and they are not the same rule.
+
+        The **orientation** half is a compustage flipped to face its objective. It
+        stays as it was: `get_stage_orientation` can never return "FM" on an offset
+        mount -- the FM is a device there and `orientations["FM"]` is a copy of the FIB
+        entry -- so that half is naturally confined to the mounting it was written for.
+
+        The **objective** half is gated on `stage_is_compustage` **temporarily**, and
+        that gate belongs to FIB-640 to remove. It has only ever run on a compustage,
+        because `self.fm` is None everywhere else, and the axes it drops are not
+        equivalent across stage types: `stage_position_to_autoscript` returns a
+        `CompustagePosition(x, y, z, a)` with no `r` field at all, so dropping `r`
+        there has never done anything, while on an offset mount it would drop a real
+        rotation axis. Opening the connection gate is what makes that reachable, so
+        the gate goes on first.
+
+        Removing it silently would be the worse failure of the two. Without the gate
+        an offset move half-succeeds -- lands at x and y, no z, no rotation -- where
+        with it the full move is sent and the *microscope* refuses if it objects,
+        which is an error an operator can see and report. FIB-640 argues for exactly
+        that preference, and is also where the axis pair gets settled: it measured
+        z and t, not z and r.
+        """
+        if self.get_stage_orientation() == "FM":
+            return True
+
+        return (
+            self.stage_is_compustage
+            and self.fm is not None
+            and self.fm.objective.state == "Inserted"
+        )
+
     def _refuse_rotation_at_the_fluorescence_microscope(
         self, stage_position: FibsemStagePosition
     ) -> None:
@@ -3232,9 +3267,7 @@ class ThermoMicroscope(FibsemMicroscope):
             position, compustage=self.stage_is_compustage
         )  # TODO: apply compucentric/raw coordinate offset here?
 
-        if self.get_stage_orientation() == "FM" or (
-            self.fm is not None and self.fm.objective.state == "Inserted"
-        ):  # ONLY when restrictions are on
+        if self._axis_restrictions_apply():  # ONLY when restrictions are on
             autoscript_position.z = None
             autoscript_position.r = None
 

--- a/tests/fm/test_objective_signal.py
+++ b/tests/fm/test_objective_signal.py
@@ -39,7 +39,9 @@ def fm():
 def moves(fm):
     """Every `(position, state)` emitted."""
     seen = []
-    fm.objective.position_changed.connect(lambda position, state: seen.append((position, state)))
+    fm.objective.position_changed.connect(
+        lambda position, state: seen.append((position, state))
+    )
     return seen
 
 
@@ -80,7 +82,9 @@ class TestTheSimulatedObjectiveAnnounces:
 
         objective = ObjectiveLens()
         seen = []
-        objective.position_changed.connect(lambda position, state: seen.append(position))
+        objective.position_changed.connect(
+            lambda position, state: seen.append(position)
+        )
 
         objective.move_absolute(1e-3)
 
@@ -146,6 +150,7 @@ class TestThePayload:
         which surfaces as a *process abort* rather than a failure once a Qt slot reads it
         (FIB-329).
         """
+
         def raises(self):
             raise RuntimeError("detector did not answer")
 
@@ -180,7 +185,9 @@ class TestEveryDriverAnnounces:
     def _announces(method: ast.FunctionDef) -> bool:
         """Either it notifies, or it delegates to something that does."""
         for child in ast.walk(method):
-            if not isinstance(child, ast.Call) or not isinstance(child.func, ast.Attribute):
+            if not isinstance(child, ast.Call) or not isinstance(
+                child.func, ast.Attribute
+            ):
                 continue
             if child.func.attr in ("_notify_moved", "move_absolute", "move_relative"):
                 return True
@@ -189,7 +196,9 @@ class TestEveryDriverAnnounces:
     def test_all_three_implementations_are_found(self):
         """Guard against the probe silently matching nothing."""
         classes = self._objective_classes()
-        assert len(classes) == 3, f"expected three ObjectiveLens classes, found {sorted(classes)}"
+        assert len(classes) == 3, (
+            f"expected three ObjectiveLens classes, found {sorted(classes)}"
+        )
 
     @pytest.mark.parametrize("write_method", WRITE_METHODS)
     def test_every_write_method_announces(self, write_method):
@@ -220,7 +229,8 @@ class TestTheGuardsStillReadTheDevice:
 
     `ObjectiveLens.position_changed` is for *displays*. Guards read the device, every time, because one
     of them is a collision guard: `ThermoMicroscope.move_stage_absolute` suppresses z and
-    r from a stage move while the objective is inserted, and a stale `"Retracted"` there
+    r from a stage move while the objective is inserted -- the condition itself now lives
+    in `FibsemMicroscope._axis_restrictions_apply` -- and a stale `"Retracted"` there
     means the stage changes height and rotates with the objective in the chamber.
 
     That is affordable because the guards were never the polling load -- this one runs
@@ -232,7 +242,9 @@ class TestTheGuardsStillReadTheDevice:
 
     @staticmethod
     def _method(class_name: str, method_name: str) -> ast.FunctionDef:
-        source = (Path(fibsem.__file__).parent / "microscope.py").read_text(encoding="utf-8")
+        source = (Path(fibsem.__file__).parent / "microscope.py").read_text(
+            encoding="utf-8"
+        )
         cls = next(
             node
             for node in ast.walk(ast.parse(source))
@@ -244,8 +256,16 @@ class TestTheGuardsStillReadTheDevice:
             if isinstance(node, ast.FunctionDef) and node.name == method_name
         )
 
-    def test_the_stage_move_reads_the_objective_state_directly(self):
-        guard = self._method("ThermoMicroscope", "move_stage_absolute")
+    def test_the_guard_reads_the_objective_state_directly(self):
+        """Wherever the predicate lives, it must ask the device.
+
+        It moved out of `move_stage_absolute` into `_axis_restrictions_apply` when the
+        objective half was compustage-gated, so that the condition could be tested at
+        all -- AutoScript is absent here, so the move itself cannot be executed. That
+        is a relocation, not a weakening: the read is still live. The companion test
+        below is what keeps the two connected.
+        """
+        guard = self._method("FibsemMicroscope", "_axis_restrictions_apply")
 
         reads = [
             node
@@ -257,8 +277,26 @@ class TestTheGuardsStillReadTheDevice:
         ]
 
         assert reads, (
-            "move_stage_absolute no longer reads `objective.state` off the device. If "
-            "that is now a cached or pushed value, the collision guard can be wrong: a "
-            "stale 'Retracted' lets the stage move in z and rotate with the objective "
-            "inserted (FIB-534)"
+            "_axis_restrictions_apply no longer reads `objective.state` off the "
+            "device. If that is now a cached or pushed value, the collision guard can "
+            "be wrong: a stale 'Retracted' lets the stage move in z and rotate with "
+            "the objective inserted (FIB-534)"
+        )
+
+    def test_the_stage_move_still_asks_the_guard(self):
+        """The other half. Splitting the predicate out means the read being live is no
+        longer enough on its own -- the move has to still consult it."""
+        move = self._method("ThermoMicroscope", "move_stage_absolute")
+
+        calls = [
+            node
+            for node in ast.walk(move)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_axis_restrictions_apply"
+        ]
+
+        assert calls, (
+            "move_stage_absolute no longer calls `_axis_restrictions_apply`, so "
+            "nothing suppresses z and r while the objective is inserted (FIB-534)"
         )

--- a/tests/test_axis_restrictions_gate.py
+++ b/tests/test_axis_restrictions_gate.py
@@ -1,0 +1,104 @@
+"""Which stage types drop z and rotation from an absolute move.
+
+`ThermoMicroscope.move_stage_absolute` blanks two axes when it believes the
+microscope will refuse them. That guard has only ever run on a compustage, because
+`microscope.fm` is None on every other system -- and opening the connection gate is
+what makes it reachable elsewhere.
+
+It is not safe to let that happen. The axes are not equivalent across stage types:
+`stage_position_to_autoscript` returns a `CompustagePosition(x, y, z, a)` with no `r`
+field at all, so dropping `r` there has never done anything, while on an offset mount
+it would drop a real rotation axis. Every absolute move would silently half-succeed --
+land at x and y, no z, no rotation.
+
+So the objective half is compustage-gated **temporarily**, and FIB-640 owns removing
+it. That issue is explicit that the branch should *not* stay gated once it is correct
+-- an iFLM has an objective too -- and it is also where the axis pair gets settled: it
+measured z and t, not z and r.
+
+The predicate is tested rather than the move: AutoScript is not installed in CI, so
+`ThermoMicroscope.move_stage_absolute` cannot be executed at all.
+"""
+
+import os
+
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+
+IFLM_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-iflm-configuration.yaml")
+ARCTIS_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
+
+
+def _microscope(config_path: str):
+    microscope, _ = utils.setup_session(config_path=config_path)
+    return microscope
+
+
+def test_a_compustage_with_the_objective_in_still_restricts():
+    """Unchanged. This is the only place the guard has ever run."""
+    microscope = _microscope(ARCTIS_CONFIG)
+    microscope.fm.objective.insert()
+
+    assert microscope._axis_restrictions_apply() is True
+
+
+def test_a_compustage_with_the_objective_out_does_not():
+    microscope = _microscope(ARCTIS_CONFIG)
+    microscope.fm.objective.retract()
+    microscope.move_to_orientation("SEM")
+
+    assert microscope._axis_restrictions_apply() is False
+
+
+def test_an_offset_mount_with_the_objective_in_does_not_restrict():
+    """The gate. Without it, every absolute move on an offset system with an FM would
+    silently lose its z and its rotation -- behaviour that has executed on no
+    instrument. Remove this with FIB-640, once the axis pair is settled on hardware."""
+    microscope = _microscope(IFLM_CONFIG)
+    microscope.move_to_orientation("FIB")
+    microscope.fm.objective.insert()
+
+    assert microscope.stage_is_compustage is False
+    assert microscope.fm.objective.state == "Inserted"
+    assert microscope._axis_restrictions_apply() is False
+
+
+def test_a_system_with_no_fluorescence_microscope_does_not_restrict():
+    """Where every offset system sits today, gate closed."""
+    microscope = _microscope(cfg.MICROSCOPE_CONFIGURATION_PATH)
+
+    assert microscope.fm is None
+    assert microscope._axis_restrictions_apply() is False
+
+
+def test_the_orientation_half_needs_no_gate_of_its_own():
+    """It is confined to the compustage by the orientations themselves.
+
+    `get_stage_orientation` can never return "FM" on an offset mount -- the FM is a
+    device there, and `orientations["FM"]` is a byte-identical copy of the FIB entry,
+    which is matched first. So that half is dead off a compustage without anything
+    saying so, and gating it would be describing the same fact twice.
+    """
+    microscope = _microscope(IFLM_CONFIG)
+    microscope.move_to_orientation("FIB")
+    microscope.move_to_microscope("FM")
+
+    assert microscope.get_current_device() == "FM"
+    assert microscope.get_stage_orientation() != "FM"
+
+
+@pytest.mark.parametrize("config_path", [ARCTIS_CONFIG, IFLM_CONFIG])
+def test_the_predicate_reads_the_microscope_rather_than_being_told(config_path: str):
+    """It answers from live objective state, so inserting flips it where it applies."""
+    microscope = _microscope(config_path)
+    microscope.move_to_orientation("SEM")
+    microscope.fm.objective.retract()
+    before = microscope._axis_restrictions_apply()
+
+    microscope.fm.objective.insert()
+    after = microscope._axis_restrictions_apply()
+
+    assert before is False
+    assert after is microscope.stage_is_compustage


### PR DESCRIPTION
> Deliberately no Linear issue id in this description — the two it relates to (the offset-FM device work and the stage-restrictions measurement) are both still open, and naming either would auto-complete it on merge. The code comments carry the references.

`ThermoMicroscope.move_stage_absolute` blanks z and rotation when it expects the microscope to refuse them:

```python
if self.get_stage_orientation() == "FM" or (
    self.fm is not None and self.fm.objective.state == "Inserted"
):
    autoscript_position.z = None
    autoscript_position.r = None
```

The objective half has **only ever run on a compustage**, because `self.fm` is `None` on every other system. Opening the fluorescence connection gate is what makes it live on an offset mount for the first time — and the axes it drops are not equivalent across stage types:

| | `stage_position_to_autoscript` returns | dropping `r` |
| -- | -- | -- |
| compustage | `CompustagePosition(x, y, z, a)` — **no `r` field** | has never done anything |
| offset | `StagePosition(x, y, z, r, t)` | **drops a real rotation axis** |

So every absolute move on an offset system with an inserted objective would silently half-succeed: land at x and y, no z, no rotation. Behaviour that has executed on no instrument.

## Gated, and temporary

`stage_is_compustage` is added to the objective half, so it stays exactly where it has always run. The stage-restrictions issue owns removing it, and is explicit the branch should **not** stay gated once it is correct — an iFLM has an objective too. It is also where the axis pair gets settled: it measured **z and t**, not z and r.

Gating is the safer of the two failures. Without it an offset move half-succeeds silently. With it the full move is sent and the *microscope* refuses if it objects, which is an error an operator can see and report — the same preference that issue argues for.

## What is not gated

The **orientation** half. `get_stage_orientation` can never return `"FM"` on an offset mount — the FM is a device there, and `orientations["FM"]` is a byte-identical copy of the FIB entry, which is matched first. It is already confined by the orientations themselves, and gating it would state the same fact twice. There is a test pinning that.

## Why the condition became a named predicate

AutoScript is not installed in CI, so `ThermoMicroscope.move_stage_absolute` cannot be executed at all — `stage_position_to_autoscript` raises without it. Extracting `_axis_restrictions_apply` onto the base class is what makes this testable rather than asserted: it is reachable from both simulator configurations.

## Verification

7 tests, mutation-checked: removing the gate fails two of them. 158 passing across the affected files.
