### PR TITLE
[feat] move_to_device(device, orientation=None): plan the route, stop refusing it (FIB-832)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -555,7 +555,8 @@ class FibsemMicroscope(ABC):
             "Cannot rotate the stage while it is at the fluorescence microscope: the "
             "rotation is compucentric about a centre at the beams, so it would swing "
             "the sample across the chamber under the objective. Move to the beams "
-            "first (move_to_microscope('FIBSEM')), re-pose there, and travel back."
+            "first (move_to_device('FIBSEM')), re-pose there, and travel back -- "
+            "or ask move_to_device for the pose and let it order the legs."
         )
 
     def move_to_orientation(self, orientation: str) -> FibsemStagePosition:
@@ -1830,7 +1831,11 @@ class FibsemMicroscope(ABC):
         sem = self.get_orientation("SEM")
         fib = self.get_orientation("FIB")
         milling = self.get_orientation("MILLING")
-        fm = self.get_orientation("FM")
+        # FM is an orientation only on a compustage -- see `_update_orientations`. On
+        # an offset mount there is no FM pose to classify against, and there never
+        # effectively was: the deleted copy was byte-identical to FIB, which matches
+        # first, so no position ever classified as FM off a compustage.
+        fm = self.orientations.get("FM")
         if sem is None or fib is None or milling is None:
             raise ValueError(
                 "SEM, FIB or MILLING orientation not defined in the system."
@@ -1853,7 +1858,7 @@ class FibsemMicroscope(ABC):
         is_fib_rotation = movement.rotation_angle_is_smaller(
             stage_rotation, fib.r, atol=5
         )
-        is_fm_rotation = movement.rotation_angle_is_smaller(
+        is_fm_rotation = fm is not None and movement.rotation_angle_is_smaller(
             stage_rotation, fm.r, atol=5
         )
 
@@ -1861,7 +1866,7 @@ class FibsemMicroscope(ABC):
         is_fib_tilt = np.isclose(stage_tilt, fib.t, atol=0.1)
 
         is_milling_tilt = np.radians(-45) < stage_tilt and not is_sem_tilt
-        is_fm_tilt = np.isclose(stage_tilt, fm.t, atol=0.1)
+        is_fm_tilt = fm is not None and np.isclose(stage_tilt, fm.t, atol=0.1)
 
         if is_sem_rotation and is_sem_tilt:
             return "SEM"
@@ -1912,6 +1917,14 @@ class FibsemMicroscope(ABC):
             ),
         }
 
+        # FM is an orientation only where reaching the FM *is* a re-pose: on a
+        # compustage the objective is under the grid and the stage turns over to face
+        # it. On an offset mount the FM is a place, not a pose -- the stage travels
+        # there holding whatever orientation it was in -- so there is no FM entry to
+        # derive. (There used to be: a `deepcopy` of the FIB pose, a second name for
+        # a pose that already had one. The classifier matched FM last, so the copy
+        # was never returned, and deleting it changes no classification -- it only
+        # stops `get_orientation("FM")` naming a pose that does not exist.)
         if self.stage_is_compustage:
             self.orientations["FIB"].r = np.radians(
                 0
@@ -1922,9 +1935,6 @@ class FibsemMicroscope(ABC):
                 r=np.radians(0),
                 t=np.radians(-180),
             )
-        else:
-            # only x/y translation, no rotation
-            self.orientations["FM"] = deepcopy(self.orientations["FIB"])
 
     def set_milling_angle(self, milling_angle: float) -> None:
         """Set the 'stored' milling angle in the system settings."""
@@ -2520,24 +2530,33 @@ class FibsemMicroscope(ABC):
                 setattr(translation, axis, end - start)
         return translation
 
