### PR TITLE
[refactor] Answer the POI question with the point itself

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -28,7 +28,6 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from fibsem import conversions
 from fibsem.applications.autolamella.ui.lamella_name_list_widget import (
     LamellaNameListWidget,
 )
@@ -43,7 +42,6 @@ from fibsem.structures import (
     FibsemImage,
     FibsemStagePosition,
     MicroscopeSettings,
-    Point,
 )
 from fibsem.ui import (
     DETECTION_AVAILABLE,
@@ -237,7 +235,6 @@ class AutoLamellaUI(QMainWindow):
         self.WORKFLOW_PENDING: bool = False
         self.USER_RESPONSE: bool = False
         self.WAITING_FOR_UI_UPDATE: bool = False
-        self.SELECTED_POI: Optional[Point] = None
         self._workflow_stop_event: threading.Event = threading.Event()
         self._task_worker_thread: Optional[FunctionWorker] = None
         self._task_manager: Optional[TaskManager] = None
@@ -1896,16 +1893,9 @@ class AutoLamellaUI(QMainWindow):
                 False
             )
 
-        # Detections and the alignment area no longer arrive here: they are
-        # questions over the Responder seam (QtResponder._confirm_detection,
-        # QtResponder._edit_alignment_area).
-
-        # POI selection
-        poi_selection = info.get("poi_selection", None)
-        if poi_selection is True:
-            self._show_poi_selection_layer(info.get("initial_poi", None))
-        elif poi_selection == "clear":
-            self._compute_and_clear_poi_layer()
+        # Detections, the alignment area and POI selection no longer arrive
+        # here: they are questions over the Responder seam
+        # (QtResponder._confirm_detection, _edit_alignment_area, _pick_poi).
 
         # spot_burn
         spot_burn = info.get("spot_burn", None)
@@ -1939,65 +1929,3 @@ class AutoLamellaUI(QMainWindow):
         self.set_current_workflow_message(info.get("workflow_info", None))
 
         self.WAITING_FOR_UI_UPDATE = False
-
-    _POI_LAYER_NAME = "Point of Interest"
-
-    def _show_poi_selection_layer(self, initial_poi: Optional[Point] = None) -> None:
-        """Show a draggable POI marker on the FIB canvas (via the controller)."""
-        controller = getattr(self.parent_widget, "view_controller", None)
-        if controller is not None:
-            self._show_poi_overlay(controller, initial_poi)
-
-    def _show_poi_overlay(self, controller, initial_poi: Optional[Point]) -> None:
-        """Quad-view POI: a magenta '+' point on the FIB canvas (move-only), via the reducer."""
-        from fibsem.ui.widgets.canvas.canvas_state import PointsSpec
-
-        ib_image = self.image_widget.ib_image
-        if initial_poi is not None:
-            px = conversions.microscope_image_to_image_coordinates(
-                initial_poi, ib_image.data.shape, ib_image.metadata.pixel_size.x
-            )
-            col, row = px.x, px.y
-        else:
-            row = ib_image.data.shape[0] / 2
-            col = ib_image.data.shape[1] / 2
-        controller.set_overlay(
-            BeamType.ION,
-            PointsSpec(
-                id="poi",
-                points=[(col, row)],
-                # Matches the protocol editor's POI, down to the legend entry: same
-                # concept, same marker. Left to the defaults this drew at size 18 with
-                # PointOverlay's 2.0 edge, a cross visibly fatter than the thin one the
-                # editor and the config preview draw, and absent from the legend
-                # (FIB-582). 1.2 keeps it reading like the centre crosshair.
-                color="magenta",
-                selected_color="magenta",
-                marker="+",
-                size=14,
-                edge_width=1.2,
-                legend_label="Point of Interest",
-                add_on_right_click=False,
-                removable=False,
-            ),
-        )
-        # POI owns FIB-canvas input: stage-move + milling menu stand down. The toolbar
-        # toggle lets the user drop to Move and back. (See active-overlay model.)
-        controller.arm_overlay(BeamType.ION, "poi", label="POI", icon="mdi:map-marker")
-        controller.fib_canvas.set_hint("drag to move")
-
-    def _compute_and_clear_poi_layer(self) -> None:
-        """Compute POI from the current marker position, clear it, store in SELECTED_POI."""
-        controller = getattr(self.parent_widget, "view_controller", None)
-        if controller is None:
-            return
-        pts = controller.overlay_points(BeamType.ION, "poi")
-        if pts:
-            col, row = pts[0]
-            ib_image = self.image_widget.ib_image
-            self.SELECTED_POI = conversions.image_to_microscope_image_coordinates(
-                Point(x=col, y=row), ib_image.data, ib_image.metadata.pixel_size.x
-            )
-        controller.arm_overlay(BeamType.ION, None)  # restore Move
-        controller.remove_overlay(BeamType.ION, "poi")
-        controller.fib_canvas.set_hint(None)

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -35,6 +35,7 @@ from fibsem.applications.autolamella.workflows.interaction import (
     Confirm,
     ConfirmDetection,
     EditAlignmentArea,
+    PickPOI,
     Request,
     SetFluorescenceChannels,
     SetImages,
@@ -74,6 +75,7 @@ class QtResponder(QObject):
             Confirm: self._confirm,
             ConfirmDetection: self._confirm_detection,
             EditAlignmentArea: self._edit_alignment_area,
+            PickPOI: self._pick_poi,
         }
         self._pending_question: Optional[Tuple[Request, "Future"]] = None
         self._submitted.connect(self._dispatch)
