### PR TITLE
[app] Add AgentContext: the read-side facade for the embedded server

### DIFF
--- a/fibsem/applications/autolamella/server/__init__.py
+++ b/fibsem/applications/autolamella/server/__init__.py
@@ -1,0 +1,3 @@
+from fibsem.applications.autolamella.server.context import AgentContext
+
+__all__ = ["AgentContext"]

--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -1,0 +1,260 @@
+"""AgentContext: the read-side facade an embedded server sees the app through.
+
+Deliberately not the ``AutoLamellaUI`` object, for the same reasons
+``ScriptContext`` isn't: the window's ``experiment`` is rebound on load, its
+``_task_manager`` is created per run and nulled in the worker's ``finally``,
+and the GUI's internals are still moving. This facade resolves those
+references **at call time, on every call**, and returns plain JSON-able data —
+never live objects, never Qt, never a pointer into a widget.
+
+Thread contract: every method is safe to call from a server thread. Reads are
+point-in-time snapshots, not transactions — the workflow worker may be mutating
+the experiment concurrently, and a snapshot that is a task older than the
+instant it was taken is the accepted cost of never blocking anything. The one
+hardware-adjacent method, :meth:`stage_position`, reads the microscope's cached
+position only; nothing here ever issues a hardware call (the app must not be
+made to poll the instrument on behalf of an observer).
+
+Vocabulary: the surface speaks ``item_name`` throughout. ``lamella_name`` is
+the deprecated alias scheduled to drop with the HookContext shims after v0.6
+and never appears in these payloads.
+
+The host is anything carrying the four attributes the facade resolves through
+(``experiment``, ``microscope``, ``_task_manager``, ``is_workflow_running``) —
+the real ``AutoLamellaUI`` in production, a plain holder of real domain objects
+in tests.
+"""
+
+import math
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from fibsem.applications.autolamella import task_outputs as _task_outputs
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+
+__all__ = ["AgentContext"]
+
+
+def _json_safe(value: Any) -> Any:
+    """Coerce one cell of a dataframe/record into something JSON can carry."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    if hasattr(value, "item") and not isinstance(value, str):
+        # numpy scalars → native python
+        try:
+            return _json_safe(value.item())
+        except (AttributeError, ValueError):
+            pass
+    if hasattr(value, "isoformat"):
+        # pandas.Timestamp and friends
+        return value.isoformat()
+    if isinstance(value, (str, int, bool)) or value is None:
+        return value
+    if isinstance(value, float):
+        return value
+    return str(value)
+
+
+def _records(df) -> List[Dict[str, Any]]:
+    return [
+        {key: _json_safe(val) for key, val in record.items()}
+        for record in df.to_dict(orient="records")
+    ]
+
+
+class AgentContext:
+    """Read-only facade over a running (or resting) AutoLamella session."""
+
+    def __init__(self, host):
+        self._host = host
+
+    # --- call-time resolution: never cache what the app rebinds ---------------
+
+    @property
+    def _experiment(self):
+        return getattr(self._host, "experiment", None)
+
+    @property
+    def _manager(self):
+        return getattr(self._host, "_task_manager", None)
+
+    @property
+    def _microscope(self):
+        return getattr(self._host, "microscope", None)
+
+    # --- status ---------------------------------------------------------------
+
+    def status(self) -> Dict[str, Any]:
+        """What the app is doing right now, at a glance."""
+        experiment = self._experiment
+        running = bool(getattr(self._host, "is_workflow_running", False))
+        payload: Dict[str, Any] = {
+            "microscope_connected": self._microscope is not None,
+            "experiment": None,
+            "workflow": {
+                "running": running,
+                "current_task": None,
+                "current_item": None,
+                "queue_total": None,
+                "queue_version": None,
+            },
+        }
+        if experiment is not None:
+            payload["experiment"] = {
+                "name": experiment.name,
+                "path": str(experiment.path),
+                "num_items": len(experiment.positions),
+            }
+        manager = self._manager
+        if manager is not None:
+            items = manager.queue.items  # thread-safe copy under the queue's lock
+            payload["workflow"]["queue_total"] = len(items)
+            payload["workflow"]["queue_version"] = manager.queue.version
+            active = next(
+                (i for i in items if i.status is AutoLamellaTaskStatus.InProgress),
+                None,
+            )
+            if active is not None:
+                payload["workflow"]["current_task"] = active.task_name
+                payload["workflow"]["current_item"] = active.lamella_name
+        return payload
+
+    def queue(self) -> Dict[str, Any]:
+        """The live work queue: id-anchored items plus the mutation version."""
+        manager = self._manager
+        if manager is None:
+            return {"available": False, "items": [], "version": None}
+        items = manager.queue.items
+        return {
+            "available": True,
+            "version": manager.queue.version,
+            "items": [
+                {
+                    "id": item.id,
+                    "item_name": item.lamella_name,
+                    "task_name": item.task_name,
+                    "status": item.status.name,
+                }
+                for item in items
+            ],
+        }
+
+    # --- experiment record ----------------------------------------------------
+
+    def experiment_summary(self) -> Dict[str, Any]:
+        experiment = self._experiment
+        if experiment is None:
+            return {"available": False, "items": []}
+        return {
+            "available": True,
+            "items": _records(experiment.experiment_summary_dataframe()),
+        }
+
+    def task_history(self) -> Dict[str, Any]:
+        experiment = self._experiment
+        if experiment is None:
+            return {"available": False, "items": []}
+        return {
+            "available": True,
+            "items": _records(experiment.task_history_dataframe()),
+        }
+
+    def run_summary(self) -> Dict[str, Any]:
+        """The most recent run's outcome table, if a run has happened."""
+        manager = self._manager
+        if manager is not None:
+            return {
+                "available": True,
+                "items": _records(manager.build_run_summary_dataframe()),
+            }
+        last = getattr(self._host, "_last_run_summary", None)
+        if last is not None:
+            return {"available": True, "items": _records(last)}
+        return {"available": False, "items": []}
+
+    def protocol(self) -> Dict[str, Any]:
+        """The workflow definition with live supervision flags and schedules."""
+        experiment = self._experiment
+        task_protocol = (
+            getattr(experiment, "task_protocol", None) if experiment else None
+        )
+        if task_protocol is None:
+            return {"available": False, "tasks": []}
+        config = task_protocol.workflow_config
+        return {
+            "available": True,
+            "name": config.name,
+            "tasks": [
+                {
+                    "name": task.name,
+                    "supervise": task.supervise,
+                    "required": task.required,
+                    "requires": list(task.requires),
+                    "scheduled_at": task.scheduled_at.isoformat()
+                    if task.scheduled_at is not None
+                    else None,
+                }
+                for task in config.tasks
+            ],
+        }
+
+    def task_outputs(self, item_name: str) -> Dict[str, Any]:
+        """The files an item's completed tasks produced, existence-checked."""
+        experiment = self._experiment
+        if experiment is None:
+            return {"available": False, "item_name": item_name}
+        lamella = experiment.get_lamella_by_name(item_name)
+        if lamella is None:
+            return {
+                "available": False,
+                "item_name": item_name,
+                "error": f"No item named {item_name!r} in this experiment.",
+            }
+        history = list(lamella.task_history)
+        return {
+            "available": True,
+            "item_name": item_name,
+            "completed_tasks": [state.task_name for state in history],
+            "final_reference_images": [
+                str(p) for p in _task_outputs.final_reference_images(lamella, *history)
+            ],
+            "fluorescence_images": [
+                str(p) for p in _task_outputs.fluorescence_images(lamella, *history)
+            ],
+        }
+
+    # --- instrument-adjacent (cached only, never a hardware call) --------------
+
+    def stage_position(self) -> Dict[str, Any]:
+        """The cached stage position. None until something has read the stage.
+
+        Deliberately reads the cache, not ``get_stage_position()`` — an observer
+        must never make the app poll hardware (and on Tescan a concurrent read
+        is a socket transaction the workflow may be mid-way through).
+        """
+        microscope = self._microscope
+        cached = getattr(microscope, "_stage_position", None) if microscope else None
+        if cached is None:
+            return {"available": False, "position": None}
+        return {"available": True, "position": cached.to_dict()}
+
+    # --- discovery --------------------------------------------------------------
+
+    def recent_experiments(self) -> List[Dict[str, Any]]:
+        """The recents list, via the never-raising peek layer."""
+        from fibsem.config import get_recent_experiments
+
+        return [
+            {
+                "name": summary.name,
+                "path": summary.path,
+                "created_at": summary.created_at,
+                "num_items": summary.num_lamella,
+                "available": summary.available,
+                "instrument_model": summary.instrument_model,
+                "software_version": summary.software_version,
+            }
+            for summary in get_recent_experiments()
+        ]

