### PR TITLE
[ui] Say what is wrong and which verb fixes it (FIB-858)

### DIFF
--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -2418,12 +2418,11 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             return
         # READY strictly: the click becomes a stage move computed through a frame
         # built from the current pose.
-        if (
-            self.microscope.get_device_imaging_state("FM")
-            is not DeviceImagingState.READY
-        ):
+        state = self.microscope.get_device_imaging_state("FM")
+        if state is not DeviceImagingState.READY:
             logging.info(
-                f"Stage must be at the fluorescence microscope to move via FM image (current: {self.microscope.get_stage_orientation()})"
+                "Cannot move the stage via the FM image. "
+                + self.microscope.describe_device_imaging_state("FM", state)
             )
             return
         image_shape = self.fm_canvas._img_shape

--- a/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_fluorescence_position.py
@@ -60,8 +60,11 @@ class SelectFluorescencePositionTask(AutoLamellaTask):
         state = self.microscope.get_device_imaging_state("FM", stage_position)
         if not state.allows_acquisition:
             raise ValueError(
-                f"Stage Position {self.lamella.name} is not one the fluorescence "
-                f"microscope can acquire from: {stage_position.pretty} ({state.value})"
+                f"Cannot acquire at the saved position for {self.lamella.name} "
+                f"({stage_position.pretty}). "
+                + self.microscope.describe_device_imaging_state(
+                    "FM", state, stage_position
+                )
             )
 
         # Check for cancellation before each position

