### PR TITLE
[refactor] Run the mill from the Responder, and answer with the config as used

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1810,6 +1810,12 @@ class AutoLamellaUI(QMainWindow):
     def _workflow_finished(self):
         """Handle the completion of the workflow."""
         logging.info("Workflow finished.")
+        # Before the early returns: whatever question the run left behind must
+        # come down even if the widgets below are gone. Covers the abort race
+        # where a finished mill re-parks the prompt in the gap before the
+        # aborting waiter cancels its future — by the time this runs, the
+        # workflow thread has exited, so anything still parked belongs to nobody.
+        self.ui_responder.abandon()
         if self.image_widget is None:
             return
         if self.microscope is None:

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1885,16 +1885,8 @@ class AutoLamellaUI(QMainWindow):
         # Images no longer arrive here: set_images_ui sends a SetImages request
         # through the Responder seam (QtResponder._set_images).
 
-        # what?
-        enable_milling = info.get("milling_enabled", None)
-        if enable_milling is not None:
-            self.tabWidget.setCurrentWidget(self.milling_task_config_widget)
-            self.milling_task_config_widget.milling_widget.pushButton_run_milling.setVisible(
-                False
-            )
-
-        # Detections, the alignment area and POI selection no longer arrive
-        # here: they are questions over the Responder seam
+        # Detections, the alignment area, POI selection and the milling question
+        # no longer arrive here: they are questions over the Responder seam
         # (QtResponder._confirm_detection, _edit_alignment_area, _pick_poi).
 
         # spot_burn

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -37,6 +37,7 @@ from fibsem.applications.autolamella.workflows.interaction import (
     EditAlignmentArea,
     PickPOI,
     Request,
+    RunMillingTask,
     SetFluorescenceChannels,
     SetImages,
     SetMillingConfig,
@@ -76,8 +77,15 @@ class QtResponder(QObject):
             ConfirmDetection: self._confirm_detection,
             EditAlignmentArea: self._edit_alignment_area,
             PickPOI: self._pick_poi,
+            RunMillingTask: self._run_milling_task,
         }
         self._pending_question: Optional[Tuple[Request, "Future"]] = None
+        # A RunMillingTask whose mill is currently running: the prompt is down,
+        # the future is pending, and finished_milling_signal decides what next.
+        self._active_milling: Optional[Tuple[RunMillingTask, "Future"]] = None
+        # Which milling widget's finished signal is wired to _on_milling_finished
+        # (by identity — the widget is rebuilt on reconnect, taking the wire with it).
+        self._milling_finished_wired: Optional[object] = None
         self._submitted.connect(self._dispatch)
 
     def submit(self, request: "Request", future: "Future") -> None:
@@ -289,6 +297,87 @@ class QtResponder(QObject):
         controller.fib_canvas.set_hint("drag to move")
         self._park_question(request, future, request.message, "Continue", None)
 
