### PR TITLE
[app] See what the GUI sees: /app/images display cache + live prompt mirror

### DIFF
--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -241,6 +241,41 @@ class AgentContext:
             return {"available": False, "position": None}
         return {"available": True, "position": cached.to_dict()}
 
+    def display_images(self) -> Dict[str, Any]:
+        """The SEM/FIB images the GUI is displaying right now, as previews.
+
+        This is the display cache, not an acquisition: nothing touches
+        hardware, and the workflow's post-mill images appear here the moment
+        the GUI shows them — long before task completion writes them to disk —
+        which is what makes inline inspection possible.
+
+        Thread note: grabs the widget's current image references (replaced
+        whole on acquisition, never mutated in place) and encodes previews on
+        the server thread; the GUI thread is neither entered nor blocked.
+        """
+        widget = getattr(self._host, "image_widget", None)
+        if widget is None:
+            return {"available": False, "sem": None, "fib": None}
+        from fibsem.applications.autolamella.server.prompts import _preview_b64
+
+        payload: Dict[str, Any] = {"available": True}
+        for key, image in (
+            ("sem", getattr(widget, "eb_image", None)),
+            ("fib", getattr(widget, "ib_image", None)),
+        ):
+            entry = _preview_b64(getattr(image, "data", None))
+            if entry is not None:
+                entry["acquired_at"] = self._acquired_at(image)
+            payload[key] = entry
+        return payload
+
+    @staticmethod
+    def _acquired_at(image) -> Optional[str]:
+        try:
+            return image.metadata.acquisition_date.isoformat()
+        except Exception:
+            return None
+
     # --- supervision prompts (FIB-851) ------------------------------------------
 
     @property
@@ -263,7 +298,38 @@ class AgentContext:
 
         payload = serialize_request(request)
         payload["nonce"] = nonce
+        current = self._peek_current(responder, payload["type"], nonce)
+        if current is not None:
+            payload["current"] = current
         return {"available": True, "pending": payload}
