### PR TITLE
[feat] Let an offset system opt in to its fluorescence microscope

### DIFF
--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -20,6 +20,8 @@ info:
     name: sim-iflm-configuration                            # a descriptive name for your configuration                     [SPECIFIED]
     ip_address: 192.168.0.1                                 # the ip address of the microscope PC                           [SPECIFIED]
     manufacturer: Demo                                      # the microscope manufactuer                                    [SPECIFIED]
+fm:
+    enabled:                    true                        # this site has a fluorescence microscope                       [USER]
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation:                   true                        # the stage is able to rotate                                   [USER]

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -477,6 +477,28 @@ class FibsemMicroscope(ABC):
             and self.fm.objective.state == "Inserted"
         )
 
+    def _fluorescence_is_configured(self) -> bool:
+        """Whether this site has said its instrument has a fluorescence microscope.
+
+        The **flag decides**; the driver's own probe only confirms afterwards, and
+        that order matters. There is no `is_installed` for the FM in AutoScript --
+        every other subsystem has one -- so the only capability test available is to
+        select it and see whether the microscope throws. Running that on every system
+        would be autodetection, and an Aquilos or Helios with an iFLM fitted would
+        find half-built offset support appearing in its UI on upgrade: a fluorescence
+        tab that builds, a button that traverses 48 mm, pose derivation that is only
+        partly right. Probing also touches the shared imaging channel on machines that
+        have never had an FM.
+
+        **A compustage keeps its answer.** `stage_is_compustage` is read from the
+        hardware (`compustage.is_installed`), not from configuration, and no shipped
+        Arctis configuration carries the flag -- `tfs-arctis-configuration.yaml` has
+        no `fm:` block at all. Replacing the old check rather than widening it would
+        take the FM away from every Arctis site on upgrade. So the compustage stays
+        exactly as it was, and an offset mount must opt in.
+        """
+        return self.system.fm.enabled or self.stage_is_compustage
+
     def _refuse_rotation_at_the_fluorescence_microscope(
         self, stage_position: FibsemStagePosition
     ) -> None:
@@ -2755,9 +2777,10 @@ class ThermoMicroscope(FibsemMicroscope):
         self.milling_channel: BeamType = BeamType.ION
 
         try:
-            if not self.stage_is_compustage:
-                logging.warning(
-                    "Fluorescence microscope module is currently only implemented for compustage systems. FM will not be available."
+            if not self._fluorescence_is_configured():
+                logging.info(
+                    "No fluorescence microscope configured for this system. Set "
+                    "`fm.enabled` in the microscope configuration to enable it."
                 )
                 self.fm = None
                 self.set_channel(BeamType.ELECTRON)

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -469,7 +469,14 @@ class DemoMicroscope(FibsemMicroscope):
         # every simulator configuration keeps its current behaviour without the key.
         has_fm = bool(self.system.sim.get("has_fm", self.stage_is_compustage))
 
-        if has_fm:
+        # Two independent questions, and the simulator is the only place both can be
+        # posed. `_fluorescence_is_configured` is whether the site said its instrument
+        # has an FM; `has_fm` is what the hardware probe would have answered. Both are
+        # required, which is what makes the middle row of the table below the sim
+        # configuration representable: an FM detected on a system nothing is
+        # configured for -- a site upgrading -- gets no FM, and that is the case worth
+        # being able to test.
+        if has_fm and self._fluorescence_is_configured():
             self.fm = SimulatedFluorescenceMicroscope(self)
             # Bringing the FM up leaves the shared channel on it, as
             # `ThermoMicroscope.__init__` does; taking it back is the next beam

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2328,6 +2328,37 @@ class SystemInfo:
 
 
 @dataclass
+class FluorescenceSystemSettings:
+    """Whether this site's instrument has a fluorescence microscope.
+
+    A hardware fact about the site, so it belongs beside `manipulator.enabled` in the
+    microscope configuration rather than in user preferences: a changed preference
+    default reaches only fresh installs, and an operator toggling one would be
+    asserting their instrument has hardware it may not have.
+
+    **Default off, and it must stay off.** Where the objective is offset, support for
+    it is incomplete -- an Aquilos or Helios with an iFLM fitted must not find half
+    of it appearing in the UI on upgrade. Detecting the hardware is the failure mode
+    here, not the goal: the flag decides, and the driver's own probe only confirms the
+    hardware is really there once a site has said it should be.
+
+    The key already existed in the file format and was read by nothing; `config` is
+    the only part of the block anything consumed.
+    """
+
+    enabled: bool = False
+
+    def to_dict(self) -> dict:
+        return {"enabled": self.enabled}
+
+    @staticmethod
+    def from_dict(settings: dict) -> "FluorescenceSystemSettings":
+        return FluorescenceSystemSettings(
+            enabled=bool((settings or {}).get("enabled", False))
+        )
+
+
+@dataclass
 class SystemSettings:
     stage: StageSystemSettings
     electron: BeamSystemSettings
@@ -2336,6 +2367,7 @@ class SystemSettings:
     gis: GISSystemSettings
     info: SystemInfo
     sim: Dict[str, Union[str, bool]] = field(default_factory=dict)
+    fm: FluorescenceSystemSettings = field(default_factory=FluorescenceSystemSettings)
 
     def to_dict(self):
         return {
@@ -2346,6 +2378,7 @@ class SystemSettings:
             "gis": self.gis.to_dict(),
             "info": self.info.to_dict(),
             "sim": self.sim,
+            "fm": self.fm.to_dict(),
         }
 
     @staticmethod
@@ -2363,6 +2396,10 @@ class SystemSettings:
             gis=GISSystemSettings.from_dict(settings["gis"]),
             info=SystemInfo.from_dict(settings["info"]),
             sim=settings.get("sim", {}),
+            # The same `fm:` block `MicroscopeSettings.from_dict` reads `config` from.
+            # Two readers, one key each: this is the hardware fact, that is a path to
+            # imaging parameters.
+            fm=FluorescenceSystemSettings.from_dict(settings.get("fm", {})),
         )
 
 

