### PR TITLE
[refactor] Send SetImages through a Responder instead of the shared flag

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -32,6 +32,7 @@ from fibsem import conversions
 from fibsem.applications.autolamella.ui.lamella_name_list_widget import (
     LamellaNameListWidget,
 )
+from fibsem.applications.autolamella.ui.qt_responder import QtResponder
 from fibsem.applications.autolamella.ui.selected_lamella_widget import (
     SelectedLamellaWidget,
 )
@@ -188,6 +189,10 @@ class AutoLamellaUI(QMainWindow):
 
         self._setup_ui()
         self.parent_widget = parent_ui
+
+        # The Qt side of the workflow's Responder seam: workflow code is handed
+        # this one-method object, never the window itself.
+        self.ui_responder = QtResponder(self)
 
         self._protocol_lock = threading.RLock()
 
@@ -1883,24 +1888,8 @@ class AutoLamellaUI(QMainWindow):
                 "No milling task config widget available. Please create a milling task config widget first."
             )
 
-        # update the image viewer
-        sem_image: FibsemImage = info.get("sem_image", None)  # type: ignore
-        if sem_image is not None:
-            self.image_widget.eb_image = sem_image
-            self.image_widget._on_acquire(sem_image)
-            self.image_widget.set_ui_from_settings(
-                image_settings=sem_image.metadata.image_settings,  # type: ignore
-                beam_type=BeamType.ELECTRON,
-            )
-
-        fib_image: FibsemImage = info.get("fib_image", None)  # type: ignore
-        if fib_image is not None:
-            self.image_widget.ib_image = fib_image
-            self.image_widget._on_acquire(fib_image)
-            self.image_widget.set_ui_from_settings(
-                image_settings=fib_image.metadata.image_settings,  # type: ignore
-                beam_type=BeamType.ION,
-            )
+        # Images no longer arrive here: set_images_ui sends a SetImages request
+        # through the Responder seam (QtResponder._set_images).
 
         # what?
         enable_milling = info.get("milling_enabled", None)

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -1,0 +1,88 @@
+"""The Qt implementation of the workflow's ``Responder`` protocol.
+
+``QtResponder`` is *given* the window rather than being the window: the workflow
+layer holds an object with one method, and the ``QMainWindow`` — with every widget
+and attribute a call site could reach into — stays on this side of the seam.
+
+``submit`` is called on the workflow thread. It marshals the request to the GUI
+thread through a queued signal (this object is constructed on the GUI thread, so
+Qt picks the queued path from the receiver's affinity), dispatches on the request
+type, and completes the future: ``set_result`` with the answer, ``set_exception``
+if acting on it failed. That second path is the point — today an exception in this
+widget code escapes a queued slot and PyQt5 aborts the whole process (FIB-329);
+here it re-raises on the workflow thread inside ``wait_for``, where the task's
+error handling already exists.
+
+Handlers are added one request type at a time, as each ``workflow_update_signal``
+site converts; an unhandled type completes the future with a ``TypeError`` rather
+than leaving the caller to its timeout.
+"""
+
+from typing import TYPE_CHECKING, Callable, Dict, Type
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+from fibsem.applications.autolamella.workflows.interaction import Request, SetImages
+from fibsem.structures import BeamType
+
+if TYPE_CHECKING:
+    from concurrent.futures import Future
+
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+
+__all__ = ["QtResponder"]
+
+
+class QtResponder(QObject):
+    """Answers workflow requests by driving the window's widgets, on the GUI thread."""
+
+    _submitted = pyqtSignal(object, object)  # (Request, Future)
+
+    def __init__(self, ui: "AutoLamellaUI"):
+        super().__init__()
+        self._ui = ui
+        self._handlers: Dict[Type[Request], Callable] = {
+            SetImages: self._set_images,
+        }
+        self._submitted.connect(self._dispatch)
+
+    def submit(self, request: "Request", future: "Future") -> None:
+        """Hand ``request`` to the GUI thread; never blocks. Any thread."""
+        self._submitted.emit(request, future)
+
+    def _dispatch(self, request: "Request", future: "Future") -> None:
+        """GUI thread. Complete the future, whatever happens in the handler."""
+        handler = self._handlers.get(type(request))
+        try:
+            if handler is None:
+                raise TypeError(
+                    f"QtResponder has no handler for {type(request).__name__}"
+                )
+            future.set_result(handler(request))
+        except Exception as exc:  # noqa: BLE001 - the caller owns the failure
+            future.set_exception(exc)
+
+    # --- handlers, one per request type ------------------------------------------
+
+    def _set_images(self, request: SetImages) -> None:
+        """Show the acquisition images. Moved from handle_workflow_update."""
+        image_widget = self._ui.image_widget
+        if image_widget is None:
+            # Under the old signal this raise was a process abort; now it surfaces
+            # in the workflow thread as this instruction's failure.
+            raise RuntimeError("No image widget available to display images.")
+
+        if request.sem_image is not None:
+            image_widget.eb_image = request.sem_image
+            image_widget._on_acquire(request.sem_image)
+            image_widget.set_ui_from_settings(
+                image_settings=request.sem_image.metadata.image_settings,
+                beam_type=BeamType.ELECTRON,
+            )
+        if request.fib_image is not None:
+            image_widget.ib_image = request.fib_image
+            image_widget._on_acquire(request.fib_image)
+            image_widget.set_ui_from_settings(
+                image_settings=request.fib_image.metadata.image_settings,
+                beam_type=BeamType.ION,
+            )

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, List, Optional, Sequence
 
 from fibsem import milling
 from fibsem.applications.autolamella.structures import Experiment
