### PR TITLE
[refactor] Send the fluorescence and spot-burn instructions through the Responder

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1932,22 +1932,10 @@ class AutoLamellaUI(QMainWindow):
             if self.spot_burn_widget is not None:
                 # hide the widget's own Burn button; the burn is run from the workflow control
                 self.spot_burn_widget.set_workflow_mode(True)
-        spot_burn_settings = info.get("spot_burn_settings", None)
-        if spot_burn_settings is not None and self.spot_burn_widget is not None:
-            self.spot_burn_widget.set_settings(spot_burn_settings)
-        if info.get("clear_spot_burn", False) and self.spot_burn_widget is not None:
-            self.spot_burn_widget.clear_points_layer()
-            self.spot_burn_widget.set_workflow_mode(False)
-
-        # Milling config no longer arrives here: the task sends SetMillingConfig /
-        # ClearMillingConfig through the Responder seam (QtResponder).
-
-        # fluorescence channel settings
-        fluorescence_channel_settings = info.get("fluorescence_channel_settings", None)
-        if fluorescence_channel_settings is not None and self.fm_control_widget:
-            self.fm_control_widget.channelSettingsWidget.channel_settings = (
-                fluorescence_channel_settings
-            )
+        # Milling config, spot-burn settings and fluorescence channels no longer
+        # arrive here: their instructions go through the Responder seam
+        # (QtResponder). The spot_burn key above stays — it is part of the
+        # ask_user question flow, which has not converted yet.
 
         # Instruction message. Read with `.get`, not indexed: this signal has no
         # declared contract, and 12 of its 13 emit sites pass an opaque variable, so

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -24,9 +24,12 @@ from PyQt5.QtCore import QObject, pyqtSignal
 
 from fibsem.applications.autolamella.workflows.interaction import (
     ClearMillingConfig,
+    ClearSpotBurn,
     Request,
+    SetFluorescenceChannels,
     SetImages,
     SetMillingConfig,
+    SetSpotBurnSettings,
 )
 from fibsem.structures import BeamType
 
@@ -50,6 +53,9 @@ class QtResponder(QObject):
             SetImages: self._set_images,
             SetMillingConfig: self._set_milling_config,
             ClearMillingConfig: self._clear_milling_config,
+            SetFluorescenceChannels: self._set_fluorescence_channels,
+            SetSpotBurnSettings: self._set_spot_burn_settings,
+            ClearSpotBurn: self._clear_spot_burn,
         }
         self._submitted.connect(self._dispatch)
 
@@ -112,3 +118,30 @@ class QtResponder(QObject):
     def _clear_milling_config(self, request: ClearMillingConfig) -> None:
         """Clear the milling editor. Moved from handle_workflow_update."""
         self._milling_widget().clear()
+
+    # Unlike the image and milling widgets, whose absence is a defect, the FM and
+    # spot-burn widgets legitimately do not exist on systems without the hardware —
+    # and a workflow must not fail over that. The old handler skipped silently;
+    # these acknowledge the instruction and do the same.
+
+    def _set_fluorescence_channels(self, request: SetFluorescenceChannels) -> None:
+        """Load the channel settings into the fluorescence widget, if there is one."""
+        widget = self._ui.fm_control_widget
+        if widget is None:
+            return
+        widget.channelSettingsWidget.channel_settings = request.channels
+
+    def _set_spot_burn_settings(self, request: SetSpotBurnSettings) -> None:
+        """Load the settings into the spot-burn widget, if there is one."""
+        widget = self._ui.spot_burn_widget
+        if widget is None:
+            return
+        widget.set_settings(request.settings)
+
+    def _clear_spot_burn(self, request: ClearSpotBurn) -> None:
+        """Clear the spot-burn overlay and leave workflow mode, if there is one."""
+        widget = self._ui.spot_burn_widget
+        if widget is None:
+            return
+        widget.clear_points_layer()
+        widget.set_workflow_mode(False)

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -52,6 +52,7 @@ from fibsem.applications.autolamella.workflows.core import (
 )
 from fibsem.applications.autolamella.workflows.interaction import (
     ClearMillingConfig,
+    SetFluorescenceChannels,
     SetMillingConfig,
     ask,
 )
