### PR TITLE
[app] start_workflow: the Run button, remotely

### DIFF
--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -299,6 +299,28 @@ class AgentContext:
         host.stop_task_workflow()
         return {"available": True, "stopped": True}
 
+    def start_workflow(
+        self,
+        task_names: List[str],
+        item_names: Optional[List[str]] = None,
+        timeout: float = 15.0,
+    ) -> Dict[str, Any]:
+        """Start a workflow as the Run button would — the batch-review opener.
+
+        Marshalled to the GUI thread (which owns worker creation and window
+        chrome); validation refusals come back structured with the valid
+        names. ``item_names`` of None means every item in the experiment.
+        Control-scope arming is the consent that stands in for the Run
+        click's confirm dialog.
+        """
+        host = self._host
+        if not hasattr(host, "request_start_workflow"):
+            return {"available": False, "started": False}
+        outcome = host.request_start_workflow(list(task_names), item_names)
+        result = outcome.result(timeout=timeout)
+        result["available"] = True
+        return result
+
     def set_supervision(self, task_name: str, supervise: bool) -> Dict[str, Any]:
         """Set whether ``task_name`` asks for supervision, in the live protocol.
 

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -103,6 +103,8 @@ from fibsem.ui.widgets.fluorescence_control_widget import FMControlWidget
 from fibsem.ui.widgets.workflow_summary_dialog import WorkflowSummaryDialog
 
 if TYPE_CHECKING:
+    from concurrent.futures import Future
+
     import pandas as pd
 
     from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
@@ -183,6 +185,9 @@ class AutoLamellaUI(QMainWindow):
     _hook_toast_signal = pyqtSignal(
         str, str
     )  # (message, notification_type) — thread-safe bridge for NotificationHook
+    # A remote (agent) start request, marshalled to the GUI thread the same
+    # way agent answers are: (task_names, item_names, Future[dict]).
+    _agent_start_workflow = pyqtSignal(list, object, object)
 
     def __init__(
         self,
@@ -199,6 +204,7 @@ class AutoLamellaUI(QMainWindow):
         # The timeline renders the responder's question-lifecycle feed; the
         # widget itself is built in _setup_ui, before the responder exists.
         self.ui_responder.add_question_observer(self.question_timeline.record)
+        self._agent_start_workflow.connect(self._apply_agent_start_workflow)
 
         self._protocol_lock = threading.RLock()
 
@@ -1033,6 +1039,88 @@ class AutoLamellaUI(QMainWindow):
             self._run_tasks_worker, selected_tasks, selected_lamella
         )
         self._task_worker_thread.start()
+
+    def request_start_workflow(
+        self, task_names: List[str], item_names: Optional[List[str]] = None
+    ) -> "Future":
+        """Start a workflow as the Run button would; any thread.
+
+        The agent-facing start: marshalled to the GUI thread (which owns the
+        worker creation and the window chrome), resolving to a plain dict —
+        ``{"started": True}`` or a structured refusal with the valid names.
+        Control-scope arming is the consent that replaces the Run click's
+        confirm dialog.
+        """
+        from concurrent.futures import Future as _Future
+
+        outcome: "_Future" = _Future()
+        self._agent_start_workflow.emit(list(task_names), item_names, outcome)
+        return outcome
+
+    def _apply_agent_start_workflow(
+        self, task_names: List[str], item_names, outcome: "Future"
+    ) -> None:
+        """GUI thread. Complete ``outcome`` with the start result."""
+        try:
+            result = self._start_workflow_for_agent(task_names, item_names)
+        except Exception as exc:  # noqa: BLE001 - the requester owns the failure
+            outcome.set_exception(exc)
+            return
+        outcome.set_result(result)
+
+    def _start_workflow_for_agent(
+        self, task_names: List[str], item_names: Optional[List[str]]
+    ) -> dict:
+        """Validate and start, mirroring the Run click's path (GUI thread)."""
+        if self.is_workflow_running:
+            return {"started": False, "reason": "a workflow is already running"}
+        if self.microscope is None:
+            return {"started": False, "reason": "no microscope is connected"}
+        experiment = self.experiment
+        protocol = self.protocol
+        if experiment is None or protocol is None:
+            return {"started": False, "reason": "no experiment is loaded"}
+        known_tasks = [t.name for t in protocol.workflow_config.tasks]
+        unknown = [t for t in task_names if t not in known_tasks]
+        if not task_names or unknown:
+            return {
+                "started": False,
+                "reason": f"unknown tasks: {unknown!r}" if unknown else "no tasks",
+                "task_names": known_tasks,
+            }
+        known_items = [p.name for p in experiment.positions]
+        if item_names is not None:
+            missing = [n for n in item_names if n not in known_items]
+            if missing:
+                return {
+                    "started": False,
+                    "reason": f"unknown items: {missing!r}",
+                    "item_names": known_items,
+                }
+        # The chrome the Run click supplies around the shared start. Guarded:
+        # the standalone window has no parent to decorate.
+        parent = self.parent_widget
+        if parent is not None:
+            try:
+                # FIB-683 one-writer rule: land any edit still in the editor
+                # before the run's thread becomes the experiment's writer.
+                parent.lamella_widget.flush_pending_save()
+            except Exception:
+                logging.exception("flush before agent start failed; continuing")
+        self._start_run_workflow_thread(
+            task_names, list(item_names) if item_names is not None else known_items
+        )
+        started = self.is_workflow_running
+        if started and parent is not None:
+            try:
+                supervised = protocol.get_supervision(task_names[0])
+                parent._set_border_state("supervised" if supervised else "automated")
+                # Show the Stop button immediately — a remotely started run
+                # must be just as cancellable as a clicked one.
+                parent.set_workflow_running()
+            except Exception:
+                logging.exception("window chrome after agent start failed")
+        return {"started": started}
 
     def _run_tasks_worker(
         self, task_names: List[str], lamella_names: Optional[List[str]] = None

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -259,6 +259,13 @@ def build_sidecar(client, capabilities):
         data, err = _call(client, "POST", "/app/workflow/stop", None)
         return err if err else data
 
+    def start_workflow(task_names: list, item_names: list = None):  # noqa: RUF013
+        payload = {"task_names": list(task_names)}
+        if item_names is not None:
+            payload["item_names"] = list(item_names)
+        data, err = _call(client, "POST", "/app/workflow/start", payload)
+        return err if err else data
+
     def set_task_supervision(task_name: str, supervise: bool):
         data, err = _call(
             client,
@@ -338,6 +345,7 @@ def build_sidecar(client, capabilities):
             stop_workflow,
             set_task_supervision,
             requeue_task,
+            start_workflow,
         )
     }
     # The catalog is the contract: refuse to start with an implementation gap.

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -12,7 +12,7 @@ The read-scope requirement is applied where the router is included, so auth
 stays in one place (build_server).
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
 