+    def _run_milling_task(self, request: RunMillingTask, future: "Future") -> None:
+        """Hand the config to the editor; run and re-ask until Continue.
+
+        The whole mill loop lives here now: show the config, ask (when
+        ``confirm``), run on the Run Milling click, wait for the widget's own
+        ``finished_milling_signal``, re-ask, and only complete the future — with
+        the config as actually used — on Continue. The workflow thread just
+        blocks on its future, instead of emitting ``start_milling_signal`` with
+        a BlockingQueuedConnection and sleep-polling ``is_milling`` across the
+        seam.
+        """
+        widget = self._milling_widget()
+        widget.update_from_settings(request.config)
+        widget.setEnabled(True)
+        self._ui.tabWidget.setCurrentWidget(widget)
+        # The workflow runs the mill; the editor's own Run button stands down
+        # (moved from handle_workflow_update's milling_enabled branch).
+        widget.milling_widget.pushButton_run_milling.setVisible(False)
+        self._wire_milling_finished(widget)
+
+        if not request.confirm:
+            if request.enabled:
+                self._start_milling_run(request, future)
+            else:
+                future.set_result(self._finish_milling_question())
+            return
+        pos, neg = (
+            ("Run Milling", "Continue") if request.enabled else ("Continue", None)
+        )
+        self._park_question(request, future, request.message, pos, neg)
+
+    def _wire_milling_finished(self, widget) -> None:
+        """Connect the (possibly rebuilt) milling widget's finished signal, once."""
+        if self._milling_finished_wired is widget:
+            return
+        widget.milling_widget.finished_milling_signal.connect(self._on_milling_finished)
+        self._milling_finished_wired = widget
+
+    def _start_milling_run(self, request: RunMillingTask, future: "Future") -> None:
+        """Run the editor's current config; the finished signal decides what next."""
+        self._active_milling = (request, future)
+        self._ui.workflow_update_signal.emit(
+            {"msg": f"Milling {request.config.name}..."}
+        )
+        # None: the widget builds the config from the editor, so the operator's
+        # edits are what actually runs — as the old start_milling_signal path did.
+        self._milling_widget().milling_widget.run_milling(None)
+
+    def _on_milling_finished(self) -> None:
+        """GUI thread, from finished_milling_signal — success and failure alike."""
+        active = self._active_milling
+        if active is None:
+            return  # a mill the operator ran outside a question
+        self._active_milling = None
+        request, future = active
+        if future.cancelled():
+            return
+        self._ui.workflow_update_signal.emit(
+            {
+                "msg": f"Milling {request.config.name} Complete: "
+                f"{len(request.config.stages)} stages completed."
+            }
+        )
+        if request.confirm:
+            # Same prompt again: Run Milling reruns (after edits), Continue ends.
+            self._park_question(
+                request, future, request.message, "Run Milling", "Continue"
+            )
+            return
+        try:
+            future.set_result(self._finish_milling_question())
+        except Exception as exc:  # noqa: BLE001 - the caller owns the failure
+            future.set_exception(exc)
+
+    def _finish_milling_question(self):
+        """The answer: the config as the editor holds it, with the editor cleared."""
+        widget = self._milling_widget()
+        config = deepcopy(widget.get_config())
+        widget.clear()
+        return config
+
     def answer_confirm(self, clicked_yes: bool) -> bool:
         """Complete the pending question from the yes/no click.
 
@@ -305,6 +394,12 @@ class QtResponder(QObject):
         request, future = pending
         self._pending_question = None
         self._ui.WAITING_FOR_USER_INTERACTION = False
+        if isinstance(request, RunMillingTask) and clicked_yes and request.enabled:
+            # Run Milling: the prompt comes down but the question stays open —
+            # the finished signal re-asks or completes. (No {"msg": ""} clear;
+            # _start_milling_run puts the running status up in its place.)
+            self._start_milling_run(request, future)
+            return True
         self._ui.workflow_update_signal.emit({"msg": ""})
         try:
             future.set_result(self._answer(request, clicked_yes))
@@ -314,6 +409,10 @@ class QtResponder(QObject):
 
     def _answer(self, request: Request, clicked_yes: bool):
         """What the click means for this question's asker."""
