### PR TITLE
[fix] Log a user Stop as a cancellation, not an error

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -35,6 +35,7 @@ from fibsem.applications.autolamella.ui.qt_responder import QtResponder
 from fibsem.applications.autolamella.ui.selected_lamella_widget import (
     SelectedLamellaWidget,
 )
+from fibsem.cancellation import OperationCancelledError
 from fibsem.constants import METRE_TO_MICRON, MICRON_TO_METRE
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import (
@@ -1036,6 +1037,12 @@ class AutoLamellaUI(QMainWindow):
             self._task_manager.run(
                 task_names=task_names, required_lamella=lamella_names
             )
+        except (InterruptedError, OperationCancelledError) as e:
+            # A user Stop, not a failure: both cancellation types unwind through
+            # here, and anyone scanning the log for problems (or filtering on
+            # ERROR) must not see one per Stop press. The task layer has already
+            # recorded the outcome as Cancelled; this is the worker's exit note.
+            logging.info(f"Workflow cancelled: {e}")
         except Exception as e:
             logging.error(f"Error during running tasks: {e}")
 

--- a/tests/ui/test_workflow_cancellation_logging.py
+++ b/tests/ui/test_workflow_cancellation_logging.py
@@ -1,0 +1,87 @@
+"""A user Stop is logged as a cancellation, not as an error (FIB-859).
+
+``_run_tasks_worker``'s catch-all treated the cancellation unwind the same as a
+real failure, so every Stop press put ``ERROR — Error during running tasks:
+Workflow aborted by user.`` in the log — a false positive for anyone scanning a
+session log for problems, once per Stop. Both cancellation types
+(``InterruptedError`` from the abort checks, ``OperationCancelledError`` from
+milling/autofocus) log at INFO now; genuine failures still log at ERROR.
+"""
+
+import logging
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.structures import Experiment
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.cancellation import OperationCancelledError
+
+
+@pytest.fixture
+def ui(qapp, tmp_path, monkeypatch):
+    """A real AutoLamellaUI, connected (Demo), ready to run the worker inline."""
+    widget = AutoLamellaUI(parent_ui=None)
+    widget.system_widget.connect_to_microscope()
+    widget.experiment = Experiment(path=tmp_path, name="test-exp")
+    # The hook set is irrelevant here and pulls in user preferences.
+    monkeypatch.setattr(widget, "setup_hooks", lambda: None)
+    yield widget
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+
+
+def _run_with_manager_raising(ui, monkeypatch, exc):
+    from fibsem.applications.autolamella.ui import AutoLamellaUI as module
+
+    class _RaisingManager:
+        is_stopped = True
+
+        def __init__(self, **kwargs):
+            pass
+
+        def stop(self):
+            pass
+
+        def run(self, **kwargs):
+            raise exc
+
+        def build_run_summary_dataframe(self):
+            return None
+
+    monkeypatch.setattr(module, "TaskManager", _RaisingManager)
+    ui._run_tasks_worker(["Rough Milling"], ["01-test"])
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        InterruptedError("Workflow aborted by user."),
+        OperationCancelledError("Milling cancelled"),
+    ],
+    ids=["interrupted", "operation-cancelled"],
+)
+def test_a_user_stop_logs_no_error(ui, monkeypatch, caplog, exc):
+    with caplog.at_level(logging.INFO):
+        _run_with_manager_raising(ui, monkeypatch, exc)
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors == [], [r.message for r in errors]
+    assert any("cancelled" in r.message.lower() for r in caplog.records), (
+        "the cancellation must still leave a trace, just not an ERROR"
+    )
+
+
+def test_a_genuine_failure_still_logs_an_error(ui, monkeypatch, caplog):
+    with caplog.at_level(logging.INFO):
+        _run_with_manager_raising(ui, monkeypatch, RuntimeError("stage fell over"))
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert any("stage fell over" in r.message for r in errors), (
+        "downgrading cancellation must not swallow real failures"
+    )


### PR DESCRIPTION
Every Stop press wrote `ERROR — Error during running tasks: Workflow aborted by user.` to the log — `_run_tasks_worker`'s catch-all treated the cancellation unwind the same as a real failure, one false positive per Stop for anyone scanning a session log for problems (or filtering on ERROR).

Both cancellation types — `InterruptedError` from the abort checks, `OperationCancelledError` from milling/autofocus — now log at INFO (`Workflow cancelled: …`); genuine failures still log at ERROR unchanged.

The sweep the issue asked for found nothing else to fix: the task layer already distinguishes cancellation (`_is_cancellation` → Cancelled status, its own hook), the milling task catches `OperationCancelledError` itself and logs INFO, and a cancelled spot burn returns normally with a CANCELLED report — this catch-all was the one place funnelling a Stop into ERROR.

Tests (3): both cancellation types produce zero ERROR records while still leaving an INFO trace, and a genuine failure still logs at ERROR — both cancellation tests verified to fail against the unfixed handler.

Fixes FIB-859.