+from fibsem.applications.autolamella.workflows.interaction import SetImages, ask
 from fibsem.detection import detection
 from fibsem.detection import utils as det_utils
 from fibsem.detection.detection import DetectedFeatures, Feature
@@ -24,32 +25,46 @@ if TYPE_CHECKING:
     from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
     from fibsem.imaging.spot import SpotBurnSettings
 
+# Instructions are answered by a machine, so silence past this is a wedged GUI
+# thread, not thinking. Generous because the GUI thread may legitimately be busy
+# painting; the real waits are milliseconds.
+INSTRUCTION_TIMEOUT_S = 30
+
+
 # CORE UI FUNCTIONS -> PROBS SEPARATE FILE
-def _check_for_abort(parent_ui: Optional['AutoLamellaUI'], msg: str = "Workflow aborted by user.") -> bool:
-    # headless mode
+def _abort_requested(parent_ui: Optional["AutoLamellaUI"]) -> bool:
+    """Whether the workflow has been asked to stop. Never raises.
+
+    Asks the manager rather than reading its stop event: the same predicate
+    AutoLamellaTask._check_for_abort uses, so the two cannot disagree about what
+    counts as cancelled. Falls back to the legacy UI event for the window before
+    the manager exists. Also the ``abort`` predicate for :func:`interaction.ask`.
+    """
     if parent_ui is None:
         return False
-
-    # Ask the manager whether this task should unwind, rather than reading its
-    # stop event: the same predicate AutoLamellaTask._check_for_abort uses, so
-    # the two cannot disagree about what counts as cancelled. Falls back to the
-    # legacy UI event for the window before the manager exists.
-    task_manager = getattr(parent_ui, '_task_manager', None)
+    task_manager = getattr(parent_ui, "_task_manager", None)
     if task_manager is not None:
-        if task_manager.should_abort:
-            raise InterruptedError(msg)
-    elif parent_ui._workflow_stop_event.is_set():
+        return task_manager.should_abort
+    return parent_ui._workflow_stop_event.is_set()
+
+
+def _check_for_abort(
+    parent_ui: Optional["AutoLamellaUI"], msg: str = "Workflow aborted by user."
+) -> bool:
+    if _abort_requested(parent_ui):
         raise InterruptedError(msg)
     return False
 
+
 def update_detection_ui(
-    microscope: FibsemMicroscope, 
-    image_settings: ImageSettings, # TODO: deprecate
+    microscope: FibsemMicroscope,
+    image_settings: ImageSettings,  # TODO: deprecate
     checkpoint: str,
-    features: Sequence[Feature], 
-    parent_ui: Optional['AutoLamellaUI'] = None, 
-    validate: bool = True, 
-    msg: str = "Lamella", position: Optional[FibsemStagePosition] = None,
+    features: Sequence[Feature],
+    parent_ui: Optional["AutoLamellaUI"] = None,
+    validate: bool = True,
+    msg: str = "Lamella",
+    position: Optional[FibsemStagePosition] = None,
 ) -> DetectedFeatures:
     feat_str = ", ".join([f.name for f in features])
     if len(feat_str) > 15:
@@ -85,14 +100,14 @@ def update_detection_ui(
 
 
 def set_images_ui(
-    parent_ui: Optional['AutoLamellaUI'],
+    parent_ui: Optional["AutoLamellaUI"],
     eb_image: Optional[FibsemImage] = None,
     ib_image: Optional[FibsemImage] = None,
 ):
     # headless mode
     if parent_ui is None:
         return
-    
+
     _check_for_abort(parent_ui)
 
     # TMP: prevent milling images overwriting existing
@@ -101,21 +116,23 @@ def set_images_ui(
     if ib_image is not None:
         ib_image.metadata.image_settings.save = False
 
-    INFO = {
-        "msg": "Updating Images",
-        "sem_image": eb_image,
-        "fib_image": ib_image,
+    # One future per call, owned by this caller — unlike WAITING_FOR_UI_UPDATE,
+    # no other emitter can release it. A GUI-side failure re-raises here, on the
+    # workflow thread, instead of aborting the process out of a queued slot.
+    ask(
+        parent_ui.ui_responder,
+        SetImages(sem_image=eb_image, fib_image=ib_image),
+        abort=lambda: _abort_requested(parent_ui),
+        timeout=INSTRUCTION_TIMEOUT_S,
+    )
 
-    }
-    parent_ui.WAITING_FOR_UI_UPDATE = True
-    parent_ui.workflow_update_signal.emit(INFO)
 
-    while parent_ui.WAITING_FOR_UI_UPDATE:
-        time.sleep(0.5)
-
-def update_status_ui(parent_ui: Optional['AutoLamellaUI'], msg: str,
-                     workflow_info: Optional[str] = None,
-                     status_bar: Optional[str] = None) -> None:
+def update_status_ui(
+    parent_ui: Optional["AutoLamellaUI"],
+    msg: str,
+    workflow_info: Optional[str] = None,
+    status_bar: Optional[str] = None,
+) -> None:
 
     if parent_ui is None:
         logging.info(msg or status_bar or "")
@@ -132,7 +149,7 @@ def update_status_ui(parent_ui: Optional['AutoLamellaUI'], msg: str,
 
 
 def ask_user(
-    parent_ui: Optional['AutoLamellaUI'],
+    parent_ui: Optional["AutoLamellaUI"],
     msg: str,
     pos: str,
     neg: Optional[str] = None,
@@ -142,7 +159,9 @@ def ask_user(
 ) -> bool:
 
     if parent_ui is None:
-        logging.warning(f"User input requested in headless mode: {msg}, always returning True.")
+        logging.warning(
+            f"User input requested in headless mode: {msg}, always returning True."
+        )
         return True
 
     INFO = {
@@ -164,24 +183,32 @@ def ask_user(
     INFO = {
         "msg": "",
     }
-    parent_ui.workflow_update_signal.emit(INFO) # clear the message
+    parent_ui.workflow_update_signal.emit(INFO)  # clear the message
 
     return parent_ui.USER_RESPONSE
 
-def ask_user_continue_workflow(parent_ui, msg: str = "Continue with the next stage?", validate: bool = True):
+
+def ask_user_continue_workflow(
+    parent_ui, msg: str = "Continue with the next stage?", validate: bool = True
+):
 
     ret = True
     if validate:
         ret = ask_user(parent_ui=parent_ui, msg=msg, pos="Continue", neg="Exit")
     return ret
 
-def update_alignment_area_ui(alignment_area: FibsemRectangle, parent_ui: Optional['AutoLamellaUI'],
-        msg: str = "Edit Alignment Area", validate: bool = True) -> FibsemRectangle:
-    """ Update the alignment area in the UI and return the updated alignment area."""
-    
+
+def update_alignment_area_ui(
+    alignment_area: FibsemRectangle,
+    parent_ui: Optional["AutoLamellaUI"],
+    msg: str = "Edit Alignment Area",
+    validate: bool = True,
+) -> FibsemRectangle:
+    """Update the alignment area in the UI and return the updated alignment area."""
+
     _check_for_abort(parent_ui)
 
-    # headless mode, return the alignment area   
+    # headless mode, return the alignment area
     if parent_ui is None or not validate:
         return alignment_area
 
@@ -215,17 +242,25 @@ def update_alignment_area_ui(alignment_area: FibsemRectangle, parent_ui: Optiona
 
     return alignment_area
 
-def select_poi_ui(parent_ui: Optional['AutoLamellaUI'],
-                  msg: str = "Select Point of Interest",
-                  validate: bool = True,
-                  initial_poi: Optional[Point] = None) -> Optional[Point]:
+
+def select_poi_ui(
+    parent_ui: Optional["AutoLamellaUI"],
+    msg: str = "Select Point of Interest",
+    validate: bool = True,
+    initial_poi: Optional[Point] = None,
+) -> Optional[Point]:
     """Display a draggable POI marker on the FIB image; return the selected point in milling coordinates."""
     _check_for_abort(parent_ui)
 
     if parent_ui is None or not validate:
         return None
 
-    INFO = {"msg": msg, "pos": "Continue", "poi_selection": True, "initial_poi": initial_poi}
+    INFO = {
+        "msg": msg,
+        "pos": "Continue",
+        "poi_selection": True,
+        "initial_poi": initial_poi,
+    }
     parent_ui.workflow_update_signal.emit(INFO)
 
     parent_ui.WAITING_FOR_USER_INTERACTION = True
@@ -245,7 +280,10 @@ def select_poi_ui(parent_ui: Optional['AutoLamellaUI'],
 
     return deepcopy(parent_ui.SELECTED_POI)
 
-def update_experiment_ui(parent_ui: Optional['AutoLamellaUI'], experiment: Experiment) -> None:
+
+def update_experiment_ui(
+    parent_ui: Optional["AutoLamellaUI"], experiment: Experiment
+) -> None:
 
     # headless mode
     if parent_ui is None:
@@ -253,9 +291,12 @@ def update_experiment_ui(parent_ui: Optional['AutoLamellaUI'], experiment: Exper
 
     parent_ui.update_experiment_signal.emit(deepcopy(experiment))
 
-def update_spot_burn_parameters(parent_ui: 'AutoLamellaUI',
-                                settings: Optional['SpotBurnSettings'] = None,
-                                clear_spots: bool = False):
+
+def update_spot_burn_parameters(
+    parent_ui: "AutoLamellaUI",
+    settings: Optional["SpotBurnSettings"] = None,
+    clear_spots: bool = False,
+):
     """Push spot-burn settings to the UI (or clear them)."""
     _check_for_abort(parent_ui)
 
@@ -270,6 +311,7 @@ def update_spot_burn_parameters(parent_ui: 'AutoLamellaUI',
     while parent_ui.WAITING_FOR_UI_UPDATE:
         time.sleep(0.5)
 
-def clear_spot_burn_ui(parent_ui: 'AutoLamellaUI'):
+
+def clear_spot_burn_ui(parent_ui: "AutoLamellaUI"):
     """Clear the spot burn UI."""
     update_spot_burn_parameters(parent_ui=parent_ui, settings=None, clear_spots=True)

--- a/tests/ui/test_qt_responder.py
+++ b/tests/ui/test_qt_responder.py
@@ -1,0 +1,186 @@
+"""The Responder seam, driven end to end: workflow thread in, GUI thread out.
+
+First conversion off the hand-rolled RPC: ``set_images_ui`` sends a ``SetImages``
+request through ``QtResponder`` and waits on a future of its own, instead of
+setting ``WAITING_FOR_UI_UPDATE``, emitting a dict, and sleep-polling a flag any
+other emitter could clear.
+
+Everything here calls ``set_images_ui`` from a real worker thread while the test
+spins the GUI event loop — the same shape as production, where the workflow
+thread blocks and the GUI thread answers.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import threading
+import time
+from copy import deepcopy
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.applications.autolamella.workflows import ui as workflow_ui
+from fibsem.applications.autolamella.workflows.interaction import (
+    EditAlignmentArea,
+    ask,
+)
+from fibsem.applications.autolamella.workflows.ui import set_images_ui
+from fibsem.structures import FibsemRectangle
+
+
+@pytest.fixture
+def ui(qapp):
+    """A real AutoLamellaUI, connected (Demo), same harness as the payload tests."""
+    widget = AutoLamellaUI(parent_ui=None)
+    widget.system_widget.connect_to_microscope()
+    yield widget
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+
+
+def _call_on_worker_thread(qapp, fn, timeout_s=10.0):
+    """Run ``fn`` on a worker thread while spinning the GUI loop; return its outcome."""
+    outcome = {}
+
+    def target():
+        try:
+            outcome["value"] = fn()
+        except Exception as exc:  # noqa: BLE001 - the test inspects it
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + timeout_s
+    while thread.is_alive() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+    thread.join(timeout=1.0)
+    assert not thread.is_alive(), "worker thread never finished"
+    return outcome
+
+
+def test_images_land_in_the_widget_from_a_worker_thread(ui, qapp):
+    sem = deepcopy(ui.image_widget.eb_image)
+    fib = deepcopy(ui.image_widget.ib_image)
+
+    outcome = _call_on_worker_thread(
+        qapp, lambda: set_images_ui(ui, eb_image=sem, ib_image=fib)
+    )
+
+    assert "error" not in outcome
+    assert ui.image_widget.eb_image is sem
+    assert ui.image_widget.ib_image is fib
+    # The old mechanism must stay untouched: nothing set or cleared the flag.
+    assert ui.WAITING_FOR_UI_UPDATE is False
+
+
+def test_the_widget_update_runs_on_the_gui_thread(ui, qapp):
+    threads = []
+    original = ui.image_widget._on_acquire
+
+    def recording(image):
+        threads.append(threading.current_thread().name)
+        return original(image)
+
+    ui.image_widget._on_acquire = recording
+    sem = deepcopy(ui.image_widget.eb_image)
+
+    _call_on_worker_thread(qapp, lambda: set_images_ui(ui, eb_image=sem))
+
+    assert threads == ["MainThread"]
+
+
+def test_a_gui_side_failure_reraises_on_the_workflow_thread(ui, qapp):
+    # Under the old signal this exception escaped a queued slot, which PyQt5
+    # turns into a process abort (FIB-329) — the pytest process would be gone.
+    # Now it is this instruction's failure, on the thread that asked.
+    def broken(image):
+        raise RuntimeError("display fell over")
+
+    ui.image_widget._on_acquire = broken
+    sem = deepcopy(ui.image_widget.eb_image)
+
+    outcome = _call_on_worker_thread(qapp, lambda: set_images_ui(ui, eb_image=sem))
+
+    assert isinstance(outcome.get("error"), RuntimeError)
+    assert "display fell over" in str(outcome["error"])
+
+
+def test_an_unhandled_request_type_fails_fast_not_by_timeout(ui, qapp):
+    # EditAlignmentArea has no QtResponder handler yet (it converts in a later
+    # step). Asking for it must fail the caller immediately with a TypeError,
+    # not leave it hanging until the instruction timeout.
+    started = time.monotonic()
+    outcome = _call_on_worker_thread(
+        qapp,
+        lambda: ask(ui.ui_responder, EditAlignmentArea(initial=FibsemRectangle())),
+    )
+
+    assert isinstance(outcome.get("error"), TypeError)
+    assert "EditAlignmentArea" in str(outcome["error"])
+    assert time.monotonic() - started < 5
+
+
+def _call_with_the_gui_wedged(fn, timeout_s=10.0):
+    """Run ``fn`` on a worker thread and never spin the GUI loop.
+
+    From the main thread the responder's connection is direct and dispatch is
+    synchronous — nothing can wedge. From a worker thread the dispatch is queued,
+    and with nobody pumping events it never runs: exactly a wedged GUI thread.
+    """
+    outcome = {}
+
+    def target():
+        try:
+            outcome["value"] = fn()
+        except Exception as exc:  # noqa: BLE001 - the test inspects it
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    thread.join(timeout=timeout_s)
+    assert not thread.is_alive(), "the caller is stuck: neither abort nor timeout"
+    return outcome
+
+
+def test_a_stop_interrupts_the_wait(ui):
+    # Stop must get the caller out of a wait the GUI will never answer, and as
+    # InterruptedError — the abort path's own exception, one unwind path. The
+    # event is set only after the call is under way, so the entry abort check
+    # cannot be what raises: this pins the wait loop's own abort.
+    sem = deepcopy(ui.image_widget.eb_image)
+    outcome = {}
+
+    def target():
+        try:
+            set_images_ui(ui, eb_image=sem)
+        except Exception as exc:  # noqa: BLE001 - the test inspects it
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    time.sleep(0.3)  # past the entry check and into the wait
+    ui._workflow_stop_event.set()  # legacy event: no task manager in this harness
+    try:
+        thread.join(timeout=10.0)
+        assert not thread.is_alive(), "Stop did not interrupt the wait"
+    finally:
+        ui._workflow_stop_event.clear()
+
+    assert isinstance(outcome.get("error"), InterruptedError)
+
+
+def test_a_wedged_gui_thread_times_out_instead_of_hanging_forever(ui, monkeypatch):
+    monkeypatch.setattr(workflow_ui, "INSTRUCTION_TIMEOUT_S", 0.4)
+    sem = deepcopy(ui.image_widget.eb_image)
+    started = time.monotonic()
+
+    outcome = _call_with_the_gui_wedged(lambda: set_images_ui(ui, eb_image=sem))
+
+    assert isinstance(outcome.get("error"), TimeoutError)
+    assert time.monotonic() - started < 5


### PR DESCRIPTION
First conversion of a `workflow_update_signal` blocking site to the typed request/answer primitive that landed in #636 — the `SetImages` instruction, end to end.

## The Qt responder

`QtResponder` (new, `fibsem/applications/autolamella/ui/qt_responder.py`) is the Qt implementation of the workflow's `Responder` protocol. It is **given** the window rather than being it: workflow code is handed a one-method object, and the `QMainWindow` — with every widget and attribute a call site could otherwise reach into — stays on the GUI side of the seam.

`submit(request, future)` is callable from any thread. A queued signal marshals the request to the GUI thread (this object is constructed there, so Qt picks the queued path from the receiver's affinity), a type-keyed handler table dispatches, and the future is completed: `set_result` with the answer, `set_exception` if the widget work failed. That second path is the point — an exception in this widget code used to escape a queued slot, which PyQt5 turns into a process abort with nothing reaching the logfile; now it re-raises on the workflow thread inside `wait_for`, where the task's error handling already exists. An unhandled request type fails the caller immediately with `TypeError` rather than leaving it to the timeout.

One handler so far: `_set_images`, the image block moved verbatim out of `handle_workflow_update`. Handlers grow one per conversion PR.

## The conversion

`set_images_ui` now does:

```python
ask(
    parent_ui.ui_responder,
    SetImages(sem_image=eb_image, fib_image=ib_image),
    abort=lambda: _abort_requested(parent_ui),
    timeout=INSTRUCTION_TIMEOUT_S,
)
```

replacing `WAITING_FOR_UI_UPDATE = True` → emit → `while flag: time.sleep(0.5)`. One future per call, owned by its caller — no other emitter can release it (the shared flag is cleared unconditionally by every emission on the old signal). Instructions are answered by a machine, so silence past 30 s means a wedged GUI thread, not thinking — the timeout lets the workflow unwind and save the record, since Stop is itself a GUI button. `_check_for_abort` is split so the never-raising predicate `_abort_requested` doubles as `ask`'s abort argument: one definition of "stopped" for both mechanisms, and cancellation stays `InterruptedError`, the unwind path call sites already have.

The image branch leaves `handle_workflow_update` in the same PR — `set_images_ui` was its only feeder (verified by grep over the emit sites).

## Tests

`tests/ui/test_qt_responder.py` (new, 6) — all end to end from a real worker thread against the connected Demo harness, the same shape as production:

- images land in the widget, with `WAITING_FOR_UI_UPDATE` untouched throughout
- the widget update runs on the GUI thread
- **a GUI-side failure re-raises on the workflow thread** — previously untestable, because the test process itself would have aborted
- an unhandled request type fails fast, not by timeout
- Stop interrupts a wait the GUI will never answer (the stop event is set only after the wait begins, pinning the wait-loop abort rather than the entry check)
- a wedged GUI thread times out instead of hanging forever

One nonobvious mechanic the wedged tests encode: from the GUI thread itself the responder's connection is direct and dispatch is synchronous, so a wedge is only expressible from a worker thread.

## Notes

- `workflows/ui.py` carried whole-file `ruff format` debt (quotes, spacing); CI lint checks changed files whole, so this PR picks those hunks up.
- Four `F401` dead imports flagged nearby predate this change (their only "uses" on main are words in comments) and are left alone.
- `WAITING_FOR_UI_UPDATE` itself survives until the other two instruction sites (milling config, fluorescence channels) convert.

## Verification

- `pytest tests/ui/test_qt_responder.py tests/ui/test_workflow_update_payload.py tests/autolamella/` — 602 passed.
- `ruff check` and `ruff format --check` clean on the four changed files.