+        if isinstance(request, RunMillingTask):
+            # Only the not-run clicks reach here (answer_confirm intercepts Run
+            # Milling): Continue, or either button when running is disabled.
+            return self._finish_milling_question()
         if isinstance(request, ConfirmDetection):
             # Both the read-back and the save used to straddle threads: the
             # workflow thread called _get_detected_features across the seam, then

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -24,6 +24,7 @@ workflow thread blocks on each; a pending future found when the next question
 arrives belonged to a waiter that aborted and unwound, and is cancelled.
 """
 
+from concurrent.futures import InvalidStateError
 from copy import deepcopy
 from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple, Type
 
@@ -99,7 +100,7 @@ class QtResponder(QObject):
             try:
                 deferred(request, future)
             except Exception as exc:  # noqa: BLE001 - the caller owns the failure
-                future.set_exception(exc)
+                self._fail(future, exc)
             return
         handler = self._handlers.get(type(request))
         try:
@@ -107,9 +108,30 @@ class QtResponder(QObject):
                 raise TypeError(
                     f"QtResponder has no handler for {type(request).__name__}"
                 )
-            future.set_result(handler(request))
+            self._deliver(future, handler(request))
         except Exception as exc:  # noqa: BLE001 - the caller owns the failure
+            self._fail(future, exc)
+
+    # An abandoned ask cancels its future (wait_for, on abort or timeout), and
+    # the cancel runs on the workflow thread — so any GUI-side completion can
+    # find the future already cancelled, including between a cancelled() check
+    # and the set. set_result on a cancelled future is InvalidStateError inside
+    # a Qt slot, i.e. a process abort; these two tolerate it instead. Dropping
+    # the value is correct: cancellation means nobody will read it.
+
+    @staticmethod
+    def _deliver(future: "Future", value) -> None:
+        try:
+            future.set_result(value)
+        except InvalidStateError:
+            pass
+
+    @staticmethod
+    def _fail(future: "Future", exc: Exception) -> None:
+        try:
             future.set_exception(exc)
+        except InvalidStateError:
+            pass
 
     # --- handlers, one per request type ------------------------------------------
 
@@ -256,7 +278,7 @@ class QtResponder(QObject):
         """
         controller = self._view_controller()
         if controller is None:
-            future.set_result(None)
+            self._deliver(future, None)
             return
 
         from fibsem import conversions
@@ -321,7 +343,7 @@ class QtResponder(QObject):
             if request.enabled:
                 self._start_milling_run(request, future)
             else:
-                future.set_result(self._finish_milling_question())
+                self._deliver(future, self._finish_milling_question())
             return
         pos, neg = (
             ("Run Milling", "Continue") if request.enabled else ("Continue", None)
@@ -367,9 +389,9 @@ class QtResponder(QObject):
             )
             return
         try:
-            future.set_result(self._finish_milling_question())
+            self._deliver(future, self._finish_milling_question())
         except Exception as exc:  # noqa: BLE001 - the caller owns the failure
-            future.set_exception(exc)
+            self._fail(future, exc)
 
     def _finish_milling_question(self):
         """The answer: the config as the editor holds it, with the editor cleared."""
@@ -377,6 +399,24 @@ class QtResponder(QObject):
         config = deepcopy(widget.get_config())
         widget.clear()
         return config
