### PR TITLE
[fix] Supervised spot burn crashes the app: one dict-era line survived the typed progress signal

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -80,6 +80,7 @@ from fibsem.applications.autolamella.workflows.workflow_estimate import (
     estimate_addition,
     estimate_workflow,
 )
+from fibsem.imaging.spot import SpotBurnProgress
 from fibsem.imaging.tiling.progress import TiledProgress, TiledStatus
 from fibsem.milling.progress import (
     MillingMessageTracker,
@@ -1601,10 +1602,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
                 self.milling_progress_bar.setFormat(label)
 
     @ensure_main_thread
-    def _on_spot_burn_progress(self, ddict: dict) -> None:
+    def _on_spot_burn_progress(self, report: SpotBurnProgress) -> None:
         """Handle spot burn progress updates from the microscope (supervised + unsupervised)."""
-        self.progress_widget.update_progress(build_spot_burn_progress_update(ddict))
-        if ddict.get("finished"):
+        self.progress_widget.update_progress(build_spot_burn_progress_update(report))
+        if report.status.is_terminal:
             # hide the Done/Failed state after a moment; reset_if_finished leaves the
             # widget alone if another operation has started rendering progress since
             QTimer.singleShot(2000, self.progress_widget.reset_if_finished)

--- a/tests/ui/test_mainui_workflow_status.py
+++ b/tests/ui/test_mainui_workflow_status.py
@@ -33,6 +33,7 @@ from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
 from fibsem.applications.autolamella.workflows.tasks.status import (
     WorkflowStatusUpdate,
 )
+from fibsem.imaging.spot import SpotBurnProgress, SpotBurnStatus
 
 
 @pytest.fixture(scope="module")
@@ -117,3 +118,46 @@ def test_a_lifecycle_report_flips_the_run_button_to_stop(main_ui):
 
     assert main_ui.stop_workflow_btn.isVisibleTo(main_ui)
     assert not main_ui.run_workflow_btn.isVisibleTo(main_ui)
+
+
+# --- spot burn progress ----------------------------------------------------
+#
+# The same slot, reached by a different signal. `spot_burn_progress_signal` was typed
+# in #595, and the main window's handler kept one line that read the report as the dict
+# it used to be -- `ddict.get("finished")`. `SpotBurnProgress` is a frozen dataclass with
+# no `.get`, so the first report of every supervised burn raised AttributeError inside a
+# queued slot, which PyQt5 turns into a process abort: the application vanished the
+# moment burning started, on v0.5.2rc1.
+#
+# Both tests below fail on that line, and neither needs hardware: the handler is called
+# directly, exactly as the queued connection would call it.
+
+
+def test_a_burning_report_renders_without_taking_the_app_down(main_ui):
+    """The crash. Reaching the assertion at all is most of what this tests."""
+    report = SpotBurnProgress(
+        status=SpotBurnStatus.BURNING,
+        current_point=2,
+        total_points=5,
+        total_remaining_time=30.0,
+        total_estimated_time=50.0,
+    )
+
+    main_ui._on_spot_burn_progress(report)
+
+    assert main_ui.progress_widget.isVisibleTo(main_ui)
+
+
+def test_a_terminal_report_is_recognised_as_terminal(main_ui):
+    """The other half of the same line: `.get("finished")` decided when to schedule the
+    bar's reset, so a fix that stopped the crash but misread the outcome would leave the
+    bar full forever. Read through `status.is_terminal`, which is what both consumers of
+    this signal use."""
+    main_ui._on_spot_burn_progress(
+        SpotBurnProgress(
+            status=SpotBurnStatus.FINISHED, current_point=5, total_points=5
+        )
+    )
+
+    assert SpotBurnStatus.FINISHED.is_terminal
+    assert not SpotBurnStatus.BURNING.is_terminal


### PR DESCRIPTION
Running a spot burn in **supervised mode** crashes the whole application the moment burning starts, on v0.5.2rc1.

## Cause

The spot-burn progress signal was typed in #595 (`Signal(SpotBurnProgress)`), and `build_spot_burn_progress_update` was migrated with it — but the main window's slot kept one dict-era line:

```python
if ddict.get("finished"):
```

`SpotBurnProgress` is a frozen dataclass with no `.get`, so the first progress report raises `AttributeError` inside a queued slot, which PyQt5 turns into a process abort. Reproduced in the simulator: add spots on the supervised Spot Burn step, press Run Spot Burn, app gone.

## Fix

Read `report.status.is_terminal` — the same property `build_spot_burn_progress_update` already uses, and the one place the four statuses are interpreted.

Checked for a second site: `FibsemSpotBurnWidget._update_progress_bar` still *names* its parameter `ddict`, but only passes it through to the typed builder, so it was never broken. The stale name is worth a follow-up, not a fix here.

## Retargeted to main

This PR originally targeted `release/v0.5.2`. Two things were wrong with that:

- **`main` has the identical crash.** Fixing only the release branch would have left every release after v0.5.2 shipping it again, since the branch is abandoned once v0.5.2 is out.
- **It had no CI whatsoever** — zero checks. `release/v0.5.2` was cut before #608 added `release/**` to the workflow filters, so the `pull_request` trigger never matched.

It now targets `main`, gets full CI, and gets cherry-picked onto `release/v0.5.2` for the release.

## Tests

Deferred in the original because `tests/ui/test_mainui_workflow_status.py` (#638) does not exist at rc1. It exists on `main`, so they ride with the fix now.

Both **fail on the broken line and pass with the fix** — verified by restoring `report.get("finished")` in `_on_spot_burn_progress` alone and re-running: 2 failed, 4 passed. The first asserts almost nothing on purpose; reaching the assertion at all is the regression. The second covers the other half of that line, which also decided when to schedule the bar's reset — a fix that stopped the crash while misreading the outcome would leave the bar full forever.

That file already builds the real main window offscreen, and its module docstring already describes this exact mechanism.

Release-Note: Fixed a crash that took the application down when a spot burn started in supervised mode.