### PR TITLE
[app] Expose the pending question over HTTP and MCP, answerable behind control

### DIFF
--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -241,6 +241,41 @@ class AgentContext:
             return {"available": False, "position": None}
         return {"available": True, "position": cached.to_dict()}
 
+    # --- supervision prompts (FIB-851) ------------------------------------------
+
+    @property
+    def _responder(self):
+        return getattr(self._host, "ui_responder", None)
+
+    def pending_prompt(self) -> Dict[str, Any]:
+        """The supervision question currently awaiting an answer, if any.
+
+        The serialized request carries everything needed to answer it — the
+        FIB-826 contract — including context images as agent-sized previews.
+        """
+        responder = self._responder
+        if responder is None:
+            return {"available": False, "pending": None}
+        request = responder.pending_question()
+        if request is None:
+            return {"available": True, "pending": None}
+        from fibsem.applications.autolamella.server.prompts import serialize_request
+
+        return {"available": True, "pending": serialize_request(request)}
+
+    def answer_prompt(self, response: bool, timeout: float = 10.0) -> Dict[str, Any]:
+        """Answer the pending question as the matching button click would.
+
+        Routed through the responder's own GUI-thread path, so agent and human
+        answers share one first-writer-wins mechanism; ``applied`` is False when
+        nothing was pending or a human answered first.
+        """
+        responder = self._responder
+        if responder is None:
+            return {"available": False, "applied": False}
+        outcome = responder.submit_answer(bool(response))
+        return {"available": True, "applied": bool(outcome.result(timeout=timeout))}
+
     # --- events -----------------------------------------------------------------
 
     def events(self, since: int = 0, timeout: float = 0.0) -> Dict[str, Any]:

--- a/fibsem/applications/autolamella/server/hosting.py
+++ b/fibsem/applications/autolamella/server/hosting.py
@@ -25,6 +25,7 @@ exactly as if the feature were off.
 
 import atexit
 import logging
+import os
 import threading
 import time
 from typing import Callable, List, Optional
@@ -98,8 +99,17 @@ class AgentServerHost:
             )
             return False
 
-        # Read-only until scopes are armed; arming arrives with the GUI dialog.
-        self.auth = AuthConfig.generate()
+        # Read-only until scopes are armed; proper arming arrives with the GUI
+        # dialog. FIBSEM_AGENT_ARM_CONTROL=1 is the developer override until
+        # then: set by whoever launches the app, never by a config file, and
+        # loudly logged. It arms answering supervision prompts — not hardware.
+        arm_control = os.environ.get("FIBSEM_AGENT_ARM_CONTROL") == "1"
+        if arm_control:
+            logging.warning(
+                "agent server: control scope ARMED via FIBSEM_AGENT_ARM_CONTROL "
+                "(developer override; the arming dialog replaces this)"
+            )
+        self.auth = AuthConfig.generate(arm_control=arm_control)
         self.event_buffer = EventBuffer()
         self.lifecycle_hook = make_lifecycle_hook(self.event_buffer)
         self._disposers = attach_microscope_taps(self.event_buffer, microscope)
@@ -152,7 +162,8 @@ class AgentServerHost:
         )
         self._wrote_discovery = True
         atexit.register(self._remove_discovery)
-        logging.info("agent server on %s — scopes: read only", self.url)
+        armed = ", ".join(s.value for s in self.auth.armed_scopes())
+        logging.info("agent server on %s — scopes: %s", self.url, armed)
         logging.info("agent server token: %s", self.auth.token)
         return True
 

