### PR TITLE
[refactor] Give fire-and-forget status its own signal and typed event

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -72,6 +72,7 @@ from fibsem.applications.autolamella.ui.workflow_timeline_widget import (
 )
 from fibsem.applications.autolamella.workflows.tasks.queue import QueueOp, QueueResult
 from fibsem.applications.autolamella.workflows.tasks.status import (
+    WorkflowStatusEvent,
     WorkflowStatusUpdate,
 )
 from fibsem.applications.autolamella.workflows.tasks.tasks import get_task_supervision
@@ -454,6 +455,11 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self._user_interaction_sound_played = False  # Track if sound was played
         self._sound_enabled = self._preferences.display.sound_enabled
         self._border_enabled = self._preferences.display.border_enabled
+        # First assigned here rather than on the Run click: the workflow handlers
+        # read it unconditionally, and an AttributeError in a queued slot is a
+        # process abort (FIB-329), not a missing border. The attribute alone -- the
+        # frame is unstyled until _set_border_state changes it, which is idle's look.
+        self._border_state = "idle"
         self.dev_mode = self._preferences.display.dev_mode
 
         # create menus, status bar, and tabs
@@ -1719,6 +1725,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         # Connect to workflow update signal from AutoLamellaUI
         self.autolamella_ui.workflow_update_signal.connect(self._on_workflow_update)
+        self.autolamella_ui.workflow_status_signal.connect(self._on_workflow_status)
         self.autolamella_ui.queue_changed_signal.connect(self._on_queue_changed)
         self.autolamella_ui.step_update_signal.connect(self._on_step_update)
         self.autolamella_ui.experiment_update_signal.connect(self._on_experiment_update)
@@ -2613,106 +2620,100 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if message and self.status_bar is not None:
             self.status_bar.showMessage(message, 4000)
 
-    def _on_workflow_update(self, info: dict):
-        """Handle workflow update signal and update the workflow status bar."""
-        t0 = t1 = time.time()
-        timings = {}
+    def _on_workflow_status(self, event: "WorkflowStatusEvent"):
+        """Handle a fire-and-forget status update, from workflow_status_signal.
 
+        The status half of what _on_workflow_update used to do, on the notification
+        channel. The run indicators refresh from both handlers because both kinds of
+        traffic change what they show: a lifecycle report starts or finishes the
+        run, an instruction or question flips the waiting state.
+        """
+        # transient status-bar messages (e.g. scheduled-start countdown)
+        if event.status_bar is not None and self.status_bar is not None:
+            self.status_bar.showMessage(event.status_bar)
+
+        if event.report is not None:
+            self._apply_status_report(event.report)
+
+        if self.autolamella_ui is None:
+            return
+        self._refresh_workflow_indicators()
+
+    def _apply_status_report(self, report: "WorkflowStatusUpdate") -> None:
+        """Render one task-lifecycle report: timeline, run message, list refreshes."""
+        # No build-once guard: update_from_status reconciles rows against the
+        # snapshot by WorkItem id, so first paint and every later change go
+        # through the same path.
+        self.workflow_timeline.update_from_status(report)
+
+        task_name = report.task_name
+        lamella_name = report.item_name
+        queue_position = report.queue_position
+        queue_total = report.queue_total
+        status = report.status
+
+        # Position in the live queue, not the launch matrix — stays correct
+        # when the queue is added to or reordered mid-run.
+        txt = f"Workflow: {task_name} | {lamella_name}"
+        # `queue_total` is a count, so 0 means "nothing to be in the middle of"
+        # rather than "unknown" -- truthiness, not `is not None`, or a malformed
+        # payload renders "3/0".
+        if queue_position is not None and queue_total:
+            txt += f" | {queue_position}/{queue_total}"
+
+        self.set_workflow_running(txt)
+
+        # update current task
+        self._current_task_name = task_name
+
+        # Lock editor when the active lamella/task is being processed
+        if status is AutoLamellaTaskStatus.InProgress:
+            self.lamella_widget.set_active_lamella_name(lamella_name, task_name)
+        else:
+            self.lamella_widget.set_active_lamella_name(None)
+
+        # Refresh only the affected lamella if we can identify it
+        lamella = None
+        experiment = self.autolamella_ui.experiment
+        if experiment is not None and lamella_name is not None:
+            lamella = experiment.get_lamella_by_name(lamella_name)
+
+        # The name list is refreshed from here rather than subscribing per row.
+        # `_LamellaRow` used to connect to `task_state.events.name`/`.status`, which
+        # the workflow writes from its worker thread; the marshalled refresh then
+        # arrived after the row had been replaced and its widgets destroyed
+        # (`RuntimeError: wrapped C/C++ object of type QLabel has been deleted`).
+        # It joins the other two on the same named-lamella path, so it costs one row
+        # -- unlike them, though, nothing else was refreshing this list mid-workflow.
+        if lamella is not None:
+            self.lamella_list_widget.refresh_lamella(lamella)
+            self.lamella_card_container.refresh_lamella(lamella)
+            self.autolamella_ui.lamella_list.refresh_lamella(lamella)
+        else:
+            self.lamella_list_widget.refresh_all()
+            self.lamella_card_container.refresh_all()
+            self.autolamella_ui.lamella_list.refresh_all()
+        self._on_lamella_card_selected(getattr(self, "_selected_card_lamella", None))
+
+    def _on_workflow_update(self, info: dict):
+        """Handle the remaining workflow_update_signal traffic.
+
+        Status now arrives on workflow_status_signal (_on_workflow_status); what is
+        left on the dict signal is the instructions and questions, plus
+        update_status_ui's payloads until that converts too — hence the status_bar
+        read staying for now.
+        """
         # transient status-bar messages (e.g. scheduled-start countdown)
         status_bar_msg = info.get("status_bar", None)
         if status_bar_msg is not None and self.status_bar is not None:
             self.status_bar.showMessage(status_bar_msg)
 
