### PR TITLE
[refactor] Run the spot burn from the Responder, and answer with the settings as used

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1895,17 +1895,10 @@ class AutoLamellaUI(QMainWindow):
         # no longer arrive here: they are questions over the Responder seam
         # (QtResponder._confirm_detection, _edit_alignment_area, _pick_poi).
 
-        # spot_burn
-        spot_burn = info.get("spot_burn", None)
-        if spot_burn:
-            self.set_spot_burn_widget_active(True)
-            if self.spot_burn_widget is not None:
-                # hide the widget's own Burn button; the burn is run from the workflow control
-                self.spot_burn_widget.set_workflow_mode(True)
         # Milling config, spot-burn settings and fluorescence channels no longer
         # arrive here: their instructions go through the Responder seam
-        # (QtResponder). The spot_burn key above stays — it is part of the
-        # ask_user question flow, which has not converted yet.
+        # (QtResponder). The spot-burn question converted last (RunSpotBurn), so
+        # no variant payloads remain — only status text below.
 
         # Instruction message. Read with `.get`, not indexed: this signal has no
         # declared contract, and 12 of its 13 emit sites pass an opaque variable, so

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -39,6 +39,7 @@ from fibsem.applications.autolamella.workflows.interaction import (
     PickPOI,
     Request,
     RunMillingTask,
+    RunSpotBurn,
     SetFluorescenceChannels,
     SetImages,
     SetMillingConfig,
@@ -79,6 +80,7 @@ class QtResponder(QObject):
             EditAlignmentArea: self._edit_alignment_area,
             PickPOI: self._pick_poi,
             RunMillingTask: self._run_milling_task,
+            RunSpotBurn: self._run_spot_burn,
         }
         self._pending_question: Optional[Tuple[Request, "Future"]] = None
         # A RunMillingTask whose mill is currently running: the prompt is down,
@@ -87,6 +89,9 @@ class QtResponder(QObject):
         # Which milling widget's finished signal is wired to _on_milling_finished
         # (by identity — the widget is rebuilt on reconnect, taking the wire with it).
         self._milling_finished_wired: Optional[object] = None
+        # Same pair for the spot-burn question.
+        self._active_spot_burn: Optional[Tuple[RunSpotBurn, "Future"]] = None
+        self._spot_burn_finished_wired: Optional[object] = None
         self._submitted.connect(self._dispatch)
 
     def submit(self, request: "Request", future: "Future") -> None:
@@ -403,20 +408,84 @@ class QtResponder(QObject):
     def abandon(self) -> None:
         """Drop whatever a finished run left behind. GUI thread, workflow end.
 
-        An abort races the GUI: a cancelled mill that finishes quickly re-parks
-        the prompt in the gap before the aborting waiter cancels its future.
-        The run is over when this is called — the workflow thread has exited —
-        so a question still parked, or a run still tracked, belongs to nobody:
-        cancel it and take the prompt down.
+        An abort races the GUI: a cancelled mill or burn that finishes quickly
+        re-parks the prompt in the gap before the aborting waiter cancels its
+        future. The run is over when this is called — the workflow thread has
+        exited — so a question still parked, or a run still tracked, belongs to
+        nobody: cancel it and take the prompt down.
         """
         pending, self._pending_question = self._pending_question, None
-        active, self._active_milling = self._active_milling, None
-        for pair in (pending, active):
+        milling, self._active_milling = self._active_milling, None
+        burning, self._active_spot_burn = self._active_spot_burn, None
+        for pair in (pending, milling, burning):
             if pair is not None:
                 pair[1].cancel()
         if pending is not None:
             self._ui.WAITING_FOR_USER_INTERACTION = False
             self._ui.workflow_update_signal.emit({"msg": ""})