--- a/fibsem/applications/autolamella/server/prompts.py
+++ b/fibsem/applications/autolamella/server/prompts.py
@@ -1,0 +1,130 @@
+"""Serializing a pending supervision question for a remote agent.
+
+The requests already obey FIB-826's rule — "a responder must be able to answer
+from the request alone" — so serializing one *is* handing the agent everything
+it needs: the question, the options, and the context images, rendered through
+the same preview pipeline the acquisition endpoints use (agent-sized JPEG,
+never raw arrays).
+
+Everything returned is plain data. Unknown request types degrade to their type
+name and JSON-able fields rather than failing: an agent that sees a question it
+cannot fully parse should still know one is standing.
+"""
+
+import base64
+from typing import Any, Dict, Optional
+
+from fibsem.applications.autolamella.server.events import to_plain
+
+__all__ = ["serialize_request"]
+
+
+def _preview_b64(data) -> Optional[Dict[str, Any]]:
+    """An ndarray as the standard agent-sized JPEG payload, or None."""
+    if data is None:
+        return None
+    try:
+        from fibsem.server.images import preview_jpeg_bytes
+
+        jpeg, width, height = preview_jpeg_bytes(data)
+        return {
+            "image_b64_jpeg": base64.b64encode(jpeg).decode(),
+            "width": width,
+            "height": height,
+        }
+    except Exception:
+        # A preview failure must not hide the question itself.
+        return None
+
+
+def _image_data(image) -> Optional[Any]:
+    return getattr(image, "data", None) if image is not None else None
+
+
+def serialize_request(request) -> Dict[str, Any]:
+    from fibsem.applications.autolamella.workflows.interaction import (
+        Confirm,
+        ConfirmDetection,
+        EditAlignmentArea,
+        PickPOI,
+        RunMillingTask,
+    )
+
+    payload: Dict[str, Any] = {"type": type(request).__name__}
+
+    if isinstance(request, Confirm):
+        payload.update(
+            {
+                "message": request.message,
+                "positive": request.positive,
+                "negative": request.negative,
+            }
+        )
+        return payload
+
+    if isinstance(request, ConfirmDetection):
+        detection = request.detection
+        payload.update(
+            {
+                "message": "Confirm the detected features (answering yes accepts "
+                "the positions as currently shown).",
+                "features": [
+                    {"name": f.name, "px": to_plain(f.px.to_dict())}
+                    for f in getattr(detection, "features", [])
+                ],
+                "pixelsize": to_plain(getattr(detection, "pixelsize", None)),
+                "image": _preview_b64(getattr(detection, "image", None)),
+            }
+        )
+        return payload
+
+    if isinstance(request, EditAlignmentArea):
+        payload.update(
+            {
+                "message": "Confirm the alignment area (answering yes accepts "
+                "the area as currently shown).",
+                "initial": to_plain(request.initial.to_dict())
+                if request.initial is not None
+                else None,
+            }
+        )
+        return payload
+
+    if isinstance(request, PickPOI):
+        payload.update(
+            {
+                "message": "Pick the point of interest on the image.",
+                "initial": to_plain(request.initial.to_dict())
+                if request.initial is not None
+                else None,
+                "image": _preview_b64(_image_data(request.image)),
+            }
+        )
+        return payload
+
+    if isinstance(request, RunMillingTask):
+        config = request.config
+        payload.update(
+            {
+                "message": "Confirm and run this milling task (answering yes "
+                "runs the mill with the configuration as currently shown).",
+                "enabled": request.enabled,
+                "task_name": to_plain(getattr(config, "name", None)),
+                "num_stages": len(getattr(config, "stages", []) or []),
+            }
+        )
+        return payload
+
+    # Unknown/newer request types: name + whatever serializes cleanly.
+    try:
+        import dataclasses
+
+        if dataclasses.is_dataclass(request):
+            for f in dataclasses.fields(request):
+                value = getattr(request, f.name)
+                if hasattr(value, "data") or type(value).__name__ == "ndarray":
+                    continue  # images only travel as previews, never raw
+                payload[f.name] = to_plain(value)
+    except Exception:
+        pass
+    return payload

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -255,6 +255,15 @@ def build_sidecar(client, capabilities):
     def get_events(since: int = 0, timeout: float = 0.0):
         return _app_get(f"/app/events?since={since}&timeout={timeout}")
 
+    def get_pending_prompt():
+        return _app_get("/app/prompt")
+
+    def answer_prompt(response: bool):
+        data, err = _call(
+            client, "POST", "/app/prompt/answer", {"response": bool(response)}
+        )
+        return err if err else data
+
     implementations = {
         fn.__name__: fn
         for fn in (
@@ -282,6 +291,8 @@ def build_sidecar(client, capabilities):
             get_task_outputs,
             list_recent_experiments,
             get_events,
+            get_pending_prompt,
+            answer_prompt,
         )
     }
     # The catalog is the contract: refuse to start with an implementation gap.

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -21,7 +21,7 @@ try:  # Protocol is typing-only; keep import robust on the 3.8 floor
 except ImportError:  # pragma: no cover
     Protocol = object  # type: ignore[assignment]
 