-        status_msg = info.get("status", None)
-        if status_msg is not None:
-            # No build-once guard: update_from_status reconciles rows against the
-            # snapshot by WorkItem id, so first paint and every later change go
-            # through the same path.
-            self.workflow_timeline.update_from_status(status_msg)
-
-            # One decode at the boundary rather than a `.get()` per field. Accepts the
-            # dict the signal still carries and the typed report the producer will send
-            # (FIB-827); total by construction, because raising here is a process abort
-            # rather than a missing label (FIB-329).
-            report = WorkflowStatusUpdate.from_payload(status_msg)
-
-            task_name = report.task_name
-            lamella_name = report.item_name
-            queue_position = report.queue_position
-            queue_total = report.queue_total
-            # `error_message`, `timestamp` and `task_duration` were decoded here and
-            # never used -- dead before this change, so not converted into typed dead
-            # code. The timeline renders all three from the same report; the status bar
-            # never did. If the intent was for it to, that is a feature to add rather
-            # than three assignments to keep warm.
-            msg = info.get("msg", "No message")
-            status = report.status
-
-            # Position in the live queue, not the launch matrix — stays correct
-            # when the queue is added to or reordered mid-run.
-            txt = f"Workflow: {task_name} | {lamella_name}"
-            # `queue_total` is a count, so 0 means "nothing to be in the middle of"
-            # rather than "unknown" -- truthiness, not `is not None`, or a malformed
-            # payload renders "3/0".
-            if queue_position is not None and queue_total:
-                txt += f" | {queue_position}/{queue_total}"
-
-            self.set_workflow_running(txt)
-            timings["set_workflow_running"] = time.time() - t1
-            t1 = time.time()
-
-            # update current task
-            self._current_task_name = task_name
-
-            # Lock editor when the active lamella/task is being processed
-            if status is AutoLamellaTaskStatus.InProgress:
-                self.lamella_widget.set_active_lamella_name(lamella_name, task_name)
-            else:
-                self.lamella_widget.set_active_lamella_name(None)
-
-            # Refresh only the affected lamella if we can identify it
-            lamella = None
-            experiment = self.autolamella_ui.experiment
-            if experiment is not None and lamella_name is not None:
-                lamella = experiment.get_lamella_by_name(lamella_name)
-
-            # The name list is refreshed from here rather than subscribing per row.
-            # `_LamellaRow` used to connect to `task_state.events.name`/`.status`, which
-            # the workflow writes from its worker thread; the marshalled refresh then
-            # arrived after the row had been replaced and its widgets destroyed
-            # (`RuntimeError: wrapped C/C++ object of type QLabel has been deleted`).
-            # It joins the other two on the same named-lamella path, so it costs one row
-            # -- unlike them, though, nothing else was refreshing this list mid-workflow.
-            if lamella is not None:
-                self.lamella_list_widget.refresh_lamella(lamella)
-                timings["lamella_list.refresh_lamella"] = time.time() - t1
-                t1 = time.time()
-                self.lamella_card_container.refresh_lamella(lamella)
-                timings["lamella_cards.refresh_lamella"] = time.time() - t1
-                t1 = time.time()
-                self.autolamella_ui.lamella_list.refresh_lamella(lamella)
-                timings["lamella_name_list.refresh_lamella"] = time.time() - t1
-                t1 = time.time()
-            else:
-                self.lamella_list_widget.refresh_all()
-                timings["lamella_list.refresh_all"] = time.time() - t1
-                t1 = time.time()
-                self.lamella_card_container.refresh_all()
-                timings["lamella_cards.refresh_all"] = time.time() - t1
-                t1 = time.time()
-                self.autolamella_ui.lamella_list.refresh_all()
-                timings["lamella_name_list.refresh_all"] = time.time() - t1
-                t1 = time.time()
-            self._on_lamella_card_selected(
-                getattr(self, "_selected_card_lamella", None)
-            )
-            timings["lamella_card_selected"] = time.time() - t1
-            t1 = time.time()
-
-        # Check if waiting for user response and update status bar
         if self.autolamella_ui is None:
             return
+        self._refresh_workflow_indicators()
 
+    def _refresh_workflow_indicators(self) -> None:
+        """Re-read the waiting/supervised/running state into the window chrome."""
         # refresh the supervised status chip
         supervised = self._update_supervised_status()
 
@@ -2731,7 +2732,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             # Hide user attention button and reset to original dark theme
             self.user_attention_btn.hide()
             self._user_interaction_sound_played = False  # Reset for next time
-        t1 = time.time()
 
         # Update border to reflect current workflow state
         if self._border_state == "stopping":
@@ -2744,7 +2744,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self._set_border_state("supervised" if supervised else "automated")
         else:
             self._set_border_state("idle")
-        timings["set_border_state"] = time.time() - t1
 
     def _rebuild_lamella_list(self):
         """Clear and repopulate the lamella list and card container from the current experiment."""

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -110,6 +110,9 @@ if TYPE_CHECKING:
     from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
         AutoLamellaSingleWindowUI,
     )
+    from fibsem.applications.autolamella.workflows.tasks.status import (
+        WorkflowStatusEvent,
+    )
 
 # Suppress a specific upstream Napari/NumPy warning from shapes miter computation. This
 # module no longer imports napari, but the minimap still loads it, and a filter is matched
@@ -168,6 +171,12 @@ INSTRUCTIONS = {
 
 class AutoLamellaUI(QMainWindow):
     workflow_update_signal = pyqtSignal(dict)
+    # The fire-and-forget third of workflow_update_signal's traffic, moving to its
+    # own channel for the same reason queue_changed_signal has one: that signal's
+    # handler clears WAITING_FOR_UI_UPDATE on every emission, so on the shared
+    # channel merely saying something releases whoever is blocked on that flag.
+    # Carries a WorkflowStatusEvent.
+    workflow_status_signal = pyqtSignal(object)
     # Kept separate from workflow_update_signal on purpose: that one drives
     # handle_workflow_update, which reconfigures the interaction UI and clears
     # WAITING_FOR_UI_UPDATE on every emission. A queue edit is not a step in the
@@ -353,6 +362,7 @@ class AutoLamellaUI(QMainWindow):
         # signals
         self.detection_confirmed_signal.connect(self.handle_confirmed_detection_signal)
         self.workflow_update_signal.connect(self.handle_workflow_update)
+        self.workflow_status_signal.connect(self.handle_workflow_status)
         self._workflow_finished_signal.connect(self._workflow_finished)  # type: ignore
 
         # workflow info
@@ -1879,6 +1889,19 @@ class AutoLamellaUI(QMainWindow):
             dialog.exec_()
         except Exception as e:
             logging.warning(f"Failed to show workflow summary dialog: {e}")
+
+    def handle_workflow_status(self, event: "WorkflowStatusEvent") -> None:
+        """Show a fire-and-forget status update. GUI thread, via workflow_status_signal.
+
+        The display half of what handle_workflow_update does for a status payload,
+        and nothing else. Two deliberate absences: no widget-existence guards (these
+        two labels exist from construction, so there is nothing to raise about in a
+        queued slot), and no touching of the WAITING_* flags — a status update on its
+        own channel can never release a blocked waiter, which is the point of the
+        channel.
+        """
+        self.set_instructions_msg(event.message)
+        self.set_current_workflow_message(event.workflow_info)
 
     def handle_workflow_update(self, info: dict) -> None:
         """Update the UI with the given information, ready for user interaction"""

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -11,6 +11,7 @@ import pandas as pd
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
 from fibsem.applications.autolamella.workflows.tasks.queue import TaskQueue, WorkItem
 from fibsem.applications.autolamella.workflows.tasks.status import (
+    WorkflowStatusEvent,
     WorkflowStatusUpdate,
 )
 from fibsem.applications.autolamella.workflows.ui import update_status_ui
@@ -552,7 +553,12 @@ class TaskManager:
         task_duration: Optional[float] = None,
         skip_reason: Optional[str] = None,
     ) -> None:
-        """Emit workflow_update_signal with the standard status dict.
+        """Emit one lifecycle report on workflow_status_signal.
+
+        On the notification channel rather than workflow_update_signal for the same
+        reason notify_queue_changed is: that signal's handler rebuilds the
+        interaction UI and clears WAITING_FOR_UI_UPDATE every time it fires, and a
+        report that a task started is not a step in any request's handshake.
 
         This stream and the hook stream describe the same lifecycle from two different
         brackets — the manager brackets the task *call*, the task brackets its own
@@ -595,7 +601,9 @@ class TaskManager:
             lamella_names=self.queue.lamella_names,
         )
 
-        self.parent_ui.workflow_update_signal.emit({"msg": msg, "status": update})
+        self.parent_ui.workflow_status_signal.emit(
+            WorkflowStatusEvent(message=msg, report=update)
+        )
 
     def _run_single_task(
         self, task_name: str, lamella: "Lamella"

--- a/fibsem/applications/autolamella/workflows/tasks/status.py
+++ b/fibsem/applications/autolamella/workflows/tasks/status.py
@@ -117,3 +117,32 @@ class WorkflowStatusUpdate:
             task_names=list(payload.get("task_names") or []),
             lamella_names=list(payload.get("lamella_names") or []),
         )
+
+
+@dataclass(frozen=True)
+class WorkflowStatusEvent:
+    """One fire-and-forget status update, on ``workflow_status_signal``.
+
+    The envelope for the notification third of ``workflow_update_signal``'s traffic,
+    on its own channel so that saying something can never release a blocked waiter:
+    ``handle_workflow_update`` ends with an unconditional
+    ``WAITING_FOR_UI_UPDATE = False``, so on the shared signal *any* emission frees
+    *every* waiter. ``queue_changed_signal`` was split out for exactly that reason;
+    this continues the split for the traffic that is genuinely a signal.
+
+    Three text destinations and one structured report, and every field optional
+    because the emit sites say different subsets:
+
+    * ``message`` — the instruction label. ``""`` means "no message", which takes
+      the label down (that is how a prompt is cleared today, and an update that
+      says nothing about the prompt must not leave a stale question standing).
+    * ``workflow_info`` — the workflow-information label. ``None`` leaves its text
+      alone (it still shows the label; pinned behaviour).
+    * ``status_bar`` — transient main-window status-bar text.
+    * ``report`` — a task-lifecycle report, for the timeline and run controls.
+    """
+
+    message: str = ""
+    workflow_info: Optional[str] = None
+    status_bar: Optional[str] = None
+    report: Optional[WorkflowStatusUpdate] = None

--- a/tests/autolamella/test_scheduled_tasks.py
+++ b/tests/autolamella/test_scheduled_tasks.py
@@ -12,6 +12,7 @@ driven without a microscope.
 Waits here are tenths of a second. A test that really waited for a scheduled time
 would be measuring `time.sleep`.
 """
+
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Thread
@@ -41,8 +42,10 @@ def manager(tmp_path: Path) -> TaskManager:
     experiment = Experiment(path=tmp_path, name="test-exp")
     experiment.task_protocol = AutoLamellaTaskProtocol(
         workflow_config=AutoLamellaWorkflowConfig(
-            tasks=[AutoLamellaTaskDescription(name=n, supervise=False, required=False)
-                   for n in TASKS]
+            tasks=[
+                AutoLamellaTaskDescription(name=n, supervise=False, required=False)
+                for n in TASKS
+            ]
         )
     )
     experiment.positions.append(
@@ -89,6 +92,7 @@ def elapsed_running(manager: TaskManager, **kwargs) -> float:
 
 
 # ── the wait always ends ──────────────────────────────────────────────────────
+
 
 def test_a_time_that_has_passed_does_not_wait(manager):
     """The common case after this feature went on by default: a protocol carrying a
@@ -143,6 +147,7 @@ def test_a_timezone_aware_time_does_not_raise(manager):
 
 # ── through the queue ─────────────────────────────────────────────────────────
 
+
 def test_an_unscheduled_task_runs_straight_away(manager):
     """No schedule is the default, and must stay the cheap path."""
     from time import monotonic
@@ -194,6 +199,7 @@ def test_stopping_during_a_wait_ends_the_run(manager):
 
 # ── the schedule survives the protocol file ───────────────────────────────────
 
+
 def test_a_schedule_round_trips_through_the_protocol():
     """It is stored in the task protocol yaml, so it has to serialise. `asdict` would
     otherwise hand yaml a datetime, which is why `to_dict` writes an isoformat."""
@@ -222,8 +228,9 @@ def test_the_workflow_config_finds_a_task_schedule():
     when = datetime(2026, 8, 13, 9, 30)
     config = AutoLamellaWorkflowConfig(
         tasks=[
-            AutoLamellaTaskDescription(name="Trench", supervise=False, required=True,
-                                       scheduled_at=when),
+            AutoLamellaTaskDescription(
+                name="Trench", supervise=False, required=True, scheduled_at=when
+            ),
             AutoLamellaTaskDescription(name="Undercut", supervise=False, required=True),
         ]
     )
@@ -234,6 +241,7 @@ def test_the_workflow_config_finds_a_task_schedule():
 
 
 # ── the border can tell a parked run from a running one (FIB-676) ─────────────
+
 
 class _Signal:
     """The one method `update_status_ui` calls on `workflow_update_signal`."""
@@ -258,8 +266,14 @@ class RecordingUI:
         self._task_manager = manager
         self.WORKFLOW_PENDING = False
         self.pending_at_each_emit: List[bool] = []
+        # The border block runs at the end of both handlers now: lifecycle
+        # reports arrive on workflow_status_signal, update_status_ui still on
+        # the dict signal. Sample at each, as the real window would.
         self.workflow_update_signal = _Signal(
             lambda info: self.pending_at_each_emit.append(self.WORKFLOW_PENDING)
+        )
+        self.workflow_status_signal = _Signal(
+            lambda event: self.pending_at_each_emit.append(self.WORKFLOW_PENDING)
         )
 
 

