### PR TITLE
[refactor] Point every FM gate at get_device_imaging_state, delete the orientation zoo (FIB-839)

### DIFF
--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -73,7 +73,7 @@ from fibsem.milling.progress import (
     MillingProgressStatus,
 )
 from fibsem.milling.strategy.coincidence import CoincidenceMillingStrategy
-from fibsem.structures import BeamType, FibsemImage, Point
+from fibsem.structures import BeamType, DeviceImagingState, FibsemImage, Point
 from fibsem.ui import notification_service, stylesheets
 from fibsem.ui.fm.widgets import LinePlotWidget
 from fibsem.ui.icon import fibsem_icon
@@ -2416,9 +2416,14 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         )
         if not pixelsize:
             return
-        if not self.microscope.fm.has_valid_orientation():
+        # READY strictly: the click becomes a stage move computed through a frame
+        # built from the current pose.
+        if (
+            self.microscope.get_device_imaging_state("FM")
+            is not DeviceImagingState.READY
+        ):
             logging.info(
-                f"Stage must be in a valid FM orientation to move via FM image (current: {self.microscope.get_stage_orientation()})"
+                f"Stage must be at the fluorescence microscope to move via FM image (current: {self.microscope.get_stage_orientation()})"
             )
             return
         image_shape = self.fm_canvas._img_shape

--- a/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/acquire_fluorescence.py
@@ -257,9 +257,12 @@ class AcquireFluorescenceImageTask(AutoLamellaTask):
                 stage_position=stage_position,
                 target_orientation=self.config.orientation,
             )
