### PR TITLE
[server] Answers that carry a value: adjust alignment areas and POIs

### DIFF
--- a/.claude/skills/supervise-autolamella/SKILL.md
+++ b/.claude/skills/supervise-autolamella/SKILL.md
@@ -117,12 +117,20 @@ placement, that is the operator's decision (see the ladder).
 FIB view). Sanity-check against the image: in bounds, non-degenerate size,
 covering the fiducial, consistent with previous items. Yes accepts it as
 shown. In a fiducial task this prompt arrives at the task's *end*, not its
-start.
+start. An answer may carry a **corrected rectangle**:
+`{"response": true, "nonce": N, "value": {"left", "top", "width", "height"}}`
+(fractions of the frame, origin top-left). The server validates it and
+places it on the operator's screen through the same widget they would drag,
+then accepts it — use this for a small correction you can justify from your
+criteria, never to invent an area from scratch (that is an escalation).
 
 **`PickPOI`** — a placement. The payload carries the image and the live
 `current` marker (microscope image coordinates, +y up, origin centre). In
 collaborative mode this is **held for the operator**: report it, show where
-the marker is, and wait.
+the marker is, and wait. Where placement has been delegated (exemplar mode,
+or an explicit "you place the rest"), the answer may carry the point:
+`"value": {"x", "y"}` in the payload's stated coordinates — validated
+against the image bounds, and landed on screen before acceptance.
 
 **`ConfirmDetection`** — feature positions. Held for the operator in
 collaborative mode.
@@ -161,9 +169,12 @@ The argument selects a variation on the same loop:
   state, not the live prompt: after an `ANSWERED by=operator` line, read
   `GET /app/items/{item_name}` — the accepted POI, alignment area, and
   milling angle are there — and pair it with the display image. Never race
-  the operator for the prompt's `current` value. Escalate when a criterion
-  is violated, when you cannot evaluate one, or when a question type the
-  exemplar never showed appears.
+  the operator for the prompt's `current` value. A small drift against a
+  criterion you can state is a correction, not an escalation: answer with a
+  `value` carrying the fixed geometry (the alignment rectangle nudged off
+  the POI, the point moved onto the feature) — the operator sees it land.
+  Escalate when you cannot state the correction, when you cannot evaluate a
+  criterion, or when a question type the exemplar never showed appears.
 - **batch-review**: supervision is off or minimal; let the run complete, then
   present the outputs (`/app/run_summary`, `/app/task_outputs/{item}`,
   `/app/items/{item}`, final images) and act on the verdicts —

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -62,7 +62,14 @@ In **Tools → Agent Server**, the *Act* switch lets the agent:
 - **answer supervision questions** — through exactly the same path as your
   Yes/No buttons. First answer wins: you can always answer first, and your
   click beats the agent's every time. Every answer is attributed — the line
-  under the buttons reads `agent · answered Run Milling · 14:22:31`;
+  under the buttons reads `agent · answered Run Milling · 14:22:31`.
+  For the two geometry questions (alignment area, point of interest) an
+  answer can carry an adjustment: the agent's proposed rectangle or marker
+  is placed on your screen through the same widgets you would drag, then
+  accepted — you see exactly what it chose, out-of-bounds proposals are
+  refused before anything moves, and the record marks the answer as
+  adjusted. Milling parameters cannot travel this way; only the geometry
+  the question itself is about;
 - **start and stop workflows** — the same as your Run and Stop buttons
   (stopping, like the stop-milling command, actually works for *any* connected
   agent regardless of permission: the emergency brake is never gated);

--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -526,7 +526,11 @@ class AgentContext:
             return None
 
     def answer_prompt(
-        self, response: bool, nonce: int, timeout: float = 10.0
+        self,
+        response: bool,
+        nonce: int,
+        value: Optional[Dict[str, Any]] = None,
+        timeout: float = 10.0,
     ) -> Dict[str, Any]:
         """Answer the pending question as the matching button click would.
 
@@ -536,6 +540,17 @@ class AgentContext:
         :meth:`pending_prompt`) names the question being answered: if that
         posting is gone — answered, withdrawn, or replaced — the result is
         ``stale`` and nothing was clicked.
+
+        ``value`` optionally carries adjusted geometry for the two questions
+        answered from live widget state: an alignment area
+        (``{"left", "top", "width", "height"}``, fractions of the frame) for
+        ``EditAlignmentArea``, or a point (``{"x", "y"}``, metres in microscope
+        image coordinates, origin centre, +y up) for ``PickPOI``. The value is
+        validated here — in bounds, non-degenerate, the right shape for the
+        pending question — and refused as ``invalid_value`` without clicking
+        anything when it is not. A valid value is placed into the widget as if
+        the operator had dragged it there, then the ordinary click path accepts
+        it, so attribution and first-writer-wins hold unchanged.
         """
         responder = self._responder
         if responder is None:
@@ -544,12 +559,98 @@ class AgentContext:
             StalePromptError,
         )
 
-        outcome = responder.submit_answer(bool(response), nonce=int(nonce))
+        parsed = None
+        if value is not None:
+            parsed, refusal = self._parse_answer_value(responder, int(nonce), value)
+            if refusal is not None:
+                return refusal
+
+        outcome = responder.submit_answer(
+            bool(response), nonce=int(nonce), value=parsed
+        )
         try:
             applied = bool(outcome.result(timeout=timeout))
         except StalePromptError:
             return {"available": True, "applied": False, "stale": True}
-        return {"available": True, "applied": applied, "stale": False}
+        result = {"available": True, "applied": applied, "stale": False}
+        if parsed is not None:
+            result["adjusted"] = True
+        return result
+
+    @staticmethod
+    def _parse_answer_value(responder, nonce: int, value: Any):
+        """Turn a wire ``value`` into the domain object for the pending question.
+
+        Returns ``(parsed, None)`` on success or ``(None, refusal)`` — the
+        refusal already shaped for :meth:`answer_prompt` to return. Validation
+        happens against the frozen pending request; the responder's own nonce
+        check on the GUI thread still guards the actual apply, so a question
+        swap between here and there is refused as stale, never mis-applied.
+        """
+
+        def _refuse(message: str) -> Dict[str, Any]:
+            return {
+                "available": True,
+                "applied": False,
+                "stale": False,
+                "invalid_value": message,
+            }
+
+        request, pending_nonce = responder.pending_question_and_nonce()
+        if request is None or pending_nonce != nonce:
+            return None, {"available": True, "applied": False, "stale": True}
+        type_name = type(request).__name__
+        if not isinstance(value, dict):
+            return None, _refuse("value must be a JSON object.")
+
+        if type_name == "EditAlignmentArea":
+            from fibsem.structures import FibsemRectangle
+
+            try:
+                rect = FibsemRectangle.from_dict(value)
+            except Exception:
+                return None, _refuse(
+                    "an EditAlignmentArea value needs numeric left, top, "
+                    "width, height — fractions of the frame, origin top-left."
+                )
+            if not rect.is_valid_reduced_area:
+                return None, _refuse(
+                    "alignment area out of bounds: left/top must be >= 0, "
+                    "width/height > 0, and the rectangle must fit inside "
+                    "the frame (left+width <= 1, top+height <= 1)."
+                )
+            return rect, None
+
+        if type_name == "PickPOI":
+            from fibsem.structures import Point
+
+            try:
+                point = Point.from_dict(value)
+            except Exception:
+                return None, _refuse(
+                    "a PickPOI value needs numeric x, y — metres in "
+                    "microscope image coordinates, origin centre, +y up."
+                )
+            image = getattr(request, "image", None)
+            try:
+                half_width = image.data.shape[1] / 2 * image.metadata.pixel_size.x
+                half_height = image.data.shape[0] / 2 * image.metadata.pixel_size.x
+            except Exception:
+                return None, _refuse(
+                    "the pending question's image is missing its scale; "
+                    "the point cannot be validated."
+                )
+            if abs(point.x) > half_width or abs(point.y) > half_height:
+                return None, _refuse(
+                    f"point ({point.x:.3e}, {point.y:.3e}) m is outside the "
+                    f"image: |x| <= {half_width:.3e}, |y| <= {half_height:.3e}."
+                )
+            return point, None
+
+        return None, _refuse(
+            f"{type_name} answers cannot carry a value; "
+            "only EditAlignmentArea and PickPOI can."
+        )
 
     # --- events -----------------------------------------------------------------
 

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -63,8 +63,8 @@ class QtResponder(QObject):
 
     _submitted = pyqtSignal(object, object)  # (Request, Future)
     _agent_answered = pyqtSignal(
-        bool, object, object
-    )  # (clicked_yes, nonce, Future[bool])
+        bool, object, object, object
+    )  # (clicked_yes, nonce, value, Future[bool])
     _agent_peeked = pyqtSignal(object)  # (Future[(nonce, live value)])
 
     def __init__(self, ui: "AutoLamellaUI"):
