### PR TITLE
[app] Hand a question to the operator the moment nobody is on the other end

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -91,7 +91,12 @@ enabled). A task set to *Agent* raises its questions to the connected agent:
   (Preferences → Agent, default 5 minutes), the question becomes yours: the
   ordinary orange border, attention button, and sound, plus a message saying
   why. This hand-over runs inside AutoLamella, so it works even if the agent's
-  own process has died.
+  own process has died;
+- and the app knows whether anyone is actually out there: a watching agent is
+  in touch with the server every half-minute, so if it hasn't been heard from
+  — it never connected, or its session died — a question is handed to you
+  right away instead of waiting out the timer. The Agent Server dialog shows
+  when the agent was last heard from.
 
 You can always answer any question yourself, whoever it is addressed to.
 

--- a/fibsem/applications/autolamella/server/hosting.py
+++ b/fibsem/applications/autolamella/server/hosting.py
@@ -64,6 +64,15 @@ class AgentServerHost:
     def running(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
 
+    def agent_seconds_since_seen(self) -> Optional[float]:
+        """Seconds since the agent's token last made a request, or None if the
+        server isn't running or nothing has connected yet. A live supervising
+        agent long-polls the event stream, so this stays small while one is
+        attached — staleness means nobody is on the other end."""
+        if not self.running or self.auth is None:
+            return None
+        return self.auth.seconds_since_seen()
+
     @property
     def url(self) -> str:
         return f"http://{self._host}:{self._port}"

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -227,6 +227,12 @@ def set_menu_icon(action: QAction, key: str) -> None:
 # escalates to the operator. A preference later; a constant until the arming
 # dialog gives it a home.
 AGENT_WATCHDOG_MS = 5 * 60 * 1000
+# A live supervising agent long-polls the event stream every ~25 s, so its
+# token is heard from continuously. Silence this long means nobody is on the
+# other end — a parked question is handed to the operator immediately instead
+# of waiting out the full hand-over time above.
+AGENT_PRESUMED_GONE_S = 90
+AGENT_LIVENESS_CHECK_MS = 15 * 1000
 
 
 def play_notification_sound():
@@ -1251,6 +1257,13 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self._agent_watchdog.setSingleShot(True)
         self._agent_watchdog.timeout.connect(self._on_agent_watchdog_expired)
         self._agent_watchdog_expired = False
+        # The companion check: while a question parks on the agent's clock,
+        # confirm someone is actually on the other end (the agent's token is
+        # heard from continuously while it watches). An agent that dies
+        # mid-question hands over in seconds, not the full deadline above.
+        self._agent_liveness_check = QTimer(self)
+        self._agent_liveness_check.setInterval(AGENT_LIVENESS_CHECK_MS)
+        self._agent_liveness_check.timeout.connect(self._on_agent_liveness_check)
         self.supervised_status_btn = QPushButton("Supervised")
         self.supervised_status_btn.setCursor(Qt.PointingHandCursor)  # type: ignore
         self.supervised_status_btn.setToolTip("Click to toggle supervision")
@@ -2798,30 +2811,69 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         except Exception:
             return AGENT_WATCHDOG_MS
 
+    def _agent_seconds_since_seen(self) -> Optional[float]:
+        """Seconds since the agent's token last made a request, or None."""
+        host = getattr(self.autolamella_ui, "_agent_server_host", None)
+        if host is None:
+            return None
+        try:
+            return host.agent_seconds_since_seen()
+        except Exception:
+            return None
+
+    def _agent_presumed_gone(self) -> bool:
+        """Nobody is on the other end: never connected, or silent too long."""
+        age = self._agent_seconds_since_seen()
+        return age is None or age > AGENT_PRESUMED_GONE_S
+
     def _on_question_event(self, kind: str, payload: dict) -> None:
         """GUI thread, from the responder: arm/disarm the agent watchdog."""
         if kind == "prompt_raised":
             self._agent_watchdog_expired = False
             if self._agent_supervision_active(self._current_task_name):
+                if self._agent_presumed_gone():
+                    # Don't park a question for an agent that isn't there.
+                    self._hand_question_to_operator(
+                        "The agent hasn't been in touch — this question is yours."
+                    )
+                    return
                 self._agent_watchdog.start(self._watchdog_ms())
+                self._agent_liveness_check.start()
             else:
                 self._agent_watchdog.stop()
+                self._agent_liveness_check.stop()
         elif kind in ("prompt_answered", "prompt_cancelled"):
             self._agent_watchdog.stop()
+            self._agent_liveness_check.stop()
             self._agent_watchdog_expired = False
         self._refresh_workflow_indicators()
 
     def _on_agent_watchdog_expired(self) -> None:
         """The agent went quiet: the standing question becomes the operator's."""
-        if not self.autolamella_ui.WAITING_FOR_USER_INTERACTION:
-            return  # the answer raced the timer; nothing is standing
-        self._agent_watchdog_expired = True
         minutes = max(1, self._watchdog_ms() // 60000)
-        notification_service.show_toast(
+        self._hand_question_to_operator(
             f"The agent hasn't answered in {minutes} minutes — "
-            "this question is now yours.",
-            "warning",
+            "this question is now yours."
         )
+
+    def _on_agent_liveness_check(self) -> None:
+        """Periodic while a question parks on the agent's clock: hand over the
+        moment the agent stops being heard from, not at the full deadline."""
+        if self._agent_presumed_gone():
+            self._hand_question_to_operator(
+                "The agent hasn't been in touch — this question is yours."
+            )
+
+    def _hand_question_to_operator(self, message: str) -> None:
+        """Escalate the standing question: ordinary waiting chrome + a toast
+        saying why. Informs, never revokes — a late agent answer still applies,
+        and the first writer still wins."""
+        self._agent_watchdog.stop()
+        self._agent_liveness_check.stop()
+        if not self.autolamella_ui.WAITING_FOR_USER_INTERACTION:
+            return  # the answer raced the escalation; nothing is standing
+        self._agent_watchdog_expired = True
+        notification_service.show_toast(message, "warning")
         # The ordinary waiting chrome (orange border, attention button, sound)
         # takes over below, now that agent_holding no longer suppresses it.
         self._refresh_workflow_indicators()

--- a/fibsem/applications/autolamella/ui/agent_server_dialog.py
+++ b/fibsem/applications/autolamella/ui/agent_server_dialog.py
@@ -214,6 +214,14 @@ class AgentServerDialog(QDialog):
         self._btn_copy.clicked.connect(self._on_copy_clicked)
         self._chk_control.toggled.connect(self._on_control_toggled)
 
+        # Keep the status line live while the dialog is open: "last heard
+        # from" is only useful if it ticks. Status text only — a full
+        # refresh() would rewrite the token field under the user.
+        self._status_timer = QTimer(self)
+        self._status_timer.setInterval(2000)
+        self._status_timer.timeout.connect(self._update_status_line)
+        self._status_timer.start()
+
         self.refresh()
 
     # --- live state -----------------------------------------------------------
@@ -223,6 +231,27 @@ class AgentServerDialog(QDialog):
         if host is None or not getattr(host, "running", False):
             return None
         return host
+
+    @staticmethod
+    def _status_text(host) -> str:
+        """The status line: where it's running, and when an agent was last
+        heard from — the human-readable face of the presence signal."""
+        text = f"Running on {host.url}"
+        try:
+            age = host.agent_seconds_since_seen()
+        except Exception:
+            return text
+        if age is None:
+            return text + " · nothing has connected yet"
+        if age < 60:
+            return text + f" · last heard from {int(age)} s ago"
+        return text + f" · last heard from {int(age // 60)} min ago"
+
+    def _update_status_line(self) -> None:
+        """Timer tick: refresh only the status text, never the token field."""
+        host = self._host()
+        if host is not None:
+            self._status_label.setText(self._status_text(host))
 
     def refresh(self) -> None:
         """Re-read the session's server into the dialog."""
@@ -246,7 +275,7 @@ class AgentServerDialog(QDialog):
         from fibsem.server.auth import Scope
 
         self._status_dot.setStyleSheet(f"color: {OK_COLOR};")
-        self._status_label.setText(f"Running on {host.url}")
+        self._status_label.setText(self._status_text(host))
         self._status_label.setStyleSheet(f"color: {TEXT_STRONG_COLOR};")
         self._token_edit.setText(host.auth.token)
         # Reflect without re-arming: setChecked fires toggled, which would log

--- a/fibsem/server/auth.py
+++ b/fibsem/server/auth.py
@@ -15,6 +15,7 @@ supply one), and only ``read`` is armed unless the hosting says otherwise.
 import hmac
 import secrets
 import threading
+import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import FrozenSet, Iterable, Optional
@@ -44,6 +45,24 @@ class AuthConfig:
 
     token: str
     armed: FrozenSet[Scope] = field(default_factory=frozenset)
+    # Monotonic time of the last request that presented the valid token; None
+    # until one arrives. The connected agent's proof of life: its event
+    # long-poll alone touches the server every half-minute, so staleness here
+    # means nobody is on the other end (used to hand a parked question to the
+    # operator without waiting out the full hand-over time).
+    last_seen_monotonic: Optional[float] = None
+
+    def mark_seen(self) -> None:
+        """Record that the token holder just made a request. Any thread —
+        a float rebind is atomic, and readers only ever want 'roughly now'."""
+        self.last_seen_monotonic = time.monotonic()
+
+    def seconds_since_seen(self) -> Optional[float]:
+        """Seconds since the token holder was last heard from, or None if never."""
+        seen = self.last_seen_monotonic
+        if seen is None:
+            return None
+        return max(0.0, time.monotonic() - seen)
 
     def set_armed(self, scope: Scope, armed: bool) -> None:
         """Arm or disarm one scope, effective for the next request."""
@@ -99,6 +118,9 @@ def require_scope(scope: Scope):
                     "message": "Missing or invalid bearer token.",
                 },
             )