+
+    def abandon(self) -> None:
+        """Drop whatever a finished run left behind. GUI thread, workflow end.
+
+        An abort races the GUI: a cancelled mill that finishes quickly re-parks
+        the prompt in the gap before the aborting waiter cancels its future.
+        The run is over when this is called — the workflow thread has exited —
+        so a question still parked, or a run still tracked, belongs to nobody:
+        cancel it and take the prompt down.
+        """
+        pending, self._pending_question = self._pending_question, None
+        active, self._active_milling = self._active_milling, None
+        for pair in (pending, active):
+            if pair is not None:
+                pair[1].cancel()
+        if pending is not None:
+            self._ui.WAITING_FOR_USER_INTERACTION = False
+            self._ui.workflow_update_signal.emit({"msg": ""})
 
     def answer_confirm(self, clicked_yes: bool) -> bool:
         """Complete the pending question from the yes/no click.
@@ -394,6 +434,12 @@ class QtResponder(QObject):
         request, future = pending
         self._pending_question = None
         self._ui.WAITING_FOR_USER_INTERACTION = False
+        if future.cancelled():
+            # The asker aborted while the prompt stood. The click means nothing
+            # beyond taking the stale prompt down — in particular it must not
+            # start a mill for a question nobody is waiting on.
+            self._ui.workflow_update_signal.emit({"msg": ""})
+            return True
         if isinstance(request, RunMillingTask) and clicked_yes and request.enabled:
             # Run Milling: the prompt comes down but the question stays open —
             # the finished signal re-asks or completes. (No {"msg": ""} clear;
@@ -402,9 +448,9 @@ class QtResponder(QObject):
             return True
         self._ui.workflow_update_signal.emit({"msg": ""})
         try:
-            future.set_result(self._answer(request, clicked_yes))
+            self._deliver(future, self._answer(request, clicked_yes))
         except Exception as exc:  # noqa: BLE001 - the caller owns the failure
-            future.set_exception(exc)
+            self._fail(future, exc)
         return True
 
     def _answer(self, request: Request, clicked_yes: bool):

--- a/fibsem/applications/autolamella/workflows/interaction.py
+++ b/fibsem/applications/autolamella/workflows/interaction.py
@@ -235,8 +235,16 @@ def wait_for(
             return future.result(timeout=_POLL_INTERVAL_S)
         except _FutureTimeoutError:
             if abort is not None and abort():
+                # Cancel before leaving: this tells the responder nobody will
+                # read an answer, so it must not act for this question again —
+                # concretely, a Stop mid-mill must not resurrect the prompt when
+                # the cancelled mill finishes. cancel() always succeeds here
+                # (the future has no runner), and the race where the responder
+                # completes it first is benign: the answer is simply dropped.
+                future.cancel()
                 raise InterruptedError(f"{description} cancelled")
             if deadline is not None and time.monotonic() >= deadline:
+                future.cancel()
                 raise TimeoutError(f"No response to {description} within {timeout} s")
 
 

--- a/fibsem/applications/autolamella/workflows/interaction.py
+++ b/fibsem/applications/autolamella/workflows/interaction.py
@@ -141,10 +141,16 @@ class RunMillingTask(Request["FibsemMillingTaskConfig"]):
     """Hand over a milling config to edit and (if ``enabled``) run; answer with the
     config as actually used. Absorbs today's ``start_milling_signal`` sibling poll:
     running the mill is the responder's job, not a second channel's.