@@ -164,7 +164,12 @@ class QtResponder(QObject):
             return None, None
         return pending[0], pending[2]
 
-    def submit_answer(self, clicked_yes: bool, nonce: Optional[int] = None) -> "Future":
+    def submit_answer(
+        self,
+        clicked_yes: bool,
+        nonce: Optional[int] = None,
+        value: Optional[object] = None,
+    ) -> "Future":
         """Answer the pending question as if the matching button were clicked.
 
         Any thread; returns a Future[bool] that resolves True when the answer
@@ -180,23 +185,36 @@ class QtResponder(QObject):
         :class:`StalePromptError` and nothing is clicked. Without one, the
         answer takes whatever is pending — the trusting form, for callers that
         just looked (tests, a local console).
+
+        ``value`` optionally carries an adjusted answer for the questions read
+        from live widget state — a :class:`FibsemRectangle` for
+        ``EditAlignmentArea``, a :class:`Point` (microscope image coordinates)
+        for ``PickPOI``. It is applied to the widget first, exactly as if the
+        operator had dragged it there, and then the ordinary click path reads
+        it back — so the proposed geometry lands on screen, and attribution,
+        the nonce, and first-writer-wins all hold unchanged. A value on any
+        other question type fails the future without clicking anything.
         """
         from concurrent.futures import Future as _Future
 
         outcome: "_Future" = _Future()
-        self._agent_answered.emit(clicked_yes, nonce, outcome)
+        self._agent_answered.emit(clicked_yes, nonce, value, outcome)
         return outcome
 
     def _apply_agent_answer(
-        self, clicked_yes: bool, nonce: Optional[int], outcome: "Future"
+        self,
+        clicked_yes: bool,
+        nonce: Optional[int],
+        value: Optional[object],
+        outcome: "Future",
     ) -> None:
         """GUI thread. Complete ``outcome`` with whether the answer applied.
 
         The nonce check happens here, on the thread that posts and clears
         questions — the one place it cannot race a swap.
         """
+        pending = self._pending_question
         if nonce is not None:
-            pending = self._pending_question
             if pending is None or pending[1].cancelled() or pending[2] != nonce:
                 self._fail(
                     outcome,
@@ -206,11 +224,56 @@ class QtResponder(QObject):
                 )
                 return
         try:
-            applied = self.answer_confirm(clicked_yes, source="agent")
+            if value is not None:
+                if pending is None or pending[1].cancelled():
+                    raise StalePromptError(
+                        "a value-carrying answer needs a pending question"
+                    )
+                self._apply_value(pending[0], value)
+            applied = self.answer_confirm(
+                clicked_yes, source="agent", adjusted=value is not None
+            )
         except Exception as exc:  # noqa: BLE001 - the asker owns the failure
             self._fail(outcome, exc)
             return
         self._deliver(outcome, applied)