+        # A valid token is proof of life whatever happens next — a scope
+        # refusal below is still the agent talking.
+        auth.mark_seen()
         if not auth.is_armed(scope):
             raise HTTPException(
                 status_code=403,

--- a/tests/server/test_server_factory.py
+++ b/tests/server/test_server_factory.py
@@ -117,6 +117,31 @@ def test_stop_milling_allowed_with_read_scope(read_client):
     assert resp.status_code == 200
 
 
+def test_valid_requests_stamp_last_seen(microscope):
+    """The presence signal: any request bearing the valid token marks the
+    agent as heard from — including a scope refusal, which is still the agent
+    talking. An invalid token marks nothing."""
+    auth = AuthConfig(token=TOKEN)
+    app = build_server(microscope, auth=auth)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        assert auth.seconds_since_seen() is None
+
+        client.get("/stage_position", headers=AUTH)
+        age = auth.seconds_since_seen()
+        assert age is not None and age < 5.0
+
+        auth.last_seen_monotonic = None
+        refused = client.post(
+            "/move_stage_relative", headers=AUTH, json={"dx": 0, "dy": 0, "dz": 0}
+        )
+        assert refused.status_code == 403  # hardware not armed
+        assert auth.seconds_since_seen() is not None
+
+        auth.last_seen_monotonic = None
+        client.get("/stage_position", headers={"Authorization": "Bearer wrong"})
+        assert auth.seconds_since_seen() is None
+
+
 def test_hardware_route_works_when_armed(armed_client):
     resp = armed_client.get("/stage_position", headers=AUTH)
     start = resp.json()["position"]

--- a/tests/ui/test_agent_server_dialog.py
+++ b/tests/ui/test_agent_server_dialog.py
@@ -75,3 +75,26 @@ def test_the_token_starts_hidden(qapp, host):
     dialog._btn_reveal.setChecked(True)
     assert dialog._token_edit.echoMode() == QLineEdit.Normal
     dialog.deleteLater()
+
+
+def test_status_text_reports_when_the_agent_was_last_heard_from():
+    """The presence signal's face: the status line says when the agent's
+    token last made a request, in units a human reads at a glance."""
+    from fibsem.applications.autolamella.ui.agent_server_dialog import (
+        AgentServerDialog,
+    )
+
+    class _Host:
+        url = "http://127.0.0.1:8001"
+
+        def __init__(self, age):
+            self._age = age
+
+        def agent_seconds_since_seen(self):
+            return self._age
+
+    assert AgentServerDialog._status_text(_Host(None)).endswith(
+        "nothing has connected yet"
+    )
+    assert "last heard from 5 s ago" in AgentServerDialog._status_text(_Host(5.4))
+    assert "last heard from 3 min ago" in AgentServerDialog._status_text(_Host(200))

--- a/tests/ui/test_agent_watchdog.py
+++ b/tests/ui/test_agent_watchdog.py
@@ -48,7 +48,14 @@ def main_ui(qapp):
 
 
 class _RunningHost:
+    """Running, with a live agent: heard from a second ago (the shape
+    AgentServerHost.agent_seconds_since_seen returns while a watcher polls)."""
+
     running = True
+    seconds_since_seen = 1.0
+
+    def agent_seconds_since_seen(self):
+        return self.seconds_since_seen
 
 
 @pytest.fixture
@@ -75,6 +82,7 @@ def agent_question_standing(main_ui, tmp_path):
     ui.WAITING_FOR_USER_INTERACTION = True
     yield experiment
     main_ui._agent_watchdog.stop()
+    main_ui._agent_liveness_check.stop()
     main_ui._agent_watchdog_expired = False
     (
         ui.experiment,
@@ -135,3 +143,54 @@ def test_expiry_with_nothing_standing_is_a_noop(main_ui, agent_question_standing
     main_ui.autolamella_ui.WAITING_FOR_USER_INTERACTION = False
     main_ui._on_agent_watchdog_expired()
     assert main_ui._agent_watchdog_expired is False
+
+
+def test_a_question_for_an_absent_agent_is_yours_immediately(
+    main_ui, agent_question_standing
+):
+    """No one has connected (or the server can't say): don't park the question
+    on the agent's clock at all — straight to the ordinary waiting chrome."""
+    ui = main_ui.autolamella_ui
+    ui._agent_server_host.agent_seconds_since_seen = lambda: None
+    main_ui._on_question_event("prompt_raised", {})
+
+    assert main_ui._agent_watchdog_expired is True
+    assert not main_ui._agent_watchdog.isActive()
+    assert not main_ui._agent_liveness_check.isActive()
+    assert main_ui._border_state == "waiting"
+    assert not main_ui.user_attention_btn.isHidden()
+
+
+def test_an_agent_that_dies_mid_question_hands_over_early(
+    main_ui, agent_question_standing
+):
+    """Alive at the ask, silent afterwards: the periodic check hands over as
+    soon as the agent stops being heard from, not at the full deadline."""
+    ui = main_ui.autolamella_ui
+    main_ui._on_question_event("prompt_raised", {})
+    assert main_ui._border_state == "agent"
+    assert main_ui._agent_liveness_check.isActive()
+
+    from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
+        AGENT_PRESUMED_GONE_S,
+    )
+
+    ui._agent_server_host.seconds_since_seen = AGENT_PRESUMED_GONE_S + 1.0
+    main_ui._on_agent_liveness_check()
+
+    assert main_ui._agent_watchdog_expired is True
+    assert not main_ui._agent_watchdog.isActive()
+    assert not main_ui._agent_liveness_check.isActive()
+    assert main_ui._border_state == "waiting"
+
+
+def test_a_live_agent_still_gets_the_full_deadline(main_ui, agent_question_standing):
+    """Liveness never shortens the clock for an agent that is in touch."""
+    main_ui._on_question_event("prompt_raised", {})
+    assert main_ui._agent_watchdog.isActive()
+
+    main_ui._on_agent_liveness_check()  # heard from 1 s ago: nothing changes
+
+    assert main_ui._agent_watchdog.isActive()
+    assert main_ui._agent_watchdog_expired is False
+    assert main_ui._border_state == "agent"


### PR DESCRIPTION
The hand-over timer (*Hand questions to me after*, default 5 min) measures one thing: no answer yet on this question. It cannot tell a thinking agent from a dead one — so a question raised after the agent's session died sat purple and quiet for the full deadline, wasting instrument time per question, silently.

## How it works (plain language)

A supervising agent is never actually silent: its background watcher asks the server for news every half-minute, and every image it fetches or answer it posts is a request too. So "when did the agent's token last make a request" is a built-in proof of life — no heartbeat endpoint, no agent-side changes, nothing new on the wire. The app now uses it: if a question comes up for an agent that hasn't been in touch, it's yours immediately, with a message saying why.

## What changed

- **Auth layer**: every request presenting the valid token stamps a last-seen time (a scope refusal included — that's still the agent talking; an invalid token stamps nothing). Monotonic clock, atomic rebind, no lock.
- **App**: a question raised for an agent never heard from — or silent past 90 s (about three missed watcher cycles) — goes straight to the ordinary waiting chrome + toast instead of parking on the agent's clock. While a question parks, a 15 s check hands over as soon as the agent goes silent, instead of at the full deadline. A **live agent is untouched**: the configured hand-over time still governs, late answers still apply, first writer still wins.
- **Agent Server dialog**: the status line shows when the agent was last heard from, ticking every 2 s while open (status text only — a full refresh would rewrite the token field under the user).
- No new preference: presumed-gone hand-over isn't something you'd opt out of.

## Tests

Auth stamping over HTTP (valid / refused / invalid-token); three new app tests (absent agent → immediate hand-over, dies-mid-question → early hand-over via the periodic check, live agent → full deadline untouched) alongside the five existing hold/expiry tests; dialog status-line wording. All green with ruff check + format clean.

Not yet live-tested — needs an app restart to pick up; happy to run the kill-the-agent standoff on the sim after merge.