### PR TITLE
[app] Add the event buffer: typed signals and hooks become a pollable stream

### DIFF
--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -67,8 +67,9 @@ def _records(df) -> List[Dict[str, Any]]:
 class AgentContext:
     """Read-only facade over a running (or resting) AutoLamella session."""
 
-    def __init__(self, host):
+    def __init__(self, host, event_buffer=None):
         self._host = host
+        self._event_buffer = event_buffer
 
     # --- call-time resolution: never cache what the app rebinds ---------------
 
@@ -239,6 +240,20 @@ class AgentContext:
         if cached is None:
             return {"available": False, "position": None}
         return {"available": True, "position": cached.to_dict()}
+
+    # --- events -----------------------------------------------------------------
+
+    def events(self, since: int = 0, timeout: float = 0.0) -> Dict[str, Any]:
+        """Events after ``since``, parking up to ``timeout`` seconds for news.
+
+        Unavailable (rather than empty) when the hosting wired no buffer, so a
+        client can tell "no events yet" from "this server has no event stream".
+        """
+        from fibsem.applications.autolamella.server.events import (
+            buffer_or_unavailable,
+        )
+
+        return buffer_or_unavailable(self._event_buffer, since=since, timeout=timeout)
 
     # --- discovery --------------------------------------------------------------
 

