### PR TITLE
[mcp] Wait for a server instead of dying on launch order

### DIFF
--- a/fibsem/mcp/README.md
+++ b/fibsem/mcp/README.md
@@ -71,10 +71,12 @@ tools) and ask:
 
 ## Order and troubleshooting
 
-- **Server first, then the sidecar.** The sidecar exits immediately when it
-  finds no server, which an MCP client reports as `CONNECTION_CLOSED`. Start
-  the server, then reconnect (`/mcp` in the session, or restart `claude`).
-  Run `fibsem-mcp` directly in a terminal to see the actual error.
+- **Order barely matters**: the sidecar waits up to 30 s for a server to
+  appear (`--wait` tunes it), so starting the server a moment later is fine.
+  If none appears in time it exits with guidance, which an MCP client shows
+  as `CONNECTION_CLOSED` — start the server and reconnect (`/mcp` in the
+  session). `fibsem-mcp --check` prints the connection status and exits;
+  run it in a terminal to see what the sidecar sees.
 - **Wrong server version / unknown arguments**: if you launched with
   `python -m` from inside another fibsem checkout, that directory shadows
   your installed copy. Run from the repo you installed, or any directory

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -31,8 +31,16 @@ from fibsem.server.catalog import CATALOG
 _TIMEOUT_S = 120.0  # acquisitions and moves on real hardware are slow
 
 
-def _resolve_connection(url, token):
-    # type: (Optional[str], Optional[str]) -> Tuple[str, str]
+_NO_SERVER_MSG = (
+    "fibsem-mcp: no server found. Pass --url and --token, set "
+    "FIBSEM_SERVER_URL/FIBSEM_SERVER_TOKEN, or start a fibsem server on "
+    "this machine (it writes ~/.fibsem/agent-server.json)."
+)
+
+
+def _try_resolve(url, token):
+    # type: (Optional[str], Optional[str]) -> Optional[Tuple[str, str]]
+    """One resolution attempt; None when no server is known (yet)."""
     url = url or os.environ.get("FIBSEM_SERVER_URL")
     token = token or os.environ.get("FIBSEM_SERVER_TOKEN")
     if url and token:
@@ -42,11 +50,50 @@ def _resolve_connection(url, token):
     found = read_discovery_file()
     if found is not None:
         return url or found["url"], token or found["token"]
-    sys.exit(
-        "fibsem-mcp: no server found. Pass --url and --token, set "
-        "FIBSEM_SERVER_URL/FIBSEM_SERVER_TOKEN, or start a fibsem server on "
-        "this machine (it writes ~/.fibsem/agent-server.json)."
-    )
+    return None
+
+
+def _connect_with_retry(client_factory, url, token, wait_s, sleep_fn=None):
+    """Resolve + reach a server, retrying until the deadline.
+
+    MCP clients launch the sidecar at session start, often before the human has
+    started the server — dying instantly turns a harmless ordering mistake into
+    a CONNECTION_CLOSED (learned in the very first live session). So: keep
+    re-resolving (the discovery file appears when the server starts) and
+    re-trying /capabilities until ``wait_s`` runs out.
+
+    Returns (client, capabilities). Exits with guidance on timeout.
+    """
+    import time
+
+    sleep_fn = sleep_fn or time.sleep
+    deadline = time.monotonic() + wait_s
+    waiting_reported = False
+    while True:
+        resolved = _try_resolve(url, token)
+        if resolved is not None:
+            client = client_factory(resolved[0], resolved[1])
+            try:
+                capabilities, err = _call(client, "GET", "/capabilities")
+            except Exception as e:  # connection refused, DNS, ...
+                capabilities, err = None, str(e)
+            if err is None:
+                return client, capabilities
+            client.close()
+        if time.monotonic() >= deadline:
+            if resolved is None:
+                sys.exit(_NO_SERVER_MSG)
+            sys.exit(
+                f"fibsem-mcp: cannot reach the server at {resolved[0]} — "
+                "is it running, and is the token current?"
+            )
+        if not waiting_reported:
+            print(
+                f"fibsem-mcp: waiting up to {wait_s:.0f}s for a fibsem server...",
+                file=sys.stderr,
+            )
+            waiting_reported = True
+        sleep_fn(1.0)
 
 
 def _call(client, method, path, payload=None):
@@ -223,22 +270,37 @@ def main(argv=None):
     parser.add_argument(
         "--token", default=None, help="Bearer token (from the server log or dialog)"
     )
+    parser.add_argument(
+        "--wait",
+        type=float,
+        default=30.0,
+        help="seconds to keep retrying for a server before giving up (default 30)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="print connection status and exit (does not start the MCP server)",
+    )
     args = parser.parse_args(argv)
 
