### PR TITLE
[server] Mount the app router: the AgentContext surface over HTTP and MCP

### DIFF
--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -26,7 +26,7 @@ import os
 import sys
 from typing import Optional, Tuple
 
-from fibsem.server.catalog import CATALOG
+from fibsem.server.catalog import CATALOG, tools_for_capabilities
 
 _TIMEOUT_S = 120.0  # acquisitions and moves on real hardware are slow
 
@@ -112,16 +112,17 @@ def _call(client, method, path, payload=None):
     return resp.json(), None
 
 
-def build_sidecar(client, scopes):
-    """Build the FastMCP server over an httpx-compatible client.
+def build_sidecar(client, capabilities):
+    """Build the MCP server over an httpx-compatible client.
 
-    ``scopes`` is the /capabilities scopes payload; only tools whose scope is
-    armed get registered (the server enforces regardless).
+    ``capabilities`` is the full /capabilities payload; a tool registers only
+    when its scope is armed AND its router is mounted (an app tool exists only
+    when the server hosts an application). The server enforces regardless.
     """
     from mcp.server.mcpserver import Image, MCPServer
 
     mcp = MCPServer("fibsem")
-    armed = {t.name for t in CATALOG if scopes.get(t.scope, False)}
+    armed = {t.name for t in tools_for_capabilities(capabilities)}
     by_name = {t.name: t for t in CATALOG}
 
     def _json_tool(name, payload_fn=None):
@@ -223,6 +224,34 @@ def build_sidecar(client, scopes):
         data, err = _call(client, "POST", "/autocontrast", {"beam_type": beam_type})
         return err if err else data
 
+    def _app_get(path):
+        data, err = _call(client, "GET", path)
+        return err if err else data
+
+    def get_app_status():
+        return _app_get("/app/status")
+
+    def get_app_queue():
+        return _app_get("/app/queue")
+
+    def get_experiment_summary():
+        return _app_get("/app/experiment_summary")
+
+    def get_task_history():
+        return _app_get("/app/task_history")
+
+    def get_run_summary():
+        return _app_get("/app/run_summary")
+
+    def get_protocol():
+        return _app_get("/app/protocol")
+
+    def get_task_outputs(item_name: str):
+        return _app_get(f"/app/task_outputs/{item_name}")
+
+    def list_recent_experiments():
+        return _app_get("/app/recent_experiments")
+
     implementations = {
         fn.__name__: fn
         for fn in (
@@ -241,6 +270,14 @@ def build_sidecar(client, scopes):
             move_stage_absolute,
             move_to_milling_angle,
             autocontrast,
+            get_app_status,
+            get_app_queue,
+            get_experiment_summary,
+            get_task_history,
+            get_run_summary,
+            get_protocol,
+            get_task_outputs,
+            list_recent_experiments,
         )
     }
     # The catalog is the contract: refuse to start with an implementation gap.
@@ -301,7 +338,7 @@ def main(argv=None):
     )
     if args.check:
         return
-    build_sidecar(client, capabilities.get("scopes", {})).run()
+    build_sidecar(client, capabilities).run()
 
 
 if __name__ == "__main__":

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -1,0 +1,82 @@
+"""The app-level router: observation of a running AutoLamella session.
+
+Dependency direction is one-way — autolamella imports fibsem.server, never the
+reverse — so this module never imports the application. It defines the
+:class:`AppContext` protocol structurally; the application's ``AgentContext``
+(fibsem.applications.autolamella.server) satisfies it and is passed into
+``build_server(app_context=...)`` by whoever hosts the server inside the app.
+
+Every route is a thin pass-through: the context returns plain JSON-able
+snapshots and owns all app knowledge; nothing here touches domain objects.
+The read-scope requirement is applied where the router is included, so auth
+stays in one place (build_server).
+"""
+
+from typing import Any, Dict, List
+
+from fastapi import APIRouter
+
+try:  # Protocol is typing-only; keep import robust on the 3.8 floor
+    from typing import Protocol
+except ImportError:  # pragma: no cover
+    Protocol = object  # type: ignore[assignment]
+
+__all__ = ["AppContext", "build_app_router"]
+
+
+class AppContext(Protocol):
+    """What a hosted application must answer. Matched structurally."""
+
+    def status(self) -> Dict[str, Any]: ...
+
+    def queue(self) -> Dict[str, Any]: ...
+
+    def experiment_summary(self) -> Dict[str, Any]: ...
+
+    def task_history(self) -> Dict[str, Any]: ...
+
+    def run_summary(self) -> Dict[str, Any]: ...
+
+    def protocol(self) -> Dict[str, Any]: ...
+
+    def task_outputs(self, item_name: str) -> Dict[str, Any]: ...
+
+    def recent_experiments(self) -> List[Dict[str, Any]]: ...
+
+
+def build_app_router(context: AppContext) -> APIRouter:
+    router = APIRouter(prefix="/app")
+
+    @router.get("/status")
+    def app_status():
+        return context.status()
+
+    @router.get("/queue")
+    def app_queue():
+        return context.queue()
+
+    @router.get("/experiment_summary")
+    def experiment_summary():
+        return context.experiment_summary()
+
+    @router.get("/task_history")
+    def task_history():
+        return context.task_history()
+
+    @router.get("/run_summary")
+    def run_summary():
+        return context.run_summary()
+
+    @router.get("/protocol")
+    def protocol():
+        return context.protocol()
+
+    @router.get("/task_outputs/{item_name}")
+    def task_outputs(item_name: str):
+        return context.task_outputs(item_name)
+
+    @router.get("/recent_experiments")
+    def recent_experiments():
+        return {"items": context.recent_experiments()}
+
+    return router

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -23,6 +23,9 @@ class ToolSpec:
     path: str
     scope: str  # "read" | "hardware"
     params: Dict[str, str] = field(default_factory=dict)  # name -> description
+    # Which router serves it: "microscope" is always mounted; "app" only when
+    # the server was built with an app_context (/capabilities reports which).
+    router: str = "microscope"
 
 
 CATALOG: Tuple[ToolSpec, ...] = (
@@ -152,6 +155,93 @@ CATALOG: Tuple[ToolSpec, ...] = (
 )
 
 
+APP_TOOLS: Tuple[ToolSpec, ...] = (
+    ToolSpec(
+        name="get_app_status",
+        description="What the application is doing: experiment, running workflow, current task and item.",
+        method="GET",
+        path="/app/status",
+        scope="read",
+        router="app",
+    ),
+    ToolSpec(
+        name="get_app_queue",
+        description="The live work queue: id-anchored items with status, plus the mutation version.",
+        method="GET",
+        path="/app/queue",
+        scope="read",
+        router="app",
+    ),
+    ToolSpec(
+        name="get_experiment_summary",
+        description="Per-item summary of the open experiment.",
+        method="GET",
+        path="/app/experiment_summary",
+        scope="read",
+        router="app",
+    ),
+    ToolSpec(
+        name="get_task_history",
+        description="Every task run so far: outcomes, durations, errors.",
+        method="GET",
+        path="/app/task_history",
+        scope="read",
+        router="app",
+    ),
+    ToolSpec(
+        name="get_run_summary",
+        description="The most recent workflow run's outcome table.",
+        method="GET",
+        path="/app/run_summary",
+        scope="read",
+        router="app",
+    ),
+    ToolSpec(
+        name="get_protocol",
+        description="The workflow definition with live supervision flags and schedules.",
+        method="GET",
+        path="/app/protocol",
+        scope="read",
+        router="app",
+    ),
+    ToolSpec(
+        name="get_task_outputs",
+        description="The files an item's completed tasks produced (reference images by role).",
+        method="GET",
+        path="/app/task_outputs/{item_name}",
+        scope="read",
+        router="app",
+        params={"item_name": "the item (lamella) name"},
+    ),
+    ToolSpec(
+        name="list_recent_experiments",
+        description="Recently opened experiments on this machine, without loading them.",
+        method="GET",
+        path="/app/recent_experiments",
+        scope="read",
+        router="app",
+    ),
+)
+
+CATALOG = CATALOG + APP_TOOLS
+
+
 def tools_for_scopes(armed: Dict[str, bool]) -> Tuple[ToolSpec, ...]:
-    """The catalog entries usable given the /capabilities scopes payload."""
+    """Catalog entries usable given armed scopes alone (router-blind)."""
     return tuple(t for t in CATALOG if armed.get(t.scope, False))
+
+
+def tools_for_capabilities(capabilities: Dict) -> Tuple[ToolSpec, ...]:
+    """Catalog entries usable given a full /capabilities payload.
+
+    Filters on both dimensions: the tool's scope must be armed AND the router
+    serving it must be mounted. The server enforces either way -- this filter
+    only keeps the agent's tool list honest about what can succeed.
+    """
+    scopes = capabilities.get("scopes", {})
+    routers = capabilities.get("routers", {})
+    return tuple(
+        t
+        for t in CATALOG
+        if scopes.get(t.scope, False) and routers.get(t.router, False)
+    )

--- a/fibsem/server/server.py
+++ b/fibsem/server/server.py
@@ -41,6 +41,7 @@ from fastapi.responses import JSONResponse, Response
 
 from fibsem import utils
 from fibsem.microscope import FibsemMicroscope
+from fibsem.server.app_routes import build_app_router
 from fibsem.server.auth import AuthConfig, Scope, command_slot, require_scope
 from fibsem.server.discovery import (
     DISCOVERY_FILE,
@@ -140,13 +141,10 @@ def build_server(
     """Build the server app around an already-connected microscope.
 
     ``auth`` defaults to a generated token with only the ``read`` scope armed.
