### PR TITLE
[refactor] Answer the alignment-area question with the area itself

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -41,7 +41,6 @@ from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import (
     BeamType,
     FibsemImage,
-    FibsemRectangle,
     FibsemStagePosition,
     MicroscopeSettings,
     Point,
@@ -1897,19 +1896,9 @@ class AutoLamellaUI(QMainWindow):
                 False
             )
 
-        # Detections no longer arrive here: update_detection_ui asks a
-        # ConfirmDetection question through the Responder seam
-        # (QtResponder._confirm_detection).
-
-        # update the alignment area
-        alignment_area = info.get("alignment_area", None)
-        if isinstance(alignment_area, FibsemRectangle):
-            self.image_widget.toggle_alignment_area(alignment_area)
-        if alignment_area == "clear":
-            # `clear` here means hide-but-keep: update_alignment_area_ui reads
-            # get_alignment_area() straight after, so the rect has to survive.
-            # (#111 renamed this to hide_alignment_area; 4a kept main's name.)
-            self.image_widget.clear_alignment_area()
+        # Detections and the alignment area no longer arrive here: they are
+        # questions over the Responder seam (QtResponder._confirm_detection,
+        # QtResponder._edit_alignment_area).
 
         # POI selection
         poi_selection = info.get("poi_selection", None)

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -24,6 +24,7 @@ workflow thread blocks on each; a pending future found when the next question
 arrives belonged to a waiter that aborted and unwound, and is cancelled.
 """
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple, Type
 
 from PyQt5.QtCore import QObject, pyqtSignal
@@ -33,6 +34,7 @@ from fibsem.applications.autolamella.workflows.interaction import (
     ClearSpotBurn,
     Confirm,
     ConfirmDetection,
+    EditAlignmentArea,
     Request,
     SetFluorescenceChannels,
     SetImages,
@@ -71,6 +73,7 @@ class QtResponder(QObject):
         self._deferred_handlers: Dict[Type[Request], Callable] = {
             Confirm: self._confirm,
             ConfirmDetection: self._confirm_detection,
+            EditAlignmentArea: self._edit_alignment_area,
         }
         self._pending_question: Optional[Tuple[Request, "Future"]] = None
         self._submitted.connect(self._dispatch)
@@ -219,6 +222,16 @@ class QtResponder(QObject):
             None,
         )
 
+    def _edit_alignment_area(
+        self, request: EditAlignmentArea, future: "Future"
+    ) -> None:
+        """Show the editable alignment overlay; the click answers with the area."""
+        image_widget = self._ui.image_widget
+        if image_widget is None:
+            raise RuntimeError("No image widget available to edit the alignment area.")
+        image_widget.toggle_alignment_area(request.initial)
+        self._park_question(request, future, request.message, "Continue", None)
+
     def answer_confirm(self, clicked_yes: bool) -> bool:
         """Complete the pending question from the yes/no click.
 
@@ -253,4 +266,13 @@ class QtResponder(QObject):
             detection = det_widget._get_detected_features()
             det_widget.confirm_button_clicked()
             return detection
+        if isinstance(request, EditAlignmentArea):
+            # Read, then hide. This absorbs the old flow's second handshake: the
+            # workflow used to emit "clear" and poll WAITING_FOR_UI_UPDATE before
+            # reading the area across the seam — here both run in the click's
+            # slot, and clear_alignment_area hides the overlay but keeps the rect.
+            image_widget = self._ui.image_widget
+            area = deepcopy(image_widget.get_alignment_area())
+            image_widget.clear_alignment_area()
+            return area
         return clicked_yes

--- a/fibsem/applications/autolamella/workflows/interaction.py
+++ b/fibsem/applications/autolamella/workflows/interaction.py
@@ -120,6 +120,7 @@ class EditAlignmentArea(Request["FibsemRectangle"]):
     """Let the supervisor adjust an alignment area; answer with the final area."""
 
     initial: "FibsemRectangle"