-    def move_to_microscope(self, target: str) -> None:
-        """Move the stage to the specified microscope (FIBSEM <-> FM)"""
-        self._get_device(target)  # refuses by name if it is not a configured device
+    def move_to_device(self, device: str, orientation: Optional[str] = None) -> None:
+        """Travel to `device`, re-posing on the way when the pose has to change.
+
+        One call that owns the safe order -- retract the objective, re-pose at the
+        beams, travel out -- so a rotation never happens with the stage parked under
+        an objective. The rotation guard (FIB-841) stays underneath as the last-line
+        assert; the route this composes never trips it.
+
+        `orientation` names the pose to arrive in. Omitted, the pose is carried
+        across untouched whenever the target device can image from it -- that is the
+        point of a traverse, and the reason this must not pass the current
+        orientation's *name* through `move_to_orientation`: doing so would snap r and
+        t to nominal and quietly discard a milling angle somebody dialled in. When
+        the pose does have to change (an offset FM images in the FIB pose; asking
+        for it from SEM used to be a refusal), the device's first declared
+        acquisition orientation is used.
+        """
+        target_device = self._get_device(device)  # refuses by name
 
         if self.stage_is_compustage:
-            self.move_to_microscope_compustage(target)
+            self._move_to_device_compustage(device, orientation)
             return
 
-        if not self.fm:
+        if device == "FM" and not self.fm:
             raise ValueError("FM module is not available. Cannot move to FM position.")
 
         stage_position = self.get_stage_position()
-
-        if target == "FM" and self.get_stage_orientation(stage_position) != "FIB":
-            raise ValueError(
-                "Cannot move to FM from SEM or MILLING orientation. Please switch to FIB orientation first."
-            )
-
         source = self.get_current_device(stage_position)
         if source is None:
             raise ValueError(
@@ -2546,55 +2565,86 @@ class FibsemMicroscope(ABC):
                 f"travel from. Position: {stage_position}."
             )
 
-        if source == target:
-            logging.info(f"Already at {target} position, no need to move.")
-        else:
-            # Retracted immediately before the stage travels, and only then. The
-            # objective must not be out over the sample while the stage moves, but
-            # every reason to retract it is the move itself -- so a call that refuses,
-            # or that finds it has nowhere to go, leaves the objective exactly as it
-            # found it rather than pulling it out of the sample for nothing.
-            logging.info(f"Moving to {target} position...")
-            self.fm.objective.retract()
+        # The pose to arrive in. An explicit ask is honoured as asked; otherwise the
+        # pose is carried across, unless the target device cannot image from it --
+        # then its first declared acquisition orientation stands in.
+        desired = orientation
+        allowed = target_device.acquisition_orientations
+        if desired is None and allowed:
+            if self.get_stage_orientation(stage_position) not in allowed:
+                desired = allowed[0]
+                logging.info(
+                    f"The {device} device images from {allowed}; re-posing to "
+                    f"{desired} at the beams before travelling."
+                )
 
-            # No orientation asked for, so the pose comes across untouched. That is
-            # the whole point of the traverse, and the reason this cannot pass the
-            # current orientation's name instead: doing so would snap r and t to
-            # nominal and quietly discard a milling angle somebody dialled in.
-            self.move_stage_relative(self._device_translation(source, target))
+        if desired is None and source == device:
+            logging.info(f"Already at {device} position, no need to move.")
+        else:
+            # Retracted immediately before the stage moves, and only then. The
+            # objective must not be out over the sample while the stage moves, but
+            # every reason to retract it is the motion itself -- so a call that
+            # refuses, or finds it has nowhere to go, leaves the objective exactly
+            # as it found it rather than pulling it out of the sample for nothing.
+            logging.info(f"Moving to {device} position...")
+            if self.fm is not None:
+                self.fm.objective.retract()
+
+            if desired is not None:
+                # The bracketing order: every re-pose happens at the beams, where
+                # the rotation is about the sample rather than a 48.8 mm arm.
+                if source != "FIBSEM":
+                    self.move_stage_relative(self._device_translation(source, "FIBSEM"))
+                self.move_to_orientation(desired)
+                if device != "FIBSEM":
+                    self.move_stage_relative(self._device_translation("FIBSEM", device))
+            else:
+                self.move_stage_relative(self._device_translation(source, device))
 
         # Unconditional, so that the postcondition is the device *and* the objective
         # state together: asking again for a device the stage is already at cannot
         # leave the FM blind.
