### PR TITLE
[app] The arming dialog: session consent in Tools, durable policy in Preferences

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -670,6 +670,18 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             parent=self,
         )
 
+        # Session controls for the embedded agent server: status, token, and
+        # scope arming (arming is per-session consent; the durable policy is in
+        # Preferences -> Agent). Visible only with the feature enabled, next to
+        # Scripts — its future Automation-menu sibling (FIB-863).
+        self.action_agent_server = QAction("Agent Server...", self)
+        self.action_agent_server.setMenuRole(QAction.NoRole)
+        self.action_agent_server.setToolTip(
+            "Session status, access token, and what the connected agent may do"
+        )
+        self.action_agent_server.triggered.connect(self._on_agent_server_dialog)
+        tools_menu.addAction(self.action_agent_server)
+
         # Below the separator because these act on the install rather than on the
         # experiment. The wizard needs a home here as well as on the connection tab:
         # the callout there appears once and is dismissible, so without this entry a
@@ -914,6 +926,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.scripts_menu.menuAction().setVisible(
             self._preferences.features.scripts_enabled
             or self.script_menu_controller.runner.is_running
+        )
+        # Same rule as the rest of the agent chrome: invisible unless enabled.
+        self.action_agent_server.setVisible(
+            self._preferences.features.agent_server_enabled
         )
         # getattr because this also runs from the preferences dialog, and the tab it
         # reaches into is built by AutoLamellaUI rather than here.
@@ -2760,12 +2776,34 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.autolamella_ui.lamella_list.refresh_all()
         self._on_lamella_card_selected(getattr(self, "_selected_card_lamella", None))
 
+    def _on_agent_server_dialog(self) -> None:
+        """Open the session dialog: status, token, and scope arming."""
+        from fibsem.applications.autolamella.ui.agent_server_dialog import (
+            AgentServerDialog,
+        )
+
+        dialog = AgentServerDialog(
+            host_provider=lambda: getattr(
+                self.autolamella_ui, "_agent_server_host", None
+            ),
+            parent=self,
+        )
+        dialog.exec_()
+
+    def _watchdog_ms(self) -> int:
+        """The watchdog deadline, from Preferences → Agent (constant fallback)."""
+        try:
+            minutes = fibsem_cfg.load_user_preferences().agent.watchdog_minutes
+            return max(1, int(minutes)) * 60 * 1000
+        except Exception:
+            return AGENT_WATCHDOG_MS
+
     def _on_question_event(self, kind: str, payload: dict) -> None:
         """GUI thread, from the responder: arm/disarm the agent watchdog."""
         if kind == "prompt_raised":
             self._agent_watchdog_expired = False
             if self._agent_supervision_active(self._current_task_name):
-                self._agent_watchdog.start(AGENT_WATCHDOG_MS)
+                self._agent_watchdog.start(self._watchdog_ms())
             else:
                 self._agent_watchdog.stop()
         elif kind in ("prompt_answered", "prompt_cancelled"):
@@ -2778,7 +2816,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if not self.autolamella_ui.WAITING_FOR_USER_INTERACTION:
             return  # the answer raced the timer; nothing is standing
         self._agent_watchdog_expired = True
