### PR TITLE
[app] supervisor: who a supervised task's questions are addressed to

### DIFF
--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -191,6 +191,7 @@ class AgentContext:
                 {
                     "name": task.name,
                     "supervise": task.supervise,
+                    "supervisor": getattr(task, "supervisor", "human"),
                     "required": task.required,
                     "requires": list(task.requires),
                     "scheduled_at": task.scheduled_at.isoformat()
@@ -299,7 +300,12 @@ class AgentContext:
         host.stop_task_workflow()
         return {"available": True, "stopped": True}
 
-    def set_supervision(self, task_name: str, supervise: bool) -> Dict[str, Any]:
+    def set_supervision(
+        self,
+        task_name: str,
+        supervise: bool,
+        supervisor: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Set whether ``task_name`` asks for supervision, in the live protocol.
 
         The workflow reads this at every decision point (never a snapshot), so
@@ -307,7 +313,19 @@ class AgentContext:
         the mid-run behaviour the GUI's supervised/automated toggle has. The
         GUI's own indicators refresh on the next task transition rather than
         instantly.
+
+        ``supervisor`` optionally sets who the task's questions are addressed
+        to ("human" or "agent") — display and watchdog semantics only; the
+        questions themselves are raised identically, the operator can always
+        answer first, and the designation shows nothing in the GUI unless the
+        agent server is running.
         """
+        if supervisor not in (None, "human", "agent"):
+            return {
+                "available": True,
+                "applied": False,
+                "error": f"supervisor must be 'human' or 'agent', not {supervisor!r}",
+            }
         experiment = self._experiment
         protocol = getattr(experiment, "task_protocol", None) if experiment else None
         config = getattr(protocol, "workflow_config", None) if protocol else None
@@ -316,11 +334,14 @@ class AgentContext:
         for task in config.tasks:
             if task.name == task_name:
                 task.supervise = bool(supervise)
+                if supervisor is not None:
+                    task.supervisor = supervisor
                 return {
                     "available": True,
                     "applied": True,
                     "task_name": task_name,
                     "supervise": bool(supervise),
+                    "supervisor": getattr(task, "supervisor", "human"),
                 }
         return {
             "available": True,

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -52,8 +52,6 @@ if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
 
 
-
-
 class AutoLamellaTaskStatus(Enum):
     NotStarted = auto()
     InProgress = auto()
@@ -61,7 +59,7 @@ class AutoLamellaTaskStatus(Enum):
     Failed = auto()
     Skipped = auto()
     Cancelled = auto()  # aborted by the user (Stop), distinct from a genuine Failure
-    Removed = auto()    # pulled from the queue by the user before it ran
+    Removed = auto()  # pulled from the queue by the user before it ran
 
 
 # AutoLamellaUser lived here: a richer user identity (role, preferences, is_default)
@@ -80,7 +78,9 @@ class AutoLamellaTaskState:
     task_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     task_type: str = ""
     lamella_id: str = ""
-    start_timestamp: float = field(default_factory=lambda: datetime.timestamp(datetime.now()))
+    start_timestamp: float = field(
+        default_factory=lambda: datetime.timestamp(datetime.now())
+    )
     end_timestamp: Optional[float] = None
     status: AutoLamellaTaskStatus = AutoLamellaTaskStatus.NotStarted
     status_message: str = ""
@@ -100,11 +100,15 @@ class AutoLamellaTaskState:
     def completed_at(self) -> str:
         if self.end_timestamp is None:
             return "in progress"
-        return datetime.fromtimestamp(self.end_timestamp).strftime(TIME_DISPLAY_AMPM_SHORT)
+        return datetime.fromtimestamp(self.end_timestamp).strftime(
+            TIME_DISPLAY_AMPM_SHORT
+        )
 
     @property
     def started_at(self) -> str:
-        return datetime.fromtimestamp(self.start_timestamp).strftime(TIME_DISPLAY_AMPM_SHORT)
+        return datetime.fromtimestamp(self.start_timestamp).strftime(
+            TIME_DISPLAY_AMPM_SHORT
+        )
 
     @property
     def duration(self) -> float:
@@ -123,7 +127,7 @@ class AutoLamellaTaskState:
         return ddict
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'AutoLamellaTaskState':
+    def from_dict(cls, data: dict) -> "AutoLamellaTaskState":
         """Create a task state from a dictionary."""
         if data is None:
             return cls()
@@ -139,21 +143,20 @@ class AutoLamellaTaskState:
 @dataclass
 class AutoLamellaTaskConfig(ABC):
     """Configuration for AutoLamella tasks."""
+
     task_type: ClassVar[str]
     display_name: ClassVar[str]
-    related_tasks: ClassVar[list[type['AutoLamellaTaskConfig']]] = []
-    task_name: str = "" # unique name for identifying in multi-task workflows
+    related_tasks: ClassVar[list[type["AutoLamellaTaskConfig"]]] = []
+    task_name: str = ""  # unique name for identifying in multi-task workflows
     milling: Dict[str, FibsemMillingTaskConfig] = field(default_factory=dict)
-    reference_imaging: ReferenceImageParameters = field(default_factory=ReferenceImageParameters)
+    reference_imaging: ReferenceImageParameters = field(
+        default_factory=ReferenceImageParameters
+    )
 
     @property
     def parameters(self) -> Tuple[str, ...]:
         core_params = [f.name for f in fields(AutoLamellaTaskConfig)]
-        return tuple(
-            f.name
-            for f in fields(self)
-            if f.name not in core_params
-        )
+        return tuple(f.name for f in fields(self) if f.name not in core_params)
 
     @property
     def field_metadata(self) -> Dict[str, Dict[str, Any]]:
@@ -181,7 +184,7 @@ class AutoLamellaTaskConfig(ABC):
         return ddict
 
     @classmethod
-    def from_dict(cls, ddict: Dict[str, Any]) -> 'AutoLamellaTaskConfig':
+    def from_dict(cls, ddict: Dict[str, Any]) -> "AutoLamellaTaskConfig":
         kwargs = {}
 
         for f in fields(cls):
@@ -189,7 +192,7 @@ class AutoLamellaTaskConfig(ABC):
                 kwargs[f.name] = ddict[f.name]
 
         # unroll the parameters dictionary
-        if "parameters" in ddict and ddict["parameters"] is not None:                
+        if "parameters" in ddict and ddict["parameters"] is not None:
             for key, value in ddict["parameters"].items():
                 if key in cls.__annotations__:
                     kwargs[key] = value
@@ -198,10 +201,13 @@ class AutoLamellaTaskConfig(ABC):
 
         if "milling" in ddict:
             kwargs["milling"] = {
-                k: FibsemMillingTaskConfig.from_dict(v) for k, v in ddict["milling"].items()
+                k: FibsemMillingTaskConfig.from_dict(v)
+                for k, v in ddict["milling"].items()
             }
         if "reference_imaging" in ddict:
-            kwargs["reference_imaging"] = ReferenceImageParameters.from_dict(ddict["reference_imaging"])
+            kwargs["reference_imaging"] = ReferenceImageParameters.from_dict(
+                ddict["reference_imaging"]
+            )
 
         return cls(**kwargs)
 
@@ -260,12 +266,12 @@ class AutoLamellaTaskConfig(ABC):
         for milling_task in self.milling.values():
             total += timing.milling_task_cost(milling_task)
         return total
-    
+
     @property
     def imaging(self) -> ImageSettings:
         """Get the imaging settings from the reference imaging parameters."""
         return self.reference_imaging.imaging
-    
+
     @imaging.setter
     def imaging(self, value: ImageSettings):
         """Set the imaging settings in the reference imaging parameters."""
@@ -275,11 +281,16 @@ class AutoLamellaTaskConfig(ABC):
 @evented
 @dataclass
 class AutoLamellaTaskDescription:
-    name: str # unique_name
+    name: str  # unique_name
     supervise: bool
     required: bool
     requires: List[str] = field(default_factory=list)
     scheduled_at: Optional[datetime] = None
+    # Who a supervised task's questions are addressed to: "human" (the
+    # operator, today's behaviour and the default) or "agent" (a connected
+    # agent answers; the operator can still answer first). Display-and-watchdog
+    # semantics only — prompts are raised identically either way.
+    supervisor: str = "human"
 
     def to_dict(self) -> Dict[str, Any]:
         d = asdict(self)
@@ -288,10 +299,13 @@ class AutoLamellaTaskDescription:
         return d
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaTaskDescription':
+    def from_dict(cls, data: Dict[str, Any]) -> "AutoLamellaTaskDescription":
         if data is None:
-            return cls(name="", task_type="", supervise=False, required=False, requires=[])
-        data = dict(data)
+            return cls(name="", supervise=False, required=False, requires=[])
+        # Known fields only: a protocol written by a newer version (with fields
+        # this one does not know) must load, not crash on an unexpected kwarg.
+        known = {f.name for f in fields(cls)}
+        data = {k: v for k, v in data.items() if k in known}
         sa = data.get("scheduled_at")
         if isinstance(sa, str):
             data["scheduled_at"] = datetime.fromisoformat(sa)
@@ -311,8 +325,10 @@ class AutoLamellaWorkflowConfig:
         return ddict
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaWorkflowConfig':
-        data["tasks"] = [AutoLamellaTaskDescription.from_dict(task) for task in data.get("tasks", [])]
+    def from_dict(cls, data: Dict[str, Any]) -> "AutoLamellaWorkflowConfig":
+        data["tasks"] = [
+            AutoLamellaTaskDescription.from_dict(task) for task in data.get("tasks", [])
+        ]
         return cls(**data)
 
     @property
@@ -330,7 +346,9 @@ class AutoLamellaWorkflowConfig:
                 return task.requires
         return []
 
-    def get_completed_tasks(self, lamella: 'Lamella', with_timestamps: bool = False) -> List[str]:
+    def get_completed_tasks(
+        self, lamella: "Lamella", with_timestamps: bool = False
+    ) -> List[str]:
         """Get the list of completed tasks for a given lamella.
 
         Filtered on status for the same reason as Lamella.completed_tasks:
@@ -350,7 +368,7 @@ class AutoLamellaWorkflowConfig:
                 completed_tasks.append(txt)
         return completed_tasks
 
-    def get_remaining_tasks(self, lamella: 'Lamella') -> List[str]:
+    def get_remaining_tasks(self, lamella: "Lamella") -> List[str]:
         """Get the list of remaining tasks for a given lamella."""
         remaining_tasks = []
         completed_tasks = self.get_completed_tasks(lamella)
@@ -359,7 +377,7 @@ class AutoLamellaWorkflowConfig:
                 remaining_tasks.append(task)
         return remaining_tasks
 
-    def is_completed(self, lamella: 'Lamella') -> bool:
+    def is_completed(self, lamella: "Lamella") -> bool:
         """Check if all required tasks for the workflow are completed."""
         completed_tasks = self.get_completed_tasks(lamella)
         for task in self.required_tasks:
@@ -374,6 +392,13 @@ class AutoLamellaWorkflowConfig:
                 return task.supervise
         return False
 
+    def get_supervisor(self, task_name: str) -> str:
+        """Who a supervised task's questions are addressed to: human or agent."""
+        for task in self.tasks:
+            if task.name == task_name:
+                return getattr(task, "supervisor", "human") or "human"
+        return "human"
+
     def get_scheduled_at(self, task_name: str) -> Optional[datetime]:
         """Get the scheduled start time for a task, or None if not scheduled."""
         for task in self.tasks:
@@ -383,10 +408,11 @@ class AutoLamellaWorkflowConfig:
 
     def add_task(self, task: AutoLamellaTaskConfig) -> None:
         """Add a task to the workflow configuration."""
-        self.tasks.append(AutoLamellaTaskDescription(name=task.task_name, 
-                                                     supervise=True, 
-                                                     required=True, 
-                                                     requires=[]))
+        self.tasks.append(
+            AutoLamellaTaskDescription(
+                name=task.task_name, supervise=True, required=True, requires=[]
+            )
+        )
 
     @property
     def is_valid(self) -> bool:
@@ -403,7 +429,9 @@ class AutoLamellaWorkflowConfig:
                 if req not in task_names:
                     issues.append(f"Task '{task.name}' requires unknown task '{req}'.")
                 elif req not in task_names[:i]:
-                    issues.append(f"Task '{task.name}' requires '{req}' which comes after it in the workflow.")
+                    issues.append(
+                        f"Task '{task.name}' requires '{req}' which comes after it in the workflow."
+                    )
         return issues
 
 
@@ -416,7 +444,7 @@ class AutoLamellaWorkflowOptions:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaWorkflowOptions':
+    def from_dict(cls, data: Dict[str, Any]) -> "AutoLamellaWorkflowOptions":
         return cls(**data)
 
 
@@ -424,6 +452,7 @@ class AutoLamellaWorkflowOptions:
 @dataclass
 class LamellaDefaultConfig:
     """Initial state applied to every new Lamella created from this protocol."""
+
     use_petname: bool = True
     name_prefix: str = ""
     alignment_area: Optional[FibsemRectangle] = None
@@ -441,13 +470,15 @@ class LamellaDefaultConfig:
         return d
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'LamellaDefaultConfig':
+    def from_dict(cls, data: Dict[str, Any]) -> "LamellaDefaultConfig":
         aa = data.get("alignment_area")
         poi = data.get("poi")
         return cls(
             use_petname=data.get("use_petname", True),
             name_prefix=data.get("name_prefix", ""),
-            alignment_area=FibsemRectangle.from_dict(aa) if isinstance(aa, dict) else None,
+            alignment_area=FibsemRectangle.from_dict(aa)
+            if isinstance(aa, dict)
+            else None,
             poi=Point.from_dict(poi) if isinstance(poi, dict) else None,
         )
 
@@ -459,9 +490,15 @@ class AutoLamellaTaskProtocol:
     description: str = "Protocol for AutoLamella"
     version: str = "1.0"
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    task_config: EventedDict[str, AutoLamellaTaskConfig] = field(default_factory=lambda: EventedDict())   # unique_name: AutoLamellaTaskConfig
-    workflow_config: AutoLamellaWorkflowConfig = field(default_factory=AutoLamellaWorkflowConfig)
-    options: AutoLamellaWorkflowOptions = field(default_factory=AutoLamellaWorkflowOptions)
+    task_config: EventedDict[str, AutoLamellaTaskConfig] = field(
+        default_factory=lambda: EventedDict()
+    )  # unique_name: AutoLamellaTaskConfig
+    workflow_config: AutoLamellaWorkflowConfig = field(
+        default_factory=AutoLamellaWorkflowConfig
+    )
+    options: AutoLamellaWorkflowOptions = field(
+        default_factory=AutoLamellaWorkflowOptions
+    )
     lamella_defaults: LamellaDefaultConfig = field(default_factory=LamellaDefaultConfig)
     # Experiment-global correlation config (FIB-298): a user-step config, not an
     # automated task, so a peer field rather than an entry in task_config.
@@ -481,8 +518,9 @@ class AutoLamellaTaskProtocol:
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AutoLamellaTaskProtocol':
+    def from_dict(cls, data: Dict[str, Any]) -> "AutoLamellaTaskProtocol":
         from fibsem.applications.autolamella.workflows.tasks import load_task_config
+
         task_config = load_task_config(data.get("tasks", {}))
         workflow_config = AutoLamellaWorkflowConfig.from_dict(data.get("workflow", {}))
 
@@ -493,7 +531,9 @@ class AutoLamellaTaskProtocol:
             task_config=task_config,
             workflow_config=workflow_config,
             options=AutoLamellaWorkflowOptions.from_dict(data.get("options", {})),
-            lamella_defaults=LamellaDefaultConfig.from_dict(data.get("lamella_defaults", {})),
+            lamella_defaults=LamellaDefaultConfig.from_dict(
+                data.get("lamella_defaults", {})
+            ),
             # Missing on protocols saved before this field -> a default config.
             correlation=CorrelationConfig.from_dict(data.get("correlation")),
         )
@@ -502,26 +542,32 @@ class AutoLamellaTaskProtocol:
         return protocol
 
     @classmethod
-    def load(cls, filename: str) -> 'AutoLamellaTaskProtocol':
-        with open(filename, 'r') as file:
+    def load(cls, filename: str) -> "AutoLamellaTaskProtocol":
+        with open(filename, "r") as file:
             data = yaml.safe_load(file)
         return cls.from_dict(data)
 
     def save(self, filename: str) -> None:
         """Save the task protocol to a YAML file."""
-        with open(filename, 'w') as file:
-            yaml.safe_dump(self.to_dict(), 
-                           file,
-                           indent=4, 
-                           default_flow_style=False, 
-                           sort_keys=False)
+        with open(filename, "w") as file:
+            yaml.safe_dump(
+                self.to_dict(),
+                file,
+                indent=4,
+                default_flow_style=False,
+                sort_keys=False,
+            )
 
     def get_supervision(self, task_name: str) -> bool:
         """Check if a task requires supervision."""
         return self.workflow_config.get_supervision(task_name)
 
+    def get_supervisor(self, task_name: str) -> str:
+        """Who a supervised task's questions are addressed to: human or agent."""
+        return self.workflow_config.get_supervisor(task_name)
+
     @classmethod
-    def load_from_old_protocol(cls, path: Path) -> 'AutoLamellaTaskProtocol':
+    def load_from_old_protocol(cls, path: Path) -> "AutoLamellaTaskProtocol":
         """Convert an AutoLamellaProtocol to an AutoLamellaTaskProtocol.
         This involves mapping the milling configurations to the new task names.
         Used to converte old protocols to the new task-based protocol format."""
@@ -539,6 +585,7 @@ class AutoLamellaTaskProtocol:
             MillUndercutTaskConfig,
             SelectMillingPositionTaskConfig,
         )
