### PR TITLE
[refactor] Retire the hand-rolled RPC's shared flags (FIB-826)

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -175,9 +175,9 @@ class AutoLamellaUI(QMainWindow):
     # Carries a WorkflowStatusEvent.
     workflow_status_signal = pyqtSignal(object)
     # Kept separate from workflow_update_signal on purpose: that one drives
-    # handle_workflow_update, which reconfigures the interaction UI and clears
-    # WAITING_FOR_UI_UPDATE on every emission. A queue edit is not a step in the
-    # task lifecycle and must not disturb any of that.
+    # handle_workflow_update, which reconfigures the interaction UI on every
+    # emission. A queue edit is not a step in the task lifecycle and must not
+    # disturb any of that.
     queue_changed_signal = pyqtSignal(dict)
     step_update_signal = pyqtSignal(str)  # emits human-readable step label
     _workflow_finished_signal = pyqtSignal(bool)
@@ -238,12 +238,16 @@ class AutoLamellaUI(QMainWindow):
         if not self._connection_chip_enabled:
             self.tabWidget.insertTab(0, self.system_widget, "Connection")
 
+        # Display state, not a handshake: a question is up and waiting for a
+        # click. QtResponder is the only setter; the attention button, border
+        # and timeline pause read it. The cross-thread flag-poll it used to be
+        # -- and USER_RESPONSE and WAITING_FOR_UI_UPDATE alongside it -- is
+        # gone: every workflow interaction is a typed request on its own future
+        # (workflows/interaction.py).
         self.WAITING_FOR_USER_INTERACTION: bool = False
         # A run is active but nothing is executing -- today only during a
         # scheduled-start wait. Set from the worker thread, read by the border.
         self.WORKFLOW_PENDING: bool = False
-        self.USER_RESPONSE: bool = False
-        self.WAITING_FOR_UI_UPDATE: bool = False
         self._workflow_stop_event: threading.Event = threading.Event()
         self._task_worker_thread: Optional[FunctionWorker] = None
         self._task_manager: Optional[TaskManager] = None
@@ -1782,13 +1786,10 @@ class AutoLamellaUI(QMainWindow):
         self.pushButton_no.setEnabled(False)
 
         clicked_yes = bool(self.sender() == self.pushButton_yes)
-        # A pending Confirm question owns this click; the legacy flag path serves
-        # the questions that have not converted yet (detection, milling, spot burn).
-        if self.ui_responder.answer_confirm(clicked_yes):
-            return
-        # positve / negative response
-        self.USER_RESPONSE = clicked_yes
-        self.WAITING_FOR_USER_INTERACTION = False
+        # The pending question owns this click; with every interaction converted
+        # to the Responder there is no other path. A click with nothing pending
+        # (a stray double-click after the answer landed) means nothing.
+        self.ui_responder.answer_confirm(clicked_yes)
 
     def handle_acquisition_update(self, ddict: dict) -> None:
         if ddict.get("finished", False):
@@ -1941,5 +1942,3 @@ class AutoLamellaUI(QMainWindow):
             info.get("msg", ""), info.get("pos", None), info.get("neg", None)
         )
         self.set_current_workflow_message(info.get("workflow_info", None))
-
-        self.WAITING_FOR_UI_UPDATE = False

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -32,7 +32,6 @@ from PyQt5.QtCore import QObject, pyqtSignal
 
 from fibsem.applications.autolamella.workflows.interaction import (
     ClearMillingConfig,
-    ClearSpotBurn,
     Confirm,
     ConfirmDetection,
     EditAlignmentArea,
@@ -43,7 +42,6 @@ from fibsem.applications.autolamella.workflows.interaction import (
     SetFluorescenceChannels,
     SetImages,
     SetMillingConfig,
-    SetSpotBurnSettings,
 )
 from fibsem.structures import BeamType
 
@@ -68,8 +66,6 @@ class QtResponder(QObject):
             SetMillingConfig: self._set_milling_config,
             ClearMillingConfig: self._clear_milling_config,
             SetFluorescenceChannels: self._set_fluorescence_channels,
-            SetSpotBurnSettings: self._set_spot_burn_settings,
-            ClearSpotBurn: self._clear_spot_burn,
         }
         # Deferred: the handler shows the prompt and someone else completes the
         # future later. Kept out of _handlers so _dispatch cannot complete these