-        minutes = max(1, AGENT_WATCHDOG_MS // 60000)
+        minutes = max(1, self._watchdog_ms() // 60000)
         notification_service.show_toast(
             f"The agent hasn't answered in {minutes} minutes — "
             "this question is now yours.",

--- a/fibsem/applications/autolamella/ui/agent_server_dialog.py
+++ b/fibsem/applications/autolamella/ui/agent_server_dialog.py
@@ -35,6 +35,7 @@ from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.stylesheets import BORDER_STATE_COLOURS
 from fibsem.ui.tokens import (
     BORDER_COLOR,
+    GRAY_ICON_COLOR,
     OK_COLOR,
     PANEL_COLOR,
     TEXT_COLOR,
@@ -136,10 +137,16 @@ class AgentServerDialog(QDialog):
         from PyQt5.QtGui import QFontDatabase
 
         self._token_edit.setFont(QFontDatabase.systemFont(QFontDatabase.FixedFont))
+        # checked-state swap is the widget's own machinery — icons and
+        # colours both, so a toggle can never drop to the black default.
         self._btn_reveal = IconToolButton(
-            icon="mdi:eye-outline", tooltip="Show the token", size=26
+            icon="mdi:eye-outline",
+            checked_icon="mdi:eye-off-outline",
+            tooltip="Show the token",
+            checked_tooltip="Hide the token",
+            checkable=True,
+            size=26,
         )
-        self._btn_reveal.setCheckable(True)
         self._btn_copy = IconToolButton(
             icon="mdi:content-copy", tooltip="Copy the token", size=26
         )
@@ -252,10 +259,6 @@ class AgentServerDialog(QDialog):
 
     def _on_reveal_toggled(self, show: bool) -> None:
         self._token_edit.setEchoMode(QLineEdit.Normal if show else QLineEdit.Password)
-        self._btn_reveal.setIcon(
-            fibsem_icon("mdi:eye-off-outline" if show else "mdi:eye-outline")
-        )
-        self._btn_reveal.setToolTip("Hide the token" if show else "Show the token")
 
     def _on_copy_clicked(self) -> None:
         clipboard = QApplication.clipboard()
@@ -268,7 +271,7 @@ class AgentServerDialog(QDialog):
         QTimer.singleShot(1500, self._restore_copy_button)
 
     def _restore_copy_button(self) -> None:
-        self._btn_copy.setIcon(fibsem_icon("mdi:content-copy"))
+        self._btn_copy.setIcon(fibsem_icon("mdi:content-copy", color=GRAY_ICON_COLOR))
         self._btn_copy.setToolTip("Copy the token")
 
     def _on_control_toggled(self, checked: bool) -> None:

--- a/fibsem/applications/autolamella/ui/agent_server_dialog.py
+++ b/fibsem/applications/autolamella/ui/agent_server_dialog.py
@@ -1,0 +1,268 @@
+"""Tools → Agent Server: session status, token, and scope arming.
+
+The durable policy (enable flag, watchdog minutes) lives in Preferences; this
+dialog holds only what belongs to the running session. Arming is consent and
+deliberately does not persist: every session starts read-only, and flipping a
+scope here mutates the live ``AuthConfig`` (the token stays the same, so a
+connected agent gains or loses the scope without being disconnected).
+
+This dialog retires the ``FIBSEM_AGENT_ARM_CONTROL`` developer override as the
+GUI path (the env var remains for headless/bench use).
+
+Layout follows the project mockup: a status line, the token with show/copy,
+and a scope ladder — each scope a row with its name, what it permits, and its
+switch; hardware present but visibly not yet climbable.
+"""
+
+import logging
+from typing import Callable, Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from fibsem.ui import stylesheets
+from fibsem.ui.stylesheets import BORDER_STATE_COLOURS
+from fibsem.ui.tokens import (
+    BORDER_COLOR,
+    OK_COLOR,
+    PANEL_COLOR,
+    TEXT_COLOR,
+    TEXT_MUTED_COLOR,
+    TEXT_STRONG_COLOR,
+)
+
+__all__ = ["AgentServerDialog"]
+
+_AGENT_COLOR = BORDER_STATE_COLOURS["agent"]
+
+_SECTION_STYLE = (
+    f"color: {TEXT_MUTED_COLOR}; font-size: 10px; font-weight: bold; "
+    "letter-spacing: 1px;"
+)
+_CARD_STYLE = (
+    f"QFrame#scopeCard {{ background: {PANEL_COLOR}; "
+    f"border: 1px solid {BORDER_COLOR}; border-radius: 5px; }}"
+)
+_TOKEN_STYLE = (
+    f"QLineEdit {{ background: {PANEL_COLOR}; color: {TEXT_COLOR}; "
+    f"border: 1px solid {BORDER_COLOR}; border-radius: 4px; padding: 5px 8px; "
+    "font-size: 11px; }"
+)
+
+
+def _section(text: str) -> QLabel:
+    label = QLabel(text.upper())
+    label.setStyleSheet(_SECTION_STYLE)
+    return label
+
+
+class _ScopeRow(QFrame):
+    """One rung of the scope ladder: name, what it permits, and its switch."""
+
+    def __init__(self, name: str, detail: str, accent: str, parent=None):
+        super().__init__(parent)
+        self.setObjectName("scopeCard")
+        self.setStyleSheet(_CARD_STYLE)
+        row = QHBoxLayout(self)
+        row.setContentsMargins(10, 8, 10, 8)
+        text_col = QVBoxLayout()
+        text_col.setSpacing(1)
+        self.name_label = QLabel(name)
+        self.name_label.setStyleSheet(
+            f"color: {accent}; font-weight: bold; font-size: 12px; border: none;"
+        )
+        self.detail_label = QLabel(detail)
+        self.detail_label.setWordWrap(True)
+        self.detail_label.setStyleSheet(
+            f"color: {TEXT_MUTED_COLOR}; font-size: 11px; border: none;"
+        )
+        text_col.addWidget(self.name_label)
+        text_col.addWidget(self.detail_label)
+        row.addLayout(text_col, stretch=1)
+        self.toggle = QCheckBox()
+        self.toggle.setStyleSheet("border: none; background: transparent;")
+        row.addWidget(self.toggle, alignment=Qt.AlignVCenter)
+
+
+class AgentServerDialog(QDialog):
+    """Live view and arming controls for the embedded agent server."""
+
+    def __init__(self, host_provider: Callable[[], Optional[object]], parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Agent Server")
+        self.setMinimumWidth(440)
+        self._host_provider = host_provider
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 14, 16, 12)
+        layout.setSpacing(8)
+
+        # --- status ---------------------------------------------------------
+        layout.addWidget(_section("Status"))
+        status_row = QHBoxLayout()
+        self._status_dot = QLabel("●")
+        self._status_label = QLabel("")
+        self._status_label.setWordWrap(True)
+        status_row.addWidget(self._status_dot)
+        status_row.addWidget(self._status_label, stretch=1)
+        layout.addLayout(status_row)
+
+        layout.addSpacing(6)
+
+        # --- token ----------------------------------------------------------
+        layout.addWidget(_section("Session token"))
+        token_row = QHBoxLayout()
+        token_row.setSpacing(6)
+        self._token_edit = QLineEdit()
+        self._token_edit.setReadOnly(True)
+        self._token_edit.setEchoMode(QLineEdit.Password)
+        self._token_edit.setStyleSheet(_TOKEN_STYLE)
+        # The system's fixed-width face, set in code: QSS font-family takes a
+        # single family, which cannot be right cross-platform.
+        from PyQt5.QtGui import QFontDatabase
+
+        self._token_edit.setFont(QFontDatabase.systemFont(QFontDatabase.FixedFont))
+        self._btn_reveal = QPushButton("Show")
+        self._btn_reveal.setCheckable(True)
+        self._btn_reveal.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self._btn_copy = QPushButton("Copy")
+        self._btn_copy.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        token_row.addWidget(self._token_edit, stretch=1)
+        token_row.addWidget(self._btn_reveal)
+        token_row.addWidget(self._btn_copy)
+        layout.addLayout(token_row)
+        token_note = QLabel(
+            "New each session. An agent on this machine finds it by itself; "
+            "copy it only to connect one from elsewhere."
+        )
+        token_note.setWordWrap(True)
+        token_note.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 11px;")
+        layout.addWidget(token_note)
+
+        layout.addSpacing(6)
+
+        # --- the scope ladder ----------------------------------------------
+        layout.addWidget(_section("What the agent may do"))
+        self._read_row = _ScopeRow(
+            "Observe",
+            "Watch the workflow, read images and state. Always on.",
+            OK_COLOR,
+        )
+        self._read_row.toggle.setChecked(True)
+        self._read_row.toggle.setEnabled(False)
+        layout.addWidget(self._read_row)
+
+        self._control_row = _ScopeRow(
+            "Act",
+            "Answer questions, start, stop and change workflows. "
+            "You can always override.",
+            _AGENT_COLOR,
+        )
+        layout.addWidget(self._control_row)
+        self._chk_control = self._control_row.toggle  # the arming switch
+
+        self._hardware_row = _ScopeRow(
+            "Command hardware",
+            "Move the stage, acquire, mill. Not yet available.",
+            TEXT_MUTED_COLOR,
+        )
+        self._hardware_row.toggle.setEnabled(False)
+        self._chk_hardware = self._hardware_row.toggle
+        layout.addWidget(self._hardware_row)
+
+        # --- footer ---------------------------------------------------------
+        note = QLabel(
+            "Arming lasts this session only — it never persists. The enable "
+            "switch and the watchdog live in Preferences → Agent."
+        )
+        note.setWordWrap(True)
+        note.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 11px;")
+        layout.addWidget(note)
+
+        footer = QHBoxLayout()
+        footer.addStretch(1)
+        self._btn_close = QPushButton("Close")
+        self._btn_close.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self._btn_close.clicked.connect(self.accept)
+        footer.addWidget(self._btn_close)
+        layout.addLayout(footer)
+
+        self._btn_reveal.toggled.connect(self._on_reveal_toggled)
+        self._btn_copy.clicked.connect(self._on_copy_clicked)
+        self._chk_control.toggled.connect(self._on_control_toggled)
+
+        self.refresh()
+
+    # --- live state -----------------------------------------------------------
+
+    def _host(self):
+        host = self._host_provider()
+        if host is None or not getattr(host, "running", False):
+            return None
+        return host
+
+    def refresh(self) -> None:
+        """Re-read the session's server into the dialog."""
+        host = self._host()
+        running = host is not None
+        for widget in (self._token_edit, self._btn_reveal, self._btn_copy):
+            widget.setEnabled(running)
+        self._chk_control.setEnabled(running)
+        if not running:
+            self._status_dot.setStyleSheet(f"color: {TEXT_MUTED_COLOR};")
+            self._status_label.setText(
+                "Not running — enable it in Preferences → Agent and connect "
+                "a microscope."
+            )
+            self._status_label.setStyleSheet(f"color: {TEXT_MUTED_COLOR};")
+            self._token_edit.setText("")
+            self._chk_control.blockSignals(True)
+            self._chk_control.setChecked(False)
+            self._chk_control.blockSignals(False)
+            return
+        from fibsem.server.auth import Scope
+
+        self._status_dot.setStyleSheet(f"color: {OK_COLOR};")
+        self._status_label.setText(f"Running on {host.url}")
+        self._status_label.setStyleSheet(f"color: {TEXT_STRONG_COLOR};")
+        self._token_edit.setText(host.auth.token)
+        # Reflect without re-arming: setChecked fires toggled, which would log
+        # a no-op arm; block while mirroring.
+        self._chk_control.blockSignals(True)
+        self._chk_control.setChecked(host.auth.is_armed(Scope.CONTROL))
+        self._chk_control.blockSignals(False)
+
+    # --- actions --------------------------------------------------------------
+
+    def _on_reveal_toggled(self, show: bool) -> None:
+        self._token_edit.setEchoMode(QLineEdit.Normal if show else QLineEdit.Password)
+        self._btn_reveal.setText("Hide" if show else "Show")
+
+    def _on_copy_clicked(self) -> None:
+        clipboard = QApplication.clipboard()
+        if clipboard is not None:
+            clipboard.setText(self._token_edit.text())
+            self._btn_copy.setText("Copied")
+            self._btn_copy.setStyleSheet(stylesheets.CONFIRM_BUTTON_STYLESHEET)
+
+    def _on_control_toggled(self, checked: bool) -> None:
+        host = self._host()
+        if host is None:
+            return
+        from fibsem.server.auth import Scope
+
+        host.auth.set_armed(Scope.CONTROL, checked)
+        logging.warning(
+            "agent server: control scope %s via the Agent Server dialog",
+            "ARMED" if checked else "disarmed",
+        )

--- a/fibsem/applications/autolamella/ui/agent_server_dialog.py
+++ b/fibsem/applications/autolamella/ui/agent_server_dialog.py
@@ -17,7 +17,7 @@ switch; hardware present but visibly not yet climbable.
 import logging
 from typing import Callable, Optional
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -31,6 +31,7 @@ from PyQt5.QtWidgets import (
 )
 
 from fibsem.ui import stylesheets
+from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.stylesheets import BORDER_STATE_COLOURS
 from fibsem.ui.tokens import (
     BORDER_COLOR,
@@ -40,6 +41,7 @@ from fibsem.ui.tokens import (
     TEXT_MUTED_COLOR,
     TEXT_STRONG_COLOR,
 )
+from fibsem.ui.widgets.custom_widgets import IconToolButton
 
 __all__ = ["AgentServerDialog"]
 
@@ -79,12 +81,14 @@ class _ScopeRow(QFrame):
         text_col.setSpacing(1)
         self.name_label = QLabel(name)
         self.name_label.setStyleSheet(
-            f"color: {accent}; font-weight: bold; font-size: 12px; border: none;"
+            f"color: {accent}; font-weight: bold; font-size: 12px; "
+            "border: none; background: transparent;"
         )
         self.detail_label = QLabel(detail)
         self.detail_label.setWordWrap(True)
         self.detail_label.setStyleSheet(
-            f"color: {TEXT_MUTED_COLOR}; font-size: 11px; border: none;"
+            f"color: {TEXT_MUTED_COLOR}; font-size: 11px; "
+            "border: none; background: transparent;"
         )
         text_col.addWidget(self.name_label)
         text_col.addWidget(self.detail_label)
@@ -132,11 +136,13 @@ class AgentServerDialog(QDialog):
         from PyQt5.QtGui import QFontDatabase
 
         self._token_edit.setFont(QFontDatabase.systemFont(QFontDatabase.FixedFont))
-        self._btn_reveal = QPushButton("Show")
+        self._btn_reveal = IconToolButton(
+            icon="mdi:eye-outline", tooltip="Show the token", size=26
+        )
         self._btn_reveal.setCheckable(True)
-        self._btn_reveal.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
-        self._btn_copy = QPushButton("Copy")
-        self._btn_copy.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self._btn_copy = IconToolButton(
+            icon="mdi:content-copy", tooltip="Copy the token", size=26
+        )
         token_row.addWidget(self._token_edit, stretch=1)
         token_row.addWidget(self._btn_reveal)
         token_row.addWidget(self._btn_copy)
@@ -182,8 +188,8 @@ class AgentServerDialog(QDialog):
 
         # --- footer ---------------------------------------------------------
         note = QLabel(
-            "Arming lasts this session only — it never persists. The enable "
-            "switch and the watchdog live in Preferences → Agent."
+            "Permissions last this session only — they never persist. "
+            "Everything else lives in Preferences → Agent."
         )
         note.setWordWrap(True)
         note.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 11px;")
@@ -246,14 +252,24 @@ class AgentServerDialog(QDialog):
 
     def _on_reveal_toggled(self, show: bool) -> None:
         self._token_edit.setEchoMode(QLineEdit.Normal if show else QLineEdit.Password)
-        self._btn_reveal.setText("Hide" if show else "Show")
+        self._btn_reveal.setIcon(
+            fibsem_icon("mdi:eye-off-outline" if show else "mdi:eye-outline")
+        )
+        self._btn_reveal.setToolTip("Hide the token" if show else "Show the token")
 
     def _on_copy_clicked(self) -> None:
         clipboard = QApplication.clipboard()
-        if clipboard is not None:
-            clipboard.setText(self._token_edit.text())
-            self._btn_copy.setText("Copied")
-            self._btn_copy.setStyleSheet(stylesheets.CONFIRM_BUTTON_STYLESHEET)
+        if clipboard is None:
+            return
+        clipboard.setText(self._token_edit.text())
+        # A moment of confirmation, then back — the tooltip carries the words.
+        self._btn_copy.setIcon(fibsem_icon("mdi:check", color=OK_COLOR))
+        self._btn_copy.setToolTip("Copied")
+        QTimer.singleShot(1500, self._restore_copy_button)
+
+    def _restore_copy_button(self) -> None:
+        self._btn_copy.setIcon(fibsem_icon("mdi:content-copy"))
+        self._btn_copy.setToolTip("Copy the token")
 
     def _on_control_toggled(self, checked: bool) -> None:
         host = self._host()

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -469,12 +469,24 @@ class ReportingPreferences:
 
 
 @dataclass
+class AgentPreferences:
+    """Durable agent-supervision policy (the session-scoped half — scope
+    arming — deliberately does NOT live here: arming is consent, dies with
+    the session, and is granted in the Tools → Agent Server dialog)."""
+
+    # How long a question addressed to the agent may stand unanswered before
+    # the watchdog hands it to the operator.
+    watchdog_minutes: int = 5
+
+
+@dataclass
 class UserPreferences:
     display: DisplayPreferences = field(default_factory=DisplayPreferences)
     features: FeatureFlags = field(default_factory=FeatureFlags)
     movement: MovementPreferences = field(default_factory=MovementPreferences)
     experiment: ExperimentPreferences = field(default_factory=ExperimentPreferences)
     reporting: ReportingPreferences = field(default_factory=ReportingPreferences)
+    agent: AgentPreferences = field(default_factory=AgentPreferences)
     # Serialized hooks, as HookManager.to_dict()["hooks"] produces them. Held as plain
     # dicts rather than Hook objects on purpose: to_dict() below is dataclasses.asdict,
     # which would recurse into a Hook, strip the "type" key that reconstructs it, and
@@ -501,6 +513,7 @@ class UserPreferences:
                 "movement",
                 "experiment",
                 "reporting",
+                "agent",
                 "hooks",
             )
         ):
@@ -512,6 +525,7 @@ class UserPreferences:
                     ExperimentPreferences, d.get("experiment", {})
                 ),
                 reporting=_sub_from_dict(ReportingPreferences, d.get("reporting", {})),
+                agent=_sub_from_dict(AgentPreferences, d.get("agent", {})),
                 # .get() rather than a default, so an absent key stays None
                 hooks=d.get("hooks"),
             )

--- a/fibsem/server/auth.py
+++ b/fibsem/server/auth.py
@@ -28,15 +28,34 @@ class Scope(str, Enum):
     HARDWARE = "hardware"
 
 
-@dataclass(frozen=True)
+@dataclass
 class AuthConfig:
     """Token + armed scopes for one server instance.
 
     ``read`` is implicitly armed for any valid token and need not be listed.
+
+    The token is fixed for the instance's lifetime; the armed set is the one
+    mutable thing, and only through :meth:`set_armed` — the arming dialog's
+    seam. Mutating it live (rather than rebuilding the server) keeps the
+    token stable, so connected agents gain or lose a scope without being
+    disconnected. Arming is deliberately never persisted: every session
+    starts read-only and arming is a fresh, deliberate act.
     """
 
     token: str
     armed: FrozenSet[Scope] = field(default_factory=frozenset)
+
+    def set_armed(self, scope: Scope, armed: bool) -> None:
+        """Arm or disarm one scope, effective for the next request."""
+        if scope is Scope.READ:
+            return  # read is unconditional; there is nothing to disarm
+        current = set(self.armed)
+        if armed:
+            current.add(scope)
+        else:
+            current.discard(scope)
+        # One atomic rebind (reads never see a half-edited set).
+        self.armed = frozenset(current)
 
     @classmethod
     def generate(

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -11,6 +11,7 @@ from PyQt5.QtWidgets import (
     QListWidget,
     QMessageBox,
     QPushButton,
+    QSpinBox,
     QStackedWidget,
     QVBoxLayout,
     QWidget,
@@ -77,11 +78,17 @@ _TIP_SCRIPTS = (
     "itself and none of its safety checks — nothing validates what it does."
 )
 _LBL_AGENT_SERVER = "Enable Agent Server"
+_LBL_WATCHDOG = "Watchdog (minutes)"
+_TIP_WATCHDOG = (
+    "How long a question addressed to the agent may stand unanswered before "
+    "it is handed to you — orange border, attention button, sound. Applies "
+    "only to tasks supervised by the agent."
+)
 _TIP_AGENT_SERVER = (
     "Host a local, token-protected API over this session when a microscope "
     "connects, so an AI agent (via the fibsem-mcp sidecar) can observe it. "
-    "Read-only: nothing can move hardware through it. The session token is "
-    "printed in the log on connect."
+    "Read-only until scopes are armed for the session in Tools → Agent "
+    "Server, which also shows the session token."
 )
 
 # Experiment defaults
@@ -136,7 +143,9 @@ class PreferencesDialog(QDialog):
 
         self._sidebar = QListWidget()
         self._sidebar.setFixedWidth(120)
-        self._sidebar.addItems(["Display", "Features", "Experiment", "Movement"])
+        self._sidebar.addItems(
+            ["Display", "Features", "Experiment", "Movement", "Agent"]
+        )
         self._sidebar.setCurrentRow(0)
 
         self._stack = QStackedWidget()
@@ -177,8 +186,6 @@ class PreferencesDialog(QDialog):
         self._chk_bug_report.setToolTip(_TIP_BUG_REPORT)
         self._chk_scripts = QCheckBox()
         self._chk_scripts.setToolTip(_TIP_SCRIPTS)
-        self._chk_agent_server = QCheckBox()
-        self._chk_agent_server.setToolTip(_TIP_AGENT_SERVER)
         self._chk_napari_overview = QCheckBox()
         self._chk_napari_overview.setToolTip(_TIP_NAPARI_OVERVIEW)
         self._chk_connection_chip = QCheckBox()
@@ -187,7 +194,6 @@ class PreferencesDialog(QDialog):
         features_form.addRow(_LBL_SAMPLE_HOLDER, self._chk_sample_holder)
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
         features_form.addRow(_LBL_SCRIPTS, self._chk_scripts)
-        features_form.addRow(_LBL_AGENT_SERVER, self._chk_agent_server)
         features_form.addRow(_LBL_NAPARI_OVERVIEW, self._chk_napari_overview)
         features_form.addRow(_LBL_CONNECTION_CHIP, self._chk_connection_chip)
         self._stack.addWidget(features_page)
@@ -222,6 +228,21 @@ class PreferencesDialog(QDialog):
         movement_form.addRow(_LBL_ACQ_SEM, self._chk_acquire_sem)
         movement_form.addRow(_LBL_ACQ_FIB, self._chk_acquire_fib)
         self._stack.addWidget(movement_page)
+
+        # --- Agent ---
+        # Durable policy only. Scope ARMING is deliberately absent: arming is
+        # consent, granted per session in Tools -> Agent Server, and must not
+        # survive a restart via this file.
+        agent_page = QWidget()
+        agent_form = QFormLayout(agent_page)
+        self._chk_agent_server = QCheckBox()
+        self._chk_agent_server.setToolTip(_TIP_AGENT_SERVER)
+        self._spin_watchdog = QSpinBox()
+        self._spin_watchdog.setRange(1, 120)
+        self._spin_watchdog.setToolTip(_TIP_WATCHDOG)
+        agent_form.addRow(_LBL_AGENT_SERVER, self._chk_agent_server)
+        agent_form.addRow(_LBL_WATCHDOG, self._spin_watchdog)
+        self._stack.addWidget(agent_page)
 
         self._sidebar.currentRowChanged.connect(self._stack.setCurrentIndex)
 
@@ -263,6 +284,8 @@ class PreferencesDialog(QDialog):
         self._chk_agent_server.setChecked(f.agent_server_enabled)
         self._chk_napari_overview.setChecked(f.napari_overview_tab)
         self._chk_connection_chip.setChecked(f.connection_chip)
+
+        self._spin_watchdog.setValue(prefs.agent.watchdog_minutes)
 
         e = prefs.experiment
         self._dir_experiment.setText(e.default_experiment_directory)
@@ -314,6 +337,7 @@ class PreferencesDialog(QDialog):
     def get_preferences(self) -> UserPreferences:
         """Build a UserPreferences instance from current widget state."""
         from fibsem.config import (
+            AgentPreferences,
             DisplayPreferences,
             ExperimentPreferences,
             FeatureFlags,
@@ -339,6 +363,9 @@ class PreferencesDialog(QDialog):
             movement=MovementPreferences(
                 acquire_sem_after_stage_movement=self._chk_acquire_sem.isChecked(),
                 acquire_fib_after_stage_movement=self._chk_acquire_fib.isChecked(),
+            ),
+            agent=AgentPreferences(
+                watchdog_minutes=self._spin_watchdog.value(),
             ),
             experiment=ExperimentPreferences(
                 default_experiment_directory=self._dir_experiment.text(),

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox,
     QFormLayout,
     QHBoxLayout,
+    QLabel,
     QLineEdit,
     QListWidget,
     QMessageBox,
@@ -78,11 +79,11 @@ _TIP_SCRIPTS = (
     "itself and none of its safety checks — nothing validates what it does."
 )
 _LBL_AGENT_SERVER = "Enable Agent Server"
-_LBL_WATCHDOG = "Watchdog (minutes)"
+_LBL_WATCHDOG = "Hand questions to me after"
 _TIP_WATCHDOG = (
-    "How long a question addressed to the agent may stand unanswered before "
-    "it is handed to you — orange border, attention button, sound. Applies "
-    "only to tasks supervised by the agent."
+    "If the agent leaves a question unanswered this long, it becomes yours — "
+    "orange border, attention button, sound. Applies only to tasks the agent "
+    "supervises."
 )
 _TIP_AGENT_SERVER = (
     "Host a local, token-protected API over this session when a microscope "
@@ -239,7 +240,16 @@ class PreferencesDialog(QDialog):
         self._chk_agent_server.setToolTip(_TIP_AGENT_SERVER)
         self._spin_watchdog = QSpinBox()
         self._spin_watchdog.setRange(1, 120)
+        self._spin_watchdog.setSuffix(" min")
         self._spin_watchdog.setToolTip(_TIP_WATCHDOG)
+        agent_intro = QLabel(
+            "Let an AI agent watch this session — and, with permission you "
+            "grant per session in Tools → Agent Server, act on it — over a "
+            "local, token-protected connection."
+        )
+        agent_intro.setWordWrap(True)
+        agent_intro.setStyleSheet("color: #868e93; font-size: 11px;")
+        agent_form.addRow(agent_intro)
         agent_form.addRow(_LBL_AGENT_SERVER, self._chk_agent_server)
         agent_form.addRow(_LBL_WATCHDOG, self._spin_watchdog)
         self._stack.addWidget(agent_page)

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -88,7 +88,7 @@ _TIP_WATCHDOG = (
 _TIP_AGENT_SERVER = (
     "Host a local, token-protected API over this session when a microscope "
     "connects, so an AI agent (via the fibsem-mcp sidecar) can observe it. "
-    "Read-only until scopes are armed for the session in Tools → Agent "
+    "Read-only until you grant permissions for the session in Tools → Agent "
     "Server, which also shows the session token."
 )
 

--- a/tests/server/test_server_factory.py
+++ b/tests/server/test_server_factory.py
@@ -185,3 +185,32 @@ def test_fibsem_server_defaults_to_localhost(microscope):
     assert server.host == "127.0.0.1"
     assert server.auth.is_armed(Scope.READ)
     assert not server.auth.is_armed(Scope.HARDWARE)
+
+
+def test_arming_mid_session_takes_effect_without_a_new_token(microscope):
+    """The arming dialog's contract: flip the live AuthConfig, next request obeys."""
+    from fastapi.testclient import TestClient
+
+    from fibsem.server import AuthConfig, build_server
+    from fibsem.server.auth import Scope
+
+    auth = AuthConfig.generate(token="live-arm-token")
+    app = build_server(microscope, auth=auth)
+    headers = {"Authorization": "Bearer live-arm-token"}
+    with TestClient(app, raise_server_exceptions=False) as client:
+        refused = client.post(
+            "/autocontrast", headers=headers, json={"beam_type": "ELECTRON"}
+        )
+        assert refused.status_code == 403
+
+        auth.set_armed(Scope.HARDWARE, True)
+        allowed = client.post(
+            "/autocontrast", headers=headers, json={"beam_type": "ELECTRON"}
+        )
+        assert allowed.status_code == 200
+
+        auth.set_armed(Scope.HARDWARE, False)
+        refused_again = client.post(
+            "/autocontrast", headers=headers, json={"beam_type": "ELECTRON"}
+        )
+        assert refused_again.status_code == 403

--- a/tests/ui/test_agent_server_dialog.py
+++ b/tests/ui/test_agent_server_dialog.py
@@ -1,0 +1,77 @@
+"""Tools → Agent Server: arming is a live, session-only act on the running
+server's AuthConfig — the token never changes, and nothing here persists."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+pytest.importorskip("fastapi")
+
+from fibsem.applications.autolamella.ui.agent_server_dialog import AgentServerDialog
+from fibsem.server.auth import AuthConfig, Scope
+
+
+class _Host:
+    running = True
+    url = "http://127.0.0.1:8001"
+
+    def __init__(self, arm_control=False):
+        self.auth = AuthConfig.generate(arm_control=arm_control, token="tok")
+
+
+@pytest.fixture
+def host():
+    return _Host()
+
+
+def test_arming_flips_the_live_auth_and_keeps_the_token(qapp, host):
+    dialog = AgentServerDialog(lambda: host)
+    assert not host.auth.is_armed(Scope.CONTROL)
+
+    dialog._chk_control.setChecked(True)
+    assert host.auth.is_armed(Scope.CONTROL)
+    dialog._chk_control.setChecked(False)
+    assert not host.auth.is_armed(Scope.CONTROL)
+    assert host.auth.token == "tok"  # arming never re-mints the token
+    dialog.deleteLater()
+
+
+def test_refresh_mirrors_armed_state_without_rearming(qapp):
+    host = _Host(arm_control=True)
+    dialog = AgentServerDialog(lambda: host)
+    assert dialog._chk_control.isChecked()
+    # Mirroring must not have *set* anything: disarm externally, refresh follows.
+    host.auth.set_armed(Scope.CONTROL, False)
+    dialog.refresh()
+    assert not dialog._chk_control.isChecked()
+    assert not host.auth.is_armed(Scope.CONTROL)
+    dialog.deleteLater()
+
+
+def test_no_server_disables_everything(qapp):
+    dialog = AgentServerDialog(lambda: None)
+    assert not dialog._chk_control.isEnabled()
+    assert not dialog._token_edit.isEnabled()
+    assert dialog._token_edit.text() == ""
+    assert "Not running" in dialog._status_label.text()
+    dialog.deleteLater()
+
+
+def test_hardware_stays_visibly_unclimbable(qapp, host):
+    dialog = AgentServerDialog(lambda: host)
+    assert not dialog._chk_hardware.isEnabled()
+    assert not dialog._chk_hardware.isChecked()
+    dialog.deleteLater()
+
+
+def test_the_token_starts_hidden(qapp, host):
+    from PyQt5.QtWidgets import QLineEdit
+
+    dialog = AgentServerDialog(lambda: host)
+    assert dialog._token_edit.echoMode() == QLineEdit.Password
+    dialog._btn_reveal.setChecked(True)
+    assert dialog._token_edit.echoMode() == QLineEdit.Normal
+    dialog.deleteLater()

--- a/tests/ui/test_agent_watchdog.py
+++ b/tests/ui/test_agent_watchdog.py
@@ -106,9 +106,8 @@ def test_an_answer_disarms_the_watchdog(main_ui, agent_question_standing):
 def test_expiry_hands_the_question_to_the_operator(
     main_ui, agent_question_standing, qapp, monkeypatch
 ):
-    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
-
-    monkeypatch.setattr(module, "AGENT_WATCHDOG_MS", 50)
+    # The deadline comes from Preferences -> Agent; shorten it at the seam.
+    monkeypatch.setattr(main_ui, "_watchdog_ms", lambda: 50)
     main_ui._on_question_event("prompt_raised", {})
     assert main_ui._border_state == "agent"
 

--- a/tests/ui/test_preferences_dialog.py
+++ b/tests/ui/test_preferences_dialog.py
@@ -10,6 +10,7 @@ So these tests drive the dialog's own load/save round trip rather than looking f
 attributes by name: what matters is that a value put in comes back out, not that some
 particular widget exists.
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -93,3 +94,21 @@ def test_the_exemption_list_only_names_flags_that_exist(qapp):
     known = {f.name for f in dataclasses.fields(FeatureFlags)}
 
     assert NOT_IN_DIALOG <= known, f"stale exemptions: {NOT_IN_DIALOG - known}"
+
+
+def test_agent_section_round_trips(qapp):
+    from fibsem.config import UserPreferences
+    from fibsem.ui.widgets.preferences_dialog import PreferencesDialog
+
+    prefs = UserPreferences()
+    prefs.agent.watchdog_minutes = 12
+    dialog = PreferencesDialog(prefs)
+    assert dialog._spin_watchdog.value() == 12
+    dialog._spin_watchdog.setValue(7)
+    rebuilt = dialog.get_preferences()
+    assert rebuilt.agent.watchdog_minutes == 7
+    # And the section survives serialization (absent key -> defaults).
+    again = UserPreferences.from_dict(rebuilt.to_dict())
+    assert again.agent.watchdog_minutes == 7
+    assert UserPreferences.from_dict({"features": {}}).agent.watchdog_minutes == 5
+    dialog.deleteLater()


### PR DESCRIPTION
Stacked on #696 (→ #695 → #693). **Merge bottom-up**, retargeting as each lands.

Screenshots in the thread: the dialog in running-armed and not-running states, rendered from the real widgets.

## The design decision

**Arming is consent, and consent is not a config file.** So the feature splits along the durable/session line:

- **Preferences → Agent** (new page): the enable switch (moved from Features) and the watchdog minutes (now a real preference, replacing the module constant). Durable policy, saved to YAML, survives restarts.
- **Tools → Agent Server** (visible only with the feature enabled): everything that belongs to the *session* — status, the token (hidden by default, Show/Copy), and the scope ladder. Arming lives here and **never persists**: every session starts read-only, and arming is a fresh act by whoever is standing at the microscope. This retires the `FIBSEM_AGENT_ARM_CONTROL` env var as the GUI path (it remains for headless/bench).

## The scope ladder

Three rungs, each a card with its name, what it permits, and its switch:

- **Observe** (green) — always on while the server runs; the switch is shown checked and disabled.
- **Act** (agent purple) — the arming switch: answer questions, start/stop/change workflows, "you can always override".
- **Command hardware** (muted) — present but disabled, "not yet available": the ladder is visible while its top rung clearly isn't climbable.

## Live arming mechanics

Flipping Act calls `AuthConfig.set_armed` on the **live** auth object — an atomic frozenset rebind, the one mutation the class now permits (`frozen=` dropped for exactly this seam). The token never changes, so a connected agent gains or loses the scope without being disconnected. A server test proves the full cycle on one token: 403 → arm mid-session → 200 → disarm → 403.

## Tests

Dialog: arming flips the live auth and keeps the token; refresh mirrors without re-arming; no-server disables everything; hardware stays unclimbable; token starts hidden. Preferences: the Agent page round-trips, absent YAML keys default. Server: the mid-session arming cycle. Watchdog: now reads the preference (test retargeted to the seam). 95 green across the dialog/preferences/watchdog/chrome/server/hosting suites.