### PR TITLE
[refactor] Answer plain confirmations through the Responder, from the click

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1777,8 +1777,13 @@ class AutoLamellaUI(QMainWindow):
         self.pushButton_yes.setEnabled(False)
         self.pushButton_no.setEnabled(False)
 
+        clicked_yes = bool(self.sender() == self.pushButton_yes)
+        # A pending Confirm question owns this click; the legacy flag path serves
+        # the questions that have not converted yet (detection, milling, spot burn).
+        if self.ui_responder.answer_confirm(clicked_yes):
+            return
         # positve / negative response
-        self.USER_RESPONSE = bool(self.sender() == self.pushButton_yes)
+        self.USER_RESPONSE = clicked_yes
         self.WAITING_FOR_USER_INTERACTION = False
 
     def handle_acquisition_update(self, ddict: dict) -> None:

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -16,15 +16,22 @@ error handling already exists.
 Handlers are added one request type at a time, as each ``workflow_update_signal``
 site converts; an unhandled type completes the future with a ``TypeError`` rather
 than leaving the caller to its timeout.
+
+Questions are the deferred half: their handlers show the prompt and return
+*without* completing the future — the answer arrives from a click, later, through
+:meth:`answer_confirm`. Only one question can be pending at a time, because the
+workflow thread blocks on each; a pending future found when the next question
+arrives belonged to a waiter that aborted and unwound, and is cancelled.
 """
 
-from typing import TYPE_CHECKING, Callable, Dict, Type
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Type
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
 from fibsem.applications.autolamella.workflows.interaction import (
     ClearMillingConfig,
     ClearSpotBurn,
+    Confirm,
     Request,
     SetFluorescenceChannels,
     SetImages,
@@ -57,6 +64,13 @@ class QtResponder(QObject):
             SetSpotBurnSettings: self._set_spot_burn_settings,
             ClearSpotBurn: self._clear_spot_burn,
         }
+        # Deferred: the handler shows the prompt and someone else completes the
+        # future later. Kept out of _handlers so _dispatch cannot complete these
+        # with the handler's return value.
+        self._deferred_handlers: Dict[Type[Request], Callable] = {
+            Confirm: self._confirm,
+        }
+        self._pending_confirm: Optional["Future"] = None
         self._submitted.connect(self._dispatch)
 
     def submit(self, request: "Request", future: "Future") -> None:
@@ -65,6 +79,13 @@ class QtResponder(QObject):
 
     def _dispatch(self, request: "Request", future: "Future") -> None:
         """GUI thread. Complete the future, whatever happens in the handler."""
+        deferred = self._deferred_handlers.get(type(request))
+        if deferred is not None:
+            try:
+                deferred(request, future)
+            except Exception as exc:  # noqa: BLE001 - the caller owns the failure
+                future.set_exception(exc)
+            return
         handler = self._handlers.get(type(request))
         try:
             if handler is None:
@@ -145,3 +166,46 @@ class QtResponder(QObject):
             return
         widget.clear_points_layer()
         widget.set_workflow_mode(False)
+
+    # --- questions: the answer arrives from a click, later -------------------------
+
+    def _confirm(self, request: Confirm, future: "Future") -> None:
+        """Show a yes/no prompt; :meth:`answer_confirm` completes the future."""
+        if self._pending_confirm is not None:
+            # The workflow thread blocks on each question, so a live second
+            # question is impossible: a pending future here belonged to a waiter
+            # that aborted and unwound without an answer. Cancel it so nobody
+            # trips over the corpse.
+            self._pending_confirm.cancel()
+        self._pending_confirm = future
+        # Display state, not a handshake: the workflow no longer polls this flag
+        # for converted questions, but the attention button, border and timeline
+        # pause still read it.
+        self._ui.WAITING_FOR_USER_INTERACTION = True
+        # Reuse the whole existing display path — prompt label, yes/no buttons,
+        # and the main window's waiting indicators — by emitting the payload the
+        # old mechanism showed. We are on the GUI thread, so both windows' slots
+        # run directly, before this returns.
+        self._ui.workflow_update_signal.emit(
+            {
+                "msg": request.message,
+                "pos": request.positive,
+                "neg": request.negative,
+            }
+        )
+
+    def answer_confirm(self, clicked_yes: bool) -> bool:
+        """Complete a pending :class:`Confirm` from the yes/no click.
+
+        Returns False when no question is pending, so the caller can fall through
+        to the legacy flag path. Clears the prompt and the waiting state first,
+        then delivers the answer — the waiter wakes to a consistent UI.
+        """
+        future = self._pending_confirm
+        if future is None:
+            return False
+        self._pending_confirm = None
+        self._ui.WAITING_FOR_USER_INTERACTION = False
+        self._ui.workflow_update_signal.emit({"msg": ""})
+        future.set_result(clicked_yes)
+        return True

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -9,6 +9,7 @@ from fibsem import milling
 from fibsem.applications.autolamella.structures import Experiment
 from fibsem.applications.autolamella.workflows.interaction import (
     ClearSpotBurn,
+    Confirm,
     SetImages,
     SetSpotBurnSettings,
     ask,
@@ -168,6 +169,17 @@ def ask_user(
             f"User input requested in headless mode: {msg}, always returning True."
         )
         return True
+
+    if mill is None and det is None and spot_burn is None:
+        # A plain yes/no confirmation: the typed path. The answer arrives on this
+        # call's own future when a button is clicked — USER_RESPONSE and the
+        # polled flag are not involved. No timeout: a human answers, and silence
+        # means thinking; `abort` keeps Stop working while the prompt is up.
+        return ask(
+            parent_ui.ui_responder,
+            Confirm(message=msg, positive=pos, negative=neg),
+            abort=lambda: _abort_requested(parent_ui),
+        )
 
     INFO = {
         "msg": msg,

--- a/tests/ui/test_confirm_question.py
+++ b/tests/ui/test_confirm_question.py
@@ -1,0 +1,149 @@
+"""The first question over the Responder seam: Confirm, answered by a click.
+
+Instructions complete their future inside the handler; a question's handler shows
+the prompt and returns, and the yes/no click completes the future later — the
+deferred half of the seam. Every plain ``ask_user`` call (no detection, milling
+or spot-burn variant) now takes this path; ``USER_RESPONSE`` and the polled
+``WAITING_FOR_USER_INTERACTION`` handshake stay behind for the unconverted
+variants only.
+
+Each test calls ``ask_user`` from a real worker thread, spins the GUI loop until
+the prompt is up, clicks, and reads the answer off the worker — the production
+shape end to end.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.applications.autolamella.workflows.ui import ask_user
+
+
+@pytest.fixture
+def ui(qapp):
+    """A real AutoLamellaUI, connected (Demo), same harness as the responder tests."""
+    widget = AutoLamellaUI(parent_ui=None)
+    widget.system_widget.connect_to_microscope()
+    yield widget
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+
+
+def _ask_on_worker_thread(ui, qapp, msg="Continue?", pos="Continue", neg="Exit"):
+    """Start a plain ask_user on a worker thread; spin until the prompt is up."""
+    outcome = {}
+
+    def target():
+        try:
+            outcome["answer"] = ask_user(ui, msg=msg, pos=pos, neg=neg)
+        except Exception as exc:  # noqa: BLE001 - the test inspects it
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if ui.label_instructions.text() == msg and ui.pushButton_yes.isEnabled():
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("the prompt never appeared")
+    return thread, outcome
+
+
+def _finish(thread, qapp, timeout_s=10.0):
+    deadline = time.monotonic() + timeout_s
+    while thread.is_alive() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+    thread.join(timeout=1.0)
+    assert not thread.is_alive(), "ask_user never returned"
+
+
+def test_the_yes_click_answers_true(ui, qapp):
+    thread, outcome = _ask_on_worker_thread(ui, qapp)
+
+    # Mid-wait: the prompt is up, its buttons say what was asked, and the
+    # waiting display state is on for the attention button and border.
+    assert ui.pushButton_yes.text() == "Continue"
+    assert ui.pushButton_no.text() == "Exit"
+    assert ui.WAITING_FOR_USER_INTERACTION is True
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert outcome.get("answer") is True
+
+
+def test_the_no_click_answers_false(ui, qapp):
+    thread, outcome = _ask_on_worker_thread(ui, qapp)
+
+    ui.pushButton_no.click()
+    _finish(thread, qapp)
+
+    assert outcome.get("answer") is False
+
+
+def test_the_answer_does_not_travel_through_the_legacy_channel(ui, qapp):
+    # USER_RESPONSE is the shared mutable the typed path exists to retire. Park
+    # it opposite to the answer we will click: if the click still wrote it, or
+    # ask_user still read it, this catches either direction.
+    ui.USER_RESPONSE = False
+    thread, outcome = _ask_on_worker_thread(ui, qapp)
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert outcome.get("answer") is True
+    assert ui.USER_RESPONSE is False
+
+
+def test_the_prompt_comes_down_with_the_answer(ui, qapp):
+    thread, _ = _ask_on_worker_thread(ui, qapp)
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert not ui.label_instructions.isVisibleTo(ui)
+    assert not ui.pushButton_yes.isVisibleTo(ui)
+    assert ui.WAITING_FOR_USER_INTERACTION is False
+
+
+def test_a_stop_interrupts_a_prompt_nobody_answers(ui, qapp):
+    thread, outcome = _ask_on_worker_thread(ui, qapp)
+
+    ui._workflow_stop_event.set()
+    try:
+        _finish(thread, qapp)
+    finally:
+        ui._workflow_stop_event.clear()
+
+    assert isinstance(outcome.get("error"), InterruptedError)
+
+
+def test_a_question_after_an_aborted_one_still_works(ui, qapp):
+    # The aborted question's future is still parked in the responder; the next
+    # question must cancel that corpse and proceed, not trip over it.
+    thread, outcome = _ask_on_worker_thread(ui, qapp)
+    ui._workflow_stop_event.set()
+    try:
+        _finish(thread, qapp)
+    finally:
+        ui._workflow_stop_event.clear()
+    assert isinstance(outcome.get("error"), InterruptedError)
+
+    thread, outcome = _ask_on_worker_thread(ui, qapp, msg="Try again?")
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert outcome.get("answer") is True


