### PR TITLE
[app] Ticking the agent-server box acts now, not at the next connect

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -868,6 +868,11 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
     def _apply_preferences(self):
         """Apply current preferences to UI state."""
+        # The embedded agent server follows its flag immediately: ticking the
+        # box mid-session starts it against the connected microscope (or stops
+        # it), instead of waiting for the next connect.
+        if getattr(self, "autolamella_ui", None) is not None:
+            self.autolamella_ui.sync_agent_server_with_preference()
         d = self._preferences.display
         self._sound_enabled = d.sound_enabled
         self._border_enabled = d.border_enabled

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -639,6 +639,21 @@ class AutoLamellaUI(QMainWindow):
                 self._agent_server_host = AgentServerHost(self)
             self._agent_server_host.start(self.microscope)
 
+    def sync_agent_server_with_preference(self) -> None:
+        """Start or stop the embedded server to match the saved preference.
+
+        Called after preferences are saved, so ticking the box acts now rather
+        than at the next connect. Starting needs a connected microscope (the
+        server wraps it); without one this is a no-op and the connect path
+        picks the preference up as before.
+        """
+        host = self._agent_server_host
+        if fibsem_cfg.load_user_preferences().features.agent_server_enabled:
+            if self.microscope is not None and (host is None or not host.running):
+                self._start_agent_server()
+        elif host is not None and host.running:
+            host.stop()
+
     def disconnect_from_microscope(self):
         if self._agent_server_host is not None:
             self._agent_server_host.stop()

--- a/tests/ui/test_agent_server_hosting.py
+++ b/tests/ui/test_agent_server_hosting.py
@@ -77,7 +77,60 @@ def test_connect_starts_a_live_read_only_server(ui, agent_server_enabled):
     assert not host.running
 
 
-def test_default_preference_hosts_nothing(ui):
+def _confine_and_control_preferences(monkeypatch, tmp_path):
+    """A mutable preferences object the tests flip, host confined to a test port."""
+    preferences = fibsem_cfg.UserPreferences()
+    monkeypatch.setattr(fibsem_cfg, "load_user_preferences", lambda: preferences)
+    real_host = hosting.AgentServerHost
+    port = _free_port()
+    monkeypatch.setattr(
+        hosting,
+        "AgentServerHost",
+        lambda ui_object, **kwargs: real_host(
+            ui_object, port=port, discovery_path=tmp_path / "agent-server.json"
+        ),
+    )
+    return preferences
+
+
+def test_saving_the_preference_mid_session_starts_and_stops_the_server(
+    ui, monkeypatch, tmp_path
+):
+    preferences = _confine_and_control_preferences(monkeypatch, tmp_path)
+    ui.system_widget.connect_to_microscope()
+    ui.connect_to_microscope()
+    assert ui._agent_server_host is None  # flag off at connect, as before
+
+    # The user ticks the box and saves: the server starts now, not next connect.
+    preferences.features.agent_server_enabled = True
+    ui.sync_agent_server_with_preference()
+    host = ui._agent_server_host
+    assert host is not None and host.running
+
+    # Already matching: syncing again must not restart or double-bind.
+    ui.sync_agent_server_with_preference()
+    assert ui._agent_server_host is host and host.running
+
+    # Unticking stops it just as immediately.
+    preferences.features.agent_server_enabled = False
+    ui.sync_agent_server_with_preference()
+    assert not host.running
+
+
+def test_syncing_without_a_microscope_waits_for_connect(ui, monkeypatch, tmp_path):
+    preferences = _confine_and_control_preferences(monkeypatch, tmp_path)
+    preferences.features.agent_server_enabled = True
+    ui.sync_agent_server_with_preference()
+    # Nothing to serve yet: the connect path picks the preference up, as before.
+    assert ui._agent_server_host is None
+
+
+def test_default_preference_hosts_nothing(ui, monkeypatch):
+    # Pinned to actual defaults: this machine's preference file may have the
+    # flag on (it survives in the worktree), and that must not fake a failure.
+    monkeypatch.setattr(
+        fibsem_cfg, "load_user_preferences", lambda: fibsem_cfg.UserPreferences()
+    )
     ui.system_widget.connect_to_microscope()
     ui.connect_to_microscope()
     assert ui._agent_server_host is None


### PR DESCRIPTION
Stacked on #687. The last item from the live run's build list (the one-shot acquisition events item was deliberately dropped — single-shot acquires not emitting signals is by design, so the GUI isn't repainted by every workflow acquire; revisit separately if ever).

## How it works

The agent-server preference was only read inside the microscope-connect path, so enabling it mid-session silently did nothing until a reconnect — exactly what happened in the demo. `AutoLamellaUI` gains `sync_agent_server_with_preference()": start the host against the connected microscope when the flag is on, stop it when the flag goes off, no-op when nothing is connected (the connect path still picks it up, as before) or when the state already matches (no restart, no double-bind). The main window calls it from `_apply_preferences()", which runs on every preferences-dialog accept.

Also makes `test_default_preference_hosts_nothing` hermetic: it read the machine's real preference file, where the flag can legitimately be on (it survives in a worktree), faking a failure. "Default preference" now means default `UserPreferences`.

19 tests green in the hosting + preferences-dialog suites, including start→idempotent-sync→stop mid-session coverage.