-        if target == "FM":
+        if device == "FM":
             self.fm.objective.insert()
 
-    def move_to_microscope_compustage(self, target: str) -> None:
-        """Special method to move to the specified microscope (FIBSEM <-> FM) for Compustage microscopes."""
+    def _move_to_device_compustage(
+        self, device: str, orientation: Optional[str] = None
+    ) -> None:
+        """The compustage's devices are one place: reaching either is a re-pose.
 
-        if not self.stage_is_compustage:
-            raise ValueError(
-                "This method is only available for Compustage microscopes."
-            )
-
+        With no `orientation` asked for, FIBSEM lands at SEM -- the pose every
+        caller of the old `move_to_microscope` relied on -- and the FM lands at its
+        own orientation, under the objective.
+        """
         if not self.fm:
             raise ValueError("FM module is not available. Cannot move to FM position.")
 
         self.fm.objective.retract()  # retract objective (safety precaution)
 
-        if target == "FIBSEM":
-            # The same move `move_flat_to_beam(BeamType.ELECTRON)` made -- the
-            # deprecated method's electron branch is `orientations["SEM"]` (measured:
-            # identical r, t and coordinate system on a compustage), and its one
-            # compustage special case applies to the ion beam only. `move_to_orientation`
-            # is now how the FM side reaches a beam pose, and the FM branch below has
-            # always gone through `get_orientation`.
-            self.move_to_orientation("SEM")
+        if device == "FIBSEM":
+            self.move_to_orientation(orientation or "SEM")
 
-        if target == "FM":
-            fm_orientation = self.get_orientation("FM")
-            self.move_stage_absolute(fm_orientation)
+        if device == "FM":
+            if orientation is not None:
+                self.move_to_orientation(orientation)
+            else:
+                self.move_stage_absolute(self.get_orientation("FM"))
             self.fm.objective.insert()  # insert objective
+
+    def move_to_microscope(self, target: str) -> None:
+        """Deprecated name for `move_to_device(target)` -- the last place a device
+        was called a microscope. Kept as a shim for its many callers."""
+        self.move_to_device(target)
+
+    def move_to_microscope_compustage(self, target: str) -> None:
+        """Deprecated name for the compustage half of `move_to_device`."""
+
+        if not self.stage_is_compustage:
+            raise ValueError(
+                "This method is only available for Compustage microscopes."
+            )
+        self._get_device(target)  # refuses by name if it is not a configured device
+        self._move_to_device_compustage(target)
 
     @property
     def current_grid(self) -> str:

--- a/tests/autolamella/test_poses.py
+++ b/tests/autolamella/test_poses.py
@@ -192,17 +192,19 @@ def test_an_offset_mount_cannot_tell_a_fluorescence_position_apart():
 
     Deriving the orientation from the position works on a compustage, where each
     orientation has its own tilt. On an offset mount the fluorescence position is
