### PR TITLE
[app] Let an agent answer the pending question through the click's own path

### DIFF
--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -57,6 +57,7 @@ class QtResponder(QObject):
     """Answers workflow requests by driving the window's widgets, on the GUI thread."""
 
     _submitted = pyqtSignal(object, object)  # (Request, Future)
+    _agent_answered = pyqtSignal(bool, object)  # (clicked_yes, Future[bool])
 
     def __init__(self, ui: "AutoLamellaUI"):
         super().__init__()
@@ -89,10 +90,52 @@ class QtResponder(QObject):
         self._active_spot_burn: Optional[Tuple[RunSpotBurn, "Future"]] = None
         self._spot_burn_finished_wired: Optional[object] = None
         self._submitted.connect(self._dispatch)
+        self._agent_answered.connect(self._apply_agent_answer)
 
     def submit(self, request: "Request", future: "Future") -> None:
         """Hand ``request`` to the GUI thread; never blocks. Any thread."""
         self._submitted.emit(request, future)
+
+    # --- the agent's side of the seam (FIB-851) --------------------------------
+
+    def pending_question(self) -> Optional["Request"]:
+        """The request currently awaiting an answer, or None. Any thread.
+
+        Returns the frozen request itself — safe to read cross-thread, and it
+        carries its own context by contract ("a responder must be able to
+        answer from the request alone"), which is exactly what lets a remote
+        agent see what it is being asked. A question whose asker already
+        aborted reads as None: nobody is waiting on it.
+        """
+        pending = self._pending_question
+        if pending is None or pending[1].cancelled():
+            return None
+        return pending[0]
+
+    def submit_answer(self, clicked_yes: bool) -> "Future":
+        """Answer the pending question as if the matching button were clicked.
+
+        Any thread; returns a Future[bool] that resolves True when the answer
+        was applied and False when there was nothing pending (the human beat
+        this answer to it, or the prompt was already gone). Routes through
+        :meth:`answer_confirm` on the GUI thread — the *same* path as the
+        buttons, so widget read-backs, the Run Milling interception, and the
+        first-writer-wins guards all behave identically for agent and human.
+        """
+        from concurrent.futures import Future as _Future
+
+        outcome: "_Future" = _Future()
+        self._agent_answered.emit(clicked_yes, outcome)
+        return outcome
+
+    def _apply_agent_answer(self, clicked_yes: bool, outcome: "Future") -> None:
+        """GUI thread. Complete ``outcome`` with whether the answer applied."""
+        try:
+            applied = self.answer_confirm(clicked_yes)
+        except Exception as exc:  # noqa: BLE001 - the asker owns the failure
+            self._fail(outcome, exc)
+            return
+        self._deliver(outcome, applied)
 
     def _dispatch(self, request: "Request", future: "Future") -> None:
         """GUI thread. Complete the future, whatever happens in the handler."""

