### PR TITLE
[app] Host the agent server inside AutoLamella, read-only, off by default

### DIFF
--- a/fibsem/applications/autolamella/server/hosting.py
+++ b/fibsem/applications/autolamella/server/hosting.py
@@ -1,0 +1,180 @@
+"""Embedded hosting: the agent server running inside the AutoLamella process.
+
+This is the piece that turns the factory into the app's public interface: when
+a microscope connects (and the ``agent_server_enabled`` preference is on), the
+app builds ``build_server(microscope, app_context=AgentContext(ui, buffer))``
+and runs it on a daemon thread. One process, one microscope connection, one
+commander — the whole reason embedded hosting exists.
+
+Threading notes, because this file is where the server meets Qt:
+
+* The server runs via ``uvicorn.Server`` on a plain daemon thread with signal
+  handling disabled — ``uvicorn.run()`` wants the main thread, which belongs
+  to Qt. The thread owns no Qt objects (main-thread-only GC: off-thread Qt
+  finalization is the Windows crash class).
+* Request handlers only ever touch the app through the ``AgentContext``
+  facade, which returns plain-data snapshots — nothing here adds a new way
+  for a server thread to reach into widgets.
+* ``stop()`` asks uvicorn to exit (``should_exit``) and joins briefly; the
+  thread is a daemon either way, so a wedged shutdown cannot hang app exit.
+
+Failure posture: this is an optional observer, so it must never take the app
+down. ``start()`` catches its own failures, logs them, and leaves the app
+exactly as if the feature were off.
+"""
+
+import atexit
+import logging
+import threading
+import time
+from typing import Callable, List, Optional
+
+from fibsem.applications.autolamella.server.context import AgentContext
+from fibsem.applications.autolamella.server.events import (
+    EventBuffer,
+    attach_microscope_taps,
+    make_lifecycle_hook,
+)
+
+__all__ = ["AgentServerHost"]
+
+_START_TIMEOUT_S = 10.0
+
+
+class AgentServerHost:
+    """Owns the embedded server's lifecycle: buffer, taps, thread, discovery."""
+
+    def __init__(
+        self, ui, host: str = "127.0.0.1", port: int = 8001, discovery_path=None
+    ):
+        self._ui = ui
+        self._host = host
+        self._port = port
+        self._discovery_path = discovery_path
+        self._server = None
+        self._thread: Optional[threading.Thread] = None
+        self._disposers: List[Callable[[], None]] = []
+        self._wrote_discovery = False
+        self.auth = None
+        self.event_buffer: Optional[EventBuffer] = None
+        self.lifecycle_hook = None
+
+    @property
+    def running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    @property
+    def url(self) -> str:
+        return f"http://{self._host}:{self._port}"
+
+    def start(self, microscope) -> bool:
+        """Start serving. Returns False (and logs) rather than ever raising."""
+        try:
+            return self._start(microscope)
+        except Exception:
+            logging.exception("agent server failed to start; continuing without it")
+            self.stop()
+            return False
+
+    def _start(self, microscope) -> bool:
+        import uvicorn
+
+        from fibsem.server import AuthConfig, build_server
+        from fibsem.server.discovery import (
+            read_discovery_file,
+            remove_discovery_file,
+            write_discovery_file,
+        )
+
+        if self.running:
+            return True
+
+        # One server per microscope/machine; a live bench server wins.
+        existing = read_discovery_file(self._discovery_path)
+        if existing is not None:
+            logging.error(
+                "agent server not started: another fibsem server is running "
+                f"(pid {existing.get('pid')}, {existing.get('url')})"
+            )
+            return False
+
+        # Read-only until scopes are armed; arming arrives with the GUI dialog.
+        self.auth = AuthConfig.generate()
+        self.event_buffer = EventBuffer()
+        self.lifecycle_hook = make_lifecycle_hook(self.event_buffer)
+        self._disposers = attach_microscope_taps(self.event_buffer, microscope)
+
+        app = build_server(
+            microscope,
+            app_context=AgentContext(self._ui, event_buffer=self.event_buffer),
+            auth=self.auth,
+        )
+        config = uvicorn.Config(
+            app,
+            host=self._host,
+            port=self._port,
+            log_level="warning",
+            # No websocket support: nothing serves WS, and uvicorn's WS protocol
+            # import warns via websockets.legacy — which the test suite's
+            # warnings-as-errors policy would turn fatal inside this thread.
+            ws="none",
+        )
+        self._server = uvicorn.Server(config)
+        # Signal handlers belong to the main thread, which belongs to Qt.
+        self._server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
+
+        def run_server(server=self._server):
+            # uvicorn sys.exit()s on startup failure (e.g. port in use); a bare
+            # SystemExit escaping a thread is noise at best and, under a test
+            # suite's thread-exception hooks, a failure. Contain and log.
+            try:
+                server.run()
+            except SystemExit:
+                logging.error("agent server exited at startup (port in use?)")
+            except Exception:
+                logging.exception("agent server crashed")
+
+        self._thread = threading.Thread(
+            target=run_server, name="fibsem-agent-server", daemon=True
+        )
+        self._thread.start()
+
+        deadline = time.monotonic() + _START_TIMEOUT_S
+        while not self._server.started:
+            if not self._thread.is_alive() or time.monotonic() > deadline:
+                logging.error("agent server did not start (port in use?)")
+                self.stop()
+                return False
+            time.sleep(0.05)
+
+        write_discovery_file(
+            self._host, self._port, self.auth, path=self._discovery_path
+        )
+        self._wrote_discovery = True
+        atexit.register(self._remove_discovery)
+        logging.info("agent server on %s — scopes: read only", self.url)
+        logging.info("agent server token: %s", self.auth.token)
+        return True
+
+    def stop(self) -> None:
+        for dispose in self._disposers:
+            try:
+                dispose()
+            except Exception:
+                pass
+        self._disposers = []
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+        self._thread = None
+        self._server = None
+        self._remove_discovery()
+
+    def _remove_discovery(self) -> None:
+        if not self._wrote_discovery:
+            return
+        from fibsem.server.discovery import remove_discovery_file
+
+        remove_discovery_file(self._discovery_path)
+        self._wrote_discovery = False

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -251,6 +251,9 @@ class AutoLamellaUI(QMainWindow):
         self._workflow_stop_event: threading.Event = threading.Event()
         self._task_worker_thread: Optional[FunctionWorker] = None
         self._task_manager: Optional[TaskManager] = None
