### PR TITLE
[refactor] Describe devices along both axes: origin and acquisition_orientations

### DIFF
--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -36,6 +36,7 @@ stage:
             origin:     {x: 0.0}                            # the beams: the chamber origin                         [metres][SPECIFIED]
         FM:
             origin:     {x: 48.8e-3}                        # the FM: offset along x                                [metres][SPECIFIED]
+            acquisition_orientations: [FIB]                 # the objective images the sample in the FIB pose       [SPECIFIED]
 electron:
     enabled:                    true                        # the electron beam is enabled                                  [USER]
     column_tilt:                0                           # the column tilt of the electron beam                          [DERIVED - manufactuer]

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -756,9 +756,28 @@ class FluorescenceMicroscope(ABC):
         # not, since on a compustage the sample is flipped away from the objective there
         # and on an offset mount it is translated out from under it.
         #
-        # A list rather than `default_orientation` alone: a system whose objective sees
-        # the sample from more than one pose says so here, and has somewhere to say it.
-        self.acquisition_orientations: list[str] = [self.default_orientation]
+        # Read from the device declaration (`stage.devices.FM.acquisition_orientations`)
+        # so there is exactly one source of truth. On a compustage that is `["FM"]` --
+        # what this attribute always held. On an offset mount it is the beam pose the
+        # sample is held in at the FM (`["FIB"]` on the iFLM simulator), which the old
+        # hardcoded `[default_orientation]` got wrong: `"FM"` is a pose the classifier
+        # never returns there. This attribute survives only until its readers move onto
+        # `get_device_imaging_state` (FIB-839), then goes with them.
+        self.acquisition_orientations: list[str] = (
+            self._configured_acquisition_orientations()
+        )
+
+    def _configured_acquisition_orientations(self) -> list[str]:
+        """The FM device's declared imaging orientations, from the stage configuration.
+
+        Falls back to `[default_orientation]` for an FM constructed without a parent
+        microscope (widget tests do this), where there is no configuration to read.
+        """
+        try:
+            devices = self.parent.system.stage.devices
+            return list(devices["FM"].acquisition_orientations)
+        except (AttributeError, KeyError, TypeError):
+            return [self.default_orientation]
 
     def has_valid_orientation(
         self, stage_position: Optional["FibsemStagePosition"] = None

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -1973,6 +1973,12 @@ class FibsemMillingSettings:
 # `shuttle_pre_tilt` are degrees, converted at use.
 DEVICE_AXES = ("x", "y", "z")
 
+# The named orientations the microscope derives poses for -- see
+# `_update_orientations`. The poses themselves are computed from physical parameters
+# (pre-tilt, column tilt, milling angle); these are the only names a device's
+# `acquisition_orientations` may reference.
+KNOWN_ORIENTATIONS = ("SEM", "FIB", "MILLING", "FM")
+
 
 def device_axes_to_dict(position: FibsemStagePosition) -> dict:
     """The device axes a partial position sets, as a plain dict. Absent axes are absent."""
@@ -2006,9 +2012,40 @@ class StageDeviceSettings:
     travels by the difference between two origins and arrives wherever that puts it.
     Partial, too -- an offset FM is an x location and leaves y, z, r and t free, so an
     axis that is absent does not decide anything.
+
+    A device is therefore described along **both** axes: `origin` says where the stage
+    goes, `acquisition_orientations` says which poses the instrument can see the sample
+    in once it is there. Neither answers on its own -- see `FibsemMicroscope` and
+    FIB-839 -- and which of the two does the discriminating is a fact about the
+    mounting rather than about the code:
+
+    | | origin | acquisition_orientations |
+    | -- | -- | -- |
+    | compustage | shared with the beams, so the term is true everywhere | `["FM"]` -- carries it |
+    | offset mount | 48.8 mm away -- carries it | `["FIB"]`, true wherever the objective reaches |
+
+    So the same conjunction discriminates on both, and the term that *fails* names the
+    remedy: a wrong place means travel, a wrong pose means re-pose.
     """
 
     origin: FibsemStagePosition
+
+    # Named orientations, not poses. The poses themselves stay derived in code from
+    # physical parameters -- pre-tilt, column tilt, milling angle -- so a site cannot
+    # write one that contradicts its own geometry (Patrick, 2026-08-31: "just ship with
+    # code only orientations"). Which *named* orientations an instrument can image
+    # from is a different kind of fact: it is how the device is bolted on, nothing
+    # derives it, and a list of names can only reference the derived poses, never
+    # disagree with them.
+    #
+    # Empty means the device does not constrain the pose: the orientation half of the
+    # question is vacuously TRUE, not false. The beams are that case -- SEM, FIB and
+    # MILLING are all views of the sample from there, and choosing between them is not
+    # this field's business. The other reading, "this device can never image", is
+    # deliberately unrepresentable: a device that can never image should not be
+    # declared, and making the empty list mean that would turn every forgotten key
+    # into a silently dead instrument.
+    acquisition_orientations: List[str] = field(default_factory=list)
 
     def contains(
         self, stage_position: FibsemStagePosition, device_range: FibsemStagePosition
@@ -2061,12 +2098,29 @@ class StageDeviceSettings:
         return True
 
     def to_dict(self) -> dict:
-        return {"origin": device_axes_to_dict(self.origin)}
+        return {
+            "origin": device_axes_to_dict(self.origin),
+            "acquisition_orientations": list(self.acquisition_orientations),
+        }
 
     @staticmethod
     def from_dict(ddict: dict) -> "StageDeviceSettings":
+        orientations = [
+            str(orientation)
+            for orientation in ddict.get("acquisition_orientations") or []
+        ]
+        # Validated here, at the one place configuration enters, because a typo would
+        # otherwise be perfectly quiet: the conjunction that reads this list would
+        # simply never be true, and the instrument would be dead with no error.
+        unknown = [o for o in orientations if o not in KNOWN_ORIENTATIONS]
+        if unknown:
+            raise ValueError(
+                f"Unknown acquisition orientation(s) {unknown}. "
+                f"Known orientations: {list(KNOWN_ORIENTATIONS)}"
+            )
         return StageDeviceSettings(
-            origin=device_axes_from_dict(ddict.get("origin"), "device origin")
+            origin=device_axes_from_dict(ddict.get("origin"), "device origin"),
+            acquisition_orientations=orientations,
         )
 
 
@@ -2076,18 +2130,30 @@ class StageDeviceSettings:
 # per-device windows are how it happened.
 DEFAULT_DEVICE_RANGE = FibsemStagePosition(x=20.0e-3)
 
-# The TFS SDB chamber layout -- piescope, METEOR, iFLM -- which is where every offset
-# fluorescence microscope sits today. The traverse between these two was a constant
-# inlined in `move_to_microscope` (`TRANSLATION_DX`), carrying its own "THIS needs to
-# be configurable" note, with two further constants for the windows it had to agree
-# with. They stay the defaults so that no existing configuration changes behaviour by
-# saying nothing; a site whose chamber differs now has somewhere to say so.
+# **The default is the objective under the grid**: the FM shares the beams' origin, and
+# is told apart by the pose the sample is held in. A site whose objective is offset --
+# piescope, METEOR, iFLM, all in the TFS SDB chamber -- declares the traverse instead,
+# as `sim-iflm-configuration.yaml` does.
 #
-# A compustage never reaches them: its objective is under the grid, so it takes the
-# `move_to_microscope_compustage` branch and does not travel to the FM at all.
+# The default used to be the other way round, with the FM 48.8 mm along x, because
+# these entries were lifted from `move_to_microscope`'s inlined `TRANSLATION_DX` and
+# that function only ever ran on an offset mount. Nothing declares a `devices:` block
+# except the offset simulator, so every other configuration -- Aquilos, Hydra, Arctis,
+# Tescan, Odemis, several with no fluorescence microscope at all -- inherited a phantom
+# FM 48.8 mm away, somewhere their stage never goes. It was invisible because
+# `_device_translation` short-circuits on a compustage; `contains` does not, and reads
+# these origins literally.
+#
+# Getting this the right way round is what lets one question be asked of both mountings
+# instead of each caller branching on the stage type (FIB-839).
 DEFAULT_STAGE_DEVICES: Dict[str, StageDeviceSettings] = {
+    # The beams say nothing about the pose: SEM, FIB and MILLING are all views of the
+    # sample from here, and choosing between them is not this dict's business.
     "FIBSEM": StageDeviceSettings(origin=FibsemStagePosition(x=0.0)),
-    "FM": StageDeviceSettings(origin=FibsemStagePosition(x=48.8e-3)),
+    "FM": StageDeviceSettings(
+        origin=FibsemStagePosition(x=0.0),
+        acquisition_orientations=["FM"],
+    ),
 }
 
 

--- a/tests/test_fm_device_position.py
+++ b/tests/test_fm_device_position.py
@@ -30,14 +30,17 @@ from fibsem.structures import (
 )
 
 IFLM_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-iflm-configuration.yaml")
+# The other mounting. Its objective is under the grid, and it declares no `devices:`
+# block at all -- so it is also the test of what saying nothing gets you.
+ARCTIS_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
 
 # Between the two windows: past the beams' 20 mm, short of the FM's 28.8 mm.
 # Mid-traverse, and at no device.
 IN_THE_GAP_MM = 24.0
 
 
-def _microscope():
-    microscope, _ = utils.setup_session(config_path=IFLM_CONFIG)
+def _microscope(config_path: str = IFLM_CONFIG):
+    microscope, _ = utils.setup_session(config_path=config_path)
     return microscope
 
 
@@ -64,11 +67,15 @@ def test_the_devices_come_from_the_configuration_file():
     assert microscope.system.stage.device_range.x == pytest.approx(20.0e-3)
 
 
-def test_a_configuration_that_says_nothing_gets_the_chamber_it_had_before():
-    """No existing configuration changes behaviour by not mentioning devices.
+def test_a_configuration_that_says_nothing_gets_the_objective_under_the_grid():
+    """Saying nothing describes the *common* chamber, not the rare one.
 
-    The defaults are the TFS SDB chamber layout the constants described, so a site
-    that never had a reason to think about this keeps exactly what it had.
+    The defaults used to be the TFS SDB layout -- FM 48.8 mm along x -- because they
+    were lifted from constants inlined in `move_to_microscope`, which only ever ran on
+    an offset mount. Since nothing but the offset simulator declares a `devices:`
+    block, every other configuration inherited a fluorescence microscope somewhere its
+    stage never goes. Now the default is the objective under the grid, and a site
+    whose objective is offset says so.
     """
     default, _ = utils.setup_session(config_path=cfg.MICROSCOPE_CONFIGURATION_PATH)
 
@@ -99,6 +106,175 @@ def test_the_configuration_survives_a_round_trip():
 
     assert restored.devices == stage.devices
     assert restored.device_range == stage.device_range
+
+
+# ── the other half of a device: which poses it can image from ────────
+
+
+def _can_see_the_sample(microscope, device: str) -> bool:
+    """The conjunction, spelled out.
+
+    It is written inline here rather than called because it does not exist yet: this
+    file pins the *data* that makes one expression work on both mountings, and the
+    method that asks it lands next (FIB-839). Written out, the two terms and the two
+    remedies stay visible.
+
+    An empty list is vacuously TRUE -- the device does not constrain the pose -- so
+    the place term alone decides. The beams are that case.
+    """
+    orientations = microscope.system.stage.devices[device].acquisition_orientations
+    return microscope.is_at_device(device) and (
+        not orientations or microscope.get_stage_orientation() in orientations
+    )
+
+
+def test_a_device_says_which_poses_it_can_image_from():
+    """A place is only half of a device. The other half is what it can see from there.
+
+    The offset simulator's objective images the sample held in the FIB pose -- not
+    because the ion beam is looking at it, it is 48.8 mm away, but because that is the
+    pose the holder grips it in and the pose is a property of the holder.
+    """
+    microscope = _microscope()
+
+    assert microscope.system.stage.devices["FM"].acquisition_orientations == ["FIB"]
+
+
+def test_the_beams_say_nothing_about_the_pose():
+    """Empty means unconstrained: the orientation term is vacuously true.
+
+    SEM, FIB and MILLING are all views of the sample from the beams, and choosing
+    between them is not the device axis's business -- so the place term alone decides,
+    and the beams can see the sample in every pose. The other reading, "can never
+    image", is deliberately unrepresentable: a device that can never image should not
+    be declared, and an empty list must not silently mean a dead instrument.
+    """
+    microscope = _microscope()
+
+    assert microscope.system.stage.devices["FIBSEM"].acquisition_orientations == []
+    for orientation in ("SEM", "FIB", "MILLING"):
+        microscope.move_to_orientation(orientation)
+        assert _can_see_the_sample(microscope, "FIBSEM") is True
+
+
+def test_a_misspelt_orientation_is_refused_at_load():
+    """A typo here would otherwise be perfectly quiet.
+
+    The conjunction that reads this list would simply never be true, and the
+    instrument would be dead with no error -- undetectable in normal operation,
+    because the load-bearing field on each mounting is the other mounting's inert one.
+    """
+    with pytest.raises(ValueError, match=r"Unknown acquisition orientation.*FIBB"):
+        StageDeviceSettings.from_dict(
+            {"origin": {"x": 48.8e-3}, "acquisition_orientations": ["FIBB"]}
+        )
+
+
+def test_the_fm_object_reads_the_device_declaration():
+    """One source of truth, not two fields with the same name.
+
+    `FluorescenceMicroscope.acquisition_orientations` used to hardcode
+    `[default_orientation]` -- `["FM"]` on every mounting, which on offset names a
+    pose the classifier never returns there. It now reads the device declaration, so
+    the widget gates that consume it can be true at the actual FM.
+    """
+    offset = _microscope()
+    compustage = _microscope(ARCTIS_CONFIG)
+
+    assert offset.fm.acquisition_orientations == ["FIB"]
+    assert compustage.fm.acquisition_orientations == ["FM"]
+
+
+def test_neither_axis_answers_on_both_mountings():
+    """The finding this whole field exists for. Measured, and exact mirror images.
+
+    At the fluorescence microscope on each mounting:
+
+    | | compustage | offset |
+    | -- | -- | -- |
+    | `get_stage_orientation() == "FM"` | True | False -- it reads FIB |
+    | `is_at_device("FM")` | False* | True |
+
+    (*before this change; the compustage FM now shares the beams' origin, which is
+    what makes the row below true rather than accidental.)
+
+    So "replace the orientation check with a device check" breaks the compustage as
+    thoroughly as the orientation check breaks the offset mount.
+    """
+    compustage = _microscope(ARCTIS_CONFIG)
+    compustage.move_to_microscope("FM")
+
+    offset = _at_fib(_microscope())
+    offset.move_to_microscope("FM")
+
+    assert compustage.get_stage_orientation() == "FM"
+    assert offset.get_stage_orientation() == "FIB"
+
+
+def test_the_same_question_answers_at_the_fm_on_both_mountings():
+    """One expression, no `stage_is_compustage`. The mounting lives in configuration.
+
+    Each mounting makes a *different* term trivially true -- the compustage's FM is
+    where the beams are, so the place carries nothing and the pose carries it all; the
+    offset FM images from the pose it was already in, so the pose carries nothing and
+    the place carries it all. Which is why the conjunction discriminates on both.
+    """
+    compustage = _microscope(ARCTIS_CONFIG)
+    compustage.move_to_microscope("FM")
+
+    offset = _at_fib(_microscope())
+    offset.move_to_microscope("FM")
+
+    assert _can_see_the_sample(compustage, "FM") is True
+    assert _can_see_the_sample(offset, "FM") is True
+
+
+def test_the_term_that_fails_names_the_remedy():
+    """A wrong place means travel; a wrong pose means re-pose. Different remedies.
+
+    Today they collapse into one `False`, so a refusal cannot say which. Both rows
+    below are live states an operator reaches by doing something ordinary: the
+    compustage one by looking at the sample with a beam, the offset one by not having
+    travelled yet.
+    """
+    compustage = _microscope(ARCTIS_CONFIG)
+    compustage.move_to_orientation("SEM")
+
+    offset = _at_fib(_microscope())
+
+    # Right place, wrong pose: flip it over.
+    assert compustage.is_at_device("FM") is True
+    assert compustage.get_stage_orientation() == "SEM"
+
+    # Right pose, wrong place: drive it out.
+    assert offset.is_at_device("FM") is False
+    assert offset.get_stage_orientation() == "FIB"
+
+    assert _can_see_the_sample(compustage, "FM") is False
+    assert _can_see_the_sample(offset, "FM") is False
+
+
+def test_the_acquisition_orientations_survive_a_round_trip():
+    """`system.to_dict()` is served over the API and written into image metadata."""
+    devices = _microscope().system.stage.devices
+
+    restored = StageDeviceSettings.from_dict(devices["FM"].to_dict())
+
+    assert restored == devices["FM"]
+    assert restored.acquisition_orientations == ["FIB"]
+
+
+def test_a_configuration_that_says_nothing_can_still_see_the_sample():
+    """The default has to be a working compustage, not an empty list.
+
+    Neither shipped compustage configuration declares a `devices:` block, so if the
+    default said nothing about the pose the conjunction would be false at the one
+    place an Arctis takes fluorescence images.
+    """
+    microscope = _microscope(ARCTIS_CONFIG)
+
+    assert "devices" not in utils.load_yaml(ARCTIS_CONFIG)["stage"]
+    assert microscope.system.stage.devices["FM"].acquisition_orientations == ["FM"]
 
 
 # ── the question nothing could ask ───────────────────────────────────

--- a/tests/test_no_repose_at_fm.py
+++ b/tests/test_no_repose_at_fm.py
@@ -156,11 +156,16 @@ def test_a_compustage_is_not_affected():
 
 
 def test_a_system_with_no_fluorescence_microscope_is_not_affected():
-    """Dormant until the connection gate opens.
+    """Dormant on a beam-only system, and now for two reasons rather than one.
 
-    `microscope.fm` is `None` on every non-compustage system today, so nothing can be
-    parked at the FM to begin with -- and a beam-only system must not be told it
-    cannot rotate somewhere it has every right to be.
+    The first is the guard's own: `microscope.fm` is `None`, so it returns before it
+    ever looks at where the stage is. The second is that there is nothing out there to
+    find -- the default FM shares the beams' origin, so a system that never declared a
+    `devices:` block no longer carries a phantom fluorescence microscope 48.8 mm along
+    x, somewhere its stage has every right to be.
+
+    Both halves matter. A beam-only system must not be told it cannot rotate, and it
+    must not be told it is standing at an instrument it does not have.
     """
     microscope = _microscope(cfg.MICROSCOPE_CONFIGURATION_PATH)
     assert microscope.fm is None
@@ -169,7 +174,7 @@ def test_a_system_with_no_fluorescence_microscope_is_not_affected():
     microscope.move_stage_relative(
         FibsemStagePosition(x=48.8e-3, y=0.0, z=0.0, r=0.0, t=0.0)
     )
-    assert microscope.get_current_device() == "FM"
+    assert microscope.get_current_device() is None
 
     microscope.move_to_orientation("MILLING")
 


### PR DESCRIPTION
A device is a place the stage travels to **and** the poses the instrument can image the sample in once there. Neither answers "can this device see the sample" on its own — on a compustage the FM shares the beams' origin and the pose carries the question; on an offset mount the pose is preserved across the traverse and the place carries it. This PR adds the data; the predicate that reads it comes next in the stack.

- `StageDeviceSettings` gains `acquisition_orientations`, validated at load against the known orientation names — a typo would otherwise silently disable the instrument, undetectably, because the load-bearing field on each mounting is the other mounting's inert one.
- **Empty means unconstrained** (the pose term is vacuously true), never "can never image". The beams (`FIBSEM: []`) are that case.
- `DEFAULT_STAGE_DEVICES` flips to the objective-under-the-grid layout. The old default gave every non-declaring configuration — Aquilos, Hydra, Arctis, Tescan, Odemis, several with no FM at all — a phantom FM 48.8 mm along x, because the entries were lifted from constants that only ever ran on an offset mount. Offset sites now declare the traverse, as `sim-iflm-configuration.yaml` does.
- `FluorescenceMicroscope.acquisition_orientations` reads the device declaration instead of hardcoding `[default_orientation]`, so there is one source of truth — and on an offset mount the widget gates that consume it can finally be true at the actual FM (`["FIB"]`, not a pose the classifier never returns there).

One test changed meaning: a beam-only system driven to x=48.8 mm used to assert it was standing at an FM it does not have; it now asserts `get_current_device() is None`.

**Stack (2/6).**