+
+    ``confirm`` is the supervision mode: True shows the prompt (Run Milling reruns
+    after edits, Continue ends the question); False runs once unprompted when
+    ``enabled``, or just delivers the config back when not.
     """
 
     config: "FibsemMillingTaskConfig"
     enabled: bool = True
+    confirm: bool = True
+    message: str = "Run Milling"
 
 
 # --- instructions: one-way, answered with a bare acknowledgement ------------------

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -52,6 +52,7 @@ from fibsem.applications.autolamella.workflows.core import (
 )
 from fibsem.applications.autolamella.workflows.interaction import (
     ClearMillingConfig,
+    RunMillingTask,
     SetFluorescenceChannels,
     SetMillingConfig,
     ask,
@@ -392,7 +393,17 @@ class AutoLamellaTask(ABC):
         msg: str = "Run Milling",
         milling_enabled: bool = True,
     ) -> FibsemMillingTaskConfig:
-        """Update the milling config in the milling widget, and optionally run the milling task."""
+        """Hand the config to the UI to edit and (optionally) run; return it as used.
+
+        One question over the Responder. The whole mill loop — prompt, run on
+        Run Milling, wait for the widget's finished signal, re-prompt, read the
+        editor back and clear it on Continue — runs on the GUI thread that owns
+        it; this thread just blocks on the answer. Replaces the
+        ``start_milling_signal`` BlockingQueuedConnection emit, the ``is_milling``
+        sleep-poll, and the ``get_config()`` read-back across the seam.
+        No timeout: milling takes as long as it takes, and a human may hold the
+        prompt; ``abort`` keeps Stop working throughout.
+        """
         # headless mode
         if self.parent_ui is None:
             if milling_enabled:
@@ -400,60 +411,18 @@ class AutoLamellaTask(ABC):
                 return milling_task.config
             return milling_config
 
-        if self.parent_ui.milling_task_config_widget is None:
-            raise ValueError("Milling task config widget is not set in the parent UI.")
-
-        # set milling config in milling widget
-        self._set_milling_config_ui(milling_config)
-
-        # ask user to confirm milling config
-        pos, neg = "Run Milling", "Continue"
-
-        # we only want the user to confirm the milling patterns, not acatually run them
-        if milling_enabled is False:
-            pos = "Continue"
-            neg = None
-
-        response = True
-        if self.validate:
-            response = ask_user(
-                self.parent_ui, msg=msg, pos=pos, neg=neg, mill=milling_enabled
-            )
-
-        while response and milling_enabled:
-            self.update_status_ui(f"Milling {milling_config.name}...")
-            # BlockingQueuedConnection guarantees run_milling() has returned and
-            # _milling_thread.start() has been called before emit() unblocks.
-            # No need to poll for is_milling to become True — it already is (or
-            # milling finished before we got here, in which case the loop below
-            # exits immediately, which is correct).
-            self.parent_ui.milling_task_config_widget.milling_widget.start_milling_signal.emit()
-
-            # wait for milling to finish
-            logging.info("WAITING FOR MILLING TO FINISH... ")
-            while self.parent_ui.milling_task_config_widget.milling_widget.is_milling:
-                self._check_for_abort()
-                time.sleep(1)
-
-            self.update_status_ui(
-                f"Milling {milling_config.name} Complete: {len(milling_config.stages)} stages completed."
-            )
-
-            response = False
-            if self.validate:
-                response = ask_user(
-                    self.parent_ui, msg=msg, pos=pos, neg=neg, mill=milling_enabled
-                )
-
-        # get milling config from milling widget
-        milling_config = deepcopy(
-            self.parent_ui.milling_task_config_widget.get_config()
+        return ask(
+            self.parent_ui.ui_responder,
+            RunMillingTask(
+                # deepcopy kept from the signal days: the editor's copy must be
+                # the operator's to edit without the task's own moving under it.
+                config=deepcopy(milling_config),
+                enabled=milling_enabled,
+                confirm=self.validate,
+                message=msg,
+            ),
+            abort=lambda: _abort_requested(self.parent_ui),
         )
-
-        # clear milling config from milling widget
-        self.clear_milling_config_ui()
-
-        return milling_config
 
     def _set_milling_config_ui(self, milling_config: FibsemMillingTaskConfig):
         """Set the milling config in the milling widget."""

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -159,7 +159,6 @@ def ask_user(
     msg: str,
     pos: str,
     neg: Optional[str] = None,
-    mill: Optional[bool] = None,
     spot_burn: Optional[bool] = None,
 ) -> bool:
 
@@ -169,7 +168,7 @@ def ask_user(
         )
         return True
 
-    if mill is None and spot_burn is None:
+    if spot_burn is None:
         # A plain yes/no confirmation: the typed path. The answer arrives on this
         # call's own future when a button is clicked — USER_RESPONSE and the
         # polled flag are not involved. No timeout: a human answers, and silence
@@ -184,7 +183,6 @@ def ask_user(
         "msg": msg,
         "pos": pos,
         "neg": neg,
-        "milling_enabled": mill,
         "spot_burn": spot_burn,
     }
     parent_ui.workflow_update_signal.emit(INFO)

--- a/tests/test_workflow_interaction.py
+++ b/tests/test_workflow_interaction.py
@@ -9,6 +9,7 @@ run, rather than only in ``tests/ui``.
 import dataclasses
 import threading
 import time
+from concurrent.futures import Future
 
 import pytest
 
@@ -16,6 +17,7 @@ from fibsem.applications.autolamella.workflows.interaction import (
     Confirm,
     SetImages,
     ask,
+    wait_for,
 )
 
 
@@ -113,3 +115,25 @@ def test_requests_are_immutable():
 
     with pytest.raises(dataclasses.FrozenInstanceError):
         request.message = "changed"
+
+
+def test_an_abandoned_wait_cancels_its_future():
+    # The responder's contract for a Stop: cancellation is visible on the future
+    # itself, so a responder does not act again for a question nobody will read
+    # (bench-found: a Stop mid-mill resurrected the prompt when the cancelled
+    # mill finished, because the future looked like it still had a waiter).
+    future = Future()
+
+    with pytest.raises(InterruptedError):
+        wait_for(future, abort=lambda: True)
+
+    assert future.cancelled()
+
+
+def test_a_timed_out_wait_cancels_its_future():
+    future = Future()
+
+    with pytest.raises(TimeoutError):
+        wait_for(future, timeout=0.05)
+
+    assert future.cancelled()

--- a/tests/ui/test_run_milling_question.py
+++ b/tests/ui/test_run_milling_question.py
@@ -1,0 +1,186 @@
+"""The milling question over the Responder seam: RunMillingTask.
+
+The old mill loop straddled threads four ways: ``ask_user(mill=...)`` parked on
+the polled flag; the workflow thread emitted ``start_milling_signal`` over a
+BlockingQueuedConnection; it sleep-polled ``widget.is_milling`` across the seam;
+and it read ``get_config()`` back at the end. Now the whole loop — prompt, run
+on Run Milling, wait for the widget's ``finished_milling_signal``, re-prompt,
+read back and clear on Continue — lives in ``QtResponder`` on the GUI thread,
+and the workflow blocks on one future whose answer is the config as used.
+
+``run_milling_task`` is stubbed at the milling widget's import site: the run
+still goes through the widget's real thread, buttons and finished signal — only
+the beam time is gone.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.applications.autolamella.workflows.interaction import (
+    RunMillingTask,
+    ask,
+)
+from fibsem.milling import FibsemMillingStage
+from fibsem.milling.tasks import FibsemMillingTaskConfig
+
+MSG = "Check the patterns, then run."
+
+
+def _config(name: str) -> FibsemMillingTaskConfig:
+    # One real stage: the widget's worker refuses a config with none enabled.
+    return FibsemMillingTaskConfig(name=name, stages=[FibsemMillingStage()])
+
+
+@pytest.fixture
+def ui(qapp, monkeypatch):
+    """A real AutoLamellaUI, connected (Demo), with the mill run itself stubbed."""
+    from fibsem.ui.widgets import milling_widget as mw
+
+    runs = []
+
+    def fake_run_milling_task(microscope, config, parent_ui=None, **kwargs):
+        runs.append(config)
+        time.sleep(0.05)  # long enough for is_milling to be observable
+
+    monkeypatch.setattr(mw, "run_milling_task", fake_run_milling_task)
+    widget = AutoLamellaUI(parent_ui=None)
+    widget.system_widget.connect_to_microscope()
+    widget._mill_runs = runs  # for the tests to inspect
+    yield widget
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+
+
+def _ask_on_worker_thread(ui, qapp, request, wait_for_prompt=True):
+    outcome = {}
+
+    def target():
+        try:
+            outcome["config"] = ask(
+                ui.ui_responder, request, abort=ui._workflow_stop_event.is_set
+            )
+        except Exception as exc:  # noqa: BLE001 - the test inspects it
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    if wait_for_prompt:
+        _wait_for_prompt(ui, qapp, request.message)
+    return thread, outcome
+
+
+def _wait_for_prompt(ui, qapp, msg, timeout_s=10.0):
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if ui.label_instructions.text() == msg and ui.pushButton_yes.isEnabled():
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"the prompt {msg!r} never appeared")
+
+
+def _finish(thread, qapp, timeout_s=10.0):
+    deadline = time.monotonic() + timeout_s
+    while thread.is_alive() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+    thread.join(timeout=1.0)
+    assert not thread.is_alive(), "the asker never returned"
+
+
+def test_run_then_continue_runs_once_and_answers_the_editor_config(ui, qapp):
+    request = RunMillingTask(config=_config("rough-mill"), message=MSG)
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request)
+
+    assert ui.pushButton_yes.text() == "Run Milling"
+    assert ui.pushButton_no.text() == "Continue"
+    assert ui.WAITING_FOR_USER_INTERACTION is True
+
+    ui.pushButton_yes.click()  # run
+    # The prompt is down while the mill runs, and comes back when it finishes.
+    _wait_for_prompt(ui, qapp, MSG)
+    assert len(ui._mill_runs) == 1
+
+    ui.pushButton_no.click()  # continue
+    _finish(thread, qapp)
+
+    assert "error" not in outcome
+    assert isinstance(outcome["config"], FibsemMillingTaskConfig)
+    assert outcome["config"].name == "rough-mill"
+    assert ui.WAITING_FOR_USER_INTERACTION is False
+    # The old handshakes are gone: nothing touched the polled flags.
+    assert ui.WAITING_FOR_UI_UPDATE is False
+
+
+def test_continue_without_running_answers_without_a_mill(ui, qapp):
+    request = RunMillingTask(config=_config("skip"), message=MSG)
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request)
+
+    ui.pushButton_no.click()
+    _finish(thread, qapp)
+
+    assert "error" not in outcome
+    assert outcome["config"].name == "skip"
+    assert ui._mill_runs == []
+
+
+def test_unsupervised_runs_once_without_a_prompt(ui, qapp):
+    request = RunMillingTask(config=_config("auto"), confirm=False, message=MSG)
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request, wait_for_prompt=False)
+
+    _finish(thread, qapp)
+
+    assert "error" not in outcome
+    assert outcome["config"].name == "auto"
+    assert len(ui._mill_runs) == 1
+    # No prompt was ever shown for it.
+    assert ui.WAITING_FOR_USER_INTERACTION is False
+
+
+def test_disabled_milling_only_confirms_the_patterns(ui, qapp):
+    request = RunMillingTask(config=_config("preview"), enabled=False, message=MSG)
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request)
+
+    # Confirm-only: one button, and the positive click must not start a mill.
+    assert ui.pushButton_yes.text() == "Continue"
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+    assert "error" not in outcome
+    assert outcome["config"].name == "preview"
+    assert ui._mill_runs == []
+
+
+def test_the_answer_is_the_editors_config_not_the_requests(ui, qapp):
+    request = RunMillingTask(config=_config("sent"), message=MSG)
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request)
+
+    # The operator edits while the prompt is up; the answer must be the editor's.
+    ui.milling_task_config_widget.update_from_settings(_config("edited-by-operator"))
+    ui.pushButton_no.click()
+    _finish(thread, qapp)
+
+    assert outcome["config"].name == "edited-by-operator"
+
+
+def test_a_stop_interrupts_the_prompt(ui, qapp):
+    request = RunMillingTask(config=_config("stop"), message=MSG)
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request)
+
+    ui._workflow_stop_event.set()
+    try:
+        _finish(thread, qapp)
+    finally:
+        ui._workflow_stop_event.clear()
+
+    assert isinstance(outcome.get("error"), InterruptedError)