--- a/tests/autolamella/test_agent_context.py
+++ b/tests/autolamella/test_agent_context.py
@@ -1,0 +1,165 @@
+"""Tests for AgentContext: the read-side facade the embedded server will use.
+
+Real domain objects throughout — a real Experiment with real lamellae, the real
+TaskQueue mechanics, the Demo microscope — held by a plain host object standing
+where AutoLamellaUI stands in production (the real-window pairing lives in
+tests/ui/test_agent_context_host.py)."""
+
+import json
+import os
+
+import pytest
+from psygnal.containers import EventedDict
+
+from fibsem import utils
+from fibsem.applications.autolamella.server import AgentContext
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    AutoLamellaTaskStatus,
+    Experiment,
+)
+from fibsem.structures import MicroscopeState
+
+
+class Host:
+    """The four attributes the facade resolves through; all start empty."""
+
+    experiment = None
+    microscope = None
+    _task_manager = None
+    is_workflow_running = False
+
+
+@pytest.fixture
+def experiment(tmp_path) -> Experiment:
+    exp = Experiment(path=tmp_path / "exp", name="agent-context-exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    (tmp_path / "exp").mkdir(parents=True, exist_ok=True)
+    for _ in range(2):
+        exp.add_new_lamella(MicroscopeState(), EventedDict())
+    return exp
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    os.environ.setdefault("FIBSEM_SIM_NO_DELAY", "1")
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    return microscope
+
+
+def _assert_json_safe(payload):
+    json.dumps(payload)  # raises on anything a wire client couldn't carry
+
+
+def test_every_method_tolerates_an_empty_host():
+    ctx = AgentContext(Host())
+    payloads = [
+        ctx.status(),
+        ctx.queue(),
+        ctx.experiment_summary(),
+        ctx.task_history(),
+        ctx.run_summary(),
+        ctx.protocol(),
+        ctx.task_outputs("anything"),
+        ctx.stage_position(),
+    ]
+    for payload in payloads:
+        _assert_json_safe(payload)
+    assert ctx.status()["experiment"] is None
+    assert ctx.queue() == {"available": False, "items": [], "version": None}
+
+
+def test_resolution_is_call_time_not_construction_time(experiment):
+    # The app rebinds `experiment` on load; a facade built earlier must see the
+    # new binding, not the one from construction (the ScriptContext hazard).
+    host = Host()
+    ctx = AgentContext(host)
+    assert ctx.status()["experiment"] is None
+    host.experiment = experiment
+    assert ctx.status()["experiment"]["name"] == "agent-context-exp"
+    host.experiment = None
+    assert ctx.status()["experiment"] is None
+
+
+def test_status_and_summaries_reflect_a_real_experiment(experiment):
+    host = Host()
+    host.experiment = experiment
+    ctx = AgentContext(host)
+
+    status = ctx.status()
+    assert status["experiment"]["num_items"] == 2
+    assert status["workflow"]["running"] is False
+
+    summary = ctx.experiment_summary()
+    assert summary["available"] is True
+    assert len(summary["items"]) == 2
+    _assert_json_safe(summary)
+
+    protocol = ctx.protocol()
+    assert protocol["available"] is True
+    _assert_json_safe(protocol)
+
+
+def test_task_outputs_for_a_real_item_and_a_missing_one(experiment):
+    host = Host()
+    host.experiment = experiment
+    ctx = AgentContext(host)
+
+    name = experiment.positions[0].name
+    payload = ctx.task_outputs(name)
+    assert payload["available"] is True
+    assert payload["item_name"] == name
+    assert payload["final_reference_images"] == []  # nothing has run
+    _assert_json_safe(payload)
+
+    missing = ctx.task_outputs("no-such-item")
+    assert missing["available"] is False
+    assert "no-such-item" in missing["error"]
+
+
+def test_queue_snapshot_uses_item_name_vocabulary(experiment, microscope):
+    from fibsem.applications.autolamella.workflows.tasks.manager import TaskManager
+
+    manager = TaskManager(microscope, experiment, parent_ui=None)
+    names = [p.name for p in experiment.positions]
+    manager.queue.build_from_matrix(["Task A", "Task B"], names)
+
+    host = Host()
+    host.experiment = experiment
+    host._task_manager = manager
+    ctx = AgentContext(host)
+
+    queue = ctx.queue()
+    assert queue["available"] is True
+    assert len(queue["items"]) == 4  # 2 tasks x 2 items
+    first = queue["items"][0]
+    assert set(first) == {"id", "item_name", "task_name", "status"}
+    assert "lamella_name" not in first  # the deprecated alias never crosses the wire
+    assert first["status"] == AutoLamellaTaskStatus.NotStarted.name
+    assert queue["version"] == manager.queue.version
+    _assert_json_safe(queue)
+
+    status = ctx.status()
+    assert status["workflow"]["queue_total"] == 4
+    assert status["workflow"]["current_task"] is None  # nothing running
+
+
+def test_stage_position_reads_the_cache_only(microscope):
+    host = Host()
+    host.microscope = microscope
+    ctx = AgentContext(host)
+
+    microscope.get_stage_position()  # populate the cache, as the app would
+    cached = ctx.stage_position()
+    assert cached["available"] is True
+    _assert_json_safe(cached)
+
+    # The facade must not have issued a hardware read itself: poking the cache
+    # attribute directly proves which side it reads from.
+    microscope._stage_position = None
+    assert ctx.stage_position() == {"available": False, "position": None}
+
+
+def test_recent_experiments_is_json_safe():
+    ctx = AgentContext(Host())
+    _assert_json_safe(ctx.recent_experiments())

--- a/tests/ui/test_agent_context_host.py
+++ b/tests/ui/test_agent_context_host.py
@@ -1,0 +1,64 @@
+"""AgentContext against the real window.
+
+The unit tests (tests/autolamella/test_agent_context.py) drive the facade over
+real domain objects in a plain holder; this file proves the production host —
+an actual AutoLamellaUI — satisfies the same contract, in the states the facade
+will actually meet it: freshly constructed (nothing connected, nothing loaded)
+and with an experiment adopted."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import json
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from psygnal.containers import EventedDict
+
+from fibsem.applications.autolamella.server import AgentContext
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.structures import MicroscopeState
+
+
+@pytest.fixture
+def ui(qapp):
+    window = AutoLamellaUI(parent_ui=None)
+    try:
+        yield window
+    finally:
+        window.close()
+        window.deleteLater()
+        qapp.processEvents()
+
+
+def test_a_fresh_window_satisfies_the_host_contract(ui):
+    ctx = AgentContext(ui)
+    status = ctx.status()
+    json.dumps(status)
+    assert status["microscope_connected"] is False
+    assert status["experiment"] is None
+    assert status["workflow"]["running"] is False
+    assert ctx.queue()["available"] is False
+    assert ctx.run_summary()["available"] is False
+
+
+def test_an_adopted_experiment_is_visible_through_the_facade(ui, tmp_path):
+    exp = Experiment(path=tmp_path / "exp", name="host-exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    (tmp_path / "exp").mkdir(parents=True, exist_ok=True)
+    exp.add_new_lamella(MicroscopeState(), EventedDict())
+
+    ctx = AgentContext(ui)  # built BEFORE the experiment exists — call-time wins
+    ui.experiment = exp
+
+    status = ctx.status()
+    assert status["experiment"]["name"] == "host-exp"
+    assert status["experiment"]["num_items"] == 1
+    assert ctx.task_outputs(exp.positions[0].name)["available"] is True


### PR DESCRIPTION
First app-layer piece of the agent-server work — deliberately a standalone branch off main: no files shared with the server stack (#640–#646) or the workflow-responder stack (#647–#649).

## What

`fibsem/applications/autolamella/server/context.py` — a read-only facade with call-time resolution over a host carrying `experiment` / `microscope` / `_task_manager` / `is_workflow_running` (the real `AutoLamellaUI` in production). Surface: `status`, `queue` (id + version, `item_name` vocabulary), `experiment_summary` / `task_history` / `run_summary` (dataframe records, JSON-coerced), `protocol` (live supervise flags + schedules), `task_outputs` (role-keyed files via `task_outputs.py`), `stage_position` (cached only — never a hardware call), `recent_experiments` (the never-raising peek layer).

Nothing imports it yet (ship-groundwork pattern); the embedded hosting wires it to `build_server(app_context=...)` next.

## Deliberate choices

- Payloads are data, never live objects — safe to build from a server thread; point-in-time snapshot semantics documented.
- `lamella_name` never crosses the surface (drops with the v0.6 shims); a test pins that.
- `estimate_remaining_time` is deliberately absent — the method this surface expected no longer exists under that name on main; it returns when the ETA surface stabilises.

## Verification

7 unit tests over real domain objects (real `Experiment` + lamellae, real `TaskQueue` via `build_from_matrix`, Demo microscope) in `tests/autolamella/` — covered by the existing CI matrix, no extras needed — including call-time-rebinding, the cache-only stage read, and JSON-safety of every payload. Plus 2 tests in `tests/ui/` pairing the facade with a real offscreen `AutoLamellaUI`. All green; ruff clean.