+
         protocol = AutoLamellaProtocol.load(path)
 
         # we need to map the milling configurations to the new task names
@@ -549,9 +596,15 @@ class AutoLamellaTaskProtocol:
         # undercut -> Trench Milling / undercut
         # fiducial -> Setup Lamella / fiducial
         # mill_polishing -> Polishing
-        
-        if protocol.method not in [AutoLamellaMethod.ON_GRID, AutoLamellaMethod.TRENCH, AutoLamellaMethod.WAFFLE]:
-            raise ValueError(f"Protocol method {protocol.method} not supported for conversion to task protocol")
+
+        if protocol.method not in [
+            AutoLamellaMethod.ON_GRID,
+            AutoLamellaMethod.TRENCH,
+            AutoLamellaMethod.WAFFLE,
+        ]:
+            raise ValueError(
+                f"Protocol method {protocol.method} not supported for conversion to task protocol"
+            )
 
         ROUGH_MILLING_TASK_NAME = "Rough Milling"
         POLISHING_TASK_NAME = "Polishing"
@@ -566,22 +619,40 @@ class AutoLamellaTaskProtocol:
         if protocol.method in [AutoLamellaMethod.ON_GRID, AutoLamellaMethod.WAFFLE]:
             rough_milling_task = MillRoughTaskConfig(
                 task_name=ROUGH_MILLING_TASK_NAME,
-                milling={MILL_ROUGH_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[MILL_ROUGH_KEY], name="Rough Milling")},
+                milling={
+                    MILL_ROUGH_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[MILL_ROUGH_KEY], name="Rough Milling"
+                    )
+                },
             )
 
             if protocol.options.use_microexpansion:
-                rough_milling_task.milling[MILL_ROUGH_KEY].stages.extend(protocol.milling[MICROEXPANSION_KEY])
+                rough_milling_task.milling[MILL_ROUGH_KEY].stages.extend(
+                    protocol.milling[MICROEXPANSION_KEY]
+                )
             if protocol.options.use_notch:
-                rough_milling_task.milling[STRESS_RELIEF_KEY] = FibsemMillingTaskConfig.from_stages(protocol.milling[NOTCH_KEY], name="Notch")
+                rough_milling_task.milling[STRESS_RELIEF_KEY] = (
+                    FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[NOTCH_KEY], name="Notch"
+                    )
+                )
 
             polishing_milling_task = MillPolishingTaskConfig(
                 task_name=POLISHING_TASK_NAME,
-                milling={MILL_POLISHING_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[MILL_POLISHING_KEY], name="Polishing")},
+                milling={
+                    MILL_POLISHING_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[MILL_POLISHING_KEY], name="Polishing"
+                    )
+                },
             )
 
             mill_fiducial_task = MillFiducialTaskConfig(
                 task_name=MILL_FIDUCIAL_TASK_NAME,
-                milling={FIDUCIAL_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[FIDUCIAL_KEY], name="Fiducial")},
+                milling={
+                    FIDUCIAL_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[FIDUCIAL_KEY], name="Fiducial"
+                    )
+                },
             )
             setup_lamella_task = SelectMillingPositionTaskConfig(
                 task_name=SETUP_LAMELLA_POSITION_TASK_NAME,
@@ -595,57 +666,93 @@ class AutoLamellaTaskProtocol:
             task_config[SETUP_LAMELLA_POSITION_TASK_NAME] = setup_lamella_task
 
             workflow_config.tasks = [
-                AutoLamellaTaskDescription(name=SETUP_LAMELLA_POSITION_TASK_NAME, supervise=protocol.supervision[AutoLamellaStage.SetupLamella], required=True),
-                AutoLamellaTaskDescription(name=MILL_FIDUCIAL_TASK_NAME, supervise=protocol.supervision[AutoLamellaStage.SetupLamella], required=True),
-                AutoLamellaTaskDescription(name=ROUGH_MILLING_TASK_NAME, supervise=protocol.supervision[AutoLamellaStage.MillRough], required=True, requires=[MILL_FIDUCIAL_TASK_NAME]),
-                AutoLamellaTaskDescription(name=POLISHING_TASK_NAME, supervise=protocol.supervision[AutoLamellaStage.MillPolishing], required=True, requires=[ROUGH_MILLING_TASK_NAME]),
+                AutoLamellaTaskDescription(
+                    name=SETUP_LAMELLA_POSITION_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.SetupLamella],
+                    required=True,
+                ),
+                AutoLamellaTaskDescription(
+                    name=MILL_FIDUCIAL_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.SetupLamella],
+                    required=True,
+                ),
+                AutoLamellaTaskDescription(
+                    name=ROUGH_MILLING_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.MillRough],
+                    required=True,
+                    requires=[MILL_FIDUCIAL_TASK_NAME],
+                ),
+                AutoLamellaTaskDescription(
+                    name=POLISHING_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.MillPolishing],
+                    required=True,
+                    requires=[ROUGH_MILLING_TASK_NAME],
+                ),
             ]