--- a/fibsem/applications/autolamella/server/events.py
+++ b/fibsem/applications/autolamella/server/events.py
@@ -1,0 +1,227 @@
+"""The event buffer: a bounded in-memory log adapting push to pull.
+
+Events are born on worker threads — the microscope's psygnal signals fire
+mid-mill, the hook system fires as tasks finish — but agents consume over
+HTTP, whenever they next ask. This module is the adapter between those two
+tempos: taps subscribe to each source and drop plain-data records into a
+bounded, sequence-numbered buffer; the ``/app/events`` long-poll drains it.
+
+Rules the taps live by:
+
+* **Copy, serialize, return.** psygnal subscribers run synchronously on the
+  emitting thread (the documented THREADING CONTRACT) — a slow tap literally
+  slows the mill. Serialization to plain dicts happens immediately, and
+  nothing downstream ever holds a live object.
+* **No Qt, ever.** Taps run on whatever thread emits; the process disables
+  automatic GC precisely because off-thread Qt finalization crashes.
+* **Metadata, not pixels.** Acquisition events carry beam/field-of-view/shape;
+  the images themselves are fetched through the preview endpoints on demand.
+  Known upstream gap: the acquisition signals fire only from the streaming
+  live-view worker -- a one-shot ``acquire_image`` emits nothing on them, so
+  single-shot acquisitions are invisible to this stream until that changes.
+
+Sequence numbers make polling honest: a client asks for everything after seq
+N, and if eviction has eaten past N the response's ``oldest_available`` says
+so — a visible gap instead of silent continuity.
+
+Wiring that deliberately does NOT live here (it belongs to the embedded
+hosting, FIB-845): constructing the buffer in the app, attaching the
+microscope taps at connect time, and re-registering the lifecycle hook inside
+``setup_hooks()`` — the app rebuilds its hook set every run, so a
+once-at-startup registration silently goes deaf after the first run.
+"""
+
+import dataclasses
+import threading
+import time
+from collections import deque
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+__all__ = [
+    "EventBuffer",
+    "attach_microscope_taps",
+    "make_lifecycle_hook",
+    "to_plain",
+]
+
+
+def to_plain(value: Any) -> Any:
+    """Recursively convert a typed record into JSON-able plain data."""
+    # Enum before str: str-enums (MillingProgressStatus et al.) must serialize
+    # as their wire value ("stage-update"), the vocabulary consumers already
+    # parse — not the Python member name.
+    if isinstance(value, Enum):
+        return value.value if isinstance(value.value, str) else value.name
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {
+            f.name: to_plain(getattr(value, f.name)) for f in dataclasses.fields(value)
+        }
+    if isinstance(value, dict):
+        return {str(k): to_plain(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [to_plain(v) for v in value]
+    if hasattr(value, "to_dict"):
+        return to_plain(value.to_dict())
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    if hasattr(value, "item") and not isinstance(value, bytes):
+        try:  # numpy scalars
+            return to_plain(value.item())
+        except (AttributeError, ValueError):
+            pass
+    return str(value)
+
+
+class EventBuffer:
+    """Bounded, sequence-numbered, thread-safe event log with long-poll wait."""
+
+    def __init__(self, maxlen: int = 1000):
+        self._events: "deque[Dict[str, Any]]" = deque(maxlen=maxlen)
+        self._seq = 0
+        self._cond = threading.Condition()
+
+    def append(self, kind: str, payload: Dict[str, Any]) -> int:
+        """Record one event. Cheap and non-blocking; safe from any thread."""
+        with self._cond:
+            self._seq += 1
+            self._events.append(
+                {
+                    "seq": self._seq,
+                    "timestamp": time.time(),
+                    "kind": kind,
+                    "payload": payload,
+                }
+            )
+            self._cond.notify_all()
+            return self._seq
+
+    def events_since(self, since: int = 0) -> Dict[str, Any]:
+        with self._cond:
+            events = [e for e in self._events if e["seq"] > since]
+            oldest = self._events[0]["seq"] if self._events else None
+        return {
+            "available": True,
+            "events": events,
+            "latest_seq": self._seq,
+            # A client that asked for `since < oldest_available - 1` missed
+            # evicted events: re-snapshot state rather than assume continuity.
+            "oldest_available": oldest,
+        }
+
+    def wait_for(self, since: int = 0, timeout: float = 0.0) -> Dict[str, Any]:
+        """events_since, but park up to ``timeout`` seconds for something new."""
+        deadline = time.monotonic() + max(0.0, timeout)
+        with self._cond:
+            while self._seq <= since:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._cond.wait(remaining)
+        return self.events_since(since)
+
+
+# --- taps: the sources feeding the buffer ------------------------------------------
+
+
+def _image_metadata(image: Any) -> Dict[str, Any]:
+    """Metadata-only record of an acquisition; pixels never enter the buffer."""
+    payload: Dict[str, Any] = {
+        "shape": list(getattr(image, "data", None).shape)
+        if getattr(image, "data", None) is not None
+        else None,
+        "beam_type": None,
+        "hfw": None,
+    }
+    metadata = getattr(image, "metadata", None)
+    settings = getattr(metadata, "image_settings", None) if metadata else None
+    if settings is not None:
+        beam_type = getattr(settings, "beam_type", None)
+        payload["beam_type"] = beam_type.name if beam_type is not None else None
+        payload["hfw"] = to_plain(getattr(settings, "hfw", None))
+    return payload
+
+
+def attach_microscope_taps(buffer: EventBuffer, microscope) -> List[Callable[[], None]]:
+    """Subscribe the buffer to a microscope's progress signals.
+
+    Returns disposer callables (one per tap) so a hosting can detach cleanly.
+    Every callback serializes immediately and returns — nothing blocks the
+    emitting thread beyond building one small dict.
+    """
+    disposers: List[Callable[[], None]] = []
+
+    def tap(signal, kind: str, serialize: Callable[[Any], Dict[str, Any]]):
+        def callback(value):
+            buffer.append(kind, serialize(value))
+
+        signal.connect(callback)
+        disposers.append(lambda: signal.disconnect(callback))
+
+    tap(microscope.milling_progress_signal, "milling_progress", to_plain)
+    tap(microscope.spot_burn_progress_signal, "spot_burn_progress", to_plain)
+    tap(microscope.tiled_acquisition_signal, "tiled_acquisition", to_plain)
+    tap(
+        microscope.stage_position_changed,
+        "stage_position_changed",
+        lambda position: {"position": to_plain(position.to_dict())},
+    )
+    tap(microscope.sem_acquisition_signal, "sem_acquisition", _image_metadata)
+    tap(microscope.fib_acquisition_signal, "fib_acquisition", _image_metadata)
+
+    fm = getattr(microscope, "fm", None)
+    if fm is not None:
+        tap(fm.acquisition_progress_signal, "fm_acquisition_progress", to_plain)
+
+    return disposers
+
+
+def make_lifecycle_hook(buffer: EventBuffer):
+    """A FunctionHook feeding workflow lifecycle events into the buffer.
+
+    Must be registered per run (the app rebuilds its HookManager in
+    setup_hooks each run); HookContext already deep-copies task_state, so
+    serializing here reads a stable snapshot.
+    """
+    from fibsem.hooks import FunctionHook, HookContext, HookEvent
+
+    def callback(context: "HookContext") -> None:
+        task_state = getattr(context, "task_state", None)
+        buffer.append(
+            context.event,
+            {
+                "task_name": context.task_name,
+                "task_type": context.task_type,
+                "item_name": context.item_name,
+                "item_id": context.item_id,
+                "task_id": context.task_id,
+                "experiment_id": context.experiment_id,
+                "experiment_name": context.experiment_name,
+                "tasks_remaining": context.tasks_remaining,
+                "tasks_total": context.tasks_total,
+                "error": context.error,
+                "skip_reason": context.skip_reason,
+                "timestamp": to_plain(context.timestamp),
+                "task_state": to_plain(task_state) if task_state is not None else None,
+            },
+        )
+
+    # An empty subscription list matches nothing, so name every event: the
+    # buffer is the one consumer that genuinely wants the whole lifecycle.
+    return FunctionHook(callback=callback, events=[e.value for e in HookEvent])
+
+
+def buffer_or_unavailable(
+    buffer: Optional[EventBuffer], since: int, timeout: float
+) -> Dict[str, Any]:
+    """The facade-facing read: tolerate a hosting that wired no buffer."""
+    if buffer is None:
+        return {
+            "available": False,
+            "events": [],
+            "latest_seq": None,
+            "oldest_available": None,
+        }
+    return buffer.wait_for(since=since, timeout=timeout)

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -252,6 +252,9 @@ def build_sidecar(client, capabilities):
     def list_recent_experiments():
         return _app_get("/app/recent_experiments")
 
+    def get_events(since: int = 0, timeout: float = 0.0):
+        return _app_get(f"/app/events?since={since}&timeout={timeout}")
+
     implementations = {
         fn.__name__: fn
         for fn in (
@@ -278,6 +281,7 @@ def build_sidecar(client, capabilities):
             get_protocol,
             get_task_outputs,
             list_recent_experiments,
+            get_events,
         )
     }
     # The catalog is the contract: refuse to start with an implementation gap.

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -43,6 +43,8 @@ class AppContext(Protocol):
 
     def recent_experiments(self) -> List[Dict[str, Any]]: ...
 
+    def events(self, since: int = 0, timeout: float = 0.0) -> Dict[str, Any]: ...
+
 
 def build_app_router(context: AppContext) -> APIRouter:
     router = APIRouter(prefix="/app")
@@ -78,5 +80,12 @@ def build_app_router(context: AppContext) -> APIRouter:
     @router.get("/recent_experiments")
     def recent_experiments():
         return {"items": context.recent_experiments()}
+
+    @router.get("/events")
+    def events(since: int = 0, timeout: float = 0.0):
+        # A long-poll: parks up to `timeout` seconds waiting for news. Capped
+        # here because the park occupies a threadpool worker — a transport
+        # concern, so the transport owns the ceiling.
+        return context.events(since=since, timeout=min(max(timeout, 0.0), 30.0))
 
     return router

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -214,6 +214,18 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         params={"item_name": "the item (lamella) name"},
     ),
     ToolSpec(
+        name="get_events",
+        description="Events after a sequence number: milling/acquisition progress, stage moves, task lifecycle. Long-polls up to timeout seconds.",
+        method="GET",
+        path="/app/events",
+        scope="read",
+        router="app",
+        params={
+            "since": "return events with seq greater than this (0 for all held)",
+            "timeout": "seconds to wait for new events before returning (max 30)",
+        },
+    ),
+    ToolSpec(
         name="list_recent_experiments",
         description="Recently opened experiments on this machine, without loading them.",
         method="GET",

--- a/tests/server/test_app_router.py
+++ b/tests/server/test_app_router.py
@@ -52,9 +52,18 @@ def host(tmp_path, microscope):
 
 
 @pytest.fixture
-def client(microscope, host):
+def event_buffer():
+    from fibsem.applications.autolamella.server.events import EventBuffer
+
+    return EventBuffer()
+
+
+@pytest.fixture
+def client(microscope, host, event_buffer):
     app = build_server(
-        microscope, app_context=AgentContext(host), auth=AuthConfig(token=TOKEN)
+        microscope,
+        app_context=AgentContext(host, event_buffer=event_buffer),
+        auth=AuthConfig(token=TOKEN),
     )
     with TestClient(app, raise_server_exceptions=False) as client:
         yield client
@@ -118,3 +127,26 @@ def test_sidecar_grows_the_app_tools_from_capabilities(client):
     contents = list(getattr(result, "content", result))
     text = "".join(getattr(c, "text", "") for c in contents)
     assert "router-exp" in text
+
+
+def test_events_long_poll_over_http(client, event_buffer):
+    empty = client.get("/app/events?since=0&timeout=0", headers=AUTH).json()
+    assert empty["available"] is True
+    assert empty["events"] == []
+
+    event_buffer.append("milling_progress", {"stage_name": "Rough Mill 01"})
+    body = client.get("/app/events?since=0", headers=AUTH).json()
+    assert body["latest_seq"] == 1
+    assert body["events"][0]["kind"] == "milling_progress"
+
+    caught_up = client.get("/app/events?since=1&timeout=0", headers=AUTH).json()
+    assert caught_up["events"] == []
+
+
+def test_events_unavailable_without_a_buffer(microscope, host):
+    app = build_server(
+        microscope, app_context=AgentContext(host), auth=AuthConfig(token=TOKEN)
+    )
+    with TestClient(app, raise_server_exceptions=False) as bare:
+        body = bare.get("/app/events", headers=AUTH).json()
+    assert body["available"] is False

--- a/tests/server/test_event_buffer.py
+++ b/tests/server/test_event_buffer.py
@@ -1,0 +1,198 @@
+"""The event buffer: sequence/eviction semantics, the long-poll, and the taps
+fed by real signals — the Demo microscope's psygnal emissions and a real
+HookManager firing lifecycle events."""
+
+import json
+import os
+import threading
+import time
+
+import pytest
+
+from fibsem.applications.autolamella.server.events import (
+    EventBuffer,
+    attach_microscope_taps,
+    make_lifecycle_hook,
+    to_plain,
+)
+
+
+def test_sequences_are_monotonic_and_filterable():
+    buffer = EventBuffer()
+    for i in range(5):
+        buffer.append("tick", {"i": i})
+    result = buffer.events_since(3)
+    assert [e["seq"] for e in result["events"]] == [4, 5]
+    assert result["latest_seq"] == 5
+    assert result["oldest_available"] == 1
+    json.dumps(result)
+
+
+def test_eviction_is_a_visible_gap_not_silent_continuity():
+    buffer = EventBuffer(maxlen=3)
+    for i in range(10):
+        buffer.append("tick", {"i": i})
+    result = buffer.events_since(0)
+    # A client that was at seq 0 can SEE it missed 1..7: oldest_available says so.
+    assert result["oldest_available"] == 8
+    assert [e["seq"] for e in result["events"]] == [8, 9, 10]
+
+
+def test_long_poll_wakes_on_append():
+    buffer = EventBuffer()
+
+    def late_append():
+        time.sleep(0.15)
+        buffer.append("news", {"n": 1})
+
+    thread = threading.Thread(target=late_append, daemon=True)
+    start = time.monotonic()
+    thread.start()
+    result = buffer.wait_for(since=0, timeout=5.0)
+    waited = time.monotonic() - start
+    assert [e["kind"] for e in result["events"]] == ["news"]
+    assert waited < 2.0  # woke on the append, not the timeout
+
+
+def test_long_poll_times_out_empty():
+    buffer = EventBuffer()
+    start = time.monotonic()
+    result = buffer.wait_for(since=0, timeout=0.2)
+    assert result["events"] == []
+    assert 0.15 <= time.monotonic() - start < 2.0
+
+
+def test_appends_from_many_threads_never_lose_or_duplicate_a_seq():
+    buffer = EventBuffer(maxlen=5000)
+    threads = [
+        threading.Thread(
+            target=lambda: [buffer.append("t", {}) for _ in range(200)], daemon=True
+        )
+        for _ in range(5)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    result = buffer.events_since(0)
+    seqs = [e["seq"] for e in result["events"]]
+    assert seqs == list(range(1, 1001))
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    os.environ.setdefault("FIBSEM_SIM_NO_DELAY", "1")
+    from fibsem import utils
+
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    return microscope
+
+
+def test_microscope_taps_capture_real_emissions(microscope):
+    from fibsem.structures import BeamType
+
+    buffer = EventBuffer()
+    disposers = attach_microscope_taps(buffer, microscope)
+    try:
+        # A real image through the real signal. Note: one-shot acquire_image
+        # does NOT emit on the acquisition signals today -- only the streaming
+        # worker does (a documented upstream gap) -- so the test emits the way
+        # the worker would, with a genuinely acquired image.
+        image = microscope.acquire_image(beam_type=BeamType.ION)
+        microscope.fib_acquisition_signal.emit(image)
+        from fibsem.structures import FibsemStagePosition
+
+        microscope.move_stage_relative(
+            FibsemStagePosition(
+                x=1e-6, y=0.0, z=0.0, r=0.0, t=0.0, coordinate_system="RAW"
+            )
+        )
+        result = buffer.events_since(0)
+        kinds = [e["kind"] for e in result["events"]]
+        assert "fib_acquisition" in kinds
+        assert "stage_position_changed" in kinds
+        acquisition = next(
+            e for e in result["events"] if e["kind"] == "fib_acquisition"
+        )
+        assert acquisition["payload"]["beam_type"] == "ION"
+        assert acquisition["payload"]["shape"] is not None
+        assert "image_b64" not in json.dumps(acquisition)  # metadata, never pixels
+        json.dumps(result)
+    finally:
+        for dispose in disposers:
+            dispose()
+
+
+def test_disposers_detach_the_taps(microscope):
+    from fibsem.structures import BeamType
+
+    buffer = EventBuffer()
+    for dispose in attach_microscope_taps(buffer, microscope):
+        dispose()
+    image = microscope.acquire_image(beam_type=BeamType.ION)
+    microscope.fib_acquisition_signal.emit(image)
+    assert buffer.events_since(0)["events"] == []
+
+
+def test_typed_milling_progress_serializes_through_the_real_signal(microscope):
+    from fibsem.milling.progress import MillingProgress, MillingProgressStatus
+
+    buffer = EventBuffer()
+    disposers = attach_microscope_taps(buffer, microscope)
+    try:
+        microscope.milling_progress_signal.emit(
+            MillingProgress(
+                status=MillingProgressStatus.STAGE_UPDATE,
+                stage_name="Rough Mill 01",
+                current_stage=0,
+                total_stages=2,
+                remaining_time=42.0,
+            )
+        )
+        event = buffer.events_since(0)["events"][-1]
+        assert event["kind"] == "milling_progress"
+        assert event["payload"]["status"] == MillingProgressStatus.STAGE_UPDATE.value
+        assert event["payload"]["stage_name"] == "Rough Mill 01"
+        assert event["payload"]["remaining_time"] == 42.0
+        json.dumps(event)
+    finally:
+        for dispose in disposers:
+            dispose()
+
+
+def test_lifecycle_hook_feeds_the_buffer_through_a_real_hook_manager():
+    from fibsem.hooks import HookContext, HookEvent, HookManager
+
+    buffer = EventBuffer()
+    manager = HookManager()
+    manager.register(make_lifecycle_hook(buffer))
+    manager.fire(
+        HookContext(
+            event=HookEvent.TASK_COMPLETED.value,
+            task_name="Rough Milling",
+            item_name="sunny-mole",
+            tasks_remaining=3,
+        )
+    )
+    event = buffer.events_since(0)["events"][0]
+    assert event["kind"] == "task_completed"
+    assert event["payload"]["item_name"] == "sunny-mole"
+    assert event["payload"]["tasks_remaining"] == 3
+    assert "lamella_name" not in event["payload"]
+    json.dumps(event)
+
+
+def test_to_plain_handles_the_awkward_types():
+    import numpy as np
+
+    from fibsem.milling.progress import MillingProgressStatus
+
+    assert (
+        to_plain(MillingProgressStatus.TASK_STARTED)
+        == MillingProgressStatus.TASK_STARTED.value
+    )
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
+
+    assert to_plain(AutoLamellaTaskStatus.InProgress) == "InProgress"
+    assert to_plain(np.float64(1.5)) == 1.5
+    assert to_plain({"a": (1, 2)}) == {"a": [1, 2]}


### PR DESCRIPTION
Stacked on #655. FIB-847's buildable core — the app wiring (three lines in the hosting) lands with FIB-845.

## What

- `events.py`: `EventBuffer` (bounded deque + monotonic seq + Condition), `attach_microscope_taps` (milling/spot/tiled/stage/acquisition/FM signals → plain dicts, with disposers), `make_lifecycle_hook` (a FunctionHook subscribed to all ten events — an empty subscription list matches nothing, learned the careful way)
- `AgentContext.events(since, timeout)` + `GET /app/events` long-poll (timeout capped at 30 s server-side), `get_events` in the catalog → the sidecar picks it up automatically (24 tools now)
- str-enums serialize as their **wire value** (`stage-update`), matching the typed contracts' vocabulary

## How it works, in plain language

Events are born on worker threads (a mill emits progress mid-burn; hooks fire as tasks finish) but agents consume over HTTP, whenever they next ask. The buffer is the adapter between those tempos: a short in-memory log where writers drop facts instantly and readers fetch "everything after sequence N". The *long-poll* is the one trick: if nothing is newer than N, the request parks (a `threading.Condition`) until something arrives or the timeout lapses — push-like latency over plain request/response, no WebSockets needed. Sequence numbers keep polling honest: when old events are evicted, the reply's `oldest_available` makes the gap visible so a client re-snapshots instead of assuming continuity.

## Found while testing (documented, not fixed here)

The `sem/fib_acquisition_signal`s fire **only from the streaming live-view worker** — a one-shot `acquire_image` emits nothing on them, so single-shot acquisitions are invisible to any event stream until upstream emits there. Joins the known-gaps list (manual widget actions carry no lifecycle framing; pose edits emit nothing anywhere).

## Verification

10 buffer tests: seq/eviction semantics, long-poll wake vs timeout, 1000 appends from 5 threads with no lost/duplicate seq, real Demo emissions through real psygnal signals (typed `MillingProgress` round-trip, metadata-not-pixels assertion, disposer detach), a real `HookManager` firing into the FunctionHook. Plus HTTP long-poll + no-buffer-unavailable tests on the app router. 63 tests green across the server suites; ruff clean.