@@ -232,6 +234,61 @@ class QtResponder(QObject):
         image_widget.toggle_alignment_area(request.initial)
         self._park_question(request, future, request.message, "Continue", None)
 
+    def _view_controller(self):
+        """The main window's quad-view controller, or None standalone."""
+        return getattr(self._ui.parent_widget, "view_controller", None)
+
+    def _pick_poi(self, request: PickPOI, future: "Future") -> None:
+        """Show a draggable POI marker on the FIB canvas; the click answers with it.
+
+        The overlay lives on the main window's quad view. Without one (the
+        standalone embedded window) there is nothing to pick on: the old flow
+        no-oped and delivered None, so answer None immediately rather than
+        putting up a prompt about a marker that is not there.
+        """
+        controller = self._view_controller()
+        if controller is None:
+            future.set_result(None)
+            return
+
+        from fibsem import conversions
+        from fibsem.ui.widgets.canvas.canvas_state import PointsSpec
+
+        image = request.image
+        if request.initial is not None:
+            px = conversions.microscope_image_to_image_coordinates(
+                request.initial, image.data.shape, image.metadata.pixel_size.x
+            )
+            col, row = px.x, px.y
+        else:
+            row = image.data.shape[0] / 2
+            col = image.data.shape[1] / 2
+        controller.set_overlay(
+            BeamType.ION,
+            PointsSpec(
+                id="poi",
+                points=[(col, row)],
+                # Matches the protocol editor's POI, down to the legend entry: same
+                # concept, same marker. Left to the defaults this drew at size 18 with
+                # PointOverlay's 2.0 edge, a cross visibly fatter than the thin one the
+                # editor and the config preview draw, and absent from the legend
+                # (FIB-582). 1.2 keeps it reading like the centre crosshair.
+                color="magenta",
+                selected_color="magenta",
+                marker="+",
+                size=14,
+                edge_width=1.2,
+                legend_label="Point of Interest",
+                add_on_right_click=False,
+                removable=False,
+            ),
+        )
+        # POI owns FIB-canvas input: stage-move + milling menu stand down. The toolbar
+        # toggle lets the user drop to Move and back. (See active-overlay model.)
+        controller.arm_overlay(BeamType.ION, "poi", label="POI", icon="mdi:map-marker")
+        controller.fib_canvas.set_hint("drag to move")
+        self._park_question(request, future, request.message, "Continue", None)
+
     def answer_confirm(self, clicked_yes: bool) -> bool:
         """Complete the pending question from the yes/no click.
 
@@ -275,4 +332,26 @@ class QtResponder(QObject):
             area = deepcopy(image_widget.get_alignment_area())
             image_widget.clear_alignment_area()
             return area
+        if isinstance(request, PickPOI):
+            # Read the marker, convert against the image the request carried (the
+            # one the marker was placed on), and take the overlay down — the old
+            # flow's second handshake plus its SELECTED_POI read-back, all in the
+            # click's slot.
+            from fibsem import conversions
+            from fibsem.structures import Point
+
+            controller = self._view_controller()
+            poi = None
+            if controller is not None:
+                pts = controller.overlay_points(BeamType.ION, "poi")
+                if pts:
+                    col, row = pts[0]
+                    image = request.image
+                    poi = conversions.image_to_microscope_image_coordinates(
+                        Point(x=col, y=row), image.data, image.metadata.pixel_size.x
+                    )
+                controller.arm_overlay(BeamType.ION, None)  # restore Move
+                controller.remove_overlay(BeamType.ION, "poi")
+                controller.fib_canvas.set_hint(None)
+            return poi
         return clicked_yes

--- a/fibsem/applications/autolamella/workflows/interaction.py
+++ b/fibsem/applications/autolamella/workflows/interaction.py
@@ -133,6 +133,7 @@ class PickPOI(Request[Optional["Point"]]):
 
     image: "FibsemImage"
     initial: Optional["Point"] = None
+    message: str = "Select Point of Interest"
 
 
 @dataclass(frozen=True)

--- a/fibsem/applications/autolamella/workflows/tasks/select_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_position.py
@@ -1,4 +1,3 @@
-
 ######## SELECT MILLING POSITION TASK DEFINITIONS ########
 
 import logging
@@ -23,35 +22,41 @@ class SelectMillingPositionTaskConfig(AutoLamellaTaskConfig):
         metadata=field_meta(
             tooltip="The angle between the FIB and sample used for milling",
             unit=constants.DEGREE_SYMBOL,
-        ),)
+        ),
+    )
     auto_milling_alignment: bool = field(
         default=False,
         metadata=field_meta(
             label="Auto Milling Angle Alignment",
-            tooltip="Whether to automatically align for a milling position"),
+            tooltip="Whether to automatically align for a milling position",
+        ),
     )
     use_autofocus: bool = field(
         default=True,
         metadata=field_meta(
             label="Use Autofocus",
-            tooltip="Whether to autofocus before moving to the milling position"),
+            tooltip="Whether to autofocus before moving to the milling position",
+        ),
     )
 
     select_poi: bool = field(
         default=True,
         metadata=field_meta(
             label="Select Point of Interest",
-            tooltip="Whether to ask the user to select a point of interest in the FIB image"),
+            tooltip="Whether to ask the user to select a point of interest in the FIB image",
+        ),
     )
     task_type: ClassVar[str] = "SELECT_MILLING_POSITION"
     display_name: ClassVar[str] = "Select Milling Position"
 
 
-
 class SelectMillingPositionTask(AutoLamellaTask):
     """Task to setup the lamella for milling."""
+
     config: SelectMillingPositionTaskConfig
-    config_cls: ClassVar[Type[SelectMillingPositionTaskConfig]] = SelectMillingPositionTaskConfig
+    config_cls: ClassVar[Type[SelectMillingPositionTaskConfig]] = (
+        SelectMillingPositionTaskConfig
+    )
 
     def _run(self) -> None:
         """Run the task to select the milling position for the lamella for milling."""
@@ -65,58 +70,81 @@ class SelectMillingPositionTask(AutoLamellaTask):
 
         self.log_status_message("SELECT_POSITION", "Selecting Position...")
         milling_angle = self.config.milling_angle
-        is_close = self.microscope.is_close_to_milling_angle(milling_angle=milling_angle)
+        is_close = self.microscope.is_close_to_milling_angle(
+            milling_angle=milling_angle
+        )
 
         # acquire an image at the milling position
         if self.config.use_autofocus:
             self._run_autofocus(beam_type=BeamType.ELECTRON)
             self._run_autofocus(beam_type=BeamType.ION)
-        self._acquire_reference_image(image_settings=self.image_settings,
-                                      filename=f"ref_{self.task_name}_start",
-                                      field_of_view=self.config.reference_imaging.field_of_view1)
+        self._acquire_reference_image(
+            image_settings=self.image_settings,
+            filename=f"ref_{self.task_name}_start",
+            field_of_view=self.config.reference_imaging.field_of_view1,
+        )
 
         if not is_close:
             if self.config.auto_milling_alignment:
                 from fibsem import alignment
                 from fibsem.transformations import get_stage_tilt_from_milling_angle
-                target_stage_tilt_degrees = np.degrees(get_stage_tilt_from_milling_angle(self.microscope,
-                                                                                 np.radians(milling_angle)))
-                alignment._eucentric_tilt_alignment(microscope=self.microscope,
-                                                    image_settings=self.image_settings,
-                                                    target_angle=float(target_stage_tilt_degrees),
-                                                    step_size=3,
-                                                    )
+
+                target_stage_tilt_degrees = np.degrees(
+                    get_stage_tilt_from_milling_angle(
+                        self.microscope, np.radians(milling_angle)
+                    )
+                )
+                alignment._eucentric_tilt_alignment(
+                    microscope=self.microscope,
+                    image_settings=self.image_settings,
+                    target_angle=float(target_stage_tilt_degrees),
+                    step_size=3,
+                )
 
             elif self.validate:
                 current_milling_angle = self.microscope.get_current_milling_angle()
-                ret = ask_user(parent_ui=self.parent_ui,
-                            msg=f"Tilt to specified milling angle ({milling_angle:.1f}{constants.DEGREE_SYMBOL})? "
-                            f"Current milling angle is {current_milling_angle:.1f}{constants.DEGREE_SYMBOL}.",
-                            pos="Tilt", neg="Skip")
+                ret = ask_user(
+                    parent_ui=self.parent_ui,
+                    msg=f"Tilt to specified milling angle ({milling_angle:.1f}{constants.DEGREE_SYMBOL})? "
+                    f"Current milling angle is {current_milling_angle:.1f}{constants.DEGREE_SYMBOL}.",
+                    pos="Tilt",
+                    neg="Skip",
+                )
                 if ret:
-                    self.microscope.move_to_milling_angle(milling_angle=np.radians(milling_angle))
+                    self.microscope.move_to_milling_angle(
+                        milling_angle=np.radians(milling_angle)
+                    )
             else:
-                self.microscope.move_to_milling_angle(milling_angle=np.radians(milling_angle))
+                self.microscope.move_to_milling_angle(
+                    milling_angle=np.radians(milling_angle)
+                )
 
             if self.config.use_autofocus:
                 self._run_autofocus(beam_type=BeamType.ION)
 
             # reacquire image at milling angle
-            self._acquire_reference_image(image_settings=self.image_settings,
-                                        filename=f"ref_{self.task_name}_post_tilt",
-                                        field_of_view=self.config.reference_imaging.field_of_view1)
+            self._acquire_reference_image(
+                image_settings=self.image_settings,
+                filename=f"ref_{self.task_name}_post_tilt",
+                field_of_view=self.config.reference_imaging.field_of_view1,
+            )
 
         # confirm with user to move to milling position
         if self.validate:
-            ask_user(parent_ui=self.parent_ui,
-                    msg=f"Double click the image to move to the milling position for {self.lamella.name}. "
-                        f"Press Continue when done.",
-                    pos="Continue")
-        
+            ask_user(
+                parent_ui=self.parent_ui,
+                msg=f"Double click the image to move to the milling position for {self.lamella.name}. "
+                f"Press Continue when done.",
+                pos="Continue",
+            )
+
         # select point of interest
         if self.config.select_poi:
             poi = select_poi_ui(
                 parent_ui=self.parent_ui,
+                # the FIB image the reference acquisition above displayed — the
+                # marker's coordinates only mean something against it
+                image=self._last_fib_image,
                 msg=f"Move the marker to the point of interest for {self.lamella.name}. Press Continue when done.",
                 validate=self.validate,
                 initial_poi=self.lamella.poi,
@@ -131,9 +159,11 @@ class SelectMillingPositionTask(AutoLamellaTask):
         self._validate_alignment_area()
 
         # acquire alignment reference image
-        self._acquire_alignment_reference_image(image_settings=self.image_settings,
-                                      reduced_area=self.lamella.alignment_area,
-                                      field_of_view=self.config.reference_imaging.field_of_view1)
+        self._acquire_alignment_reference_image(
+            image_settings=self.image_settings,
+            reduced_area=self.lamella.alignment_area,
+            field_of_view=self.config.reference_imaging.field_of_view1,
+        )
 
         # reference images
         self._acquire_set_of_reference_images(self.image_settings)

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -12,6 +12,7 @@ from fibsem.applications.autolamella.workflows.interaction import (
     Confirm,
     ConfirmDetection,
     EditAlignmentArea,
+    PickPOI,
     SetImages,
     SetSpotBurnSettings,
     ask,
@@ -241,40 +242,29 @@ def update_alignment_area_ui(
 
 def select_poi_ui(
     parent_ui: Optional["AutoLamellaUI"],
+    image: Optional[FibsemImage],
     msg: str = "Select Point of Interest",
     validate: bool = True,
     initial_poi: Optional[Point] = None,
 ) -> Optional[Point]:
-    """Display a draggable POI marker on the FIB image; return the selected point in milling coordinates."""
+    """Show a draggable POI marker on ``image`` and return the picked point.
+
+    The image travels in the request (the marker's coordinates only mean
+    something against it), and the answer IS the point: the Continue click reads
+    the marker, converts, and takes the overlay down on the GUI thread — no
+    SELECTED_POI read-back, no second WAITING_FOR_UI_UPDATE handshake.
+    No timeout: a human answers, and silence means thinking.
+    """
     _check_for_abort(parent_ui)
 
-    if parent_ui is None or not validate:
+    if parent_ui is None or not validate or image is None:
         return None
 
-    INFO = {
-        "msg": msg,
-        "pos": "Continue",
-        "poi_selection": True,
-        "initial_poi": initial_poi,
-    }
-    parent_ui.workflow_update_signal.emit(INFO)
-
-    parent_ui.WAITING_FOR_USER_INTERACTION = True
-    logging.info("WAITING_FOR_USER_INTERACTION (POI selection)...")
-    while parent_ui.WAITING_FOR_USER_INTERACTION:
-        _check_for_abort(parent_ui=parent_ui)
-        time.sleep(1)
-
-    _check_for_abort(parent_ui)
-
-    # clear the layer and compute POI
-    INFO = {"msg": "", "poi_selection": "clear"}
-    parent_ui.WAITING_FOR_UI_UPDATE = True
-    parent_ui.workflow_update_signal.emit(INFO)
-    while parent_ui.WAITING_FOR_UI_UPDATE:
-        time.sleep(0.5)
-
-    return deepcopy(parent_ui.SELECTED_POI)
+    return ask(
+        parent_ui.ui_responder,
+        PickPOI(image=image, initial=initial_poi, message=msg),
+        abort=lambda: _abort_requested(parent_ui),
+    )
 
 
 def update_experiment_ui(

--- a/tests/ui/test_pick_poi.py
+++ b/tests/ui/test_pick_poi.py
@@ -1,0 +1,160 @@
+"""The POI question over the Responder seam: PickPOI.
+
+The old flow parked on the polled flag, then ran a second handshake — emit
+``"clear"``, poll ``WAITING_FOR_UI_UPDATE`` — whose GUI half computed the point
+and stored it in ``SELECTED_POI`` for the workflow thread to read back. Now the
+answer IS the point: the request carries the image the marker is placed on, and
+the Continue click reads the marker, converts against that image, and takes the
+overlay down on the GUI thread. ``SELECTED_POI`` is gone.
+
+The overlay lives on the main window's quad-view controller, so the fixture is
+the full offscreen ``AutoLamellaSingleWindowUI`` — same harness as the
+alignment-area tests.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import threading
+import time
+from copy import deepcopy
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.workflows.ui import select_poi_ui
+from fibsem.structures import BeamType, Point
+
+
+@pytest.fixture(scope="module")
+def window(qapp):
+    """A real main window, connected (Demo), minimap stubbed."""
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
+    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
+    try:
+        win = module.AutoLamellaSingleWindowUI()
+    finally:
+        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    win.autolamella_ui.system_widget.connect_to_microscope()
+    # The main window's _on_workflow_update reads _border_state unconditionally,
+    # and it is first assigned on the Run click (the latent init gap
+    # test_mainui_workflow_status documents; its fix rides the typed-status PR).
+    win._set_border_state("idle")
+    yield win
+    if win.autolamella_ui.microscope is not None:
+        win.autolamella_ui.microscope.disconnect()
+    # closeEvent ends in app.quit(); on the shared test QApplication that latches
+    # and breaks every later QEventLoop.exec_() — close with quit stubbed out.
+    original_quit = qapp.quit
+    qapp.quit = lambda: None
+    try:
+        win.close()
+    finally:
+        qapp.quit = original_quit
+
+
+@pytest.fixture
+def ui(window):
+    return window.autolamella_ui
+
+
+def _fib_image(ui):
+    """The FIB image on display — what the workflow would pass with the request."""
+    return deepcopy(ui.image_widget.ib_image)
+
+
+def _pick_on_worker_thread(ui, qapp, image, initial=None, msg="Pick the point."):
+    outcome = {}
+
+    def target():
+        try:
+            outcome["poi"] = select_poi_ui(
+                parent_ui=ui, image=image, msg=msg, validate=True, initial_poi=initial
+            )
+        except Exception as exc:  # noqa: BLE001 - the test inspects it
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if ui.label_instructions.text() == msg and ui.pushButton_yes.isEnabled():
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("the POI prompt never appeared")
+    return thread, outcome
+
+
+def _finish(thread, qapp, timeout_s=10.0):
+    deadline = time.monotonic() + timeout_s
+    while thread.is_alive() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+    thread.join(timeout=1.0)
+    assert not thread.is_alive(), "the asker never returned"
+
+
+def test_the_click_answers_with_the_marker_position(window, ui, qapp):
+    image = _fib_image(ui)
+    initial = Point(x=1e-6, y=2e-6)
+    thread, outcome = _pick_on_worker_thread(ui, qapp, image, initial=initial)
+
+    # Mid-wait: the marker is on the FIB canvas and the waiting state is on.
+    controller = window.view_controller
+    assert controller.overlay_points(BeamType.ION, "poi")
+    assert ui.WAITING_FOR_USER_INTERACTION is True
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    poi = outcome.get("poi")
+    assert isinstance(poi, Point)
+    # Un-dragged, the marker answers with the initial point (pixel-rounded).
+    assert poi.x == pytest.approx(initial.x, abs=image.metadata.pixel_size.x)
+    assert poi.y == pytest.approx(initial.y, abs=image.metadata.pixel_size.x)
+
+
+def test_the_overlay_comes_down_with_the_answer(window, ui, qapp):
+    image = _fib_image(ui)
+    thread, _ = _pick_on_worker_thread(ui, qapp, image)
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert not window.view_controller.overlay_points(BeamType.ION, "poi")
+    assert ui.WAITING_FOR_USER_INTERACTION is False
+
+
+def test_the_second_handshake_is_gone(ui, qapp):
+    # The old flow set WAITING_FOR_UI_UPDATE for its embedded clear-and-compute
+    # wait; both now run inside the click's slot. Nothing may touch the flag.
+    thread, _ = _pick_on_worker_thread(ui, qapp, _fib_image(ui))
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert ui.WAITING_FOR_UI_UPDATE is False
+
+
+def test_no_image_or_no_validation_answers_none(ui):
+    assert select_poi_ui(parent_ui=ui, image=None) is None
+    assert select_poi_ui(parent_ui=None, image=_fib_image(ui)) is None
+    assert select_poi_ui(parent_ui=ui, image=_fib_image(ui), validate=False) is None
+
+
+def test_a_stop_interrupts_a_pick_nobody_confirms(ui, qapp):
+    thread, outcome = _pick_on_worker_thread(ui, qapp, _fib_image(ui))
+
+    ui._workflow_stop_event.set()
+    try:
+        _finish(thread, qapp)
+    finally:
+        ui._workflow_stop_event.clear()
+
+    assert isinstance(outcome.get("error"), InterruptedError)

