### PR TITLE
[app] The question timeline: who answered what, under the buttons

### DIFF
--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -299,6 +299,28 @@ class AgentContext:
         host.stop_task_workflow()
         return {"available": True, "stopped": True}
 
+    def start_workflow(
+        self,
+        task_names: List[str],
+        item_names: Optional[List[str]] = None,
+        timeout: float = 15.0,
+    ) -> Dict[str, Any]:
+        """Start a workflow as the Run button would — the batch-review opener.
+
+        Marshalled to the GUI thread (which owns worker creation and window
+        chrome); validation refusals come back structured with the valid
+        names. ``item_names`` of None means every item in the experiment.
+        Control-scope arming is the consent that stands in for the Run
+        click's confirm dialog.
+        """
+        host = self._host
+        if not hasattr(host, "request_start_workflow"):
+            return {"available": False, "started": False}
+        outcome = host.request_start_workflow(list(task_names), item_names)
+        result = outcome.result(timeout=timeout)
+        result["available"] = True
+        return result
+
     def set_supervision(self, task_name: str, supervise: bool) -> Dict[str, Any]:
         """Set whether ``task_name`` asks for supervision, in the live protocol.
 

--- a/fibsem/applications/autolamella/server/hosting.py
+++ b/fibsem/applications/autolamella/server/hosting.py
@@ -120,10 +120,8 @@ class AgentServerHost:
         # polling /app/prompt, and answers carry who answered them.
         responder = getattr(self._ui, "ui_responder", None)
         if responder is not None:
-            buffer = self.event_buffer
-            responder.on_question_event = buffer.append
             self._disposers.append(
-                lambda: setattr(responder, "on_question_event", None)
+                responder.add_question_observer(self.event_buffer.append)
             )
 
         app = build_server(

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -196,6 +196,9 @@ class AutoLamellaUI(QMainWindow):
         # The Qt side of the workflow's Responder seam: workflow code is handed
         # this one-method object, never the window itself.
         self.ui_responder = QtResponder(self)
+        # The timeline renders the responder's question-lifecycle feed; the
+        # widget itself is built in _setup_ui, before the responder exists.
+        self.ui_responder.add_question_observer(self.question_timeline.record)
 
         self._protocol_lock = threading.RLock()
 
@@ -302,11 +305,20 @@ class AutoLamellaUI(QMainWindow):
         self.pushButton_yes = QPushButton("Yes")
         self.pushButton_no = QPushButton("No")
 
+        # Who answered what, under the buttons: fed by the responder's
+        # question-lifecycle feed, hidden until the first answer.
+        from fibsem.applications.autolamella.ui.question_timeline_widget import (
+            QuestionTimelineWidget,
+        )
+
+        self.question_timeline = QuestionTimelineWidget(self.centralwidget)
+
         self.gridLayout.addWidget(self.tabWidget, 1, 0, 1, 2)
         self.gridLayout.addWidget(self.label_workflow_information, 2, 0, 1, 2)
         self.gridLayout.addWidget(self.label_instructions, 3, 0, 1, 2)
         self.gridLayout.addWidget(self.pushButton_yes, 4, 0)
         self.gridLayout.addWidget(self.pushButton_no, 4, 1)
+        self.gridLayout.addWidget(self.question_timeline, 5, 0, 1, 2)
 
         self.setCentralWidget(self.centralwidget)
         self.tabWidget.setCurrentIndex(0)

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -103,6 +103,8 @@ from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget
 from fibsem.ui.widgets.workflow_summary_dialog import WorkflowSummaryDialog
 
 if TYPE_CHECKING:
+    from concurrent.futures import Future
+
     import pandas as pd
 
     from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
@@ -183,6 +185,9 @@ class AutoLamellaUI(QMainWindow):
     _hook_toast_signal = pyqtSignal(
         str, str
     )  # (message, notification_type) — thread-safe bridge for NotificationHook
+    # A remote (agent) start request, marshalled to the GUI thread the same
+    # way agent answers are: (task_names, item_names, Future[dict]).
+    _agent_start_workflow = pyqtSignal(list, object, object)
 
     def __init__(
         self,
@@ -199,6 +204,7 @@ class AutoLamellaUI(QMainWindow):
         # The timeline renders the responder's question-lifecycle feed; the
         # widget itself is built in _setup_ui, before the responder exists.
         self.ui_responder.add_question_observer(self.question_timeline.record)
+        self._agent_start_workflow.connect(self._apply_agent_start_workflow)
 
         self._protocol_lock = threading.RLock()
 
@@ -1033,6 +1039,88 @@ class AutoLamellaUI(QMainWindow):
             self._run_tasks_worker, selected_tasks, selected_lamella
         )
         self._task_worker_thread.start()
+
+    def request_start_workflow(
+        self, task_names: List[str], item_names: Optional[List[str]] = None
+    ) -> "Future":
+        """Start a workflow as the Run button would; any thread.
+
+        The agent-facing start: marshalled to the GUI thread (which owns the
+        worker creation and the window chrome), resolving to a plain dict —
+        ``{"started": True}`` or a structured refusal with the valid names.
+        Control-scope arming is the consent that replaces the Run click's
+        confirm dialog.
+        """
+        from concurrent.futures import Future as _Future
+
+        outcome: "_Future" = _Future()
+        self._agent_start_workflow.emit(list(task_names), item_names, outcome)
+        return outcome
+
+    def _apply_agent_start_workflow(
+        self, task_names: List[str], item_names, outcome: "Future"
+    ) -> None:
+        """GUI thread. Complete ``outcome`` with the start result."""
+        try:
+            result = self._start_workflow_for_agent(task_names, item_names)
+        except Exception as exc:  # noqa: BLE001 - the requester owns the failure
+            outcome.set_exception(exc)
+            return
+        outcome.set_result(result)
+
+    def _start_workflow_for_agent(
+        self, task_names: List[str], item_names: Optional[List[str]]
+    ) -> dict:
+        """Validate and start, mirroring the Run click's path (GUI thread)."""
+        if self.is_workflow_running:
+            return {"started": False, "reason": "a workflow is already running"}
+        if self.microscope is None:
+            return {"started": False, "reason": "no microscope is connected"}
+        experiment = self.experiment
+        protocol = self.protocol
+        if experiment is None or protocol is None:
+            return {"started": False, "reason": "no experiment is loaded"}
+        known_tasks = [t.name for t in protocol.workflow_config.tasks]
+        unknown = [t for t in task_names if t not in known_tasks]
+        if not task_names or unknown:
+            return {
+                "started": False,
+                "reason": f"unknown tasks: {unknown!r}" if unknown else "no tasks",
+                "task_names": known_tasks,
+            }
+        known_items = [p.name for p in experiment.positions]
+        if item_names is not None:
+            missing = [n for n in item_names if n not in known_items]
+            if missing:
+                return {
+                    "started": False,
+                    "reason": f"unknown items: {missing!r}",
+                    "item_names": known_items,
+                }
+        # The chrome the Run click supplies around the shared start. Guarded:
+        # the standalone window has no parent to decorate.
+        parent = self.parent_widget
+        if parent is not None:
+            try:
+                # FIB-683 one-writer rule: land any edit still in the editor
+                # before the run's thread becomes the experiment's writer.
+                parent.lamella_widget.flush_pending_save()
+            except Exception:
+                logging.exception("flush before agent start failed; continuing")
+        self._start_run_workflow_thread(
+            task_names, list(item_names) if item_names is not None else known_items
+        )
+        started = self.is_workflow_running
+        if started and parent is not None:
+            try:
+                supervised = protocol.get_supervision(task_names[0])
+                parent._set_border_state("supervised" if supervised else "automated")
+                # Show the Stop button immediately — a remotely started run
+                # must be just as cancellable as a clicked one.
+                parent.set_workflow_running()
+            except Exception:
+                logging.exception("window chrome after agent start failed")
+        return {"started": started}
 
     def _run_tasks_worker(
         self, task_names: List[str], lamella_names: Optional[List[str]] = None

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -27,7 +27,7 @@ arrives belonged to a waiter that aborted and unwound, and is cancelled.
 import logging
 from concurrent.futures import InvalidStateError
 from copy import deepcopy
-from typing import TYPE_CHECKING, Callable, Dict, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Type
 
 from PyQt5.QtCore import QObject, pyqtSignal
 
@@ -102,26 +102,37 @@ class QtResponder(QObject):
         # Same pair for the spot-burn question.
         self._active_spot_burn: Optional[Tuple[RunSpotBurn, "Future"]] = None
         self._spot_burn_finished_wired: Optional[object] = None
-        # Question-lifecycle observer (prompt_raised / prompt_answered /
-        # prompt_cancelled), set by whoever wants the feed — the agent server's
-        # hosting points it at the event buffer. One optional callable rather
-        # than a signal: there is exactly one feed, and a missing observer must
-        # cost nothing on the click path.
-        self.on_question_event: Optional[Callable[[str, Dict], None]] = None
+        # Question-lifecycle observers (prompt_raised / prompt_answered /
+        # prompt_cancelled): the agent server's hosting feeds the event buffer,
+        # the GUI timeline records who answered. A plain list rather than a Qt
+        # signal so each observer is exception-isolated — a failing observer
+        # must never break the click (or the other observers) it is watching.
+        self._question_observers: List[Callable[[str, Dict], None]] = []
         self._submitted.connect(self._dispatch)
         self._agent_answered.connect(self._apply_agent_answer)
         self._agent_peeked.connect(self._apply_agent_peek)
 
+    def add_question_observer(
+        self, observer: Callable[[str, Dict], None]
+    ) -> Callable[[], None]:
+        """Subscribe to question-lifecycle events; returns the unsubscribe."""
+        self._question_observers.append(observer)
+
+        def dispose() -> None:
+            try:
+                self._question_observers.remove(observer)
+            except ValueError:
+                pass
+
+        return dispose
+
     def _emit_question_event(self, kind: str, payload: Dict) -> None:
-        """Tell the observer, if any. An observer failure must never break the
-        click (or the agent answer) that caused the event."""
-        observer = self.on_question_event
-        if observer is None:
-            return
-        try:
-            observer(kind, payload)
-        except Exception:  # noqa: BLE001 - observers are not allowed to matter
-            logging.exception("question-event observer failed; continuing")
+        """Tell every observer, each on its own; failures are logged, never raised."""
+        for observer in list(self._question_observers):
+            try:
+                observer(kind, payload)
+            except Exception:  # noqa: BLE001 - observers are not allowed to matter
+                logging.exception("question-event observer failed; continuing")
 
     def submit(self, request: "Request", future: "Future") -> None:
         """Hand ``request`` to the GUI thread; never blocks. Any thread."""

--- a/fibsem/applications/autolamella/ui/question_timeline_widget.py
+++ b/fibsem/applications/autolamella/ui/question_timeline_widget.py
@@ -1,0 +1,85 @@
+"""Who answered what: the question timeline under the workflow interaction area.
+
+A dumb render of the responder's question-lifecycle feed — one row per
+answered (or withdrawn) question, newest first, capped. It subscribes to the
+same single code path that applies answers, so it can never show something
+that didn't happen; there is no "update the timeline" step to forget.
+
+User-facing wording rule: who · what · when. Wire vocabulary (nonces, request
+type names) stays off the screen.
+"""
+
+import time
+from typing import Dict
+
+from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+from fibsem.ui import tokens
+from fibsem.ui.stylesheets import BORDER_STATE_COLOURS
+
+__all__ = ["QuestionTimelineWidget"]
+
+# Request type -> what the row calls it. Fallback is the type name itself,
+# so a new question type degrades to jargon rather than to silence.
+_QUESTION_LABELS = {
+    "Confirm": "confirmation",
+    "RunMillingTask": "Run Milling",
+    "RunSpotBurn": "Run Spot Burn",
+    "PickPOI": "point of interest",
+    "EditAlignmentArea": "alignment area",
+    "ConfirmDetection": "detection",
+}
+
+_ROW_STYLESHEET = (
+    f"color: {tokens.TEXT_MUTED_COLOR}; font-size: 11px; "
+    'font-family: "Menlo", "Consolas", monospace;'
+)
+_AGENT_ROW_STYLESHEET = (
+    f"color: {BORDER_STATE_COLOURS['agent']}; font-size: 11px; "
+    'font-family: "Menlo", "Consolas", monospace;'
+)
+
+
+class QuestionTimelineWidget(QWidget):
+    """The last few supervision answers, newest first. GUI thread only."""
+
+    MAX_ROWS = 6
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._layout = QVBoxLayout(self)
+        self._layout.setContentsMargins(0, 2, 0, 0)
+        self._layout.setSpacing(1)
+        # Nothing to show until a question is answered; an empty strip is noise.
+        self.setVisible(False)
+
+    def record(self, kind: str, payload: Dict) -> None:
+        """One lifecycle event in; zero or one row out. Ignores prompt_raised —
+        the standing question already has the whole instruction label."""
+        if kind == "prompt_answered":
+            who = "agent" if payload.get("answered_by") == "agent" else "you"
+            verb = "answered" if payload.get("response") else "declined"
+            label = _QUESTION_LABELS.get(payload.get("type"), payload.get("type"))
+            self._add_row(f"{who} · {verb} {label} · {self._now()}", who == "agent")
+        elif kind == "prompt_cancelled":
+            self._add_row(f"question withdrawn · {self._now()}", False)
+
+    def _now(self) -> str:
+        return time.strftime("%H:%M:%S")
+
+    def _add_row(self, text: str, is_agent: bool) -> None:
+        row = QLabel(text)
+        row.setStyleSheet(_AGENT_ROW_STYLESHEET if is_agent else _ROW_STYLESHEET)
+        self._layout.insertWidget(0, row)
+        while self._layout.count() > self.MAX_ROWS:
+            item = self._layout.takeAt(self._layout.count() - 1)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+        self.setVisible(True)
+
+    def rows(self):
+        """The visible row texts, newest first (for tests and tooling)."""
+        return [
+            self._layout.itemAt(i).widget().text() for i in range(self._layout.count())
+        ]

--- a/fibsem/applications/autolamella/ui/question_timeline_widget.py
+++ b/fibsem/applications/autolamella/ui/question_timeline_widget.py
@@ -1,17 +1,25 @@
-"""Who answered what: the question timeline under the workflow interaction area.
+"""Who answered what: the latest supervision answer, under the interaction area.
 
-A dumb render of the responder's question-lifecycle feed — one row per
-answered (or withdrawn) question, newest first, capped. It subscribes to the
-same single code path that applies answers, so it can never show something
-that didn't happen; there is no "update the timeline" step to forget.
+A dumb render of the responder's question-lifecycle feed — the single most
+recent answered (or withdrawn) question on one line, with the last few kept
+as the line's tooltip. One line rather than a stack: the glance question is
+"did the agent just act?", and a growing list under the buttons is noise
+(operator feedback from the first live look). The durable history is the
+experiment logfile and the event stream, not this label.
+
+It subscribes to the same single code path that applies answers, so it can
+never show something that didn't happen; there is no "update the timeline"
+step to forget.
 
 User-facing wording rule: who · what · when. Wire vocabulary (nonces, request
 type names) stays off the screen.
 """
 
 import time
-from typing import Dict
+from collections import deque
+from typing import Deque, Dict, Tuple
 
+from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 from fibsem.ui import tokens
@@ -34,52 +42,63 @@ _ROW_STYLESHEET = (
     f"color: {tokens.TEXT_MUTED_COLOR}; font-size: 11px; "
     'font-family: "Menlo", "Consolas", monospace;'
 )
-_AGENT_ROW_STYLESHEET = (
-    f"color: {BORDER_STATE_COLOURS['agent']}; font-size: 11px; "
-    'font-family: "Menlo", "Consolas", monospace;'
-)
+_AGENT_COLOR = BORDER_STATE_COLOURS["agent"]
 
 
 class QuestionTimelineWidget(QWidget):
-    """The last few supervision answers, newest first. GUI thread only."""
+    """The most recent supervision answer; recent ones on hover. GUI thread only."""
 
-    MAX_ROWS = 6
+    HISTORY = 6
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self._layout = QVBoxLayout(self)
-        self._layout.setContentsMargins(0, 2, 0, 0)
-        self._layout.setSpacing(1)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 2, 0, 0)
+        layout.setSpacing(0)
+        self._label = QLabel("")
+        self._label.setTextFormat(Qt.RichText)  # only "agent" is coloured
+        self._label.setStyleSheet(_ROW_STYLESHEET)
+        layout.addWidget(self._label)
+        self._current = ""
+        self._history: Deque[Tuple[str, bool]] = deque(maxlen=self.HISTORY)
         # Nothing to show until a question is answered; an empty strip is noise.
         self.setVisible(False)
 
     def record(self, kind: str, payload: Dict) -> None:
-        """One lifecycle event in; zero or one row out. Ignores prompt_raised —
+        """One lifecycle event in; the line updates. Ignores prompt_raised —
         the standing question already has the whole instruction label."""
         if kind == "prompt_answered":
             who = "agent" if payload.get("answered_by") == "agent" else "you"
             verb = "answered" if payload.get("response") else "declined"
             label = _QUESTION_LABELS.get(payload.get("type"), payload.get("type"))
-            self._add_row(f"{who} · {verb} {label} · {self._now()}", who == "agent")
+            self._show(f"{who} · {verb} {label} · {self._now()}", who == "agent")
         elif kind == "prompt_cancelled":
-            self._add_row(f"question withdrawn · {self._now()}", False)
+            self._show(f"question withdrawn · {self._now()}", False)
 
     def _now(self) -> str:
         return time.strftime("%H:%M:%S")
 
-    def _add_row(self, text: str, is_agent: bool) -> None:
-        row = QLabel(text)
-        row.setStyleSheet(_AGENT_ROW_STYLESHEET if is_agent else _ROW_STYLESHEET)
-        self._layout.insertWidget(0, row)
-        while self._layout.count() > self.MAX_ROWS:
-            item = self._layout.takeAt(self._layout.count() - 1)
-            widget = item.widget()
-            if widget is not None:
-                widget.deleteLater()
+    def _show(self, text: str, is_agent: bool) -> None:
+        self._history.appendleft((text, is_agent))
+        self._current = text
+        if is_agent:
+            # Just the who is purple; the rest of the line stays quiet.
+            self._label.setText(
+                text.replace(
+                    "agent", f'<span style="color:{_AGENT_COLOR}">agent</span>', 1
+                )
+            )
+        else:
+            self._label.setText(text)
+        # The recent trail lives in the tooltip, newest first.
+        self._label.setToolTip("\n".join(row for row, _ in self._history))
         self.setVisible(True)
 
     def rows(self):
-        """The visible row texts, newest first (for tests and tooling)."""
-        return [
-            self._layout.itemAt(i).widget().text() for i in range(self._layout.count())
-        ]
+        """The remembered rows, newest first (for tests, tooling — and the
+        tooltip)."""
+        return [row for row, _ in self._history]
+
+    def current_text(self) -> str:
+        """The one visible line, as plain text."""
+        return self._current

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -259,6 +259,13 @@ def build_sidecar(client, capabilities):
         data, err = _call(client, "POST", "/app/workflow/stop", None)
         return err if err else data
 
+    def start_workflow(task_names: list, item_names: list = None):  # noqa: RUF013
+        payload = {"task_names": list(task_names)}
+        if item_names is not None:
+            payload["item_names"] = list(item_names)
+        data, err = _call(client, "POST", "/app/workflow/start", payload)
+        return err if err else data
+
     def set_task_supervision(task_name: str, supervise: bool):
         data, err = _call(
             client,
@@ -338,6 +345,7 @@ def build_sidecar(client, capabilities):
             stop_workflow,
             set_task_supervision,
             requeue_task,
+            start_workflow,
         )
     }
     # The catalog is the contract: refuse to start with an implementation gap.

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -12,7 +12,7 @@ The read-scope requirement is applied where the router is included, so auth
 stays in one place (build_server).
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
 
