### PR TITLE
[docs] The Agent, Explained: a user guide for the agent server

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -115,9 +115,9 @@ bearer token — the sidecar is convenience, not a requirement.
 
 - **One token per session**, generated fresh at server start, shown only in
   the dialog. It is the whole key: no token, no access.
-- **Scopes fail closed.** Reading needs a valid token; acting needs the *Act*
-  permission; hardware has no permission at all.
-- **Permissions are session-scoped** — granted by whoever is at the
+- **Access fails closed.** Reading needs a valid token; acting needs the
+  *Act* permission; hardware has no permission at all.
+- **Permissions last one session** — granted by whoever is at the
   microscope, dead when the app closes. There is nothing in any config file
   that arms anything.
 - **Localhost by default.** Out of the box, only processes on the same

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -1,0 +1,141 @@
+# The Agent, Explained
+
+What the AutoLamella agent server is, what an AI agent can see and do through
+it, and how to connect one — locally or from another machine.
+
+(Setup commands for the `fibsem-mcp` sidecar live in
+[fibsem/mcp/README.md](../fibsem/mcp/README.md); this guide is the *what* and
+the *why*.)
+
+## What it is
+
+When you enable the agent server, AutoLamella hosts a small, token-protected
+API on your machine while a microscope is connected. An AI agent (Claude,
+Codex, or anything that speaks MCP or plain HTTP) can connect to it and watch
+your session: the workflow, the queue, the images on screen, the questions the
+workflow is asking. With permission you grant per session, it can also act —
+answer those questions, start and stop workflows, change supervision.
+
+Nothing about your workflow changes when the feature is off, and nothing about
+it changes when the feature is on but no agent is connected. The server is an
+observer with a doorbell, not a second driver.
+
+## Turning it on
+
+1. **Preferences → Agent**: tick *Enable Agent Server*. This is the durable
+   switch; it also holds the hand-over time (below).
+2. Connect a microscope. The server starts with the session and stops with it.
+3. **Tools → Agent Server** shows the live session: whether it is running, the
+   session token, and what the agent may do.
+
+## What the agent can see (always, while running)
+
+Reading is on for any connected agent — it is the point of the feature:
+
+- **Status and queue** — what is running, which item, what is next.
+- **The protocol** — task list, supervision settings, schedules.
+- **What your screen shows** — the SEM/FIB images on display, as small
+  previews, with when they were acquired. Not a fresh acquisition: the agent
+  sees what you see.
+- **The standing question** — when a supervised task asks something, the agent
+  sees the same question, including its images and the live position of a
+  marker you are dragging.
+- **Events** — task starts and finishes, milling progress, questions raised
+  and answered (and by whom), as a live feed.
+- **Run history** — the run summary and each item's produced files.
+
+## What the agent may do (with your permission)
+
+In **Tools → Agent Server**, the *Act* switch lets the agent:
+
+- **answer supervision questions** — through exactly the same path as your
+  Yes/No buttons. First answer wins: you can always answer first, and your
+  click beats the agent's every time. Every answer is attributed — the line
+  under the buttons reads `agent · answered Run Milling · 14:22:31`;
+- **start and stop workflows** — the same as your Run and Stop buttons
+  (stopping, like the stop-milling command, actually works for *any* connected
+  agent regardless of permission: the emergency brake is never gated);
+- **change supervision** — flip a task between automated, supervised, and
+  agent-supervised, mid-run;
+- **re-queue a task** — "run 03's fiducial again" during a run.
+
+Permissions last the session only. They are granted in the dialog, die when
+the app closes, and never persist — every session starts read-only.
+
+## What the agent cannot do
+
+Command hardware. There is no permission that lets an agent move the stage,
+acquire, or mill directly — the switch exists in the dialog so the ladder is
+visible, and it is disabled. Milling happens only the way it always has:
+through a workflow's own steps, with its checks.
+
+## Agent-supervised tasks
+
+In the workflow tab, each task's supervision control cycles **Automated →
+Supervised → Agent** (the third option appears only when the feature is
+enabled). A task set to *Agent* raises its questions to the connected agent:
+
+- the window border turns **purple** while it runs, and the supervision chip
+  shows **✦ Agent** — you can walk away;
+- if the agent answers, you never notice; the timeline records who answered;
+- if the agent goes quiet for longer than *Hand questions to me after*
+  (Preferences → Agent, default 5 minutes), the question becomes yours: the
+  ordinary orange border, attention button, and sound, plus a message saying
+  why. This hand-over runs inside AutoLamella, so it works even if the agent's
+  own process has died.
+
+You can always answer any question yourself, whoever it is addressed to.
+
+## Connecting an agent
+
+**On the same machine** — nothing to copy. The running server writes a
+discovery file (`~/.fibsem/agent-server.json`) that the `fibsem-mcp` sidecar
+finds by itself:
+
+```bash
+claude mcp add fibsem -- fibsem-mcp
+```
+
+**From another machine** — copy the session token from Tools → Agent Server
+and point the sidecar at the microscope PC:
+
+```bash
+claude mcp add fibsem -- fibsem-mcp --url http://<microscope-pc>:8001 --token <token>
+```
+
+(Or set `FIBSEM_SERVER_URL` and `FIBSEM_SERVER_TOKEN`.) The server binds to
+localhost by default; reaching it from another machine means running it on a
+reachable address — do that only on a network you trust, because the
+connection is plain HTTP: anyone who can read the traffic can read the token.
+
+Any MCP-speaking agent works, and so does anything that can send HTTP with a
+bearer token — the sidecar is convenience, not a requirement.
+
+## The security model, briefly
+
+- **One token per session**, generated fresh at server start, shown only in
+  the dialog. It is the whole key: no token, no access.
+- **Scopes fail closed.** Reading needs a valid token; acting needs the *Act*
+  permission; hardware has no permission at all.
+- **Permissions are session-scoped** — granted by whoever is at the
+  microscope, dead when the app closes. There is nothing in any config file
+  that arms anything.
+- **Localhost by default.** Out of the box, only processes on the same
+  machine — running as someone who can read your files anyway — can even
+  attempt to connect.
+- **One server per machine.** A second AutoLamella (or a bench server) refuses
+  to start its own while one is alive.
+- **Everything is attributed.** Answers carry who gave them; the event stream
+  and the log keep the record.
+
+## When something is off
+
+- *The dialog says "Not running"* — the feature is enabled but no microscope
+  is connected yet, or the enable box was ticked after connecting (it starts
+  on the next connect, or immediately after saving Preferences).
+- *The sidecar exits with "no server found"* — it waited for a server that
+  never appeared; start AutoLamella (with the feature on) first, or pass
+  `--url`/`--token` explicitly.
+- *An agent's answer is refused with `stale_prompt`* — the question changed
+  between the agent reading it and answering (often: you answered first).
+  That refusal is correct behaviour; the agent re-reads and continues.

