### PR TITLE
[app] Prompt nonce: an answer must name the question it answers (+ task_outputs fix)

### DIFF
--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -217,7 +217,7 @@ class AgentContext:
         return {
             "available": True,
             "item_name": item_name,
-            "completed_tasks": [state.task_name for state in history],
+            "completed_tasks": [state.name for state in history],
             "final_reference_images": [
                 str(p) for p in _task_outputs.final_reference_images(lamella, *history)
             ],
@@ -256,25 +256,40 @@ class AgentContext:
         responder = self._responder
         if responder is None:
             return {"available": False, "pending": None}
-        request = responder.pending_question()
+        request, nonce = responder.pending_question_and_nonce()
         if request is None:
             return {"available": True, "pending": None}
         from fibsem.applications.autolamella.server.prompts import serialize_request
 
-        return {"available": True, "pending": serialize_request(request)}
+        payload = serialize_request(request)
+        payload["nonce"] = nonce
+        return {"available": True, "pending": payload}
 
-    def answer_prompt(self, response: bool, timeout: float = 10.0) -> Dict[str, Any]:
+    def answer_prompt(
+        self, response: bool, nonce: int, timeout: float = 10.0
+    ) -> Dict[str, Any]:
         """Answer the pending question as the matching button click would.
 
         Routed through the responder's own GUI-thread path, so agent and human
         answers share one first-writer-wins mechanism; ``applied`` is False when
-        nothing was pending or a human answered first.
+        nothing was pending or a human answered first. The ``nonce`` (from
+        :meth:`pending_prompt`) names the question being answered: if that
+        posting is gone — answered, withdrawn, or replaced — the result is
+        ``stale`` and nothing was clicked.
         """
         responder = self._responder
         if responder is None:
-            return {"available": False, "applied": False}
-        outcome = responder.submit_answer(bool(response))
-        return {"available": True, "applied": bool(outcome.result(timeout=timeout))}
+            return {"available": False, "applied": False, "stale": False}
+        from fibsem.applications.autolamella.workflows.interaction import (
+            StalePromptError,
+        )
+
+        outcome = responder.submit_answer(bool(response), nonce=int(nonce))
+        try:
+            applied = bool(outcome.result(timeout=timeout))
+        except StalePromptError:
+            return {"available": True, "applied": False, "stale": True}
+        return {"available": True, "applied": applied, "stale": False}
 
     # --- events -----------------------------------------------------------------
 

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -42,6 +42,7 @@ from fibsem.applications.autolamella.workflows.interaction import (
     SetFluorescenceChannels,
     SetImages,
     SetMillingConfig,
+    StalePromptError,
 )
 from fibsem.applications.autolamella.workflows.tasks.status import (
     WorkflowStatusEvent,
@@ -60,7 +61,9 @@ class QtResponder(QObject):
     """Answers workflow requests by driving the window's widgets, on the GUI thread."""
 
     _submitted = pyqtSignal(object, object)  # (Request, Future)
-    _agent_answered = pyqtSignal(bool, object)  # (clicked_yes, Future[bool])
+    _agent_answered = pyqtSignal(
+        bool, object, object
+    )  # (clicked_yes, nonce, Future[bool])
 
     def __init__(self, ui: "AutoLamellaUI"):
         super().__init__()
@@ -82,7 +85,12 @@ class QtResponder(QObject):
             RunMillingTask: self._run_milling_task,
             RunSpotBurn: self._run_spot_burn,
         }
-        self._pending_question: Optional[Tuple[Request, "Future"]] = None
+        # (request, future, nonce): one attribute so a cross-thread reader sees
+        # a question and its nonce as a single consistent pair. The nonce names
+        # this posting of a question — a re-park (post-mill re-ask, replaced
+        # corpse) is a new question and gets a new one.
+        self._pending_question: Optional[Tuple[Request, "Future", int]] = None
+        self._question_seq = 0
         # A RunMillingTask whose mill is currently running: the prompt is down,
         # the future is pending, and finished_milling_signal decides what next.
         self._active_milling: Optional[Tuple[RunMillingTask, "Future"]] = None
@@ -110,12 +118,22 @@ class QtResponder(QObject):
         agent see what it is being asked. A question whose asker already
         aborted reads as None: nobody is waiting on it.
         """
+        request, _ = self.pending_question_and_nonce()
+        return request
+
+    def pending_question_and_nonce(self) -> Tuple[Optional["Request"], Optional[int]]:
+        """The pending request and the nonce naming it, or (None, None). Any thread.
+
+        The nonce is how a remote answer names *which* question it answers:
+        echo it back through :meth:`submit_answer` and the answer applies only
+        if that exact posting is still standing.
+        """
         pending = self._pending_question
         if pending is None or pending[1].cancelled():
-            return None
-        return pending[0]
+            return None, None
+        return pending[0], pending[2]
 
-    def submit_answer(self, clicked_yes: bool) -> "Future":
+    def submit_answer(self, clicked_yes: bool, nonce: Optional[int] = None) -> "Future":
         """Answer the pending question as if the matching button were clicked.
 
         Any thread; returns a Future[bool] that resolves True when the answer
@@ -124,15 +142,38 @@ class QtResponder(QObject):
         :meth:`answer_confirm` on the GUI thread — the *same* path as the
         buttons, so widget read-backs, the Run Milling interception, and the
         first-writer-wins guards all behave identically for agent and human.
+
+        With a ``nonce`` (from :meth:`pending_question_and_nonce`), the answer
+        applies only to that posting of the question: if it has meanwhile been
+        answered, withdrawn, or replaced, the future fails with
+        :class:`StalePromptError` and nothing is clicked. Without one, the
+        answer takes whatever is pending — the trusting form, for callers that
+        just looked (tests, a local console).
         """
         from concurrent.futures import Future as _Future
 
         outcome: "_Future" = _Future()
-        self._agent_answered.emit(clicked_yes, outcome)
+        self._agent_answered.emit(clicked_yes, nonce, outcome)
         return outcome
 
-    def _apply_agent_answer(self, clicked_yes: bool, outcome: "Future") -> None:
-        """GUI thread. Complete ``outcome`` with whether the answer applied."""
+    def _apply_agent_answer(
+        self, clicked_yes: bool, nonce: Optional[int], outcome: "Future"
+    ) -> None:
+        """GUI thread. Complete ``outcome`` with whether the answer applied.
+
+        The nonce check happens here, on the thread that posts and clears
+        questions — the one place it cannot race a swap.
+        """
+        if nonce is not None:
+            pending = self._pending_question
+            if pending is None or pending[1].cancelled() or pending[2] != nonce:
+                self._fail(
+                    outcome,
+                    StalePromptError(
+                        f"answer named question {nonce}, which is no longer pending"
+                    ),
+                )
+                return
         try:
             applied = self.answer_confirm(clicked_yes)
         except Exception as exc:  # noqa: BLE001 - the asker owns the failure
@@ -248,7 +289,8 @@ class QtResponder(QObject):
             # that aborted and unwound without an answer. Cancel it so nobody
             # trips over the corpse.
             self._pending_question[1].cancel()
-        self._pending_question = (request, future)
+        self._question_seq += 1
+        self._pending_question = (request, future, self._question_seq)
         # Display state, not a handshake: the workflow no longer polls this flag
         # for converted questions, but the attention button, border and timeline
         # pause still read it.
@@ -532,7 +574,7 @@ class QtResponder(QObject):
         pending = self._pending_question
         if pending is None:
             return False
-        request, future = pending
+        request, future = pending[0], pending[1]
         self._pending_question = None
         self._ui.WAITING_FOR_USER_INTERACTION = False
         if future.cancelled():

--- a/fibsem/applications/autolamella/workflows/interaction.py
+++ b/fibsem/applications/autolamella/workflows/interaction.py
@@ -75,9 +75,20 @@ __all__ = [
     "ClearMillingConfig",
     "SetFluorescenceChannels",
     "Responder",
+    "StalePromptError",
     "ask",
     "wait_for",
 ]
+
+
+class StalePromptError(Exception):
+    """An answer named a question that is no longer the pending one.
+
+    Raised back to a remote answerer (never to the workflow thread) when the
+    nonce it echoed does not match the standing question — the prompt it saw
+    was answered, withdrawn, or replaced while its answer was in flight.
+    """
+
 
 R = TypeVar("R")
 

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -258,9 +258,12 @@ def build_sidecar(client, capabilities):
     def get_pending_prompt():
         return _app_get("/app/prompt")
 
-    def answer_prompt(response: bool):
+    def answer_prompt(response: bool, nonce: int):
         data, err = _call(
-            client, "POST", "/app/prompt/answer", {"response": bool(response)}
+            client,
+            "POST",
+            "/app/prompt/answer",
+            {"response": bool(response), "nonce": int(nonce)},
         )
         return err if err else data
 

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -14,7 +14,7 @@ stays in one place (build_server).
 
 from typing import Any, Dict, List
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
 try:  # Protocol is typing-only; keep import robust on the 3.8 floor
     from typing import Protocol
@@ -47,7 +47,7 @@ class AppContext(Protocol):
 
     def pending_prompt(self) -> Dict[str, Any]: ...
 
-    def answer_prompt(self, response: bool) -> Dict[str, Any]: ...
+    def answer_prompt(self, response: bool, nonce: int) -> Dict[str, Any]: ...
 
 
 def build_app_router(context: AppContext) -> APIRouter:
@@ -110,6 +110,30 @@ def build_app_control_router(context: AppContext) -> APIRouter:
 
     @router.post("/prompt/answer")
     def answer_prompt(body: Dict[str, Any]):
-        return context.answer_prompt(bool(body.get("response", False)))
+        # The nonce is mandatory: an answer must name the question it answers
+        # (from GET /app/prompt), never "whatever is pending by the time this
+        # lands" — the prompt can change between the read and the answer.
+        try:
+            nonce = int(body["nonce"])
+        except (KeyError, TypeError, ValueError):
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "error_type": "missing_nonce",
+                    "message": "Echo the integer nonce from GET /app/prompt; "
+                    "an answer must name the question it answers.",
+                },
+            )
+        result = context.answer_prompt(bool(body.get("response", False)), nonce)
+        if result.get("stale"):
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error_type": "stale_prompt",
+                    "message": "That question is no longer pending; "
+                    "re-read /app/prompt and answer the current one.",
+                },
+            )
+        return result
 
     return router

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -235,12 +235,15 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
     ),
     ToolSpec(
         name="answer_prompt",
-        description="Answer the pending supervision question, exactly as clicking the matching button would. True = the positive option.",
+        description="Answer the pending supervision question, exactly as clicking the matching button would. True = the positive option. Echo the nonce from get_pending_prompt; if that question is no longer pending the answer is refused (409 stale_prompt) — re-read and answer the current one.",
         method="POST",
         path="/app/prompt/answer",
         scope="control",
         router="app",
-        params={"response": "true for the positive option, false for the negative"},
+        params={
+            "response": "true for the positive option, false for the negative",
+            "nonce": "the nonce from get_pending_prompt, naming the question being answered",
+        },
     ),
     ToolSpec(
         name="list_recent_experiments",

--- a/tests/autolamella/test_agent_context.py
+++ b/tests/autolamella/test_agent_context.py
@@ -112,6 +112,17 @@ def test_task_outputs_for_a_real_item_and_a_missing_one(experiment):
     assert payload["final_reference_images"] == []  # nothing has run
     _assert_json_safe(payload)
 
+    # With history: the live-run 500 — the field is `name`, and an empty
+    # history hid the read of a field that doesn't exist.
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskState
+
+    experiment.positions[0].task_history.append(
+        AutoLamellaTaskState(name="Rough Milling")
+    )
+    completed = ctx.task_outputs(name)
+    assert completed["completed_tasks"] == ["Rough Milling"]
+    _assert_json_safe(completed)
+
     missing = ctx.task_outputs("no-such-item")
     assert missing["available"] is False
     assert "no-such-item" in missing["error"]

--- a/tests/ui/test_agent_prompt_surface.py
+++ b/tests/ui/test_agent_prompt_surface.py
@@ -99,6 +99,7 @@ def test_agent_sees_and_answers_the_question_over_http(ui, qapp):
         assert pending["type"] == "Confirm"
         assert pending["message"] == "Continue to polishing?"
         assert pending["positive"] == "Continue"
+        assert isinstance(pending["nonce"], int)
 
         # POST from a separate thread, as production does: the answer applies on
         # the GUI thread, which in this test is the thread running the loop —
@@ -107,7 +108,9 @@ def test_agent_sees_and_answers_the_question_over_http(ui, qapp):
 
         def do_post():
             posted["response"] = client.post(
-                "/app/prompt/answer", headers=AUTH, json={"response": True}
+                "/app/prompt/answer",
+                headers=AUTH,
+                json={"response": True, "nonce": pending["nonce"]},
             )
 
         poster = threading.Thread(target=do_post, daemon=True)
@@ -121,12 +124,50 @@ def test_agent_sees_and_answers_the_question_over_http(ui, qapp):
         assert outcome.get("answer") is True
 
 
+def test_a_stale_nonce_is_refused_and_the_question_stands(ui, qapp):
+    with _client(ui, arm_control=True) as client:
+        thread, outcome = _ask_on_worker(ui, qapp)
+        nonce = client.get("/app/prompt", headers=AUTH).json()["pending"]["nonce"]
+
+        posted = {}
+
+        def do_post():
+            posted["response"] = client.post(
+                "/app/prompt/answer",
+                headers=AUTH,
+                json={"response": True, "nonce": nonce - 1},
+            )
+
+        poster = threading.Thread(target=do_post, daemon=True)
+        poster.start()
+        _spin_until(qapp, lambda: "response" in posted)
+        refused = posted["response"]
+        assert refused.status_code == 409
+        assert refused.json()["detail"]["error_type"] == "stale_prompt"
+        # Nothing was clicked: the question still stands and the asker waits.
+        assert ui.ui_responder.pending_question() is not None
+        assert outcome == {}
+        # Clean up: answer for real so the worker thread can finish.
+        ui.ui_responder.answer_confirm(False)
+        _spin_until(qapp, lambda: "answer" in outcome)
+        thread.join(timeout=5)
+
+
+def test_an_answer_without_a_nonce_is_rejected(ui, qapp):
+    with _client(ui, arm_control=True) as client:
+        rejected = client.post(
+            "/app/prompt/answer", headers=AUTH, json={"response": True}
+        )
+        assert rejected.status_code == 422
+        assert rejected.json()["detail"]["error_type"] == "missing_nonce"
+
+
 def test_answering_requires_the_control_scope(ui, qapp):
     with _client(ui, arm_control=False) as client:
         # Reading the prompt is observation: read scope suffices.
         assert client.get("/app/prompt", headers=AUTH).status_code == 200
         refused = client.post(
-            "/app/prompt/answer", headers=AUTH, json={"response": True}
+            "/app/prompt/answer", headers=AUTH, json={"response": True, "nonce": 1}
         )
         assert refused.status_code == 403
         assert refused.json()["detail"]["scope"] == "control"

--- a/tests/ui/test_qt_responder_agent_answer.py
+++ b/tests/ui/test_qt_responder_agent_answer.py
@@ -120,6 +120,58 @@ def test_agent_and_human_race_produces_one_winner(ui, qapp):
     assert outcome.get("answer") is False  # and the asker got exactly one answer
 
 
+def test_an_answer_naming_the_question_applies(ui, qapp):
+    thread, outcome = _ask_on_worker(ui, qapp, Confirm("Continue?"))
+    request, nonce = ui.ui_responder.pending_question_and_nonce()
+    assert isinstance(request, Confirm)
+    assert isinstance(nonce, int)
+
+    answered = ui.ui_responder.submit_answer(True, nonce=nonce)
+    _spin_until(qapp, answered.done)
+    assert answered.result() is True
+    thread.join(timeout=5)
+    assert outcome.get("answer") is True
+
+
+def test_a_wrong_nonce_is_refused_and_clicks_nothing(ui, qapp):
+    from fibsem.applications.autolamella.workflows.interaction import (
+        StalePromptError,
+    )
+
+    thread, outcome = _ask_on_worker(ui, qapp, Confirm("Continue?"))
+    _, nonce = ui.ui_responder.pending_question_and_nonce()
+
+    answered = ui.ui_responder.submit_answer(True, nonce=nonce + 1)
+    _spin_until(qapp, answered.done)
+    with pytest.raises(StalePromptError):
+        answered.result()
+    # The refused answer clicked nothing: the question still stands.
+    assert ui.ui_responder.pending_question() is not None
+    assert outcome == {}
+
+    ui.ui_responder.answer_confirm(False)
+    thread.join(timeout=5)
+    assert outcome.get("answer") is False
+
+
+def test_each_posting_gets_a_fresh_nonce(ui, qapp):
+    thread1, _ = _ask_on_worker(ui, qapp, Confirm("First?"))
+    _, first = ui.ui_responder.pending_question_and_nonce()
+    ui.ui_responder.answer_confirm(True)
+    thread1.join(timeout=5)
+
+    thread2, outcome2 = _ask_on_worker(ui, qapp, Confirm("Second?"))
+    _, second = ui.ui_responder.pending_question_and_nonce()
+    assert second != first
+    # An answer still naming the first question is stale, not misapplied.
+    answered = ui.ui_responder.submit_answer(True, nonce=first)
+    _spin_until(qapp, answered.done)
+    assert answered.exception() is not None
+    ui.ui_responder.answer_confirm(False)
+    thread2.join(timeout=5)
+    assert outcome2.get("answer") is False
+
+
 def test_aborted_question_reads_as_nothing_pending(ui, qapp):
     thread, outcome = _ask_on_worker(ui, qapp, Confirm("Continue?"))
     # The asker's future is cancelled (abort path); the corpse must not look


### PR DESCRIPTION
Stacked on #674. Two fixes straight from today's live supervised run.

## The bug this kills

During the run, the agent's answer targeted "whatever question is pending when the POST lands". Twice the prompt changed between the agent reading it and answering — harmless both times only because the answer failed for other reasons. On real hardware that's an approval meant for *align at rough milling* landing on *start polishing*.

## How it works (plain language)

Every time the responder puts a question up, it stamps it with a **nonce** — a counter that increments per posting, like the ticket number at a deli. `GET /app/prompt` hands the agent the question *and* its ticket number. The answer must bring the ticket back: `POST /app/prompt/answer {"response": true, "nonce": 7}`.

On the GUI thread — the only thread that ever posts or clears questions, so the check can't race — the responder compares the ticket to the standing question:

- match → the answer applies through the same click path as before;
- no match (question was answered, withdrawn, or replaced — even by the *same* question re-asked after a mill run, which gets a fresh ticket because the post-mill re-ask is a genuinely different decision) → **409 `stale_prompt`**, nothing is clicked, and the agent re-reads;
- no ticket at all → **422 `missing_nonce`** — the trusting form isn't available over HTTP.

`submit_answer` without a nonce keeps the old take-whatever behaviour for in-process callers (tests, a local console) — the requirement lives at the transport boundary, where the race lives.

## Also: the task_outputs 500

`/app/task_outputs/{item}` read `state.task_name`; the field on `AutoLamellaTaskState` is `name`. The existing test used an item with an empty task history, so the bad read never executed — it now walks a real history entry.

## Tests

- Responder level: right nonce applies; wrong nonce → `StalePromptError`, question still standing, workflow still waiting; each posting gets a fresh nonce.
- HTTP level: payload carries the nonce; stale → 409; missing → 422; control scope still required.
- 91 tests green across `tests/ui` responder/prompt/hosting + `tests/autolamella` + `tests/server`. (One pre-existing local-only failure: `test_default_preference_hosts_nothing` trips on this machine because the demo left `agent_server_enabled: true` in the worktree's preference file — passes with default prefs, unrelated to this diff.)