@@ -52,6 +52,10 @@ class AppContext(Protocol):
     def answer_prompt(self, response: bool, nonce: int) -> Dict[str, Any]: ...
 
     def stop_workflow(self) -> Dict[str, Any]: ...
+
+    def start_workflow(
+        self, task_names: List[str], item_names: Optional[List[str]] = None
+    ) -> Dict[str, Any]: ...
 
     def set_supervision(self, task_name: str, supervise: bool) -> Dict[str, Any]: ...
 
@@ -156,6 +160,33 @@ def build_app_control_router(context: AppContext) -> APIRouter:
                 },
             )
         return result
+
+    @router.post("/workflow/start")
+    def start_workflow(body: Dict[str, Any]):
+        task_names = body.get("task_names")
+        item_names = body.get("item_names")
+        if (
+            not isinstance(task_names, list)
+            or not task_names
+            or not all(isinstance(t, str) for t in task_names)
+            or (
+                item_names is not None
+                and not (
+                    isinstance(item_names, list)
+                    and all(isinstance(i, str) for i in item_names)
+                )
+            )
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "error_type": "missing_field",
+                    "message": "Pass task_names (non-empty list of strings); "
+                    "item_names (list of strings) is optional — omitted "
+                    "means every item.",
+                },
+            )
+        return context.start_workflow(task_names, item_names)
 
     @router.post("/supervision")
     def set_supervision(body: Dict[str, Any]):

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -234,6 +234,18 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         router="app",
     ),
     ToolSpec(
+        name="start_workflow",
+        description="Start a workflow — the Run button, remotely. Names the tasks to run (from the protocol) and optionally the items; omitted items means all of them. Refused while a workflow is already running.",
+        method="POST",
+        path="/app/workflow/start",
+        scope="control",
+        router="app",
+        params={
+            "task_names": "the tasks to run, from the protocol's task names",
+            "item_names": "the items (lamellae) to run them for; omit for all",
+        },
+    ),
+    ToolSpec(
         name="set_task_supervision",
         description="Set whether a task asks for supervision, in the live protocol. Takes effect at the workflow's next prompt-or-proceed decision, mid-run — the same behaviour as the GUI's supervised/automated toggle.",
         method="POST",

--- a/tests/ui/test_agent_prompt_surface.py
+++ b/tests/ui/test_agent_prompt_surface.py
@@ -228,6 +228,92 @@ def test_stop_workflow_rides_the_read_scope(ui, qapp):
         }
 
 
