### PR TITLE
[app] The run summary survives its own dialog

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -253,6 +253,10 @@ class AutoLamellaUI(QMainWindow):
         # agent_server_enabled preference is on; None means the feature is off.
         self._agent_server_host = None
         self._last_run_summary: Optional["pd.DataFrame"] = None
+        # The summary the dialog has already shown (by identity): the dialog is
+        # once-per-run, while _last_run_summary itself must survive as the
+        # record remote readers see.
+        self._shown_run_summary: Optional["pd.DataFrame"] = None
 
         # setup connections
         self.setup_connections()
@@ -1904,10 +1908,20 @@ class AutoLamellaUI(QMainWindow):
         self._show_workflow_summary()
 
     def _show_workflow_summary(self) -> None:
-        """Show a modal summary dialog of the tasks run in the last workflow."""
+        """Show a modal summary dialog of the tasks run in the last workflow.
+
+        Show-once, but never consume: ``_last_run_summary`` is also the
+        record the agent server's ``run_summary`` endpoint reads after the
+        worker nulls the manager — nulling it here meant the record lived
+        only for the milliseconds between the worker's capture and this
+        handler, and every remote read found nothing. The record stays until
+        the next run's capture overwrites it; only the dialog is once-only.
+        """
         summary = self._last_run_summary
-        self._last_run_summary = None
-        if summary is None or summary.empty:
+        if summary is None or summary is self._shown_run_summary:
+            return
+        self._shown_run_summary = summary
+        if summary.empty:
             return
         try:
             dialog = WorkflowSummaryDialog(summary, parent=self)

--- a/tests/ui/test_agent_context_host.py
+++ b/tests/ui/test_agent_context_host.py
@@ -62,3 +62,47 @@ def test_an_adopted_experiment_is_visible_through_the_facade(ui, tmp_path):
     assert status["experiment"]["name"] == "host-exp"
     assert status["experiment"]["num_items"] == 1
     assert ctx.task_outputs(exp.positions[0].name)["available"] is True
+
+
+def test_run_summary_survives_the_post_run_dialog(ui, monkeypatch):
+    # The live-run regression: _show_workflow_summary used to consume
+    # _last_run_summary to make the dialog once-only, so a remote read after
+    # the run always found nothing. The dialog stays once-only; the record
+    # stays readable.
+    import pandas as pd
+
+    from fibsem.applications.autolamella.ui import AutoLamellaUI as ui_module
+
+    shown = []
+
+    class _Dialog:
+        def __init__(self, summary, parent=None):
+            shown.append(summary)
+
+        def exec_(self):
+            return 0
+
+    monkeypatch.setattr(ui_module, "WorkflowSummaryDialog", _Dialog)
+    ui._last_run_summary = pd.DataFrame(
+        [
+            {
+                "lamella_name": "01",
+                "task_name": "Rough Milling",
+                "task_status": "Finished",
+            }
+        ]
+    )
+
+    ui._show_workflow_summary()
+    ui._show_workflow_summary()  # a second finished-signal must not re-show
+    assert len(shown) == 1
+
+    payload = AgentContext(ui).run_summary()
+    assert payload["available"] is True
+    assert payload["items"][0]["task_name"] == "Rough Milling"
+    json.dumps(payload)
+
+    # The next run's capture is a new object: the dialog shows again.
+    ui._last_run_summary = pd.DataFrame([{"task_name": "Polishing"}])
+    ui._show_workflow_summary()
+    assert len(shown) == 2


### PR DESCRIPTION
Independent of the agent-server stack (branched off main).

The live supervised run found `/app/run_summary` always `available: false` after a workflow ended, even though the worker's `finally` dutifully captures `_last_run_summary` before nulling the task manager. The thief was the post-run summary **dialog**: `_show_workflow_summary` consumed the attribute (set it to None) to make itself once-only. So the record existed for exactly the milliseconds between the worker's capture and the GUI's finished handler — every remote read after a run found nothing, while the in-app dialog worked perfectly, which is why this survived until something *other than the dialog* wanted the data.

Fix: the dialog stays once-only, tracked by object identity (`_shown_run_summary`); the record itself stays until the next run's capture overwrites it. A second finished-signal can't re-show the dialog; the next run's summary (a new object) shows again.

Regression test drives the real window: dialog shown once across two calls, the facade's `run_summary()` still serves the items afterwards, and a fresh run's summary re-shows.