-    url, token = _resolve_connection(args.url, args.token)
-    client = httpx.Client(
-        base_url=url,
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=_TIMEOUT_S,
+    def client_factory(url, token):
+        return httpx.Client(
+            base_url=url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=_TIMEOUT_S,
+        )
+
+    wait_s = 0.0 if args.check else max(0.0, args.wait)
+    client, capabilities = _connect_with_retry(
+        client_factory, args.url, args.token, wait_s
     )
-    capabilities, err = _call(client, "GET", "/capabilities")
-    if err:
-        sys.exit(f"fibsem-mcp: cannot reach the server at {url} — {err}")
     print(
-        f"fibsem-mcp: connected to {url} "
+        f"fibsem-mcp: connected to {client.base_url} "
         f"({capabilities.get('manufacturer')}, scopes {capabilities.get('scopes')})",
         file=sys.stderr,
     )
+    if args.check:
+        return
     build_sidecar(client, capabilities.get("scopes", {})).run()
 
 

--- a/tests/server/test_sidecar_connect.py
+++ b/tests/server/test_sidecar_connect.py
@@ -1,0 +1,95 @@
+"""Tests for the sidecar's connection resolution and wait-for-server retry."""
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+pytest.importorskip("mcp")
+
+from fibsem.mcp import sidecar  # noqa: E402
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, responses):
+        self._responses = responses
+        self.base_url = "http://fake:1"
+        self.closed = False
+
+    def request(self, method, path, json=None):
+        result = self._responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    def close(self):
+        self.closed = True
+
+
+def test_try_resolve_returns_none_without_exiting(monkeypatch, tmp_path):
+    monkeypatch.delenv("FIBSEM_SERVER_URL", raising=False)
+    monkeypatch.delenv("FIBSEM_SERVER_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "fibsem.server.discovery.DISCOVERY_FILE", tmp_path / "absent.json"
+    )
+    assert sidecar._try_resolve(None, None) is None
+    assert sidecar._try_resolve("http://x", None) is None  # url without token
+    assert sidecar._try_resolve("http://x", "t") == ("http://x", "t")
+
+
+def test_retry_succeeds_after_server_appears():
+    ok = _FakeResponse(200, {"scopes": {"read": True}})
+    attempts = [
+        _FakeClient([ConnectionError("refused")]),
+        _FakeClient([_FakeResponse(401, {"detail": "unauthorized"})]),
+        _FakeClient([ok]),
+    ]
+    sleeps = []
+    client, caps = sidecar._connect_with_retry(
+        lambda url, token: attempts.pop(0),
+        "http://x",
+        "t",
+        wait_s=60,
+        sleep_fn=sleeps.append,
+    )
+    assert caps == {"scopes": {"read": True}}
+    assert len(sleeps) == 2  # slept between the three attempts
+    assert not client.closed  # the successful client stays open
+
+
+def test_retry_times_out_with_guidance():
+    with pytest.raises(SystemExit) as excinfo:
+        sidecar._connect_with_retry(
+            lambda url, token: _FakeClient([ConnectionError("refused")]),
+            "http://x",
+            "t",
+            wait_s=0,
+            sleep_fn=lambda s: None,
+        )
+    assert "cannot reach the server" in str(excinfo.value)
+
+
+def test_no_server_at_all_times_out_with_the_setup_message(monkeypatch, tmp_path):
+    monkeypatch.delenv("FIBSEM_SERVER_URL", raising=False)
+    monkeypatch.delenv("FIBSEM_SERVER_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "fibsem.server.discovery.DISCOVERY_FILE", tmp_path / "absent.json"
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        sidecar._connect_with_retry(
+            lambda url, token: _FakeClient([]),
+            None,
+            None,
+            wait_s=0,
+            sleep_fn=lambda s: None,
+        )
+    assert "no server found" in str(excinfo.value)


### PR DESCRIPTION
Stacked on #645. Fixes the first real-session papercut: registering the sidecar before starting the server produced an instant `CONNECTION_CLOSED`.

- `_connect_with_retry`: re-resolves the connection (args → env → discovery file, so a server appearing mid-wait is picked up) and retries `/capabilities` for up to `--wait` seconds (default 30) before exiting with guidance
- `fibsem-mcp --check`: connect, print status, exit — the "what does the sidecar see" debugging command
- README's troubleshooting updated accordingly

Verification: 4 new tests with injected client/sleep (retry-until-appears incl. a 401-then-success sequence, both timeout messages, resolution precedence); 36 total in `tests/server/`, green; `--check` exercised live against a stopped server (correct guidance, exit 1). Ruff clean.