-
 
         if protocol.method in [AutoLamellaMethod.TRENCH, AutoLamellaMethod.WAFFLE]:
             trench_milling_task = MillTrenchTaskConfig(
                 task_name=TRENCH_MILLING_TASK_NAME,
-                milling={TRENCH_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[TRENCH_KEY], name="Trench"),
+                milling={
+                    TRENCH_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[TRENCH_KEY], name="Trench"
+                    ),
                 },
                 orientation="FIB",
             )
             task_config[TRENCH_MILLING_TASK_NAME] = trench_milling_task
-            workflow_config.tasks.insert(0, AutoLamellaTaskDescription(name=TRENCH_MILLING_TASK_NAME,
-                                                                    supervise=protocol.supervision[AutoLamellaStage.MillTrench], 
-                                                                    required=True))
+            workflow_config.tasks.insert(
+                0,
+                AutoLamellaTaskDescription(
+                    name=TRENCH_MILLING_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.MillTrench],
+                    required=True,
+                ),
+            )
 
         if protocol.method is AutoLamellaMethod.WAFFLE:
-
             undercut_task = MillUndercutTaskConfig(
                 task_name=UNDERCUT_TASK_NAME,
-                milling={UNDERCUT_KEY: FibsemMillingTaskConfig.from_stages(protocol.milling[UNDERCUT_KEY], name="Undercut")},
+                milling={
+                    UNDERCUT_KEY: FibsemMillingTaskConfig.from_stages(
+                        protocol.milling[UNDERCUT_KEY], name="Undercut"
+                    )
+                },
                 orientation="SEM",
-
             )
             task_config[UNDERCUT_TASK_NAME] = undercut_task
-            workflow_config.tasks.insert(1, AutoLamellaTaskDescription(name=UNDERCUT_TASK_NAME,
-                                                                    supervise=protocol.supervision[AutoLamellaStage.MillUndercut], 
-                                                                    required=True, requires=[TRENCH_MILLING_TASK_NAME]))
-
+            workflow_config.tasks.insert(
+                1,
+                AutoLamellaTaskDescription(
+                    name=UNDERCUT_TASK_NAME,
+                    supervise=protocol.supervision[AutoLamellaStage.MillUndercut],
+                    required=True,
+                    requires=[TRENCH_MILLING_TASK_NAME],
+                ),
+            )
 
         options = AutoLamellaWorkflowOptions(
             turn_beams_off=protocol.options.turn_beams_off,
         )
 
         workflow_config.name = protocol.name
-        workflow_config.description = f"auto-converted protocol from {protocol.name} - {protocol.method.name}"
+        workflow_config.description = (
+            f"auto-converted protocol from {protocol.name} - {protocol.method.name}"
+        )
 
         task_protocol = AutoLamellaTaskProtocol(
             name=protocol.name,
             description=f"auto-converted protocol from {protocol.name} - {protocol.method.name}",
             task_config=task_config,
             workflow_config=workflow_config,
-            options=options
+            options=options,
         )
 
         return task_protocol
 
-    def get_task_config_by_type(self, task_type: Type['AutoLamellaTaskConfig']) -> EventedDict[str, AutoLamellaTaskConfig]:
+    def get_task_config_by_type(
+        self, task_type: Type["AutoLamellaTaskConfig"]
+    ) -> EventedDict[str, AutoLamellaTaskConfig]:
         """Get the task configuration by type."""
         task_configs = EventedDict()
         for k, v in self.task_config.items():
@@ -677,13 +784,17 @@ class DefectState:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'DefectState':
+    def from_dict(cls, data: dict) -> "DefectState":
         if not data:
             return cls()
         # Backwards compatibility: old format used has_defect / requires_rework bools
         if "has_defect" in data:
             if data.get("has_defect"):
-                state = DefectType.REWORK if data.get("requires_rework") else DefectType.FAILURE
+                state = (
+                    DefectType.REWORK
+                    if data.get("requires_rework")
+                    else DefectType.FAILURE
+                )
             else:
                 state = DefectType.NONE
             return cls(
@@ -726,6 +837,7 @@ _THUMBNAIL_MAX_EDGE = 512
 def _make_thumbnail_placeholder():
     import numpy as np
     from PIL import Image, ImageDraw, ImageFont
+
     img = Image.new("RGB", (256, 170), color=(30, 30, 30))
     draw = ImageDraw.Draw(img)
     text = "No Data"
@@ -746,17 +858,23 @@ _THUMBNAIL_PLACEHOLDER = None
 @dataclass
 class Lamella:
     path: Path
-    number: int                                                             # TODO: deprecate, use petname instead
+    number: int  # TODO: deprecate, use petname instead
     petname: str
-    alignment_area: FibsemRectangle = field(default_factory=lambda: FibsemRectangle.from_dict(DEFAULT_ALIGNMENT_AREA))
+    alignment_area: FibsemRectangle = field(
+        default_factory=lambda: FibsemRectangle.from_dict(DEFAULT_ALIGNMENT_AREA)
+    )
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    task_config: EventedDict[str, 'AutoLamellaTaskConfig'] = field(default_factory=lambda: EventedDict())
+    task_config: EventedDict[str, "AutoLamellaTaskConfig"] = field(
+        default_factory=lambda: EventedDict()
+    )
     poses: Dict[str, MicroscopeState] = field(default_factory=dict)
     task_state: AutoLamellaTaskState = field(default_factory=AutoLamellaTaskState)
-    task_history: List['AutoLamellaTaskState'] = field(default_factory=list)
+    task_history: List["AutoLamellaTaskState"] = field(default_factory=list)
     defect: DefectState = field(default_factory=DefectState)
     milling_angle: Optional[float] = None
-    poi: Point = field(default_factory=lambda: Point(0,0))  # point of interest within lamella area (milling coordinate system)
+    poi: Point = field(
+        default_factory=lambda: Point(0, 0)
+    )  # point of interest within lamella area (milling coordinate system)
     description: str = ""  # free-text note about the lamella
 
     def __post_init__(self):
@@ -823,7 +941,7 @@ class Lamella:
 
     @property
     def stage_position(self) -> FibsemStagePosition:
-        return self.milling_pose.stage_position # type: ignore
+        return self.milling_pose.stage_position  # type: ignore
 
     @stage_position.setter
     def stage_position(self, value: FibsemStagePosition):
@@ -849,7 +967,7 @@ class Lamella:
         ]
 
     @property
-    def last_completed_task(self) -> Optional['AutoLamellaTaskState']:
+    def last_completed_task(self) -> Optional["AutoLamellaTaskState"]:
         """Return the last completed task state.
 
         The last *completed* one, not the last recorded: a failure landing last
@@ -900,7 +1018,10 @@ class Lamella:
 
     @property
     def fluorescence_selected(self) -> bool:
-        return self.fluorescence_pose is not None and self.fluorescence_pose.objective_position is not None
+        return (
+            self.fluorescence_pose is not None
+            and self.fluorescence_pose.objective_position is not None
+        )
 
     def update_milling_angle(self, microscope: "FibsemMicroscope") -> None:
         """Recompute milling_angle from the milling-pose stage tilt.
