### PR TITLE
[feat] One question for both mountings: get_device_imaging_state

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -114,12 +114,14 @@ from fibsem.microscopes.autoscript import (
 from fibsem.milling.progress import MillingProgress, MillingProgressStatus
 from fibsem.structures import (
     ACTIVE_MILLING_STATES,
+    DEFAULT_STAGE_DEVICES,
     DEVICE_AXES,
     BeamSettings,
     BeamSystemSettings,
     BeamType,
     CameraImageTransform,
     CrossSectionPattern,
+    DeviceImagingState,
     FibsemBitmapSettings,
     FibsemCircleSettings,
     FibsemDetectorSettings,
@@ -2407,6 +2409,89 @@ class FibsemMicroscope(ABC):
                 return device
         return None
 
+    def get_device_imaging_state(
+        self, device: str, stage_position: Optional[FibsemStagePosition] = None
+    ) -> DeviceImagingState:
+        """Can `device` see the sample from where the stage is -- and if not, why not.
+
+        One question, answered the same way on both mountings, with the mounting
+        expressed entirely in configuration (FIB-839). Two terms:
+
+        * **place** -- `is_at_device`, against the device's declared origin
+        * **pose** -- `get_stage_orientation`, against the device's declared
+          `acquisition_orientations`; an empty list constrains nothing and the term
+          is vacuously true
+
+        Each mounting makes a *different* term trivially true. A compustage FM shares
+        the beams' origin, so the place carries nothing and the pose carries it all;
+        an offset FM images from the pose the sample was carried out in, so the pose
+        carries nothing and the place carries it all. Which is why the same
+        conjunction discriminates on both -- and why the failing term names the
+        remedy: a wrong place means travel, a wrong pose means re-pose.
+
+        Callers act on the value by policy, not uniformly -- see
+        `DeviceImagingState`. Pass `stage_position` to ask about a stored pose rather
+        than the current one; both workflow tasks do.
+        """
+        # The fluorescence microscope is the one device whose instrument can be
+        # absent -- the beams always exist, and there is no third device yet. `fm` is
+        # an object or None (a present-but-faulted state is not modelled; noted on
+        # FIB-839), so this is the whole of the "no device" test.
+        if device == "FM" and self.fm is None:
+            return DeviceImagingState.NO_DEVICE
+
+        at_device = self.is_at_device(device, stage_position)
+        orientations = self._get_device(device).acquisition_orientations
+        in_orientation = (
+            not orientations
+            or self.get_stage_orientation(stage_position) in orientations
+        )
+
+        if at_device and in_orientation:
+            return DeviceImagingState.READY
+        if in_orientation:
+            return DeviceImagingState.NEEDS_TRAVEL
+        if at_device:
+            return DeviceImagingState.NEEDS_REPOSE
+        return DeviceImagingState.NEEDS_REPOSE_THEN_TRAVEL
+
+    def _warn_on_fluorescence_geometry(self) -> None:
+        """Warn, at connect, about FM geometry that will misbehave quietly later.
+
+        Both cases produce no error at all in operation -- the imaging-state
+        conjunction is simply never (or always) true somewhere it should not be --
+        so the one loud moment available is connection, while the configuration is
+        in front of the person who wrote it.
+        """
+        if self.fm is None:
+            return
+
+        devices = self.system.stage.devices
+
+        # An offset mount that enabled the FM but declared no geometry inherits the
+        # default -- the objective under the grid, sharing the beams' origin -- so
+        # every place-term answer is about somewhere its FM is not.
+        if not self.stage_is_compustage and devices == DEFAULT_STAGE_DEVICES:
+            logging.warning(
+                "A fluorescence microscope is enabled but no `stage.devices` block "
+                "is declared, so the FM defaults to the beams' origin. An offset "
+                "mount (METEOR, iFLM) must declare its traverse -- see "
+                "sim-iflm-configuration.yaml."
+            )
+
+        # A compustage FM declared away from the beams is a phantom: the stage
+        # reaches its FM by flipping, not travelling, so a distinct origin is
+        # somewhere it never goes and `is_at_device(\"FM\")` is False at the
+        # objective itself.
+        if self.stage_is_compustage and "FM" in devices and "FIBSEM" in devices:
+            if devices["FM"].origin != devices["FIBSEM"].origin:
+                logging.warning(
+                    "This compustage declares an FM device origin away from the "
+                    "beams. Its objective is under the grid: the FM shares the "
+                    "beams' origin, and a distinct origin is a place the stage "
+                    "never travels to."
+                )
+
     def _device_translation(self, source: str, target: str) -> FibsemStagePosition:
         """The relative stage move from one device to another.
 
@@ -2799,6 +2884,8 @@ class ThermoMicroscope(FibsemMicroscope):
             )
             self.fm = None
             self.set_channel(BeamType.ELECTRON)
+
+        self._warn_on_fluorescence_geometry()
 
         try:
             self._create_sample_stage()

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -486,6 +486,8 @@ class DemoMicroscope(FibsemMicroscope):
             logging.info("No fluorescence microscope in this simulated system.")
             self.fm = None
 
+        self._warn_on_fluorescence_geometry()
+
         # user, experiment metadata
         # TODO: remove once db integrated
         self.user = FibsemUser.from_environment()

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -1980,6 +1980,43 @@ DEVICE_AXES = ("x", "y", "z")
 KNOWN_ORIENTATIONS = ("SEM", "FIB", "MILLING", "FM")
 
 
+class DeviceImagingState(Enum):
+    """Can this device see the sample from where the stage is -- and if not, why not.
+
+    The answer to `FibsemMicroscope.get_device_imaging_state`, and a state rather than
+    a bool because the *reason* is the useful part: each failing value names the remedy
+    a caller should offer, and on either mounting the geometry makes the right one fall
+    out of the same two questions (FIB-839).
+
+    Callers act on it by policy, not uniformly. Acquisition gates refuse `NO_DEVICE`
+    and the travel states but permit `NEEDS_REPOSE` -- acquiring from a "wrong" pose is
+    a harmless watch when the device is here, and a different place in the chamber when
+    it is not. That single policy is what preserves the compustage's acquire-anywhere
+    behaviour (it can never need travel) while refusing at the beams on an offset mount
+    (it always does) -- with no flag and no per-mounting branch. Planning and
+    move-prompt sites require `READY` strictly.
+    """
+
+    # The instrument behind the device is absent: nothing to travel to, nothing to
+    # offer. Terminal -- distinct from every other value, which all mean "it exists
+    # and here is how to reach it".
+    NO_DEVICE = "no_device"
+
+    READY = "ready"
+
+    # Right pose, wrong place: traverse to the device.
+    NEEDS_TRAVEL = "needs_travel"
+
+    # Right place, wrong pose: re-pose. On an offset mount the route is longer --
+    # back to the beams, re-pose there, travel out again -- because rotating while
+    # parked at the device is refused (FIB-841).
+    NEEDS_REPOSE = "needs_repose"
+
+    # Wrong on both axes. Re-pose first, then travel: the bracketing order, so the
+    # rotation happens at the beams and never under an objective.
+    NEEDS_REPOSE_THEN_TRAVEL = "needs_repose_then_travel"
+
+
 def device_axes_to_dict(position: FibsemStagePosition) -> dict:
     """The device axes a partial position sets, as a plain dict. Absent axes are absent."""
     return {

--- a/tests/test_device_imaging_state.py
+++ b/tests/test_device_imaging_state.py
@@ -1,0 +1,226 @@
+"""Can this device see the sample from here -- one question, both mountings.
+
+`get_device_imaging_state` is the conjunction FIB-839 measured, promoted to a method
+on `FibsemMicroscope` -- the top-level system, which owns the stage and so owns the
+question. It returns a state rather than a bool because the reason is the useful
+part: each failing value names the remedy, and callers act on the value by policy
+(acquisition gates permit NEEDS_REPOSE; planning sites require READY).
+
+Nothing calls it yet. The gates move onto it in the next change; this file pins what
+they will find when they do.
+"""
+
+import logging
+import os
+
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.structures import DeviceImagingState, FibsemStagePosition
+
+IFLM_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-iflm-configuration.yaml")
+ARCTIS_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
+
+
+def _microscope(config_path: str = IFLM_CONFIG):
+    microscope, _ = utils.setup_session(config_path=config_path)
+    return microscope
+
+
+def _offset_at_the_fm():
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+    microscope.move_to_microscope("FM")
+    return microscope
+
+
+# ── READY: the one cell per mounting ─────────────────────────────────
+
+
+def test_ready_at_the_fm_on_an_offset_mount():
+    assert (
+        _offset_at_the_fm().get_device_imaging_state("FM") is DeviceImagingState.READY
+    )
+
+
+def test_ready_at_the_fm_on_a_compustage():
+    microscope = _microscope(ARCTIS_CONFIG)
+    microscope.move_to_microscope("FM")
+
+    assert microscope.get_device_imaging_state("FM") is DeviceImagingState.READY
+
+
+def test_the_failing_term_names_the_remedy_on_an_offset_mount():
+    """At the beams in FIB pose: the pose is right, the place is wrong. Travel."""
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+
+    assert microscope.get_device_imaging_state("FM") is DeviceImagingState.NEEDS_TRAVEL
+
+
+def test_the_failing_term_names_the_remedy_on_a_compustage():
+    """Looking at the sample with a beam: the place is right (it always is -- the FM
+    shares the beams' origin), the pose is wrong. Re-pose, which is exactly how a
+    compustage reaches its FM."""
+    microscope = _microscope(ARCTIS_CONFIG)
+    microscope.move_to_orientation("SEM")
+
+    assert microscope.get_device_imaging_state("FM") is DeviceImagingState.NEEDS_REPOSE
+
+
+def test_wrong_on_both_axes_brackets_the_repose_first():
+    """Offset at the beams in SEM: not at the FM, and SEM is not a pose the objective
+    images from. The remedy order is re-pose THEN travel, so the rotation happens at
+    the beams and never under the objective (FIB-841)."""
+    microscope = _microscope()
+    microscope.move_to_orientation("SEM")
+
+    assert (
+        microscope.get_device_imaging_state("FM")
+        is DeviceImagingState.NEEDS_REPOSE_THEN_TRAVEL
+    )
+
+
+def test_a_compustage_can_never_need_travel():
+    """The geometry, not a branch, is what preserves acquire-anywhere on an Arctis:
+    its FM shares the beams' origin, so the place term is true at every pose and no
+    travel state is reachable. An acquisition gate that refuses travel states
+    therefore never refuses on a compustage -- the ALLOW_UNKNOWN_ORIENTATIONS
+    behaviour, derived rather than flagged."""
+    microscope = _microscope(ARCTIS_CONFIG)
+
+    for orientation in ("SEM", "FIB", "MILLING"):
+        microscope.move_to_orientation(orientation)
+        assert microscope.get_device_imaging_state("FM") in (
+            DeviceImagingState.READY,
+            DeviceImagingState.NEEDS_REPOSE,
+        )
+
+
+# ── the beams as a device ────────────────────────────────────────────
+
+
+def test_the_beams_are_ready_in_every_pose():
+    """FIBSEM declares no acquisition orientations: the pose term is vacuously true,
+    and the place term alone decides."""
+    microscope = _microscope()
+
+    for orientation in ("SEM", "FIB", "MILLING"):
+        microscope.move_to_orientation(orientation)
+        assert microscope.get_device_imaging_state("FIBSEM") is DeviceImagingState.READY
+
+
+def test_the_beams_need_travel_from_the_fm():
+    microscope = _offset_at_the_fm()
+
+    assert (
+        microscope.get_device_imaging_state("FIBSEM") is DeviceImagingState.NEEDS_TRAVEL
+    )
+
+
+# ── no device ────────────────────────────────────────────────────────
+
+
+def test_a_system_with_no_fluorescence_microscope_says_so():
+    """The tri-state's whole point: NO_DEVICE is terminal, distinct from every
+    remedy state. Today's callers collapse this into the same False as "away", so a
+    refusal cannot say whether to move the stage or give up."""
+    microscope = _microscope(cfg.MICROSCOPE_CONFIGURATION_PATH)
+    assert microscope.fm is None
+
+    assert microscope.get_device_imaging_state("FM") is DeviceImagingState.NO_DEVICE
+
+
+# ── stored poses ─────────────────────────────────────────────────────
+
+
+def test_a_stored_pose_is_answered_without_moving_anything():
+    """Both workflow tasks ask about a lamella's saved position, not the stage's."""
+    microscope = _microscope()
+    at_the_fm_in_fib = FibsemStagePosition(
+        x=48.8e-3,
+        y=0.0,
+        z=0.0,
+        r=microscope.get_orientation("FIB").r,
+        t=microscope.get_orientation("FIB").t,
+    )
+    before = microscope.get_stage_position()
+
+    state = microscope.get_device_imaging_state("FM", at_the_fm_in_fib)
+
+    assert state is DeviceImagingState.READY
+    assert microscope.get_stage_position().is_close(before, tol=1e-9)
+
+
+# ── the connect-time geometry warnings ───────────────────────────────
+
+
+def _write_config(tmp_path, source, edit):
+    data = utils.load_yaml(source)
+    edit(data)
+    path = os.path.join(tmp_path, "config.yaml")
+    utils.save_yaml(path, data)
+    return path
+
+
+# `setup_session` reconfigures logging with `force=True`, which strips caplog's
+# handler, so these capture with a plain handler and call
+# `_warn_on_fluorescence_geometry` directly -- it is the same method the connect path
+# runs (one line in each __init__), and it is idempotent.
+
+
+def _warnings_from(microscope) -> str:
+    captured: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record.getMessage())
+
+    handler = _Capture(level=logging.WARNING)
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        microscope._warn_on_fluorescence_geometry()
+    finally:
+        root.removeHandler(handler)
+    return "\n".join(captured)
+
+
+def test_an_offset_fm_with_no_declared_geometry_warns_at_connect(tmp_path):
+    """The silent case the default flip created: `fm.enabled` without a `devices:`
+    block inherits the objective-under-the-grid default, and every place-term answer
+    is about somewhere its FM is not. No error ever follows -- the conjunction is
+    just never true at the FM -- so connect is the one loud moment available."""
+
+    def drop_devices(data):
+        del data["stage"]["devices"]
+        del data["stage"]["device_range"]
+
+    path = _write_config(tmp_path, IFLM_CONFIG, drop_devices)
+
+    assert "no `stage.devices` block is declared" in _warnings_from(_microscope(path))
+
+
+def test_a_compustage_with_a_phantom_offset_fm_warns_at_connect(tmp_path):
+    """The pre-flip world, declared explicitly: a compustage whose FM origin is away
+    from the beams describes a place its stage never travels to."""
+
+    def add_phantom(data):
+        data["stage"]["devices"] = {
+            "FIBSEM": {"origin": {"x": 0.0}},
+            "FM": {"origin": {"x": 48.8e-3}},
+        }
+
+    path = _write_config(tmp_path, ARCTIS_CONFIG, add_phantom)
+
+    assert "a place the stage never travels to" in _warnings_from(_microscope(path))
+
+
+@pytest.mark.parametrize(
+    "config_path",
+    [IFLM_CONFIG, ARCTIS_CONFIG, cfg.MICROSCOPE_CONFIGURATION_PATH],
+    ids=["declared-offset", "default-compustage", "beam-only"],
+)
+def test_a_coherent_configuration_does_not_warn(config_path):
+    assert _warnings_from(_microscope(config_path)) == ""


### PR DESCRIPTION
Can this device see the sample from where the stage is — and if not, why not. A device-parameterised method on `FibsemMicroscope`, the top-level system, so the `FluorescenceMicroscope` object never has to answer stage questions.

Two terms, place (`is_at_device`) and pose (`get_stage_orientation` against the device's declared `acquisition_orientations`), each mounting making a different term trivially true — so the same conjunction discriminates on both, with no `stage_is_compustage` branch, and the failing term names the remedy:

| state | remedy |
| -- | -- |
| `NO_DEVICE` | terminal — distinct from "away" for the first time |
| `NEEDS_TRAVEL` | right pose, wrong place |
| `NEEDS_REPOSE` | right place, wrong pose |
| `NEEDS_REPOSE_THEN_TRAVEL` | both — re-pose at the beams first, then travel |

`DeviceImagingState.allows_acquisition` carries the acquisition-gate policy in one place: permit `NEEDS_REPOSE` (acquiring in place from a "wrong" pose is a harmless watch), refuse travel states. A compustage can never need travel, so it keeps acquire-anywhere **by geometry** — the `ALLOW_UNKNOWN_ORIENTATIONS` behaviour, derived rather than flagged — while an offset mount at the beams always does, so it refuses, which the flag never could.

Also warns at connect about the two geometries that misbehave silently: an offset FM with no `devices:` block declared, and a compustage FM declared away from the beams.

Nothing calls the predicate yet; the gates move onto it in the next PR. Measured on both simulator configurations — the 8-cell matrix, the remedies, stored poses.

**Stack (3/6).**