+
+    def _peek_current(
+        self, responder, request_type: str, nonce: int
+    ) -> Optional[Dict[str, Any]]:
+        """The live half of the question — where the marker IS, not where it
+        started.
+
+        PickPOI and EditAlignmentArea are answered from widget state the
+        operator may still be adjusting; the frozen request only shows the
+        starting value. The peek marshals to the GUI thread, so it is skipped
+        entirely for question types with no live half, and degrades to absent
+        (never an error — the question itself must still be visible) if the GUI
+        is too busy to answer within 2 s or the prompt changed mid-peek.
+        """
+        if request_type not in ("PickPOI", "EditAlignmentArea"):
+            return None
+        from fibsem.applications.autolamella.server.events import to_plain
+
+        try:
+            peeked_nonce, value = responder.peek_live_answer().result(timeout=2.0)
+        except Exception:
+            return None
+        if peeked_nonce != nonce or value is None:
+            return None
+        try:
+            return to_plain(value.to_dict())
+        except Exception:
+            return None
 
     def answer_prompt(
         self, response: bool, nonce: int, timeout: float = 10.0

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -64,6 +64,7 @@ class QtResponder(QObject):
     _agent_answered = pyqtSignal(
         bool, object, object
     )  # (clicked_yes, nonce, Future[bool])
+    _agent_peeked = pyqtSignal(object)  # (Future[(nonce, live value)])
 
     def __init__(self, ui: "AutoLamellaUI"):
         super().__init__()
@@ -102,6 +103,7 @@ class QtResponder(QObject):
         self._spot_burn_finished_wired: Optional[object] = None
         self._submitted.connect(self._dispatch)
         self._agent_answered.connect(self._apply_agent_answer)
+        self._agent_peeked.connect(self._apply_agent_peek)
 
     def submit(self, request: "Request", future: "Future") -> None:
         """Hand ``request`` to the GUI thread; never blocks. Any thread."""
@@ -180,6 +182,63 @@ class QtResponder(QObject):
             self._fail(outcome, exc)
             return
         self._deliver(outcome, applied)
+
+    def peek_live_answer(self) -> "Future":
+        """What would the answer be if Yes were clicked right now? Any thread.
+
+        Some questions are answered from live widget state — the POI marker the
+        operator is dragging, the alignment area being resized — which the
+        frozen request cannot show a remote agent. This reads that state on the
+        GUI thread, without disturbing it: no overlay comes down, nothing is
+        answered. Resolves to ``(nonce, value)`` — the nonce pairs the value
+        with a posting of the question, and value is None for question types
+        with no live half (or no question at all, in which case nonce is None
+        too).
+        """
+        from concurrent.futures import Future as _Future
+
+        outcome: "_Future" = _Future()
+        self._agent_peeked.emit(outcome)
+        return outcome
+
+    def _apply_agent_peek(self, outcome: "Future") -> None:
+        """GUI thread. Complete ``outcome`` with (nonce, live value)."""
+        try:
+            result = self._live_answer()
+        except Exception as exc:  # noqa: BLE001 - the peeker owns the failure
+            self._fail(outcome, exc)
+            return
+        self._deliver(outcome, result)
+
+    def _live_answer(self):
+        """The live half of the pending question, read without taking anything
+        down — the same widget reads as :meth:`answer_confirm`, minus the
+        teardown."""
+        pending = self._pending_question
+        if pending is None or pending[1].cancelled():
+            return None, None
+        request, _, nonce = pending
+        if isinstance(request, PickPOI):
+            controller = self._view_controller()
+            if controller is None:
+                return nonce, None
+            pts = controller.overlay_points(BeamType.ION, "poi")
+            if not pts:
+                return nonce, None
+            from fibsem import conversions
+            from fibsem.structures import Point
+
+            col, row = pts[0]
+            image = request.image
+            return nonce, conversions.image_to_microscope_image_coordinates(
+                Point(x=col, y=row), image.data, image.metadata.pixel_size.x
+            )
+        if isinstance(request, EditAlignmentArea):
+            image_widget = self._ui.image_widget
+            if image_widget is None:
+                return nonce, None
+            return nonce, deepcopy(image_widget.get_alignment_area())
+        return nonce, None
 
     def _dispatch(self, request: "Request", future: "Future") -> None:
         """GUI thread. Complete the future, whatever happens in the handler."""

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -255,6 +255,22 @@ def build_sidecar(client, capabilities):
     def get_events(since: int = 0, timeout: float = 0.0):
         return _app_get(f"/app/events?since={since}&timeout={timeout}")
 
+    def get_display_images():
+        data, err = _call(client, "GET", "/app/images", None)
+        if err:
+            return err
+        # The previews travel as MCP images so the agent sees them directly;
+        # everything else (availability, timestamps) rides along as JSON.
+        content = []
+        for key in ("sem", "fib"):
+            entry = data.get(key)
+            if isinstance(entry, dict) and "image_b64_jpeg" in entry:
+                jpeg = base64.b64decode(entry.pop("image_b64_jpeg"))
+                entry["beam"] = key
+                content.append(Image(data=jpeg, format="jpeg"))
+        content.insert(0, json.dumps(data))
+        return content
+
     def get_pending_prompt():
         return _app_get("/app/prompt")
 
@@ -294,6 +310,7 @@ def build_sidecar(client, capabilities):
             get_task_outputs,
             list_recent_experiments,
             get_events,
+            get_display_images,
             get_pending_prompt,
             answer_prompt,
         )

--- a/fibsem/server/__init__.py
+++ b/fibsem/server/__init__.py
@@ -1,5 +1,41 @@
-from fibsem.server.auth import AuthConfig, Scope
-from fibsem.server.client import FibsemClient
-from fibsem.server.server import FibsemServer, build_server
+"""The fibsem server package.
+
+Exports resolve lazily (PEP 562): the factory and auth pull in FastAPI, but
+sibling modules like ``fibsem.server.images`` (PIL-only) and
+``fibsem.server.catalog`` (stdlib-only) are deliberately importable in
+environments without the [server] extra — the app's prompt/image serializers
+run in the GUI process whether or not a server can be built there. An eager
+import here would make ``from fibsem.server.images import ...`` require
+fastapi transitively, which is exactly what bit the ui-tests CI leg (no
+fastapi installed, preview silently degraded to None).
+"""
+
+from typing import TYPE_CHECKING
 
 __all__ = ["AuthConfig", "FibsemClient", "FibsemServer", "Scope", "build_server"]
+
+_EXPORTS = {
+    "AuthConfig": "fibsem.server.auth",
+    "Scope": "fibsem.server.auth",
+    "FibsemClient": "fibsem.server.client",
+    "FibsemServer": "fibsem.server.server",
+    "build_server": "fibsem.server.server",
+}
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from fibsem.server.auth import AuthConfig, Scope  # noqa: F401
+    from fibsem.server.client import FibsemClient  # noqa: F401
+    from fibsem.server.server import FibsemServer, build_server  # noqa: F401
+
+
+def __getattr__(name):
+    module_name = _EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    return getattr(importlib.import_module(module_name), name)
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -45,6 +45,8 @@ class AppContext(Protocol):
 
     def events(self, since: int = 0, timeout: float = 0.0) -> Dict[str, Any]: ...
 
