### PR TITLE
[app] The agent watchdog: a quiet agent hands its question to you

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -223,6 +223,12 @@ def set_menu_icon(action: QAction, key: str) -> None:
     action.setIconVisibleInMenu(True)
 
 
+# How long a question addressed to the agent may stand unanswered before it
+# escalates to the operator. A preference later; a constant until the arming
+# dialog gives it a home.
+AGENT_WATCHDOG_MS = 5 * 60 * 1000
+
+
 def play_notification_sound():
     """Play a notification sound to alert the user."""
     QApplication.beep()
@@ -1220,6 +1226,15 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         # Add supervised status chip (shown during workflow to indicate supervision mode)
         self._current_task_name = None  # Track current task for supervision toggle
+        # The agent watchdog: a question addressed to the agent that goes
+        # unanswered this long stops being the agent's and becomes yours —
+        # the ordinary waiting chrome (orange border, attention button, sound)
+        # takes over, with a toast saying why. Lives in the app, so it
+        # survives the agent's own loop dying — the whole point.
+        self._agent_watchdog = QTimer(self)
+        self._agent_watchdog.setSingleShot(True)
+        self._agent_watchdog.timeout.connect(self._on_agent_watchdog_expired)
+        self._agent_watchdog_expired = False
         self.supervised_status_btn = QPushButton("Supervised")
         self.supervised_status_btn.setCursor(Qt.PointingHandCursor)  # type: ignore
         self.supervised_status_btn.setToolTip("Click to toggle supervision")
@@ -1778,6 +1793,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self._on_workflow_finished
         )
         self.autolamella_ui._hook_toast_signal.connect(self.show_toast)