-__all__ = ["AppContext", "build_app_router"]
+__all__ = ["AppContext", "build_app_control_router", "build_app_router"]
 
 
 class AppContext(Protocol):
@@ -44,6 +44,10 @@ class AppContext(Protocol):
     def recent_experiments(self) -> List[Dict[str, Any]]: ...
 
     def events(self, since: int = 0, timeout: float = 0.0) -> Dict[str, Any]: ...
+
+    def pending_prompt(self) -> Dict[str, Any]: ...
+
+    def answer_prompt(self, response: bool) -> Dict[str, Any]: ...
 
 
 def build_app_router(context: AppContext) -> APIRouter:
@@ -81,11 +85,31 @@ def build_app_router(context: AppContext) -> APIRouter:
     def recent_experiments():
         return {"items": context.recent_experiments()}
 
+    @router.get("/prompt")
+    def pending_prompt():
+        return context.pending_prompt()
+
     @router.get("/events")
     def events(since: int = 0, timeout: float = 0.0):
         # A long-poll: parks up to `timeout` seconds waiting for news. Capped
         # here because the park occupies a threadpool worker — a transport
         # concern, so the transport owns the ceiling.
         return context.events(since=since, timeout=min(max(timeout, 0.0), 30.0))
+
+    return router
+
+
+def build_app_control_router(context: AppContext) -> APIRouter:
+    """Routes that act on the session rather than observe it.
+
+    Mounted (by build_server) behind the ``control`` scope, which embedded
+    hosting does not arm yet — so today these exist only where a hosting
+    explicitly arms control (tests; later, the arming dialog).
+    """
+    router = APIRouter(prefix="/app")
+
+    @router.post("/prompt/answer")
+    def answer_prompt(body: Dict[str, Any]):
+        return context.answer_prompt(bool(body.get("response", False)))
 
     return router

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -226,6 +226,23 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         },
     ),
     ToolSpec(
+        name="get_pending_prompt",
+        description="The supervision question awaiting an answer, if any — message, options, and context images.",
+        method="GET",
+        path="/app/prompt",
+        scope="read",
+        router="app",
+    ),
+    ToolSpec(
+        name="answer_prompt",
+        description="Answer the pending supervision question, exactly as clicking the matching button would. True = the positive option.",
+        method="POST",
+        path="/app/prompt/answer",
+        scope="control",
+        router="app",
+        params={"response": "true for the positive option, false for the negative"},
+    ),
+    ToolSpec(
         name="list_recent_experiments",
         description="Recently opened experiments on this machine, without loading them.",
         method="GET",

--- a/fibsem/server/server.py
+++ b/fibsem/server/server.py
@@ -41,7 +41,7 @@ from fastapi.responses import JSONResponse, Response
 
 from fibsem import utils
 from fibsem.microscope import FibsemMicroscope
-from fibsem.server.app_routes import build_app_router
+from fibsem.server.app_routes import build_app_control_router, build_app_router
 from fibsem.server.auth import AuthConfig, Scope, command_slot, require_scope
 from fibsem.server.discovery import (
     DISCOVERY_FILE,
@@ -672,6 +672,12 @@ def build_server(
         app.include_router(
             build_app_router(app_context),
             dependencies=[Depends(require_scope(Scope.READ))],
+        )
+        # Acting on the session (answering prompts) is control scope — armed by
+        # the hosting, never by default; unarmed callers get 403 scope_not_armed.
+        app.include_router(
+            build_app_control_router(app_context),
+            dependencies=[Depends(require_scope(Scope.CONTROL))],
         )
     return app
 

--- a/tests/server/test_app_router.py
+++ b/tests/server/test_app_router.py
@@ -119,7 +119,10 @@ def test_sidecar_grows_the_app_tools_from_capabilities(client):
     sidecar = build_sidecar(client, capabilities)
     listed = asyncio.run(sidecar.list_tools())
     names = {t.name for t in getattr(listed, "tools", listed)}
-    assert {t.name for t in CATALOG if t.router == "app"} <= names
+    # Control-scope app tools (answer_prompt) need arming; this server is
+    # read-only, so only the read-scope app tools must appear.
+    assert {t.name for t in CATALOG if t.router == "app" and t.scope == "read"} <= names
+    assert "answer_prompt" not in names
 
     result = asyncio.run(sidecar.call_tool("get_app_status", {}))
     if isinstance(result, tuple):

--- a/tests/server/test_catalog_discovery.py
+++ b/tests/server/test_catalog_discovery.py
@@ -60,14 +60,14 @@ def test_every_catalog_entry_is_a_real_route(app):
 def test_catalog_names_unique_and_scopes_valid():
     names = [t.name for t in CATALOG]
     assert len(names) == len(set(names))
-    assert set(t.scope for t in CATALOG) <= {"read", "hardware"}
+    assert set(t.scope for t in CATALOG) <= {"read", "control", "hardware"}
 
 
 def test_tools_for_scopes_filters_hardware():
     read_only = tools_for_scopes({"read": True, "hardware": False})
     assert all(t.scope == "read" for t in read_only)
     assert any(t.name == "stop_milling" for t in read_only)
-    armed = tools_for_scopes({"read": True, "hardware": True})
+    armed = tools_for_scopes({"read": True, "control": True, "hardware": True})
     assert len(armed) == len(CATALOG)
 
 

--- a/tests/server/test_hosting.py
+++ b/tests/server/test_hosting.py
@@ -128,3 +128,18 @@ def test_start_failure_is_contained_not_raised(microscope, tmp_path):
     )
     assert server_host.start(microscope) is False
     assert not server_host.running
+
+
+def test_env_override_arms_control_scope(microscope, tmp_path, monkeypatch):
+    monkeypatch.setenv("FIBSEM_AGENT_ARM_CONTROL", "1")
+    ui = Host()
+    server_host = AgentServerHost(
+        ui, port=_free_port(), discovery_path=tmp_path / "agent-server.json"
+    )
+    try:
+        assert server_host.start(microscope) is True
+        scopes = _get(server_host, "/capabilities").json()["scopes"]
+        assert scopes["control"] is True
+        assert scopes["hardware"] is False  # the override never arms hardware
+    finally:
+        server_host.stop()

--- a/tests/ui/test_agent_prompt_surface.py
+++ b/tests/ui/test_agent_prompt_surface.py
@@ -1,0 +1,158 @@
+"""Supervision answering end to end: a real workflow-thread question, seen and
+answered over HTTP through the mounted server — the killer-app data path.
+
+Three threads, like production: the worker asks through ``ask()``, the GUI spins,
+and the 'agent' speaks HTTP from the test thread via TestClient."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("PyQt5")
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient
+
+from fibsem.applications.autolamella.server import AgentContext
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.applications.autolamella.workflows.interaction import Confirm, ask
+from fibsem.server import AuthConfig, build_server
+
+TOKEN = "test-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+
+@pytest.fixture
+def ui(qapp, monkeypatch):
+    import fibsem.config as fibsem_config
+
+    arctis_config = os.path.join(
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "sim-arctis-configuration.yaml",
+    )
+    widget = AutoLamellaUI(parent_ui=None)
+    monkeypatch.setattr(
+        widget.system_widget,
+        "load_configuration",
+        lambda configuration_name=None: arctis_config,
+    )
+    widget.system_widget.connect_to_microscope()
+    yield widget
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+    widget.deleteLater()
+    qapp.processEvents()
+
+
+def _client(ui, arm_control):
+    app = build_server(
+        ui.microscope,
+        app_context=AgentContext(ui),
+        auth=AuthConfig.generate(arm_control=arm_control, token=TOKEN),
+    )
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _spin_until(qapp, predicate, timeout_s=10.0):
+    deadline = time.monotonic() + timeout_s
+    while not predicate():
+        if time.monotonic() > deadline:
+            raise TimeoutError("condition not reached")
+        qapp.processEvents()
+        time.sleep(0.01)
+
+
+def _ask_on_worker(ui, qapp):
+    outcome = {}
+
+    def target():
+        try:
+            outcome["answer"] = ask(
+                ui.ui_responder,
+                Confirm("Continue to polishing?", positive="Continue", negative="Stop"),
+            )
+        except Exception as exc:  # noqa: BLE001
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    _spin_until(qapp, lambda: ui.ui_responder.pending_question() is not None)
+    return thread, outcome
+
+
+def test_agent_sees_and_answers_the_question_over_http(ui, qapp):
+    with _client(ui, arm_control=True) as client:
+        # Nothing pending yet: available, but no question.
+        body = client.get("/app/prompt", headers=AUTH).json()
+        assert body == {"available": True, "pending": None}
+
+        thread, outcome = _ask_on_worker(ui, qapp)
+        pending = client.get("/app/prompt", headers=AUTH).json()["pending"]
+        assert pending["type"] == "Confirm"
+        assert pending["message"] == "Continue to polishing?"
+        assert pending["positive"] == "Continue"
+
+        # POST from a separate thread, as production does: the answer applies on
+        # the GUI thread, which in this test is the thread running the loop —
+        # a blocking post from here would deadlock into the 10 s timeout.
+        posted = {}
+
+        def do_post():
+            posted["response"] = client.post(
+                "/app/prompt/answer", headers=AUTH, json={"response": True}
+            )
+
+        poster = threading.Thread(target=do_post, daemon=True)
+        poster.start()
+        _spin_until(qapp, lambda: "response" in posted)
+        answered = posted["response"]
+        assert answered.status_code == 200
+        assert answered.json()["applied"] is True
+        _spin_until(qapp, lambda: "answer" in outcome or "error" in outcome)
+        thread.join(timeout=5)
+        assert outcome.get("answer") is True
+
+
+def test_answering_requires_the_control_scope(ui, qapp):
+    with _client(ui, arm_control=False) as client:
+        # Reading the prompt is observation: read scope suffices.
+        assert client.get("/app/prompt", headers=AUTH).status_code == 200
+        refused = client.post(
+            "/app/prompt/answer", headers=AUTH, json={"response": True}
+        )
+        assert refused.status_code == 403
+        assert refused.json()["detail"]["scope"] == "control"
+
+
+def test_capabilities_reflect_the_armed_control_scope(ui, qapp):
+    with _client(ui, arm_control=True) as client:
+        scopes = client.get("/capabilities", headers=AUTH).json()["scopes"]
+        assert scopes["control"] is True
+        from fibsem.server.catalog import tools_for_capabilities
+
+        names = {
+            t.name
+            for t in tools_for_capabilities(
+                client.get("/capabilities", headers=AUTH).json()
+            )
+        }
+        assert "answer_prompt" in names
+    with _client(ui, arm_control=False) as client:
+        from fibsem.server.catalog import tools_for_capabilities
+
+        names = {
+            t.name
+            for t in tools_for_capabilities(
+                client.get("/capabilities", headers=AUTH).json()
+            )
+        }
+        assert "get_pending_prompt" in names
+        assert "answer_prompt" not in names


### PR DESCRIPTION
Stacked on #672. Together they are the supervision-answering phase's core: **an agent can now see a live workflow's question and answer it exactly as a click would.**

## What

- `GET /app/prompt` (read): the pending request serialized per type — Confirm's message/options; detection's features + image preview; POI's image; milling's task/stage summary. Images travel as agent-sized JPEGs via the existing preview pipeline; unknown future request types degrade to name+fields, never to a 500
- `POST /app/prompt/answer` (**control scope**, its own router): routes through `submit_answer` → `answer_confirm` — the buttons' own path — and reports `applied: true/false` so the agent knows if it won the race
- Catalog + sidecar: `get_pending_prompt` / `answer_prompt` (26 tools; the first control-scope tool). The capability filter means `answer_prompt` only exists on servers where control is armed — verified in tests both ways
- `FIBSEM_AGENT_ARM_CONTROL=1`: the developer arming override until the dialog lands — env-only, warn-logged, never arms hardware

## How it works, in plain language

A supervision question is a parked Future waiting for one completion. The GUI buttons complete it from a click; this PR gives the agent a second finger on the *same* button — marshalled to the GUI thread, using the same guarded completion — so "who answers first" is decided by the Future itself, race-free, with the loser told cleanly. Reading the question costs nothing and needs no permission beyond read; *answering* is acting on the session, which is why it lives behind the armed control scope.

## Verification

3 end-to-end tests through a real connected window: worker asks via `ask()`, the 'agent' reads the prompt over HTTP and answers from a separate thread (as production does — a note in the test explains the GUI-thread deadlock the harness must avoid), worker wakes with the answer; control-scope 403 with structured detail when unarmed; capability-driven tool visibility both ways. Plus the env-override hosting test (control armed, hardware never). **88 tests green** across all agent-server suites; ruff clean.