### PR TITLE
[skills] Harden supervise-autolamella with the fresh-session test's lessons

### DIFF
--- a/.claude/skills/supervise-autolamella/SKILL.md
+++ b/.claude/skills/supervise-autolamella/SKILL.md
@@ -14,14 +14,28 @@ ever lost by waiting.
 
 ## Connect
 
-The running app advertises itself in a discovery file:
+**Prefer the native MCP tools.** If `mcp__fibsem__*` tools are available in
+your session (the repo's `.mcp.json` registers the `fibsem-mcp` sidecar),
+use them for everything below — `get_capabilities`, `get_events`,
+`get_pending_prompt`, `answer_prompt`, `start_workflow`, and the rest map
+one-to-one onto the HTTP surface, and they avoid shell-permission friction
+entirely.
+
+Fallback is plain HTTP; the running app advertises itself in a discovery
+file:
 
 ```bash
 TOKEN=$(python3 -c "import json;print(json.load(open('$HOME/.fibsem/agent-server.json'))['token'])")
 curl -s "http://127.0.0.1:8001/capabilities" -H "Authorization: Bearer $TOKEN"
 ```
 
-Check the response before doing anything else:
+Note for the curl path: your own harness may gate state-changing commands.
+In an interactive session that is a permission prompt for the operator to
+approve; running autonomously it can be a hard denial. Treat a harness
+denial exactly like a server 403 — stop and ask; never repackage the call
+to slip past it.
+
+Check the capabilities response before doing anything else:
 - `routers.app` must be true (an application is hosted, not just a bench server);
 - `scopes.control` true means you may answer and act. If it is false you can
   only watch — say so, and ask the operator to grant *Act* in
@@ -33,18 +47,21 @@ ways in.
 
 ## Watch
 
-Sleep on the events long-poll; never poll `/app/prompt` on a timer:
+Sleep on the events long-poll; never poll `/app/prompt` on a timer. **Run
+the bundled watcher as a background monitor** — do not write your own (the
+first fresh agent to try matched the wrong JSON key and slept through a
+question), and do not run it in the foreground: each line it prints is your
+wake-up call, and a foreground watcher blocks you from acting on what it
+sees.
 
 ```
-GET /app/events?since=<last_seq>&timeout=25
+python .claude/skills/supervise-autolamella/watch_events.py
 ```
 
-Wake and act on: `prompt_raised` (a question is standing — its payload carries
-the nonce), `prompt_answered` (someone answered — check `answered_by`; if it
-was the operator, your read of that question is stale), `task_started` /
-`task_completed` / `task_failed` / `task_cancelled`, `workflow_completed` /
-`workflow_cancelled` (report and stop watching). Run the watch as a background
-monitor and act per event; do not busy-wait.
+Wake and act on its lines: `PROMPT` (a question is standing, with its
+nonce), `ANSWERED` (check who — if the operator answered, your read of that
+question is stale), task lifecycle `EVENT` lines, and `RUN ENDED` (report
+and stop watching).
 
 ## Answer — the rules that are never optional
 

--- a/.claude/skills/supervise-autolamella/SKILL.md
+++ b/.claude/skills/supervise-autolamella/SKILL.md
@@ -15,11 +15,15 @@ ever lost by waiting.
 ## Connect
 
 **Prefer the native MCP tools.** If `mcp__fibsem__*` tools are available in
-your session (the repo's `.mcp.json` registers the `fibsem-mcp` sidecar),
-use them for everything below — `get_capabilities`, `get_events`,
-`get_pending_prompt`, `answer_prompt`, `start_workflow`, and the rest map
-one-to-one onto the HTTP surface, and they avoid shell-permission friction
-entirely.
+your session, use them for everything below *except the Watch step* —
+`get_capabilities`, `get_pending_prompt`, `answer_prompt`, `start_workflow`,
+and the rest map one-to-one onto the HTTP surface, and they avoid
+shell-permission friction entirely. (The tools come from the `fibsem-mcp`
+sidecar; if they are missing, the sidecar is not registered in this session's
+MCP config — e.g. `claude mcp add fibsem fibsem-mcp` — and the HTTP fallback
+below works regardless.) Watching is the exception either way: looping the
+`get_events` tool in the foreground blocks you from acting, so the bundled
+watcher stays the watch mechanism even when MCP is connected.
 
 Fallback is plain HTTP; the running app advertises itself in a discovery
 file:
@@ -57,6 +61,9 @@ sees.
 ```
 python .claude/skills/supervise-autolamella/watch_events.py
 ```
+
+(`python3` where `python` doesn't exist — stock macOS/Linux; the path is
+relative to the repo root, so run it from there or spell out the full path.)
 
 Wake and act on its lines: `PROMPT` (a question is standing, with its
 nonce), `ANSWERED` (check who — if the operator answered, your read of that

--- a/.claude/skills/supervise-autolamella/watch_events.py
+++ b/.claude/skills/supervise-autolamella/watch_events.py
@@ -11,7 +11,7 @@ watcher needs Git Bash there, this file runs anywhere fibsem does.
 
     python .claude/skills/supervise-autolamella/watch_events.py
 
-Exits 0 when the workflow ends, 1 when the server cannot be reached (start
+Exits 0 when the workflow ends, 1 when the server cannot be watched (start
 AutoLamella with the agent feature enabled, then rerun). The first fresh
 agent to write its own watcher matched the wrong JSON key and slept through
 a question — hence this file: run the tested one.
@@ -22,17 +22,20 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from http.client import HTTPException
 from pathlib import Path
 
 DISCOVERY = Path.home() / ".fibsem" / "agent-server.json"
-INTERESTING = {
+# Kinds that end the watch: the run is over, report and stop.
+TERMINAL = {"workflow_completed", "workflow_cancelled"}
+# Kinds worth a wake-up line of their own (prompts are handled separately).
+INTERESTING = TERMINAL | {
     "workflow_started",
     "task_started",
     "task_completed",
     "task_failed",
     "task_cancelled",
-    "workflow_completed",
-    "workflow_cancelled",
+    "task_skipped",
 }
 
 
@@ -47,7 +50,46 @@ def _get(url, headers, timeout):
         return json.loads(response.read().decode())
 
 
+def _print_events(events, since):
+    """Print wake-up lines; returns (new_since, run_ended)."""
+    run_ended = False
+    for event in events:
+        kind = event.get("kind", "")
+        data = event.get("payload", {})
+        since = max(since, event.get("seq", since))
+        if kind == "prompt_raised":
+            print(
+                "PROMPT nonce=%s type=%s" % (data.get("nonce"), data.get("type")),
+                flush=True,
+            )
+        elif kind == "prompt_answered":
+            print(
+                "ANSWERED nonce=%s by=%s response=%s"
+                % (
+                    data.get("nonce"),
+                    data.get("answered_by"),
+                    data.get("response"),
+                ),
+                flush=True,
+            )
+        elif kind == "prompt_cancelled":
+            print("PROMPT WITHDRAWN nonce=%s" % data.get("nonce"), flush=True)
+        elif kind in TERMINAL:
+            print("RUN ENDED (%s)" % kind, flush=True)
+            run_ended = True
+        elif kind in INTERESTING:
+            print("EVENT %s %s" % (kind, data.get("item_name", "")), flush=True)
+    return since, run_ended
+
+
 def main():
+    # Item names can carry operator-typed text; never let an exotic character
+    # kill the watch on a cp1252 console.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, OSError, ValueError):
+        pass
+
     try:
         base, headers = _connection()
     except (OSError, KeyError, ValueError):
@@ -57,7 +99,28 @@ def main():
         )
         return 1
 
-    since = 0
+    # Seed the cursor at the tail: the buffer outlives workflow runs, so
+    # starting at 0 would replay history — stale PROMPT lines, and a previous
+    # run's workflow_completed would end this watch before it began.
+    try:
+        snapshot = _get(f"{base}/app/events?since=0&timeout=0", headers, timeout=10)
+    except urllib.error.HTTPError as error:
+        print(
+            "SERVER REFUSED: HTTP %s from /app/events — check the token in "
+            "%s and that an application is hosted." % (error.code, DISCOVERY)
+        )
+        return 1
+    except (OSError, HTTPException, ValueError):
+        print("SERVER GONE: events unreachable — is the app running?")
+        return 1
+    if not snapshot.get("available"):
+        print(
+            "NO EVENTS: the server has no event stream wired — nothing to "
+            "watch. Is an application hosted (not just a bench server)?"
+        )
+        return 1
+    since = snapshot.get("latest_seq") or 0
+
     failures = 0
     while True:
         try:
@@ -65,7 +128,26 @@ def main():
                 f"{base}/app/events?since={since}&timeout=25", headers, timeout=35
             )
             failures = 0
-        except (urllib.error.URLError, OSError, TimeoutError):
+        except urllib.error.HTTPError as error:
+            # An HTTP status is the server talking, not the server gone. The
+            # common cause is an app restart rotating the token: re-read the
+            # discovery file and retry with fresh credentials.
+            failures += 1
+            if failures >= 4:
+                print(
+                    "SERVER REFUSED: HTTP %s from /app/events — the token or "
+                    "hosting changed; reconnect from the discovery file." % error.code
+                )
+                return 1
+            try:
+                base, headers = _connection()
+            except (OSError, KeyError, ValueError):
+                pass
+            time.sleep(5)
+            continue
+        except (OSError, HTTPException, ValueError):
+            # Connection-level failure, a response cut off mid-read, or a
+            # truncated body: retry, then report the server gone.
             failures += 1
             if failures >= 4:
                 print("SERVER GONE: events unreachable — the app has stopped.")
@@ -73,32 +155,24 @@ def main():
             time.sleep(5)
             continue
 
-        for event in payload.get("events", []):
-            kind = event.get("kind", "")
-            data = event.get("payload", {})
-            since = max(since, event.get("seq", since))
-            if kind == "prompt_raised":
-                print(
-                    "PROMPT nonce=%s type=%s" % (data.get("nonce"), data.get("type")),
-                    flush=True,
-                )
-            elif kind == "prompt_answered":
-                print(
-                    "ANSWERED nonce=%s by=%s response=%s"
-                    % (
-                        data.get("nonce"),
-                        data.get("answered_by"),
-                        data.get("response"),
-                    ),
-                    flush=True,
-                )
-            elif kind == "prompt_cancelled":
-                print("PROMPT WITHDRAWN nonce=%s" % data.get("nonce"), flush=True)
-            elif kind in INTERESTING:
-                print("EVENT %s %s" % (kind, data.get("item_name", "")), flush=True)
-            if kind in ("workflow_completed", "workflow_cancelled"):
-                print("RUN ENDED", flush=True)
-                return 0
+        if not payload.get("available"):
+            print("NO EVENTS: the server's event stream went away — stopping.")
+            return 1
+
+        oldest = payload.get("oldest_available")
+        if oldest is not None and oldest > since + 1:
+            # Eviction ate events between polls; continuity is broken.
+            print(
+                "GAP: events were evicted before they could be read — "
+                "re-read /app/prompt and /app/status rather than assuming "
+                "nothing happened.",
+                flush=True,
+            )
+
+        since, run_ended = _print_events(payload.get("events", []), since)
+        since = max(since, payload.get("latest_seq") or 0)
+        if run_ended:
+            return 0
 
 
 if __name__ == "__main__":

--- a/.claude/skills/supervise-autolamella/watch_events.py
+++ b/.claude/skills/supervise-autolamella/watch_events.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""The supervision watch: long-poll the agent server's events, print one line
+per thing worth waking for.
+
+Run as a BACKGROUND monitor (each printed line wakes the supervising agent);
+run in the foreground it would block you from acting on what it prints —
+the watcher must never be the actor.
+
+Stdlib only, and Python because the instrument PCs run Windows: a shell
+watcher needs Git Bash there, this file runs anywhere fibsem does.
+
+    python .claude/skills/supervise-autolamella/watch_events.py
+
+Exits 0 when the workflow ends, 1 when the server cannot be reached (start
+AutoLamella with the agent feature enabled, then rerun). The first fresh
+agent to write its own watcher matched the wrong JSON key and slept through
+a question — hence this file: run the tested one.
+"""
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DISCOVERY = Path.home() / ".fibsem" / "agent-server.json"
+INTERESTING = {
+    "workflow_started",
+    "task_started",
+    "task_completed",
+    "task_failed",
+    "task_cancelled",
+    "workflow_completed",
+    "workflow_cancelled",
+}
+
+
+def _connection():
+    info = json.loads(DISCOVERY.read_text())
+    return info["url"], {"Authorization": "Bearer " + info["token"]}
+
+
+def _get(url, headers, timeout):
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode())
+
+
+def main():
+    try:
+        base, headers = _connection()
+    except (OSError, KeyError, ValueError):
+        print(
+            "NO SERVER: no discovery file — start AutoLamella with the agent "
+            "feature enabled and a microscope connected, then rerun."
+        )
+        return 1
+
+    since = 0
+    failures = 0
+    while True:
+        try:
+            payload = _get(
+                f"{base}/app/events?since={since}&timeout=25", headers, timeout=35
+            )
+            failures = 0
+        except (urllib.error.URLError, OSError, TimeoutError):
+            failures += 1
+            if failures >= 4:
+                print("SERVER GONE: events unreachable — the app has stopped.")
+                return 1
+            time.sleep(5)
+            continue
+
+        for event in payload.get("events", []):
+            kind = event.get("kind", "")
+            data = event.get("payload", {})
+            since = max(since, event.get("seq", since))
+            if kind == "prompt_raised":
+                print(
+                    "PROMPT nonce=%s type=%s" % (data.get("nonce"), data.get("type")),
+                    flush=True,
+                )
+            elif kind == "prompt_answered":
+                print(
+                    "ANSWERED nonce=%s by=%s response=%s"
+                    % (
+                        data.get("nonce"),
+                        data.get("answered_by"),
+                        data.get("response"),
+                    ),
+                    flush=True,
+                )
+            elif kind == "prompt_cancelled":
+                print("PROMPT WITHDRAWN nonce=%s" % data.get("nonce"), flush=True)
+            elif kind in INTERESTING:
+                print("EVENT %s %s" % (kind, data.get("item_name", "")), flush=True)
+            if kind in ("workflow_completed", "workflow_cancelled"):
+                print("RUN ENDED", flush=True)
+                return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The closing PR of the agent-mode arc. A fresh-context agent ran the merged skill (#702) against a live run today with a one-sentence prompt: it found the server, paused at read-only and asked for the Act permission, refused three times to sneak past the harness's permission classifier, answered 8/9 prompts correctly (all three inspect re-asks: accept, never re-mill), caught a stale display frame and judged from telemetry with a stated rationale, and delivered a report that matched the independent event log exactly. Every place it stumbled becomes a fix:

1. **`watch_events.py` ships inside the skill folder**: a tested, stdlib-only event watcher. Python rather than shell because the instrument PCs run Windows (a .sh needs Git Bash there). The test agent's hand-rolled watcher matched `type` instead of `kind` and slept through a question — nobody writes their own anymore.
2. **SKILL.md updates**: prefer MCP tools, HTTP as fallback; a new rule codifying what the test agent did right unprompted — *treat a harness permission denial exactly like a server 403: stop and ask, never repackage the call*; and the watcher instruction now names the bundled script and explains why it must run in the background.

Review hardening (second commit) — a review of the first cut found eight defects in the watcher, all fixed and exercised by a stub-server test of the full loop:

- The cursor now seeds from the startup snapshot's `latest_seq`: the event buffer outlives workflow runs, so `since=0` replayed history — stale `PROMPT` lines, and a previous run's `workflow_completed` printed `RUN ENDED` and exited before the new run's watch began.
- HTTP statuses are the server talking, not the server gone: a 401/403 after an app restart (token rotation) re-reads the discovery file and retries with fresh credentials instead of reporting "the app has stopped".
- `http.client.HTTPException` and JSON decode errors are caught in the poll loop (a server dying mid-response used to kill the watcher with a traceback).
- The response contract is honored: `available: false` exits with a clear message instead of busy-looping the no-buffer path, and `oldest_available` gaps print a `GAP` line telling the agent to re-read `/app/prompt` rather than assume continuity.
- `task_skipped` wakes the agent (a real emitted kind the set was missing).
- stdout is reconfigured to utf-8/replace so an operator-typed item name can't kill the watch on a cp1252 console.

A note on MCP config: `.mcp.json` is **not** committed — the repo's `.gitignore` ignores `*.json`, so the sidecar has to be registered per-machine (`claude mcp add fibsem fibsem-mcp`). SKILL.md now says so instead of claiming the repo provides it, and the HTTP fallback covers sessions without it. (The stale local config pointing at `fibsem.mcp.server` — the reason MCP timed out in every session — is fixed locally.)
