### PR TITLE
[app] A protocol from a newer build must load, not crash the whole load

### DIFF
--- a/tests/autolamella/test_structures_forward_compat.py
+++ b/tests/autolamella/test_structures_forward_compat.py
@@ -1,0 +1,28 @@
+"""A protocol written by a newer build must load in this one.
+
+Live incident (2026-09-01): a protocol.yaml carrying a field this build did
+not know ('supervisor') made the whole protocol refuse to load — the
+experiment quickloaded without it. Task descriptions now keep known fields
+only, the same rule AutoLamellaTaskState already follows."""
+
+from fibsem.applications.autolamella.structures import AutoLamellaTaskDescription
+
+
+def test_unknown_fields_from_the_future_are_ignored():
+    task = AutoLamellaTaskDescription.from_dict(
+        {
+            "name": "Mill Fiducial",
+            "supervise": True,
+            "required": True,
+            "requires": [],
+            "supervisor": "agent",  # a future build's field
+            "entirely_new_thing": {"nested": 1},
+        }
+    )
+    assert task.name == "Mill Fiducial"
+    assert task.supervise is True
+
+
+def test_none_still_produces_a_blank_description():
+    task = AutoLamellaTaskDescription.from_dict(None)
+    assert task.name == ""


### PR DESCRIPTION
Independent, off main — extracted from #693 after it bit for real this morning:

```
Failed to load task protocol ...: AutoLamellaTaskDescription.__init__() got an unexpected keyword argument 'supervisor'
Quickload: AutoLamella-2026-08-31-12-40 has no protocol; not loaded.
```

A protocol.yaml written by a newer build (the unmerged supervisor branch) refused to load on main — one unknown key cost the whole protocol. `from_dict` now keeps known fields only, the same rule `AutoLamellaTaskState` has followed since FIB-490, and the `data is None` branch loses a bogus `task_type` kwarg that would itself have raised.

#693 contains the same change plus the new field; whichever merges second gets a trivial conflict that I'll resolve. `structures.py` carries the usual format-on-touch noise (~280 mechanical lines); the real change is ~8 lines in `from_dict`.