@@ -52,6 +52,10 @@ class AppContext(Protocol):
     def answer_prompt(self, response: bool, nonce: int) -> Dict[str, Any]: ...
 
     def stop_workflow(self) -> Dict[str, Any]: ...
+
+    def start_workflow(
+        self, task_names: List[str], item_names: Optional[List[str]] = None
+    ) -> Dict[str, Any]: ...
 
     def set_supervision(self, task_name: str, supervise: bool) -> Dict[str, Any]: ...
 
@@ -156,6 +160,33 @@ def build_app_control_router(context: AppContext) -> APIRouter:
                 },
             )
         return result
+
+    @router.post("/workflow/start")
+    def start_workflow(body: Dict[str, Any]):
+        task_names = body.get("task_names")
+        item_names = body.get("item_names")
+        if (
+            not isinstance(task_names, list)
+            or not task_names
+            or not all(isinstance(t, str) for t in task_names)
+            or (
+                item_names is not None
+                and not (
+                    isinstance(item_names, list)
+                    and all(isinstance(i, str) for i in item_names)
+                )
+            )
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "error_type": "missing_field",
+                    "message": "Pass task_names (non-empty list of strings); "
+                    "item_names (list of strings) is optional — omitted "
+                    "means every item.",
+                },
+            )
+        return context.start_workflow(task_names, item_names)
 
     @router.post("/supervision")
     def set_supervision(body: Dict[str, Any]):

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -234,6 +234,18 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         router="app",
     ),
     ToolSpec(
+        name="start_workflow",
+        description="Start a workflow — the Run button, remotely. Names the tasks to run (from the protocol) and optionally the items; omitted items means all of them. Refused while a workflow is already running.",
+        method="POST",
+        path="/app/workflow/start",
+        scope="control",
+        router="app",
+        params={
+            "task_names": "the tasks to run, from the protocol's task names",
+            "item_names": "the items (lamellae) to run them for; omit for all",
+        },
+    ),
+    ToolSpec(
         name="set_task_supervision",
         description="Set whether a task asks for supervision, in the live protocol. Takes effect at the workflow's next prompt-or-proceed decision, mid-run — the same behaviour as the GUI's supervised/automated toggle.",
         method="POST",

--- a/tests/ui/test_agent_prompt_surface.py
+++ b/tests/ui/test_agent_prompt_surface.py
@@ -184,7 +184,7 @@ def test_prompt_lifecycle_reaches_the_event_stream_with_attribution(ui, qapp):
         app_context=AgentContext(ui, event_buffer=buffer),
         auth=AuthConfig.generate(arm_control=True, token=TOKEN),
     )