--- a/tests/test_fluorescence_connection_gate.py
+++ b/tests/test_fluorescence_connection_gate.py
@@ -1,0 +1,148 @@
+"""Which systems get a fluorescence microscope at connection, and which are refused.
+
+`microscope.fm` was built only when the stage was a compustage. That is what made
+every offset path unreachable without hardware. Opening it is the last piece of the
+offset-FM work, and the way it opens matters more than that it opens:
+
+**Detecting the hardware is the failure mode, not the goal.** There is no
+`is_installed` for the FM in AutoScript -- every other subsystem has one -- so the
+only capability test available is to select it and see whether the microscope throws.
+Running that on every system would mean an Aquilos or Helios with an iFLM fitted finds
+half-built offset support in its UI on upgrade. So an explicit flag decides, and the
+probe only confirms afterwards.
+
+The flag *widens* the old check rather than replacing it. `stage_is_compustage` is
+read from the hardware, not configuration, and no shipped Arctis configuration carries
+the flag -- so replacing it would take the FM away from every Arctis site.
+"""
+
+import os
+
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.structures import FluorescenceSystemSettings
+
+IFLM_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-iflm-configuration.yaml")
+ARCTIS_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
+
+
+def _microscope(config_path: str):
+    microscope, _ = utils.setup_session(config_path=config_path)
+    return microscope
+
+
+def _from(settings: dict, tmp_path) -> "object":
+    """Connect to a one-off variant of a shipped configuration.
+
+    `setup_session` takes a path, not a blob, so the variant has to go through a file.
+    """
+    path = tmp_path / "variant-configuration.yaml"
+    utils.save_yaml(path, settings)
+    return _microscope(str(path))
+
+
+# ── nothing is detected into existence ───────────────────────────────
+
+
+def test_a_beam_only_system_gets_no_fluorescence_microscope():
+    """The shipped default configuration, and every Thermo site that has not opted in.
+
+    This is the leak the flag exists to prevent: an offset system must not acquire
+    in-progress fluorescence support by the software noticing the hardware.
+    """
+    microscope = _microscope(cfg.MICROSCOPE_CONFIGURATION_PATH)
+
+    assert microscope.system.fm.enabled is False
+    assert microscope.fm is None
+
+
+def test_the_flag_defaults_off():
+    """Including on systems that do have the hardware. Groundwork ships disabled."""
+    assert FluorescenceSystemSettings().enabled is False
+    assert FluorescenceSystemSettings.from_dict({}).enabled is False
+    assert "fm" not in utils.load_yaml(cfg.MICROSCOPE_CONFIGURATION_PATH)
+
+
+def test_a_configured_offset_system_gets_one():
+    """What the whole project was for: an FM on a stage that does not flip."""
+    microscope = _microscope(IFLM_CONFIG)
+
+    assert microscope.stage_is_compustage is False
+    assert microscope.system.fm.enabled is True
+    assert microscope.fm is not None
+
+
+# ── the Arctis must not lose what it already has ─────────────────────
+
+
+def test_a_compustage_needs_no_flag():
+    """`tfs-arctis-configuration.yaml` has no `fm:` block, and its FM works today.
+
+    `stage_is_compustage` comes from the hardware (`compustage.is_installed`), not
+    from configuration, so no Arctis site has ever needed to say anything. Replacing
+    the old check with the flag rather than widening it would take the FM away from
+    all of them on upgrade -- which is why this is an `or`.
+    """
+    microscope = _microscope(ARCTIS_CONFIG)
+    microscope.system.fm.enabled = False  # as a real Arctis configuration has it
+
+    assert microscope.stage_is_compustage is True
+    assert microscope._fluorescence_is_configured() is True
+
+
+def test_an_offset_system_does_need_one():
+    microscope = _microscope(IFLM_CONFIG)
+    microscope.system.fm.enabled = False
+
+    assert microscope.stage_is_compustage is False
+    assert microscope._fluorescence_is_configured() is False
+
+
+# ── configured and detected are different questions ──────────────────
+
+
+def test_detected_but_not_configured_gets_nothing(tmp_path):
+    """The row that matters, and the reason the simulator keeps two separate keys.
+
+    `has_fm` stands in for what the hardware probe would answer; `fm.enabled` is what
+    the site said. A system where an FM is present and nothing is configured for it is
+    exactly the upgrading site the flag protects, and it has to stay representable --
+    inferring one from the other would collapse it into the cases that already work.
+    """
+    settings = utils.load_yaml(IFLM_CONFIG)
+    assert settings["sim"]["has_fm"] is True  # the hardware is "there"
+    settings["fm"]["enabled"] = False  # the site has not said so
+
+    assert _from(settings, tmp_path).fm is None
+
+
+def test_configured_but_not_detected_gets_nothing_either(tmp_path):
+    """The probe still has the last word: a site can be wrong about its own hardware."""
+    settings = utils.load_yaml(IFLM_CONFIG)
+    settings["sim"]["has_fm"] = False
+
+    microscope = _from(settings, tmp_path)
+
+    assert microscope.system.fm.enabled is True
+    assert microscope.fm is None
+
+
+# ── the configuration itself ─────────────────────────────────────────
+
+
+def test_the_flag_survives_a_round_trip():
+    """`system.to_dict()` is served over the API and written into image metadata."""
+    system = _microscope(IFLM_CONFIG).system
+
+    assert type(system).from_dict(system.to_dict()).fm == system.fm
+
+
+def test_the_config_path_is_still_read_from_the_same_block():
+    """Two readers, one `fm:` block, one key each -- this is the hardware fact, the
+    other is a path to imaging parameters. Neither should have eaten the other."""
+    settings = utils.load_yaml(ARCTIS_CONFIG)
+
+    assert "enabled" in settings["fm"]
+    assert _microscope(ARCTIS_CONFIG).system.fm.enabled is True