-        elif not self.microscope.fm.has_valid_orientation(stage_position):
+        elif not self.microscope.get_device_imaging_state(
+            "FM", stage_position
+        ).allows_acquisition:
             logging.warning(
-                f"Stage Position {self.lamella.name} is not in a valid orientation: {stage_position}, moving to SEM orientation..."
+                f"Stage Position {self.lamella.name} is not one the fluorescence "
+                f"microscope can acquire from: {stage_position}, moving to SEM orientation..."
             )
             stage_position = self.microscope.get_target_position(
                 stage_position=stage_position, target_orientation="SEM"

--- a/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
@@ -57,9 +57,11 @@ class SelectFluorescencePositionTask(AutoLamellaTask):
         else:
             stage_position = self.lamella.stage_position
 
-        if not self.microscope.fm.has_valid_orientation(stage_position):
+        state = self.microscope.get_device_imaging_state("FM", stage_position)
+        if not state.allows_acquisition:
             raise ValueError(
-                f"Stage Position {self.lamella.name} is not in a valid orientation: {stage_position.pretty}, {self.microscope.fm.valid_orientations}"
+                f"Stage Position {self.lamella.name} is not one the fluorescence "
+                f"microscope can acquire from: {stage_position.pretty} ({state.value})"
             )
 
         # Check for cancellation before each position

--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -43,7 +43,12 @@ from fibsem.imaging.tiling.progress import (
     TiledProgress,
     TiledStatus,
 )
-from fibsem.structures import BeamType, FibsemStagePosition, TileOrderStrategy
+from fibsem.structures import (
+    BeamType,
+    DeviceImagingState,
+    FibsemStagePosition,
+    TileOrderStrategy,
+)
 from fibsem.util.filename import remove_suffix
 
 if TYPE_CHECKING:
@@ -200,9 +205,11 @@ def acquire_image(
     if microscope.parent is None:
         raise ValueError("Microscope parent is not set. Cannot start acquisition.")
 
-    if not microscope.has_valid_orientation():
+    state = microscope.parent.get_device_imaging_state("FM")
+    if not state.allows_acquisition:
         raise ValueError(
-            f"Stage is not in valid orientation ({microscope.parent.get_stage_orientation()!r}). Cannot start acquisition."
+            f"Cannot start acquisition: {state.value} "
+            f"(stage at {microscope.parent.get_stage_orientation()!r})."
         )
 
     if zparams is not None:
@@ -506,19 +513,17 @@ class FMTiledAcquisitionRunner:
                 "Fluorescence microscope not initialized in the FibsemMicroscope instance"
             )
 
-        # TEMPORARY (FIB-856): an inline mounting split, deleted when the gates move
-        # onto `get_device_imaging_state` (FIB-839). At the FM on an offset mount the
-        # classifier reports the pose the sample was carried out in -- "FIB", measured
-        # on sim-iflm -- so the old ["SEM", "FM"] list refused at the one place this
-        # runner is meant to run. The compustage list is unchanged; widening it instead
-        # (or swapping in `is_acquisition_orientation`) would newly refuse SEM tilesets
-        # on every Arctis.
-        orientation = microscope.get_stage_orientation()
-        allowed = ["SEM", "FM"] if microscope.stage_is_compustage else ["SEM", "FIB"]
-        if orientation not in allowed:
+        # READY strictly, not `allows_acquisition`: a tileset walks the stage across a
+        # grid and stitches the result through a frame built from the pose, so from a
+        # pose the objective cannot image from, nothing has checked where its tiles
+        # land. This is the gate the widget already applied on its acquire button; the
+        # runner used to carry its own inlined ["SEM", "FM"] list instead, which
+        # additionally allowed direct SEM tileset calls on a compustage.
+        state = microscope.get_device_imaging_state("FM")
+        if state is not DeviceImagingState.READY:
             raise ValueError(
-                f"Stage orientation is {orientation}, not one of {allowed}. "
-                "Cannot start acquisition."
+                f"Cannot start a tiled acquisition: {state.value} "
+                f"(stage at {microscope.get_stage_orientation()!r})."
             )
 
         if not isinstance(self.channel_settings, list):

--- a/fibsem/fm/calibration/__init__.py
+++ b/fibsem/fm/calibration/__init__.py
@@ -120,8 +120,9 @@ def run_autofocus(
         >>> best_z = run_autofocus(microscope, roi=roi)
     """
 
-    if not microscope.has_valid_orientation():
-        raise ValueError("Microscope orientation is not valid for autofocus")
+    state = microscope.parent.get_device_imaging_state("FM")
+    if not state.allows_acquisition:
+        raise ValueError(f"Cannot start autofocus: {state.value}.")
 
     # Held for the whole sweep, as a tileset holds it for a whole run. Without it
     # every step took and returned the channel on its own -- measured at 43 scopes

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -60,7 +60,6 @@ UINT16_MAX = np.iinfo(np.uint16).max  # 65535 for uint16
 BINNING_VALUES = [1, 2, 4, 8]  # typical binning values
 
 RATE_LIMIT_DEFAULT = 0.05  # seconds between updates
-ALLOW_UNKNOWN_ORIENTATIONS = True  # allow fm control at any orientation
 
 
 class ObjectiveLens(ABC):
@@ -739,22 +738,15 @@ class FluorescenceMicroscope(ABC):
         self._transform: Optional[CameraImageTransform] = (
             CameraImageTransform.NONE
         )  # image transformation
-        self.valid_orientations: list[str] = [
-            "FM",
-            "SEM",
-            "MILLING",
-        ]  # valid orientations for fluorescence acquisition
-        self._allow_unknown_orientations: bool = ALLOW_UNKNOWN_ORIENTATIONS
         self.default_orientation: str = (
             "FM"  # orientation used when computing fluorescence pose for new lamellas
         )
-        # Orientations the objective can actually image the sample from -- a stricter
-        # question than `valid_orientations`, which asks only whether FM control is
-        # allowed. Turning the light on and watching the camera from a beam pose is
-        # harmless and sometimes useful, so `valid_orientations` includes SEM and
-        # MILLING; driving the stage across a grid and stitching the result from one is
-        # not, since on a compustage the sample is flipped away from the objective there
-        # and on an offset mount it is translated out from under it.
+        # Orientations the objective can actually image the sample from. Not a control
+        # gate: whether the user may *operate* the FM somewhere is answered by hardware
+        # interlocks (the objective's own z/t restrictions, the no-rotation-at-the-FM
+        # guard), and whether an *acquisition* may start is
+        # `get_device_imaging_state(...).allows_acquisition` on the parent microscope
+        # -- the stage owns stage questions.
         #
         # Read from the device declaration (`stage.devices.FM.acquisition_orientations`)
         # so there is exactly one source of truth. On a compustage that is `["FM"]` --
@@ -778,42 +770,6 @@ class FluorescenceMicroscope(ABC):
             return list(devices["FM"].acquisition_orientations)
         except (AttributeError, KeyError, TypeError):
             return [self.default_orientation]
-
-    def has_valid_orientation(
-        self, stage_position: Optional["FibsemStagePosition"] = None
-    ) -> bool:
-        """Return True if the current (or given) stage orientation is allowed for FM acquisition."""
-        if self._allow_unknown_orientations:
-            return True
-        orientation = self.parent.get_stage_orientation(stage_position)
-        return orientation in self.valid_orientations
-
-    def is_acquisition_orientation(
-        self, stage_position: Optional["FibsemStagePosition"] = None
-    ) -> bool:
-        """Return True if the objective can image the sample at the current (or given) pose.
-
-        The question anything that drives the stage should ask, and stricter than
-        `has_valid_orientation` in two ways: it asks the narrower
-        `acquisition_orientations`, and it has no `ALLOW_UNKNOWN_ORIENTATIONS` escape
-        hatch. The hatch exists so live FM control works from anywhere while a system is
-        being set up; an unrecognised pose is not an inconvenience to a tileset, which
-        would walk the stage across a grid and stitch the result against a frame nobody
-        has checked.
-
-        Answers True unconditionally on an offset mount, where the question cannot be
-        asked: `_update_orientations` gives a non-compustage system an FM orientation
-        copied from its FIB one, so `get_stage_orientation` at the fluorescence position
-        returns a beam orientation -- measured, "MILLING", since the milling tilt band
-        matches first. It cannot tell a fluorescence position from a beam one at all,
-        which is the same limitation `build_lamella_poses` refuses over (FIB-93).
-        Refusing on a question with no answer is not a guard, it is a lockout: it would
-        leave the overview tab permanently dead on every METEOR.
-        """
-        if not self.parent.stage_is_compustage:
-            return True
-        orientation = self.parent.get_stage_orientation(stage_position)
-        return orientation in self.acquisition_orientations
 
     def __repr__(self):
         """Return a string representation of the fluorescence microscope.

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2016,6 +2016,22 @@ class DeviceImagingState(Enum):
     # rotation happens at the beams and never under an objective.
     NEEDS_REPOSE_THEN_TRAVEL = "needs_repose_then_travel"
 
+    @property
+    def allows_acquisition(self) -> bool:
+        """The acquisition-gate policy, in one place.
+
+        Acquiring in place from a "wrong" pose is a harmless watch when the device is
+        here -- an Arctis user turning the light on at a beam pose -- so a re-pose
+        does not refuse. Travel states do: from a different place in the chamber the
+        device is not looking at the sample at all. `NO_DEVICE` refuses, terminally.
+
+        Sites that *drive the stage* through an FM-built frame, or *write the pose
+        down* (marking a lamella, a tileset walking a grid), require `READY` and do
+        not use this: from a pose the device cannot image from, nothing has checked
+        the frame their numbers go through.
+        """
+        return self in (DeviceImagingState.READY, DeviceImagingState.NEEDS_REPOSE)
+
 
 def device_axes_to_dict(position: FibsemStagePosition) -> dict:
     """The device axes a partial position sets, as a plain dict. Absent axes are absent."""

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -52,7 +52,7 @@ from fibsem.imaging.tiling.progress import (
     TiledStatus,
 )
 from fibsem.microscope import FibsemMicroscope
-from fibsem.structures import FibsemStagePosition
+from fibsem.structures import DeviceImagingState, FibsemStagePosition
 from fibsem.ui import notification_service, stylesheets
 from fibsem.ui import utils as ui_utils
 from fibsem.ui.fm.widgets.fm_multi_channel_widget import FluorescenceMultiChannelWidget
@@ -284,6 +284,9 @@ class FMOverviewWidget(QWidget):
         # agrees by construction instead of because two callers happened to poll
         # together. See `_current_stage_position` for why polling is the odd one out.
         self._stage_position: Optional[FibsemStagePosition] = None
+        # The last answer to "can the FM image from here" -- see `_on_stage_moved`,
+        # which re-derives the gate and banner only when this changes.
+        self._last_imaging_state: Optional[DeviceImagingState] = None
         # The objective half of the canvas info bar, cached. Read from hardware only
         # when something may have moved it -- see `_refresh_objective_info`.
         self._objective_info: Optional[str] = None
@@ -1740,30 +1743,22 @@ class FMOverviewWidget(QWidget):
     # ── stage orientation ────────────────────────────────────────────────
 
     def at_acquisition_orientation(self) -> bool:
-        """Whether the stage is somewhere the objective can image the sample from.
+        """Whether the FM can image the sample from where the stage is.
 
-        `fm.acquisition_orientations`, and not a single pose of our own choosing: a
-        system whose objective sees the sample from more than one orientation says so
-        there, and hard-coding one here would lock the other out.
+        `READY` strictly -- place and pose both right -- because everything asking is
+        about to drive the stage through, or write down, a frame built from the pose:
+        the acquire gate walks a grid and stitches through it, marking writes the pose
+        into a lamella. From a pose the objective cannot image from, nothing has
+        checked those numbers.
 
-        Not `fm.has_valid_orientation()`, which asks the looser question of whether FM
-        *control* is allowed -- true at SEM and MILLING, where a compustage has flipped
-        the sample away from the objective -- and which `ALLOW_UNKNOWN_ORIENTATIONS`
-        answers yes to unconditionally anyway. The canvas frame is built from the pose
-        (see `_posed`), so tiles acquired somewhere the code cannot name are placed
-        against a projection nobody has checked.
+        On an offset mount this used to be unanswerable -- the old predicate returned
+        True everywhere off a compustage by documented design, and its stricter
+        sibling (`== default_orientation`) was never true there, which is why *Add
+        Position Here* declined forever with no error.
         """
-        return self.fm.is_acquisition_orientation()
-
-    def at_fluorescence_pose(self) -> bool:
-        """Whether the stage is at *the* fluorescence orientation, not merely a workable one.
-
-        Stricter than `at_acquisition_orientation`, and asked only where something is written
-        down. Asked of `fm.default_orientation` because that is the orientation
-        `build_lamella_poses` derives a fluorescence pose *into*: two names for the same
-        thing could drift, one cannot.
-        """
-        return self.microscope.get_stage_orientation() == self.fm.default_orientation
+        return (
+            self.microscope.get_device_imaging_state("FM") is DeviceImagingState.READY
+        )
 
     def move_to_fm_orientation(self) -> None:
         """Drive the stage to the fluorescence orientation, having asked first.
@@ -1823,7 +1818,11 @@ class FMOverviewWidget(QWidget):
         and naming only `default_orientation` would send the user further than they have
         to go.
         """
-        allowed = self.fm.acquisition_orientations
+        allowed = self.microscope.system.stage.devices["FM"].acquisition_orientations
+        if not allowed:
+            # An unconstrained device -- the pose is not what is wrong, so this string
+            # is never shown for one; named defensively all the same.
+            return "a pose the objective can image from"
         if len(allowed) == 1:
             named = allowed[0]
         else:
@@ -1881,6 +1880,15 @@ class FMOverviewWidget(QWidget):
         reposed = self._pose_changed(position)
         self._stage_position = position
         self._refresh_current_position()
+        # The gate and the banner answer "can the FM image from here", and on an offset
+        # mount that changes with pure *translation* -- the 48.8 mm traverse to the FM
+        # alters no rotation or tilt at all -- so they cannot hide behind `reposed`.
+        # Gating them on it left the acquire button and the banner stale across the
+        # whole traverse. Asked with the polled position, and re-derived only when the
+        # answer actually changes.
+        state = self.microscope.get_device_imaging_state("FM", position)
+        imaging_changed = state is not self._last_imaging_state
+        self._last_imaging_state = state
         # Everything else on the canvas is placed through a frame whose rotation and
         # tilt come from wherever the stage is (see `_posed`), so a re-pose moves all of
         # it. Redrawn only when the pose actually changes: the stage is polled
@@ -1889,8 +1897,7 @@ class FMOverviewWidget(QWidget):
         if reposed:
             self._refresh_positions()
             self._refresh_stage_metadata()
-            # The orientation is read off rotation and tilt, so it can only have changed
-            # when they did -- the same reason the redraws above are gated on it.
+        if reposed or imaging_changed:
             self._refresh_orientation_banner()
             self._apply_enabled_state()
         # The grid follows the stage only when it is not pinned to a target and not
@@ -2011,12 +2018,12 @@ class FMOverviewWidget(QWidget):
     def _may_move(self) -> bool:
         """Whether driving the stage from this tab is allowed right now, and say if not.
 
-        The orientation check here used to be `fm.has_valid_orientation()`, which
-        `ALLOW_UNKNOWN_ORIENTATIONS` answers yes to unconditionally -- so it refused
-        nothing. It now asks the same question with the escape hatch off, which is what
-        it was always meant to mean: a click is a stage move computed through a frame
-        built from the current pose, and from a pose the code cannot name there is
-        nothing that has checked where it would send the stage (FIB-436).
+        The orientation check here used to be a predicate an escape flag answered yes
+        to unconditionally -- so it refused nothing. It now asks the enforced
+        question, which is what it was always meant to mean: a click is a stage move
+        computed through a frame built from the current pose, and from a pose the
+        objective cannot image from there is nothing that has checked where it would
+        send the stage (FIB-436).
         """
         if self.is_acquiring:
             notification_service.show_toast(
@@ -2100,11 +2107,10 @@ class FMOverviewWidget(QWidget):
                 "Cannot mark positions while an acquisition is running.", "warning"
             )
             return None
-        # Stricter than the double-click's check, and deliberately so. Moving needs only
-        # a pose the FM can work from; marking has to survive being written down, since
-        # the position becomes a lamella's *fluorescence* pose -- and one carrying SEM
-        # rotation and tilt is not one, however right it looked on screen.
-        if not self.at_fluorescence_pose():
+        # Marking has to survive being written down: the position becomes a lamella's
+        # *fluorescence* pose, so it must be one the objective actually images from --
+        # however right it looked on screen.
+        if not self.at_acquisition_orientation():
             notification_service.show_toast(
                 f"Move to the fluorescence position before marking on the overview "
                 f"(the stage is at {self.microscope.get_stage_orientation()}).",

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -33,7 +33,7 @@ from fibsem.fm.structures import (
     ZParameters,
 )
 from fibsem.microscope import FibsemMicroscope
-from fibsem.structures import Point
+from fibsem.structures import DeviceImagingState, Point
 from fibsem.ui import notification_service
 from fibsem.ui.fm.widgets import (
     AutofocusWidget,
@@ -451,9 +451,15 @@ class FMControlWidget(QWidget):
         if self.is_acquisition_active:
             logging.info("Stage movement disabled during acquisition")
             return
-        if not self.microscope.fm.has_valid_orientation():
+        # READY strictly: a click is a stage move computed through a frame built from
+        # the current pose, so from one the objective cannot image from, nothing has
+        # checked where it would send the stage.
+        if (
+            self.microscope.get_device_imaging_state("FM")
+            is not DeviceImagingState.READY
+        ):
             logging.info(
-                "Stage must be in a valid FM orientation to move via FM "
+                "Stage must be at the fluorescence microscope to move via FM "
                 f"(current: {self.microscope.get_stage_orientation()})"
             )
             return
@@ -631,10 +637,11 @@ class FMControlWidget(QWidget):
                 f"Cannot start {what}: the fluorescence microscope is in use ({reason})."
             )
             return True
-        if not self.fm.has_valid_orientation():
+        state = self.microscope.get_device_imaging_state("FM")
+        if not state.allows_acquisition:
             logging.warning(
-                f"Cannot start {what}: the stage is not in a valid FM orientation "
-                f"(currently {self.microscope.get_stage_orientation()})."
+                f"Cannot start {what}: {state.value} "
+                f"(the stage is at {self.microscope.get_stage_orientation()})."
             )
             return True
         return False
@@ -932,9 +939,12 @@ class FMControlWidget(QWidget):
         # buttons and skipped every line below, so the objective panel and the channel
         # settings kept whatever they were last set to, including enabled during
         # somebody else's tileset. It also missed two of the buttons it claimed to
-        # cover. Dead as shipped -- `ALLOW_UNKNOWN_ORIENTATIONS` answers this yes
-        # unconditionally -- which is why nobody noticed.
-        posed = self.microscope.fm.has_valid_orientation()
+        # cover. Enforcing for the first time here: the old predicate was answered
+        # yes unconditionally by its escape flag, which is why nobody noticed. A
+        # compustage keeps its buttons everywhere (it can never need
+        # travel); an offset mount loses them at the beams, where the objective is
+        # 48.8 mm from the sample.
+        posed = self.microscope.get_device_imaging_state("FM").allows_acquisition
         may_start = posed and not acquiring
         may_touch = posed and interactive
 

--- a/tests/fm/test_fm_autofocus.py
+++ b/tests/fm/test_fm_autofocus.py
@@ -1,4 +1,5 @@
 """Tests for fm autofocus: run_autofocus and run_coarse_fine_autofocus."""
+
 from __future__ import annotations
 
 import threading
@@ -14,8 +15,10 @@ from fibsem.autofunctions.autofocus import (
 )
 from fibsem.fm.calibration import run_autofocus, run_coarse_fine_autofocus
 from fibsem.fm.structures import AutoFocusSettings, FocusMethod, ZParameters
+from fibsem.structures import DeviceImagingState
 
 # ── helpers ───────────────────────────────────────────────────────────────────
+
 
 def _make_image(score: float) -> MagicMock:
     """Return a mock FM image whose .data encodes the given sharpness score."""
@@ -32,7 +35,7 @@ def _mock_fm(best_z: float = 0.0, initial_z: float = 5e-6):
     objective.position tracks move_absolute() calls.
     """
     m = MagicMock()
-    m.has_valid_orientation.return_value = True
+    m.parent.get_device_imaging_state.return_value = DeviceImagingState.READY
     m.acquisition_progress_signal = MagicMock()
 
     current_z = [initial_z]
@@ -61,6 +64,7 @@ DEFAULT_Z_PARAMS = ZParameters(zmin=-10e-6, zmax=10e-6, zstep=2e-6)
 
 # ── ZParameters.from_focus_pass ────────────────────────────────────────────────
 
+
 def test_zparameters_from_focus_pass():
     zp = ZParameters.from_focus_pass(FocusSweepPass(search_range=10e-6, step_size=2e-6))
     assert zp.zmin == pytest.approx(-5e-6)
@@ -77,9 +81,13 @@ def test_zparameters_from_focus_pass_positions_centred():
 
 # ── run_autofocus ─────────────────────────────────────────────────────────────
 
+
 def test_run_autofocus_returns_result():
     m = _mock_fm(best_z=0.0, initial_z=0.0)
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_autofocus(m, z_parameters=DEFAULT_Z_PARAMS)
     assert isinstance(result, AutoFocusResult)
 
@@ -87,7 +95,10 @@ def test_run_autofocus_returns_result():
 def test_run_autofocus_finds_best_z():
     best_z = 0.0
     m = _mock_fm(best_z=best_z, initial_z=5e-6)
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_autofocus(m, z_parameters=DEFAULT_Z_PARAMS)
     assert result is not None
     assert abs(result.working_distance - best_z) <= DEFAULT_Z_PARAMS.zstep
@@ -95,7 +106,10 @@ def test_run_autofocus_finds_best_z():
 
 def test_run_autofocus_result_fields_populated():
     m = _mock_fm(best_z=0.0)
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_autofocus(m, z_parameters=DEFAULT_Z_PARAMS, method="laplacian")
     scores = [it.focus_score for it in result.iterations]
     best_idx = int(np.argmax(scores))
@@ -108,7 +122,10 @@ def test_run_autofocus_result_fields_populated():
 def test_run_autofocus_moves_to_best_z():
     best_z = 0.0
     m = _mock_fm(best_z=best_z, initial_z=5e-6)
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_autofocus(m, z_parameters=DEFAULT_Z_PARAMS)
     assert abs(m.objective.position - result.working_distance) < 1e-12
 
@@ -116,14 +133,20 @@ def test_run_autofocus_moves_to_best_z():
 def test_run_autofocus_sets_channel_when_provided():
     m = _mock_fm()
     channel = MagicMock()
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         run_autofocus(m, channel_settings=channel, z_parameters=DEFAULT_Z_PARAMS)
     m.set_channel.assert_called_once_with(channel_settings=channel)
 
 
 def test_run_autofocus_no_channel_does_not_set_channel():
     m = _mock_fm()
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         run_autofocus(m, z_parameters=DEFAULT_Z_PARAMS)
     m.set_channel.assert_not_called()
 
@@ -132,7 +155,10 @@ def test_run_autofocus_cancellation_returns_none():
     stop = threading.Event()
     stop.set()
     m = _mock_fm()
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_autofocus(m, z_parameters=DEFAULT_Z_PARAMS, stop_event=stop)
     assert result is None
 
@@ -142,24 +168,30 @@ def test_run_autofocus_cancellation_restores_position():
     stop = threading.Event()
     stop.set()
     m = _mock_fm(initial_z=initial_z)
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         run_autofocus(m, z_parameters=DEFAULT_Z_PARAMS, stop_event=stop)
     assert abs(m.objective.position - initial_z) < 1e-12
 
 
 def test_run_autofocus_iterations_are_autofocus_iterations():
     m = _mock_fm(best_z=0.0)
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_autofocus(m, z_parameters=DEFAULT_Z_PARAMS)
     assert all(isinstance(it, AutoFocusIteration) for it in result.iterations)
     assert all(it.pass_index == 0 for it in result.iterations)
     assert all(isinstance(it.image, np.ndarray) for it in result.iterations)
 
 
-def test_run_autofocus_invalid_orientation_raises():
+def test_run_autofocus_refuses_where_the_fm_cannot_image():
     m = _mock_fm()
-    m.has_valid_orientation.return_value = False
-    with pytest.raises(ValueError, match="orientation"):
+    m.parent.get_device_imaging_state.return_value = DeviceImagingState.NEEDS_TRAVEL
+    with pytest.raises(ValueError, match="autofocus"):
         run_autofocus(m)
 
 
@@ -172,13 +204,17 @@ def test_run_autofocus_invalid_method_raises():
 def test_run_autofocus_default_z_parameters():
     """run_autofocus should work with no z_parameters (uses default ±10µm / 1µm step)."""
     m = _mock_fm(best_z=0.0, initial_z=0.0)
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_autofocus(m)
     assert result is not None
     assert len(result.iterations) > 0
 
 
 # ── run_coarse_fine_autofocus ─────────────────────────────────────────────────
+
 
 def _af_settings(coarse_range=20e-6, coarse_step=5e-6, fine_range=4e-6, fine_step=1e-6):
     return AutoFocusSettings.from_coarse_fine(
@@ -192,7 +228,10 @@ def _af_settings(coarse_range=20e-6, coarse_step=5e-6, fine_range=4e-6, fine_ste
 
 def test_run_coarse_fine_returns_result():
     m = _mock_fm(best_z=0.0, initial_z=8e-6)
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_coarse_fine_autofocus(m, _af_settings())
     assert isinstance(result, AutoFocusResult)
 
@@ -204,20 +243,31 @@ def test_run_coarse_fine_improves_over_single_pass():
     m_single = _mock_fm(best_z=best_z, initial_z=initial_z)
     m_two = _mock_fm(best_z=best_z, initial_z=initial_z)
 
-    settings = _af_settings(coarse_range=20e-6, coarse_step=5e-6, fine_range=4e-6, fine_step=1e-6)
+    settings = _af_settings(
+        coarse_range=20e-6, coarse_step=5e-6, fine_range=4e-6, fine_step=1e-6
+    )
     single_params = ZParameters(zmin=-10e-6, zmax=10e-6, zstep=5e-6)
 
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         r_single = run_autofocus(m_single, z_parameters=single_params)
         r_two = run_coarse_fine_autofocus(m_two, settings)
 
     fine_step = settings.passes[-1].step_size
-    assert abs(r_two.working_distance - best_z) <= abs(r_single.working_distance - best_z) + fine_step
+    assert (
+        abs(r_two.working_distance - best_z)
+        <= abs(r_single.working_distance - best_z) + fine_step
+    )
 
 
 def test_run_coarse_fine_iterations_contains_both_stages():
     m = _mock_fm(best_z=0.0, initial_z=8e-6)
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_coarse_fine_autofocus(m, _af_settings())
     # iterations are flat AutoFocusIteration objects tagged with pass_index
     assert any(it.pass_index == 0 for it in result.iterations)
@@ -228,7 +278,10 @@ def test_run_coarse_fine_iterations_contains_both_stages():
 def test_run_coarse_fine_moves_to_coarse_best_before_fine():
     """run_coarse_fine_autofocus must call move_absolute(coarse_best_z) between stages."""
     m = _mock_fm(best_z=0.0, initial_z=8e-6)
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_coarse_fine_autofocus(m, _af_settings())
 
     coarse_iters = [it for it in result.iterations if it.pass_index == 0]
@@ -243,7 +296,10 @@ def test_run_coarse_fine_returns_none_if_coarse_cancelled():
     stop = threading.Event()
     stop.set()
     m = _mock_fm()
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_coarse_fine_autofocus(m, _af_settings(), stop_event=stop)
     assert result is None
 
@@ -265,7 +321,10 @@ def test_run_coarse_fine_returns_coarse_if_fine_cancelled():
 
     m.acquire_image.side_effect = cancel_after_coarse
 
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_coarse_fine_autofocus(m, _af_settings(), stop_event=stop)
 
     assert result is not None  # coarse result returned, not None
@@ -274,7 +333,10 @@ def test_run_coarse_fine_returns_coarse_if_fine_cancelled():
 def test_run_coarse_fine_passes_channel_to_both_stages():
     m = _mock_fm()
     channel = MagicMock()
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         run_coarse_fine_autofocus(m, _af_settings(), channel_settings=channel)
     # set_channel should have been called for both coarse and fine sweeps
     assert m.set_channel.call_count == 2
@@ -283,9 +345,15 @@ def test_run_coarse_fine_passes_channel_to_both_stages():
 def test_run_coarse_fine_with_roi():
     m = _mock_fm(best_z=0.0)
     from fibsem.structures import FibsemRectangle
+
     roi = FibsemRectangle(left=0.25, top=0.25, width=0.5, height=0.5)
-    with patch("fibsem.fm.calibration.calculate_focus_quality", side_effect=lambda arr, method: float(np.mean(arr))):
+    with patch(
+        "fibsem.fm.calibration.calculate_focus_quality",
+        side_effect=lambda arr, method: float(np.mean(arr)),
+    ):
         result = run_coarse_fine_autofocus(m, _af_settings(), roi=roi)
     assert result is not None
     # crop() should have been called on acquired images
-    assert m.acquire_image.return_value.crop.called or True  # side_effect overrides return_value
+    assert (
+        m.acquire_image.return_value.crop.called or True
+    )  # side_effect overrides return_value

--- a/tests/fm/test_offset_overview_gate.py
+++ b/tests/fm/test_offset_overview_gate.py
@@ -6,9 +6,9 @@ have an answer. At the FM on an offset mount the classifier reports the pose the
 sample was carried out in -- "FIB", measured -- so the runner refused at the one
 place it is meant to run, and nothing noticed.
 
-This file is the pin from FIB-856. The gate here is interim (an inline mounting
-split); when the gates move onto `get_device_imaging_state` (FIB-839) the gate
-changes and these tests keep it honest.
+This file is the pin from FIB-856. The gate started as an interim inline mounting
+split and now asks `get_device_imaging_state` (FIB-839), READY strictly -- the same
+gate the overview widget always applied on its acquire button.
 """
 
 import os
@@ -110,18 +110,18 @@ def test_an_offset_system_still_refuses_at_milling():
         )
 
 
-def test_a_compustage_keeps_exactly_the_list_it_had():
-    """["SEM", "FM"] on a compustage, unchanged.
+def test_a_compustage_tileset_needs_the_fm_pose():
+    """The runner now applies the gate the widget always applied.
 
-    The tempting one-liner -- swap the inlined list for
-    `is_acquisition_orientation()` -- would have *newly refused* SEM tilesets on
-    every Arctis, because that predicate's list is `["FM"]` there. The refusal at
-    FIB below is the old behaviour too, kept.
+    A tileset walks the stage and stitches through a frame built from the pose, so it
+    requires the pose the objective images from -- `["FM"]` on a compustage. The
+    widget's acquire button was already gated exactly this way; only direct API calls
+    could previously start a tileset from SEM, through the runner's own inlined list.
     """
     microscope, _ = utils.setup_session(config_path=ARCTIS_CONFIG)
     microscope.fm.objective.insert()
 
-    microscope.move_to_orientation("SEM")
+    microscope.move_to_microscope("FM")
     tiles = acquire_tileset(
         microscope=microscope,
         channel_settings=CHANNEL,
@@ -129,8 +129,8 @@ def test_a_compustage_keeps_exactly_the_list_it_had():
     )
     assert tiles[0][0] is not None
 
-    microscope.move_to_orientation("FIB")
-    with pytest.raises(ValueError, match="FIB"):
+    microscope.move_to_orientation("SEM")
+    with pytest.raises(ValueError, match="needs_repose"):
         acquire_tileset(
             microscope=microscope,
             channel_settings=CHANNEL,

--- a/tests/test_simulated_offset_fm.py
+++ b/tests/test_simulated_offset_fm.py
@@ -127,17 +127,20 @@ def test_marking_from_the_beam_side_yields_no_fluorescence_pose():
     assert _to_fluorescence(microscope, microscope.get_orientation("MILLING")) is None
 
 
-def test_the_acquisition_guard_cannot_answer_and_says_yes():
-    """`is_acquisition_orientation` returns True unconditionally off a compustage.
+def test_the_acquisition_guard_can_answer_now():
+    """The placeholder guard used to say yes unconditionally off a compustage,
+    because neither axis alone could tell an FM position from a beam one. The
+    predicate asks both axes, so the offset mount finally gets a real answer:
+    not at the FM, and SEM is not a pose the objective images from."""
+    from fibsem.structures import DeviceImagingState
 
-    Refusing would be worse -- it would leave the overview tab permanently dead on
-    every offset system -- so the guard gives up rather than locking out. It is not a
-    guard on this mounting; it is a placeholder for one.
-    """
     microscope = _microscope(IFLM_CONFIG)
 
     microscope.move_to_orientation("SEM")
-    assert microscope.fm.is_acquisition_orientation() is True
+    assert (
+        microscope.get_device_imaging_state("FM")
+        is DeviceImagingState.NEEDS_REPOSE_THEN_TRAVEL
+    )
 
 
 def test_the_traverse_refuses_unless_the_stage_is_already_at_fib():

--- a/tests/ui/test_fm_acquisition_state.py
+++ b/tests/ui/test_fm_acquisition_state.py
@@ -10,6 +10,7 @@ tileset moves the stage between every pair of tiles with no stream running, so
 came to be startable mid-tileset, and how the objective panel came to stay live against
 a runner that was stepping the objective itself.
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -221,7 +222,9 @@ class TestTheOverviewRespectsTheInstrument:
 
         assert accept_dialog == [], "asked the user to confirm a run it then refused"
 
-    def test_it_starts_once_the_instrument_is_free(self, widget, accept_dialog, no_worker):
+    def test_it_starts_once_the_instrument_is_free(
+        self, widget, accept_dialog, no_worker
+    ):
         widget.fm.set_acquiring(True, "z-stack")
         widget.fm.set_acquiring(False)
 
@@ -271,11 +274,13 @@ class TestTheControlWidgetGuard:
     """
 
     @staticmethod
-    def _widget(fm):
+    def _widget(fm, state=None):
+        from fibsem.structures import DeviceImagingState
         from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget
 
         widget = FMControlWidget.__new__(FMControlWidget)
         widget.fm = fm
+        widget.microscope = _StageAt(state or DeviceImagingState.READY)
         widget._acquisition_thread = None
         return widget
 
@@ -360,9 +365,7 @@ class TestTheControlWidgetWiring:
     def test_every_worker_is_marked_for(self, name):
         assert "set_acquiring" in self._calls(self._functions()[name])
 
-    @pytest.mark.parametrize(
-        "name", ["_image_acquistion_worker", "_autofocus_worker"]
-    )
+    @pytest.mark.parametrize("name", ["_image_acquistion_worker", "_autofocus_worker"])
     def test_every_worker_clears_on_the_way_out(self, name):
         """In the `finally`, not the happy path: a worker that raises still holds it."""
         import ast
@@ -379,18 +382,31 @@ class TestTheControlWidgetWiring:
     def test_it_refuses_a_pose_the_fm_cannot_see_from(self):
         """`start_acquisition` had this check and the other two did not, so an image, a
         z-stack or an autofocus sweep could be started from a beam pose with nothing but
-        the button stopping it."""
+        the button stopping it. The gate refuses travel states and permits a re-pose --
+        the acquisition policy, in one place on the enum."""
         from fibsem.fm.microscope import FluorescenceMicroscope
+        from fibsem.structures import DeviceImagingState
 
         fm = FluorescenceMicroscope()
-        fm._allow_unknown_orientations = False  # the escape hatch is on by default
-        fm.valid_orientations = []  # so no pose is a valid one
-        fm.parent = _StageAt("SEM")
-        widget = TestTheControlWidgetGuard._widget(fm)
-        widget.microscope = fm.parent
+        widget = TestTheControlWidgetGuard._widget(
+            fm, state=DeviceImagingState.NEEDS_TRAVEL
+        )
 
         assert fm.is_acquiring is False, "refused for the pose, not for being busy"
         assert widget._refuse_to_start("image acquisition") is True
+
+    def test_a_repose_is_permitted(self):
+        """The Arctis allowance, as gate policy: acquiring in place from a "wrong"
+        pose is a harmless watch. A compustage can never need travel, so this row is
+        the only refusable one it has -- and it does not refuse."""
+        from fibsem.fm.microscope import FluorescenceMicroscope
+        from fibsem.structures import DeviceImagingState
+
+        widget = TestTheControlWidgetGuard._widget(
+            FluorescenceMicroscope(), state=DeviceImagingState.NEEDS_REPOSE
+        )
+
+        assert widget._refuse_to_start("image acquisition") is False
 
     def test_every_control_is_set_on_every_path(self):
         """`_update_acquisition_button_states` returned early on a bad pose, setting
@@ -420,14 +436,16 @@ class TestTheControlWidgetWiring:
 
 
 class _StageAt:
-    """The parent microscope, for the two orientation questions the FM forwards."""
+    """The parent microscope, answering the one question the guard asks now."""
 
-    def __init__(self, orientation: str):
-        self._orientation = orientation
-        self.stage_is_compustage = True
+    def __init__(self, state: "DeviceImagingState"):
+        self._state = state
+
+    def get_device_imaging_state(self, device: str, stage_position=None):
+        return self._state
 
     def get_stage_orientation(self, stage_position=None) -> str:
-        return self._orientation
+        return "SEM"
 
 
 class _AliveThread:

--- a/tests/ui/test_fm_overview_orientation.py
+++ b/tests/ui/test_fm_overview_orientation.py
@@ -13,6 +13,7 @@ acquiring and driving the stage; `default_orientation` (the single pose a fluore
 position is written down as) gates marking. Neither is `valid_orientations`, which is
 the looser "FM control is allowed here" and still includes the beam poses.
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -161,9 +162,13 @@ class TestTheGate:
         assert widget._may_move() is False
 
     def test_the_list_is_what_decides_not_a_hard_coded_pose(self, widget, qapp):
-        """A system whose objective sees the sample from more than one pose widens
-        `acquisition_orientations`; nothing here compares against `default_orientation`."""
-        widget.fm.acquisition_orientations = ["FM", "SEM"]
+        """A system whose objective sees the sample from more than one pose widens the
+        device's `acquisition_orientations`; nothing here compares against
+        `default_orientation`."""
+        widget.microscope.system.stage.devices["FM"].acquisition_orientations = [
+            "FM",
+            "SEM",
+        ]
         _pose(widget, "SEM")
         qapp.processEvents()
 
@@ -171,51 +176,58 @@ class TestTheGate:
         assert widget.button_acquire.isEnabled() is True
         assert widget._may_move() is True
 
-    def test_marking_stays_on_the_fluorescence_pose_alone(self, widget):
-        """The distinction the gate rests on. Stricter than acquiring or moving: a
-        marked position becomes a lamella's *fluorescence* pose, and one carrying SEM
-        rotation and tilt is not one, however right it looked on screen -- so widening
-        `acquisition_orientations` must not widen this."""
-        widget.fm.acquisition_orientations = ["FM", "SEM"]
+    def test_marking_follows_the_device_list_too(self, widget):
+        """Marking and acquiring ask the one question now. A marked position becomes a
+        lamella's *fluorescence* pose, so it must be a pose the objective actually
+        images from -- which is exactly what the device list declares. Widening the
+        list widens both: a site whose objective images at SEM may write SEM
+        fluorescence poses, which is what the Default Orientation planner already
+        allowed."""
         _pose(widget, "SEM")
+        assert widget._position_menu(0.0, 0.0) is None, "SEM is not in the list yet"
+
+        widget.microscope.system.stage.devices["FM"].acquisition_orientations = [
+            "FM",
+            "SEM",
+        ]
 
         assert widget.at_acquisition_orientation() is True
-        assert widget.at_fluorescence_pose() is False
-        assert widget._may_move() is True, "the looser check should still pass here"
-        assert widget._position_menu(0.0, 0.0) is None
+        assert widget._position_menu(0.0, 0.0) is not None
 
 
 class TestOffsetMounts:
-    """Where the question cannot be asked, it must not be answered "no" (FIB-93).
+    """The question has an answer on an offset mount now, and the gate uses it.
 
-    `_update_orientations` gives a non-compustage system an FM orientation copied from
-    its FIB one, so `get_stage_orientation` at the fluorescence position comes back as a
-    beam orientation and never as "FM". A gate that refused on that would leave the tab
-    permanently dead on every METEOR rather than guarding anything.
+    The old predicate returned True everywhere off a compustage by documented design
+    -- neither axis alone could tell an FM position from a beam one, and refusing on
+    an unanswerable question would have left the tab dead on every METEOR. The
+    device axis answers it: the gate opens at the FM and closes at the beams.
     """
 
     @pytest.fixture()
     def offset_widget(self, qapp):
+        import fibsem.config as cfg
         from fibsem import utils
-        from fibsem.fm.microscope import FluorescenceMicroscope
 
-        microscope, _ = utils.setup_session(manufacturer="Demo")
-        microscope.stage_is_compustage = False
-        microscope._update_orientations()
-        if microscope.fm is None:
-            microscope.fm = FluorescenceMicroscope(parent=microscope)
-        return FMOverviewWidget(microscope)
+        config = os.path.join(cfg.CONFIG_PATH, "sim-iflm-configuration.yaml")
+        microscope, _ = utils.setup_session(config_path=config)
+        built = FMOverviewWidget(microscope)
+        built.fm.objective.insert()
+        return built
 
     def test_the_fluorescence_pose_does_not_report_itself_as_fm(self, offset_widget):
-        """The premise. If this ever starts returning "FM", the exemption below can go."""
+        """The premise: the classifier still cannot name the FM there -- the pose at
+        the device is the FIB pose it was carried out in."""
         microscope = offset_widget.microscope
-        microscope.move_stage_absolute(microscope.get_orientation("FM"))
+        microscope.move_to_orientation("FIB")
+        microscope.move_to_microscope("FM")
 
-        assert microscope.get_stage_orientation() != "FM"
+        assert microscope.get_stage_orientation() == "FIB"
 
-    def test_acquisition_is_not_gated_there(self, offset_widget, qapp):
+    def test_the_gate_opens_at_the_fm_device(self, offset_widget, qapp):
         microscope = offset_widget.microscope
-        microscope.move_stage_absolute(microscope.get_orientation("FM"))
+        microscope.move_to_orientation("FIB")
+        microscope.move_to_microscope("FM")
         offset_widget._on_stage_moved(microscope.get_stage_position())
         qapp.processEvents()
 
@@ -224,9 +236,25 @@ class TestOffsetMounts:
         assert offset_widget._may_move() is True
         assert offset_widget.orientation_banner.isVisibleTo(offset_widget) is False
 
+    def test_the_gate_closes_at_the_beams(self, offset_widget, qapp):
+        """The half that used to be impossible: at the beams in FIB pose the old
+        predicate said yes, and an overview started there would have stitched tiles
+        of nothing 48.8 mm from the objective."""
+        microscope = offset_widget.microscope
+        microscope.move_to_orientation("FIB")
+        offset_widget._on_stage_moved(microscope.get_stage_position())
+        qapp.processEvents()
+
+        assert offset_widget.at_acquisition_orientation() is False
+        assert offset_widget.button_acquire.isEnabled() is False
+        assert offset_widget._may_move() is False
+        assert offset_widget.orientation_banner.isVisibleTo(offset_widget) is True
+
 
 class TestTheRefusal:
-    def test_acquire_refuses_from_the_wrong_pose(self, widget, accept_dialog, no_worker):
+    def test_acquire_refuses_from_the_wrong_pose(
+        self, widget, accept_dialog, no_worker
+    ):
         """The button is not the guard: a host can call this, and the stage can move
         between the click and here."""
         _pose(widget, "NONE")
@@ -235,7 +263,9 @@ class TestTheRefusal:
 
         assert accept_dialog == [], "asked the user to confirm a run it then refused"
 
-    def test_acquire_runs_once_the_stage_is_posed(self, widget, accept_dialog, no_worker):
+    def test_acquire_runs_once_the_stage_is_posed(
+        self, widget, accept_dialog, no_worker
+    ):
         _pose(widget, "NONE")
         _pose(widget, "FM")
 
@@ -277,13 +307,16 @@ class TestTheBanner:
     def test_it_names_every_orientation_that_would_do(self, widget, allowed, expected):
         """Not only the one the button goes to: on a system configured for more than one
         the stage may already be a shorter move from a different one."""
-        widget.fm.acquisition_orientations = allowed
+        widget.microscope.system.stage.devices["FM"].acquisition_orientations = allowed
         _pose(widget, "NONE")
 
         assert widget.orientation_notice.text().endswith(f"needs to be at {expected}.")
 
-    def test_it_stays_hidden_at_a_valid_but_non_fluorescence_pose(self, widget):
-        widget.fm.acquisition_orientations = ["FM", "SEM"]
+    def test_it_stays_hidden_at_a_widened_pose(self, widget):
+        widget.microscope.system.stage.devices["FM"].acquisition_orientations = [
+            "FM",
+            "SEM",
+        ]
         _pose(widget, "SEM")
 
         assert widget.orientation_banner.isVisibleTo(widget) is False
@@ -339,6 +372,7 @@ class TestTheMoveAction:
 
     def test_a_failed_move_is_logged_not_raised(self, widget, monkeypatch, caplog):
         """It runs on a worker thread, where an exception has nowhere to go."""
+
         def _boom(target):
             raise RuntimeError("stage refused")
 


### PR DESCRIPTION
The nine gates that asked five different orientation predicates now ask one question, under two policies that both live on the enum:

- **Acquisition gates** (`acquire_image`, autofocus, the control widget's start/refuse/buttons, both workflow tasks) use `allows_acquisition`: permit `NEEDS_REPOSE`, refuse travel states. Compustage keeps acquire-anywhere by geometry; an offset mount at the beams refuses — the explicit per-mounting gate the flag could never be.
- **Sites that drive the stage through an FM-built frame or write the pose down** (canvas double-click moves, marking, the tiled runner) require `READY` strictly — the gate the overview widget always applied on its own acquire button.

**Deleted, un-ported:** `ALLOW_UNKNOWN_ORIENTATIONS`, `valid_orientations`, `has_valid_orientation`, `is_acquisition_orientation`, `at_fluorescence_pose`, and the interim mounting split from the first PR in this stack. Operate-safety belongs to the hardware interlocks (FIB-640's measured z/t restrictions, the FIB-841 rotation guard), not an orientation name list.

**Behaviour changes to review deliberately:**
- Direct-API tilesets at SEM on a compustage are now refused (the widget already refused them; only scripts could reach the old allowance).
- Marking follows the device list — widening it widens marking, consistent with the planning path that already ships.
- Six refusal messages are reachable for the first time.

**Also fixes a staleness bug the device axis exposed:** the overview tab's acquire gate and banner re-derived only on a re-pose, but on an offset mount the imaging state changes with pure translation — the 48.8 mm traverse alters no rotation or tilt, so the button stayed stale across it. They now re-derive whenever the imaging state changes.

11 files — over the usual target because the gates and the predicates they replace have to change in one move, or the zoo stays half-alive.

**Stack (4/6).**