+
+    def _run_spot_burn(self, request: RunSpotBurn, future: "Future") -> None:
+        """Place-points-and-burn, mirroring the milling question.
+
+        Without a spot-burn widget the answer is None immediately: optional
+        hardware must not fail a workflow, same as the spot-burn instructions.
+        """
+        widget = self._ui.spot_burn_widget
+        if widget is None:
+            self._deliver(future, None)
+            return
+        widget.set_settings(request.settings)
+        # Front the tab and enter workflow mode (moved from
+        # handle_workflow_update's spot_burn branch).
+        self._ui.set_spot_burn_widget_active(True)
+        widget.set_workflow_mode(True)
+        self._wire_spot_burn_finished(widget)
+        self._park_question(
+            request, future, request.message, "Run Spot Burn", "Continue"
+        )
+
+    def _wire_spot_burn_finished(self, widget) -> None:
+        """Connect the (possibly rebuilt) spot-burn widget's finished signal, once."""
+        if self._spot_burn_finished_wired is widget:
+            return
+        widget.finished_spot_burn_signal.connect(self._on_spot_burn_finished)
+        self._spot_burn_finished_wired = widget
+
+    def _start_spot_burn_run(self, request: RunSpotBurn, future: "Future") -> None:
+        """Run the widget's current points; the finished signal re-asks."""
+        self._active_spot_burn = (request, future)
+        self._ui.workflow_update_signal.emit({"msg": "Running Spot Burn..."})
+        widget = self._ui.spot_burn_widget
+        widget.run_spot_burn_worker()
+        if not widget.is_burning:
+            # Refused — no in-bounds points — so no finished signal will come.
+            # The old is_milling-style poll fell straight through and re-asked;
+            # do the same now.
+            self._active_spot_burn = None
+            self._park_question(
+                request, future, request.message, "Run Spot Burn", "Continue"
+            )
+
+    def _on_spot_burn_finished(self) -> None:
+        """GUI thread, from finished_spot_burn_signal — success and failure alike."""
+        active = self._active_spot_burn
+        if active is None:
+            return  # a burn the operator ran outside a question
+        self._active_spot_burn = None
+        request, future = active
+        if future.cancelled():
+            return
+        self._park_question(
+            request, future, request.message, "Run Spot Burn", "Continue"
+        )
+
+    def _finish_spot_burn_question(self):
+        """The answer: the settings as the widget holds them, widget cleared."""
+        widget = self._ui.spot_burn_widget
+        settings = widget.get_settings()
+        widget.clear_points_layer()
+        widget.set_workflow_mode(False)
+        return settings
 
     def answer_confirm(self, clicked_yes: bool) -> bool:
         """Complete the pending question from the yes/no click.
@@ -446,6 +515,10 @@ class QtResponder(QObject):
             # _start_milling_run puts the running status up in its place.)
             self._start_milling_run(request, future)
             return True
+        if isinstance(request, RunSpotBurn) and clicked_yes:
+            # Run Spot Burn: same shape — the finished signal re-asks.
+            self._start_spot_burn_run(request, future)
+            return True
         self._ui.workflow_update_signal.emit({"msg": ""})
         try:
             self._deliver(future, self._answer(request, clicked_yes))
@@ -459,6 +532,9 @@ class QtResponder(QObject):
             # Only the not-run clicks reach here (answer_confirm intercepts Run
             # Milling): Continue, or either button when running is disabled.
             return self._finish_milling_question()
+        if isinstance(request, RunSpotBurn):
+            # Only Continue reaches here; Run Spot Burn is intercepted above.
+            return self._finish_spot_burn_question()
         if isinstance(request, ConfirmDetection):
             # Both the read-back and the save used to straddle threads: the
             # workflow thread called _get_detected_features across the seam, then

--- a/fibsem/applications/autolamella/workflows/interaction.py
+++ b/fibsem/applications/autolamella/workflows/interaction.py
@@ -69,6 +69,7 @@ __all__ = [
     "EditAlignmentArea",
     "PickPOI",
     "RunMillingTask",
+    "RunSpotBurn",
     "SetImages",
     "SetMillingConfig",
     "ClearMillingConfig",
@@ -151,6 +152,21 @@ class RunMillingTask(Request["FibsemMillingTaskConfig"]):
     enabled: bool = True
     confirm: bool = True
     message: str = "Run Milling"
+
+
+@dataclass(frozen=True)
+class RunSpotBurn(Request[Optional["SpotBurnSettings"]]):
+    """Hand over spot-burn settings to place points and run; answer with the
+    settings as actually used — or None without a spot-burn widget (optional
+    hardware must not fail a workflow).
+
+    Mirrors :class:`RunMillingTask`: Run Spot Burn runs the widget's current
+    points, the widget's finished signal re-raises the prompt, and Continue
+    answers with ``get_settings()`` and clears the widget.
+    """
+
+    settings: "SpotBurnSettings"
+    message: str = "Run Spot Burn"
 
 
 # --- instructions: one-way, answered with a bare acknowledgement ------------------

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -1,24 +1,19 @@
-
 ######## SPOT BURN FIDUCIAL TASK DEFINITIONS ########
 from __future__ import annotations
 
 import logging
-import time
 from dataclasses import dataclass, field
 from typing import ClassVar, Optional, Type
 
 from fibsem import config as fcfg
 from fibsem import timing
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.applications.autolamella.workflows.interaction import RunSpotBurn, ask
 from fibsem.applications.autolamella.workflows.tasks.base import (
     ALIGNMENT_REFERENCE_IMAGE_FILENAME,
     AutoLamellaTask,
 )
-from fibsem.applications.autolamella.workflows.ui import (
-    ask_user,
-    clear_spot_burn_ui,
-    update_spot_burn_parameters,
-)
+from fibsem.applications.autolamella.workflows.ui import _abort_requested
 from fibsem.imaging.spot import SpotBurnSettings, run_spot_burn
 from fibsem.structures import BeamType, Point, field_meta
 
@@ -26,35 +21,30 @@ from fibsem.structures import BeamType, Point, field_meta
 @dataclass
 class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
     """Configuration for the SpotBurnFiducialTask."""
+
     task_type: ClassVar[str] = "SPOT_BURN_FIDUCIAL"
     display_name: ClassVar[str] = "Spot Burn Fiducial"
     milling_current: float = field(
         default=60.0e-12,  # in Amperes
-        metadata=field_meta(
-            tooltip='Milling current in Amperes',
-            unit='A',
-            scale=1e12
-        )
+        metadata=field_meta(tooltip="Milling current in Amperes", unit="A", scale=1e12),
     )
     exposure_time: int = field(
         default=10,
-        metadata=field_meta(
-            tooltip='Exposure time in seconds',
-            unit='s',
-            scale=1
-        )
+        metadata=field_meta(tooltip="Exposure time in seconds", unit="s", scale=1),
     )
     autofocus: bool = field(
         default=False,
         metadata=field_meta(
             tooltip="Run a FIB autofocus before acquiring the reference image, so the "
-                    "points are placed on (and burned into) a focused image",
+            "points are placed on (and burned into) a focused image",
             label="Autofocus",
         ),
     )
     coordinates: list[Point] = field(
         default_factory=list,
-        metadata=field_meta(tooltip="Spot burn positions in normalised image coordinates (0-1)"),
+        metadata=field_meta(
+            tooltip="Spot burn positions in normalised image coordinates (0-1)"
+        ),
     )
 
     @property
@@ -78,7 +68,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
         Each point costs its exposure plus a blank/park/unblank cycle.
         """
         total = super().estimated_duration