-    ui.ui_responder.on_question_event = buffer.append
+    dispose = ui.ui_responder.add_question_observer(buffer.append)
     try:
         with TestClient(app, raise_server_exceptions=False) as client:
             thread, outcome = _ask_on_worker(ui, qapp)
@@ -213,7 +213,7 @@ def test_prompt_lifecycle_reaches_the_event_stream_with_attribution(ui, qapp):
             assert answered["payload"]["response"] is True
             assert answered["payload"]["nonce"] == nonce
     finally:
-        ui.ui_responder.on_question_event = None
+        dispose()
 
 
 def test_stop_workflow_rides_the_read_scope(ui, qapp):

--- a/tests/ui/test_agent_prompt_surface.py
+++ b/tests/ui/test_agent_prompt_surface.py
@@ -228,6 +228,92 @@ def test_stop_workflow_rides_the_read_scope(ui, qapp):
         }
 
 
+def test_start_workflow_validates_and_starts_on_the_gui_thread(ui, qapp):
+    from psygnal.containers import EventedDict
+
+    from fibsem.applications.autolamella.structures import (
+        AutoLamellaTaskDescription,
+        AutoLamellaTaskProtocol,
+        Experiment,
+    )
+    from fibsem.structures import MicroscopeState
+
+    experiment = Experiment(path="/tmp/agent-start", name="agent-start")
+    experiment.task_protocol = AutoLamellaTaskProtocol()
+    experiment.task_protocol.workflow_config.tasks.append(
+        AutoLamellaTaskDescription(name="Mill Fiducial", supervise=True, required=True)
+    )
+    experiment.add_new_lamella(MicroscopeState(), EventedDict())
+    ui.experiment = experiment
+
+    calls = []
+
+    class _AliveThread:
+        @staticmethod
+        def is_alive():
+            return True
+
+    def fake_start(task_names, item_names):
+        calls.append((task_names, item_names))
+        ui._task_worker_thread = _AliveThread()
+
+    ui._start_run_workflow_thread = fake_start
+
+    with _client(ui, arm_control=True) as client:
+        posted = {}
+
+        def do_post(body):
+            posted["response"] = client.post(
+                "/app/workflow/start", headers=AUTH, json=body
+            )
+
+        # Unknown task: structured refusal carrying the valid names.
+        poster = threading.Thread(
+            target=do_post, args=({"task_names": ["No Such Task"]},), daemon=True
+        )
+        poster.start()
+        _spin_until(qapp, lambda: "response" in posted)
+        refused = posted["response"].json()
+        assert refused["started"] is False
+        assert refused["task_names"] == ["Mill Fiducial"]
+        assert calls == []
+
+        # Valid start; omitted items means every item in the experiment.
+        posted.clear()
+        poster = threading.Thread(
+            target=do_post, args=({"task_names": ["Mill Fiducial"]},), daemon=True
+        )
+        poster.start()
+        _spin_until(qapp, lambda: "response" in posted)
+        assert posted["response"].json() == {"available": True, "started": True}
+        assert calls == [(["Mill Fiducial"], [experiment.positions[0].name])]
+
+        # And now that it is "running", a second start is refused.
+        posted.clear()
+        poster = threading.Thread(
+            target=do_post, args=({"task_names": ["Mill Fiducial"]},), daemon=True
+        )
+        poster.start()
+        _spin_until(qapp, lambda: "response" in posted)
+        assert posted["response"].json()["started"] is False
+        ui._task_worker_thread = None
+
+    ui.experiment = None
+
+
+def test_start_workflow_requires_control_and_a_valid_body(ui, qapp):
+    with _client(ui, arm_control=False) as client:
+        refused = client.post(
+            "/app/workflow/start", headers=AUTH, json={"task_names": ["x"]}
+        )
+        assert refused.status_code == 403
+        assert refused.json()["detail"]["scope"] == "control"
+    with _client(ui, arm_control=True) as client:
+        rejected = client.post("/app/workflow/start", headers=AUTH, json={})
+        assert rejected.status_code == 422
+        assert rejected.json()["detail"]["error_type"] == "missing_field"
+
+
 def test_supervision_and_requeue_require_the_control_scope(ui, qapp):
     with _client(ui, arm_control=False) as client:
         for path, payload in (

--- a/tests/ui/test_agent_server_hosting.py
+++ b/tests/ui/test_agent_server_hosting.py
@@ -74,12 +74,12 @@ def test_connect_starts_a_live_read_only_server(ui, agent_server_enabled):
     assert host.lifecycle_hook in manager._hooks
 
     # The question-lifecycle feed is wired straight into the buffer...
-    assert ui.ui_responder.on_question_event == host.event_buffer.append
+    assert host.event_buffer.append in ui.ui_responder._question_observers
 
     ui.disconnect_from_microscope()
     assert not host.running
     # ...and unwired with the rest of the taps on stop.
-    assert ui.ui_responder.on_question_event is None
+    assert host.event_buffer.append not in ui.ui_responder._question_observers
 
 
 def _confine_and_control_preferences(monkeypatch, tmp_path):

--- a/tests/ui/test_qt_responder_agent_answer.py
+++ b/tests/ui/test_qt_responder_agent_answer.py
@@ -174,8 +174,8 @@ def test_each_posting_gets_a_fresh_nonce(ui, qapp):
 
 def test_question_lifecycle_events_carry_who_answered(ui, qapp):
     events = []
-    ui.ui_responder.on_question_event = lambda kind, payload: events.append(
-        (kind, payload)
+    dispose = ui.ui_responder.add_question_observer(
+        lambda kind, payload: events.append((kind, payload))
     )
     try:
         # Operator answers via the button path.
@@ -190,7 +190,7 @@ def test_question_lifecycle_events_carry_who_answered(ui, qapp):
         _spin_until(qapp, answered.done)
         thread.join(timeout=5)
     finally:
-        ui.ui_responder.on_question_event = None
+        dispose()
 
     kinds = [k for k, _ in events]
     assert kinds == [
@@ -214,25 +214,27 @@ def test_a_broken_observer_cannot_break_the_click(ui, qapp):
     def broken(kind, payload):
         raise RuntimeError("observer fell over")
 
-    ui.ui_responder.on_question_event = broken
+    dispose = ui.ui_responder.add_question_observer(broken)
     try:
         thread, outcome = _ask_on_worker(ui, qapp, Confirm("Continue?"))
         assert ui.ui_responder.answer_confirm(True) is True
         thread.join(timeout=5)
         assert outcome.get("answer") is True  # the click still applied
     finally:
-        ui.ui_responder.on_question_event = None
+        dispose()
 
 
 def test_an_abandoned_question_reports_cancelled(ui, qapp):
     events = []
-    ui.ui_responder.on_question_event = lambda kind, payload: events.append(kind)
+    dispose = ui.ui_responder.add_question_observer(
+        lambda kind, payload: events.append(kind)
+    )
     try:
         thread, _ = _ask_on_worker(ui, qapp, Confirm("Continue?"))
         ui.ui_responder.abandon()
         thread.join(timeout=5)
     finally:
-        ui.ui_responder.on_question_event = None
+        dispose()
     assert events == ["prompt_raised", "prompt_cancelled"]
 
 

--- a/tests/ui/test_question_timeline.py
+++ b/tests/ui/test_question_timeline.py
@@ -83,25 +83,27 @@ def test_answers_land_as_rows_with_who_and_what(ui, qapp):
     _spin_until(qapp, answered.done)
     thread.join(timeout=5)
 
+    # One visible line (the latest); the trail lives in memory + tooltip.
+    assert timeline.current_text().startswith("agent · declined confirmation · ")
     rows = timeline.rows()
     assert len(rows) == 2
-    # Newest first; who · what · when, no wire vocabulary.
     assert rows[0].startswith("agent · declined confirmation · ")
     assert rows[1].startswith("you · answered confirmation · ")
     assert "nonce" not in rows[0]
     assert not timeline.isHidden()
+    assert rows[1] in timeline._label.toolTip()
 
 
 def test_a_withdrawn_question_reads_as_withdrawn(ui, qapp):
     thread, _ = _ask_on_worker(ui, qapp, Confirm("Continue?"))
     ui.ui_responder.abandon()
     thread.join(timeout=5)
-    assert ui.question_timeline.rows()[0].startswith("question withdrawn · ")
+    assert ui.question_timeline.current_text().startswith("question withdrawn · ")
 
 
-def test_the_timeline_stays_bounded(ui, qapp):
-    for _ in range(ui.question_timeline.MAX_ROWS + 3):
+def test_the_remembered_trail_stays_bounded(ui, qapp):
+    for _ in range(ui.question_timeline.HISTORY + 3):
         thread, _ = _ask_on_worker(ui, qapp, Confirm("Continue?"))
         ui.ui_responder.answer_confirm(True)
         thread.join(timeout=5)
-    assert len(ui.question_timeline.rows()) == ui.question_timeline.MAX_ROWS
+    assert len(ui.question_timeline.rows()) == ui.question_timeline.HISTORY

--- a/tests/ui/test_question_timeline.py
+++ b/tests/ui/test_question_timeline.py
@@ -1,0 +1,107 @@
+"""The who-answered timeline: a dumb render of the responder's lifecycle feed.
+
+Driven through the real window and the real answer paths — the rows can only
+come from the single code path that applies answers, which is the widget's
+whole design ("there is no update-the-timeline step to forget")."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.applications.autolamella.workflows.interaction import Confirm, ask
+
+
+@pytest.fixture
+def ui(qapp, monkeypatch):
+    import fibsem.config as fibsem_config
+
+    arctis_config = os.path.join(
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "sim-arctis-configuration.yaml",
+    )
+    widget = AutoLamellaUI(parent_ui=None)
+    monkeypatch.setattr(
+        widget.system_widget,
+        "load_configuration",
+        lambda configuration_name=None: arctis_config,
+    )
+    widget.system_widget.connect_to_microscope()
+    yield widget
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+    widget.deleteLater()
+    qapp.processEvents()
+
+
+def _spin_until(qapp, predicate, timeout_s=10.0):
+    deadline = time.monotonic() + timeout_s
+    while not predicate():
+        if time.monotonic() > deadline:
+            raise TimeoutError("condition not reached")
+        qapp.processEvents()
+        time.sleep(0.01)
+
+
+def _ask_on_worker(ui, qapp, request):
+    outcome = {}
+
+    def target():
+        try:
+            outcome["answer"] = ask(ui.ui_responder, request)
+        except Exception as exc:  # noqa: BLE001
+            outcome["error"] = exc
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    _spin_until(qapp, lambda: ui.ui_responder.pending_question() is not None)
+    return thread, outcome
+
+
+def test_answers_land_as_rows_with_who_and_what(ui, qapp):
+    timeline = ui.question_timeline
+    assert timeline.isHidden()  # nothing to say until something happens
+
+    # Operator answers via the click path.
+    thread, _ = _ask_on_worker(ui, qapp, Confirm("Continue?"))
+    ui.ui_responder.answer_confirm(True)
+    thread.join(timeout=5)
+
+    # Agent answers via the marshalled path.
+    thread, _ = _ask_on_worker(ui, qapp, Confirm("Again?"))
+    _, nonce = ui.ui_responder.pending_question_and_nonce()
+    answered = ui.ui_responder.submit_answer(False, nonce=nonce)
+    _spin_until(qapp, answered.done)
+    thread.join(timeout=5)
+
+    rows = timeline.rows()
+    assert len(rows) == 2
+    # Newest first; who · what · when, no wire vocabulary.
+    assert rows[0].startswith("agent · declined confirmation · ")
+    assert rows[1].startswith("you · answered confirmation · ")
+    assert "nonce" not in rows[0]
+    assert not timeline.isHidden()
+
+
+def test_a_withdrawn_question_reads_as_withdrawn(ui, qapp):
+    thread, _ = _ask_on_worker(ui, qapp, Confirm("Continue?"))
+    ui.ui_responder.abandon()
+    thread.join(timeout=5)
+    assert ui.question_timeline.rows()[0].startswith("question withdrawn · ")
+
+
+def test_the_timeline_stays_bounded(ui, qapp):
+    for _ in range(ui.question_timeline.MAX_ROWS + 3):
+        thread, _ = _ask_on_worker(ui, qapp, Confirm("Continue?"))
+        ui.ui_responder.answer_confirm(True)
+        thread.join(timeout=5)
+    assert len(ui.question_timeline.rows()) == ui.question_timeline.MAX_ROWS


### PR DESCRIPTION
Stacked on #689. The GUI half of the who-answered design — [mockup](https://claude.ai/code/artifact/85c7658d-653f-47a0-879c-a104b8cbe067) on the project.

## How it works

A compact strip under the Yes/No buttons, one row per answered (or withdrawn) question, newest first, capped at 6, hidden until it has something to say:

```
agent · declined Run Milling · 14:22:31
you · answered point of interest · 14:21:04
```

Agent rows render in the agent purple (`BORDER_STATE_COLOURS["agent"]` — single source, no new literal). Wording follows the rule from the design thread: **who · what · when** — no wire vocabulary on screen, question types get human names ('confirmation', 'alignment area'), unknown types degrade to their type name rather than to silence.

**One API evolution from #689**: the responder's single observer callable becomes a small observer list — `add_question_observer(cb) -> dispose` — now that the feed has two consumers (the event buffer and this widget). Each observer is exception-isolated: a failing one can break neither the click that caused the event nor the other observers. A plain list rather than a Qt signal deliberately, for exactly that isolation. Hosting subscribes through the same API; its unsubscribe rides the existing disposer list.

The widget is a dumb render of the responder's feed — the same single code path that applies answers — so it can never show something that didn't happen, and there is no 'update the timeline' step to forget.

## Tests

Driven through the real window and both real answer paths: operator rows say 'you', agent rows say 'agent', withdrawn questions show as withdrawn, the strip stays hidden until the first answer and bounded after many. 104 tests green across the responder/prompt/hosting/timeline suites.