### PR TITLE
[server] Item detail: one read for everything durable about an item

### DIFF
--- a/.claude/skills/supervise-autolamella/SKILL.md
+++ b/.claude/skills/supervise-autolamella/SKILL.md
@@ -142,9 +142,13 @@ The argument selects a variation on the same loop:
 - **collaborative** (default): the ladder above, operator in the loop for
   firsts and placements. Report progress as tasks complete.
 - **exemplar**: the operator handles the first item end to end; you record
-  what they accepted (images, areas, answers) as the reference, then handle
-  the remaining items, comparing each inspect against the exemplar. Divergence
-  from the exemplar is a first-of-class: escalate.
+  what they accepted as the reference, then handle the remaining items,
+  comparing each inspect against the exemplar. Divergence from the exemplar
+  is a first-of-class: escalate. Record from durable state, not the live
+  prompt: after an `ANSWERED by=operator` line, read
+  `GET /app/items/{item_name}` — the accepted POI, alignment area, and
+  milling angle are there — and pair it with the display image. Never race
+  the operator for the prompt's `current` value.
 - **batch-review**: supervision is off or minimal; let the run complete, then
   present the outputs (`/app/run_summary`, `/app/task_outputs/{item}`, final
   images) and act on the operator's verdicts — `requeue_task` for the items

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -43,6 +43,8 @@ Reading is on for any connected agent — it is the point of the feature:
 - **Events** — task starts and finishes, milling progress, questions raised
   and answered (and by whom), as a live feed.
 - **Run history** — the run summary and each item's produced files.
+- **Each item's details** — status, failure flag, point of interest,
+  alignment area, milling angle, and where its poses put the stage.
 
 Every image travels as a downscaled preview that carries its own scale: the
 preview's size, the source image's size, the field width, and the physical

--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -227,6 +227,46 @@ class AgentContext:
             ],
         }
 
+    def item_detail(self, item_name: str) -> Dict[str, Any]:
+        """The durable facts about one item, as a curated snapshot.
+
+        One read for everything a supervisor judges an item by: status,
+        geometry (POI, alignment area, milling angle), and where its poses
+        put the stage. Curated rather than a ``to_dict`` dump — this payload
+        serves agents and the monitor dashboard, so every field in it is
+        wire contract; internals stay internal. Pointer facts live on their
+        own surfaces (files: task_outputs; history: task_history).
+        """
+        experiment = self._experiment
+        if experiment is None:
+            return {"available": False, "item_name": item_name}
+        lamella = experiment.get_lamella_by_name(item_name)
+        if lamella is None:
+            return {
+                "available": False,
+                "item_name": item_name,
+                "error": f"No item named {item_name!r} in this experiment.",
+            }
+        poses = {}
+        for pose_name, pose in dict(lamella.poses).items():
+            position = getattr(pose, "stage_position", None)
+            poses[pose_name] = position.to_dict() if position is not None else None
+        return {
+            "available": True,
+            "item_name": lamella.name,
+            "id": lamella.id,
+            "is_failure": bool(lamella.is_failure),
+            "description": lamella.description,
+            # metres, in the milling coordinate system (+y up, origin centre)
+            "poi": lamella.poi.to_dict() if lamella.poi is not None else None,
+            # fractions of the FIB frame, origin top-left
+            "alignment_area": lamella.alignment_area.to_dict()
+            if lamella.alignment_area is not None
+            else None,
+            "milling_angle": lamella.milling_angle,
+            "poses": poses,
+        }
+
     # --- instrument-adjacent (cached only, never a hardware call) --------------
 
     def stage_position(self) -> Dict[str, Any]:

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -249,6 +249,9 @@ def build_sidecar(client, capabilities):
     def get_task_outputs(item_name: str):
         return _app_get(f"/app/task_outputs/{item_name}")
 
+    def get_item_detail(item_name: str):
+        return _app_get(f"/app/items/{item_name}")
+
     def list_recent_experiments():
         return _app_get("/app/recent_experiments")
 
@@ -335,6 +338,7 @@ def build_sidecar(client, capabilities):
             get_run_summary,
             get_protocol,
             get_task_outputs,
+            get_item_detail,
             list_recent_experiments,
             get_events,
             get_display_images,

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -41,6 +41,8 @@ class AppContext(Protocol):
 
     def task_outputs(self, item_name: str) -> Dict[str, Any]: ...
 
+    def item_detail(self, item_name: str) -> Dict[str, Any]: ...
+
     def recent_experiments(self) -> List[Dict[str, Any]]: ...
 
     def events(self, since: int = 0, timeout: float = 0.0) -> Dict[str, Any]: ...