-        total += 2 * timing.BEAM_CURRENT_CHANGE_S     # into the burn current and back
+        total += 2 * timing.BEAM_CURRENT_CHANGE_S  # into the burn current and back
         total += len(self.coordinates) * (
             self.exposure_time + timing.SPOT_BURN_POINT_OVERHEAD_S
         )
@@ -99,7 +89,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
         return ddict
 
     @classmethod
-    def from_dict(cls, ddict: dict) -> 'SpotBurnFiducialTaskConfig':
+    def from_dict(cls, ddict: dict) -> "SpotBurnFiducialTaskConfig":
         cfg = AutoLamellaTaskConfig.from_dict(ddict)
         params = ddict.get("parameters", {})
         coordinates = [Point.from_dict(pt) for pt in ddict.get("coordinates", [])]
@@ -131,6 +121,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
 
 class SpotBurnFiducialTask(AutoLamellaTask):
     """Task to mill spot fiducial markers for correlation."""
+
     config: SpotBurnFiducialTaskConfig
     config_cls: ClassVar[Type[SpotBurnFiducialTaskConfig]] = SpotBurnFiducialTaskConfig
 
@@ -180,50 +171,36 @@ class SpotBurnFiducialTask(AutoLamellaTask):
                 )
                 return
             # burn the stored coordinates directly (progress via the microscope signal)
-            run_spot_burn(microscope=self.microscope,
-                          settings=self.config.to_settings(),
-                          beam_type=BeamType.ION,
-                          stop_event=self._stop_event)
+            run_spot_burn(
+                microscope=self.microscope,
+                settings=self.config.to_settings(),
+                beam_type=BeamType.ION,
+                stop_event=self._stop_event,
+            )
             return
 
-        # supervised path: task-orchestrated run/wait/re-prompt loop (mirrors milling).
-        # The user runs the burn via the workflow "Run Spot Burn" button; the task waits
-        # for each burn to finish before continuing so the workflow can't advance mid-burn.
-        if self.parent_ui.spot_burn_widget is None:
-            logging.warning("Spot burn widget not available in UI.")
-            return
-
-        update_spot_burn_parameters(
-            parent_ui=self.parent_ui, settings=self.config.to_settings()
-        )
-
-        # supervised run/wait/re-prompt loop (mirrors milling): the user runs each burn
-        # via the workflow "Run Spot Burn" control, and the task waits for it to finish
-        # before continuing so the workflow can't advance mid-burn.
-        spot_burn_widget = self.parent_ui.spot_burn_widget
+        # supervised path: one question over the Responder, mirroring milling. The
+        # whole run/wait/re-prompt loop lives on the GUI thread that owns the
+        # widget; this thread blocks on the answer — the settings as actually used
+        # (coordinates + current/exposure), with the widget already cleared. None
+        # means no spot-burn widget: optional hardware must not fail a workflow.
         msg = f"Place points and run the spot burn for {self.lamella.name}. Press Continue when finished."