+        # Question lifecycle drives the agent watchdog (armed per prompt on
+        # agent-designated tasks, disarmed by any answer). GUI thread: the
+        # responder emits these where the lifecycle already runs.
+        self.autolamella_ui.ui_responder.add_question_observer(self._on_question_event)
         notification_service._get_service().toast.connect(self._on_notification_service)
         self.autolamella_ui.system_widget.connected_signal.connect(
             self._on_microscope_connected
@@ -2741,16 +2760,54 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.autolamella_ui.lamella_list.refresh_all()
         self._on_lamella_card_selected(getattr(self, "_selected_card_lamella", None))
 
+    def _on_question_event(self, kind: str, payload: dict) -> None:
+        """GUI thread, from the responder: arm/disarm the agent watchdog."""
+        if kind == "prompt_raised":
+            self._agent_watchdog_expired = False
+            if self._agent_supervision_active(self._current_task_name):
+                self._agent_watchdog.start(AGENT_WATCHDOG_MS)
+            else:
+                self._agent_watchdog.stop()
+        elif kind in ("prompt_answered", "prompt_cancelled"):
+            self._agent_watchdog.stop()
+            self._agent_watchdog_expired = False
+        self._refresh_workflow_indicators()
+
+    def _on_agent_watchdog_expired(self) -> None:
+        """The agent went quiet: the standing question becomes the operator's."""
+        if not self.autolamella_ui.WAITING_FOR_USER_INTERACTION:
+            return  # the answer raced the timer; nothing is standing
+        self._agent_watchdog_expired = True
+        minutes = max(1, AGENT_WATCHDOG_MS // 60000)
+        notification_service.show_toast(
+            f"The agent hasn't answered in {minutes} minutes — "
+            "this question is now yours.",
+            "warning",
+        )
+        # The ordinary waiting chrome (orange border, attention button, sound)
+        # takes over below, now that agent_holding no longer suppresses it.
+        self._refresh_workflow_indicators()
+
     def _refresh_workflow_indicators(self) -> None:
         """Re-read the waiting/supervised/running state into the window chrome."""
         # refresh the supervised status chip
         self._update_supervised_status()
 
         waiting = self.autolamella_ui.WAITING_FOR_USER_INTERACTION
-        # The timeline freezes its countdown on this: a wait for a human is not machine
-        # time, and left running it would spend the estimate while nothing is happening.
+        # A question addressed to a running agent is not (yet) a wait for the
+        # operator: the chrome stays agent-purple and quiet while the watchdog
+        # counts down. Expiry — or a human-designated question — is what turns
+        # this into the ordinary waiting state.
+        agent_holding = (
+            waiting
+            and not self._agent_watchdog_expired
+            and self._agent_supervision_active(self._current_task_name)
+        )
+        # The timeline freezes its countdown on this: a wait for an answer is not
+        # machine time whoever is answering, and left running it would spend the
+        # estimate while nothing is happening.
         self.workflow_timeline.set_waiting_for_user(waiting)
-        if waiting:
+        if waiting and not agent_holding:
             # Show user attention button and change status bar color
             self.user_attention_btn.show()
             # Play notification sound once when entering waiting state
@@ -2765,6 +2822,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # Update border to reflect current workflow state
         if self._border_state == "stopping":
             pass  # Keep the red border until the workflow finishes unwinding
+        elif waiting and agent_holding:
+            self._set_border_state("agent")
         elif waiting:
             self._set_border_state("waiting")
         elif self.autolamella_ui.WORKFLOW_PENDING:

--- a/tests/ui/test_agent_watchdog.py
+++ b/tests/ui/test_agent_watchdog.py
@@ -1,0 +1,138 @@
+"""The agent watchdog: a question addressed to the agent stays purple and
+quiet while the timer counts; expiry hands it to the operator with the
+ordinary waiting chrome. Lives in the app so it survives the agent's own
+loop dying.
+
+Same offscreen main-window harness as the supervisor-chrome tests."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import time
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from psygnal.containers import EventedDict
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.structures import MicroscopeState
+
+
+@pytest.fixture(scope="module")
+def main_ui(qapp):
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
+    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
+    try:
+        window = module.AutoLamellaSingleWindowUI()
+    finally:
+        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    window.autolamella_ui.system_widget.connect_to_microscope()
+    yield window
+    if window.autolamella_ui.microscope is not None:
+        window.autolamella_ui.microscope.disconnect()
+    original_quit = qapp.quit
+    qapp.quit = lambda: None
+    try:
+        window.close()
+    finally:
+        qapp.quit = original_quit
+
+
+class _RunningHost:
+    running = True
+
+
+@pytest.fixture
+def agent_question_standing(main_ui, tmp_path):
+    """An agent-designated task with a question standing (waiting flag up)."""
+    ui = main_ui.autolamella_ui
+    experiment = Experiment(path=tmp_path / "exp", name="watchdog-exp")
+    experiment.task_protocol = AutoLamellaTaskProtocol()
+    experiment.task_protocol.workflow_config.tasks.append(
+        AutoLamellaTaskDescription(
+            name="Mill Fiducial", supervise=True, required=True, supervisor="agent"
+        )
+    )
+    experiment.add_new_lamella(MicroscopeState(), EventedDict())
+    previous = (
+        ui.experiment,
+        ui._agent_server_host,
+        main_ui._current_task_name,
+        ui.WAITING_FOR_USER_INTERACTION,
+    )
+    ui.experiment = experiment
+    ui._agent_server_host = _RunningHost()
+    main_ui._current_task_name = "Mill Fiducial"
+    ui.WAITING_FOR_USER_INTERACTION = True
+    yield experiment
+    main_ui._agent_watchdog.stop()
+    main_ui._agent_watchdog_expired = False
+    (
+        ui.experiment,
+        ui._agent_server_host,
+        main_ui._current_task_name,
+        ui.WAITING_FOR_USER_INTERACTION,
+    ) = previous
+    main_ui._refresh_workflow_indicators()
+
+
+def test_an_agent_question_holds_purple_and_quiet(main_ui, agent_question_standing):
+    main_ui._on_question_event("prompt_raised", {})
+    assert main_ui._agent_watchdog.isActive()
+    assert main_ui._border_state == "agent"  # not "waiting"
+    assert main_ui.user_attention_btn.isHidden()
+
+
+def test_an_answer_disarms_the_watchdog(main_ui, agent_question_standing):
+    main_ui._on_question_event("prompt_raised", {})
+    assert main_ui._agent_watchdog.isActive()
+    main_ui.autolamella_ui.WAITING_FOR_USER_INTERACTION = False
+    main_ui._on_question_event(
+        "prompt_answered", {"answered_by": "agent", "response": True}
+    )
+    assert not main_ui._agent_watchdog.isActive()
+    assert main_ui._agent_watchdog_expired is False
+
+
+def test_expiry_hands_the_question_to_the_operator(
+    main_ui, agent_question_standing, qapp, monkeypatch
+):
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    monkeypatch.setattr(module, "AGENT_WATCHDOG_MS", 50)
+    main_ui._on_question_event("prompt_raised", {})
+    assert main_ui._border_state == "agent"
+
+    deadline = time.monotonic() + 5
+    while not main_ui._agent_watchdog_expired and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+
+    assert main_ui._agent_watchdog_expired is True
+    assert main_ui._border_state == "waiting"  # the ordinary chrome took over
+    assert not main_ui.user_attention_btn.isHidden()
+
+
+def test_a_human_question_escalates_immediately(main_ui, agent_question_standing):
+    # Same standing question, but designated back to the human: no hold.
+    task = agent_question_standing.task_protocol.workflow_config.tasks[-1]
+    task.supervisor = "human"
+    main_ui._on_question_event("prompt_raised", {})
+    assert not main_ui._agent_watchdog.isActive()
+    assert main_ui._border_state == "waiting"
+    assert not main_ui.user_attention_btn.isHidden()
+
+
+def test_expiry_with_nothing_standing_is_a_noop(main_ui, agent_question_standing):
+    main_ui.autolamella_ui.WAITING_FOR_USER_INTERACTION = False
+    main_ui._on_agent_watchdog_expired()
+    assert main_ui._agent_watchdog_expired is False


### PR DESCRIPTION
Stacked on #693 — **merge #693 into main first, then retarget/merge this** (yesterday's stranded-stack lesson: never merge a child into an already-merged parent branch).

## How it works (plain language)

The failure this exists for: a task is designated `supervisor: agent`, the operator walks away — and the agent's session dies. Questions have no timeout by design (FIB-826), so the workflow would wait forever, silently.

Three states now:

1. **Question parks on an agent-designated task** → the window *stays agent-purple and quiet*: no orange border, no attention button, no sound. (This also fixes the wart #693 left, where any parked prompt immediately fired the full waiting chrome even mid-agent-supervision.) A 5-minute timer starts.
2. **Agent answers in time** → timer disarmed; the operator never notices anything happened.
3. **Timer expires** → the question becomes the operator's: ordinary waiting chrome takes over — orange border, attention button, notification sound — plus a toast: *"The agent hasn't answered in 5 minutes — this question is now yours."* No state changes hands mechanically; first-writer-wins always meant the operator could answer, this just tells them they should.

The timer is driven by the responder's own lifecycle events (#689): armed per `prompt_raised` when the current task is agent-designated, disarmed by any `prompt_answered`/`prompt_cancelled`. **It lives in the app process** — a watchdog running inside the watcher would die with it. Human-designated questions escalate immediately, exactly as before; expiry that races an answer is a no-op.

The 5 minutes is a module constant for now; it gets a preferences home with the FIB-845 arming dialog.

## Tests

Real main-window harness: agent question holds purple with the attention button hidden; an answer disarms; expiry (shortened timer) flips to the ordinary waiting chrome; human-designated questions escalate immediately; expiry with nothing standing is a no-op. 15 tests green in the chrome/watchdog/status suites, responder/timeline/POI suites unaffected.