--- a/fibsem/fm/acquisition.py
+++ b/fibsem/fm/acquisition.py
@@ -208,8 +208,8 @@ def acquire_image(
     state = microscope.parent.get_device_imaging_state("FM")
     if not state.allows_acquisition:
         raise ValueError(
-            f"Cannot start acquisition: {state.value} "
-            f"(stage at {microscope.parent.get_stage_orientation()!r})."
+            "Cannot start acquisition. "
+            + microscope.parent.describe_device_imaging_state("FM", state)
         )
 
     if zparams is not None:
@@ -522,8 +522,8 @@ class FMTiledAcquisitionRunner:
         state = microscope.get_device_imaging_state("FM")
         if state is not DeviceImagingState.READY:
             raise ValueError(
-                f"Cannot start a tiled acquisition: {state.value} "
-                f"(stage at {microscope.get_stage_orientation()!r})."
+                "Cannot start a tiled acquisition. "
+                + microscope.describe_device_imaging_state("FM", state)
             )
 
         if not isinstance(self.channel_settings, list):

--- a/fibsem/fm/calibration/__init__.py
+++ b/fibsem/fm/calibration/__init__.py
@@ -122,7 +122,10 @@ def run_autofocus(
 
     state = microscope.parent.get_device_imaging_state("FM")
     if not state.allows_acquisition:
-        raise ValueError(f"Cannot start autofocus: {state.value}.")
+        raise ValueError(
+            "Cannot start autofocus. "
+            + microscope.parent.describe_device_imaging_state("FM", state)
+        )
 
     # Held for the whole sweep, as a tileset holds it for a whole run. Without it
     # every step took and returned the channel on its own -- measured at 43 scopes

--- a/fibsem/fm/microscope.py
+++ b/fibsem/fm/microscope.py
@@ -850,6 +850,35 @@ class FluorescenceMicroscope(ABC):
         self._acquiring_reason = reason if acquiring else ""
         self.acquiring_changed.emit(self.is_acquiring)
 
+    def refusal_to_start(self, what: str) -> Optional[str]:
+        """Why *what* may not start right now, as one actionable sentence -- or None.
+
+        The two questions every entry point has to ask, in the order that matters
+        (FIB-839): *when* first -- is something already driving the instrument --
+        then *where* -- can it image the sample from here. Asked together so no
+        caller assembles them its own way; the control widget used to be the only
+        site that composed both, as a private method returning a bare bool, and
+        every other gate either asked half the question or logged a message about
+        the wrong half.
+
+        Returns the message rather than raising or logging, because the right
+        delivery differs per caller: a workflow raises, a widget toasts, a canvas
+        handler logs. `None` means go.
+        """
+        if self.is_acquiring:
+            reason = self.acquiring_reason or "another acquisition"
+            return (
+                f"Cannot start {what}: the fluorescence microscope is in use "
+                f"({reason})."
+            )
+        state = self.parent.get_device_imaging_state("FM")
+        if not state.allows_acquisition:
+            return (
+                f"Cannot start {what}. "
+                f"{self.parent.describe_device_imaging_state('FM', state)}"
+            )
+        return None
+
     def set_active_channel(self) -> None:
         """Point the microscope's imaging channel at the FM, and leave it there.
 

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -2465,6 +2465,66 @@ class FibsemMicroscope(ABC):
             return DeviceImagingState.NEEDS_REPOSE
         return DeviceImagingState.NEEDS_REPOSE_THEN_TRAVEL
 
+    def describe_device_imaging_state(
+        self,
+        device: str,
+        state: Optional[DeviceImagingState] = None,
+        stage_position: Optional[FibsemStagePosition] = None,
+    ) -> str:
+        """One sentence a person can act on, for each imaging state.
+
+        The vocabulary is the two axes' (FIB-858): the stage travels between
+        *devices* and is re-posed between *orientations*, and the failing term names
+        the verb -- so a refusal built from this says which of the two to do, in
+        which order, rather than announcing a false generality like "not in a valid
+        orientation" for a stage that is 48.8 mm from the instrument.
+
+        Pass `state` when it has already been asked, so a message and the decision it
+        explains cannot be about two different moments.
+        """
+        if state is None:
+            state = self.get_device_imaging_state(device, stage_position)
+
+        instrument = (
+            "the fluorescence microscope" if device == "FM" else f"the {device} device"
+        )
+
+        if state is DeviceImagingState.NO_DEVICE:
+            return "This system has no fluorescence microscope."
+        if state is DeviceImagingState.READY:
+            return f"{instrument.capitalize()} can image the sample from here."
+
+        orientation = self.get_stage_orientation(stage_position)
+        held = (
+            f"held in the {orientation} orientation"
+            if orientation != "NONE"
+            else "held in an unrecognised orientation"
+        )
+        allowed = self._get_device(device).acquisition_orientations
+        images_from = (
+            f"images from the {' or '.join(allowed)} orientation"
+            if allowed
+            else "images from any orientation"
+        )
+
+        if state is DeviceImagingState.NEEDS_TRAVEL:
+            return (
+                f"The stage is {held}, which {instrument} images from, but it is "
+                f"away from the {device} device: travel there "
+                f"(move_to_device('{device}'))."
+            )
+        if state is DeviceImagingState.NEEDS_REPOSE:
+            return (
+                f"The stage is at the {device} device but {held}; {instrument} "
+                f"{images_from}. Re-pose via the beams "
+                f"(move_to_device('{device}', orientation='{allowed[0]}'))."
+            )
+        return (
+            f"The stage is {held}, away from the {device} device; {instrument} "
+            f"{images_from}. Re-pose at the beams and travel out "
+            f"(move_to_device('{device}'))."
+        )
+
     def _warn_on_fluorescence_geometry(self) -> None:
         """Warn, at connect, about FM geometry that will misbehave quietly later.
 

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -556,7 +556,7 @@ class FMOverviewWidget(QWidget):
         # button naming one orientation while going to another is worse than no button.
         self.button_move_to_fm = QPushButton()
         self.button_move_to_fm.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
-        self.button_move_to_fm.clicked.connect(self.move_to_fm_orientation)
+        self.button_move_to_fm.clicked.connect(self.move_to_fm_device)
 
         self.orientation_banner = QWidget()
         banner_layout = QHBoxLayout(self.orientation_banner)
@@ -1760,11 +1760,18 @@ class FMOverviewWidget(QWidget):
             self.microscope.get_device_imaging_state("FM") is DeviceImagingState.READY
         )
 
-    def move_to_fm_orientation(self) -> None:
-        """Drive the stage to the fluorescence orientation, having asked first.
+    def move_to_fm_device(self) -> None:
+        """Drive the stage to where the FM can image, having asked first.
+
+        The target is the *device*, not an orientation -- this used to read a variable
+        named `orientation` from `fm.default_orientation` and pass it to a device
+        parameter, which worked only because "FM" happened to name both (FIB-832). On
+        an offset mount the move is a traverse across the chamber, possibly with a
+        re-pose at the beams first; the confirmation describes the actual route, since
+        one button press should not grow into a multi-leg motion silently.
 
         A real stage move, so it gets the same confirmation as the other moves in this
-        widget -- and the same worker, since `move_to_microscope` blocks for as long as
+        widget -- and the same worker, since `move_to_device` blocks for as long as
         the stage takes.
         """
         if self._running or self.fm.is_acquiring:
@@ -1772,30 +1779,29 @@ class FMOverviewWidget(QWidget):
                 "Cannot move the stage during an acquisition.", "warning"
             )
             return
-        orientation = self.fm.default_orientation
         reply = QMessageBox.question(
             self,
             "Confirm Movement",
-            f"Move the stage to the {orientation} orientation?\n\n"
-            f"The stage is currently at {self.microscope.get_stage_orientation()}.",
+            f"Move the stage to the fluorescence microscope?\n\n"
+            f"{self.microscope.describe_device_imaging_state('FM')}",
             QMessageBox.Yes | QMessageBox.No,
             QMessageBox.No,
         )
         if reply != QMessageBox.Yes:
-            logging.info("Move to FM orientation cancelled by user")
+            logging.info("Move to FM device cancelled by user")
             return
 
-        self.status.setText(f"Moving to {orientation}…")
-        worker = FunctionWorker(self._move_to_orientation_worker, orientation)
+        self.status.setText("Moving to the FM…")
+        worker = FunctionWorker(self._move_to_device_worker, "FM")
         worker.start()
 
-    def _move_to_orientation_worker(self, orientation: str) -> None:
+    def _move_to_device_worker(self, device: str) -> None:
         """Runs off the GUI thread. Only signals may cross back."""
         try:
-            self.microscope.move_to_microscope(orientation)
-            logging.info(f"Moved to {orientation} orientation")
+            self.microscope.move_to_device(device)
+            logging.info(f"Moved to the {device} device")
         except Exception as e:
-            logging.error(f"Failed to move to {orientation} orientation: {e}")
+            logging.error(f"Failed to move to the {device} device: {e}")
         # Not followed by a refresh: the move raises `stage_position_changed`, which
         # arrives at `_on_stage_moved` and re-derives everything the pose feeds.
 
@@ -1838,7 +1844,10 @@ class FMOverviewWidget(QWidget):
                 f"Stage is at {self._where_the_stage_is()} — an overview needs to be at "
                 f"{self._where_the_stage_needs_to_be()}."
             )
-            self.button_move_to_fm.setText(f"Move to {self.fm.default_orientation}")
+            # The device, by name: the button travels to the FM, whatever pose that
+            # takes on this mounting -- naming an orientation here was half of the
+            # device/orientation mix-up FIB-832 records.
+            self.button_move_to_fm.setText("Move to FM")
 
     def _on_fm_acquiring_signal(self, acquiring: bool) -> None:
         """Called by psygnal, on whichever thread started or stopped. No widgets here."""

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -167,7 +167,10 @@ class FMControlWidget(QWidget):
         self.pushButton_run_autofocus = QPushButton("Run Auto-Focus", self)
         self.pushButton_cancel_acquisition = QPushButton("Cancel Acquisition", self)
 
-        # Default orientation for fluorescence pose when adding a lamella
+        # Default orientation for fluorescence pose when adding a lamella. This is a
+        # *planning* choice -- which pose new lamellas get their fluorescence pose
+        # derived into -- and both options are orientations; the device the pose is
+        # imaged at is not this control's business.
         self.label_default_orientation = QLabel("Default Orientation", self)
         self.comboBox_default_orientation = ValueComboBox(parent=self)
         self.comboBox_default_orientation.addItems(["SEM", "FM"])
@@ -175,6 +178,16 @@ class FMControlWidget(QWidget):
         self.comboBox_default_orientation.setToolTip(
             "Stage orientation used when computing the fluorescence pose for new lamellas"
         )
+        # On an offset mount there is no FM orientation and the pose derivation cannot
+        # produce a fluorescence pose at all yet (it needs the device leg -- FIB-831),
+        # so a choice here would decide nothing. Disabled rather than hidden, with the
+        # reason where the user's pointer already is.
+        if not self.microscope.stage_is_compustage:
+            self.comboBox_default_orientation.setEnabled(False)
+            self.comboBox_default_orientation.setToolTip(
+                "Fluorescence poses cannot yet be derived on an offset-mounted FM; "
+                "mark positions from the FM overview instead."
+            )
 
         # Checkbox for lamella association
         self.checkBox_associate_with_lamella = QCheckBox(
@@ -630,19 +643,14 @@ class FMControlWidget(QWidget):
         The pose check used to live in `start_acquisition` alone, so an image, a z-stack
         or an autofocus sweep could be started from a pose the FM cannot see anything
         from. Nothing but the buttons stopped them, and the buttons are not the guard.
+
+        Both questions now live on the instrument (`fm.refusal_to_start`), where every
+        entry point can ask them; this wrapper is the widget's delivery -- log it --
+        plus the bool shape its three callers already branch on.
         """
-        if self.fm.is_acquiring:
-            reason = self.fm.acquiring_reason or "another acquisition"
-            logging.warning(
-                f"Cannot start {what}: the fluorescence microscope is in use ({reason})."
-            )
-            return True
-        state = self.microscope.get_device_imaging_state("FM")
-        if not state.allows_acquisition:
-            logging.warning(
-                f"Cannot start {what}: {state.value} "
-                f"(the stage is at {self.microscope.get_stage_orientation()})."
-            )
+        refusal = self.fm.refusal_to_start(what)
+        if refusal is not None:
+            logging.warning(refusal)
             return True
         return False
 

--- a/tests/fm/test_fm_autofocus.py
+++ b/tests/fm/test_fm_autofocus.py
@@ -191,6 +191,7 @@ def test_run_autofocus_iterations_are_autofocus_iterations():
 def test_run_autofocus_refuses_where_the_fm_cannot_image():
     m = _mock_fm()
     m.parent.get_device_imaging_state.return_value = DeviceImagingState.NEEDS_TRAVEL
+    m.parent.describe_device_imaging_state.return_value = "travel there"
     with pytest.raises(ValueError, match="autofocus"):
         run_autofocus(m)
 

--- a/tests/fm/test_offset_overview_gate.py
+++ b/tests/fm/test_offset_overview_gate.py
@@ -130,7 +130,7 @@ def test_a_compustage_tileset_needs_the_fm_pose():
     assert tiles[0][0] is not None
 
     microscope.move_to_orientation("SEM")
-    with pytest.raises(ValueError, match="needs_repose"):
+    with pytest.raises(ValueError, match="Re-pose"):
         acquire_tileset(
             microscope=microscope,
             channel_settings=CHANNEL,

--- a/tests/test_imaging_state_messages.py
+++ b/tests/test_imaging_state_messages.py
@@ -1,0 +1,170 @@
+"""What a refusal says, now that it can say something true (FIB-858).
+
+Every refusal string in the FM tree used to be phrased as if the system had no
+fluorescence microscope, or as if the stage were merely "not in a valid orientation"
+-- a false generality when it is 48.8 mm from the instrument. The message helper
+speaks the two axes' vocabulary: the stage travels between *devices* and is re-posed
+between *orientations*, and the failing term names the verb.
+"""
+
+import os
+
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.structures import DeviceImagingState
+
+IFLM_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-iflm-configuration.yaml")
+ARCTIS_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
+
+
+def _microscope(config_path: str = IFLM_CONFIG):
+    microscope, _ = utils.setup_session(config_path=config_path)
+    return microscope
+
+
+# ── the failing term names the verb ──────────────────────────────────
+
+
+def test_a_wrong_place_says_travel():
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+
+    message = microscope.describe_device_imaging_state("FM")
+
+    assert "travel" in message
+    assert "move_to_device('FM')" in message
+    assert "re-pose" not in message.lower()
+
+
+def test_a_wrong_pose_says_re_pose():
+    microscope = _microscope(ARCTIS_CONFIG)
+    microscope.move_to_orientation("SEM")
+
+    message = microscope.describe_device_imaging_state("FM")
+
+    assert "Re-pose" in message
+    assert "held in the SEM orientation" in message
+    assert "travel there" not in message
+
+
+def test_wrong_on_both_axes_says_both_in_the_bracketing_order():
+    microscope = _microscope()
+    microscope.move_to_orientation("SEM")
+
+    message = microscope.describe_device_imaging_state("FM")
+
+    assert message.index("Re-pose") < message.index("travel")
+
+
+def test_no_device_is_terminal_and_says_so():
+    microscope = _microscope(cfg.MICROSCOPE_CONFIGURATION_PATH)
+
+    message = microscope.describe_device_imaging_state("FM")
+
+    assert message == "This system has no fluorescence microscope."
+
+
+def test_an_unrecognised_pose_is_not_called_the_none_orientation():
+    """`get_stage_orientation` returns "NONE" for a pose it cannot name, and "held in
+    the NONE orientation" is not a thing to say to anyone."""
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+    position = microscope.get_stage_position()
+    position.t = position.t + 0.5  # ~29 degrees: nothing classifies this
+    microscope.move_stage_absolute(position)
+
+    message = microscope.describe_device_imaging_state("FM")
+
+    assert "NONE" not in message
+    assert "unrecognised" in message
+
+
+def test_a_passed_state_is_the_one_described():
+    """A gate asks once and describes what it asked -- the message and the decision
+    it explains must be about the same moment, even if the stage has since moved."""
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+
+    message = microscope.describe_device_imaging_state(
+        "FM", DeviceImagingState.NEEDS_REPOSE
+    )
+
+    assert "Re-pose" in message
+
+
+# ── the lifted two-question guard ────────────────────────────────────
+
+
+def test_refusal_to_start_asks_when_before_where():
+    """A busy instrument is the answer wherever the stage is."""
+    microscope = _microscope()
+    microscope.move_to_orientation("SEM")  # the where-answer would also refuse
+    microscope.fm.set_acquiring(True, "overview acquisition")
+    try:
+        refusal = microscope.fm.refusal_to_start("a z-stack")
+    finally:
+        microscope.fm.set_acquiring(False)
+
+    assert refusal is not None
+    assert "in use" in refusal
+    assert "overview acquisition" in refusal
+
+
+def test_refusal_to_start_then_asks_where():
+    microscope = _microscope()
+    microscope.move_to_orientation("SEM")
+
+    refusal = microscope.fm.refusal_to_start("a z-stack")
+
+    assert refusal is not None
+    assert refusal.startswith("Cannot start a z-stack.")
+    assert "Re-pose" in refusal and "travel" in refusal
+
+
+def test_nothing_to_refuse_is_none():
+    microscope = _microscope()
+    microscope.move_to_orientation("FIB")
+    microscope.move_to_device("FM")
+
+    assert microscope.fm.refusal_to_start("a z-stack") is None
+
+
+def test_a_compustage_at_a_beam_pose_is_not_refused():
+    """The allowance, surviving the message layer: acquiring in place is permitted
+    from any pose there, so no refusal exists to phrase."""
+    microscope = _microscope(ARCTIS_CONFIG)
+    microscope.move_to_orientation("MILLING")
+
+    assert microscope.fm.refusal_to_start("an image") is None
+
+
+# ── the raised messages carry the same sentences ─────────────────────
+
+
+def test_the_tiled_runner_raises_the_route():
+    from fibsem.fm.acquisition import acquire_tileset
+    from fibsem.fm.structures import (
+        AutoFocusMode,
+        ChannelSettings,
+        OverviewParameters,
+    )
+
+    microscope = _microscope()
+    microscope.move_to_orientation("SEM")
+
+    with pytest.raises(ValueError, match="Re-pose at the beams and travel out"):
+        acquire_tileset(
+            microscope=microscope,
+            channel_settings=ChannelSettings(
+                name="DAPI",
+                excitation_wavelength=358,
+                emission_wavelength=461,
+                power=0.1,
+                exposure_time=0.001,
+            ),
+            overview_parameters=OverviewParameters(
+                rows=1, cols=1, overlap=0.1, autofocus_mode=AutoFocusMode.NONE
+            ),
+        )

--- a/tests/ui/test_fm_acquisition_state.py
+++ b/tests/ui/test_fm_acquisition_state.py
@@ -281,6 +281,10 @@ class TestTheControlWidgetGuard:
         widget = FMControlWidget.__new__(FMControlWidget)
         widget.fm = fm
         widget.microscope = _StageAt(state or DeviceImagingState.READY)
+        # The guard now lives on the instrument (`fm.refusal_to_start`) and asks the
+        # top-level system through `fm.parent` -- wire the harness the way a real
+        # connection does.
+        fm.parent = widget.microscope
         widget._acquisition_thread = None
         return widget
 
@@ -443,6 +447,11 @@ class _StageAt:
 
     def get_device_imaging_state(self, device: str, stage_position=None):
         return self._state
+
+    def describe_device_imaging_state(
+        self, device: str, state=None, stage_position=None
+    ) -> str:
+        return f"described({(state or self._state).value})"
 
     def get_stage_orientation(self, stage_position=None) -> str:
         return "SEM"

--- a/tests/ui/test_fm_overview_orientation.py
+++ b/tests/ui/test_fm_overview_orientation.py
@@ -321,9 +321,13 @@ class TestTheBanner:
 
         assert widget.orientation_banner.isVisibleTo(widget) is False
 
-    def test_the_button_names_where_it_goes(self, widget):
-        """From `default_orientation`, which the control widget can change at runtime --
-        a button naming one orientation while going to another is worse than none."""
+    def test_the_button_names_the_device(self, widget):
+        """ "Move to FM" means the device, on every mounting.
+
+        It used to follow `default_orientation` -- half of the device/orientation
+        mix-up FIB-832 records: the button travels, and on an offset mount what it
+        does is a traverse, not a re-pose, so an orientation name would be wrong
+        exactly where the distinction matters."""
         _pose(widget, "NONE")
 
         assert widget.button_move_to_fm.text() == "Move to FM"
@@ -331,7 +335,7 @@ class TestTheBanner:
         widget.fm.default_orientation = "SEM-ish"
         widget._refresh_orientation_banner()
 
-        assert widget.button_move_to_fm.text() == "Move to SEM-ish"
+        assert widget.button_move_to_fm.text() == "Move to FM"
 
     def test_it_goes_away_again(self, widget):
         _pose(widget, "NONE")
@@ -348,7 +352,7 @@ class TestTheMoveAction:
         _pose(widget, "NONE")
         monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.No)
 
-        widget.move_to_fm_orientation()
+        widget.move_to_fm_device()
 
         assert no_worker == [], "moved the stage without asking"
 
@@ -356,17 +360,17 @@ class TestTheMoveAction:
         _pose(widget, "NONE")
         monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.Yes)
 