+    message: str = "Edit Alignment Area"
 
 
 @dataclass(frozen=True)

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -11,6 +11,7 @@ from fibsem.applications.autolamella.workflows.interaction import (
     ClearSpotBurn,
     Confirm,
     ConfirmDetection,
+    EditAlignmentArea,
     SetImages,
     SetSpotBurnSettings,
     ask,
@@ -217,7 +218,13 @@ def update_alignment_area_ui(
     msg: str = "Edit Alignment Area",
     validate: bool = True,
 ) -> FibsemRectangle:
-    """Update the alignment area in the UI and return the updated alignment area."""
+    """Show the editable alignment area and return the (possibly edited) area.
+
+    The answer IS the area: the Continue click reads it and hides the overlay on
+    the GUI thread, so the old second handshake — emit "clear", poll
+    WAITING_FOR_UI_UPDATE, then read across the seam — is gone with it.
+    No timeout: a human answers, and silence means thinking.
+    """
 
     _check_for_abort(parent_ui)
 
@@ -225,35 +232,11 @@ def update_alignment_area_ui(
     if parent_ui is None or not validate:
         return alignment_area
 
-    INFO = {
-        "msg": msg,
-        "pos": "Continue",
-        "alignment_area": alignment_area,
-    }
-    parent_ui.workflow_update_signal.emit(INFO)
-
-    parent_ui.WAITING_FOR_USER_INTERACTION = True
-    logging.info("WAITING_FOR_USER_INTERACTION...")
-    while parent_ui.WAITING_FOR_USER_INTERACTION:
-        _check_for_abort(parent_ui=parent_ui)
-        time.sleep(1)
-
-    _check_for_abort(parent_ui)
-
-    INFO = {
-        "msg": "Clearing Alignment Area",
-        "alignment_area": "clear",
-    }
-
-    parent_ui.WAITING_FOR_UI_UPDATE = True
-    parent_ui.workflow_update_signal.emit(INFO)
-    while parent_ui.WAITING_FOR_UI_UPDATE:
-        time.sleep(0.5)
-
-    # retrieve the updated alignment area
-    alignment_area = deepcopy(parent_ui.image_widget.get_alignment_area())
-
-    return alignment_area
+    return ask(
+        parent_ui.ui_responder,
+        EditAlignmentArea(initial=alignment_area, message=msg),
+        abort=lambda: _abort_requested(parent_ui),
+    )
 
 
 def select_poi_ui(

--- a/tests/ui/test_edit_alignment_area.py
+++ b/tests/ui/test_edit_alignment_area.py
@@ -1,0 +1,157 @@
+"""The alignment-area question over the Responder seam: EditAlignmentArea.
+
+The old flow needed two handshakes and a read-back: ``update_alignment_area_ui``
+emitted the area and polled ``WAITING_FOR_USER_INTERACTION``; after the click it
+emitted ``"clear"`` and polled ``WAITING_FOR_UI_UPDATE``; then it read
+``image_widget.get_alignment_area()`` across the seam. Now the answer IS the
+area: the Continue click reads it and hides the overlay on the GUI thread, and
+the future carries the rect back — one wait, no flags, no read-back.
+
+The real widgets answer here: the overlay round-trips through the actual quad-view
+controller, which lives on the main window — so the fixture is the full offscreen
+``AutoLamellaSingleWindowUI`` (minimap stubbed, as in test_mainui_workflow_status),
+not a bare embedded window, whose ``get_alignment_area`` is None-for-no-controller.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.workflows.ui import update_alignment_area_ui
+from fibsem.structures import FibsemRectangle
+
+INITIAL = FibsemRectangle(left=0.3, top=0.3, width=0.2, height=0.25)
+
+
+@pytest.fixture(scope="module")
+def ui(qapp):
+    """The embedded AutoLamellaUI of a real main window, connected (Demo)."""
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
+    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
+    try:
+        window = module.AutoLamellaSingleWindowUI()
+    finally:
+        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    window.autolamella_ui.system_widget.connect_to_microscope()
+    # What _on_run_workflow_clicked does before any prompt can arrive: the main
+    # window's _on_workflow_update reads _border_state unconditionally, and it is
+    # first assigned on the Run click (the latent init gap test_mainui_workflow_status
+    # documents; its fix rides the typed-status-event PR).
+    window._set_border_state("idle")
+    yield window.autolamella_ui
+    if window.autolamella_ui.microscope is not None:
+        window.autolamella_ui.microscope.disconnect()
+    # closeEvent ends in app.quit(); on the shared test QApplication that latches
+    # and breaks every later QEventLoop.exec_() — close with quit stubbed out.
+    original_quit = qapp.quit
+    qapp.quit = lambda: None
+    try:
+        window.close()
+    finally:
+        qapp.quit = original_quit
+
+
+def _edit_on_worker_thread(ui, qapp, msg="Adjust the area, then Continue."):
+    """Start update_alignment_area_ui on a worker thread; spin until the prompt is up."""
+    outcome = {}
+
+    def target():
+        try:
+            outcome["area"] = update_alignment_area_ui(
+                alignment_area=INITIAL, parent_ui=ui, msg=msg, validate=True
+            )
+        except Exception as exc:  # noqa: BLE001 - the test inspects it
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if ui.label_instructions.text() == msg and ui.pushButton_yes.isEnabled():
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("the alignment prompt never appeared")
+    return thread, outcome
+
+
+def _finish(thread, qapp, timeout_s=10.0):
+    deadline = time.monotonic() + timeout_s
+    while thread.is_alive() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+    thread.join(timeout=1.0)
+    assert not thread.is_alive(), "the asker never returned"
+
+
+def test_the_click_answers_with_the_area_from_the_widget(ui, qapp):
+    thread, outcome = _edit_on_worker_thread(ui, qapp)
+
+    # Mid-wait: the overlay is up and editable, the prompt shows the caller's
+    # message, and the waiting display state is on.
+    shown = ui.image_widget.get_alignment_area()
+    assert shown is not None
+    assert ui.WAITING_FOR_USER_INTERACTION is True
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    area = outcome.get("area")
+    assert isinstance(area, FibsemRectangle)
+    assert area.width == pytest.approx(INITIAL.width)
+    assert area.height == pytest.approx(INITIAL.height)
+    assert ui.WAITING_FOR_USER_INTERACTION is False
+
+
+def test_the_second_handshake_is_gone(ui, qapp):
+    # The old flow set WAITING_FOR_UI_UPDATE for its embedded overlay-clear wait;
+    # the clear now runs inside the click's slot. Nothing may touch the flag.
+    thread, _ = _edit_on_worker_thread(ui, qapp)
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert ui.WAITING_FOR_UI_UPDATE is False
+
+
+def test_the_rect_survives_the_overlay_coming_down(ui, qapp):
+    # clear_alignment_area hides but keeps: the answer is read before the hide,
+    # and asking again must start from a working overlay, not a torn-down one.
+    thread, outcome = _edit_on_worker_thread(ui, qapp)
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+    first = outcome["area"]
+
+    thread, outcome = _edit_on_worker_thread(ui, qapp, msg="Round two.")
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert isinstance(outcome["area"], FibsemRectangle)
+    assert outcome["area"].width == pytest.approx(first.width)
+
+
+def test_headless_and_unvalidated_return_the_input(ui):
+    assert update_alignment_area_ui(INITIAL, parent_ui=None, validate=True) is INITIAL
+    assert update_alignment_area_ui(INITIAL, parent_ui=ui, validate=False) is INITIAL
+
+
+def test_a_stop_interrupts_an_edit_nobody_confirms(ui, qapp):
+    thread, outcome = _edit_on_worker_thread(ui, qapp)
+
+    ui._workflow_stop_event.set()
+    try:
+        _finish(thread, qapp)
+    finally:
+        ui._workflow_stop_event.clear()
+
+    assert isinstance(outcome.get("error"), InterruptedError)

--- a/tests/ui/test_qt_responder.py
+++ b/tests/ui/test_qt_responder.py
@@ -24,12 +24,8 @@ pytest.importorskip("PyQt5")
 
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
 from fibsem.applications.autolamella.workflows import ui as workflow_ui
-from fibsem.applications.autolamella.workflows.interaction import (
-    EditAlignmentArea,
-    ask,
-)
+from fibsem.applications.autolamella.workflows.interaction import ask
 from fibsem.applications.autolamella.workflows.ui import set_images_ui
-from fibsem.structures import FibsemRectangle
 
 
 @pytest.fixture
@@ -131,17 +127,26 @@ def test_a_gui_side_failure_reraises_on_the_workflow_thread(ui, qapp):
 
 
 def test_an_unhandled_request_type_fails_fast_not_by_timeout(ui, qapp):
-    # EditAlignmentArea has no QtResponder handler yet (it converts in a later
-    # step). Asking for it must fail the caller immediately with a TypeError,
-    # not leave it hanging until the instruction timeout.
+    # A request type QtResponder has never heard of must fail the caller
+    # immediately with a TypeError, not leave it hanging until the instruction
+    # timeout. Purpose-built rather than borrowing a not-yet-converted type, so
+    # this test survives every conversion.
+    from dataclasses import dataclass
+
+    from fibsem.applications.autolamella.workflows.interaction import Request
+
+    @dataclass(frozen=True)
+    class NeverHandled(Request[None]):
+        pass
+
     started = time.monotonic()
     outcome = _call_on_worker_thread(
         qapp,
-        lambda: ask(ui.ui_responder, EditAlignmentArea(initial=FibsemRectangle())),
+        lambda: ask(ui.ui_responder, NeverHandled()),
     )
 
     assert isinstance(outcome.get("error"), TypeError)
-    assert "EditAlignmentArea" in str(outcome["error"])
+    assert "NeverHandled" in str(outcome["error"])
     assert time.monotonic() - started < 5
 
 


### PR DESCRIPTION
Third question over the Responder seam: `EditAlignmentArea`, which also retires one of the two remaining `WAITING_FOR_UI_UPDATE` setters. Stacks on the ConfirmDetection PR (shares the generalised pending-question machinery).

**Before:** `update_alignment_area_ui` needed two handshakes and a read-back — emit the area and poll `WAITING_FOR_USER_INTERACTION`; after the click, emit `"clear"` and poll `WAITING_FOR_UI_UPDATE` (the embedded overlay-clear wait); then read `image_widget.get_alignment_area()` across the seam from the workflow thread.

**After:** the answer IS the area. `QtResponder._edit_alignment_area` shows the editable overlay and parks the future; the Continue click reads the area and hides the overlay (`clear_alignment_area` hides-but-keeps) in the click's slot on the GUI thread, then completes the future with the rect. One wait, no flags, no read-back.

**Also:**
- `EditAlignmentArea` gains a `message` field — the caller passes a custom prompt ("Drag to edit the Alignment Area…").
- Deleted: both `alignment_area` branches in `handle_workflow_update` (this was their only emitter).
- The unhandled-type test used `EditAlignmentArea` as its guinea pig; it now defines a purpose-built never-handled request so it survives every remaining conversion.

**Tests** (`tests/ui/test_edit_alignment_area.py`, 5): the click answers with the area round-tripped through the real quad-view controller (the fixture is the full offscreen main window — the controller lives there, a bare embedded window returns None); the second handshake is gone (`WAITING_FOR_UI_UPDATE` untouched); the rect survives the overlay coming down and a second ask works; headless/unvalidated return the input; Stop interrupts. The fixture pre-sets `_border_state` for the same latent init gap the status characterisation tests documented — its real fix rides the typed-status-event PR.