@@ -822,15 +823,12 @@ class AutoLamellaTask(ABC):
         if self.parent_ui is None:
             return
 
-        info = {
-            "msg": "Updating Fluorescence Channel Settings",
-            "fluorescence_channel_settings": deepcopy(channel_settings),
-        }
-
-        self.parent_ui.WAITING_FOR_UI_UPDATE = True
-        self.parent_ui.workflow_update_signal.emit(info)  # type: ignore
-        while self.parent_ui.WAITING_FOR_UI_UPDATE:
-            time.sleep(0.5)
+        ask(
+            self.parent_ui.ui_responder,
+            SetFluorescenceChannels(channels=deepcopy(channel_settings)),
+            abort=lambda: _abort_requested(self.parent_ui),
+            timeout=INSTRUCTION_TIMEOUT_S,
+        )
 
 
 def get_task_supervision(

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -7,7 +7,12 @@ from typing import TYPE_CHECKING, List, Optional, Sequence
 
 from fibsem import milling
 from fibsem.applications.autolamella.structures import Experiment
-from fibsem.applications.autolamella.workflows.interaction import SetImages, ask
+from fibsem.applications.autolamella.workflows.interaction import (
+    ClearSpotBurn,
+    SetImages,
+    SetSpotBurnSettings,
+    ask,
+)
 from fibsem.detection import detection
 from fibsem.detection import utils as det_utils
 from fibsem.detection.detection import DetectedFeatures, Feature
@@ -300,16 +305,21 @@ def update_spot_burn_parameters(
     """Push spot-burn settings to the UI (or clear them)."""
     _check_for_abort(parent_ui)
 
-    INFO = {
-        "msg": "Updating Spot Burn Parameters",
-        "spot_burn_settings": settings,
-        "clear_spot_burn": clear_spots,
-    }
-
-    parent_ui.WAITING_FOR_UI_UPDATE = True
-    parent_ui.workflow_update_signal.emit(INFO)
-    while parent_ui.WAITING_FOR_UI_UPDATE:
-        time.sleep(0.5)
+    abort = lambda: _abort_requested(parent_ui)  # noqa: E731 - two waits, one predicate
+    if settings is not None:
+        ask(
+            parent_ui.ui_responder,
+            SetSpotBurnSettings(settings=settings),
+            abort=abort,
+            timeout=INSTRUCTION_TIMEOUT_S,
+        )
+    if clear_spots:
+        ask(
+            parent_ui.ui_responder,
+            ClearSpotBurn(),
+            abort=abort,
+            timeout=INSTRUCTION_TIMEOUT_S,
+        )
 
 
 def clear_spot_burn_ui(parent_ui: "AutoLamellaUI"):

--- a/tests/ui/test_qt_responder.py
+++ b/tests/ui/test_qt_responder.py
@@ -33,9 +33,28 @@ from fibsem.structures import FibsemRectangle
 
 
 @pytest.fixture
-def ui(qapp):
-    """A real AutoLamellaUI, connected (Demo), same harness as the payload tests."""
+def ui(qapp, monkeypatch):
+    """A real AutoLamellaUI, connected (Demo), same harness as the payload tests.
+
+    Pinned to the simulated Arctis configuration rather than whatever this
+    machine's default is: `DemoMicroscope` only builds a fluorescence microscope
+    on a compustage config, and the fluorescence test needs `fm_control_widget`
+    to exist. Resolving the default made the test pass on a machine whose
+    default is a compustage and fail on CI, whose default is not.
+    """
+    import fibsem.config as fibsem_config
+
+    arctis_config = os.path.join(
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "sim-arctis-configuration.yaml",
+    )
     widget = AutoLamellaUI(parent_ui=None)
+    monkeypatch.setattr(
+        widget.system_widget,
+        "load_configuration",
+        lambda configuration_name=None: arctis_config,
+    )
     widget.system_widget.connect_to_microscope()
     yield widget
     if widget.microscope is not None:

--- a/tests/ui/test_qt_responder.py
+++ b/tests/ui/test_qt_responder.py
@@ -234,3 +234,55 @@ def test_clearing_the_milling_config_resets_the_editor(ui, qapp):
         ui.milling_task_config_widget.get_config().name
         == FibsemMillingTaskConfig().name
     )
+
+
+# ── fluorescence + spot-burn instructions ───────────────────────────────────────
+
+
+def test_spot_burn_settings_land_in_the_widget(ui, qapp):
+    from fibsem.applications.autolamella.workflows.ui import (
+        update_spot_burn_parameters,
+    )
+    from fibsem.imaging.spot import SpotBurnSettings
+
+    settings = SpotBurnSettings(exposure_time=17.0)
+
+    outcome = _call_on_worker_thread(
+        qapp, lambda: update_spot_burn_parameters(ui, settings=settings)
+    )
+
+    assert "error" not in outcome
+    assert ui.spot_burn_widget.get_settings().exposure_time == 17.0
+    assert ui.WAITING_FOR_UI_UPDATE is False
+
+
+def test_clearing_spot_burn_leaves_workflow_mode(ui, qapp):
+    from fibsem.applications.autolamella.workflows.ui import clear_spot_burn_ui
+
+    ui.spot_burn_widget.set_workflow_mode(True)
+
+    outcome = _call_on_worker_thread(qapp, lambda: clear_spot_burn_ui(ui))
+
+    assert "error" not in outcome
+    assert ui.spot_burn_widget._workflow_mode is False
+
+
+def test_fluorescence_channels_reach_the_fm_widget(ui, qapp):
+    from fibsem.fm.structures import ChannelSettings
+
+    channels = [ChannelSettings(name="channel-from-the-workflow")]
+
+    class _Task:
+        parent_ui = ui
+        _check_for_abort = staticmethod(lambda *a, **k: False)
+
+    from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
+
+    outcome = _call_on_worker_thread(
+        qapp,
+        lambda: AutoLamellaTask.set_fluorescence_channels_ui(_Task(), channels),
+    )
+
+    assert "error" not in outcome
+    got = ui.fm_control_widget.channelSettingsWidget.channel_settings
+    assert [c.name for c in got] == ["channel-from-the-workflow"]


### PR DESCRIPTION
Stacked on #648. The last two standalone instruction conversions off the hand-rolled RPC.

## What moves

- `set_fluorescence_channels_ui` (`workflows/tasks/base.py`) → `ask(SetFluorescenceChannels(channels), abort=..., timeout=...)`; the `deepcopy` at the send is kept, as in the milling conversion.
- `update_spot_burn_parameters` / `clear_spot_burn_ui` (`workflows/ui.py`) → `ask(SetSpotBurnSettings(settings))` and `ask(ClearSpotBurn())`. The old helper put both meanings in one payload with a which-field-is-set convention; its two real call shapes (settings-only from the spot-burn task, clear-only from `clear_spot_burn_ui`) map to the two distinct request types.
- Their three branches leave `handle_workflow_update` for `QtResponder` handlers. The `spot_burn` activation key stays on the dict signal — it belongs to the `ask_user` question flow, which has not converted yet.

## One behaviour preserved deliberately

Unlike the image and milling widgets, whose absence is a defect worth failing over, the FM and spot-burn widgets legitimately do not exist on systems without the hardware. The old branches skipped silently; the new handlers acknowledge the instruction and do the same — a workflow must never fail over missing optional hardware. The handlers carry that reasoning as a comment.

As with the previous conversions, the transient `"msg"` display text the old payloads carried ("Updating Spot Burn Parameters", "Updating Fluorescence Channel Settings") is not reproduced: an instruction carries its content, not display copy.

## State of the flag

After this, the only remaining `WAITING_FOR_UI_UPDATE` setters are the two overlay-clear waits embedded *inside* the alignment-area and POI question flows (`workflows/ui.py`). They convert with their questions, per the design — the overlay teardown becomes responder-internal rather than a second wait.

## Tests

`tests/ui/test_qt_responder.py` +3, same worker-thread-in / GUI-thread-out shape: spot-burn settings round-trip into the widget (`exposure_time` compared), clearing leaves workflow mode, and channel settings reach the FM widget by name — all with the flag untouched.

## Verification

- `pytest tests/ui/test_qt_responder.py tests/ui/test_workflow_update_payload.py tests/autolamella/` — 607 passed.
- `ruff check` / `ruff format --check` clean on all changed files.