-    distinguished by travelling ~48 mm in x, and the tilt is no help: measured on the
-    simulator, FM and FIB share a tilt of 17 degrees and both come back as MILLING.
+    distinguished by travelling ~48 mm in x, which no r/t derivation can see: the
+    stage at the FM holds the FIB pose it was carried out in, and there is no FM
+    orientation there at all any more.
 
     So a caller there cannot rely on the derivation, and this test says so rather than
     leaving the next person to discover it.
     """
     microscope = _microscope(compustage=False)
 
-    fm_orientation = microscope.get_orientation(FLUORESCENCE_ORIENTATION)
+    fib = microscope.get_orientation("FIB")
+    at_the_fm = FibsemStagePosition(x=48.8e-3, y=0.0, z=0.0, r=fib.r, t=fib.t)
 
-    assert microscope.get_stage_orientation(fm_orientation) != FLUORESCENCE_ORIENTATION
+    assert microscope.get_stage_orientation(at_the_fm) != FLUORESCENCE_ORIENTATION
 
 
 def test_marking_from_fluorescence_is_refused_on_an_offset_mount():
@@ -217,9 +219,7 @@ def test_marking_from_fluorescence_is_refused_on_an_offset_mount():
     )
 
     with pytest.raises(ValueError, match="FIB-93"):
-        build_lamella_poses(
-            microscope, fm_position, marked_at=FLUORESCENCE_ORIENTATION
-        )
+        build_lamella_poses(microscope, fm_position, marked_at=FLUORESCENCE_ORIENTATION)
 
 
 def test_a_declared_orientation_wins_over_the_derived_one():
@@ -334,9 +334,7 @@ def test_an_offset_mount_says_so_rather_than_inventing_a_pose():
     microscope = _microscope(compustage=False)
     lamella = _lamella(microscope)
     lamella.fluorescence_pose = deepcopy(lamella.milling_pose)
-    lamella.fluorescence_pose.stage_position = _at(
-        microscope, FLUORESCENCE_ORIENTATION, 1e-6, 2e-6
-    )
+    lamella.fluorescence_pose.stage_position = _at(microscope, "FIB", 1e-6, 2e-6)
     _move_milling_to(microscope, lamella, 400e-6, -200e-6)
 
     assert sync_fluorescence_pose(microscope, lamella) is False

--- a/tests/test_move_to_device.py
+++ b/tests/test_move_to_device.py
@@ -1,0 +1,178 @@
+"""`move_to_device(device, orientation=None)`: one call that plans the route.
+
+The old `move_to_microscope` refused what it could have done -- "Cannot move to FM
+from SEM or MILLING orientation. Please switch to FIB orientation first." was an
+instruction to the user to perform, by hand, exactly the sequence the software
+composes everywhere else. The replacement owns the safe order: retract the
+objective, re-pose at the beams, travel out. The rotation guard (FIB-841) stays
+underneath as the last-line assert -- several tests here would trip it if the legs
+were ever composed in the wrong order.
+
+See FIB-832.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.structures import FibsemStagePosition
+
+IFLM_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-iflm-configuration.yaml")
+ARCTIS_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
+
+
+def _microscope(config_path: str = IFLM_CONFIG):
+    microscope, _ = utils.setup_session(config_path=config_path)
+    return microscope
+
+
+# ── the refusal is now a route ───────────────────────────────────────
+
+
+def test_to_the_fm_from_sem_re_poses_then_travels():
+    """The first thing a real workflow does, and the thing that used to raise."""
+    microscope = _microscope()
+    microscope.move_to_orientation("SEM")
+
+    microscope.move_to_device("FM")
+
+    assert microscope.get_current_device() == "FM"
+    assert microscope.get_stage_orientation() == "FIB"
+    assert microscope.fm.objective.state == "Inserted"
+
+
+def test_the_re_pose_happens_at_the_beams_not_at_the_fm():
+    """The bracketing order, proven by the guard underneath.
+
+    Coming back from the FM and asking for MILLING requires a half turn. Rotating
+    where the stage stands -- at the FM -- is exactly what FIB-841 refuses, so a
+    wrong leg order cannot pass this test quietly: the guard would raise.
+    """
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+    microscope.move_to_device("FM")
+
+    microscope.move_to_device("FIBSEM", orientation="MILLING")
+
+    assert microscope.get_current_device() == "FIBSEM"
+    assert microscope.get_stage_orientation() == "MILLING"
+
+
+def test_the_round_trip_is_one_call_each_way():
+    """The FIB-832 complaint: the last leg used to be two moves, every time."""
+    microscope = _microscope()
+    microscope.move_to_orientation("SEM")
+
+    microscope.move_to_device("FM")
+    microscope.move_to_device("FIBSEM", orientation="MILLING")
+    microscope.move_to_device("FM")
+
+    assert microscope.get_current_device() == "FM"
+    assert microscope.get_stage_orientation() == "FIB"
+
+
+# ── what a traverse still does not do ────────────────────────────────
+
+
+def test_an_acceptable_pose_is_carried_across_untouched():
+    """No orientation asked for and the pose is one the FM images from: no snap.
+
+    Three degrees off the nominal FIB tilt -- inside the band the classifier calls
+    FIB -- must survive the traverse. Routing through `move_to_orientation`
+    unconditionally would snap r and t to nominal and quietly discard it.
+    """
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+    position = microscope.get_stage_position()
+    position.t = position.t + np.radians(3)
+    microscope.move_stage_absolute(position)
+    tilt_before = microscope.get_stage_position().t
+
+    microscope.move_to_device("FM")
+
+    assert microscope.get_stage_position().t == pytest.approx(tilt_before)
+
+
+def test_asking_for_the_device_it_is_at_does_not_move():
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+    microscope.move_to_device("FM")
+    before = microscope.get_stage_position()
+
+    microscope.move_to_device("FM")
+
+    assert microscope.get_stage_position().is_close(before, tol=1e-9)
+    assert microscope.fm.objective.state == "Inserted"
+
+
+def test_travelling_from_neither_device_is_still_refused():
+    """Mid-traverse is a real state, and not one to guess a starting device for."""
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+    microscope.move_stage_relative(FibsemStagePosition(x=24.0e-3, y=0.0, z=0.0))
+
+    with pytest.raises(ValueError, match="not at any configured device"):
+        microscope.move_to_device("FM")
+
+
+# ── the compustage gets the same signature ───────────────────────────
+
+
+def test_a_compustage_lands_at_the_orientation_it_asked_for():
+    """The extra stage move every round trip used to pay: FIBSEM always landed at
+    SEM, and MILLING was a second call."""
+    microscope = _microscope(ARCTIS_CONFIG)
+    microscope.move_to_device("FM")
+
+    microscope.move_to_device("FIBSEM", orientation="MILLING")
+
+    assert microscope.get_stage_orientation() == "MILLING"
+
+
+def test_a_compustage_keeps_its_default_landing_poses():
+    """Unasked, FIBSEM still lands at SEM and the FM at its own orientation --
+    every existing caller relies on exactly that."""
+    microscope = _microscope(ARCTIS_CONFIG)
+
+    microscope.move_to_device("FM")
+    assert microscope.get_stage_orientation() == "FM"
+    assert microscope.fm.objective.state == "Inserted"
+
+    microscope.move_to_device("FIBSEM")
+    assert microscope.get_stage_orientation() == "SEM"
+
+
+# ── the deprecated names still work ──────────────────────────────────
+
+
+def test_move_to_microscope_is_a_shim():
+    """~15 production call sites and ~40 in tests keep working unchanged."""
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+
+    microscope.move_to_microscope("FM")
+    assert microscope.get_current_device() == "FM"
+
+    microscope.move_to_microscope("FIBSEM")
+    assert microscope.get_current_device() == "FIBSEM"
+
+
+# ── the FM orientation no longer exists where it never was one ───────
+
+
+def test_an_offset_mount_has_no_fm_orientation_to_ask_for():
+    """`orientations["FM"]` off a compustage was a deepcopy of FIB -- a second name
+    for a pose that already had one, never returned by the classifier, and the root
+    of the whole conflation. Deleting it changes no classification; it only stops
+    `get_orientation("FM")` naming a pose that does not exist.
+    """
+    offset = _microscope()
+    compustage = _microscope(ARCTIS_CONFIG)
+
+    with pytest.raises(Exception):
+        offset.get_orientation("FM")
+
+    assert compustage.get_orientation("FM") is not None

