### PR TITLE
[refactor] Send the milling-config instructions through the Responder

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1939,13 +1939,9 @@ class AutoLamellaUI(QMainWindow):
             self.spot_burn_widget.clear_points_layer()
             self.spot_burn_widget.set_workflow_mode(False)
 
-        milling_config = info.get("milling_config", None)
-        if milling_config is not None:
-            self.milling_task_config_widget.update_from_settings(milling_config)
-            self.milling_task_config_widget.setEnabled(True)
-            self.tabWidget.setCurrentWidget(self.milling_task_config_widget)
-        if info.get("clear_milling_config", False):
-            self.milling_task_config_widget.clear()
+        # Milling config no longer arrives here: the task sends SetMillingConfig /
+        # ClearMillingConfig through the Responder seam (QtResponder).
+
         # fluorescence channel settings
         fluorescence_channel_settings = info.get("fluorescence_channel_settings", None)
         if fluorescence_channel_settings is not None and self.fm_control_widget:

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -22,7 +22,12 @@ from typing import TYPE_CHECKING, Callable, Dict, Type
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
-from fibsem.applications.autolamella.workflows.interaction import Request, SetImages
+from fibsem.applications.autolamella.workflows.interaction import (
+    ClearMillingConfig,
+    Request,
+    SetImages,
+    SetMillingConfig,
+)
 from fibsem.structures import BeamType
 
 if TYPE_CHECKING:
@@ -43,6 +48,8 @@ class QtResponder(QObject):
         self._ui = ui
         self._handlers: Dict[Type[Request], Callable] = {
             SetImages: self._set_images,
+            SetMillingConfig: self._set_milling_config,
+            ClearMillingConfig: self._clear_milling_config,
         }
         self._submitted.connect(self._dispatch)
 
@@ -86,3 +93,22 @@ class QtResponder(QObject):
                 image_settings=request.fib_image.metadata.image_settings,
                 beam_type=BeamType.ION,
             )
+
+    def _milling_widget(self):
+        widget = self._ui.milling_task_config_widget
+        if widget is None:
+            # Under the old signal this raise was a process abort; now it surfaces
+            # in the workflow thread as the instruction's failure.
+            raise RuntimeError("No milling task config widget available.")
+        return widget
+
+    def _set_milling_config(self, request: SetMillingConfig) -> None:
+        """Load the config into the milling editor and bring its tab forward."""
+        widget = self._milling_widget()
+        widget.update_from_settings(request.config)
+        widget.setEnabled(True)
+        self._ui.tabWidget.setCurrentWidget(widget)
+
+    def _clear_milling_config(self, request: ClearMillingConfig) -> None:
+        """Clear the milling editor. Moved from handle_workflow_update."""
+        self._milling_widget().clear()

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -50,7 +50,14 @@ from fibsem.applications.autolamella.workflows.core import (
     update_detection_ui,
     update_status_ui,
 )