--- a/tests/autolamella/test_status_dict_vocabulary.py
+++ b/tests/autolamella/test_status_dict_vocabulary.py
@@ -32,7 +32,7 @@ class _FakeUI:
     """Just enough parent_ui for _emit_status: it only touches this one signal."""
 
     def __init__(self) -> None:
-        self.workflow_update_signal = _FakeSignal()
+        self.workflow_status_signal = _FakeSignal()
 
 
 @pytest.fixture
@@ -57,7 +57,7 @@ def _emit(manager: TaskManager, name: str = "lam-1") -> dict:
         lamella=lamella,
         status=AutoLamellaTaskStatus.InProgress,
     )
-    return manager.parent_ui.workflow_update_signal.payloads[-1]["status"]
+    return manager.parent_ui.workflow_status_signal.payloads[-1].report
 
 
 def test_the_status_dict_names_the_item_the_way_the_hook_does(manager: TaskManager):

--- a/tests/autolamella/test_task_manager_status.py
+++ b/tests/autolamella/test_task_manager_status.py
@@ -38,11 +38,18 @@ class RecordingUI:
     """
 
     def __init__(self):
-        self.workflow_update_signal = self
-        self.emitted: List[dict] = []
+        # update_status_ui still uses the dict signal; _emit_status now reports on
+        # workflow_status_signal. Both record here, into per-channel lists.
+        self.workflow_update_signal = _Recorder()
+        self.workflow_status_signal = _Recorder()
         self._task_manager = None  # _check_for_abort reads this
 
-    def emit(self, payload: dict) -> None:
+
+class _Recorder:
+    def __init__(self):
+        self.emitted: List = []
+
+    def emit(self, payload) -> None:
         self.emitted.append(payload)
 
 
@@ -136,8 +143,8 @@ def manager(tmp_path) -> TaskManager:
     return m
 
 
-def last_status(manager: TaskManager) -> dict:
-    return manager.parent_ui.workflow_update_signal.emitted[-1]["status"]
+def last_status(manager: TaskManager):
+    return manager.parent_ui.workflow_status_signal.emitted[-1].report
 
 
 # ── _emit_status ──────────────────────────────────────────────────────────────
@@ -234,7 +241,7 @@ def test_emit_passes_through_error_and_skip_detail(manager):
     status = last_status(manager)
     assert status.error_message == "it broke"
     assert status.task_duration == 12.5
-    assert manager.parent_ui.workflow_update_signal.emitted[-1]["msg"] == "boom"
+    assert manager.parent_ui.workflow_status_signal.emitted[-1].message == "boom"
 
 
 def test_emit_is_a_noop_headless(tmp_path):
@@ -367,8 +374,8 @@ def test_status_bar_text_is_derivable_for_added_items(manager):
             added.append(manager.queue.add("L99", "Polishing"))
 
     run_queue_with(manager, on_task)
-    for payload in manager.parent_ui.workflow_update_signal.emitted:
-        status = payload.get("status")
+    for event in manager.parent_ui.workflow_status_signal.emitted:
+        status = event.report
         if status is None:
             continue
         assert status.queue_position is not None

--- a/tests/ui/test_lamella_defect_sync.py
+++ b/tests/ui/test_lamella_defect_sync.py
@@ -14,6 +14,7 @@ Driven through `LamellaNameListWidget` rather than a bare `_LamellaRow`: the def
 button is hidden until `enable_defect_button(True)`, and `refresh` skips a hidden
 button, so a bare row silently asserts nothing.
 """
+
 import ast
 import os
 
@@ -116,10 +117,12 @@ def test_the_workflow_update_refreshes_the_name_list(row, lamella):
         AutoLamellaSingleWindowUI,
     )
 
-    source = inspect.getsource(AutoLamellaSingleWindowUI._on_workflow_update)
+    # Lifecycle reports arrive on workflow_status_signal now; the refresh lives
+    # in _apply_status_report, which _on_workflow_status runs for every report.
+    source = inspect.getsource(AutoLamellaSingleWindowUI._apply_status_report)
 
     assert "autolamella_ui.lamella_list.refresh_lamella(" in source, (
-        "`_on_workflow_update` does not refresh the name list, and the row no longer "
+        "`_apply_status_report` does not refresh the name list, and the row no longer "
         "subscribes -- so nothing keeps it current while a workflow runs"
     )
 

--- a/tests/ui/test_lamella_row_task_state.py
+++ b/tests/ui/test_lamella_row_task_state.py
@@ -86,7 +86,9 @@ class TestItDoesNotSubscribeAcrossThreads:
         # would only fail for someone running them locally on 3.8.
         connects = []
         for node in ast.walk(ast.parse(source)):
-            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+            if not (
+                isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+            ):
                 continue
             if node.func.attr != "connect":
                 continue
@@ -200,14 +202,17 @@ class TestWhatItStillFollows:
             AutoLamellaSingleWindowUI,
         )
 
-        source = inspect.getsource(AutoLamellaSingleWindowUI._on_workflow_update)
+        # Lifecycle reports arrive on workflow_status_signal now; the refresh
+        # lives in _apply_status_report, which _on_workflow_status runs for
+        # every report — the same every-update cadence the dict handler had.
+        source = inspect.getsource(AutoLamellaSingleWindowUI._apply_status_report)
 
         # `autolamella_ui.lamella_list`, not `lamella_list_widget`. Those are different
         # widgets -- `lamella_list_widget` is the *workflow* list, which was already
         # refreshed here and is not the one this file is about. An earlier version
         # asserted the wrong one and passed while proving nothing.
         assert "autolamella_ui.lamella_list.refresh_lamella(" in source, (
-            "`_on_workflow_update` no longer refreshes the name list, so nothing "
+            "`_apply_status_report` no longer refreshes the name list, so nothing "
             "follows a running workflow now that the subscription is gone"
         )
         assert "autolamella_ui.lamella_list.refresh_all()" in source, (

--- a/tests/ui/test_mainui_workflow_status.py
+++ b/tests/ui/test_mainui_workflow_status.py
@@ -1,10 +1,12 @@
-"""What the main window does with a fire-and-forget status payload, pinned pre-move.
+"""What the main window does with a fire-and-forget status update.
 
-`AutoLamellaSingleWindowUI._on_workflow_update` is the main-window consumer of
-`workflow_update_signal`: transient status-bar text, and the task manager's
-lifecycle reports (timeline feed, the "Workflow: ..." message, run/stop buttons).
-Status is about to move to its own signal, so this pins the observable behaviour
-the move must preserve.
+The main window consumes workflow status twice over: transient status-bar text
+(still on `workflow_update_signal` until `update_status_ui` converts) and the
+task manager's lifecycle reports (timeline feed, the "Workflow: ..." message,
+run/stop buttons), which arrive as `WorkflowStatusEvent` on
+`workflow_status_signal`. Written pinning the dict path before the move; the
+lifecycle tests now hold the same observable behaviour on the new channel, plus
+that the dict channel ignores a straggling status key.
 
 This is the first test to construct the real main window offscreen. The only
 thing that ever prevented it is `add_minimap_tab`, which builds a `napari.Viewer`