+        # The embedded agent server (FIB-845): built on microscope connect when the
+        # agent_server_enabled preference is on; None means the feature is off.
+        self._agent_server_host = None
         self._last_run_summary: Optional["pd.DataFrame"] = None
 
         # setup connections
@@ -624,8 +627,24 @@ class AutoLamellaUI(QMainWindow):
         if self.experiment is not None:
             self._disconnect_experiment_events()
             self._setup_experiment_connections()
+        self._start_agent_server()
+
+    def _start_agent_server(self) -> None:
+        """Host the agent server over this session, if the preference asks for it.
+
+        Read-only until scopes are armed; never raises — an optional observer
+        must not be able to take the session down (see hosting.py).
+        """
+        if fibsem_cfg.load_user_preferences().features.agent_server_enabled:
+            from fibsem.applications.autolamella.server.hosting import AgentServerHost
+
+            if self._agent_server_host is None:
+                self._agent_server_host = AgentServerHost(self)
+            self._agent_server_host.start(self.microscope)
 
     def disconnect_from_microscope(self):
+        if self._agent_server_host is not None:
+            self._agent_server_host.stop()
         self.microscope = None
         self.settings = None
         self.update_microscope_ui()
@@ -1062,6 +1081,13 @@ class AutoLamellaUI(QMainWindow):
         """
         preferences = fibsem_cfg.load_user_preferences()
         manager = build_hook_manager(preferences.hooks)
+
+        # The agent server's lifecycle feed. Registered here, per run, because this
+        # manager is rebuilt each run — a once-at-startup registration would go
+        # silently deaf after the first workflow (the trap events.py documents).
+        host = self._agent_server_host
+        if host is not None and host.running and host.lifecycle_hook is not None:
+            manager.register(host.lifecycle_hook)
 
         # Deliberately not registered yet. The trigger is proven end to end and the
         # writer is tested, but completion-summary.json is a placeholder for the real

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -396,6 +396,12 @@ class FeatureFlags:
     # microscope and none of its guard rails, so the menu is not offered to anyone
     # who has not asked for it (FIB-338).
     scripts_enabled: bool = False
+    # The embedded agent server (FIB-845): an HTTP API over the running session that
+    # agents reach through the fibsem-mcp sidecar. Off by default and fail-closed like
+    # scripts: enabling starts a localhost-only, token-authenticated, READ-ONLY server
+    # when a microscope connects. Nothing can move hardware through it until the
+    # control/hardware scopes are armed, which no configuration file can do.
+    agent_server_enabled: bool = False
     # The old napari Minimap tab, beside the Overview tab that replaced it. **Off**: the
     # canvas Overview ships to everyone and holds both modalities (FIB-780), so the old
     # tab is not what anyone should land on -- it is here to be turned back on by anyone

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -76,6 +76,13 @@ _TIP_SCRIPTS = (
     "experiment. A script has the same access to the microscope as the application "
     "itself and none of its safety checks — nothing validates what it does."
 )
+_LBL_AGENT_SERVER = "Enable Agent Server"
+_TIP_AGENT_SERVER = (
+    "Host a local, token-protected API over this session when a microscope "
+    "connects, so an AI agent (via the fibsem-mcp sidecar) can observe it. "
+    "Read-only: nothing can move hardware through it. The session token is "
+    "printed in the log on connect."
+)
 
 # Experiment defaults
 _LBL_EXP_DIR = "Default Experiment Directory"
@@ -170,6 +177,8 @@ class PreferencesDialog(QDialog):
         self._chk_bug_report.setToolTip(_TIP_BUG_REPORT)
         self._chk_scripts = QCheckBox()
         self._chk_scripts.setToolTip(_TIP_SCRIPTS)
+        self._chk_agent_server = QCheckBox()
+        self._chk_agent_server.setToolTip(_TIP_AGENT_SERVER)
         self._chk_napari_overview = QCheckBox()
         self._chk_napari_overview.setToolTip(_TIP_NAPARI_OVERVIEW)
         self._chk_connection_chip = QCheckBox()
@@ -178,6 +187,7 @@ class PreferencesDialog(QDialog):
         features_form.addRow(_LBL_SAMPLE_HOLDER, self._chk_sample_holder)
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
         features_form.addRow(_LBL_SCRIPTS, self._chk_scripts)
+        features_form.addRow(_LBL_AGENT_SERVER, self._chk_agent_server)
         features_form.addRow(_LBL_NAPARI_OVERVIEW, self._chk_napari_overview)
         features_form.addRow(_LBL_CONNECTION_CHIP, self._chk_connection_chip)
         self._stack.addWidget(features_page)
@@ -250,6 +260,7 @@ class PreferencesDialog(QDialog):
         self._chk_sample_holder.setChecked(f.sample_holder_widget)
         self._chk_bug_report.setChecked(f.bug_report_enabled)
         self._chk_scripts.setChecked(f.scripts_enabled)
+        self._chk_agent_server.setChecked(f.agent_server_enabled)
         self._chk_napari_overview.setChecked(f.napari_overview_tab)
         self._chk_connection_chip.setChecked(f.connection_chip)
 
@@ -321,6 +332,7 @@ class PreferencesDialog(QDialog):
                 sample_holder_widget=self._chk_sample_holder.isChecked(),
                 bug_report_enabled=self._chk_bug_report.isChecked(),
                 scripts_enabled=self._chk_scripts.isChecked(),
+                agent_server_enabled=self._chk_agent_server.isChecked(),
                 napari_overview_tab=self._chk_napari_overview.isChecked(),
                 connection_chip=self._chk_connection_chip.isChecked(),
             ),

--- a/tests/server/test_hosting.py
+++ b/tests/server/test_hosting.py
@@ -1,0 +1,130 @@
+"""AgentServerHost over a real socket: lifecycle, discovery, events, refusal."""
+
+import os
+import socket
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+httpx = pytest.importorskip("httpx")
+
+from fibsem import utils  # noqa: E402
+from fibsem.applications.autolamella.server.hosting import AgentServerHost  # noqa: E402
+
+
+class Host:
+    experiment = None
+    microscope = None
+    _task_manager = None
+    is_workflow_running = False
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def microscope():
+    os.environ.setdefault("FIBSEM_SIM_NO_DELAY", "1")
+    microscope, _ = utils.setup_session(manufacturer="Demo", ip_address="localhost")
+    return microscope
+
+
+@pytest.fixture
+def host(tmp_path, microscope):
+    ui = Host()
+    ui.microscope = microscope
+    server_host = AgentServerHost(
+        ui, port=_free_port(), discovery_path=tmp_path / "agent-server.json"
+    )
+    yield server_host
+    server_host.stop()
+
+
+def _get(server_host, path):
+    return httpx.get(
+        f"{server_host.url}{path}",
+        headers={"Authorization": f"Bearer {server_host.auth.token}"},
+        timeout=10,
+    )
+
+
+def test_start_serves_read_only_with_the_app_router(host, microscope):
+    assert host.start(microscope) is True
+    assert host.running
+    body = _get(host, "/capabilities").json()
+    assert body["routers"]["app"] is True
+    assert body["scopes"] == {"read": True, "control": False, "hardware": False}
+    # idempotent: a second start is a no-op, not a second server
+    assert host.start(microscope) is True
+
+
+def test_discovery_file_lives_and_dies_with_the_server(host, microscope, tmp_path):
+    from fibsem.server.discovery import read_discovery_file
+
+    path = tmp_path / "agent-server.json"
+    host.start(microscope)
+    found = read_discovery_file(path)
+    assert found is not None and found["url"] == host.url
+    host.stop()
+    assert not host.running
+    assert read_discovery_file(path) is None
+    with pytest.raises(httpx.ConnectError):
+        httpx.get(f"{host.url}/health", timeout=2)
+
+
+def test_refuses_to_start_beside_a_live_server(host, microscope, tmp_path):
+    from fibsem.server import AuthConfig
+    from fibsem.server.discovery import write_discovery_file
+
+    # A live "other server" (this pid, so the liveness check passes).
+    write_discovery_file(
+        "127.0.0.1", 9, AuthConfig(token="other"), path=tmp_path / "agent-server.json"
+    )
+    assert host.start(microscope) is False
+    assert not host.running
+
+
+def test_lifecycle_events_reach_the_agent_through_the_hook(host, microscope):
+    from fibsem.hooks import HookContext, HookEvent, HookManager
+
+    host.start(microscope)
+    # The app registers this hook per run (setup_hooks); simulate one firing.
+    manager = HookManager()
+    manager.register(host.lifecycle_hook)
+    manager.fire(
+        HookContext(event=HookEvent.TASK_STARTED.value, task_name="Rough Milling")
+    )
+    events = _get(host, "/app/events?since=0").json()["events"]
+    assert any(e["kind"] == "task_started" for e in events)
+
+
+def test_microscope_taps_are_live_and_detach_on_stop(host, microscope):
+    host.start(microscope)
+    microscope.get_stage_position()  # ensure cache exists
+    from fibsem.structures import FibsemStagePosition
+
+    microscope.move_stage_relative(
+        FibsemStagePosition(x=1e-6, y=0, z=0, r=0, t=0, coordinate_system="RAW")
+    )
+    events = _get(host, "/app/events?since=0").json()["events"]
+    assert any(e["kind"] == "stage_position_changed" for e in events)
+    buffer = host.event_buffer
+    host.stop()
+    before = buffer.events_since(0)["latest_seq"]
+    microscope.move_stage_relative(
+        FibsemStagePosition(x=1e-6, y=0, z=0, r=0, t=0, coordinate_system="RAW")
+    )
+    assert buffer.events_since(0)["latest_seq"] == before  # taps detached
+
+
+def test_start_failure_is_contained_not_raised(microscope, tmp_path):
+    ui = Host()
+    # Port 1 is unbindable without privileges — start must fail closed.
+    server_host = AgentServerHost(
+        ui, port=1, discovery_path=tmp_path / "agent-server.json"
+    )
+    assert server_host.start(microscope) is False
+    assert not server_host.running

--- a/tests/ui/test_agent_server_hosting.py
+++ b/tests/ui/test_agent_server_hosting.py
@@ -1,0 +1,85 @@
+"""The embedded agent server through the real window: preference-gated start on
+microscope connect, per-run hook registration, stop on disconnect."""
+
+import os
+import socket
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+pytest.importorskip("fastapi")
+httpx = pytest.importorskip("httpx")
+
+from fibsem import config as fibsem_cfg
+from fibsem.applications.autolamella.server import hosting
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def ui(qapp):
+    window = AutoLamellaUI(parent_ui=None)
+    try:
+        yield window
+    finally:
+        if window._agent_server_host is not None:
+            window._agent_server_host.stop()
+        window.close()
+        window.deleteLater()
+        qapp.processEvents()
+
+
+@pytest.fixture
+def agent_server_enabled(monkeypatch, tmp_path):
+    """Flip the preference on and confine the host to a test port + tmp file."""
+    preferences = fibsem_cfg.UserPreferences()
+    preferences.features.agent_server_enabled = True
+    monkeypatch.setattr(fibsem_cfg, "load_user_preferences", lambda: preferences)
+
+    real_host = hosting.AgentServerHost
+    port = _free_port()
+
+    def confined(ui_object, **kwargs):
+        return real_host(
+            ui_object, port=port, discovery_path=tmp_path / "agent-server.json"
+        )
+
+    monkeypatch.setattr(hosting, "AgentServerHost", confined)
+    return preferences
+
+
+def test_connect_starts_a_live_read_only_server(ui, agent_server_enabled):
+    ui.system_widget.connect_to_microscope()
+    ui.connect_to_microscope()
+
+    host = ui._agent_server_host
+    assert host is not None and host.running
+    body = httpx.get(
+        f"{host.url}/capabilities",
+        headers={"Authorization": f"Bearer {host.auth.token}"},
+        timeout=10,
+    ).json()
+    assert body["routers"]["app"] is True
+    assert body["scopes"]["hardware"] is False
+
+    # Per-run hook registration: the manager built for a run carries the feed.
+    manager = ui.setup_hooks()
+    assert host.lifecycle_hook in manager._hooks
+
+    ui.disconnect_from_microscope()
+    assert not host.running
+
+
+def test_default_preference_hosts_nothing(ui):
+    ui.system_widget.connect_to_microscope()
+    ui.connect_to_microscope()
+    assert ui._agent_server_host is None
+    manager = ui.setup_hooks()
+    assert manager is not None  # and built without any agent involvement


### PR DESCRIPTION
Stacked on #657; top of the app stack (#651 → #655 → #657 → this). **This is the PR where the design doc's Phase 1 becomes a usable product**: enable one preference, connect a microscope, run `claude mcp add fibsem -- fibsem-mcp`, and ask Claude about your live experiment.

## What

- `agent_server_enabled` feature flag (default **off**, scripts_enabled pattern) with the fail-closed rationale inline
- `hosting.py`: `AgentServerHost` owning the lifecycle — event buffer + microscope taps + `AgentContext` + the shared `build_server`, on a named daemon thread; discovery file written (and used as the one-server-per-microscope guard: a live bench server wins); per-session token logged; **read scope only** until the arming dialog exists
- Three wiring points in `AutoLamellaUI`: start on `connect_to_microscope`, stop on disconnect, and per-run hook registration inside `setup_hooks` (rebuilt each run — the go-deaf trap events.py documents)

## How it works, in plain language

`uvicorn.run()` wants the process's main thread — it installs OS signal handlers there — but our main thread belongs to Qt. So the hosting uses the lower-level `uvicorn.Server` on an ordinary daemon thread with signal handling disabled: the event loop that serves HTTP lives entirely inside that one thread, and the *only* doorway from it into the app is the `AgentContext` facade, which hands back plain-data snapshots. Being a daemon thread means a wedged shutdown can never hang app exit; being fail-closed (`start()` catches everything, the thread contains uvicorn's `sys.exit`) means the observer can never take the session down — worst case is a log line and no server, exactly as if the preference were off.

## Two things found while building

- uvicorn's websocket protocol import warns through `websockets.legacy`, which `filterwarnings=error` turns fatal *inside the server thread* — the exact new-dep-stack hazard the CI survey predicted. Resolved by `ws='none'` (nothing here serves websockets), which also trims the import surface.
- uvicorn `sys.exit()`s on bind failure; an uncontained `SystemExit` in a thread is noise in production and a failure under pytest's thread-exception hooks. The thread target contains it.

## Verification

6 real-socket tests for the host (read-only capabilities over HTTP, discovery lifecycle incl. refusal beside a live server, lifecycle events reaching `/app/events`, tap detach on stop, contained port-failure) + 2 through the **real window** offscreen: preference on → `system_widget.connect_to_microscope()` → live server + per-run hook in `setup_hooks()` → disconnect stops it; preference off → nothing hosted. 71 tests green across the suites; ruff clean.

Natural sign-off before merge: run the actual app with the preference enabled and drive it from a Claude session — happy to write the two-line setup in the review thread.