### PR DESCRIPTION
Stacked on #643 — review that one first; this is the diff of the top commit only.

## The problem

`ThermoMicroscope.__init__` gates the FM connection on `stage_is_compustage`. That
check has been doing two jobs: *is this stage a compustage* and *does this
instrument have a fluorescence microscope at all*. On an offset mount the second
answer is yes and the first is no, so there is no way to say so.

## The change

The condition **widens**, it does not move:

```python
def _fluorescence_is_configured(self) -> bool:
    return self.system.fm.enabled or self.stage_is_compustage
```

- **A compustage keeps its answer with no configuration change.** `stage_is_compustage`
  is read from the hardware (`compustage.is_installed`), and no shipped Arctis
  configuration carries the new flag — `tfs-arctis-configuration.yaml` has no `fm:`
  block at all. Replacing the check rather than widening it would take the FM away
  from every Arctis site on upgrade.
- **An offset mount must opt in**, and the flag defaults off. Offset support is
  half-built; a beam system with an objective fitted must not find a fluorescence tab,
  a button that traverses 48 mm, and partly-right pose derivation appearing on upgrade.

### Why a flag and not a capability read

Elsewhere "is this hardware present" is a capability read, and that is the better
pattern. It is not available here: AutoScript has no `is_installed` for the FM — every
other subsystem has one — so the only test is to select it and see whether the
microscope throws. Running that on every system *is* autodetection, and it touches the
shared imaging channel on machines that have never had an FM. So the flag decides and
the probe only confirms, in that order.

`fm.enabled` sits in the microscope configuration beside `manipulator.enabled`, not in
user preferences: it is a hardware fact about the site, and an operator toggling a
preference would be asserting their instrument has hardware it may not have. The `fm:`
block already existed in the file format; only `config` was ever read from it.

### The simulator now requires both halves

`has_fm` (what a probe would answer) **and** `_fluorescence_is_configured()` (what the
site said). That is what makes the interesting row representable:

| detected | configured | result |
| -- | -- | -- |
| yes | yes | FM |
| yes | no | **no FM** — a site upgrading |
| no | yes | no FM |

## Ordering

**#643 must land first.** Without it, an offset system that opts in reaches an
absolute-move path that silently drops z and rotation — it lands at x and y and
reports success. Stacking is what enforces that.

## Verification

Full suite on this branch: **6711 passed, 23 skipped**.

End to end on `sim-iflm-configuration.yaml`:

```
at FIB: x=0,      device=FIBSEM
at FM:  x=0.0488, device=FM,     objective=Inserted
back:   x=0.0,    device=FIBSEM, objective=Retracted
round trip dx: 0.0 µm
FM image: FluorescenceImage (1024, 1024)
rotation while at the FM: refused
```

Nine tests in `tests/test_fluorescence_connection_gate.py` cover the flag default, both
mounts, both halves of the simulator gate, the config round trip, and that the other
reader of the same `fm:` block still finds its key.

(No Linear ID in this body on purpose — a referenced issue auto-completes on merge, and
the umbrella work is not finished.)