### PR TITLE
[mcp] Add fibsem-mcp: the MCP sidecar over the server's tool catalog

### DIFF
--- a/fibsem/mcp/README.md
+++ b/fibsem/mcp/README.md
@@ -1,0 +1,94 @@
+# fibsem-mcp — connect an agent to the microscope
+
+The MCP sidecar lets Claude (Code or Desktop) drive a fibsem server: acquire
+and *look at* images, read state, move the stage, and always stop a mill. The
+server is the security boundary — the sidecar registers only the tools the
+server's `/capabilities` reports, and the server enforces scopes regardless.
+
+## Install
+
+```bash
+pip install -e ".[server,mcp]"    # sidecar needs Python 3.10+
+```
+
+## 1. Start the bench server
+
+On the machine with the microscope connection (or anywhere, with the Demo
+simulator):
+
+```bash
+python -m fibsem.server.server --manufacturer Demo --arm-hardware
+```
+
+- The bearer token is generated and **logged at startup**; pass `--token <t>`
+  to choose your own.
+- Without `--arm-hardware` the server is read-only: state and stop-milling
+  work, anything that commands the hardware is refused with a structured 403.
+- Binds `127.0.0.1` by default. `--host 0.0.0.0` exposes it on the LAN —
+  an explicit choice; the token then travels as cleartext HTTP.
+- While running, the server writes `~/.fibsem/agent-server.json`
+  (url + token) so local clients connect without copying anything, and
+  refuses to start if another live server owns that file.
+- `--ip-address` / `--config` select a real microscope instead of Demo.
+
+## 2. Register the sidecar
+
+```bash
+claude mcp add fibsem -- fibsem-mcp
+```
+
+Same-machine setups need nothing more: the sidecar autodiscovers the running
+server. For a server on another machine (or a non-default setup):
+
+```bash
+claude mcp add fibsem -- fibsem-mcp --url http://hydra-support:8001 --token <token>
+```
+
+(`FIBSEM_SERVER_URL` / `FIBSEM_SERVER_TOKEN` environment variables also work.)
+
+For Claude Desktop, add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "fibsem": { "command": "fibsem-mcp" }
+  }
+}
+```
+
+If `claude` runs outside the environment where fibsem is installed, register
+the absolute path to the script (e.g. `<env>/bin/fibsem-mcp`).
+
+## 3. Use it
+
+Start a new Claude session (`/mcp` should show `fibsem` connected with 15
+tools) and ask:
+
+- "What's the stage position?"
+- "Acquire an ion image and tell me what you see."
+- "Tilt to a 15 degree milling angle and confirm the readback."
+- "Does the last electron image look focused?"
+
+## Order and troubleshooting
+
+- **Server first, then the sidecar.** The sidecar exits immediately when it
+  finds no server, which an MCP client reports as `CONNECTION_CLOSED`. Start
+  the server, then reconnect (`/mcp` in the session, or restart `claude`).
+  Run `fibsem-mcp` directly in a terminal to see the actual error.
+- **Wrong server version / unknown arguments**: if you launched with
+  `python -m` from inside another fibsem checkout, that directory shadows
+  your installed copy. Run from the repo you installed, or any directory
+  without a `fibsem/` folder.
+- **Stale discovery file**: a hard-killed server can leave
+  `~/.fibsem/agent-server.json` behind. Readers reject it (dead pid), and the
+  startup guard tells you the path — delete it if asked.
+
+## Safety model, in one paragraph
+
+Loopback bind keeps everything off the network by default; the per-session
+bearer token keeps other users on the same machine out; the `hardware` scope
+must be armed before anything moves or images; one hardware command runs at a
+time (a second gets `409 busy`); `stop_milling` is always allowed and never
+waits. **Never run this beside a running AutoLamella session** — one
+commander per microscope; agent access to a live AutoLamella session goes
+*through* the app (embedded hosting, in development), not around it.

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -71,7 +71,7 @@ def build_sidecar(client, scopes):
     ``scopes`` is the /capabilities scopes payload; only tools whose scope is
     armed get registered (the server enforces regardless).
     """
-    from mcp.server.mcpserver import MCPServer, Image
+    from mcp.server.mcpserver import Image, MCPServer
 
     mcp = MCPServer("fibsem")
     armed = {t.name for t in CATALOG if scopes.get(t.scope, False)}

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -71,9 +71,9 @@ def build_sidecar(client, scopes):
     ``scopes`` is the /capabilities scopes payload; only tools whose scope is
     armed get registered (the server enforces regardless).
     """
-    from mcp.server.fastmcp import FastMCP, Image
+    from mcp.server.mcpserver import MCPServer, Image
 
-    mcp = FastMCP("fibsem")
+    mcp = MCPServer("fibsem")
     armed = {t.name for t in CATALOG if scopes.get(t.scope, False)}
     by_name = {t.name: t for t in CATALOG}
 

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -1,0 +1,246 @@
+"""fibsem-mcp: the MCP sidecar that connects an agent to a fibsem server.
+
+Runs on the agent host (the machine running Claude Code / Claude Desktop) and
+proxies MCP tool calls to a fibsem server over HTTP with a bearer token. It
+owns no microscope connection and enforces nothing itself — the server is the
+security boundary; the sidecar merely registers the tools the server's
+``/capabilities`` says are available.
+
+Connection resolution, in order: ``--url``/``--token`` arguments, the
+``FIBSEM_SERVER_URL``/``FIBSEM_SERVER_TOKEN`` environment variables, then the
+same-machine discovery file a running server maintains.
+
+Register with Claude Code:
+
+    claude mcp add fibsem -- fibsem-mcp
+    # or explicitly:
+    claude mcp add fibsem -- fibsem-mcp --url http://hydra-support:8001 --token <token>
+
+Requires the [mcp] extra (Python 3.10+): pip install fibsem[mcp]
+"""
+
+import argparse
+import base64
+import json
+import os
+import sys
+from typing import Optional, Tuple
+
+from fibsem.server.catalog import CATALOG
+
+_TIMEOUT_S = 120.0  # acquisitions and moves on real hardware are slow
+
+
+def _resolve_connection(url, token):
+    # type: (Optional[str], Optional[str]) -> Tuple[str, str]
+    url = url or os.environ.get("FIBSEM_SERVER_URL")
+    token = token or os.environ.get("FIBSEM_SERVER_TOKEN")
+    if url and token:
+        return url, token
+    from fibsem.server.discovery import read_discovery_file
+
+    found = read_discovery_file()
+    if found is not None:
+        return url or found["url"], token or found["token"]
+    sys.exit(
+        "fibsem-mcp: no server found. Pass --url and --token, set "
+        "FIBSEM_SERVER_URL/FIBSEM_SERVER_TOKEN, or start a fibsem server on "
+        "this machine (it writes ~/.fibsem/agent-server.json)."
+    )
+
+
+def _call(client, method, path, payload=None):
+    """Call the server; refusals come back as readable text, not exceptions.
+
+    Agents act sensibly on a structured refusal string; a raw traceback for a
+    403 teaches them nothing.
+    """
+    resp = client.request(method, path, json=payload)
+    if resp.status_code >= 400:
+        try:
+            detail = resp.json().get("detail", resp.text)
+        except ValueError:
+            detail = resp.text
+        return None, f"refused ({resp.status_code}): {json.dumps(detail)}"
+    return resp.json(), None
+
+
+def build_sidecar(client, scopes):
+    """Build the FastMCP server over an httpx-compatible client.
+
+    ``scopes`` is the /capabilities scopes payload; only tools whose scope is
+    armed get registered (the server enforces regardless).
+    """
+    from mcp.server.fastmcp import FastMCP, Image
+
+    mcp = FastMCP("fibsem")
+    armed = {t.name for t in CATALOG if scopes.get(t.scope, False)}
+    by_name = {t.name: t for t in CATALOG}
+
+    def _json_tool(name, payload_fn=None):
+        spec = by_name[name]
+
+        def tool(**kwargs):
+            payload = payload_fn(**kwargs) if payload_fn else (kwargs or None)
+            data, err = _call(client, spec.method, spec.path, payload)
+            return err if err else data
+
+        return spec, tool
+
+    def _image_tool(name):
+        spec = by_name[name]
+
+        def tool(beam_type="ELECTRON"):
+            data, err = _call(client, spec.method, spec.path, {"beam_type": beam_type})
+            if err:
+                return err
+            jpeg = base64.b64decode(data.pop("image_b64_jpeg"))
+            return [json.dumps(data), Image(data=jpeg, format="jpeg")]
+
+        return spec, tool
+
+    # Explicit signatures so FastMCP derives a real parameter schema per tool.
+    def get_capabilities():
+        return _json_tool("get_capabilities")[1]()
+
+    def get_system_info():
+        return _json_tool("get_system_info")[1]()
+
+    def get_stage_position():
+        return _json_tool("get_stage_position")[1]()
+
+    def get_stage_orientation():
+        return _json_tool("get_stage_orientation")[1]()
+
+    def get_microscope_state():
+        return _json_tool("get_microscope_state")[1]()
+
+    def get_milling_angle():
+        return _json_tool("get_milling_angle")[1]()
+
+    def get_milling_state():
+        return _json_tool("get_milling_state")[1]()
+
+    def estimate_milling_time():
+        return _json_tool("estimate_milling_time")[1]()
+
+    def stop_milling():
+        return _json_tool("stop_milling")[1]()
+
+    def acquire_image_preview(beam_type: str = "ELECTRON"):
+        return _image_tool("acquire_image_preview")[1](beam_type=beam_type)
+
+    def last_image_preview(beam_type: str = "ELECTRON"):
+        return _image_tool("last_image_preview")[1](beam_type=beam_type)
+
+    def move_stage_relative(dx: float = 0.0, dy: float = 0.0, dz: float = 0.0):
+        position = {
+            "name": None,
+            "x": dx,
+            "y": dy,
+            "z": dz,
+            "r": 0.0,
+            "t": 0.0,
+            "coordinate_system": "RAW",
+        }
+        data, err = _call(
+            client, "POST", "/move_stage_relative", {"position": position}
+        )
+        return err if err else data
+
+    def move_stage_absolute(x: float, y: float, z: float, r: float, t: float):
+        position = {
+            "name": None,
+            "x": x,
+            "y": y,
+            "z": z,
+            "r": r,
+            "t": t,
+            "coordinate_system": "RAW",
+        }
+        data, err = _call(
+            client, "POST", "/move_stage_absolute", {"position": position}
+        )
+        return err if err else data
+
+    def move_to_milling_angle(milling_angle_deg: float):
+        data, err = _call(
+            client,
+            "POST",
+            "/milling_angle/move",
+            {"milling_angle_deg": milling_angle_deg},
+        )
+        return err if err else data
+
+    def autocontrast(beam_type: str = "ELECTRON"):
+        data, err = _call(client, "POST", "/autocontrast", {"beam_type": beam_type})
+        return err if err else data
+
+    implementations = {
+        fn.__name__: fn
+        for fn in (
+            get_capabilities,
+            get_system_info,
+            get_stage_position,
+            get_stage_orientation,
+            get_microscope_state,
+            get_milling_angle,
+            get_milling_state,
+            estimate_milling_time,
+            stop_milling,
+            acquire_image_preview,
+            last_image_preview,
+            move_stage_relative,
+            move_stage_absolute,
+            move_to_milling_angle,
+            autocontrast,
+        )
+    }
+    # The catalog is the contract: refuse to start with an implementation gap.
+    missing = {t.name for t in CATALOG} - set(implementations)
+    if missing:
+        raise RuntimeError(f"sidecar is missing implementations for: {sorted(missing)}")
+
+    for name, fn in implementations.items():
+        if name in armed:
+            mcp.add_tool(fn, name=name, description=by_name[name].description)
+    return mcp
+
+
+def main(argv=None):
+    try:
+        import mcp  # noqa: F401
+    except ImportError:
+        sys.exit(
+            "fibsem-mcp needs the [mcp] extra (Python 3.10+): pip install fibsem[mcp]"
+        )
+    import httpx
+
+    parser = argparse.ArgumentParser(description="MCP sidecar for a fibsem server")
+    parser.add_argument(
+        "--url", default=None, help="Server URL, e.g. http://127.0.0.1:8001"
+    )
+    parser.add_argument(
+        "--token", default=None, help="Bearer token (from the server log or dialog)"
+    )
+    args = parser.parse_args(argv)
+
+    url, token = _resolve_connection(args.url, args.token)
+    client = httpx.Client(
+        base_url=url,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=_TIMEOUT_S,
+    )
+    capabilities, err = _call(client, "GET", "/capabilities")
+    if err:
+        sys.exit(f"fibsem-mcp: cannot reach the server at {url} — {err}")
+    print(
+        f"fibsem-mcp: connected to {url} "
+        f"({capabilities.get('manufacturer')}, scopes {capabilities.get('scopes')})",
+        file=sys.stderr,
+    )
+    build_sidecar(client, capabilities.get("scopes", {})).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,13 @@ reporting = [
 
 server = ["fastapi>=0.100.0", "uvicorn[standard]>=0.20.0", "requests>=2.28.0"]
 
+# The MCP sidecar (fibsem-mcp). The mcp SDK needs py3.10+, so the extra degrades
+# gracefully on 3.8/3.9 installs; the fibsem package itself never imports mcp.
+mcp = [
+    "mcp>=1.2.0; python_version >= '3.10'",
+    "httpx>=0.27.0",
+]
+
 # Test tooling. Install with `pip install .[test]` (CI does this).
 test = [
     "pytest>=7.2.2",
@@ -95,6 +102,7 @@ fibsem-autolamella-ui = "fibsem.applications.autolamella.ui.AutoLamellaMainUI:ru
 fm-image-viewer-ui = "fibsem.ui.fm.widgets.fm_image_viewer_widget:main"
 fibsem-correlation-ui = "fibsem.ui.correlation.widgets.correlation_tab_widget:main"
 fibsem-cli = "fibsem.cli:main"
+fibsem-mcp = "fibsem.mcp.sidecar:main"
 
 # Recursive by design. A bare `packages = ["fibsem"]` is NOT recursive: it ships
 # only the top-level fibsem/*.py and none of fibsem/ui, fibsem/milling, etc. That

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ server = ["fastapi>=0.100.0", "uvicorn[standard]>=0.20.0", "requests>=2.28.0"]
 # The MCP sidecar (fibsem-mcp). The mcp SDK needs py3.10+, so the extra degrades
 # gracefully on 3.8/3.9 installs; the fibsem package itself never imports mcp.
 mcp = [
-    "mcp>=1.2.0; python_version >= '3.10'",
+    "mcp>=2,<3; python_version >= '3.10'",
     "httpx>=0.27.0",
 ]
 

--- a/tests/server/test_sidecar.py
+++ b/tests/server/test_sidecar.py
@@ -1,0 +1,102 @@
+"""End-to-end sidecar tests: MCP tool calls through the real server app.
+
+The TestClient is an httpx.Client, so the sidecar's HTTP layer runs unchanged
+against the in-process ASGI app — full stack minus the socket."""
+
+import asyncio
+import os
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+pytest.importorskip("mcp")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from fibsem import utils  # noqa: E402
+from fibsem.mcp.sidecar import build_sidecar  # noqa: E402
+from fibsem.server import AuthConfig, build_server  # noqa: E402
+from fibsem.server.catalog import CATALOG  # noqa: E402
+
+TOKEN = "test-token"
+
+
+def _make_client(arm_hardware):
+    os.environ.setdefault("FIBSEM_SIM_NO_DELAY", "1")
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    app = build_server(
+        microscope, auth=AuthConfig.generate(arm_hardware=arm_hardware, token=TOKEN)
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+    client.headers["Authorization"] = f"Bearer {TOKEN}"
+    return client
+
+
+def _scopes(client):
+    return client.get("/capabilities").json()["scopes"]
+
+
+@pytest.fixture(scope="module")
+def armed_sidecar():
+    client = _make_client(arm_hardware=True)
+    return build_sidecar(client, _scopes(client))
+
+
+def _tool_names(sidecar):
+    return {t.name for t in asyncio.run(sidecar.list_tools())}
+
+
+def test_armed_sidecar_registers_the_full_catalog(armed_sidecar):
+    assert _tool_names(armed_sidecar) == {t.name for t in CATALOG}
+
+
+def test_read_only_sidecar_registers_read_tools_only():
+    client = _make_client(arm_hardware=False)
+    sidecar = build_sidecar(client, _scopes(client))
+    names = _tool_names(sidecar)
+    assert names == {t.name for t in CATALOG if t.scope == "read"}
+    assert "stop_milling" in names
+    assert "acquire_image_preview" not in names
+
+
+def test_read_tool_round_trip(armed_sidecar):
+    result = asyncio.run(armed_sidecar.call_tool("get_stage_position", {}))
+    text = "".join(getattr(c, "text", "") for c in _contents(result))
+    assert '"position"' in text
+
+
+def test_move_tool_round_trip(armed_sidecar):
+    result = asyncio.run(armed_sidecar.call_tool("move_stage_relative", {"dx": 1e-6}))
+    text = "".join(getattr(c, "text", "") for c in _contents(result))
+    assert '"position"' in text
+
+
+def test_image_tool_returns_image_content(armed_sidecar):
+    result = asyncio.run(
+        armed_sidecar.call_tool("acquire_image_preview", {"beam_type": "ION"})
+    )
+    contents = _contents(result)
+    types = {getattr(c, "type", None) for c in contents}
+    assert "image" in types
+    image = next(c for c in contents if getattr(c, "type", None) == "image")
+    assert image.mimeType == "image/jpeg"
+
+
+def test_hardware_refusal_is_readable_text_not_an_error():
+    # Registered tools + unarmed server = the server refuses; the agent should
+    # see the structured refusal as text, not a raised exception.
+    read_client = _make_client(arm_hardware=False)
+    armed_shape = {"read": True, "control": False, "hardware": True}
+    sidecar = build_sidecar(read_client, armed_shape)
+    result = asyncio.run(sidecar.call_tool("move_stage_relative", {"dx": 1e-6}))
+    text = "".join(getattr(c, "text", "") for c in _contents(result))
+    assert "scope_not_armed" in text
+
+
+def _contents(result):
+    # FastMCP.call_tool returns a content sequence; newer versions may return
+    # (contents, structured). Normalize.
+    if isinstance(result, tuple):
+        result = result[0]
+    return list(result)

--- a/tests/server/test_sidecar.py
+++ b/tests/server/test_sidecar.py
@@ -44,7 +44,8 @@ def armed_sidecar():
 
 
 def _tool_names(sidecar):
-    return {t.name for t in asyncio.run(sidecar.list_tools())}
+    listed = asyncio.run(sidecar.list_tools())
+    return {t.name for t in getattr(listed, "tools", listed)}
 
 
 def test_armed_sidecar_registers_the_full_catalog(armed_sidecar):
@@ -80,7 +81,7 @@ def test_image_tool_returns_image_content(armed_sidecar):
     types = {getattr(c, "type", None) for c in contents}
     assert "image" in types
     image = next(c for c in contents if getattr(c, "type", None) == "image")
-    assert image.mimeType == "image/jpeg"
+    assert getattr(image, "mime_type", None) == "image/jpeg"
 
 
 def test_hardware_refusal_is_readable_text_not_an_error():
@@ -99,4 +100,4 @@ def _contents(result):
     # (contents, structured). Normalize.
     if isinstance(result, tuple):
         result = result[0]
-    return list(result)
+    return list(getattr(result, "content", result))


### PR DESCRIPTION
Stacked on #642; top of the stack (#640 → #641 → #642 → this). With this, the whole chain is testable end-to-end.

## What

- `fibsem/mcp/sidecar.py` + `fibsem-mcp` console script behind a new `[mcp]` extra (`mcp>=1.2.0; python_version >= '3.10'`, `httpx`) — the app package never imports `mcp`, and the py3.8 floor is untouched
- 15 tools registered from the shared catalog, filtered by the scopes `/capabilities` reports; a startup contract check refuses to run with an implementation gap
- Image previews return as MCP image content (the multimodal payoff); server refusals (`403 scope_not_armed`, `409 busy`) return as readable text an agent can act on, not tracebacks
- Connection resolution: `--url`/`--token` → `FIBSEM_SERVER_URL`/`_TOKEN` env → the discovery file a local server maintains

## Try it

```
pip install -e ".[server,mcp]"
python -m fibsem.server.server --manufacturer Demo --arm-hardware   # logs the token; writes the discovery file
claude mcp add fibsem -- fibsem-mcp                                  # autodiscovers url+token
```

Then ask Claude for the stage position, an ion image, or a tilt to 15° — and watch a read-only server (drop `--arm-hardware`) refuse the same requests cleanly.

## Verification

6 end-to-end tests drive MCP `call_tool` through the real ASGI app against DemoMicroscope (tool registration vs catalog for both scope shapes, read/move round-trips, image content type, refusal-as-text); 32 tests total in `tests/server/`, green; ruff clean. CI never installs these extras yet — the dedicated CI leg is deliberately left for a follow-up so this stack stays reviewable.