-        widget.move_to_fm_orientation()
+        widget.move_to_fm_device()
 
         assert len(no_worker) == 1
         func, args = no_worker[0]
-        assert func == widget._move_to_orientation_worker
+        assert func == widget._move_to_device_worker
         assert args == ("FM",)
 
     def test_the_worker_drives_the_stage(self, widget):
         _pose(widget, "NONE")
 
-        widget._move_to_orientation_worker("FM")
+        widget._move_to_device_worker("FM")
 
         assert widget.microscope.get_stage_orientation() == "FM"
 
@@ -376,9 +380,9 @@ class TestTheMoveAction:
         def _boom(target):
             raise RuntimeError("stage refused")
 
-        monkeypatch.setattr(widget.microscope, "move_to_microscope", _boom)
+        monkeypatch.setattr(widget.microscope, "move_to_device", _boom)
 
-        widget._move_to_orientation_worker("FM")
+        widget._move_to_device_worker("FM")
 
         assert "stage refused" in caplog.text
 
@@ -388,7 +392,7 @@ class TestTheMoveAction:
         monkeypatch.setattr(QMessageBox, "question", lambda *a, **k: QMessageBox.Yes)
         widget._set_running(True)
 
-        widget.move_to_fm_orientation()
+        widget.move_to_fm_device()
 
         assert no_worker == []
 


