### PR TITLE
[app] The question timeline stays hidden unless the agent feature is on

### DIFF
--- a/fibsem/applications/autolamella/ui/question_timeline_widget.py
+++ b/fibsem/applications/autolamella/ui/question_timeline_widget.py
@@ -19,6 +19,19 @@ import time
 from collections import deque
 from typing import Deque, Dict, Tuple
 
+
+def _feature_enabled() -> bool:
+    """The strip belongs to the agent feature: with it off, the widget still
+    records (cheap, and the tooltip is ready if the feature turns on) but
+    stays invisible — the no-behaviour-change-when-disabled invariant."""
+    import fibsem.config as fibsem_cfg
+
+    try:
+        return bool(fibsem_cfg.load_user_preferences().features.agent_server_enabled)
+    except Exception:
+        return False
+
+
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
 
@@ -92,7 +105,7 @@ class QuestionTimelineWidget(QWidget):
             self._label.setText(text)
         # The recent trail lives in the tooltip, newest first.
         self._label.setToolTip("\n".join(row for row, _ in self._history))
-        self.setVisible(True)
+        self.setVisible(_feature_enabled())
 
     def rows(self):
         """The remembered rows, newest first (for tests, tooling — and the

--- a/tests/ui/test_question_timeline.py
+++ b/tests/ui/test_question_timeline.py
@@ -15,8 +15,19 @@ import pytest
 
 pytest.importorskip("PyQt5")
 
+from fibsem.applications.autolamella.ui import (
+    question_timeline_widget as timeline_module,
+)
 from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
 from fibsem.applications.autolamella.workflows.interaction import Confirm, ask
+
+
+@pytest.fixture(autouse=True)
+def agent_feature_on(monkeypatch):
+    """The strip is visible only with the agent feature; these tests exercise
+    the display, so the gate is held open (and closed explicitly in the
+    gating test)."""
+    monkeypatch.setattr(timeline_module, "_feature_enabled", lambda: True)
 
 
 @pytest.fixture
@@ -107,3 +118,14 @@ def test_the_remembered_trail_stays_bounded(ui, qapp):
         ui.ui_responder.answer_confirm(True)
         thread.join(timeout=5)
     assert len(ui.question_timeline.rows()) == ui.question_timeline.HISTORY
+
+
+def test_the_strip_stays_hidden_with_the_feature_off(ui, qapp, monkeypatch):
+    # The no-behaviour-change invariant: a human-only supervised workflow must
+    # look exactly as it did before the agent feature existed.
+    monkeypatch.setattr(timeline_module, "_feature_enabled", lambda: False)
+    thread, _ = _ask_on_worker(ui, qapp, Confirm("Continue?"))
+    ui.ui_responder.answer_confirm(True)
+    thread.join(timeout=5)
+    assert ui.question_timeline.isHidden()
+    assert len(ui.question_timeline.rows()) == 1  # still recording, just unseen


### PR DESCRIPTION
Independent, off main (#691's timeline merged via #694).

Patrick's invariant audit — "if the agent server is disabled, or the dependencies aren't installed, there is no behaviour change on the existing workflow?" — found exactly one leak: the who-answered strip appeared under the interaction buttons after any answered question, for everyone. Every other piece checked out (no server without the flag; hosting swallows missing deps; all agent chrome gated on server-running; watchdog never arms; `supervisor` defaults human; the dialog imports server code only when a host exists).

Fix: the widget still records (cheap, and the trail is ready the instant the feature turns on) but is visible only with `agent_server_enabled`. A human-only supervised workflow now looks exactly as it did before the feature existed.

Tests: the display tests hold the gate open explicitly; a new test closes it and asserts hidden-but-recording.