@@ -909,14 +1030,20 @@ class Lamella:
         column-tilt configuration), so it is kept consistent with the stored milling pose.
         Leaves the existing value unchanged if the stage tilt/rotation is unavailable.
         """
-        if microscope is None or self.milling_pose is None or self.milling_pose.stage_position is None:
+        if (
+            microscope is None
+            or self.milling_pose is None
+            or self.milling_pose.stage_position is None
+        ):
             return
         try:
             self.milling_angle = microscope.get_current_milling_angle(
                 stage_position=self.milling_pose.stage_position
             )
         except ValueError:
-            logging.debug(f"Could not compute milling angle for {self.name}: stage tilt/rotation unavailable")
+            logging.debug(
+                f"Could not compute milling angle for {self.name}: stage tilt/rotation unavailable"
+            )
 
     def to_dict(self):
         return {
@@ -946,19 +1073,25 @@ class Lamella:
     @property
     def pretty_fm_name(self) -> str:
         """Generate a pretty name for the stage position."""
-        obj_pos = self.fluorescence_pose.objective_position if self.fluorescence_pose is not None else None
+        obj_pos = (
+            self.fluorescence_pose.objective_position
+            if self.fluorescence_pose is not None
+            else None
+        )
         objective_str = f"{obj_pos * 1e3:.3f}mm" if obj_pos is not None else "N/A"
         return f"{self.name} ({self.stage_position.x * 1e6:.1f}μm, {self.stage_position.y * 1e6:.1f}μm, {objective_str})"
 
     @classmethod
-    def from_dict(cls, data: dict) -> 'Lamella':
+    def from_dict(cls, data: dict) -> "Lamella":
         # backwards compatibility
         alignment_area_ddict = data.get("alignment_area", DEFAULT_ALIGNMENT_AREA)
         alignment_area = FibsemRectangle.from_dict(alignment_area_ddict)
 
         from fibsem.applications.autolamella.workflows.tasks import load_task_config
 
-        poses = {k: MicroscopeState.from_dict(v) for k, v in data.get("poses", {}).items()}
+        poses = {
+            k: MicroscopeState.from_dict(v) for k, v in data.get("poses", {}).items()
+        }
         # backwards compat: migrate legacy top-level objective_position into fluorescence_pose
         legacy_obj_pos = data.get("objective_position", None)
         if legacy_obj_pos is not None and "FLUORESCENCE" in poses:
@@ -974,10 +1107,13 @@ class Lamella:
             poses=poses,
             task_config=load_task_config(data.get("task_config", {})),
             task_state=AutoLamellaTaskState.from_dict(data.get("task_state", {})),
-            task_history=[AutoLamellaTaskState.from_dict(task) for task in data.get("task_history", [])],
+            task_history=[
+                AutoLamellaTaskState.from_dict(task)
+                for task in data.get("task_history", [])
+            ],
             defect=DefectState.from_dict(data.get("defect", {})),
             milling_angle=data.get("milling_angle", None),
-            poi=Point.from_dict(data.get("poi", {"x":0,"y":0})),
+            poi=Point.from_dict(data.get("poi", {"x": 0, "y": 0})),
             description=data.get("description", ""),
         )
 
@@ -1005,6 +1141,7 @@ class Lamella:
         thumb_path = os.path.join(self.path, "thumbnail.png")
         import numpy as np
         from PIL import Image
+
         if not os.path.exists(thumb_path):
             if _THUMBNAIL_PLACEHOLDER is None:
                 _THUMBNAIL_PLACEHOLDER = _make_thumbnail_placeholder()
@@ -1044,6 +1181,7 @@ class Lamella:
 
         import numpy as np
         from PIL import Image
+
         data = image.filtered_data
         if data.ndim == 2:
             data = np.stack([data, data, data], axis=2)
@@ -1082,7 +1220,7 @@ class Lamella:
     #     return task_configs
 
     def sync_tasks_to_poi(self, point: Optional[Point] = None) -> list[str]:
-        """Sync the milling patterns to point of interest  """
+        """Sync the milling patterns to point of interest"""
 
         if point is None:
             point = self.poi
@@ -1107,6 +1245,7 @@ class Lamella:
             synced_tasks.append(task_name)
         return synced_tasks
 
+
 @evented
 @dataclass
 class Experiment:
@@ -1115,14 +1254,21 @@ class Experiment:
     path: Path
     positions: EventedList[Lamella] = field(default_factory=EventedList)
     landing_positions: List[FibsemStagePosition] = field(default_factory=list)
-    created_at: float = field(default_factory=lambda: datetime.timestamp(datetime.now()))
-    task_protocol: 'AutoLamellaTaskProtocol' = field(default_factory=lambda: AutoLamellaTaskProtocol())
+    created_at: float = field(
+        default_factory=lambda: datetime.timestamp(datetime.now())
+    )
+    task_protocol: "AutoLamellaTaskProtocol" = field(
+        default_factory=lambda: AutoLamellaTaskProtocol()
+    )
     metadata: Dict[str, Any] = field(default_factory=dict)
     session: Optional[SessionInfo] = None
 
-    def __init__(self, path: Path,
-                 name: str = cfg.EXPERIMENT_NAME,
-                 metadata: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(
+        self,
+        path: Path,
+        name: str = cfg.EXPERIMENT_NAME,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """Create a new experiment.
 
         Args:
@@ -1138,7 +1284,7 @@ class Experiment:
         self.positions: EventedList[Lamella] = EventedList()
         self.landing_positions: List[FibsemStagePosition] = []
 
-        self.task_protocol: AutoLamellaTaskProtocol = None # must be set externally
+        self.task_protocol: AutoLamellaTaskProtocol = None  # must be set externally
         self.metadata: Dict[str, Any] = metadata if metadata is not None else {}
         # The instrument, operator and software that last worked on this. Filled in
         # by register_metadata, when a session adopts the experiment and there is a
@@ -1160,12 +1306,14 @@ class Experiment:
         }
 
         if include_protocol:
-            state_dict["protocol"] = self.task_protocol.to_dict() if self.task_protocol is not None else None
+            state_dict["protocol"] = (
+                self.task_protocol.to_dict() if self.task_protocol is not None else None
+            )
 
         return state_dict
 
     @classmethod
-    def from_dict(cls, ddict: dict) -> 'Experiment':
+    def from_dict(cls, ddict: dict) -> "Experiment":
 
         path = os.path.dirname(ddict["path"])
         name = ddict["name"]
@@ -1233,7 +1381,7 @@ class Experiment:
         """Set the organisation name in metadata."""
         self.metadata["organisation"] = value
 
-    def get_lamella_by_name(self, name: str) -> Optional['Lamella']:
+    def get_lamella_by_name(self, name: str) -> Optional["Lamella"]:
         """Return the Lamella with the given name, or None if not found."""
         return next((p for p in self.positions if p.name == name), None)
 
@@ -1253,7 +1401,7 @@ class Experiment:
         """
 
     @staticmethod
-    def load(fname: Path) -> 'Experiment':
+    def load(fname: Path) -> "Experiment":
         """Load an experiment from disk.
 
         Automatically attempts to load the task_protocol from protocol.yaml
@@ -1291,7 +1439,9 @@ class Experiment:
                 experiment.task_protocol = AutoLamellaTaskProtocol.load(protocol_path)
                 logging.info(f"Loaded task protocol from {protocol_path}")
             except Exception as e:
-                logging.warning(f"Failed to load task protocol from {protocol_path}: {e}")
+                logging.warning(
+                    f"Failed to load task protocol from {protocol_path}: {e}"
+                )
 
         return experiment
 
@@ -1350,7 +1500,9 @@ class Experiment:
                 # Preserve existing milling pattern positions
                 if existing_config is not None and new_config.milling:
                     for milling_name, new_milling_config in new_config.milling.items():
-                        existing_milling_config = existing_config.milling.get(milling_name)
+                        existing_milling_config = existing_config.milling.get(
+                            milling_name
+                        )
                         if existing_milling_config is None:
                             continue
 
@@ -1366,10 +1518,9 @@ class Experiment:
                             if existing_stage is None:
                                 continue
 
-                            if (
-                                type(existing_stage.pattern) is type(new_stage.pattern)
-                                and hasattr(existing_stage.pattern, "point")
-                            ):
+                            if type(existing_stage.pattern) is type(
+                                new_stage.pattern
+                            ) and hasattr(existing_stage.pattern, "point"):
                                 new_stage.pattern.point = deepcopy(
                                     existing_stage.pattern.point
                                 )
@@ -1383,7 +1534,11 @@ class Experiment:
             )
 
         # Update base protocol if requested (skip if source is already the base protocol)