+
+    def _apply_value(self, request: "Request", value: object) -> None:
+        """Put ``value`` into the widget the pending question reads from.
+
+        GUI thread. This is the write-side mirror of :meth:`_live_answer`: the
+        same widget the operator would drag, so the read-back in
+        :meth:`_answer` — and the operator's own eyes — see the adjusted
+        geometry before anything is accepted.
+        """
+        from fibsem.structures import FibsemRectangle, Point
+
+        if isinstance(request, EditAlignmentArea):
+            if not isinstance(value, FibsemRectangle):
+                raise ValueError("an EditAlignmentArea value must be a FibsemRectangle")
+            image_widget = self._ui.image_widget
+            if image_widget is None:
+                raise RuntimeError("No image widget to place the alignment area on.")
+            image_widget.toggle_alignment_area(value)
+            return
+        if isinstance(request, PickPOI):
+            if not isinstance(value, Point):
+                raise ValueError("a PickPOI value must be a Point")
+            controller = self._view_controller()
+            if controller is None:
+                raise RuntimeError("No canvas to place the point of interest on.")
+            from fibsem import conversions
+
+            image = request.image
+            px = conversions.microscope_image_to_image_coordinates(
+                value, image.data.shape, image.metadata.pixel_size.x
+            )
+            controller.set_points(BeamType.ION, "poi", [(px.x, px.y)])
+            return
+        raise ValueError(
+            f"{type(request).__name__} answers cannot carry a value; "
+            "only EditAlignmentArea and PickPOI can."
+        )
 
     def peek_live_answer(self) -> "Future":
         """What would the answer be if Yes were clicked right now? Any thread.
@@ -664,7 +727,9 @@ class QtResponder(QObject):
         widget.set_workflow_mode(False)
         return settings
 
-    def answer_confirm(self, clicked_yes: bool, source: str = "operator") -> bool:
+    def answer_confirm(
+        self, clicked_yes: bool, source: str = "operator", adjusted: bool = False
+    ) -> bool:
         """Complete the pending question from the yes/no click.
 
         Returns False when no question is pending, so the caller can fall through
@@ -678,6 +743,9 @@ class QtResponder(QObject):
         ``"agent"`` when routed from :meth:`submit_answer`. It rides the one
         call that applies the answer, so the attribution on the emitted
         ``prompt_answered`` event can never disagree with what happened.
