### PR TITLE
[app] The workflow tab's supervision selector cycles through Agent

### DIFF
--- a/fibsem/applications/autolamella/ui/workflow_config_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_config_widget.py
@@ -70,8 +70,35 @@ class _DraggableTaskList(QListWidget):
         self.reordered.emit(tasks)
 
 
+def _agent_supervision_available() -> bool:
+    """Whether the Agent option exists at all: the agent-server preference is on.
+
+    The preference rather than server-running — protocols are configured before
+    a microscope connects. Without it, the selector is exactly the old
+    two-state toggle and a stored ``supervisor: agent`` displays as plain
+    Supervised (the same hard-gate rule as the window chrome).
+    """
+    import fibsem.config as fibsem_cfg
+
+    try:
+        return bool(fibsem_cfg.load_user_preferences().features.agent_server_enabled)
+    except Exception:
+        return False
+
+
 def _supervise_icon(task: AutoLamellaTaskDescription) -> tuple[str, str, str]:
-    """Return (icon_name, icon_color, tooltip) for the supervised/automated indicator."""
+    """Return (icon_name, icon_color, tooltip) for the supervision indicator."""
+    if (
+        task.supervise
+        and getattr(task, "supervisor", "human") == "agent"
+        and _agent_supervision_available()
+    ):
+        return (
+            "mdi:star-four-points",
+            stylesheets.BORDER_STATE_COLOURS["agent"],
+            "Agent — the connected agent answers this task's questions "
+            "(you can always answer first). Click to change.",
+        )
     if task.supervise:
         return "mdi:account-hard-hat", stylesheets.PRIMARY_COLOR, "Supervised"
     return "mdi:lightning-bolt-circle", stylesheets.AUTOMATED_COLOR, "Automated"
@@ -183,9 +210,27 @@ class WorkflowTaskRowWidget(QWidget):
         self.refresh()
 
     def _on_supervise_clicked(self) -> None:
-        self.task.supervise = not self.task.supervise
+        """Cycle the supervision state: Automated → Supervised → Agent → Automated.
+
+        The Agent step exists only while the agent-server preference is on;
+        without it this is the old two-state toggle. Leaving the agent state
+        resets ``supervisor`` to human so no hidden designation survives the
+        cycle.
+        """
+        task = self.task
+        if not task.supervise:
+            task.supervise = True
+            task.supervisor = "human"
+        elif (
+            getattr(task, "supervisor", "human") != "agent"
+            and _agent_supervision_available()
+        ):
+            task.supervisor = "agent"
+        else:
+            task.supervise = False
+            task.supervisor = "human"
         self.refresh()
-        self.supervised_changed.emit(self.task)
+        self.supervised_changed.emit(task)
 
     def _on_remove_clicked(self) -> None:
         reply = QMessageBox.question(

--- a/tests/ui/test_workflow_supervisor_selector.py
+++ b/tests/ui/test_workflow_supervisor_selector.py
@@ -1,0 +1,73 @@
+"""The workflow tab's supervision selector: a cycle, gated on the feature.
+
+With the agent-server preference off the control is exactly the old two-state
+toggle, and a stored ``supervisor: agent`` displays as plain Supervised — the
+same hard-gate rule as the window chrome. With it on, a third step joins the
+cycle: Automated → Supervised → Agent → Automated."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskDescription
+from fibsem.applications.autolamella.ui import workflow_config_widget as module
+
+
+@pytest.fixture
+def row(qapp):
+    task = AutoLamellaTaskDescription(
+        name="Mill Fiducial", supervise=False, required=True
+    )
+    widget = module.WorkflowTaskRowWidget(task)
+    yield widget
+    widget.deleteLater()
+    qapp.processEvents()
+
+
+def test_without_the_feature_the_toggle_is_two_state(row, monkeypatch):
+    monkeypatch.setattr(module, "_agent_supervision_available", lambda: False)
+    row._on_supervise_clicked()
+    assert (row.task.supervise, row.task.supervisor) == (True, "human")
+    row._on_supervise_clicked()
+    assert (row.task.supervise, row.task.supervisor) == (False, "human")
+
+
+def test_with_the_feature_the_cycle_gains_the_agent_step(row, monkeypatch):
+    monkeypatch.setattr(module, "_agent_supervision_available", lambda: True)
+    row._on_supervise_clicked()
+    assert (row.task.supervise, row.task.supervisor) == (True, "human")
+    assert row.btn_supervise.toolTip() == "Supervised"
+    row._on_supervise_clicked()
+    assert (row.task.supervise, row.task.supervisor) == (True, "agent")
+    assert row.btn_supervise.toolTip().startswith("Agent")
+    row._on_supervise_clicked()
+    # Leaving the agent state resets the designation: nothing hidden survives.
+    assert (row.task.supervise, row.task.supervisor) == (False, "human")
+    assert row.btn_supervise.toolTip() == "Automated"
+
+
+def test_a_designated_task_displays_as_supervised_when_the_feature_is_off(
+    row, monkeypatch
+):
+    monkeypatch.setattr(module, "_agent_supervision_available", lambda: False)
+    row.task.supervise = True
+    row.task.supervisor = "agent"
+    row.refresh()
+    assert row.btn_supervise.toolTip() == "Supervised"
+    # And the click matches what is displayed: Supervised → Automated.
+    row._on_supervise_clicked()
+    assert (row.task.supervise, row.task.supervisor) == (False, "human")
+
+
+def test_each_click_announces_the_change(row, monkeypatch):
+    monkeypatch.setattr(module, "_agent_supervision_available", lambda: True)
+    seen = []
+    row.supervised_changed.connect(lambda task: seen.append(task.supervisor))
+    row._on_supervise_clicked()
+    row._on_supervise_clicked()
+    row._on_supervise_clicked()
+    assert seen == ["human", "agent", "human"]


### PR DESCRIPTION
Stacked on #695 (which stacks on #693) — **merge bottom-up: #693 → #695 → this**, retargeting as each lands.

The answer to "how does a user enable agent mode?": the workflow tab's per-task supervise button, which was a two-state icon toggle, becomes a three-step cycle:

**Automated** (green bolt) → **Supervised** (blue) → **Agent** (purple star-four-points, matching the chip and border) → back to Automated.

Rules, all live-gated on the agent-server preference:

- **Feature off** → the old two-state toggle, bit for bit; a protocol carrying `supervisor: agent` *displays* as plain Supervised and clicking it goes to Automated — display and click always agree, and no agent state can be seen or produced from the GUI (same hard-gate rule as the chrome).
- **Feature on** → the third step joins the cycle; the Agent tooltip explains the contract ("the connected agent answers this task's questions — you can always answer first").
- Gate is the *preference*, not server-running: protocols get configured before a microscope connects.
- Leaving the agent state resets `supervisor` to human — nothing hidden survives the cycle.
- The status chip's click keeps toggling supervised↔automated only: changing *who* supervises stays a deliberate act in the workflow tab, not something you cycle into by tapping a status chip mid-run.

## Tests

Cycle with feature on (including the emitted supervisor sequence human→agent→human), two-state with it off, and the designated-but-disabled display/click agreement. 12 green with the chrome + watchdog suites.