--- a/fibsem/mcp/README.md
+++ b/fibsem/mcp/README.md
@@ -1,5 +1,7 @@
 # fibsem-mcp — connect an agent to the microscope
 
+> New to the agent? Start with the guide: [docs/agent-server.md](../../docs/agent-server.md) — what the agent can see and do, permissions, and the security model.
+
 The MCP sidecar lets Claude (Code or Desktop) drive a fibsem server: acquire
 and *look at* images, read state, move the stage, and always stop a mill. The
 server is the security boundary — the sidecar registers only the tools the


### PR DESCRIPTION
Stacked on #697 (top of the #693 → #695 → #696 → #697 chain) so it can describe the finished feature — the selector, the watchdog hand-over, and the permissions dialog all appear in it.

One document, `docs/agent-server.md`, written for the operator rather than the developer:

- what the agent server is (an observer with a doorbell, not a second driver);
- what an agent can **see** (always) and **do** (with the per-session *Act* permission), and the one thing it can never do (hardware);
- agent-supervised tasks: the purple chrome, who-answered attribution, and the hand-over when the agent goes quiet;
- connecting locally (discovery, nothing to copy) and remotely (token + URL, with the plain-HTTP trust warning);
- the security model in six plain sentences (session tokens, fail-closed scopes, session-only permissions, localhost default, one server per machine, everything attributed);
- a short "when something is off" list covering the three most common first-run stumbles.

Linked from the top of the sidecar README (which keeps the setup commands). The stale mkdocs nav references pages that don't exist, so this stays a plain GitHub-readable markdown file rather than resurrecting the site.