+    def display_images(self) -> Dict[str, Any]: ...
+
     def pending_prompt(self) -> Dict[str, Any]: ...
 
     def answer_prompt(self, response: bool, nonce: int) -> Dict[str, Any]: ...
@@ -84,6 +86,10 @@ def build_app_router(context: AppContext) -> APIRouter:
     @router.get("/recent_experiments")
     def recent_experiments():
         return {"items": context.recent_experiments()}
+
+    @router.get("/images")
+    def display_images():
+        return context.display_images()
 
     @router.get("/prompt")
     def pending_prompt():

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -226,6 +226,14 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         },
     ),
     ToolSpec(
+        name="get_display_images",
+        description="The SEM and FIB images the app's GUI is displaying right now, as previews — the display cache, not a new acquisition. Post-mill images appear here as soon as the GUI shows them, before they reach disk.",
+        method="GET",
+        path="/app/images",
+        scope="read",
+        router="app",
+    ),
+    ToolSpec(
         name="get_pending_prompt",
         description="The supervision question awaiting an answer, if any — message, options, and context images.",
         method="GET",

--- a/tests/ui/test_agent_context_host.py
+++ b/tests/ui/test_agent_context_host.py
@@ -47,6 +47,35 @@ def test_a_fresh_window_satisfies_the_host_contract(ui):
     assert status["workflow"]["running"] is False
     assert ctx.queue()["available"] is False
     assert ctx.run_summary()["available"] is False
+    # No image widget until a microscope connects: unavailable, not an error.
+    assert ctx.display_images() == {"available": False, "sem": None, "fib": None}
+
+
+def test_display_images_mirror_the_widgets_current_images(ui):
+    import numpy as np
+
+    from fibsem.structures import FibsemImage
+
+    class _Widget:
+        eb_image = FibsemImage.generate_blank_image(resolution=[128, 128], hfw=1e-6)
+        ib_image = None
+
+    _Widget.eb_image.data[:] = np.random.randint(
+        0, 255, _Widget.eb_image.data.shape, dtype=np.uint8
+    )
+    ui.image_widget = _Widget()
+    ctx = AgentContext(ui)
+
+    payload = ctx.display_images()
+    json.dumps(payload)
+    assert payload["available"] is True
+    assert payload["fib"] is None  # nothing displayed on that side yet
+    sem = payload["sem"]
+    assert sem["width"] > 0 and sem["height"] > 0
+    assert sem["image_b64_jpeg"]
+    # Blank placeholders carry no acquisition date; the key degrades to None
+    # rather than the whole payload failing.
+    assert "acquired_at" in sem
 
 
 def test_an_adopted_experiment_is_visible_through_the_facade(ui, tmp_path):

--- a/tests/ui/test_agent_prompt_surface.py
+++ b/tests/ui/test_agent_prompt_surface.py
@@ -100,6 +100,8 @@ def test_agent_sees_and_answers_the_question_over_http(ui, qapp):
         assert pending["message"] == "Continue to polishing?"
         assert pending["positive"] == "Continue"
         assert isinstance(pending["nonce"], int)
+        # A Confirm has no live half — no GUI peek happens, no "current" key.
+        assert "current" not in pending
 
         # POST from a separate thread, as production does: the answer applies on
         # the GUI thread, which in this test is the thread running the loop —
@@ -151,6 +153,15 @@ def test_a_stale_nonce_is_refused_and_the_question_stands(ui, qapp):
         ui.ui_responder.answer_confirm(False)
         _spin_until(qapp, lambda: "answer" in outcome)
         thread.join(timeout=5)
+
+
+def test_display_images_are_served_read_scope(ui, qapp):
+    with _client(ui, arm_control=False) as client:
+        body = client.get("/app/images", headers=AUTH).json()
+        assert body["available"] is True
+        # A connected UI displays the seeded placeholder images on both sides.
+        for beam in ("sem", "fib"):
+            assert body[beam]["image_b64_jpeg"]
 
 
 def test_an_answer_without_a_nonce_is_rejected(ui, qapp):

--- a/tests/ui/test_pick_poi.py
+++ b/tests/ui/test_pick_poi.py
@@ -148,6 +148,59 @@ def test_no_image_or_no_validation_answers_none(ui):
     assert select_poi_ui(parent_ui=ui, image=_fib_image(ui), validate=False) is None
 
 
+def _pending_prompt_on_worker(ui, qapp):
+    """Read the serialized prompt from a worker thread, as the server does.
+
+    The live-answer peek marshals to the GUI thread, so a read from the test
+    (GUI) thread would deadlock — same shape as the HTTP answer tests.
+    """
+    from fibsem.applications.autolamella.server import AgentContext
+
+    ctx = AgentContext(ui)
+    outcome = {}
+
+    def target():
+        outcome["payload"] = ctx.pending_prompt()
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while "payload" not in outcome and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+    assert "payload" in outcome, "pending_prompt never returned"
+    return outcome["payload"]
+
+
+def test_the_prompt_mirrors_the_live_marker_not_the_frozen_request(window, ui, qapp):
+    image = _fib_image(ui)
+    initial = Point(x=1e-6, y=2e-6)
+    thread, _ = _pick_on_worker_thread(ui, qapp, image, initial=initial)
+
+    pending = _pending_prompt_on_worker(ui, qapp)["pending"]
+    assert pending["type"] == "PickPOI"
+    px = image.metadata.pixel_size.x
+    assert pending["current"]["x"] == pytest.approx(initial.x, abs=px)
+    assert pending["current"]["y"] == pytest.approx(initial.y, abs=px)
+
+    # The operator drags the marker: the next read shows where it IS.
+    from fibsem.ui.widgets.canvas.canvas_state import PointsSpec
+
+    controller = window.view_controller
+    moved_row = image.data.shape[0] / 4
+    moved_col = image.data.shape[1] / 4
+    controller.set_overlay(
+        BeamType.ION, PointsSpec(id="poi", points=[(moved_col, moved_row)])
+    )
+    moved = _pending_prompt_on_worker(ui, qapp)["pending"]["current"]
+    assert moved != pending["current"]
+    # And the peek disturbed nothing: the marker is still up, the asker waits.
+    assert controller.overlay_points(BeamType.ION, "poi")
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+
 def test_a_stop_interrupts_a_pick_nobody_confirms(ui, qapp):
     thread, outcome = _pick_on_worker_thread(ui, qapp, _fib_image(ui))
 


### PR DESCRIPTION
Stacked on #678. The other two gaps the live supervised run exposed: an agent judging "did the fiducial mill through?" could only see images after they reached disk at task completion, and a prompt about a marker the operator was still dragging showed the agent only where the marker *started*.

## How it works (plain language)

**`GET /app/images`** answers "what is on the app's screen right now?" The GUI keeps the images it displays in a cache (`image_widget.eb_image` / `ib_image`); this endpoint returns both as the standard agent-sized JPEG previews, plus `acquired_at` when the image carries an acquisition date. It is explicitly *not* an acquisition — nothing touches hardware, same rule as every read route. Post-mill images land in this cache the moment the GUI shows them, long before task completion writes them to disk, so inline inspect-before-continue works mid-task.

Threading: the endpoint grabs the widget's current image *references* — a new image object replaces the old one wholesale on each acquisition, nothing is edited in place — and does the JPEG encoding on the server thread. The GUI thread is never entered and never blocked.

**The prompt's `current` field** solves the frozen-snapshot problem. PickPOI and EditAlignmentArea are answered from live widget state; the frozen request only knows the starting value. Now `GET /app/prompt` also reports where the marker/area IS:

- the responder gains `peek_live_answer()" — the same signal-and-Future marshalling as answers, so the widget reads happen on the GUI thread (never cross-thread), using the same reads as the Yes click but with no teardown: the overlay stays up, nothing is answered;
- the peek runs *only* for question types with a live half — a plain Confirm pays zero overhead;
- the peeked value is paired with the prompt **nonce** (from #678): if the question changed mid-peek the value is dropped, so `current` can never describe a different question than the rest of the payload;
- any failure or a busy GUI (2 s timeout) degrades to the key being absent — a broken preview must never hide the question itself.

Sidecar: new `get_display_images` tool (27 total) returns the previews as MCP images so an agent sees them directly.

## Tests

- POI harness (full main window): `current` matches the initial marker, tracks a drag on re-read, and the peek disturbs nothing (overlay still up, asker still waiting).
- Confirm prompts carry no `current`; `/app/images` serves both beams on a connected UI (read scope); fresh window degrades to `available: false`; blank placeholders degrade `acquired_at` to null.
- 101 tests green across the responder/prompt/POI/context/server suites.