-    ``app_context`` mounts the app-level router (FIB-846); until that lands,
-    passing one is an error rather than a silent no-op.
+    ``app_context`` is anything satisfying app_routes.AppContext (structurally
+    -- the application's AgentContext in practice); passing one mounts the
+    app-level router and flips ``routers.app`` in /capabilities.
     """
-    if app_context is not None:
-        raise NotImplementedError(
-            "The app router lands with FIB-846; app_context is not usable yet."
-        )
     if auth is None:
         auth = AuthConfig.generate()
 
@@ -183,7 +181,7 @@ def build_server(
         return {
             "api_version": API_VERSION,
             "manufacturer": type(microscope).__name__,
-            "routers": {"microscope": True, "app": False},
+            "routers": {"microscope": True, "app": app_context is not None},
             "scopes": {s.value: auth.is_armed(s) for s in Scope},
         }
 
@@ -668,6 +666,13 @@ def build_server(
 
     app.include_router(read)
     app.include_router(hw)
+    if app_context is not None:
+        # Read scope applied here so auth stays in one place; the router itself
+        # is a thin pass-through over the context's JSON-able snapshots.
+        app.include_router(
+            build_app_router(app_context),
+            dependencies=[Depends(require_scope(Scope.READ))],
+        )
     return app
 
 

--- a/tests/server/test_app_router.py
+++ b/tests/server/test_app_router.py
@@ -1,0 +1,120 @@
+"""The app router end to end: a real AgentContext over a real experiment,
+mounted into the server, reached over HTTP and through MCP tools."""
+
+import asyncio
+import os
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient  # noqa: E402
+from psygnal.containers import EventedDict  # noqa: E402
+
+from fibsem import utils  # noqa: E402
+from fibsem.applications.autolamella.server import AgentContext  # noqa: E402
+from fibsem.applications.autolamella.structures import (  # noqa: E402
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.server import AuthConfig, build_server  # noqa: E402
+from fibsem.structures import MicroscopeState  # noqa: E402
+
+TOKEN = "test-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+
+class Host:
+    experiment = None
+    microscope = None
+    _task_manager = None
+    is_workflow_running = False
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    os.environ.setdefault("FIBSEM_SIM_NO_DELAY", "1")
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    return microscope
+
+
+@pytest.fixture
+def host(tmp_path, microscope):
+    host = Host()
+    exp = Experiment(path=tmp_path / "exp", name="router-exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    (tmp_path / "exp").mkdir(parents=True, exist_ok=True)
+    exp.add_new_lamella(MicroscopeState(), EventedDict())
+    host.experiment = exp
+    host.microscope = microscope
+    return host
+
+
+@pytest.fixture
+def client(microscope, host):
+    app = build_server(
+        microscope, app_context=AgentContext(host), auth=AuthConfig(token=TOKEN)
+    )
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+
+
+def test_capabilities_reports_the_app_router(client):
+    body = client.get("/capabilities", headers=AUTH).json()
+    assert body["routers"] == {"microscope": True, "app": True}
+
+
+def test_without_app_context_the_routes_do_not_exist(microscope):
+    app = build_server(microscope, auth=AuthConfig(token=TOKEN))
+    with TestClient(app, raise_server_exceptions=False) as bare:
+        assert bare.get("/capabilities", headers=AUTH).json()["routers"]["app"] is False
+        assert bare.get("/app/status", headers=AUTH).status_code == 404
+
+
+def test_app_routes_require_a_token(client):
+    assert client.get("/app/status").status_code == 401
+
+
+def test_status_and_queue_over_http(client):
+    status = client.get("/app/status", headers=AUTH).json()
+    assert status["experiment"]["name"] == "router-exp"
+    assert status["workflow"]["running"] is False
+    queue = client.get("/app/queue", headers=AUTH).json()
+    assert queue["available"] is False  # no run yet
+
+
+def test_task_outputs_round_trip(client, host):
+    name = host.experiment.positions[0].name
+    payload = client.get(f"/app/task_outputs/{name}", headers=AUTH).json()
+    assert payload["available"] is True
+    assert payload["item_name"] == name
+    missing = client.get("/app/task_outputs/nope", headers=AUTH).json()
+    assert missing["available"] is False
+
+
+def test_summaries_and_protocol_over_http(client):
+    for path in ("/app/experiment_summary", "/app/task_history", "/app/protocol"):
+        body = client.get(path, headers=AUTH).json()
+        assert body["available"] is True, path
+    assert client.get("/app/run_summary", headers=AUTH).json()["available"] is False
+
+
+def test_sidecar_grows_the_app_tools_from_capabilities(client):
+    pytest.importorskip("mcp")
+    from fibsem.mcp.sidecar import build_sidecar
+    from fibsem.server.catalog import CATALOG
+
+    client.headers["Authorization"] = f"Bearer {TOKEN}"
+    capabilities = client.get("/capabilities").json()
+    sidecar = build_sidecar(client, capabilities)
+    listed = asyncio.run(sidecar.list_tools())
+    names = {t.name for t in getattr(listed, "tools", listed)}
+    assert {t.name for t in CATALOG if t.router == "app"} <= names
+
+    result = asyncio.run(sidecar.call_tool("get_app_status", {}))
+    if isinstance(result, tuple):
+        result = result[0]
+    contents = list(getattr(result, "content", result))
+    text = "".join(getattr(c, "text", "") for c in contents)
+    assert "router-exp" in text

--- a/tests/server/test_catalog_discovery.py
+++ b/tests/server/test_catalog_discovery.py
@@ -23,7 +23,19 @@ from fibsem.server.discovery import (  # noqa: E402
 def app():
     os.environ.setdefault("FIBSEM_SIM_NO_DELAY", "1")
     microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
-    return build_server(microscope, auth=AuthConfig(token="t"))
+    # Mounted with a real (empty-host) AgentContext so the contract test can
+    # prove the app-router catalog entries dispatch too.
+    from fibsem.applications.autolamella.server import AgentContext
+
+    class _Host:
+        experiment = None
+        microscope = None
+        _task_manager = None
+        is_workflow_running = False
+
+    return build_server(
+        microscope, app_context=AgentContext(_Host()), auth=AuthConfig(token="t")
+    )
 
 
 def test_every_catalog_entry_is_a_real_route(app):

--- a/tests/server/test_server_factory.py
+++ b/tests/server/test_server_factory.py
@@ -180,11 +180,6 @@ def test_milling_angle_boundary_is_degrees(armed_client):
     assert body["milling_angle_deg"] == pytest.approx(15.0, abs=0.5)
 
 
-def test_app_context_not_implemented_yet(microscope):
-    with pytest.raises(NotImplementedError):
-        build_server(microscope, app_context=object())
-
-
 def test_fibsem_server_defaults_to_localhost(microscope):
     server = FibsemServer(microscope)
     assert server.host == "127.0.0.1"

--- a/tests/server/test_sidecar.py
+++ b/tests/server/test_sidecar.py
@@ -33,14 +33,14 @@ def _make_client(arm_hardware):
     return client
 
 
-def _scopes(client):
-    return client.get("/capabilities").json()["scopes"]
+def _capabilities(client):
+    return client.get("/capabilities").json()
 
 
 @pytest.fixture(scope="module")
 def armed_sidecar():
     client = _make_client(arm_hardware=True)
-    return build_sidecar(client, _scopes(client))
+    return build_sidecar(client, _capabilities(client))
 
 
 def _tool_names(sidecar):
@@ -48,15 +48,19 @@ def _tool_names(sidecar):
     return {t.name for t in getattr(listed, "tools", listed)}
 
 
-def test_armed_sidecar_registers_the_full_catalog(armed_sidecar):
-    assert _tool_names(armed_sidecar) == {t.name for t in CATALOG}
+def test_armed_sidecar_registers_the_full_microscope_catalog(armed_sidecar):
+    # No app_context on this server, so app tools must not register even armed.
+    expected = {t.name for t in CATALOG if t.router == "microscope"}
+    assert _tool_names(armed_sidecar) == expected
 
 
 def test_read_only_sidecar_registers_read_tools_only():
     client = _make_client(arm_hardware=False)
-    sidecar = build_sidecar(client, _scopes(client))
+    sidecar = build_sidecar(client, _capabilities(client))
     names = _tool_names(sidecar)
-    assert names == {t.name for t in CATALOG if t.scope == "read"}
+    assert names == {
+        t.name for t in CATALOG if t.scope == "read" and t.router == "microscope"
+    }
     assert "stop_milling" in names
     assert "acquire_image_preview" not in names
 
@@ -88,7 +92,10 @@ def test_hardware_refusal_is_readable_text_not_an_error():
     # Registered tools + unarmed server = the server refuses; the agent should
     # see the structured refusal as text, not a raised exception.
     read_client = _make_client(arm_hardware=False)
-    armed_shape = {"read": True, "control": False, "hardware": True}
+    armed_shape = {
+        "scopes": {"read": True, "control": False, "hardware": True},
+        "routers": {"microscope": True, "app": False},
+    }
     sidecar = build_sidecar(read_client, armed_shape)
     result = asyncio.run(sidecar.call_tool("move_stage_relative", {"dx": 1e-6}))
     text = "".join(getattr(c, "text", "") for c in _contents(result))


### PR DESCRIPTION
Stacked on #651. The slice that turns the facade into reachable tools — after this, only the Qt hosting (preference flag, arming, dialog) stands between an agent and a live experiment.

## What

- `fibsem/server/app_routes.py`: the `AppContext` protocol (structural — `fibsem/server` still never imports the application) + a thin read-scope router: `/app/status`, `/app/queue`, `/app/experiment_summary`, `/app/task_history`, `/app/run_summary`, `/app/protocol`, `/app/task_outputs/{item_name}`, `/app/recent_experiments`
- `build_server(app_context=...)` mounts it (auth applied at the include, so scope enforcement stays in one place) and `/capabilities` flips `routers.app`
- Catalog gains a `router` dimension + 8 app `ToolSpec`s (23 tools total); `tools_for_capabilities` filters on scope **and** mounted router
- The sidecar switches to capability-driven registration — pointed at an app-hosted server it grows the app tools with **zero sidecar changes**; pointed at a bench server they simply don't exist

## Verification

8 new tests in `test_app_router.py` driving a real `AgentContext` over a real `Experiment` through the mounted server: capabilities flip both ways, 404-without-context, 401-without-token, status/queue/summaries/task-outputs over HTTP, and the full MCP path (`get_app_status` through `call_tool` returns the real experiment name). Contract test now proves the app catalog entries dispatch too. 51 tests across `tests/server/` + the context suites, all green; ruff clean. One test removed: the `NotImplementedError` pin this PR deliberately obsoletes.