### PR TITLE
[skills] Exemplar means criteria, not coordinates; watch survives turn-based harnesses

### DIFF
--- a/.claude/skills/supervise-autolamella/SKILL.md
+++ b/.claude/skills/supervise-autolamella/SKILL.md
@@ -70,6 +70,14 @@ nonce), `ANSWERED` (check who — if the operator answered, your read of that
 question is stale), task lifecycle `EVENT` lines, and `RUN ENDED` (report
 and stop watching).
 
+If your harness cannot keep a background process alive while you are idle
+(spawned subagents usually cannot — the watcher dies with your turn, and no
+line will ever wake you), do not go idle expecting one. Hold the watch in
+the foreground of a single bounded command instead: run the watcher with
+your tool timeout as the cap, act on whatever lines it printed when the
+command returns, and run it again. A stalled watch looks exactly like a
+quiet run — when in doubt, read `/app/prompt` directly.
+
 ## Answer — the rules that are never optional
 
 1. **Name the question.** Read `GET /app/prompt`, take its `nonce`, echo it in
@@ -141,14 +149,21 @@ The argument selects a variation on the same loop:
 
 - **collaborative** (default): the ladder above, operator in the loop for
   firsts and placements. Report progress as tasks complete.
-- **exemplar**: the operator handles the first item end to end; you record
-  what they accepted as the reference, then handle the remaining items,
-  comparing each inspect against the exemplar. Divergence from the exemplar
-  is a first-of-class: escalate. Record from durable state, not the live
-  prompt: after an `ANSWERED by=operator` line, read
+- **exemplar**: the operator handles the first item end to end; you extract
+  what made their answers acceptable, then handle the remaining items. The
+  exemplar is an *example*, not a template: generalize each acceptance into
+  the criterion behind it, and judge later items by the criteria against
+  their own recorded config — never by literal match. The alignment area
+  does not have to sit where item 1's sat; it has to cover *this item's*
+  fiducial, stay clear of *this item's* POI, and be in bounds at a sensible
+  size. One mill pass sufficed on the exemplar means one pass with a fresh
+  image is acceptable — not that the pixels must match. Record from durable
+  state, not the live prompt: after an `ANSWERED by=operator` line, read
   `GET /app/items/{item_name}` — the accepted POI, alignment area, and
   milling angle are there — and pair it with the display image. Never race
-  the operator for the prompt's `current` value.
+  the operator for the prompt's `current` value. Escalate when a criterion
+  is violated, when you cannot evaluate one, or when a question type the
+  exemplar never showed appears.
 - **batch-review**: supervision is off or minimal; let the run complete, then
   present the outputs (`/app/run_summary`, `/app/task_outputs/{item}`, final
   images) and act on the operator's verdicts — `requeue_task` for the items


### PR DESCRIPTION
Two lessons from the first live exemplar-mode run (3 items, operator handled item 1, agent handled 2–3 — full sheet correct).

**Exemplar = example, not template.** The run had a built-in trap: item 1's fiducial sat on the left of the frame, items 2–3's at the default on the right — so their proposed alignment areas "diverged" from the exemplar while being exactly right. The mode's text said divergence → escalate; the live agent did something better — it checked each item's own fiducial config and accepted with a stated rationale. The text now teaches that explicitly: generalize each operator acceptance into the criterion behind it (covers *this item's* fiducial, clear of *this item's* POI, in bounds, sensible size; one pass sufficed ≠ pixels must match) and judge later items by the criteria against their own recorded config. Escalation is for violated or unevaluable criteria and never-seen question types, not literal mismatch.

**Turn-based harnesses can't sleep on the watcher.** A spawned subagent's background watcher dies when its turn ends — the run stalled on a standing prompt until nudged, and (a known token-level limitation) the in-app hand-over didn't fire because another client on the same token was still polling. The Watch section now tells agents whose harness can't keep background processes alive to hold the watch in bounded foreground commands and re-run it, and to read /app/prompt directly when in doubt.