@@ -193,21 +189,6 @@ class QtResponder(QObject):
         if widget is None:
             return
         widget.channelSettingsWidget.channel_settings = request.channels
-
-    def _set_spot_burn_settings(self, request: SetSpotBurnSettings) -> None:
-        """Load the settings into the spot-burn widget, if there is one."""
-        widget = self._ui.spot_burn_widget
-        if widget is None:
-            return
-        widget.set_settings(request.settings)
-
-    def _clear_spot_burn(self, request: ClearSpotBurn) -> None:
-        """Clear the spot-burn overlay and leave workflow mode, if there is one."""
-        widget = self._ui.spot_burn_widget
-        if widget is None:
-            return
-        widget.clear_points_layer()
-        widget.set_workflow_mode(False)
 
     # --- questions: the answer arrives from a click, later -------------------------
 

--- a/fibsem/applications/autolamella/workflows/interaction.py
+++ b/fibsem/applications/autolamella/workflows/interaction.py
@@ -74,8 +74,6 @@ __all__ = [
     "SetMillingConfig",
     "ClearMillingConfig",
     "SetFluorescenceChannels",
-    "SetSpotBurnSettings",
-    "ClearSpotBurn",
     "Responder",
     "ask",
     "wait_for",
@@ -197,18 +195,6 @@ class SetFluorescenceChannels(Request[None]):
     """Load these channel settings into the fluorescence widget."""
 
     channels: Sequence["ChannelSettings"]
-
-
-@dataclass(frozen=True)
-class SetSpotBurnSettings(Request[None]):
-    """Load these spot-burn settings into the spot-burn widget."""
-
-    settings: "SpotBurnSettings"
-
-
-@dataclass(frozen=True)
-class ClearSpotBurn(Request[None]):
-    """Clear the spot-burn widget."""
 
 
 # --- transport --------------------------------------------------------------------

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -61,9 +61,7 @@ from fibsem.applications.autolamella.workflows.ui import (
     INSTRUCTION_TIMEOUT_S,
     _abort_requested,
     ask_user,
-    clear_spot_burn_ui,
     update_alignment_area_ui,
-    update_spot_burn_parameters,
 )
 from fibsem.cancellation import OperationCancelledError
 from fibsem.detection.detection import (

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -1,20 +1,17 @@
 from __future__ import annotations
 
 import logging
-import time
 from copy import deepcopy
 from typing import TYPE_CHECKING, List, Optional, Sequence
 
 from fibsem import milling
 from fibsem.applications.autolamella.structures import Experiment
 from fibsem.applications.autolamella.workflows.interaction import (
-    ClearSpotBurn,
     Confirm,
     ConfirmDetection,
     EditAlignmentArea,
     PickPOI,
     SetImages,
-    SetSpotBurnSettings,
     ask,
 )
 from fibsem.detection import detection
@@ -32,7 +29,6 @@ from fibsem.structures import (
 
 if TYPE_CHECKING:
     from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
-    from fibsem.imaging.spot import SpotBurnSettings
 
 # Instructions are answered by a machine, so silence past this is a wedged GUI
 # thread, not thinking. Generous because the GUI thread may legitimately be busy
@@ -252,33 +248,3 @@ def update_experiment_ui(
         return
 
     parent_ui.update_experiment_signal.emit(deepcopy(experiment))
-
-
-def update_spot_burn_parameters(
-    parent_ui: "AutoLamellaUI",
-    settings: Optional["SpotBurnSettings"] = None,
-    clear_spots: bool = False,
-):
-    """Push spot-burn settings to the UI (or clear them)."""
-    _check_for_abort(parent_ui)
-
-    abort = lambda: _abort_requested(parent_ui)  # noqa: E731 - two waits, one predicate
-    if settings is not None:
-        ask(
-            parent_ui.ui_responder,
-            SetSpotBurnSettings(settings=settings),
-            abort=abort,
-            timeout=INSTRUCTION_TIMEOUT_S,
-        )
-    if clear_spots:
-        ask(
-            parent_ui.ui_responder,
-            ClearSpotBurn(),
-            abort=abort,
-            timeout=INSTRUCTION_TIMEOUT_S,
-        )
-
-
-def clear_spot_burn_ui(parent_ui: "AutoLamellaUI"):
-    """Clear the spot burn UI."""
-    update_spot_burn_parameters(parent_ui=parent_ui, settings=None, clear_spots=True)

--- a/tests/ui/test_confirm_question.py
+++ b/tests/ui/test_confirm_question.py
@@ -95,17 +95,16 @@ def test_the_no_click_answers_false(ui, qapp):
 
 
 def test_the_answer_does_not_travel_through_the_legacy_channel(ui, qapp):
-    # USER_RESPONSE is the shared mutable the typed path exists to retire. Park
-    # it opposite to the answer we will click: if the click still wrote it, or
-    # ask_user still read it, this catches either direction.
-    ui.USER_RESPONSE = False
+    # USER_RESPONSE was the shared mutable the typed path retired; it no longer
+    # exists, so a click writing it (or ask_user reading it) would have to
+    # re-create it — which is exactly what this catches.
     thread, outcome = _ask_on_worker_thread(ui, qapp)
 
     ui.pushButton_yes.click()
     _finish(thread, qapp)
 
     assert outcome.get("answer") is True
-    assert ui.USER_RESPONSE is False
+    assert not hasattr(ui, "USER_RESPONSE")
 
 
 def test_the_prompt_comes_down_with_the_answer(ui, qapp):

--- a/tests/ui/test_edit_alignment_area.py
+++ b/tests/ui/test_edit_alignment_area.py
@@ -114,14 +114,14 @@ def test_the_click_answers_with_the_area_from_the_widget(ui, qapp):
 
 
 def test_the_second_handshake_is_gone(ui, qapp):
-    # The old flow set WAITING_FOR_UI_UPDATE for its embedded overlay-clear wait;
-    # the clear now runs inside the click's slot. Nothing may touch the flag.
+    # The old flow set WAITING_FOR_UI_UPDATE for its embedded overlay-clear
+    # wait; the clear runs inside the click's slot and the flag is gone.
     thread, _ = _edit_on_worker_thread(ui, qapp)
 
     ui.pushButton_yes.click()
     _finish(thread, qapp)
 
-    assert ui.WAITING_FOR_UI_UPDATE is False
+    assert not hasattr(ui, "WAITING_FOR_UI_UPDATE")
 
 
 def test_the_rect_survives_the_overlay_coming_down(ui, qapp):

--- a/tests/ui/test_pick_poi.py
+++ b/tests/ui/test_pick_poi.py
@@ -133,13 +133,13 @@ def test_the_overlay_comes_down_with_the_answer(window, ui, qapp):
 
 def test_the_second_handshake_is_gone(ui, qapp):
     # The old flow set WAITING_FOR_UI_UPDATE for its embedded clear-and-compute
-    # wait; both now run inside the click's slot. Nothing may touch the flag.
+    # wait; both run inside the click's slot and the flag is gone.
     thread, _ = _pick_on_worker_thread(ui, qapp, _fib_image(ui))
 
     ui.pushButton_yes.click()
     _finish(thread, qapp)
 
-    assert ui.WAITING_FOR_UI_UPDATE is False
+    assert not hasattr(ui, "WAITING_FOR_UI_UPDATE")
 
 
 def test_no_image_or_no_validation_answers_none(ui):

--- a/tests/ui/test_qt_responder.py
+++ b/tests/ui/test_qt_responder.py
@@ -90,8 +90,6 @@ def test_images_land_in_the_widget_from_a_worker_thread(ui, qapp):
     assert "error" not in outcome
     assert ui.image_widget.eb_image is sem
     assert ui.image_widget.ib_image is fib
-    # The old mechanism must stay untouched: nothing set or cleared the flag.
-    assert ui.WAITING_FOR_UI_UPDATE is False
 
 
 def test_the_widget_update_runs_on_the_gui_thread(ui, qapp):
@@ -230,7 +228,6 @@ def test_a_milling_config_lands_in_the_editor_and_fronts_its_tab(ui, qapp):
     assert "error" not in outcome
     assert ui.milling_task_config_widget.get_config().name == "from-the-workflow"
     assert ui.tabWidget.currentWidget() is ui.milling_task_config_widget
-    assert ui.WAITING_FOR_UI_UPDATE is False
 
 
 def test_clearing_the_milling_config_resets_the_editor(ui, qapp):
@@ -260,35 +257,15 @@ def test_clearing_the_milling_config_resets_the_editor(ui, qapp):
     )
 
 
-# ── fluorescence + spot-burn instructions ───────────────────────────────────────
+# ── fluorescence instruction ────────────────────────────────────────────────────
 
 
-def test_spot_burn_settings_land_in_the_widget(ui, qapp):
-    from fibsem.applications.autolamella.workflows.ui import (
-        update_spot_burn_parameters,
-    )
-    from fibsem.imaging.spot import SpotBurnSettings
-
-    settings = SpotBurnSettings(exposure_time=17.0)
-
-    outcome = _call_on_worker_thread(
-        qapp, lambda: update_spot_burn_parameters(ui, settings=settings)
-    )
-
-    assert "error" not in outcome
-    assert ui.spot_burn_widget.get_settings().exposure_time == 17.0
-    assert ui.WAITING_FOR_UI_UPDATE is False
-
-
-def test_clearing_spot_burn_leaves_workflow_mode(ui, qapp):
-    from fibsem.applications.autolamella.workflows.ui import clear_spot_burn_ui
-
-    ui.spot_burn_widget.set_workflow_mode(True)
-
-    outcome = _call_on_worker_thread(qapp, lambda: clear_spot_burn_ui(ui))
-
-    assert "error" not in outcome
-    assert ui.spot_burn_widget._workflow_mode is False
+def test_the_polled_flags_are_gone(ui):
+    # The retirement pin: every workflow interaction is a typed request on its
+    # own future now. The shared mutables the hand-rolled RPC polled must not
+    # quietly come back.
+    assert not hasattr(ui, "WAITING_FOR_UI_UPDATE")
+    assert not hasattr(ui, "USER_RESPONSE")
 
 
 def test_fluorescence_channels_reach_the_fm_widget(ui, qapp):

--- a/tests/ui/test_run_milling_question.py
+++ b/tests/ui/test_run_milling_question.py
@@ -118,8 +118,8 @@ def test_run_then_continue_runs_once_and_answers_the_editor_config(ui, qapp):
     assert isinstance(outcome["config"], FibsemMillingTaskConfig)
     assert outcome["config"].name == "rough-mill"
     assert ui.WAITING_FOR_USER_INTERACTION is False
-    # The old handshakes are gone: nothing touched the polled flags.
-    assert ui.WAITING_FOR_UI_UPDATE is False
+    # The old handshakes are gone, and so is the polled flag.
+    assert not hasattr(ui, "WAITING_FOR_UI_UPDATE")
 
 
 def test_continue_without_running_answers_without_a_mill(ui, qapp):

--- a/tests/ui/test_run_spot_burn_question.py
+++ b/tests/ui/test_run_spot_burn_question.py
@@ -155,7 +155,7 @@ def test_run_then_continue_burns_once_and_answers_the_settings(ui, qapp):
     # The question cleared the widget on its way out.
     assert ui.spot_burn_widget._workflow_mode is False
     assert ui.WAITING_FOR_USER_INTERACTION is False
-    assert ui.WAITING_FOR_UI_UPDATE is False
+    assert not hasattr(ui, "WAITING_FOR_UI_UPDATE")
 
 
 def test_continue_without_running_answers_without_a_burn(ui, qapp):

--- a/tests/ui/test_workflow_status_display.py
+++ b/tests/ui/test_workflow_status_display.py
@@ -95,16 +95,14 @@ def test_absent_workflow_info_shows_the_label_without_rewriting_it(ui):
     assert ui.label_workflow_information.isVisibleTo(ui)
 
 
-def test_a_status_update_releases_a_pending_ui_update_wait(ui):
-    # The defect the move removes, pinned as it stands: the flag is scoped to the
-    # signal, not to a request, so a mere status emit releases whoever is blocked
-    # in a `while WAITING_FOR_UI_UPDATE` loop. Once status moves off this signal,
-    # this inverts: a status update must leave a pending wait alone.
-    ui.WAITING_FOR_UI_UPDATE = True
-
+def test_a_status_update_cannot_release_any_wait(ui):
+    # The defect the move removed: WAITING_FOR_UI_UPDATE was scoped to the
+    # signal, not to a request, so a mere status emit released whoever was
+    # blocked in a `while WAITING_FOR_UI_UPDATE` loop. The flag is gone; every
+    # wait is a future owned by one caller, which a status emit cannot touch.
     ui.handle_workflow_update(_status_payload("Moving stage..."))
 
-    assert ui.WAITING_FOR_UI_UPDATE is False
+    assert not hasattr(ui, "WAITING_FOR_UI_UPDATE")
 
 
 # ── the new channel ──────────────────────────────────────────────────────────────
@@ -148,16 +146,14 @@ def test_a_status_event_writes_the_workflow_information_label(ui):
     assert ui.label_workflow_information.text() == "Task 2/5: Rough Milling"
 
 
-def test_a_status_event_leaves_a_pending_wait_alone(ui):
-    # The inversion of test_a_status_update_releases_a_pending_ui_update_wait, and
-    # the reason the channel exists: a Future-style handshake (and until then, the
-    # flag) belongs to one request, and merely saying something must not complete it.
-    ui.WAITING_FOR_UI_UPDATE = True
+def test_a_status_event_leaves_a_pending_question_alone(ui):
+    # The reason the channel exists: an answer belongs to one request, and merely
+    # saying something must not complete it. The polled flag is gone entirely;
+    # the display state a parked question sets must survive a status emit.
     ui.WAITING_FOR_USER_INTERACTION = True
 
     ui.workflow_status_signal.emit(_status_event("Moving stage..."))
 
-    assert ui.WAITING_FOR_UI_UPDATE is True
     assert ui.WAITING_FOR_USER_INTERACTION is True
-    ui.WAITING_FOR_UI_UPDATE = False
+    assert not hasattr(ui, "WAITING_FOR_UI_UPDATE")
     ui.WAITING_FOR_USER_INTERACTION = False

--- a/tests/ui/test_workflow_update_payload.py
+++ b/tests/ui/test_workflow_update_payload.py
@@ -78,14 +78,11 @@ def test_a_message_is_still_shown_when_one_is_sent(ui):
     assert ui.pushButton_yes.text() == "Continue"
 
 
-def test_the_handler_releases_the_workflow_thread(ui):
-    """Every emitter sets `WAITING_FOR_UI_UPDATE` and then blocks on it in a
-    `while ... time.sleep(0.5)` loop, so the flag is the workflow thread's only way
-    out of that wait. It is cleared on the last line of the handler -- after the
-    message -- so anything that raises on the way there strands the caller as well
-    as killing the process."""
-    ui.WAITING_FOR_UI_UPDATE = True
-
+def test_the_handler_owes_the_workflow_thread_nothing(ui):
+    """Emitters used to set `WAITING_FOR_UI_UPDATE` and block on it, making the
+    handler's last line the workflow thread's only way out of the wait -- so a
+    raise on the way there stranded the caller as well as killing the process.
+    Every wait is a future owned by one caller now; the flag is gone."""
     ui.handle_workflow_update({"status": {}})
 
-    assert ui.WAITING_FOR_UI_UPDATE is False
+    assert not hasattr(ui, "WAITING_FOR_UI_UPDATE")


### PR DESCRIPTION
The closing PR of the series — merges last, and closes FIB-826.

With every workflow interaction now a typed request on its own future (`workflows/interaction.py`), the shared mutables the hand-rolled RPC polled are deleted:

- **`USER_RESPONSE`** — gone. `push_interaction_button` no longer falls through to it: the pending question owns the click, and a click with nothing pending (a stray double-click after the answer landed) means nothing.
- **`WAITING_FOR_UI_UPDATE`** — gone, along with `handle_workflow_update`'s unconditional clear on its last line: the line that let *any* emission release *every* waiter, which is the defect this whole series exists to remove.
- **`WAITING_FOR_USER_INTERACTION` stays, deliberately** (a deviation from the original sketch, which listed it for deletion): it is pure GUI display state now — `QtResponder` is its only setter, and the attention button, border and timeline pause read it. The cross-thread handshake meaning is gone; the name keeps the chrome wiring untouched.

**Also pruned:** the `SetSpotBurnSettings`/`ClearSpotBurn` instruction types, their `QtResponder` handlers, and the `update_spot_burn_parameters`/`clear_spot_burn_ui` helpers — `RunSpotBurn` absorbed both ends in the previous PR, leaving them senderless.

**Tests:** the two characterisation tests that pinned the old clearing behaviour (`test_workflow_status_display`, `test_workflow_update_payload`) anticipated this inversion in their own comments and become retirement pins — the attributes must not quietly come back (`hasattr` checks, plus one explicit pin in `test_qt_responder`). The two dead-instruction tests go with their subject; the question suites' flag assertions become `hasattr` pins. 645 tests across tests/autolamella + the seam suites green locally.

Net: −99 lines. `workflow_update_signal` still carries status text and the prompt display; moving those to the typed status channel is the 2a/2b thread (#659), independent of this series.