--- a/tests/ui/test_workflow_poi_overlay.py
+++ b/tests/ui/test_workflow_poi_overlay.py
@@ -6,10 +6,12 @@ drifted: left to `PointsSpec`'s defaults it came out at size 18 with a 2.0 edge,
 visibly fatter cross than the thin one the other two draw, and with no `legend_label` it
 was the only one missing from the canvas legend.
 
-Driven by calling the method unbound against a stub, because its host is `AutoLamellaUI`
--- a napari-backed window that cannot be constructed headless. The spec it builds is the
-whole of what this pins, so the stub costs nothing in coverage.
+Driven by calling `QtResponder._pick_poi` unbound against a stub, so the spec it
+builds is pinned without a window or a running question: the marker drawing moved
+there with the PickPOI conversion, and the image now arrives in the request rather
+than being read off the host.
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -21,7 +23,8 @@ import pytest
 
 pytest.importorskip("PyQt5")
 
-from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.applications.autolamella.ui.qt_responder import QtResponder
+from fibsem.applications.autolamella.workflows.interaction import PickPOI
 from fibsem.structures import (
     BeamType,
     FibsemImage,
@@ -55,8 +58,8 @@ class _Controller:
         self.armed = (beam, overlay_id)
 
 
-def _host(shape=(64, 64), pixel_size=1e-8):
-    """The one attribute `_show_poi_overlay` reads off its host: the FIB image."""
+def _image(shape=(64, 64), pixel_size=1e-8):
+    """The image the request carries — what the marker's coordinates mean against."""
     image = FibsemImage(
         data=np.zeros(shape, dtype=np.uint8),
         metadata=FibsemImageMetadata(
@@ -67,12 +70,18 @@ def _host(shape=(64, 64), pixel_size=1e-8):
             microscope_state=MicroscopeState(),
         ),
     )
-    return types.SimpleNamespace(image_widget=types.SimpleNamespace(ib_image=image))
+    return image
 
 
 def _poi_spec(initial_poi=None):
     controller = _Controller()
-    AutoLamellaUI._show_poi_overlay(_host(), controller, initial_poi)
+    stub = types.SimpleNamespace(
+        _view_controller=lambda: controller,
+        _park_question=lambda *a, **k: None,
+    )
+    QtResponder._pick_poi(
+        stub, PickPOI(image=_image(), initial=initial_poi), future=None
+    )
     return controller.overlays[(BeamType.ION, "poi")]
 
 


### PR DESCRIPTION
Fourth question over the Responder seam: `PickPOI`, retiring `SELECTED_POI` and the **last** `WAITING_FOR_UI_UPDATE = True` setter. Stacks on the alignment-area PR.

**Before:** `select_poi_ui` parked on the polled flag; after the click it ran a second handshake — emit `"clear"`, poll `WAITING_FOR_UI_UPDATE` — whose GUI half computed the point into `parent_ui.SELECTED_POI` for the workflow thread to read back (a shared attribute crossing threads unsynchronised).

**After:** the answer IS the point. The request carries the FIB image the marker is placed on — the caller passes the task's `_last_fib_image`, the image the preceding reference acquisition displayed, honouring the request-carries-its-context rule instead of converting against whatever happens to be on screen. `QtResponder._pick_poi` draws the marker overlay (moved verbatim from `_show_poi_overlay`); the Continue click reads the marker, converts against the request's image, and takes the overlay down, completing the future with the point.

**Edge kept:** without a quad-view controller (standalone embedded window) the old flow silently no-oped and delivered a stale-or-None `SELECTED_POI`; now the answer is None immediately, no prompt about a marker that isn't there.

**Deleted:** the `poi_selection` branches in `handle_workflow_update`, the three POI layer methods on `AutoLamellaUI` (moved into the responder), `SELECTED_POI`, and the imports the deletions orphaned (`Point`, the duplicate `conversions` — the early top-of-file `conversions` import stays, it predates the PySide6 unload hack and looks position-deliberate).

**Tests** (`tests/ui/test_pick_poi.py`, 5, full offscreen main window — the controller lives there): the click answers with the marker's position round-tripped through the real overlay (pixel-rounded against the initial point); the overlay comes down with the answer; `WAITING_FOR_UI_UPDATE` untouched; no-image / headless / unvalidated answer None; Stop interrupts.

After this, zero `WAITING_FOR_UI_UPDATE = True` setters remain — the flag itself (and `USER_RESPONSE`, `WAITING_FOR_USER_INTERACTION`) goes in the closing PR once the milling and spot-burn questions convert.