-        response = ask_user(self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True)
-        while response:
-            self.update_status_ui("Running Spot Burn...")
-            spot_burn_widget.start_spot_burn_signal.emit()
-            # BlockingQueuedConnection: on return from emit the burn is either running
-            # (is_burning=True) or was refused (no in-bounds points), in which case the
-            # wait loop exits immediately and the user is re-prompted.
-            try:
-                while spot_burn_widget.is_burning:
-                    self._check_for_abort()
-                    time.sleep(1)
-            except InterruptedError:
-                # workflow stopped: take the burn down with the task. Covers the race
-                # where the burn starts after the Stop click already ran cancel (the
-                # worker clears its stop_event on start). cancel_spot_burn only sets
-                # a threading.Event, so it is safe to call from the task thread.
+        try:
+            settings = ask(
+                self.parent_ui.ui_responder,
+                RunSpotBurn(settings=self.config.to_settings(), message=msg),
+                abort=lambda: _abort_requested(self.parent_ui),
+            )
+        except InterruptedError:
+            # workflow stopped: take a running burn down with the task. Covers the
+            # race where the burn starts after the Stop click already ran cancel
+            # (the worker clears its stop_event on start). cancel_spot_burn only
+            # sets a threading.Event, so it is safe to call from the task thread.
+            spot_burn_widget = self.parent_ui.spot_burn_widget
+            if spot_burn_widget is not None:
                 spot_burn_widget.cancel_spot_burn()
-                raise
-            response = ask_user(self.parent_ui, msg=msg, pos="Run Spot Burn", neg="Continue", spot_burn=True)
+            raise
 
-        # store the user's settings (coordinates + current/exposure) back to the config
-        self.config.apply_settings(spot_burn_widget.get_settings())
-
-        # clear the spot burn UI
-        clear_spot_burn_ui(self.parent_ui)
+        if settings is not None:
+            # store the user's settings back to the config
+            self.config.apply_settings(settings)

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -159,46 +159,24 @@ def ask_user(
     msg: str,
     pos: str,
     neg: Optional[str] = None,
-    spot_burn: Optional[bool] = None,
 ) -> bool:
-
+    """A yes/no prompt. The last variant (spot burn) converted with RunSpotBurn,
+    so every ask is the typed path now: the answer arrives on this call's own
+    future when a button is clicked — USER_RESPONSE and the polled flag are not
+    involved. No timeout: a human answers, and silence means thinking; ``abort``
+    keeps Stop working while the prompt is up.
+    """
     if parent_ui is None:
         logging.warning(
             f"User input requested in headless mode: {msg}, always returning True."
         )
         return True
 
-    if spot_burn is None:
-        # A plain yes/no confirmation: the typed path. The answer arrives on this
-        # call's own future when a button is clicked — USER_RESPONSE and the
-        # polled flag are not involved. No timeout: a human answers, and silence
-        # means thinking; `abort` keeps Stop working while the prompt is up.
-        return ask(
-            parent_ui.ui_responder,
-            Confirm(message=msg, positive=pos, negative=neg),
-            abort=lambda: _abort_requested(parent_ui),
-        )
-
-    INFO = {
-        "msg": msg,
-        "pos": pos,
-        "neg": neg,
-        "spot_burn": spot_burn,
-    }
-    parent_ui.workflow_update_signal.emit(INFO)
-
-    parent_ui.WAITING_FOR_USER_INTERACTION = True
-    logging.info("WAITING_FOR_USER_INTERACTION...")
-    while parent_ui.WAITING_FOR_USER_INTERACTION:
-        _check_for_abort(parent_ui=parent_ui)
-        time.sleep(1)
-
-    INFO = {
-        "msg": "",
-    }
-    parent_ui.workflow_update_signal.emit(INFO)  # clear the message
-
-    return parent_ui.USER_RESPONSE
+    return ask(
+        parent_ui.ui_responder,
+        Confirm(message=msg, positive=pos, negative=neg),
+        abort=lambda: _abort_requested(parent_ui),
+    )
 
 
 def ask_user_continue_workflow(

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -79,6 +79,9 @@ class FibsemSpotBurnWidget(QWidget):
 
     # emitted by the workflow task to trigger a burn (mirrors milling's start_milling_signal)
     start_spot_burn_signal = pyqtSignal()
+    # emitted when a burn ends, success and failure alike (mirrors milling's
+    # finished_milling_signal); listeners take it to mean the widget is idle again
+    finished_spot_burn_signal = pyqtSignal()
 
     def __init__(self, parent: QWidget):
         super().__init__(parent=parent)
@@ -428,6 +431,7 @@ class FibsemSpotBurnWidget(QWidget):
         )
         # in workflow mode, hide the button again now the burn is done
         self._update_run_button_visibility()