### PR DESCRIPTION
Stacked on #649. The first **question** conversion — and with it, the deferred half of the Responder seam.

## The mechanism

Instructions complete their future inside the handler. A question cannot: the answer arrives from a click, later. So `QtResponder` grows a second, deferred handler table — `_confirm` shows the prompt and returns with the future parked, and `push_interaction_button` completes it through `answer_confirm(clicked_yes)`. The click hook tries the responder first and falls through to the legacy flag path, so the unconverted `ask_user` variants (detection, milling, spot burn) keep working unchanged through the transition.

## What converts

`ask_user`'s plain path — every call with no `det`/`mill`/`spot_burn` — now does:

```python
return ask(
    parent_ui.ui_responder,
    Confirm(message=msg, positive=pos, negative=neg),
    abort=lambda: _abort_requested(parent_ui),
)
```

That flips all plain-confirm sites at once with zero call-site churn (`ask_user_continue_workflow`, the fluorescence/reference/coincident/select-position prompts, and `calibration.py`'s late import). **No timeout**, per the settled design: a human answers, and silence means thinking; `abort` keeps Stop working while the prompt is up. `USER_RESPONSE` — a bool on a `QMainWindow` written on one thread and read on another — is no longer written or read on this path.

## Two deliberate calls

- **`WAITING_FOR_USER_INTERACTION` becomes display state on this path.** The workflow no longer polls it, but the attention button, the window border and the timeline's countdown pause all read it — so the responder sets it when the prompt goes up and clears it with the answer, on the GUI thread. The unconverted variants still use it as a handshake; both meanings coexist until the last question converts.
- **Display still rides the dict signal.** The responder emits the same `{"msg", "pos", "neg"}` payload the old mechanism showed (and `{"msg": ""}` on answering), so the prompt label, buttons and main-window indicators work exactly as before — both windows' slots run directly since the responder is already on the GUI thread. Moving display to the typed status channel is separate work; this PR is only the answer channel.
- A pending future left behind by an aborted waiter is **cancelled** when the next question arrives — the workflow thread blocks on each question, so a pending future at that moment can only be a corpse.

## Tests

`tests/ui/test_confirm_question.py` (new, 6) — each drives `ask_user` from a real worker thread, spins until the prompt is up, clicks, and reads the answer off the worker: yes→True; no→False; **the answer does not travel through `USER_RESPONSE`** (parked opposite and checked after); the prompt and waiting state come down with the answer; Stop interrupts a prompt nobody answers; and a question after an aborted one still works (the corpse-cancel path).

## Verification

- `pytest tests/ui/test_confirm_question.py tests/ui/test_qt_responder.py tests/ui/test_workflow_update_payload.py tests/autolamella/` — 613 passed.
- `ruff check` / `ruff format --check` clean on all changed files.
- Remaining on the legacy question path after this: the detection, milling-run and spot-burn variants of `ask_user`, the alignment-area and POI flows, and their widget read-backs.
