### PR TITLE
[ui] Let _on_acquire own the image references in _set_images

### DIFF
--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -319,15 +319,16 @@ class QtResponder(QObject):
             # in the workflow thread as this instruction's failure.
             raise RuntimeError("No image widget available to display images.")
 
+        # _on_acquire owns the eb_image/ib_image references, routed by
+        # metadata.beam_type — assigning them positionally here too would
+        # let a mislabeled image split the two authorities silently.
         if request.sem_image is not None:
-            image_widget.eb_image = request.sem_image
             image_widget._on_acquire(request.sem_image)
             image_widget.set_ui_from_settings(
                 image_settings=request.sem_image.metadata.image_settings,
                 beam_type=BeamType.ELECTRON,
             )
         if request.fib_image is not None:
-            image_widget.ib_image = request.fib_image
             image_widget._on_acquire(request.fib_image)
             image_widget.set_ui_from_settings(
                 image_settings=request.fib_image.metadata.image_settings,


### PR DESCRIPTION
Follow-up to #704, flagged in its review.

Since #704, `_on_acquire` rebinds `eb_image`/`ib_image` on every acquisition, routed by `metadata.beam_type`. `QtResponder._set_images` still assigned the references positionally by argument slot before calling it — two authorities for the same state. They agree whenever metadata is labelled correctly, but an image whose metadata doesn't match its slot (exactly the shape #704's seeded-blank bug had) would be written to one slot positionally and the other slot by routing, silently split-braining the references.

This drops the positional assignments so metadata routing is the single authority: a mislabel now produces one visible outcome instead of two divergent ones.

Tests: `tests/ui/test_qt_responder.py` (10 passed) — its worker-thread test already asserts both references land via `set_images_ui` with correctly-labelled images, which now exercises the routing path alone. Ruff check + format clean.