--- a/tests/ui/test_qt_responder_agent_answer.py
+++ b/tests/ui/test_qt_responder_agent_answer.py
@@ -1,0 +1,132 @@
+"""The agent's side of the Responder seam (FIB-851): a remote answer routed
+through the same GUI-thread path as the buttons.
+
+Same harness shape as test_qt_responder.py: a real worker thread asks through
+``ask()`` while the test spins the GUI loop, and the "agent" answers from yet
+another thread via ``submit_answer`` — three threads, exactly like production
+(workflow, GUI, server)."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.applications.autolamella.workflows.interaction import Confirm, ask
+
+
+@pytest.fixture
+def ui(qapp, monkeypatch):
+    """A real, connected AutoLamellaUI — the prompt display path reaches real
+    widgets, so a bare window aborts in handle_workflow_update. Same pinned
+    config as test_qt_responder.py (the machine default differs on CI)."""
+    import fibsem.config as fibsem_config
+
+    arctis_config = os.path.join(
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "sim-arctis-configuration.yaml",
+    )
+    widget = AutoLamellaUI(parent_ui=None)
+    monkeypatch.setattr(
+        widget.system_widget,
+        "load_configuration",
+        lambda configuration_name=None: arctis_config,
+    )
+    widget.system_widget.connect_to_microscope()
+    yield widget
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+    widget.deleteLater()
+    qapp.processEvents()
+
+
+def _spin_until(qapp, predicate, timeout_s=10.0):
+    deadline = time.monotonic() + timeout_s
+    while not predicate():
+        if time.monotonic() > deadline:
+            raise TimeoutError("condition not reached")
+        qapp.processEvents()
+        time.sleep(0.01)
+
+
+def _ask_on_worker(ui, qapp, request):
+    """Start a workflow-thread ask; return (thread, outcome dict)."""
+    outcome = {}
+
+    def target():
+        try:
+            outcome["answer"] = ask(ui.ui_responder, request)
+        except Exception as exc:  # noqa: BLE001
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    _spin_until(qapp, lambda: ui.ui_responder.pending_question() is not None)
+    return thread, outcome
+
+
+def test_agent_answer_wakes_the_asker_like_a_click(ui, qapp):
+    request = Confirm("Continue to polishing?", positive="Continue", negative="Stop")
+    thread, outcome = _ask_on_worker(ui, qapp, request)
+
+    pending = ui.ui_responder.pending_question()
+    assert isinstance(pending, Confirm)
+    assert pending.message == "Continue to polishing?"
+
+    answered = ui.ui_responder.submit_answer(True)
+    _spin_until(qapp, answered.done)
+    assert answered.result() is True  # the answer applied
+
+    thread.join(timeout=5)
+    assert outcome.get("answer") is True
+    assert ui.ui_responder.pending_question() is None
+    assert ui.WAITING_FOR_USER_INTERACTION is False  # display state torn down
+
+
+def test_agent_no_answers_too(ui, qapp):
+    thread, outcome = _ask_on_worker(ui, qapp, Confirm("Retry?", negative="Skip"))
+    answered = ui.ui_responder.submit_answer(False)
+    _spin_until(qapp, answered.done)
+    assert answered.result() is True
+    thread.join(timeout=5)
+    assert outcome.get("answer") is False
+
+
+def test_answer_with_nothing_pending_reports_false_not_an_error(ui, qapp):
+    answered = ui.ui_responder.submit_answer(True)
+    _spin_until(qapp, answered.done)
+    assert answered.result() is False
+
+
+def test_agent_and_human_race_produces_one_winner(ui, qapp):
+    thread, outcome = _ask_on_worker(ui, qapp, Confirm("Continue?"))
+
+    # Human clicks No on the GUI thread at the same moment the agent says Yes.
+    clicked = ui.ui_responder.answer_confirm(False)
+    agent = ui.ui_responder.submit_answer(True)
+    _spin_until(qapp, agent.done)
+
+    assert clicked is True  # the human's click applied first...
+    assert agent.result() is False  # ...so the agent is told it lost, cleanly
+    thread.join(timeout=5)
+    assert outcome.get("answer") is False  # and the asker got exactly one answer
+
+
+def test_aborted_question_reads_as_nothing_pending(ui, qapp):
+    thread, outcome = _ask_on_worker(ui, qapp, Confirm("Continue?"))
+    # The asker's future is cancelled (abort path); the corpse must not look
+    # like a live question to an agent.
+    ui.ui_responder._pending_question[1].cancel()
+    assert ui.ui_responder.pending_question() is None
+    answered = ui.ui_responder.submit_answer(True)
+    _spin_until(qapp, answered.done)
+    assert answered.result() is True  # the stale prompt was taken down
+    thread.join(timeout=5)


### PR DESCRIPTION
First PR of the supervision-answering phase (plan on the Linear issue). Small on purpose: two methods and a signal on `QtResponder`, nothing else touched.

## What

- `pending_question()` — the live `Request` (or None), readable from any thread; an aborted asker's question reads as None
- `submit_answer(clicked_yes) -> Future[bool]` — marshals to the GUI thread and calls `answer_confirm`, **the same method the buttons use**. Widget read-backs (detection/alignment/POI accept what's on screen — in an unattended run, the auto-proposal), the Run Milling interception, and the first-writer-wins guards all apply identically to agent and human. The Future resolves True (applied) or False (nothing pending / lost the race).

## Why this shape

The merged responder already had everything hard: the guarded completions, the corpse-cancellation, the single pending slot. The agent seam therefore isn't a parallel answering mechanism — it's a remote finger on the same button. Any divergence between "what a click does" and "what an agent answer does" would be a bug class; this construction makes it empty.

## Verification

5 threaded tests, three threads each like production (worker asks via `ask()`, GUI spins, 'agent' answers from a third thread): answer wakes the asker with display state torn down; No works; nothing-pending reports False; **agent-vs-human race yields one clean winner and the loser is told**; an aborted question reads as nothing-pending and the stale prompt still comes down. Plus the existing 10 responder tests unchanged and green (15 total).