--- a/tests/ui/test_run_milling_question.py
+++ b/tests/ui/test_run_milling_question.py
@@ -184,3 +184,64 @@ def test_a_stop_interrupts_the_prompt(ui, qapp):
         ui._workflow_stop_event.clear()
 
     assert isinstance(outcome.get("error"), InterruptedError)
+
+
+def test_a_stop_during_the_mill_does_not_resurrect_the_prompt(ui, qapp):
+    # The bug from bench testing: Stop mid-mill aborted the waiter, but the
+    # responder still held the question — so when the cancelled mill finished,
+    # the prompt reappeared over a cleared editor, for nobody. Two defences now:
+    # an abandoned ask cancels its future (a finished mill drops a cancelled
+    # question), and the workflow-finished sweep abandons whatever the race
+    # still managed to re-park before the cancel landed.
+    request = RunMillingTask(config=_config("stopped-mid-mill"), message=MSG)
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request)
+
+    ui.pushButton_yes.click()  # run
+    ui._workflow_stop_event.set()
+    try:
+        _finish(thread, qapp)
+    finally:
+        ui._workflow_stop_event.clear()
+    assert isinstance(outcome.get("error"), InterruptedError)
+
+    # Let the (still running) stubbed mill finish and its signal land — this is
+    # the window where the resurrect happened.
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+
+    # What production does next: the workflow worker exits and fires the
+    # finished signal, whose handler abandons anything the run left behind.
+    ui._workflow_finished_signal.emit(True)
+    deadline = time.monotonic() + 0.5
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+
+    assert ui.label_instructions.text() != MSG, "the aborted prompt came back"
+    assert ui.WAITING_FOR_USER_INTERACTION is False
+
+
+def test_a_click_after_a_stop_starts_nothing(ui, qapp):
+    # Stop while the prompt stands, then a click lands anyway (the buttons are
+    # still up until the next status arrives). It must only take the stale
+    # prompt down — not start a mill for a question nobody is waiting on.
+    request = RunMillingTask(config=_config("stale-click"), message=MSG)
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request)
+
+    ui._workflow_stop_event.set()
+    try:
+        _finish(thread, qapp)
+    finally:
+        ui._workflow_stop_event.clear()
+    assert isinstance(outcome.get("error"), InterruptedError)
+
+    ui.pushButton_yes.click()  # "Run Milling", but the asker is gone
+    deadline = time.monotonic() + 0.5
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+
+    assert ui._mill_runs == []
+    assert ui.label_instructions.text() == ""