@@ -99,6 +101,10 @@ def build_app_router(context: AppContext) -> APIRouter:
     @router.get("/task_outputs/{item_name}")
     def task_outputs(item_name: str):
         return context.task_outputs(item_name)
+
+    @router.get("/items/{item_name}")
+    def item_detail(item_name: str):
+        return context.item_detail(item_name)
 
     @router.get("/recent_experiments")
     def recent_experiments():

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -205,6 +205,15 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         router="app",
     ),
     ToolSpec(
+        name="get_item_detail",
+        description="Everything durable about one item: status, failure flag, POI, alignment area, milling angle, and where its poses put the stage.",
+        method="GET",
+        path="/app/items/{item_name}",
+        scope="read",
+        router="app",
+        params={"item_name": "the item (lamella) name"},
+    ),
+    ToolSpec(
         name="get_task_outputs",
         description="The files an item's completed tasks produced (reference images by role).",
         method="GET",

--- a/tests/autolamella/test_agent_context.py
+++ b/tests/autolamella/test_agent_context.py
@@ -61,6 +61,7 @@ def test_every_method_tolerates_an_empty_host():
         ctx.run_summary(),
         ctx.protocol(),
         ctx.task_outputs("anything"),
+        ctx.item_detail("anything"),
         ctx.stage_position(),
     ]
     for payload in payloads:
@@ -124,6 +125,37 @@ def test_task_outputs_for_a_real_item_and_a_missing_one(experiment):
     _assert_json_safe(completed)
 
     missing = ctx.task_outputs("no-such-item")
+    assert missing["available"] is False
+    assert "no-such-item" in missing["error"]
+
+
+def test_item_detail_serves_the_durable_item_facts(experiment):
+    """One read for what a supervisor judges an item by — the exemplar-mode
+    seam: after the operator answers, the accepted POI/alignment area are
+    readable here rather than raced out of the live prompt mirror."""
+    from fibsem.structures import FibsemRectangle, MicroscopeState, Point
+
+    host = Host()
+    host.experiment = experiment
+    ctx = AgentContext(host)
+
+    lamella = experiment.positions[0]
+    lamella.poi = Point(1.5e-6, -2.5e-6)
+    lamella.alignment_area = FibsemRectangle(left=0.6, top=0.3, width=0.3, height=0.4)
+    lamella.milling_angle = 15.0
+    lamella.milling_pose = MicroscopeState()
+
+    detail = ctx.item_detail(lamella.name)
+    assert detail["available"] is True
+    assert detail["item_name"] == lamella.name
+    assert detail["poi"] == {"x": 1.5e-6, "y": -2.5e-6}
+    assert detail["alignment_area"]["left"] == 0.6
+    assert detail["milling_angle"] == 15.0
+    assert detail["is_failure"] is False
+    assert "MILLING" in detail["poses"]
+    _assert_json_safe(detail)
+
+    missing = ctx.item_detail("no-such-item")
     assert missing["available"] is False
     assert "no-such-item" in missing["error"]
 


### PR DESCRIPTION
`GET /app/items/{item_name}` — status, failure flag, description, point of interest, alignment area, milling angle, and where each pose puts the stage. A curated snapshot, not a `to_dict` dump: this payload serves two consumers — supervising agents and the future monitor dashboard's per-item drill-down — so every field in it is deliberate wire contract, and internals stay internal. Pointer facts keep their own surfaces (files in `task_outputs`, history in `task_history`).

## Why now

The supervision skill's *exemplar* mode (operator handles item 1, agent replicates on the rest) needs to record what the operator accepted. Until now the accepted POI/alignment area existed on the wire only as the live prompt's `current` mirror — which vanishes the moment the operator answers, so recording the reference meant racing them. Now the agent reads the item *after* the `ANSWERED` event; the workflow has written the accepted value into the lamella by the time it resumes. The skill's exemplar mode documents that flow explicitly ("record from durable state, never race the operator").

## What changed

- `AgentContext.item_detail` + `GET /app/items/{item_name}` on the read scope, structured refusal for unknown items.
- Catalog entry + sidecar `get_item_detail` (the catalog↔sidecar contract test caught the missing implementation, exactly as designed).
- Skill exemplar-mode wording + user-guide line.

## Tests

Real-objects unit tests (accepted POI/area/angle/pose round-trip, unknown-item refusal, JSON-safety incl. the empty-host sweep); full `tests/server/` green (75 passed). Ruff check + format clean.