-        if update_base_protocol and self.task_protocol is not None and source_lamella_name is not None:
+        if (
+            update_base_protocol
+            and self.task_protocol is not None
+            and source_lamella_name is not None
+        ):
             for task_name in task_names:
                 if task_name in source_task_config:
                     self.task_protocol.task_config[task_name] = deepcopy(
@@ -1416,13 +1571,20 @@ class Experiment:
 
         # check if lamella already exists
         if lamella in self.positions:
-            raise ValueError(f"Lamella {lamella.name} already exists in the experiment.")
+            raise ValueError(
+                f"Lamella {lamella.name} already exists in the experiment."
+            )
 
         self.positions.append(deepcopy(lamella))
         logging.info(f"Added lamella {lamella.name} to experiment {self.name}")
 
     @classmethod
-    def create(cls, path: Path, name: str = cfg.EXPERIMENT_NAME, metadata: Optional[Dict[str, Any]] = None) -> 'Experiment':
+    def create(
+        cls,
+        path: Path,
+        name: str = cfg.EXPERIMENT_NAME,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> "Experiment":
         """Create a new experiment with the given path and name. Also configures logging.
 
         Args:
@@ -1501,9 +1663,7 @@ class Experiment:
 
         # After _register_metadata, which sets `application` on the very SystemInfo
         # being snapshotted here.
-        self.session = SessionInfo.collect(
-            microscope, user=self._declared_user()
-        )
+        self.session = SessionInfo.collect(microscope, user=self._declared_user())
 
         # Written now rather than left to whatever saves next -- relying on someone
         # else's save is how FIB-490 lost every failed task. Only for an experiment
@@ -1543,13 +1703,15 @@ class Experiment:
         """Save the task protocol to disk in the experiment directory."""
         self.task_protocol.save(os.path.join(self.path, "protocol.yaml"))
 
-###### TASK REFACTORING ##########
+    ###### TASK REFACTORING ##########
 
-    def add_new_lamella(self,
-                        microscope_state: MicroscopeState,
-                        task_config: EventedDict[str, AutoLamellaTaskConfig],
-                        name: Optional[str] = None,
-                        fluorescence_pose: Optional[MicroscopeState] = None) -> None:
+    def add_new_lamella(
+        self,
+        microscope_state: MicroscopeState,
+        task_config: EventedDict[str, AutoLamellaTaskConfig],
+        name: Optional[str] = None,
+        fluorescence_pose: Optional[MicroscopeState] = None,
+    ) -> None:
         """Create a new lamella and add it to the experiment.
 
         Args:
@@ -1573,10 +1735,9 @@ class Experiment:
         path = Path(os.path.join(self.path, name))
 
         # create the lamella
-        lamella = Lamella(petname=name,
-                          path=path,
-                          number=number,
-                          task_config=deepcopy(task_config))
+        lamella = Lamella(
+            petname=name, path=path, number=number, task_config=deepcopy(task_config)
+        )
         if template.alignment_area is not None:
             lamella.alignment_area = deepcopy(template.alignment_area)
         if template.poi is not None:
@@ -1616,7 +1777,7 @@ class Experiment:
 
         df_task_history = pd.DataFrame(history)
         return df_task_history
-    
+
     def experiment_summary_dataframe(self) -> pd.DataFrame:
         """Create a summary dataframe of the experiment."""
         edict = []
@@ -1628,9 +1789,15 @@ class Experiment:
                 "experiment_id": self.id,
                 "lamella_name": p.name,
                 "lamella_id": p.id,
-                "last_completed": p.last_completed_task.completed if p.last_completed_task else None,
-                "last_completed_task": p.last_completed_task.name if p.last_completed_task else None,
-                "last_completed_at": p.last_completed_task.completed_at if p.last_completed_task else None,
+                "last_completed": p.last_completed_task.completed
+                if p.last_completed_task
+                else None,
+                "last_completed_task": p.last_completed_task.name
+                if p.last_completed_task
+                else None,
+                "last_completed_at": p.last_completed_task.completed_at
+                if p.last_completed_task
+                else None,
                 "is_completed": self.task_protocol.workflow_config.is_completed(p),
                 "is_failure": p.is_failure,
                 "milling_angle": p.milling_angle,
@@ -1640,9 +1807,9 @@ class Experiment:
         df = pd.DataFrame(edict)
 
         return df
-    
+
     def workflow_dataframe(self) -> pd.DataFrame:
-        """Create a dataframe with the workflow """
+        """Create a dataframe with the workflow"""
         wlist: List[Dict] = []
         for i, t in enumerate(self.task_protocol.workflow_config.tasks, 1):
             ddict = {

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1485,7 +1485,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             return False
         supervised = get_task_supervision(task_name, self.autolamella_ui)
         if supervised and self._agent_supervision_active(task_name):
-            self.supervised_status_btn.setIcon(fibsem_icon("mdi:robot", color="white"))
+            self.supervised_status_btn.setIcon(
+                fibsem_icon("mdi:star-four-points", color="white")
+            )
             self.supervised_status_btn.setText("Agent")
             self.supervised_status_btn.setToolTip(
                 f"{task_name} is supervised by the connected agent. "

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -103,6 +103,7 @@ from fibsem.ui.stylesheets import (
     PROGRESS_BAR_STYLESHEET,
     SECONDARY_BUTTON_STYLESHEET,
     STATUS_BAR_STYLESHEET,
+    SUPERVISION_STATUS_AGENT_STYLESHEET,
     SUPERVISION_STATUS_AUTOMATED_STYLESHEET,
     SUPERVISION_STATUS_SUPERVISED_STYLESHEET,
     USER_ATTENTION_BUTTON_STYLESHEET,
@@ -1295,8 +1296,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         ):
             return
 
-        initial_state = "supervised" if selected_tasks[0].supervise else "automated"
-        self._set_border_state(initial_state)
+        self._set_border_state(self._running_border_state(selected_tasks[0].name))
         self._push_timeline_estimates(
             [(ln, tn) for tn in task_names for ln in lamella_names]
         )
@@ -1450,13 +1450,52 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             style.polish(self._border_frame)
         self._border_frame.update()
 
+    def _agent_supervision_active(self, task_name: str) -> bool:
+        """Whether ``task_name``'s questions are addressed to a connected agent.
+
+        Gated on the agent server actually running — with no server there is
+        nobody the designation could refer to, so all the agent chrome stays
+        invisible and a designated task behaves as plain supervised.
+        """
+        ui = self.autolamella_ui
+        if ui is None or task_name is None:
+            return False
+        host = getattr(ui, "_agent_server_host", None)
+        if host is None or not getattr(host, "running", False):
+            return False
+        protocol = ui.protocol
+        if protocol is None:
+            return False
+        return protocol.get_supervisor(task_name) == "agent"
+
+    def _running_border_state(self, task_name: Optional[str]) -> str:
+        """The border for a running workflow: automated, supervised, or agent."""
+        if task_name is None or not get_task_supervision(
+            task_name, self.autolamella_ui
+        ):
+            return "automated"
+        if self._agent_supervision_active(task_name):
+            return "agent"
+        return "supervised"
+
     def _update_supervised_status(self) -> bool:
         """Update the supervised status chip for the current task."""
         task_name = self._current_task_name
         if task_name is None or self.autolamella_ui is None:
             return False
         supervised = get_task_supervision(task_name, self.autolamella_ui)
-        if supervised:
+        if supervised and self._agent_supervision_active(task_name):
+            self.supervised_status_btn.setIcon(fibsem_icon("mdi:robot", color="white"))
+            self.supervised_status_btn.setText("Agent")
+            self.supervised_status_btn.setToolTip(
+                f"{task_name} is supervised by the connected agent. "
+                "You can still answer any question first. Click to toggle "
+                "supervision."
+            )
+            self.supervised_status_btn.setStyleSheet(
+                SUPERVISION_STATUS_AGENT_STYLESHEET
+            )
+        elif supervised:
             self.supervised_status_btn.setIcon(
                 fibsem_icon("mdi:account-hard-hat", color="white")
             )
@@ -1493,9 +1532,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             if task.name == self._current_task_name:
                 task.supervise = not task.supervise
                 break
-        supervised = self._update_supervised_status()
+        self._update_supervised_status()
         if self.autolamella_ui.is_workflow_running:
-            self._set_border_state("supervised" if supervised else "automated")
+            self._set_border_state(self._running_border_state(self._current_task_name))
         # Refresh the workflow widget to reflect the toggled supervise state
         if hasattr(self, "lamella_workflow_widget"):
             self.lamella_workflow_widget.workflow.refresh_all()
@@ -2703,7 +2742,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
     def _refresh_workflow_indicators(self) -> None:
         """Re-read the waiting/supervised/running state into the window chrome."""
         # refresh the supervised status chip
-        supervised = self._update_supervised_status()
+        self._update_supervised_status()
 
         waiting = self.autolamella_ui.WAITING_FOR_USER_INTERACTION
         # The timeline freezes its countdown on this: a wait for a human is not machine
@@ -2729,7 +2768,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         elif self.autolamella_ui.WORKFLOW_PENDING:
             self._set_border_state("pending")
         elif self.autolamella_ui.is_workflow_running:
-            self._set_border_state("supervised" if supervised else "automated")
+            self._set_border_state(self._running_border_state(self._current_task_name))
         else:
             self._set_border_state("idle")
 

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -259,13 +259,11 @@ def build_sidecar(client, capabilities):
         data, err = _call(client, "POST", "/app/workflow/stop", None)
         return err if err else data
 
-    def set_task_supervision(task_name: str, supervise: bool):
-        data, err = _call(
-            client,
-            "POST",
-            "/app/supervision",
-            {"task_name": task_name, "supervise": bool(supervise)},
-        )
+    def set_task_supervision(task_name: str, supervise: bool, supervisor: str = None):  # noqa: RUF013
+        payload = {"task_name": task_name, "supervise": bool(supervise)}
+        if supervisor is not None:
+            payload["supervisor"] = supervisor
+        data, err = _call(client, "POST", "/app/supervision", payload)
         return err if err else data
 
     def requeue_task(item_name: str, task_name: str, front: bool = False):

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -12,7 +12,7 @@ The read-scope requirement is applied where the router is included, so auth
 stays in one place (build_server).
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
 
@@ -53,7 +53,12 @@ class AppContext(Protocol):
 
     def stop_workflow(self) -> Dict[str, Any]: ...
 
-    def set_supervision(self, task_name: str, supervise: bool) -> Dict[str, Any]: ...
+    def set_supervision(
+        self,
+        task_name: str,
+        supervise: bool,
+        supervisor: Optional[str] = None,
+    ) -> Dict[str, Any]: ...
 
     def requeue_task(
         self, item_name: str, task_name: str, front: bool = False
@@ -160,15 +165,21 @@ def build_app_control_router(context: AppContext) -> APIRouter:
     @router.post("/supervision")
     def set_supervision(body: Dict[str, Any]):
         task_name = body.get("task_name")
-        if not isinstance(task_name, str) or "supervise" not in body:
+        supervisor = body.get("supervisor")
+        if (
+            not isinstance(task_name, str)
+            or "supervise" not in body
+            or supervisor not in (None, "human", "agent")
+        ):
             raise HTTPException(
                 status_code=422,
                 detail={
                     "error_type": "missing_field",
-                    "message": "Pass task_name (string) and supervise (boolean).",
+                    "message": "Pass task_name (string) and supervise (boolean); "
+                    "supervisor is optional, 'human' or 'agent'.",
                 },
             )
-        return context.set_supervision(task_name, bool(body["supervise"]))
+        return context.set_supervision(task_name, bool(body["supervise"]), supervisor)
 
     @router.post("/queue/requeue")
     def requeue_task(body: Dict[str, Any]):

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -243,6 +243,7 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         params={
             "task_name": "the task to change, e.g. 'Rough Milling'",
             "supervise": "true to ask before acting, false to run automatically",
+            "supervisor": "optional: who supervised questions are addressed to — 'human' (default) or 'agent'; the operator can always answer first",
         },
     ),
     ToolSpec(

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -348,6 +348,26 @@ BORDER_STATE_COLOURS = {
 
 BORDER_WIDTH_PX = 4
 
+# The agent supervision chip: same colour as the agent border state, one
+# source (BORDER_STATE_COLOURS) — hover/pressed are darkened by hand like the
+# supervised/automated chips above.
+SUPERVISION_STATUS_AGENT_STYLESHEET = f"""
+                QPushButton {{
+                    background-color: {BORDER_STATE_COLOURS["agent"]};
+                    color: white;
+                    border: none;
+                    padding: 5px 12px;
+                    border-radius: 3px;
+                    font-weight: bold;
+                }}
+                QPushButton:hover {{
+                    background-color: #a300d9;
+                }}
+                QPushButton:pressed {{
+                    background-color: #8a00b8;
+                }}
+            """
+
 
 def border_stylesheet(object_name: str) -> str:
     """QSS border rules for the frame whose ``objectName`` is *object_name*.

--- a/tests/autolamella/test_agent_context.py
+++ b/tests/autolamella/test_agent_context.py
@@ -178,6 +178,47 @@ def test_set_supervision_flips_the_live_protocol(experiment):
     assert AgentContext(Host()).set_supervision("x", True)["available"] is False
 
 
+def test_supervisor_designation_round_trips_and_is_settable(experiment):
+    from fibsem.applications.autolamella.structures import (
+        AutoLamellaTaskDescription,
+    )
+
+    experiment.task_protocol.workflow_config.tasks.append(
+        AutoLamellaTaskDescription(name="Rough Milling", supervise=True, required=True)
+    )
+    host = Host()
+    host.experiment = experiment
+    ctx = AgentContext(host)
+
+    # Default is human — today's behaviour exactly.
+    task = experiment.task_protocol.workflow_config.tasks[-1]
+    assert task.supervisor == "human"
+    assert experiment.task_protocol.get_supervisor("Rough Milling") == "human"
+    assert ctx.protocol()["tasks"][-1]["supervisor"] == "human"
+
+    # The agent designates itself; the same read the chrome uses sees it.
+    applied = ctx.set_supervision("Rough Milling", True, supervisor="agent")
+    assert applied["applied"] is True
+    assert applied["supervisor"] == "agent"
+    assert experiment.task_protocol.get_supervisor("Rough Milling") == "agent"
+
+    bad = ctx.set_supervision("Rough Milling", True, supervisor="robot overlord")
+    assert bad["applied"] is False
+
+    # Serialization: the field survives a round trip, an old dict without it
+    # defaults to human, and unknown keys from a newer version are ignored.
+    reloaded = AutoLamellaTaskDescription.from_dict(task.to_dict())
+    assert reloaded.supervisor == "agent"
+    legacy = AutoLamellaTaskDescription.from_dict(
+        {"name": "x", "supervise": True, "required": False}
+    )
+    assert legacy.supervisor == "human"
+    future = AutoLamellaTaskDescription.from_dict(
+        {"name": "x", "supervise": True, "required": False, "from_the_future": 1}
+    )
+    assert future.name == "x"
+
+
 def test_requeue_task_reruns_a_completed_pair(experiment, microscope):
     from fibsem.applications.autolamella.structures import (
         AutoLamellaTaskDescription,

--- a/tests/ui/test_agent_supervisor_chrome.py
+++ b/tests/ui/test_agent_supervisor_chrome.py
@@ -1,0 +1,101 @@
+"""The agent-supervision chrome: purple only when there is actually an agent.
+
+The supervisor designation is display-and-watchdog semantics, and the display
+half is gated hard: with no agent server running, a task designated
+``supervisor: agent`` looks exactly like plain supervised — none of the agent
+chrome exists for a user who never enabled the feature.
+
+Same offscreen main-window harness as test_mainui_workflow_status (minimap
+stubbed; everything else real)."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from psygnal.containers import EventedDict
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.structures import MicroscopeState
+
+
+@pytest.fixture(scope="module")
+def main_ui(qapp):
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
+    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
+    try:
+        window = module.AutoLamellaSingleWindowUI()
+    finally:
+        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    window.autolamella_ui.system_widget.connect_to_microscope()
+    yield window
+    if window.autolamella_ui.microscope is not None:
+        window.autolamella_ui.microscope.disconnect()
+    original_quit = qapp.quit
+    qapp.quit = lambda: None
+    try:
+        window.close()
+    finally:
+        qapp.quit = original_quit
+
+
+class _RunningHost:
+    running = True
+
+
+@pytest.fixture
+def agent_supervised_task(main_ui, tmp_path):
+    """A protocol whose Rough Milling is designated supervisor: agent."""
+    ui = main_ui.autolamella_ui
+    experiment = Experiment(path=tmp_path / "exp", name="chrome-exp")
+    experiment.task_protocol = AutoLamellaTaskProtocol()
+    experiment.task_protocol.workflow_config.tasks.append(
+        AutoLamellaTaskDescription(
+            name="Rough Milling",
+            supervise=True,
+            required=True,
+            supervisor="agent",
+        )
+    )
+    experiment.add_new_lamella(MicroscopeState(), EventedDict())
+    previous = (ui.experiment, ui._agent_server_host, main_ui._current_task_name)
+    ui.experiment = experiment
+    main_ui._current_task_name = "Rough Milling"
+    yield experiment
+    ui.experiment, ui._agent_server_host, main_ui._current_task_name = previous
+
+
+def test_designation_is_invisible_without_a_running_server(
+    main_ui, agent_supervised_task
+):
+    main_ui.autolamella_ui._agent_server_host = None
+    assert main_ui._update_supervised_status() is True
+    assert main_ui.supervised_status_btn.text() == "Supervised"
+    assert main_ui._running_border_state("Rough Milling") == "supervised"
+
+
+def test_designation_shows_agent_chrome_with_a_running_server(
+    main_ui, agent_supervised_task
+):
+    main_ui.autolamella_ui._agent_server_host = _RunningHost()
+    assert main_ui._update_supervised_status() is True
+    assert main_ui.supervised_status_btn.text() == "Agent"
+    assert main_ui._running_border_state("Rough Milling") == "agent"
+
+
+def test_an_unsupervised_task_is_automated_regardless(main_ui, agent_supervised_task):
+    main_ui.autolamella_ui._agent_server_host = _RunningHost()
+    task = agent_supervised_task.task_protocol.workflow_config.tasks[-1]
+    task.supervise = False
+    assert main_ui._update_supervised_status() is False
+    assert main_ui.supervised_status_btn.text() == "Automated"
+    assert main_ui._running_border_state("Rough Milling") == "automated"


### PR DESCRIPTION
The first implementation piece of agent mode ([design](https://linear.app/fibsemos/issue/FIB-851) + [mockup](https://claude.ai/code/artifact/85c7658d-653f-47a0-879c-a104b8cbe067)).

## The model

Supervision keeps its axis (supervised/auto). Supervised tasks gain a second one:

```yaml
supervise: true
supervisor: human   # default — today's behaviour, exactly
# or
supervisor: agent   # questions addressed to the connected agent
```

## How it works (plain language)

**Semantics are display-only in this PR.** Questions are raised identically either way, first-writer-wins is untouched, and the operator can always answer anything. What the field changes is what the window *says*:

- the supervision chip gains a third state — **Agent**, robot icon, in the provisioned agent purple (`BORDER_STATE_COLOURS["agent"]`, which until now only the Test menu could reach);
- the workflow border shows purple instead of blue while an agent-designated task runs (all three border sites route through one `_running_border_state` helper).

**The visibility gate is hard**: none of this appears unless the agent server is actually *running*. With no server there is nobody the designation could refer to, so a `supervisor: agent` task looks and behaves as plain supervised — a user who never enabled the feature can never see agent chrome. (Gate is server-running, not merely the preference ticked.)

**Remote surface**: the existing `POST /app/supervision` accepts an optional `supervisor` field ('human'/'agent', validated at both layers), so an agent can designate itself before a run; the protocol payload reports it per task.

**Persistence**: absent in old YAML → `human`. `from_dict` now keeps known fields only (the same rule `AutoLamellaTaskState` follows), so a protocol written by a newer build loads in an older one instead of raising on an unexpected kwarg — and this PR is exactly the kind of change that rule exists for.

The watchdog ("agent-designated prompt unanswered N minutes → escalate to the operator") is the next PR; it needs this field to know which silences are alarming.

## Note on the diff

`structures.py` carries ~280 lines of format-on-touch noise (CI formats whole files once edited, by design). The real changes there: the `supervisor` field, two `get_supervisor` readers, and the `from_dict` known-fields filter.

## Tests

Chrome through the real main window: designation invisible without a running server (chip says Supervised, border blue); Agent chip + purple border with one; unsupervised stays Automated regardless. Field round-trips YAML, legacy dicts default human, unknown keys from the future are ignored; the endpoint sets and reports it, and rejects invalid values. 91+ tests green.