### PR TITLE
[refactor] Delete the emitter-less workflow trigger signals

### DIFF
--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import threading
 
-from PyQt5.QtCore import Qt, QTimer, pyqtSignal
+from PyQt5.QtCore import QTimer, pyqtSignal
 from PyQt5.QtWidgets import (
     QFormLayout,
     QLabel,
@@ -73,12 +73,10 @@ class FibsemSpotBurnWidget(QWidget):
     ``coordinates``, the form writes current/exposure, and the burn runs the settings.
 
     Progress is driven by ``microscope.spot_burn_progress_signal`` (shared with the
-    status bar). The burn runs directly from the widget's button, or — in a supervised
-    workflow — via ``start_spot_burn_signal`` (mirrors milling's task-orchestrated hook).
+    status bar). The burn runs from the widget's button — in a supervised workflow
+    QtResponder drives ``run_spot_burn_worker`` directly on the GUI thread.
     """
 
-    # emitted by the workflow task to trigger a burn (mirrors milling's start_milling_signal)
-    start_spot_burn_signal = pyqtSignal()
     # emitted when a burn ends, success and failure alike (mirrors milling's
     # finished_milling_signal); listeners take it to mean the widget is idle again
     finished_spot_burn_signal = pyqtSignal()
@@ -167,15 +165,6 @@ class FibsemSpotBurnWidget(QWidget):
             stylesheets.PRIMARY_BUTTON_STYLESHEET
         )
         self.pushButton_run_spot_burn.setEnabled(False)
-
-        # the workflow task drives the burn via start_spot_burn_signal (mirrors milling).
-        # BlockingQueuedConnection: emit() returns only after run_spot_burn_worker has run,
-        # so the burn is then either in progress (is_burning=True) or was refused (no
-        # in-bounds points), in which case the task re-prompts.
-        self.start_spot_burn_signal.connect(
-            self.run_spot_burn_worker,
-            Qt.BlockingQueuedConnection,  # type: ignore
-        )
 
         # coordinate signal
         self.coord_editor.settings_changed.connect(self._refresh_info)

--- a/fibsem/ui/widgets/milling_widget.py
+++ b/fibsem/ui/widgets/milling_widget.py
@@ -2,7 +2,7 @@ import logging
 import threading
 from typing import TYPE_CHECKING, Optional
 
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
     QGridLayout,
     QProgressBar,
@@ -33,7 +33,6 @@ class FibsemMillingWidget2(QWidget):
     the threading and progress updates.
     """
 
-    start_milling_signal = pyqtSignal()
     finished_milling_signal = pyqtSignal()
 
     def __init__(
@@ -78,8 +77,6 @@ class FibsemMillingWidget2(QWidget):
             stylesheets.PROGRESS_BAR_STYLESHEET
         )
         self.progressBar_milling.setStyleSheet(stylesheets.PROGRESS_BAR_STYLESHEET)
-
-        self.start_milling_signal.connect(self.run_milling, Qt.BlockingQueuedConnection)  # type: ignore
 
         if self.parent_widget._milling_enabled:
             self.microscope.milling_progress_signal.connect(self._on_milling_progress)


### PR DESCRIPTION
Last sweep after the signal untangle: `start_milling_signal` and `start_spot_burn_signal` lost their final emitters when the run loops moved into `QtResponder`, which calls `run_milling` / `run_spot_burn_worker` directly on the GUI thread that owns the widgets. What remained on each widget was a signal nobody fires, wired through a `BlockingQueuedConnection` — dead code with a loaded footgun attached (a stray same-thread emit through a BlockingQueued connect deadlocks). Deleted, with their orphaned `Qt` imports and the spot-burn widget's stale docstring. Remaining mentions in the tree are historical prose in docstrings describing what the old mechanism did. 57 tests across the mill/burn suites green.