--- a/tests/test_no_repose_at_fm.py
+++ b/tests/test_no_repose_at_fm.py
@@ -77,7 +77,7 @@ def test_the_refusal_names_the_way_out():
     """The route exists; a caller that hits this needs to be told it, not just stopped."""
     microscope = _parked_at_the_fm()
 
-    with pytest.raises(ValueError, match=r"move_to_microscope\('FIBSEM'\)"):
+    with pytest.raises(ValueError, match=r"move_to_device\('FIBSEM'\)"):
         microscope.move_to_orientation("MILLING")
 
 

--- a/tests/test_orientation_transform_parity.py
+++ b/tests/test_orientation_transform_parity.py
@@ -60,6 +60,7 @@ OFFSET_Y = -0.7e-3
 PRESERVE = "preserve"  # x/y come through untouched; only r/t are rewritten
 COMPUCENTRIC = "compucentric"  # x/y go through the compucentric rotation
 RAISES = "raises"  # the conversion is refused
+UNBUILDABLE = "unbuildable"  # the source orientation does not exist on this mounting
 
 # What each (from, to) does today. Read off the implementation and confirmed by running
 # it; see the module docstring for why this is a classification rather than a table of
@@ -86,15 +87,14 @@ COMPUSTAGE_BEHAVIOUR = {
 
 # The offset column is where the branches actually differ.
 #
-# Two entries are worth reading twice, and both are consequences of the FM orientation
-# being a verbatim copy of the FIB one on an offset mount (FIB-830):
-#
-#   FM -> FIB   is PRESERVE, not because a branch says so, but because the source
-#               *classifies as FIB* and `get_target_position` returns early on
-#               `current == target`. It hands back the caller's own position.
-#   FM -> SEM   and FM -> MILLING take the FIB branches for the same reason.
-#
-# Pinned as they are rather than as they ought to be. FIB-830 is where they change.
+# The FM rows used to pin consequences of `orientations["FM"]` being a verbatim copy
+# of the FIB one off a compustage -- FM -> FIB handed back the caller's own position
+# because the source *classified as FIB*, and the other FM sources took the FIB
+# branches the same way. The change this file said "FIB-830 is where they change"
+# about has arrived: the copy is deleted, FM is not an orientation on this mounting
+# at all, and a source position "at the FM orientation" cannot even be built --
+# `get_orientation("FM")` refuses by name. The FM *target* rows still refuse, in
+# `get_target_position` itself.
 OFFSET_BEHAVIOUR = {
     ("SEM", "FIB"): COMPUCENTRIC,
     ("SEM", "MILLING"): PRESERVE,
@@ -105,9 +105,9 @@ OFFSET_BEHAVIOUR = {
     ("MILLING", "SEM"): PRESERVE,
     ("MILLING", "FIB"): COMPUCENTRIC,
     ("MILLING", "FM"): RAISES,
-    ("FM", "SEM"): COMPUCENTRIC,
-    ("FM", "FIB"): PRESERVE,
-    ("FM", "MILLING"): COMPUCENTRIC,
+    ("FM", "SEM"): UNBUILDABLE,
+    ("FM", "FIB"): UNBUILDABLE,
+    ("FM", "MILLING"): UNBUILDABLE,
 }
 
 
@@ -169,6 +169,12 @@ def test_every_pair_keeps_its_current_behaviour(
     """
     microscope = _microscope(compustage)
     expected = behaviour[(source, target)]
+
+    if expected is UNBUILDABLE:
+        with pytest.raises(ValueError, match="not supported"):
+            _position_at(microscope, source)
+        return
+
     position = _position_at(microscope, source)
 
     if expected is RAISES:

--- a/tests/test_simulated_offset_fm.py
+++ b/tests/test_simulated_offset_fm.py
@@ -88,20 +88,22 @@ def test_the_offset_fm_looks_along_the_ion_column():
 # them by loosening the assertion.
 
 
-def test_the_fm_orientation_is_indistinguishable_from_the_fib_one():
+def test_there_is_no_fm_orientation_on_an_offset_mount():
     """The root of it: on an offset mount the FM is a place, not a pose.
 
-    `_update_orientations` copies the FIB entry, so the two are identical and
-    `get_stage_orientation` -- which checks FIB first -- can never answer "FM".
+    `_update_orientations` used to copy the FIB entry -- a second name for a pose
+    that already had one, which `get_stage_orientation` (FIB matches first) could
+    never return. The copy is gone: asking for the FM *orientation* here is a
+    category error, and the position at the FM classifies as the pose it really is.
     Everything below is downstream of this one fact.
     """
     microscope = _microscope(IFLM_CONFIG)
 
-    fm_pose = microscope.get_orientation("FM")
-    fib_pose = microscope.get_orientation("FIB")
-    assert (fm_pose.r, fm_pose.t) == (fib_pose.r, fib_pose.t)
+    with pytest.raises(ValueError, match="not supported"):
+        microscope.get_orientation("FM")
 
-    assert microscope.get_stage_orientation(fm_pose) == "FIB"
+    fib_pose = microscope.get_orientation("FIB")
+    assert microscope.get_stage_orientation(fib_pose) == "FIB"
 
 
 def test_marking_from_the_fluorescence_view_is_refused():
@@ -113,7 +115,7 @@ def test_marking_from_the_fluorescence_view_is_refused():
     microscope = _microscope(IFLM_CONFIG)
 
     with pytest.raises(ValueError, match="offset mount"):
-        _to_milling(microscope, microscope.get_orientation("FM"))
+        _to_milling(microscope, microscope.get_orientation("FIB"))
 
 
 def test_marking_from_the_beam_side_yields_no_fluorescence_pose():
@@ -143,15 +145,20 @@ def test_the_acquisition_guard_can_answer_now():
     )
 
 
-def test_the_traverse_refuses_unless_the_stage_is_already_at_fib():
-    """Step 2 of the workflow leaves the stage at SEM; step 3 will not accept that.
+def test_the_traverse_re_poses_instead_of_refusing():
+    """Step 2 of the workflow leaves the stage at SEM; step 3 accepts that now.
 
-    A real workflow acquires the beam-side overview at the SEM orientation and then
-    moves to the FM, so this refusal is on the ordinary path, not an edge case. The
-    reorientation is something the software could do itself -- see FIB-832.
+    This used to raise "Cannot move to FM from SEM or MILLING orientation" -- a
+    refusal on the ordinary path, since a real workflow acquires the beam-side
+    overview at SEM and then moves to the FM. `move_to_device` plans the route the
+    message told the user to take by hand: re-pose to FIB at the beams, then travel
+    (FIB-832).
     """
     microscope = _microscope(IFLM_CONFIG)
 
     microscope.move_to_orientation("SEM")
-    with pytest.raises(ValueError, match="Cannot move to FM"):
-        microscope.move_to_microscope("FM")
+    microscope.move_to_device("FM")
+
+    assert microscope.get_current_device() == "FM"
+    assert microscope.get_stage_orientation() == "FIB"
+    assert microscope.fm.objective.state == "Inserted"


### PR DESCRIPTION
One call that owns the safe order: retract the objective, re-pose at the beams, travel out. The *"Cannot move to FM from SEM or MILLING orientation"* refusal is deleted — it was an instruction to the user to perform by hand exactly the sequence the software composes everywhere else. The FIB-841 rotation guard stays underneath as the last-line assert; the composed route never trips it (and the tests would trip it if the legs were ever ordered wrongly).

- **Omitted orientation:** the pose is carried across untouched whenever the target device can image from it — a dialled-in milling angle survives the traverse — and otherwise the device's first declared acquisition orientation stands in.
- **The compustage gets the same signature:** `move_to_device("FIBSEM", orientation="MILLING")` lands at MILLING in one call, instead of the SEM-then-MILLING two-step every fluorescence round trip used to pay.
- `move_to_microscope` / `move_to_microscope_compustage` stay as thin deprecated shims for their ~55 call sites.

Also deletes `orientations["FM"]` on offset mounts — the `deepcopy` of the FIB pose that was the root of the whole device/orientation conflation. No classification changes: the copy was byte-identical to FIB, which matches first, so no position ever classified as FM off a compustage. `get_orientation("FM")` now refuses by name there instead of naming a pose that does not exist.

**Stack (5/6).**