@@ -13,12 +15,12 @@ down with SIGSEGV — so the fixture stubs that one method out. Nothing here goe
 near the minimap; every other tab is real. When the minimap tab is deleted
 (#585/#586) the stub can go.
 
-Latent init gap, found by these tests: `_border_state` is first assigned on the
-Run-workflow click, never in `__init__`, and `_on_workflow_update` reads it
-unconditionally — so a status payload arriving without a prior Run click is an
-AttributeError inside a queued slot, which PyQt5 turns into a process abort
-(FIB-329). Production is protected by flow order only; the fixture supplies the
-same precondition explicitly.
+Latent init gap, found by these tests and now fixed: `_border_state` used to be
+first assigned on the Run-workflow click, never in `__init__`, and every workflow
+handler reads it unconditionally — an AttributeError inside a queued slot is a
+process abort (FIB-329). It is initialised in `__init__` now, and this fixture
+deliberately adds no workaround, so any regression fails the first status these
+tests deliver to a fresh window.
 """
 
 import os
@@ -49,11 +51,6 @@ def main_ui(qapp):
     # First connect builds the protocol editor's full UI (its lock path runs on
     # every lifecycle report); Demo, so no hardware.
     window.autolamella_ui.system_widget.connect_to_microscope()
-    # What _on_run_workflow_clicked does before any status can arrive: the
-    # border state exists only from the Run click onward, and the handler under
-    # test reads it unconditionally. A bare window never receives status in
-    # production -- see the latent-init note in the module docstring.
-    window._set_border_state("idle")
     yield window
     if window.autolamella_ui.microscope is not None:
         window.autolamella_ui.microscope.disconnect()
@@ -84,10 +81,14 @@ def test_a_payload_without_status_bar_text_leaves_the_bar_alone(main_ui):
     assert main_ui.status_bar.currentMessage() == "previous message"
 
 
-def test_a_lifecycle_report_shows_the_run_on_the_status_bar(main_ui):
-    # queue_items=None on purpose: "no snapshot" leaves the timeline rows alone,
-    # so this exercises the status-bar half without building a queue. The
-    # timeline half is characterised in test_workflow_timeline_sync.
+def test_a_status_key_on_the_dict_signal_is_ignored(main_ui):
+    # Pre-move, a "status" key here drove the timeline and run controls; those
+    # display assertions live on below against workflow_status_signal. The dict
+    # handler deliberately no longer reads the key, so a straggling emitter
+    # cannot drive the run display through the interaction channel.
+    main_ui.hide_workflow_running()
+    main_ui.status_bar.showMessage("previous message")
+
     report = WorkflowStatusUpdate(
         task_name="Rough Milling",
         item_name="lamella-01",
@@ -96,28 +97,115 @@ def test_a_lifecycle_report_shows_the_run_on_the_status_bar(main_ui):
         queue_total=5,
         queue_items=None,
     )
-
     main_ui._on_workflow_update({"msg": "", "status": report})
 
-    assert (
-        main_ui.status_bar.currentMessage()
-        == "Workflow: Rough Milling | lamella-01 | 2/5"
-    )
-
-
-def test_a_lifecycle_report_flips_the_run_button_to_stop(main_ui):
-    main_ui.hide_workflow_running()
+    assert main_ui.status_bar.currentMessage() == "previous message"
     assert not main_ui.stop_workflow_btn.isVisibleTo(main_ui)
 
-    report = WorkflowStatusUpdate(
-        task_name="Rough Milling",
-        item_name="lamella-01",
-        status=AutoLamellaTaskStatus.InProgress,
-    )
-    main_ui._on_workflow_update({"msg": "", "status": report})
 
+# ── the new channel ──────────────────────────────────────────────────────────────
+# The manager's lifecycle reports now arrive as WorkflowStatusEvent on
+# workflow_status_signal; the dict handler keeps only status_bar (until
+# update_status_ui converts) and the indicator refresh.
+
+
+def test_a_status_event_report_shows_the_run_on_the_status_bar(main_ui):
+    from fibsem.applications.autolamella.workflows.tasks.status import (
+        WorkflowStatusEvent,
+    )
+
+    report = WorkflowStatusUpdate(
+        task_name="Polishing",
+        item_name="lamella-02",
+        status=AutoLamellaTaskStatus.InProgress,
+        queue_position=3,
+        queue_total=4,
+        queue_items=None,
+    )
+
+    # Through the embedded window's signal: a direct connection runs the handler
+    # synchronously, so this also pins that the main window is connected to it.
+    main_ui.autolamella_ui.workflow_status_signal.emit(
+        WorkflowStatusEvent(report=report)
+    )
+
+    assert (
+        main_ui.status_bar.currentMessage() == "Workflow: Polishing | lamella-02 | 3/4"
+    )
     assert main_ui.stop_workflow_btn.isVisibleTo(main_ui)
     assert not main_ui.run_workflow_btn.isVisibleTo(main_ui)
+
+
+def test_a_status_event_carries_transient_status_bar_text(main_ui):
+    from fibsem.applications.autolamella.workflows.tasks.status import (
+        WorkflowStatusEvent,
+    )
+
+    main_ui.autolamella_ui.workflow_status_signal.emit(
+        WorkflowStatusEvent(status_bar="Scheduled start in 4 s")
+    )
+
+    assert main_ui.status_bar.currentMessage() == "Scheduled start in 4 s"
+
+
+def test_a_status_event_snapshot_reaches_the_windows_own_timeline(main_ui):
+    # The tests above use queue_items=None, which tells the timeline to leave its
+    # rows alone — so none of them would notice the handler dropping the
+    # update_from_status call. This one hands over a real snapshot and reads the
+    # window's own timeline rows back.
+    from fibsem.applications.autolamella.workflows.tasks.queue import WorkItem
+    from fibsem.applications.autolamella.workflows.tasks.status import (
+        WorkflowStatusEvent,
+    )
+
+    items = [
+        WorkItem(
+            lamella_name="lamella-03",
+            task_name="Trench",
+            status=AutoLamellaTaskStatus.InProgress,
+        ),
+        WorkItem(lamella_name="lamella-04", task_name="Trench"),
+    ]
+    report = WorkflowStatusUpdate(
+        task_name="Trench",
+        item_name="lamella-03",
+        status=AutoLamellaTaskStatus.InProgress,
+        queue_items=items,
+    )
+
+    main_ui.autolamella_ui.workflow_status_signal.emit(
+        WorkflowStatusEvent(report=report)
+    )
+
+    rows = [(i.lamella_name, i.task_name) for i in main_ui.workflow_timeline._items]
+    assert rows == [("lamella-03", "Trench"), ("lamella-04", "Trench")]
+
+    # Reconcile back down to zero rows so the module-scoped window carries no
+    # timeline state into other tests (an empty snapshot means exactly that).
+    main_ui.autolamella_ui.workflow_status_signal.emit(
+        WorkflowStatusEvent(
+            report=WorkflowStatusUpdate(queue_items=[]),
+        )
+    )
+    assert main_ui.workflow_timeline._items == []
+
+
+def test_a_status_event_refreshes_the_waiting_indicators(main_ui):
+    # The attention button is driven by _refresh_workflow_indicators, which must
+    # run from the status handler too: a status event arriving while a question
+    # is pending must not take the waiting chrome down — and one arriving after
+    # the answer must.
+    from fibsem.applications.autolamella.workflows.tasks.status import (
+        WorkflowStatusEvent,
+    )
+
+    main_ui.autolamella_ui.WAITING_FOR_USER_INTERACTION = True
+    main_ui.autolamella_ui.workflow_status_signal.emit(WorkflowStatusEvent())
+    assert main_ui.user_attention_btn.isVisibleTo(main_ui)
+
+    main_ui.autolamella_ui.WAITING_FOR_USER_INTERACTION = False
+    main_ui.autolamella_ui.workflow_status_signal.emit(WorkflowStatusEvent())
+    assert not main_ui.user_attention_btn.isVisibleTo(main_ui)
 
 
 # --- spot burn progress ----------------------------------------------------

--- a/tests/ui/test_workflow_status_display.py
+++ b/tests/ui/test_workflow_status_display.py
@@ -105,3 +105,59 @@ def test_a_status_update_releases_a_pending_ui_update_wait(ui):
     ui.handle_workflow_update(_status_payload("Moving stage..."))
 
     assert ui.WAITING_FOR_UI_UPDATE is False
+
+
+# ── the new channel ──────────────────────────────────────────────────────────────
+# workflow_status_signal carries the same display behaviour as the dict payloads
+# above (which update_status_ui still emits, until it converts too), minus the one
+# defect: an emission can no longer release a blocked waiter.
+
+
+def _status_event(msg="", workflow_info=None):
+    from fibsem.applications.autolamella.workflows.tasks.status import (
+        WorkflowStatusEvent,
+    )
+
+    return WorkflowStatusEvent(message=msg, workflow_info=workflow_info)
+
+
+def test_a_status_event_writes_the_instruction_label(ui):
+    # Through the signal, not the slot: a direct (same-thread) connection runs the
+    # handler synchronously and propagates exceptions to the emitter, so this also
+    # pins that the signal is actually connected.
+    ui.workflow_status_signal.emit(_status_event("Milling: Preparing..."))
+
+    assert ui.label_instructions.text() == "Milling: Preparing..."
+    assert not ui.pushButton_yes.isVisibleTo(ui)
+
+
+def test_a_status_event_clears_the_prompt_when_it_says_nothing(ui):
+    ui.set_instructions_msg("Continue?", pos="Continue", neg="Exit")
+
+    ui.workflow_status_signal.emit(_status_event(""))
+
+    assert not ui.label_instructions.isVisibleTo(ui)
+    assert not ui.pushButton_yes.isVisibleTo(ui)
+
+
+def test_a_status_event_writes_the_workflow_information_label(ui):
+    ui.workflow_status_signal.emit(
+        _status_event("", workflow_info="Task 2/5: Rough Milling")
+    )
+
+    assert ui.label_workflow_information.text() == "Task 2/5: Rough Milling"
+
+
+def test_a_status_event_leaves_a_pending_wait_alone(ui):
+    # The inversion of test_a_status_update_releases_a_pending_ui_update_wait, and
+    # the reason the channel exists: a Future-style handshake (and until then, the
+    # flag) belongs to one request, and merely saying something must not complete it.
+    ui.WAITING_FOR_UI_UPDATE = True
+    ui.WAITING_FOR_USER_INTERACTION = True
+
+    ui.workflow_status_signal.emit(_status_event("Moving stage..."))
+
+    assert ui.WAITING_FOR_UI_UPDATE is True
+    assert ui.WAITING_FOR_USER_INTERACTION is True
+    ui.WAITING_FOR_UI_UPDATE = False
+    ui.WAITING_FOR_USER_INTERACTION = False

--- a/tests/ui/test_workflow_timeline_estimate.py
+++ b/tests/ui/test_workflow_timeline_estimate.py
@@ -12,6 +12,7 @@ class of bug that got through twice on the pre-flight dialog.
 
 Uses the shared offscreen ``qapp`` fixture from tests/conftest.py.
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -90,6 +91,7 @@ def column(widget) -> list:
 
 # ── pending rows ──────────────────────────────────────────────────────────────
 
+
 def test_every_pending_row_shows_its_estimate(widget):
     assert column(widget) == ["1m 40s"] * 4
 
@@ -125,14 +127,16 @@ def test_an_item_added_mid_workflow_gets_its_estimate(widget, queue):
 
 # ── the running row ───────────────────────────────────────────────────────────
 
+
 def test_the_running_row_counts_down(widget, queue, monkeypatch):
     start_next(widget, queue)
     tick(widget, monkeypatch, 40.0)
     assert column(widget)[0] == "1m 00s left"
 
 
-def test_the_running_row_stops_predicting_once_the_estimate_is_spent(widget, queue,
-                                                                    monkeypatch):
+def test_the_running_row_stops_predicting_once_the_estimate_is_spent(
+    widget, queue, monkeypatch
+):
     """It reports elapsed instead -- the same kind of number the row will show when it
     finishes. Never a negative, never a stalled zero, and never a new word for what is
     ordinary variance."""
@@ -143,7 +147,8 @@ def test_the_running_row_stops_predicting_once_the_estimate_is_spent(widget, que
 
 
 def test_the_elapsed_moves_out_of_the_subtitle_when_the_column_takes_it_over(
-        widget, queue, monkeypatch):
+    widget, queue, monkeypatch
+):
     """Both at once would be the same number twice."""
     start_next(widget, queue)
     tick(widget, monkeypatch, 40.0)
@@ -153,7 +158,8 @@ def test_the_elapsed_moves_out_of_the_subtitle_when_the_column_takes_it_over(
 
 
 def test_a_running_row_with_no_estimate_just_shows_elapsed_in_the_subtitle(
-        app, queue, monkeypatch):
+    app, queue, monkeypatch
+):
     w = WorkflowProgressWidget()
     w.set_actions_enabled(True)
     w.set_workflow(queue.items)
@@ -165,8 +171,10 @@ def test_a_running_row_with_no_estimate_just_shows_elapsed_in_the_subtitle(
 
 # ── supervised waits ──────────────────────────────────────────────────────────
 
+
 def test_a_wait_for_a_human_pauses_the_countdown_rather_than_spending_it(
-        widget, queue, monkeypatch):
+    widget, queue, monkeypatch
+):
     """40 s of work then a 300 s pause leaves the same 60 s of work to do. Left running,
     the wait would spend the whole estimate with all of the task still ahead of it."""
     start_next(widget, queue)
@@ -210,8 +218,9 @@ def test_the_pause_belongs_to_one_task_not_the_workflow(widget, queue, monkeypat
     first = start_next(widget, queue)
     widget.set_waiting_for_user(True)
     queue.mark_done(first, Status.Completed)
-    widget.update_from_status(status_for(queue, first, Status.Completed,
-                                         task_duration=50.0))
+    widget.update_from_status(
+        status_for(queue, first, Status.Completed, task_duration=50.0)
+    )
     start_next(widget, queue)
     assert widget._paused_total == 0.0
     assert widget._waiting_for_user is False
@@ -219,11 +228,13 @@ def test_the_pause_belongs_to_one_task_not_the_workflow(widget, queue, monkeypat
 
 # ── finished rows ─────────────────────────────────────────────────────────────
 
+
 def test_a_finished_row_shows_what_it_actually_took(widget, queue):
     item = start_next(widget, queue)
     queue.mark_done(item, Status.Completed)
-    widget.update_from_status(status_for(queue, item, Status.Completed,
-                                         task_duration=112.0))
+    widget.update_from_status(
+        status_for(queue, item, Status.Completed, task_duration=112.0)
+    )
     assert column(widget)[0] == "1m 52s"
     assert "1m 52s" not in widget._outer._steps[0].subtitle
 
@@ -233,8 +244,9 @@ def test_a_finished_row_is_not_overwritten_by_its_own_estimate(widget, queue):
     estimate and must keep the actual."""
     item = start_next(widget, queue)
     queue.mark_done(item, Status.Completed)
-    widget.update_from_status(status_for(queue, item, Status.Completed,
-                                         task_duration=112.0))
+    widget.update_from_status(
+        status_for(queue, item, Status.Completed, task_duration=112.0)
+    )
     widget.refresh_queue(queue.items)
     assert column(widget)[0] == "1m 52s"
 
@@ -244,12 +256,16 @@ def test_the_two_clocks_in_the_panel_agree_on_their_format(widget, queue):
     beside `7:13PM` would read as two different conventions."""
     item = start_next(widget, queue)
     queue.mark_done(item, Status.Completed)
-    widget.update_from_status(status_for(queue, item, Status.Completed,
-                                         task_duration=112.0, completed_at=START))
+    widget.update_from_status(
+        status_for(
+            queue, item, Status.Completed, task_duration=112.0, completed_at=START
+        )
+    )
     assert not widget._outer._steps[0].subtitle.split("· ")[-1].startswith("0")
 
 
 # ── the header line ───────────────────────────────────────────────────────────
+
 
 def test_the_header_quotes_what_is_left_and_when_it_lands(widget):
     text = widget._summary.text()
@@ -270,8 +286,9 @@ def test_the_header_is_silent_when_no_workflow_is_live(app, queue):
     assert w._summary.isHidden()
 
 
-def test_the_header_drops_the_clock_while_waiting_for_a_human(widget, queue,
-                                                              monkeypatch):
+def test_the_header_drops_the_clock_while_waiting_for_a_human(
+    widget, queue, monkeypatch
+):
     """The wait is unbounded, so any finish time quoted through it is a guess dressed as
     a fact. The work still to do is knowable either way."""
     start_next(widget, queue)
@@ -283,7 +300,7 @@ def test_the_header_drops_the_clock_while_waiting_for_a_human(widget, queue,
 
 
 def test_a_scheduled_hold_is_inside_the_time_the_header_quotes(app, queue):
-    """"When do I come back" includes four hours of dead time in the middle."""
+    """ "When do I come back" includes four hours of dead time in the middle."""
     w = WorkflowProgressWidget()
     w.set_actions_enabled(True)
     w.set_estimates({(i.lamella_name, i.task_name): 100.0 for i in queue.items})
@@ -296,12 +313,14 @@ def test_the_header_goes_quiet_once_there_is_nothing_left_to_do(widget, queue):
     for _ in range(4):
         item = start_next(widget, queue)
         queue.mark_done(item, Status.Completed)
-        widget.update_from_status(status_for(queue, item, Status.Completed,
-                                             task_duration=100.0))
+        widget.update_from_status(
+            status_for(queue, item, Status.Completed, task_duration=100.0)
+        )
     assert widget._summary.isHidden()
 
 
 # ── the layout this column has to survive ─────────────────────────────────────
+
 
 def test_a_long_name_elides_instead_of_pushing_the_column_off_screen(app):
     """The rows sit in a QScrollArea that is widget-resizable with horizontal scrolling
@@ -374,7 +393,7 @@ TASKS = {
 class _ParentUI(QObject):
     """The two signals TaskManager emits on, as real Qt signals."""
 
-    workflow_update_signal = pyqtSignal(dict)
+    workflow_status_signal = pyqtSignal(object)
     queue_changed_signal = pyqtSignal(dict)
 
 
@@ -396,24 +415,27 @@ def live(app, tmp_path):
 
     widget = WorkflowProgressWidget()
     parent_ui = _ParentUI()
-    parent_ui.workflow_update_signal.connect(
-        lambda info: widget.update_from_status(info["status"])
+    parent_ui.workflow_status_signal.connect(
+        lambda event: widget.update_from_status(event.report)
     )
     parent_ui.queue_changed_signal.connect(
         lambda info: widget.refresh_queue(info["queue_items"])
     )
-    manager = TaskManager(microscope=_NoMicroscope(), experiment=experiment,
-                          parent_ui=parent_ui)
+    manager = TaskManager(
+        microscope=_NoMicroscope(), experiment=experiment, parent_ui=parent_ui
+    )
     names = [p.name for p in experiment.positions]
     manager.queue.build_from_matrix(list(TASKS), names)
 
     # What AutoLamellaMainUI does at workflow start.
     widget.set_actions_enabled(True)
-    widget.set_estimates({
-        (lamella.name, task_name): lamella.task_config[task_name].estimated_duration
-        for lamella in experiment.positions
-        for task_name in TASKS
-    })
+    widget.set_estimates(
+        {
+            (lamella.name, task_name): lamella.task_config[task_name].estimated_duration
+            for lamella in experiment.positions
+            for task_name in TASKS
+        }
+    )
     widget.set_workflow(manager.queue.items)
     return manager, widget, experiment
 
@@ -436,6 +458,7 @@ def test_a_real_config_reaches_the_column_through_the_managers_own_payload(live)
 
 def _fmt(seconds: float) -> str:
     from fibsem.ui.widgets.preflight import format_duration
+
     return format_duration(seconds)
 
 

--- a/tests/ui/test_workflow_timeline_sync.py
+++ b/tests/ui/test_workflow_timeline_sync.py
@@ -376,13 +376,16 @@ class _ParentUI(QObject):
     """
 
     workflow_update_signal = pyqtSignal(dict)
+    workflow_status_signal = pyqtSignal(object)
     queue_changed_signal = pyqtSignal(dict)
 
     def __init__(self):
         super().__init__()
         self.workflow_updates = []
+        self.status_events = []
         self.queue_changes = []
         self.workflow_update_signal.connect(self.workflow_updates.append)
+        self.workflow_status_signal.connect(self.status_events.append)
         self.queue_changed_signal.connect(self.queue_changes.append)
 
 
@@ -416,8 +419,8 @@ def manager(widget, tmp_path) -> TaskManager:
     """
     experiment = _experiment(tmp_path)
     parent_ui = _ParentUI()
-    parent_ui.workflow_update_signal.connect(
-        lambda info: widget.update_from_status(info["status"])
+    parent_ui.workflow_status_signal.connect(
+        lambda event: widget.update_from_status(event.report)
     )
     parent_ui.queue_changed_signal.connect(
         lambda info: widget.refresh_queue(info["queue_items"])
@@ -490,31 +493,31 @@ def test_a_queue_edit_never_reaches_the_workflow_update_slot(manager):
     assert len(manager.parent_ui.queue_changes) == 1
 
 
-def test_task_status_still_goes_out_on_the_workflow_signal(manager):
-    """The other half of the split: don't quietly reroute the lifecycle stream."""
+def test_task_status_goes_out_on_the_status_signal(manager):
+    """The lifecycle stream has its own channel now: not the interaction signal
+    (whose handler clears WAITING_FOR_UI_UPDATE on every emission), and still
+    not the queue channel."""
     item = manager.queue.next()
     emit(manager, item, Status.InProgress)
 
-    assert len(manager.parent_ui.workflow_updates) == 1
+    assert len(manager.parent_ui.status_events) == 1
+    assert manager.parent_ui.workflow_updates == []
     assert manager.parent_ui.queue_changes == []
 
 
-def test_every_workflow_update_carries_a_message(manager):
-    """The prompt is this signal's main job, so a payload should say what to show.
+def test_every_lifecycle_event_carries_its_report(manager):
+    """Each emission must say what happened, not just that something did.
 
-    This used to be load-bearing against a crash: `handle_workflow_update` indexed
-    `info["msg"]`, and PyQt5 aborts the process on an exception escaping a slot, so
-    an emitter that forgot the key killed the app. That handler now reads it with a
-    default and a payload without one clears the prompt, which is a real outcome
-    rather than a fallback -- see `tests/ui/test_workflow_update_payload.py`.
-
-    Kept because the invariant is still worth holding at this end: every payload
-    *these* emitters put on the signal is about the prompt, and one that silently
-    blanked it would be a bug here rather than a crash there."""
+    The ancestor of this test held `"msg" in info` against a dict payload — first
+    load-bearing against a process abort (`handle_workflow_update` indexed the
+    key), later against silently blanking the prompt. The typed envelope makes
+    message-presence structural, so what is left to hold is the other field: the
+    timeline renders nothing from an event whose report is missing, and an emitter
+    that dropped it would pass every dispatch test while drawing nothing."""
     item = manager.queue.next()
     emit(manager, item, Status.InProgress)
     manager.queue.mark_done(item, Status.Completed)
     emit(manager, item, Status.Completed, task_duration=1.0)
 
-    assert manager.parent_ui.workflow_updates
-    assert all("msg" in info for info in manager.parent_ui.workflow_updates)
+    assert manager.parent_ui.status_events
+    assert all(event.report is not None for event in manager.parent_ui.status_events)


### PR DESCRIPTION
Step 2a of the workflow-signal untangle: the fire-and-forget third of `workflow_update_signal`'s traffic moves to its own channel, typed.

**Why a separate signal:** `handle_workflow_update` reconfigures the interaction UI and unconditionally clears `WAITING_FOR_UI_UPDATE` on every emission — on the shared channel, merely reporting that a task started can release whoever is blocked on that flag. `queue_changed_signal` was split out for exactly this reason; this continues the split.

**What's in it:**
- `WorkflowStatusEvent` — frozen dataclass envelope (`message`, `workflow_info`, `status_bar`, `report`) replacing the bare dict for status traffic.
- `AutoLamellaUI.workflow_status_signal` + `handle_workflow_status` — the display half of what `handle_workflow_update` did for a status payload, and nothing else: no widget-existence guards, no `WAITING_*` flag touches.
- `TaskManager._emit_status` emits the typed event on the new channel.
- Main window: `_on_workflow_update` split into `_on_workflow_status` / `_apply_status_report` / `_refresh_workflow_indicators`; dead `timings`/`t0`/`t1` instrumentation deleted.
- **Latent crash fixed:** `_border_state` was first assigned on the Run click, and the status handler reads it unconditionally — a status payload arriving before any Run was an AttributeError inside a queued slot, i.e. a process abort. Now initialised in `__init__` (the #638 characterisation fixture's workaround for this is removed, so the init is load-bearing under test).

The five status-consuming test files are repointed at the new channel, and the #638 characterisation files gain the typed-path coverage (108 tests across the seven files, plus the 17 responder/confirm tests, all green locally offscreen).

The old dict path stays for everything else; 2b (converting `update_status_ui` and the prompt-clear, then deleting the main window's dict status handling) stacks on this.