### PR TITLE
[refactor] Answer the detection question with the feature set itself

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -174,7 +174,6 @@ class AutoLamellaUI(QMainWindow):
     # task lifecycle and must not disturb any of that.
     queue_changed_signal = pyqtSignal(dict)
     step_update_signal = pyqtSignal(str)  # emits human-readable step label
-    detection_confirmed_signal = pyqtSignal(bool)
     _workflow_finished_signal = pyqtSignal(bool)
     experiment_update_signal = pyqtSignal()
     _hook_toast_signal = pyqtSignal(
@@ -351,7 +350,6 @@ class AutoLamellaUI(QMainWindow):
         self.pushButton_no.clicked.connect(self.push_interaction_button)
 
         # signals
-        self.detection_confirmed_signal.connect(self.handle_confirmed_detection_signal)
         self.workflow_update_signal.connect(self.handle_workflow_update)
         self._workflow_finished_signal.connect(self._workflow_finished)  # type: ignore
 
@@ -1790,11 +1788,6 @@ class AutoLamellaUI(QMainWindow):
         if ddict.get("finished", False):
             self.update_lamella_ui()
 
-    def handle_confirmed_detection_signal(self):
-        # TODO: this seem very redundant if we just use the signal directly
-        if self.det_widget is not None:
-            self.det_widget.confirm_button_clicked()
-
     def stop_current_operations(self) -> None:
         """Interrupt whatever the microscope is doing right now.
 
@@ -1904,14 +1897,9 @@ class AutoLamellaUI(QMainWindow):
                 False
             )
 
-        # update milling stages
-        detections = info.get("det", None)
-        if self.det_widget is not None and detections is not None:
-            self.det_widget.set_detected_features(detections)
-            det_idx = self.tabWidget.indexOf(self.det_widget)
-            if det_idx != -1:
-                self.tabWidget.setTabVisible(det_idx, True)
-                self.tabWidget.setCurrentIndex(det_idx)
+        # Detections no longer arrive here: update_detection_ui asks a
+        # ConfirmDetection question through the Responder seam
+        # (QtResponder._confirm_detection).
 
         # update the alignment area
         alignment_area = info.get("alignment_area", None)

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -24,7 +24,7 @@ workflow thread blocks on each; a pending future found when the next question
 arrives belonged to a waiter that aborted and unwound, and is cancelled.
 """
 
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Type
+from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple, Type
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
@@ -32,6 +32,7 @@ from fibsem.applications.autolamella.workflows.interaction import (
     ClearMillingConfig,
     ClearSpotBurn,
     Confirm,
+    ConfirmDetection,
     Request,
     SetFluorescenceChannels,
     SetImages,
@@ -69,8 +70,9 @@ class QtResponder(QObject):
         # with the handler's return value.
         self._deferred_handlers: Dict[Type[Request], Callable] = {
             Confirm: self._confirm,
+            ConfirmDetection: self._confirm_detection,
         }
-        self._pending_confirm: Optional["Future"] = None
+        self._pending_question: Optional[Tuple[Request, "Future"]] = None
         self._submitted.connect(self._dispatch)
 
     def submit(self, request: "Request", future: "Future") -> None:
@@ -169,15 +171,17 @@ class QtResponder(QObject):
 
     # --- questions: the answer arrives from a click, later -------------------------
 
-    def _confirm(self, request: Confirm, future: "Future") -> None:
-        """Show a yes/no prompt; :meth:`answer_confirm` completes the future."""
-        if self._pending_confirm is not None:
+    def _park_question(
+        self, request: Request, future: "Future", msg: str, pos: str, neg: Optional[str]
+    ) -> None:
+        """Hold ``future`` for :meth:`answer_confirm` and put the prompt up."""
+        if self._pending_question is not None:
             # The workflow thread blocks on each question, so a live second
             # question is impossible: a pending future here belonged to a waiter
             # that aborted and unwound without an answer. Cancel it so nobody
             # trips over the corpse.
-            self._pending_confirm.cancel()
-        self._pending_confirm = future
+            self._pending_question[1].cancel()
+        self._pending_question = (request, future)
         # Display state, not a handshake: the workflow no longer polls this flag
         # for converted questions, but the attention button, border and timeline
         # pause still read it.
@@ -186,26 +190,67 @@ class QtResponder(QObject):
         # and the main window's waiting indicators — by emitting the payload the
         # old mechanism showed. We are on the GUI thread, so both windows' slots
         # run directly, before this returns.
-        self._ui.workflow_update_signal.emit(
-            {
-                "msg": request.message,
-                "pos": request.positive,
-                "neg": request.negative,
-            }
+        self._ui.workflow_update_signal.emit({"msg": msg, "pos": pos, "neg": neg})
+
+    def _confirm(self, request: Confirm, future: "Future") -> None:
+        """Show a yes/no prompt; :meth:`answer_confirm` completes the future."""
+        self._park_question(
+            request, future, request.message, request.positive, request.negative
+        )
+
+    def _confirm_detection(self, request: ConfirmDetection, future: "Future") -> None:
+        """Show detected features for correction; the click answers with the set."""
+        det_widget = self._ui.det_widget
+        if det_widget is None:
+            # Detection reached the UI without a detection widget: a defect, not
+            # optional hardware — the model already ran to produce this request.
+            raise RuntimeError("No detection widget available to confirm features.")
+        det_widget.set_detected_features(request.detection)
+        tab_widget = self._ui.tabWidget
+        det_idx = tab_widget.indexOf(det_widget)
+        if det_idx != -1:
+            tab_widget.setTabVisible(det_idx, True)
+            tab_widget.setCurrentIndex(det_idx)
+        self._park_question(
+            request,
+            future,
+            "Confirm Feature Detection. Press Continue to proceed.",
+            "Continue",
+            None,
         )
 
     def answer_confirm(self, clicked_yes: bool) -> bool:
-        """Complete a pending :class:`Confirm` from the yes/no click.
+        """Complete the pending question from the yes/no click.
 
         Returns False when no question is pending, so the caller can fall through
         to the legacy flag path. Clears the prompt and the waiting state first,
-        then delivers the answer — the waiter wakes to a consistent UI.
+        then delivers the answer — the waiter wakes to a consistent UI. Computing
+        the answer can itself fail (it may read widgets); a failure completes the
+        future with the exception, which re-raises on the workflow thread instead
+        of escaping this slot as a process abort.
         """
-        future = self._pending_confirm
-        if future is None:
+        pending = self._pending_question
+        if pending is None:
             return False
-        self._pending_confirm = None
+        request, future = pending
+        self._pending_question = None
         self._ui.WAITING_FOR_USER_INTERACTION = False
         self._ui.workflow_update_signal.emit({"msg": ""})
-        future.set_result(clicked_yes)
+        try:
+            future.set_result(self._answer(request, clicked_yes))
+        except Exception as exc:  # noqa: BLE001 - the caller owns the failure
+            future.set_exception(exc)
         return True
+
+    def _answer(self, request: Request, clicked_yes: bool):
+        """What the click means for this question's asker."""
+        if isinstance(request, ConfirmDetection):
+            # Both the read-back and the save used to straddle threads: the
+            # workflow thread called _get_detected_features across the seam, then
+            # signalled back for confirm_button_clicked. Both now run here, on the
+            # GUI thread that owns the widget, before the waiter wakes.
+            det_widget = self._ui.det_widget
+            detection = det_widget._get_detected_features()
+            det_widget.confirm_button_clicked()
+            return detection
+        return clicked_yes

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -10,6 +10,7 @@ from fibsem.applications.autolamella.structures import Experiment
 from fibsem.applications.autolamella.workflows.interaction import (
     ClearSpotBurn,
     Confirm,
+    ConfirmDetection,
     SetImages,
     SetSpotBurnSettings,
     ask,
@@ -86,18 +87,15 @@ def update_detection_ui(
     )
 
     if validate and parent_ui is not None:
-        ask_user(
-            parent_ui,
-            msg="Confirm Feature Detection. Press Continue to proceed.",
-            pos="Continue",
-            det=det,
+        # The answer IS the (possibly corrected) feature set, read and saved on
+        # the GUI thread that owns the widget — no _get_detected_features
+        # read-back across the seam, no detection_confirmed_signal round trip.
+        # No timeout: a human answers, and silence means thinking.
+        det = ask(
+            parent_ui.ui_responder,
+            ConfirmDetection(detection=det),
+            abort=lambda: _abort_requested(parent_ui),
         )
-
-        det = parent_ui.det_widget._get_detected_features()
-
-        # I need this to happen in the parent thread for it to work correctly
-        parent_ui.detection_confirmed_signal.emit(True)
-
     else:
         det_utils.save_ml_feature_data(det)
 
@@ -160,7 +158,6 @@ def ask_user(
     pos: str,
     neg: Optional[str] = None,
     mill: Optional[bool] = None,
-    det: Optional[DetectedFeatures] = None,
     spot_burn: Optional[bool] = None,
 ) -> bool:
 
@@ -170,7 +167,7 @@ def ask_user(
         )
         return True
 
-    if mill is None and det is None and spot_burn is None:
+    if mill is None and spot_burn is None:
         # A plain yes/no confirmation: the typed path. The answer arrives on this
         # call's own future when a button is clicked — USER_RESPONSE and the
         # polled flag are not involved. No timeout: a human answers, and silence
@@ -185,7 +182,6 @@ def ask_user(
         "msg": msg,
         "pos": pos,
         "neg": neg,
-        "det": det,
         "milling_enabled": mill,
         "spot_burn": spot_burn,
     }

--- a/tests/ui/test_confirm_detection.py
+++ b/tests/ui/test_confirm_detection.py
@@ -1,0 +1,252 @@
+"""The detection question over the Responder seam: ConfirmDetection.
+
+The old flow straddled threads three ways: ``ask_user(det=...)`` parked the
+workflow on the polled flag, the workflow thread then called
+``det_widget._get_detected_features()`` across the seam, and finally signalled
+back (``detection_confirmed_signal``) so the GUI could save. Now the question's
+answer IS the (possibly corrected) feature set: the click reads and saves on the
+GUI thread that owns the widget, and the future carries the result back.
+
+The real ``FibsemEmbeddedDetectionWidget`` is unimportable without the ``ml``
+extra (``segmentation_models_pytorch``), which no test environment installs —
+CI's ui job included. The stand-in below is a real ``QWidget`` on the real
+window's tab bar exposing exactly the three methods the seam drives, so tab
+fronting, thread affinity and the click path are all the production ones.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import threading
+import time
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QWidget
+
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.applications.autolamella.workflows.interaction import (
+    ConfirmDetection,
+    ask,
+)
+from fibsem.detection.detection import DetectedFeatures, LamellaCentre
+
+PROMPT = "Confirm Feature Detection. Press Continue to proceed."
+
+
+def _make_detection() -> DetectedFeatures:
+    return DetectedFeatures(
+        features=[LamellaCentre()],
+        image=np.zeros((8, 8), dtype=np.uint8),
+        mask=np.zeros((8, 8), dtype=np.uint8),
+        rgb=np.zeros((8, 8, 3), dtype=np.uint8),
+        pixelsize=1e-9,
+    )
+
+
+class _RecordingDetWidget(QWidget):
+    """The three methods QtResponder drives, on a real widget in the tab bar."""
+
+    def __init__(self):
+        super().__init__()
+        self.det = None
+        self.confirmed = 0
+        self.threads = []
+
+    def set_detected_features(self, det):
+        self.det = det
+
+    def _get_detected_features(self):
+        self.threads.append(threading.current_thread().name)
+        return self.det
+
+    def confirm_button_clicked(self):
+        self.confirmed += 1
+
+
+@pytest.fixture
+def ui(qapp):
+    """A real AutoLamellaUI, connected (Demo), with a stand-in detection tab."""
+    widget = AutoLamellaUI(parent_ui=None)
+    widget.system_widget.connect_to_microscope()
+    det_widget = _RecordingDetWidget()
+    widget.det_widget = det_widget
+    det_idx = widget.tabWidget.addTab(det_widget, "Detection")
+    widget.tabWidget.setTabVisible(det_idx, False)
+    yield widget
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+
+
+def _ask_on_worker_thread(ui, qapp, detection):
+    """Start a ConfirmDetection ask on a worker thread; spin until the prompt is up."""
+    outcome = {}
+
+    def target():
+        try:
+            outcome["answer"] = ask(
+                ui.ui_responder,
+                ConfirmDetection(detection=detection),
+                abort=ui._workflow_stop_event.is_set,
+            )
+        except Exception as exc:  # noqa: BLE001 - the test inspects it
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if ui.label_instructions.text() == PROMPT and ui.pushButton_yes.isEnabled():
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("the detection prompt never appeared")
+    return thread, outcome
+
+
+def _finish(thread, qapp, timeout_s=10.0):
+    deadline = time.monotonic() + timeout_s
+    while thread.is_alive() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+    thread.join(timeout=1.0)
+    assert not thread.is_alive(), "the asker never returned"
+
+
+def test_the_click_answers_with_the_widgets_feature_set(ui, qapp):
+    sent = _make_detection()
+    thread, outcome = _ask_on_worker_thread(ui, qapp, sent)
+
+    # Mid-wait: the features are in the widget, its tab is fronted, and the
+    # waiting display state is on for the attention button and border.
+    assert ui.det_widget.det is sent
+    assert ui.tabWidget.currentWidget() is ui.det_widget
+    assert ui.WAITING_FOR_USER_INTERACTION is True
+
+    # The supervisor corrects the detection; the answer must be what the widget
+    # holds at click time, not what the workflow sent.
+    corrected = _make_detection()
+    ui.det_widget.det = corrected
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert outcome.get("answer") is corrected
+    assert ui.WAITING_FOR_USER_INTERACTION is False
+
+
+def test_the_read_and_the_save_run_on_the_gui_thread(ui, qapp):
+    # Both used to straddle threads: the workflow thread read the features
+    # across the seam, then signalled back for the save. Now the click does both
+    # on the thread that owns the widget, before the waiter wakes.
+    thread, _ = _ask_on_worker_thread(ui, qapp, _make_detection())
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert ui.det_widget.threads == ["MainThread"]
+    assert ui.det_widget.confirmed == 1
+
+
+def test_a_missing_detection_widget_fails_the_asker_not_the_process(ui, qapp):
+    # The model already ran to produce the request, so no widget is a defect —
+    # and it surfaces on the workflow thread, not as an abort out of a slot.
+    ui.det_widget = None
+    outcome = {}
+
+    def target():
+        try:
+            ask(ui.ui_responder, ConfirmDetection(detection=_make_detection()))
+        except Exception as exc:  # noqa: BLE001 - the test inspects it
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    _finish(thread, qapp)
+
+    assert isinstance(outcome.get("error"), RuntimeError)
+    assert "detection widget" in str(outcome["error"])
+
+
+def test_a_failing_read_back_reraises_on_the_workflow_thread(ui, qapp):
+    # Computing the answer happens in the click's slot; under the old mechanism
+    # an exception there was a process abort (FIB-329). Now it is this
+    # question's failure, delivered to the thread that asked.
+    thread, outcome = _ask_on_worker_thread(ui, qapp, _make_detection())
+
+    def broken():
+        raise RuntimeError("features fell over")
+
+    ui.det_widget._get_detected_features = broken
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert isinstance(outcome.get("error"), RuntimeError)
+    assert "features fell over" in str(outcome["error"])
+    # The prompt still came down: the waiter wakes to a consistent UI either way.
+    assert ui.WAITING_FOR_USER_INTERACTION is False
+
+
+def test_a_stop_interrupts_a_detection_nobody_confirms(ui, qapp):
+    thread, outcome = _ask_on_worker_thread(ui, qapp, _make_detection())
+
+    ui._workflow_stop_event.set()
+    try:
+        _finish(thread, qapp)
+    finally:
+        ui._workflow_stop_event.clear()
+
+    assert isinstance(outcome.get("error"), InterruptedError)
+
+
+def test_update_detection_ui_returns_the_confirmed_features(ui, qapp, monkeypatch):
+    # The workflow entry point end to end: producer monkeypatched (it needs a
+    # model checkpoint), validation through the real seam, and the return value
+    # is the widget's set — no _get_detected_features read-back at the call site.
+    from fibsem.applications.autolamella.workflows import ui as workflow_ui
+
+    produced = _make_detection()
+    monkeypatch.setattr(
+        workflow_ui.detection,
+        "take_image_and_detect_features",
+        lambda **kwargs: produced,
+    )
+
+    outcome = {}
+
+    def target():
+        try:
+            outcome["answer"] = workflow_ui.update_detection_ui(
+                microscope=ui.microscope,
+                image_settings=None,
+                checkpoint="unused",
+                features=[LamellaCentre()],
+                parent_ui=ui,
+                validate=True,
+            )
+        except Exception as exc:  # noqa: BLE001 - the test inspects it
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if ui.label_instructions.text() == PROMPT:
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("the detection prompt never appeared")
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert "error" not in outcome
+    assert outcome["answer"] is produced
+    assert ui.det_widget.confirmed == 1


### PR DESCRIPTION
Second question over the Responder seam: `ConfirmDetection`, retiring the first widget read-back.

**Before:** the detection confirmation straddled threads three ways — `ask_user(det=...)` parked the workflow on the polled flag; the workflow thread then called `det_widget._get_detected_features()` across the seam; and finally it emitted `detection_confirmed_signal` back so the GUI could save.

**After:** the question's answer IS the (possibly corrected) feature set. `QtResponder._confirm_detection` shows the features and fronts the Detection tab; the Continue click reads the set and runs `confirm_button_clicked` on the GUI thread that owns the widget, then completes the future with the result. A failure computing the answer (`_get_detected_features` can raise) completes the future with the exception and re-raises on the workflow thread — under the old mechanism that was a process abort out of the click's slot.

**Mechanics:** the pending-question slot generalises from Confirm-only (`_pending_confirm`) to `(request, future)`, and `answer_confirm` dispatches the click's meaning by request type — `push_interaction_button` is untouched. A missing `det_widget` raises immediately (the model already ran to produce the request, so that's a defect, unlike the optional FM/spot-burn hardware).

**Deleted:** `ask_user`'s `det` variant, the `det` branch in `handle_workflow_update`, and the `detection_confirmed_signal` / `handle_confirmed_detection_signal` machinery (this PR removes its last emitter).

**Tests** (`tests/ui/test_confirm_detection.py`, 6): click answers with the widget's set (not the sent one); read+save run on the GUI thread; missing widget fails the asker, not the process; a failing read-back re-raises on the workflow thread with the prompt down; Stop interrupts; `update_detection_ui` end-to-end with the producer monkeypatched. The real detection widget is unimportable without the `ml` extra in every test environment (CI's ui job included), so a minimal stand-in QWidget rides the real window's tab bar — the seam, thread affinity and click path are all production.