### PR TITLE
[refactor] Three progress hops still say `dict`, and the comments still say "today"

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -224,13 +224,14 @@ class FMOverviewWidget(QWidget):
     #
     # One per source, because the two describe different things at different scales and
     # each drives its own bar: the run as a whole, and the tile currently being taken.
-    # `object`, not `dict`: carries a dict today and a `TiledProgress` once the
-    # producers flip (FIB-402). Both marshal to `PyQt_PyObject`, so this changes nothing
-    # at the Qt level -- it stops the declaration lying.
+    # `object`, not `TiledProgress`: the producers have flipped (FIB-402), but psygnal
+    # hands a slot whatever was emitted, and a plugin-loaded producer is not obliged to
+    # emit the typed record. Both marshal to `PyQt_PyObject` regardless, so `object` is
+    # the honest declaration rather than a looser one.
     _tile_progress_received = pyqtSignal(object)
-    # `object`, not `dict`: carries a dict today and a typed report once the producers
-    # flip (FIB-401). Both marshal to `PyQt_PyObject`, so this changes nothing at the Qt
-    # level -- it stops the declaration lying.
+    # `object`, not the typed record: the producers have flipped (FIB-401), but psygnal
+    # hands a slot whatever was emitted. Both marshal to `PyQt_PyObject` regardless, so
+    # `object` is the honest declaration rather than a looser one.
     _fm_progress_received = pyqtSignal(object)
     # Same hop for stage moves: `stage_position_changed` is a psygnal, so it fires
     # on whichever thread moved the stage -- a worker, during an acquisition.
@@ -2702,11 +2703,11 @@ class FMOverviewWidget(QWidget):
 
     # ── progress ─────────────────────────────────────────────────────────
 
-    def _on_tile_progress(self, payload: dict) -> None:
+    def _on_tile_progress(self, payload: TiledProgress) -> None:
         """Called by psygnal, on whichever thread emitted. Touches no widgets."""
         self._tile_progress_received.emit(payload)
 
-    def _on_fm_progress(self, payload: dict) -> None:
+    def _on_fm_progress(self, payload: FluorescenceAcquisitionProgress) -> None:
         """Called by psygnal, on whichever thread emitted. Touches no widgets."""
         self._fm_progress_received.emit(payload)
 

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -531,9 +531,10 @@ class FibsemOverviewWidget(QWidget):
     # synchronously on whichever thread emitted -- during a run, the acquisition
     # worker. Touching widgets from there is a cross-thread GUI access; re-emitting as
     # a Qt signal gets it queued onto the GUI thread, because this widget lives there.
-    # `object`, not `dict`: this carries a dict today and a `TiledProgress` once the
-    # producers flip (FIB-402). Both marshal to `PyQt_PyObject` either way, so widening
-    # it changes nothing at the Qt level -- it just stops the declaration lying.
+    # `object`, not `TiledProgress`: the producers have flipped (FIB-402), but psygnal
+    # hands a slot whatever was emitted, and a plugin-loaded producer is not obliged to
+    # emit the typed record. Both marshal to `PyQt_PyObject` either way, so `object` is
+    # the honest declaration rather than a looser one.
     _progress_received = pyqtSignal(object)
     _stage_moved = pyqtSignal(object)
     _acquisition_finished = pyqtSignal(dict)
@@ -3112,7 +3113,7 @@ class FibsemOverviewWidget(QWidget):
 
     # ── progress ─────────────────────────────────────────────────────────
 
-    def _on_progress(self, payload: dict) -> None:
+    def _on_progress(self, payload: TiledProgress) -> None:
         """Called by psygnal, on whichever thread emitted. Touches no widgets."""
         self._progress_received.emit(payload)
 


### PR DESCRIPTION
Fallout from #658. There, a slot annotated `dict` was connected to a signal carrying a frozen dataclass, and somebody eventually wrote `.get()` on it — which took the application down the moment a supervised spot burn started.

You asked whether the same trap is set elsewhere. It is, in three places.

## What I found

I checked two ways, because the obvious scan misses the bug. Searching for dict access on parameters *annotated* as a typed payload finds nothing — and would have found nothing before #658 either, since that slot was annotated `dict`. The scan that matters walks every slot `.connect()`ed to a `Signal(<typed>)` regardless of annotation.

| | |
|---|---|
| `fm_overview_widget._on_tile_progress` | ← `tiled_acquisition_signal` (`TiledProgress`) |
| `fm_overview_widget._on_fm_progress` | ← `acquisition_progress_signal` (`FluorescenceAcquisitionProgress`) |
| `overview_widget._on_progress` | ← `tiled_acquisition_signal` (`TiledProgress`) |

All three annotated `payload: dict`.

**None of them are broken.** Each does exactly one thing — re-emit onto a Qt signal to get off the psygnal thread and onto the GUI thread — and never touches the payload, so the annotation has never been load-bearing. It is precisely the misdirection that preceded the crash, and it is one line each to stop telling it.

## The comments were stale too

```python
# `object`, not `dict`: carries a dict today and a `TiledProgress` once the
# producers flip (FIB-402).
```

The producers flipped **before v0.5.2rc1** — #549/#550 for tiled, #554/#555/#556 for fluorescence. "Today" describes a state that no longer exists.

## `pyqtSignal(object)` deliberately stays

The original reasoning was right and is now stated better: psygnal hands a slot whatever was emitted, and a plugin-loaded producer is not obliged to emit the typed record. That is the same argument the milling consumers rest on, where all three decode through `MillingProgress.from_payload` and accept either shape — the pattern that would have made #658 impossible. Both marshal to `PyQt_PyObject` regardless, so `object` is the honest declaration rather than a looser one.

## Ruled out

`handle_acquisition_progress_update` and two `handle_acquisition_update` slots use `ddict.get()`, which looks identical to the bug. They are connected to `FibsemImageSettingsWidget.acquisition_progress_signal`, which is genuinely `pyqtSignal(dict)` — two different signals share the name.

## Verified

Both type names were already imported in both files, so nothing changes at runtime on 3.8 where these annotations evaluate at definition time. `tests/ui/test_overview_widget.py` and `tests/ui/test_fm_overview_widget.py`: 478 passed. ruff check and format clean.

Not needed for v0.5.2 — `main` only.

Release-Note: none.