+        self.finished_spot_burn_signal.emit()
 
     @ensure_main_thread
     def _update_progress_bar(self, ddict: dict) -> None:

--- a/tests/autolamella/test_spot_burn.py
+++ b/tests/autolamella/test_spot_burn.py
@@ -521,11 +521,14 @@ def test_update_spot_burn_ui_runs_stored_coordinates_headless(monkeypatch, tmp_p
 # --- SpotBurnFiducialTask supervised loop ---------------------------------------
 
 
-def _make_supervised_spot_burn_task(monkeypatch, tmp_path, ask_user_responses):
-    """A supervised SpotBurnFiducialTask with a mock parent UI + spot burn widget.
+def _make_supervised_spot_burn_task(monkeypatch, tmp_path, ask_answer=None):
+    """A supervised SpotBurnFiducialTask whose RunSpotBurn ask is faked.
 
-    ask_user_responses is an iterable of the booleans ask_user should return.
-    Returns (task, widget, cleared_list).
+    ``ask_answer`` is what the fake ask delivers — a SpotBurnSettings, None
+    (no spot-burn widget), or an exception instance to raise. The supervised
+    loop itself lives in QtResponder and is covered with real widgets in
+    tests/ui/test_run_spot_burn_question.py; what this pins is the task's side
+    of the seam. Returns (task, asks_list).
     """
     import fibsem.applications.autolamella.workflows.tasks.spot_burn as sb_mod
     from fibsem.applications.autolamella.structures import Lamella
@@ -533,23 +536,19 @@ def _make_supervised_spot_burn_task(monkeypatch, tmp_path, ask_user_responses):
         SpotBurnFiducialTask,
     )
 
-    widget = MagicMock()
-    widget.is_burning = False  # each burn "completes" immediately
-    # the task now reads back the whole settings object (coordinates + current +
-    # exposure), not just the coordinates — see update_spot_burn_parameters' typed contract
-    widget.get_settings.return_value = SpotBurnSettings(
-        coordinates=[Point(0.5, 0.5)], exposure_time=1.0, milling_current=1e-9
-    )
     parent_ui = (
         MagicMock()
     )  # truthy experiment.task_protocol.get_supervision -> supervised
-    parent_ui.spot_burn_widget = widget
 
-    responses = iter(ask_user_responses)
-    monkeypatch.setattr(sb_mod, "ask_user", lambda *a, **k: next(responses))
-    monkeypatch.setattr(sb_mod, "update_spot_burn_parameters", lambda **k: None)
-    cleared = []
-    monkeypatch.setattr(sb_mod, "clear_spot_burn_ui", lambda ui: cleared.append(ui))
+    asks = []
+
+    def fake_ask(responder, request, abort=None, timeout=None):
+        asks.append(request)
+        if isinstance(ask_answer, BaseException):
+            raise ask_answer
+        return ask_answer
+
+    monkeypatch.setattr(sb_mod, "ask", fake_ask)
 
     lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
     config = SpotBurnFiducialTaskConfig(
@@ -558,55 +557,61 @@ def _make_supervised_spot_burn_task(monkeypatch, tmp_path, ask_user_responses):
     task = SpotBurnFiducialTask(
         microscope=MagicMock(), config=config, lamella=lamella, parent_ui=parent_ui
     )
-    task.update_status_ui = lambda *a, **k: None  # isolate the loop
-    task._check_for_abort = lambda: None
-    return task, widget, cleared
+    return task, asks
 
 
-def test_supervised_spot_burn_runs_then_continues(monkeypatch, tmp_path):
-    """'Run Spot Burn' triggers the widget and waits; then Continue proceeds."""
-    task, widget, cleared = _make_supervised_spot_burn_task(
-        monkeypatch, tmp_path, ask_user_responses=[True, False]
+def test_supervised_spot_burn_asks_and_applies_the_answer(monkeypatch, tmp_path):
+    """The request carries the task's settings; the answer is written back."""
+    from fibsem.applications.autolamella.workflows.interaction import RunSpotBurn
+
+    answer = SpotBurnSettings(
+        coordinates=[Point(0.1, 0.2), Point(0.3, 0.4)],
+        exposure_time=3.0,
+        milling_current=2e-9,
     )
+    task, asks = _make_supervised_spot_burn_task(monkeypatch, tmp_path, answer)
 
     task.update_spot_burn_parameters_ui()
 
-    widget.start_spot_burn_signal.emit.assert_called_once()
-    widget.get_settings.assert_called_once()
-    assert cleared  # spot burn UI was cleared afterwards
+    assert len(asks) == 1
+    assert isinstance(asks[0], RunSpotBurn)
+    assert asks[0].settings.coordinates == [Point(0.5, 0.5)]
+    # the answer — coordinates, exposure and current as the user left them —
+    # is applied back onto the task config
+    assert task.config.coordinates == answer.coordinates
+    assert task.config.exposure_time == 3.0
+    assert task.config.milling_current == 2e-9
 
 
-def test_supervised_spot_burn_continue_without_running(monkeypatch, tmp_path):
-    """Pressing Continue immediately runs no burn but still reads back + clears."""
-    task, widget, cleared = _make_supervised_spot_burn_task(
-        monkeypatch, tmp_path, ask_user_responses=[False]
-    )
+def test_supervised_spot_burn_none_answer_leaves_the_config_alone(
+    monkeypatch, tmp_path
+):
+    """None means no spot-burn widget (optional hardware): skip, do not fail."""
+    task, asks = _make_supervised_spot_burn_task(monkeypatch, tmp_path, None)
 
     task.update_spot_burn_parameters_ui()
 
-    widget.start_spot_burn_signal.emit.assert_not_called()
-    widget.get_settings.assert_called_once()
-    assert cleared
+    assert len(asks) == 1
+    assert task.config.coordinates == [Point(0.5, 0.5)]
 
 
 def test_supervised_spot_burn_abort_cancels_burn(monkeypatch, tmp_path):
-    """Workflow abort during the wait loop cancels the in-progress burn.
+    """Workflow abort during the ask cancels an in-progress burn.
 
-    Also covers the stop-vs-start race: a burn that starts after the workflow
-    Stop already ran cancel_spot_burn (clearing its stop_event) is still taken
-    down by the aborting task.
+    Covers the stop-vs-start race: a burn that starts after the workflow Stop
+    already ran cancel_spot_burn (clearing its stop_event) is still taken down
+    by the aborting task.
     """
-    task, widget, cleared = _make_supervised_spot_burn_task(
-        monkeypatch, tmp_path, ask_user_responses=[True]
+    task, _ = _make_supervised_spot_burn_task(
+        monkeypatch, tmp_path, InterruptedError("aborted")
     )
-    widget.is_burning = True  # burn in progress
-    task._check_for_abort = MagicMock(side_effect=InterruptedError("aborted"))
 
     with pytest.raises(InterruptedError):
         task.update_spot_burn_parameters_ui()
 
-    widget.cancel_spot_burn.assert_called_once()
-    assert not cleared  # abort propagates before the UI cleanup runs
+    task.parent_ui.spot_burn_widget.cancel_spot_burn.assert_called_once()
+    # the abort propagates before the answer handling runs
+    assert task.config.coordinates == [Point(0.5, 0.5)]
 
 
 # --- SpotBurnFiducialTaskConfig serialization -----------------------------------

--- a/tests/ui/test_run_spot_burn_question.py
+++ b/tests/ui/test_run_spot_burn_question.py
@@ -1,0 +1,224 @@
+"""The spot-burn question over the Responder seam: RunSpotBurn.
+
+The old supervised loop mirrored milling's hand-rolled RPC: ``ask_user(spot_burn=
+True)`` parked on the polled flag, the workflow thread emitted
+``start_spot_burn_signal`` over a BlockingQueuedConnection, sleep-polled
+``widget.is_burning`` across the seam, then read ``get_settings()`` back and sent
+a clear instruction. Now the whole loop lives in ``QtResponder``, and the answer
+is the settings as actually used — or None without a spot-burn widget (optional
+hardware must not fail a workflow).
+
+``run_spot_burn`` is stubbed at the widget's import site: runs still go through
+the widget's real worker thread, button states and new finished signal — only
+the beam time is gone.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.workflows.interaction import RunSpotBurn, ask
+from fibsem.imaging.spot import SpotBurnSettings
+from fibsem.structures import Point
+
+MSG = "Place the points, then run."
+
+
+def _settings(with_point: bool = True) -> SpotBurnSettings:
+    return SpotBurnSettings(
+        coordinates=[Point(x=0.5, y=0.5)] if with_point else [],
+        exposure_time=7.0,
+    )
+
+
+@pytest.fixture(scope="module")
+def ui(qapp):
+    """The embedded AutoLamellaUI of a real main window, with the burn stubbed.
+
+    The full main window, because entering spot-burn mode arms the coordinate
+    overlay on the quad-view controller, which lives there — same reason the
+    alignment-area and POI tests use it.
+    """
+    import importlib
+
+    # Not `import fibsem.ui.FibsemSpotBurnWidget`: the package __init__ rebinds
+    # that attribute to the widget CLASS, shadowing the submodule.
+    sbw = importlib.import_module("fibsem.ui.FibsemSpotBurnWidget")
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    burns = []
+
+    def fake_run_spot_burn(microscope, settings, beam_type, stop_event=None, **kwargs):
+        burns.append(settings)
+        time.sleep(0.05)
+
+    original_run = sbw.run_spot_burn
+    sbw.run_spot_burn = fake_run_spot_burn
+    original_minimap = module.AutoLamellaSingleWindowUI.add_minimap_tab
+    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
+    try:
+        window = module.AutoLamellaSingleWindowUI()
+    finally:
+        module.AutoLamellaSingleWindowUI.add_minimap_tab = original_minimap
+    window.autolamella_ui.system_widget.connect_to_microscope()
+    # The main window's _on_workflow_update reads _border_state unconditionally,
+    # first assigned on the Run click (the latent init gap documented in
+    # test_mainui_workflow_status; its fix rides the typed-status PR).
+    window._set_border_state("idle")
+    window.autolamella_ui._burn_runs = burns  # for the tests to inspect
+    yield window.autolamella_ui
+    sbw.run_spot_burn = original_run
+    if window.autolamella_ui.microscope is not None:
+        window.autolamella_ui.microscope.disconnect()
+    # closeEvent ends in app.quit(); on the shared test QApplication that latches
+    # and breaks every later QEventLoop.exec_() — close with quit stubbed out.
+    original_quit = qapp.quit
+    qapp.quit = lambda: None
+    try:
+        window.close()
+    finally:
+        qapp.quit = original_quit
+
+
+@pytest.fixture(autouse=True)
+def _fresh_runs(ui):
+    ui._burn_runs.clear()
+    yield
+
+
+def _ask_on_worker_thread(ui, qapp, request, wait_for_prompt=True):
+    outcome = {}
+
+    def target():
+        try:
+            outcome["settings"] = ask(
+                ui.ui_responder, request, abort=ui._workflow_stop_event.is_set
+            )
+        except Exception as exc:  # noqa: BLE001 - the test inspects it
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    if wait_for_prompt:
+        _wait_for_prompt(ui, qapp, request.message)
+    return thread, outcome
+
+
+def _wait_for_prompt(ui, qapp, msg, timeout_s=15.0):
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if ui.label_instructions.text() == msg and ui.pushButton_yes.isEnabled():
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"the prompt {msg!r} never appeared")
+
+
+def _finish(thread, qapp, timeout_s=15.0):
+    deadline = time.monotonic() + timeout_s
+    while thread.is_alive() and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+    thread.join(timeout=1.0)
+    assert not thread.is_alive(), "the asker never returned"
+
+
+def test_run_then_continue_burns_once_and_answers_the_settings(ui, qapp):
+    request = RunSpotBurn(settings=_settings(), message=MSG)
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request)
+
+    assert ui.pushButton_yes.text() == "Run Spot Burn"
+    assert ui.pushButton_no.text() == "Continue"
+    assert ui.spot_burn_widget._workflow_mode is True
+    assert ui.WAITING_FOR_USER_INTERACTION is True
+
+    ui.pushButton_yes.click()  # run
+    # Prompt down while burning; back when the widget's finished signal fires.
+    _wait_for_prompt(ui, qapp, MSG)
+    assert len(ui._burn_runs) == 1
+
+    ui.pushButton_no.click()  # continue
+    _finish(thread, qapp)
+
+    assert "error" not in outcome
+    settings = outcome["settings"]
+    assert isinstance(settings, SpotBurnSettings)
+    assert settings.exposure_time == 7.0
+    assert len(settings.coordinates) == 1
+    # The question cleared the widget on its way out.
+    assert ui.spot_burn_widget._workflow_mode is False
+    assert ui.WAITING_FOR_USER_INTERACTION is False
+    assert ui.WAITING_FOR_UI_UPDATE is False
+
+
+def test_continue_without_running_answers_without_a_burn(ui, qapp):
+    request = RunSpotBurn(settings=_settings(), message=MSG)
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request)
+
+    ui.pushButton_no.click()
+    _finish(thread, qapp)
+
+    assert "error" not in outcome
+    assert isinstance(outcome["settings"], SpotBurnSettings)
+    assert ui._burn_runs == []
+
+
+def test_a_refused_run_reasks_instead_of_hanging(ui, qapp):
+    # No in-bounds points: run_spot_burn_worker refuses before starting a worker,
+    # so no finished signal will ever come. The old is_burning poll fell straight
+    # through and re-asked; the question must do the same, not hang forever.
+    request = RunSpotBurn(settings=_settings(with_point=False), message=MSG)
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request)
+
+    ui.pushButton_yes.click()  # run — refused
+    _wait_for_prompt(ui, qapp, MSG)
+    assert ui._burn_runs == []
+
+    ui.pushButton_no.click()
+    _finish(thread, qapp)
+
+    assert "error" not in outcome
+
+
+def test_no_spot_burn_widget_answers_none_not_a_failure(ui, qapp):
+    real_widget = ui.spot_burn_widget
+    ui.spot_burn_widget = None
+    outcome = {}
+
+    def target():
+        try:
+            outcome["settings"] = ask(
+                ui.ui_responder, RunSpotBurn(settings=_settings(), message=MSG)
+            )
+        except Exception as exc:  # noqa: BLE001 - the test inspects it
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    try:
+        _finish(thread, qapp)
+    finally:
+        ui.spot_burn_widget = real_widget
+
+    assert "error" not in outcome
+    assert outcome["settings"] is None
+
+
+def test_a_stop_interrupts_the_prompt(ui, qapp):
+    request = RunSpotBurn(settings=_settings(), message=MSG)
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request)
+
+    ui._workflow_stop_event.set()
+    try:
+        _finish(thread, qapp)
+    finally:
+        ui._workflow_stop_event.clear()
+
+    assert isinstance(outcome.get("error"), InterruptedError)