+from fibsem.applications.autolamella.workflows.interaction import (
+    ClearMillingConfig,
+    SetMillingConfig,
+    ask,
+)
 from fibsem.applications.autolamella.workflows.ui import (
+    INSTRUCTION_TIMEOUT_S,
+    _abort_requested,
     ask_user,
     clear_spot_burn_ui,
     update_alignment_area_ui,
@@ -454,30 +461,26 @@ class AutoLamellaTask(ABC):
 
         self._check_for_abort()
 
-        info = {
-            "msg": "Updating Milling Config",
-            "milling_config": deepcopy(milling_config),
-        }
-
-        self.parent_ui.WAITING_FOR_UI_UPDATE = True
-        self.parent_ui.workflow_update_signal.emit(info)  # type: ignore
-        while self.parent_ui.WAITING_FOR_UI_UPDATE:
-            time.sleep(0.5)
+        # deepcopy kept from the signal days: the editor's copy must be the
+        # operator's to edit without the task's own config moving under it.
+        ask(
+            self.parent_ui.ui_responder,
+            SetMillingConfig(config=deepcopy(milling_config)),
+            abort=lambda: _abort_requested(self.parent_ui),
+            timeout=INSTRUCTION_TIMEOUT_S,
+        )
 
     def clear_milling_config_ui(self):
         """Clear the milling config from the milling widget."""
         if self.parent_ui is None:
             return
 
-        info = {
-            "msg": "Clearing Milling Config",
-            "clear_milling_config": True,
-        }
-
-        self.parent_ui.WAITING_FOR_UI_UPDATE = True
-        self.parent_ui.workflow_update_signal.emit(info)  # type: ignore
-        while self.parent_ui.WAITING_FOR_UI_UPDATE:
-            time.sleep(0.5)
+        ask(
+            self.parent_ui.ui_responder,
+            ClearMillingConfig(),
+            abort=lambda: _abort_requested(self.parent_ui),
+            timeout=INSTRUCTION_TIMEOUT_S,
+        )
 
     def _align_reference_image(self, filename: str):
         """Align to a reference image."""

--- a/tests/ui/test_qt_responder.py
+++ b/tests/ui/test_qt_responder.py
@@ -184,3 +184,53 @@ def test_a_wedged_gui_thread_times_out_instead_of_hanging_forever(ui, monkeypatc
 
     assert isinstance(outcome.get("error"), TimeoutError)
     assert time.monotonic() - started < 5
+
+
+# ── milling config instructions ─────────────────────────────────────────────────
+
+
+def test_a_milling_config_lands_in_the_editor_and_fronts_its_tab(ui, qapp):
+    from fibsem.milling.tasks import FibsemMillingTaskConfig
+
+    config = FibsemMillingTaskConfig(name="from-the-workflow")
+
+    from fibsem.applications.autolamella.workflows.interaction import (
+        SetMillingConfig,
+    )
+
+    outcome = _call_on_worker_thread(
+        qapp,
+        lambda: ask(ui.ui_responder, SetMillingConfig(config=config)),
+    )
+
+    assert "error" not in outcome
+    assert ui.milling_task_config_widget.get_config().name == "from-the-workflow"
+    assert ui.tabWidget.currentWidget() is ui.milling_task_config_widget
+    assert ui.WAITING_FOR_UI_UPDATE is False
+
+
+def test_clearing_the_milling_config_resets_the_editor(ui, qapp):
+    from fibsem.applications.autolamella.workflows.interaction import (
+        ClearMillingConfig,
+        SetMillingConfig,
+    )
+    from fibsem.milling.tasks import FibsemMillingTaskConfig
+
+    _call_on_worker_thread(
+        qapp,
+        lambda: ask(
+            ui.ui_responder,
+            SetMillingConfig(config=FibsemMillingTaskConfig(name="to-be-cleared")),
+        ),
+    )
+    assert ui.milling_task_config_widget.get_config().name == "to-be-cleared"
+
+    outcome = _call_on_worker_thread(
+        qapp, lambda: ask(ui.ui_responder, ClearMillingConfig())
+    )
+
+    assert "error" not in outcome
+    assert (
+        ui.milling_task_config_widget.get_config().name
+        == FibsemMillingTaskConfig().name
+    )


### PR DESCRIPTION
Stacked on #647. Second and third instruction conversions off the hand-rolled RPC: the two milling-config instructions in `AutoLamellaTask`.

## What moves

- `_set_milling_config_ui` and `clear_milling_config_ui` (`workflows/tasks/base.py`) convert from `WAITING_FOR_UI_UPDATE = True` → emit → sleep-poll to `ask(parent_ui.ui_responder, SetMillingConfig(config) / ClearMillingConfig(), abort=..., timeout=...)` — one future per call, owned by its caller; the instruction timeout and the shared `_abort_requested` predicate from #647.
- Their two branches leave `handle_workflow_update` for `QtResponder` handlers: `_set_milling_config` (load the editor, enable it, front its tab) and `_clear_milling_config`. A missing widget — previously a raise out of a queued slot, i.e. a process abort — now surfaces on the workflow thread as the instruction's failure.

Both dict keys had exactly one emitter each, so the branches die with the conversion.

## Two deliberate calls

- **The transient prompt text is not reproduced.** The old payloads carried `"msg": "Updating Milling Config"` / `"Clearing Milling Config"`, flashed on the instruction label. Matching the SetImages conversion: an instruction carries its content, not display copy — a request must be answerable from the request alone, by any responder.
- **The `deepcopy` at the send is kept.** The editor's copy is the operator's to edit without the task's own config moving under it; the read-back on the question side (`get_config`, a later PR) deepcopies again on the way back.

## Tests

`tests/ui/test_qt_responder.py` +2, same worker-thread-in / GUI-thread-out shape as the rest of the file: a config sent from the workflow thread lands in the editor (`get_config().name` round-trips), the editor's tab is fronted, and the flag is untouched; `ClearMillingConfig` resets the editor to the default config. The wedged/failure/abort behaviours are the seam's, already pinned by the six tests from #647.

## Verification

- `pytest tests/ui/test_qt_responder.py tests/ui/test_workflow_update_payload.py tests/autolamella/` — 604 passed.
- `ruff check` / `ruff format --check` clean on the four changed files; the 32 `F401` dead imports in `base.py` predate this change (same count on main) and are left alone.
- After this, `WAITING_FOR_UI_UPDATE` has two remaining setters: the fluorescence-channels instruction and the embedded clears inside the alignment-area/POI questions.
