### PR TITLE
[fix] Read supervision live at each milling decision, not once at ask time

### DIFF
--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -325,7 +325,7 @@ class QtResponder(QObject):
         widget.milling_widget.pushButton_run_milling.setVisible(False)
         self._wire_milling_finished(widget)
 
-        if not request.confirm:
+        if not request.confirm():
             if request.enabled:
                 self._start_milling_run(request, future)
             else:
@@ -368,8 +368,11 @@ class QtResponder(QObject):
                 f"{len(request.config.stages)} stages completed."
             }
         )
-        if request.confirm:
-            # Same prompt again: Run Milling reruns (after edits), Continue ends.
+        if request.confirm():
+            # Same prompt again: Run Milling reruns (after edits), Continue ends —
+            # and confirm is read live, so a supervision flip made during the mill
+            # decides here: auto→supervised drops the operator into the loop,
+            # supervised→auto continues without re-asking.
             self._park_question(
                 request, future, request.message, "Run Milling", "Continue"
             )

--- a/fibsem/applications/autolamella/workflows/interaction.py
+++ b/fibsem/applications/autolamella/workflows/interaction.py
@@ -135,20 +135,28 @@ class PickPOI(Request[Optional["Point"]]):
     message: str = "Select Point of Interest"
 
 
+def _always_confirm() -> bool:
+    return True
+
+
 @dataclass(frozen=True)
 class RunMillingTask(Request["FibsemMillingTaskConfig"]):
     """Hand over a milling config to edit and (if ``enabled``) run; answer with the
     config as actually used. Absorbs today's ``start_milling_signal`` sibling poll:
     running the mill is the responder's job, not a second channel's.
 
-    ``confirm`` is the supervision mode: True shows the prompt (Run Milling reruns
-    after edits, Continue ends the question); False runs once unprompted when
-    ``enabled``, or just delivers the config back when not.
+    ``confirm`` is the supervision mode, and — like ``abort`` — a predicate rather
+    than a snapshot: the old loop re-read ``self.validate`` on every iteration, so
+    flipping supervision mid-mill took effect when the mill finished, in both
+    directions (supervised→auto continued without re-asking; auto→supervised
+    dropped the operator into the loop). The responder consults it at each
+    decision point — at entry (prompt or run immediately) and when a run finishes
+    (re-ask or complete) — to keep exactly that behaviour.
     """
 
     config: "FibsemMillingTaskConfig"
     enabled: bool = True
-    confirm: bool = True
+    confirm: Callable[[], bool] = _always_confirm
     message: str = "Run Milling"
 
 

--- a/fibsem/applications/autolamella/workflows/tasks/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/base.py
@@ -416,7 +416,10 @@ class AutoLamellaTask(ABC):
                 # the operator's to edit without the task's own moving under it.
                 config=deepcopy(milling_config),
                 enabled=milling_enabled,
-                confirm=self.validate,
+                # live, not a snapshot: validate re-reads the protocol's
+                # supervision each call, so a mid-mill flip takes effect at the
+                # next decision point — as the old loop's re-read did
+                confirm=lambda: self.validate,
                 message=msg,
             ),
             abort=lambda: _abort_requested(self.parent_ui),

--- a/tests/ui/test_run_milling_question.py
+++ b/tests/ui/test_run_milling_question.py
@@ -135,7 +135,7 @@ def test_continue_without_running_answers_without_a_mill(ui, qapp):
 
 
 def test_unsupervised_runs_once_without_a_prompt(ui, qapp):
-    request = RunMillingTask(config=_config("auto"), confirm=False, message=MSG)
+    request = RunMillingTask(config=_config("auto"), confirm=lambda: False, message=MSG)
     thread, outcome = _ask_on_worker_thread(ui, qapp, request, wait_for_prompt=False)
 
     _finish(thread, qapp)
@@ -245,3 +245,56 @@ def test_a_click_after_a_stop_starts_nothing(ui, qapp):
 
     assert ui._mill_runs == []
     assert ui.label_instructions.text() == ""
+
+
+def test_flipping_to_auto_mid_mill_continues_without_reasking(ui, qapp):
+    # confirm is a live predicate, not a snapshot: the old loop re-read
+    # self.validate on every iteration, so turning supervision off during a
+    # mill meant no re-prompt at its end — pinned here because the first
+    # conversion snapshotted it and lost the behaviour (bench-found).
+    mode = {"supervised": True}
+    request = RunMillingTask(
+        config=_config("flip-to-auto"),
+        confirm=lambda: mode["supervised"],
+        message=MSG,
+    )
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request)
+
+    ui.pushButton_yes.click()  # run
+    mode["supervised"] = False  # the operator flips supervision off mid-mill
+    _finish(thread, qapp)
+
+    assert "error" not in outcome
+    assert outcome["config"].name == "flip-to-auto"
+    assert len(ui._mill_runs) == 1
+
+
+def test_flipping_to_supervised_mid_mill_drops_into_the_loop(ui, qapp):
+    # The other direction: an automated run whose operator flips supervision on
+    # while the mill runs gets the prompt when it finishes — "dropping in on a
+    # milling run", as the old loop allowed.
+    mode = {"supervised": False}
+    request = RunMillingTask(
+        config=_config("drop-in"),
+        confirm=lambda: mode["supervised"],
+        message=MSG,
+    )
+    thread, outcome = _ask_on_worker_thread(ui, qapp, request, wait_for_prompt=False)
+
+    # Flip only once the unprompted mill has actually started — flipping before
+    # the ask dispatches would just make it prompt at entry.
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not ui._mill_runs:
+        qapp.processEvents()
+        time.sleep(0.005)
+    assert ui._mill_runs, "the unprompted mill never started"
+    mode["supervised"] = True  # flipped while the mill runs
+
+    _wait_for_prompt(ui, qapp, MSG)  # ...so its end asks instead of completing
+    assert len(ui._mill_runs) == 1
+
+    ui.pushButton_no.click()  # continue
+    _finish(thread, qapp)
+
+    assert "error" not in outcome
+    assert outcome["config"].name == "drop-in"


### PR DESCRIPTION
Bench-found on the responder stack, both directions: the old mill loop re-read `self.validate` on every iteration, so flipping supervision **mid-mill** took effect when the mill finished — supervised→auto continued without re-asking, and auto→supervised dropped the operator into a running mill's loop. The `RunMillingTask` conversion snapshotted `confirm` at ask time and lost both behaviours.

**Fix:** `confirm` becomes a predicate, like `abort` (the same reasoning that made `abort` a callable: the real source is live state, not a value). The task passes `lambda: self.validate`, and the responder consults it at each decision point — at entry (prompt, or run immediately) and again when a run finishes (re-ask, or complete). The finished handler asking again on a now-supervised run is what restores the drop-in; the finished handler completing on a now-automated run is what restores the auto-continue.

The predicate runs on the GUI thread and reads the protocol's supervision setting — GUI-owned state, so this is also the right side of the seam to read it from.

**Not touched:** the spot-burn question. Its old loop never consulted `validate` once entered (it re-asked unconditionally), and its unsupervised path burns directly in the task without a question — so there is no behaviour to restore there.

**Tests:** the two flip directions pinned in `test_run_milling_question.py` (a mutable-mode predicate flipped mid-mill; the drop-in test flips only after the unprompted mill has demonstrably started, since flipping before dispatch would just prompt at entry). Ran 3× locally for flake.