### PR DESCRIPTION
Sixth and final question over the Responder seam: `RunSpotBurn` — the last `ask_user` variant. Stacks on the RunMillingTask PR (same state-machine shape).

**Before:** the supervised loop mirrored milling's hand-rolled RPC — `ask_user(spot_burn=True)` parked on the polled flag; `start_spot_burn_signal` emitted over a `BlockingQueuedConnection`; `widget.is_burning` sleep-polled across the seam; `get_settings()` read back and a clear instruction sent after.

**After:** one question, its loop on the GUI thread: enter workflow mode and front the tab (the `spot_burn` dict branch's actions, moved into the handler); prompt; run the widget's current points on **Run Spot Burn**; re-prompt from the widget's new `finished_spot_burn_signal` (emitted from `_restore_idle_state`, so success and failure alike — mirrors milling's `finished_milling_signal`); answer the settings as used, widget cleared, on **Continue**.

**Edges kept:**
- A refused run (no in-bounds points) starts no worker and fires no signal — the handler detects `not is_burning` right after the synchronous refusal and re-asks immediately, as the old poll fell straight through to.
- No spot-burn widget → the answer is None immediately: optional hardware must not fail a workflow (same rule as the spot-burn instructions).
- Stop during a burn still cancels it from the task's except path (`cancel_spot_burn` only sets a `threading.Event`, safe cross-thread) — covering the start-after-Stop race the old comment documented.

**Fallout:** with every variant gone, `ask_user` collapses to the pure typed Confirm path — the flag-poll body and its `USER_RESPONSE` return are deleted. Also deleted: the `spot_burn` branch in `handle_workflow_update`. The `SetSpotBurnSettings`/`ClearSpotBurn` instructions now have no production senders; pruning them (and the `WAITING_*`/`USER_RESPONSE` attributes) is the closing PR's business.

**Tests** (`tests/ui/test_run_spot_burn_question.py`, 5, offscreen main window — spot-burn mode arms the quad-view coordinate overlay, which lives there; `run_spot_burn` stubbed at the widget's import site so runs use the real worker thread and finished signal): run→re-prompt→Continue answers the settings with workflow mode cleared and both polled flags untouched; Continue-without-run burns nothing; a refused run re-asks instead of hanging; no widget answers None, not a failure; Stop interrupts.