+def test_start_workflow_validates_and_starts_on_the_gui_thread(ui, qapp):
+    from psygnal.containers import EventedDict
+
+    from fibsem.applications.autolamella.structures import (
+        AutoLamellaTaskDescription,
+        AutoLamellaTaskProtocol,
+        Experiment,
+    )
+    from fibsem.structures import MicroscopeState
+
+    experiment = Experiment(path="/tmp/agent-start", name="agent-start")
+    experiment.task_protocol = AutoLamellaTaskProtocol()
+    experiment.task_protocol.workflow_config.tasks.append(
+        AutoLamellaTaskDescription(name="Mill Fiducial", supervise=True, required=True)
+    )
+    experiment.add_new_lamella(MicroscopeState(), EventedDict())
+    ui.experiment = experiment
+
+    calls = []
+
+    class _AliveThread:
+        @staticmethod
+        def is_alive():
+            return True
+
+    def fake_start(task_names, item_names):
+        calls.append((task_names, item_names))
+        ui._task_worker_thread = _AliveThread()
+
+    ui._start_run_workflow_thread = fake_start
+
+    with _client(ui, arm_control=True) as client:
+        posted = {}
+
+        def do_post(body):
+            posted["response"] = client.post(
+                "/app/workflow/start", headers=AUTH, json=body
+            )
+
+        # Unknown task: structured refusal carrying the valid names.
+        poster = threading.Thread(
+            target=do_post, args=({"task_names": ["No Such Task"]},), daemon=True
+        )
+        poster.start()
+        _spin_until(qapp, lambda: "response" in posted)
+        refused = posted["response"].json()
+        assert refused["started"] is False
+        assert refused["task_names"] == ["Mill Fiducial"]
+        assert calls == []
+
+        # Valid start; omitted items means every item in the experiment.
+        posted.clear()
+        poster = threading.Thread(
+            target=do_post, args=({"task_names": ["Mill Fiducial"]},), daemon=True
+        )
+        poster.start()
+        _spin_until(qapp, lambda: "response" in posted)
+        assert posted["response"].json() == {"available": True, "started": True}
+        assert calls == [(["Mill Fiducial"], [experiment.positions[0].name])]
+
+        # And now that it is "running", a second start is refused.
+        posted.clear()
+        poster = threading.Thread(
+            target=do_post, args=({"task_names": ["Mill Fiducial"]},), daemon=True
+        )
+        poster.start()
+        _spin_until(qapp, lambda: "response" in posted)
+        assert posted["response"].json()["started"] is False
+        ui._task_worker_thread = None
+
+    ui.experiment = None
+
+
+def test_start_workflow_requires_control_and_a_valid_body(ui, qapp):
+    with _client(ui, arm_control=False) as client:
+        refused = client.post(
+            "/app/workflow/start", headers=AUTH, json={"task_names": ["x"]}
+        )
+        assert refused.status_code == 403
+        assert refused.json()["detail"]["scope"] == "control"
+    with _client(ui, arm_control=True) as client:
+        rejected = client.post("/app/workflow/start", headers=AUTH, json={})
+        assert rejected.status_code == 422
+        assert rejected.json()["detail"]["error_type"] == "missing_field"
+
+
 def test_supervision_and_requeue_require_the_control_scope(ui, qapp):
     with _client(ui, arm_control=False) as client:
         for path, payload in (


### PR DESCRIPTION
Stacked on #691. The missing verb from today's live sessions — asked for three separate times ("start the fiducial task for all three lamellae") — and the piece batch-then-review needs to *initiate* re-runs: after a run ends the queue no longer exists, so requeue alone can't open a new round.

## How it works (plain language)

`POST /app/workflow/start` (control scope) with `{"task_names": [...], "item_names": [...]}` — items omitted means every item in the experiment. The request marshals to the GUI thread through the same signal-and-Future shape as agent answers, because starting owns two things only that thread can touch: the worker creation, and the window chrome.

The GUI-side path deliberately mirrors what the Run click does around `_start_run_workflow_thread`:

- **validation first**, against the live protocol and experiment — unknown tasks/items come back as structured refusals carrying the valid names, and a second start while one is running is refused;
- **the FIB-683 flush** (`flush_pending_save`) so any edit still sitting in the lamella editor lands before the run's thread becomes the experiment's only writer;
- **the chrome**: border state (supervised/automated by the first task) and `set_workflow_running` — the Stop button appears immediately, because a remotely started run must be exactly as visible and as cancellable as a clicked one.

The one thing it does *not* replicate is the confirm dialog: control-scope arming is the operator's standing consent for agent-initiated actions, the same trade already made for answers, supervision flips, and re-queues.

Sidecar grows `start_workflow` — 32 tools.

## Tests

HTTP-level through the real window: unknown task → refusal with the protocol's names and no start; valid start → the Run path invoked with all items defaulted in; second start refused while "running"; 403 unarmed; 422 on a malformed body. 96 tests green across the prompt/timeline/responder/hosting/server suites.