### PR DESCRIPTION
Every FM refusal now comes from one message helper speaking the two axes' vocabulary: the stage **travels** between devices and is **re-posed** between orientations, and the failing term names the verb, in the bracketing order. No more *"not in a valid orientation"* for a stage that is 48.8 mm from the instrument, and `NO_DEVICE` finally gets its own terminal sentence instead of sharing a `False` with "away".

- `describe_device_imaging_state(device, state)` on `FibsemMicroscope`: one actionable sentence per state, naming the `move_to_device` call that performs the remedy. Takes the already-asked state so a message and the decision it explains cannot be about two different moments.
- `refusal_to_start(what)` on `FluorescenceMicroscope`: the Q2-then-Q1 guard the control widget privately composed, lifted onto the instrument and returning the message rather than a bool — a workflow raises it, a widget toasts it, a canvas handler logs it.
- The overview tab's move button targets the **device**: "Move to FM" means the FM device on every mounting, the confirmation describes the actual route (one press should not grow into a multi-leg motion silently), and the worker calls `move_to_device` — ending the variable named `orientation` that was passed to a device parameter.
- The Default Orientation planner combo is disabled on offset mounts, with the tooltip saying why: fluorescence poses cannot be derived there until the derivation gains the device leg (FIB‑831 — written so the merge does not auto-complete that still-open issue). Compustage behaviour unchanged.

**Stack (6/6).** Top-of-stack verification: `tests/ --ignore=tests/ui` 4384 passed; the FM ui suites 328 passed; and the end-to-end workflow on the offset sim — SEM → `move_to_device("FM")` → z-stack → 2×2 overview → `move_to_device("FIBSEM", orientation="MILLING")` — each leg one call.