### PR DESCRIPTION
Fifth question over the Responder seam: `RunMillingTask` — the biggest of the hand-rolled RPCs. Stacks on the PickPOI PR.

**Before:** the mill loop straddled threads four ways — `ask_user(mill=...)` parked on the polled flag; the workflow thread emitted `start_milling_signal` over a `BlockingQueuedConnection`; it sleep-polled `widget.is_milling` across the seam; and it read `get_config()` back at the end.

**After:** one question, and the whole loop lives in `QtResponder` on the GUI thread that owns the widgets:
- show the config in the editor, front the tab, stand the editor's own Run button down (the old `milling_enabled` branch's action, moved into the handler);
- prompt when supervised (`confirm`, from the task's `validate`): **Run Milling** runs the *editor's current* config (operator edits are what actually mill, as before), **Continue** ends the question;
- the widget's own `finished_milling_signal` (success and failure alike, same as the old `is_milling` poll) re-raises the prompt for another round, or completes unsupervised;
- the answer is the config as the editor holds it, with the editor cleared.

Unsupervised runs once unprompted; `enabled=False` only confirms the patterns (single Continue button, no run possible). The workflow thread blocks on one future throughout — no timeout (milling takes as long as it takes), Stop interrupts via the abort predicate at every stage. Headless mode is untouched (runs `run_milling_task` directly).

**Deleted:** `ask_user`'s `mill` variant (the spot-burn variant is now the last one standing) and the `milling_enabled` branch in `handle_workflow_update`.

**Tests** (`tests/ui/test_run_milling_question.py`, 6): `run_milling_task` is stubbed at the milling widget's import site, so runs go through the widget's real thread, button states and finished signal — only the beam time is gone. Run→re-prompt→Continue answers the editor's config with both polled flags untouched; Continue-without-run mills nothing; unsupervised runs once with no prompt; disabled shows confirm-only and the positive click starts no mill; operator edits win; Stop interrupts.