+        ``adjusted`` marks an answer that carried its own geometry (the value
+        path), so the record shows the agent changed the widget, not just
+        accepted what stood.
         """
         pending = self._pending_question
         if pending is None:
@@ -697,17 +765,17 @@ class QtResponder(QObject):
             return True
         logging.info(
             f"prompt answered: {type(request).__name__} "
-            f"response={clicked_yes} by={source}"
+            f"response={clicked_yes} by={source} adjusted={adjusted}"
         )
-        self._emit_question_event(
-            "prompt_answered",
-            {
-                "type": type(request).__name__,
-                "response": bool(clicked_yes),
-                "answered_by": source,
-                "nonce": pending[2],
-            },
-        )
+        answered_payload = {
+            "type": type(request).__name__,
+            "response": bool(clicked_yes),
+            "answered_by": source,
+            "nonce": pending[2],
+        }
+        if adjusted:
+            answered_payload["adjusted"] = True
+        self._emit_question_event("prompt_answered", answered_payload)
         if isinstance(request, RunMillingTask) and clicked_yes and request.enabled:
             # Run Milling: the prompt comes down but the question stays open —
             # the finished signal re-asks or completes. (No {"msg": ""} clear;

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -304,13 +304,11 @@ def build_sidecar(client, capabilities):
     def get_pending_prompt():
         return _app_get("/app/prompt")
 
-    def answer_prompt(response: bool, nonce: int):
-        data, err = _call(
-            client,
-            "POST",
-            "/app/prompt/answer",
-            {"response": bool(response), "nonce": int(nonce)},
-        )
+    def answer_prompt(response: bool, nonce: int, value: Optional[dict] = None):
+        body = {"response": bool(response), "nonce": int(nonce)}
+        if value is not None:
+            body["value"] = dict(value)
+        data, err = _call(client, "POST", "/app/prompt/answer", body)
         return err if err else data
 
     implementations = {

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -51,7 +51,9 @@ class AppContext(Protocol):
 
     def pending_prompt(self) -> Dict[str, Any]: ...
 
-    def answer_prompt(self, response: bool, nonce: int) -> Dict[str, Any]: ...
+    def answer_prompt(
+        self, response: bool, nonce: int, value: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]: ...
 
     def stop_workflow(self) -> Dict[str, Any]: ...
 
@@ -160,7 +162,20 @@ def build_app_control_router(context: AppContext) -> APIRouter:
                     "an answer must name the question it answers.",
                 },
             )
-        result = context.answer_prompt(bool(body.get("response", False)), nonce)
+        value = body.get("value")
+        if value is not None and not isinstance(value, dict):
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "error_type": "invalid_value",
+                    "message": "value, when given, must be a JSON object: "
+                    "{left, top, width, height} for EditAlignmentArea, "
+                    "{x, y} for PickPOI.",
+                },
+            )
+        result = context.answer_prompt(
+            bool(body.get("response", False)), nonce, value=value
+        )
         if result.get("stale"):
             raise HTTPException(
                 status_code=409,
@@ -168,6 +183,14 @@ def build_app_control_router(context: AppContext) -> APIRouter:
                     "error_type": "stale_prompt",
                     "message": "That question is no longer pending; "
                     "re-read /app/prompt and answer the current one.",
+                },
+            )
+        if result.get("invalid_value"):
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "error_type": "invalid_value",
+                    "message": result["invalid_value"],
                 },
             )
         return result

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -298,7 +298,7 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
     ),
     ToolSpec(
         name="answer_prompt",
-        description="Answer the pending supervision question, exactly as clicking the matching button would. True = the positive option. Echo the nonce from get_pending_prompt; if that question is no longer pending the answer is refused (409 stale_prompt) — re-read and answer the current one.",
+        description="Answer the pending supervision question, exactly as clicking the matching button would. True = the positive option. Echo the nonce from get_pending_prompt; if that question is no longer pending the answer is refused (409 stale_prompt) — re-read and answer the current one. For EditAlignmentArea and PickPOI the answer may carry a value: adjusted geometry that is placed into the widget (the operator sees it land) and then accepted through the same click path. An out-of-bounds or wrong-shape value is refused (422 invalid_value) without clicking anything.",
         method="POST",
         path="/app/prompt/answer",
         scope="control",
@@ -306,6 +306,7 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         params={
             "response": "true for the positive option, false for the negative",
             "nonce": "the nonce from get_pending_prompt, naming the question being answered",
+            "value": "optional adjusted geometry: {left, top, width, height} (fractions of the frame, origin top-left) for EditAlignmentArea, or {x, y} (metres, microscope image coordinates, origin centre, +y up) for PickPOI",
         },
     ),
     ToolSpec(

--- a/tests/ui/test_agent_prompt_surface.py
+++ b/tests/ui/test_agent_prompt_surface.py
@@ -255,6 +255,58 @@ def test_alignment_prompt_carries_the_fib_display_frame(ui, qapp):
     assert "error" not in outcome
 
 
+def test_a_value_on_a_valueless_question_is_refused(ui, qapp):
+    """Only EditAlignmentArea and PickPOI answers can carry a value; a value on
+    anything else — or a value that is not an object — is a 422 refusal that
+    clicks nothing, and the question stands."""
+    with _client(ui, arm_control=True) as client:
+        thread, outcome = _ask_on_worker(ui, qapp)
+        nonce = client.get("/app/prompt", headers=AUTH).json()["pending"]["nonce"]
+
+        malformed = client.post(
+            "/app/prompt/answer",
+            headers=AUTH,
+            json={"response": True, "nonce": nonce, "value": [1, 2]},
+        )
+        assert malformed.status_code == 422
+        assert malformed.json()["detail"]["error_type"] == "invalid_value"
+
+        posted = {}
+
+        def do_post():
+            posted["response"] = client.post(
+                "/app/prompt/answer",
+                headers=AUTH,
+                json={"response": True, "nonce": nonce, "value": {"x": 0, "y": 0}},
+            )
+
+        poster = threading.Thread(target=do_post, daemon=True)
+        poster.start()
+        _spin_until(qapp, lambda: "response" in posted)
+        refused = posted["response"]
+        assert refused.status_code == 422
+        assert refused.json()["detail"]["error_type"] == "invalid_value"
+        assert "Confirm" in refused.json()["detail"]["message"]
+
+        # The refusals clicked nothing: the same nonce still answers.
+        posted.clear()
+
+        def do_plain_post():
+            posted["response"] = client.post(
+                "/app/prompt/answer",
+                headers=AUTH,
+                json={"response": True, "nonce": nonce},
+            )
+
+        poster = threading.Thread(target=do_plain_post, daemon=True)
+        poster.start()
+        _spin_until(qapp, lambda: "response" in posted)
+        assert posted["response"].status_code == 200
+        _spin_until(qapp, lambda: "answer" in outcome or "error" in outcome)
+        thread.join(timeout=5)
+        assert outcome.get("answer") is True
+
+
 def test_an_answer_without_a_nonce_is_rejected(ui, qapp):
     with _client(ui, arm_control=True) as client:
         rejected = client.post(

--- a/tests/ui/test_edit_alignment_area.py
+++ b/tests/ui/test_edit_alignment_area.py
@@ -140,6 +140,81 @@ def test_the_rect_survives_the_overlay_coming_down(ui, qapp):
     assert outcome["area"].width == pytest.approx(first.width)
 
 
+def _answer_with_value_on_worker(ui, qapp, response, nonce, value):
+    """Call AgentContext.answer_prompt from a worker thread, as the server does.
+
+    The answer marshals to the GUI thread and blocks on the outcome — calling
+    it from the test (GUI) thread would deadlock into the timeout.
+    """
+    from fibsem.applications.autolamella.server import AgentContext
+
+    ctx = AgentContext(ui)
+    outcome = {}
+
+    def target():
+        outcome["result"] = ctx.answer_prompt(response, nonce, value=value)
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while "result" not in outcome and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+    assert "result" in outcome, "answer_prompt never returned"
+    return outcome["result"]
+
+
+def test_a_value_answer_moves_the_area_and_answers_with_it(ui, qapp):
+    thread, outcome = _edit_on_worker_thread(ui, qapp)
+    _, nonce = ui.ui_responder.pending_question_and_nonce()
+
+    events = []
+    dispose = ui.ui_responder.add_question_observer(
+        lambda kind, payload: events.append((kind, payload))
+    )
+    proposed = {"left": 0.1, "top": 0.2, "width": 0.3, "height": 0.25}
+    try:
+        result = _answer_with_value_on_worker(ui, qapp, True, nonce, proposed)
+    finally:
+        dispose()
+    _finish(thread, qapp)
+
+    assert result["applied"] is True
+    assert result["adjusted"] is True
+    area = outcome.get("area")
+    assert isinstance(area, FibsemRectangle)
+    assert area.left == pytest.approx(proposed["left"])
+    assert area.top == pytest.approx(proposed["top"])
+    assert area.width == pytest.approx(proposed["width"])
+    assert area.height == pytest.approx(proposed["height"])
+    # The record shows the agent changed the geometry, not just accepted it.
+    answered = [p for k, p in events if k == "prompt_answered"][-1]
+    assert answered["answered_by"] == "agent"
+    assert answered["adjusted"] is True
+
+
+def test_an_invalid_value_is_refused_and_the_prompt_stands(ui, qapp):
+    thread, outcome = _edit_on_worker_thread(ui, qapp)
+    _, nonce = ui.ui_responder.pending_question_and_nonce()
+    before = ui.image_widget.get_alignment_area()
+
+    result = _answer_with_value_on_worker(
+        ui, qapp, True, nonce, {"left": 0.9, "top": 0.9, "width": 0.5, "height": 0.5}
+    )
+
+    assert result["applied"] is False
+    assert "invalid_value" in result
+    # Nothing was clicked and nothing moved: the question still stands.
+    assert ui.ui_responder.pending_question_and_nonce()[1] == nonce
+    after = ui.image_widget.get_alignment_area()
+    assert after.left == pytest.approx(before.left)
+    assert after.width == pytest.approx(before.width)
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+    assert isinstance(outcome.get("area"), FibsemRectangle)
+
+
 def test_headless_and_unvalidated_return_the_input(ui):
     assert update_alignment_area_ui(INITIAL, parent_ui=None, validate=True) is INITIAL
     assert update_alignment_area_ui(INITIAL, parent_ui=ui, validate=False) is INITIAL

--- a/tests/ui/test_pick_poi.py
+++ b/tests/ui/test_pick_poi.py
@@ -201,6 +201,71 @@ def test_the_prompt_mirrors_the_live_marker_not_the_frozen_request(window, ui, q
     _finish(thread, qapp)
 
 
+def _answer_with_value_on_worker(ui, qapp, response, nonce, value):
+    """Call AgentContext.answer_prompt from a worker thread, as the server does."""
+    from fibsem.applications.autolamella.server import AgentContext
+
+    ctx = AgentContext(ui)
+    outcome = {}
+
+    def target():
+        outcome["result"] = ctx.answer_prompt(response, nonce, value=value)
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while "result" not in outcome and time.monotonic() < deadline:
+        qapp.processEvents()
+        time.sleep(0.01)
+    assert "result" in outcome, "answer_prompt never returned"
+    return outcome["result"]
+
+
+def test_a_value_answer_moves_the_marker_and_answers_with_it(window, ui, qapp):
+    image = _fib_image(ui)
+    thread, outcome = _pick_on_worker_thread(
+        ui, qapp, image, initial=Point(x=1e-6, y=2e-6)
+    )
+    _, nonce = ui.ui_responder.pending_question_and_nonce()
+
+    proposed = {"x": 5e-6, "y": -3e-6}
+    result = _answer_with_value_on_worker(ui, qapp, True, nonce, proposed)
+    _finish(thread, qapp)
+
+    assert result["applied"] is True
+    assert result["adjusted"] is True
+    poi = outcome.get("poi")
+    assert isinstance(poi, Point)
+    # The marker landed where proposed, and the answer read it back
+    # (pixel-rounded through the overlay).
+    px = image.metadata.pixel_size.x
+    assert poi.x == pytest.approx(proposed["x"], abs=px)
+    assert poi.y == pytest.approx(proposed["y"], abs=px)
+
+
+def test_an_out_of_bounds_point_is_refused_and_the_marker_stands(window, ui, qapp):
+    image = _fib_image(ui)
+    initial = Point(x=1e-6, y=2e-6)
+    thread, _ = _pick_on_worker_thread(ui, qapp, image, initial=initial)
+    _, nonce = ui.ui_responder.pending_question_and_nonce()
+    px = image.metadata.pixel_size.x
+    half_width = image.data.shape[1] / 2 * px
+
+    result = _answer_with_value_on_worker(
+        ui, qapp, True, nonce, {"x": 2 * half_width, "y": 0.0}
+    )
+
+    assert result["applied"] is False
+    assert "invalid_value" in result
+    # Nothing was clicked and the marker did not move.
+    assert ui.ui_responder.pending_question_and_nonce()[1] == nonce
+    marker = window.view_controller.overlay_points(BeamType.ION, "poi")
+    assert marker, "the marker should still be up"
+
+    ui.pushButton_yes.click()
+    _finish(thread, qapp)
+
+
 def test_a_stop_interrupts_a_pick_nobody_confirms(ui, qapp):
     thread, outcome = _pick_on_worker_thread(ui, qapp, _fib_image(ui))
 


### PR DESCRIPTION
The deliberately unbuilt Phase 4, now the demonstrated binding constraint: during the first live exemplar-mode run the agent judged alignment areas competently but could only accept-as-shown or refuse — it could review, not adjust.

`POST /app/prompt/answer` now takes an optional `value` for the two questions answered from live widget state:

- **EditAlignmentArea**: `{"left", "top", "width", "height"}` — fractions of the frame, origin top-left.
- **PickPOI**: `{"x", "y"}` — metres, microscope image coordinates, origin centre, +y up.

Mechanically the write-side mirror of the existing live-answer peek. The value is validated at the server seam against the frozen pending request (right shape for the question, in bounds, non-degenerate — refused `422 invalid_value` without clicking anything), then GUI-marshalled into the same widget the operator would drag, and accepted through the ordinary click path. What falls out for free:

- the operator **sees the proposed geometry land on screen** through the widgets they know;
- the nonce, first-writer-wins, and attribution hold unchanged — it is the same answer path;
- the `prompt_answered` event and the answer result carry `adjusted: true`, so the timeline record shows the agent changed the geometry rather than accepting it.

A value on any other question type is refused; milling parameters deliberately cannot travel this way (config editing is separate work with its own permission notch). Rides the existing *Act* permission: proposing a rectangle is what a human supervisor does when answering.

Skill + docs: exemplar mode now corrects small stateable drift instead of escalating it (escalation remains for corrections it cannot state); the playbook documents the wire shape; the user doc explains the operator-visible behaviour.

Tests: full-window round-trips for both types (value lands in the widget, answer reads it back, event carries `adjusted`), refusal paths (out-of-bounds rect and point leave the prompt standing and the widget untouched), and HTTP-level 422s for malformed values and values on valueless questions.

Over the ~5-file target because the answer path spans the seam by design: responder (apply) + context (validate) + route/protocol + catalog/sidecar (contract) + skill/docs/tests.