### PR TITLE
[server] Serve recorded output images as JPEG previews

### DIFF
--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -227,6 +227,70 @@ class AgentContext:
             ],
         }
 
+    def output_image(
+        self, item_name: str, filename: str, max_width: int = 768
+    ) -> Dict[str, Any]:
+        """One recorded output image, rendered as JPEG bytes.
+
+        The read side of :meth:`task_outputs` for clients that cannot touch the
+        disk — the dashboard's thumbnails. ``filename`` must be the basename of
+        a path :meth:`task_outputs` itself listed; anything else is refused
+        with the valid names, so a client can never reach outside the item's
+        own recorded outputs. Stacks and multi-channel images are max-projected
+        to something viewable; this is a preview, not the data.
+        """
+        import os
+
+        experiment = self._experiment
+        if experiment is None:
+            return {"available": False, "jpeg": None}
+        lamella = experiment.get_lamella_by_name(item_name)
+        if lamella is None:
+            return {
+                "available": False,
+                "jpeg": None,
+                "error": f"No item named {item_name!r} in this experiment.",
+            }
+        history = list(lamella.task_history)
+        paths = _task_outputs.final_reference_images(
+            lamella, *history
+        ) + _task_outputs.fluorescence_images(lamella, *history)
+        match = next((p for p in paths if os.path.basename(p) == filename), None)
+        if match is None:
+            return {
+                "available": True,
+                "jpeg": None,
+                "error": f"No output named {filename!r} for {item_name!r}.",
+                "filenames": [os.path.basename(p) for p in paths],
+            }
+        try:
+            import numpy as np
+            import tifffile
+
+            from fibsem.server.images import preview_jpeg_bytes
+
+            data = np.squeeze(np.asarray(tifffile.imread(match)))
+            # z-stacks / channel stacks project on leading axes; a trailing
+            # RGB(A) axis is colour, not a stack, and stays.
+            while data.ndim > 2 and data.shape[-1] not in (3, 4):
+                data = data.max(axis=0)
+            if data.ndim == 3 and data.shape[-1] == 4:
+                data = data[..., :3]
+            jpeg, width, height = preview_jpeg_bytes(data, max_width=max_width)
+        except Exception as exc:  # noqa: BLE001 - a broken file is a data fact
+            return {
+                "available": True,
+                "jpeg": None,
+                "error": f"Could not render {filename!r}: {exc}",
+            }
+        return {
+            "available": True,
+            "jpeg": jpeg,
+            "width": width,
+            "height": height,
+            "filename": filename,
+        }
+
     def item_detail(self, item_name: str) -> Dict[str, Any]:
         """The durable facts about one item, as a curated snapshot.
 

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -14,7 +14,7 @@ stays in one place (build_server).
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
 
 try:  # Protocol is typing-only; keep import robust on the 3.8 floor
     from typing import Protocol
@@ -42,6 +42,8 @@ class AppContext(Protocol):
     def task_outputs(self, item_name: str) -> Dict[str, Any]: ...
 
     def item_detail(self, item_name: str) -> Dict[str, Any]: ...
+
+    def output_image(self, item_name: str, filename: str) -> Dict[str, Any]: ...
 
     def recent_experiments(self) -> List[Dict[str, Any]]: ...
 
@@ -107,6 +109,23 @@ def build_app_router(context: AppContext) -> APIRouter:
     @router.get("/items/{item_name}")
     def item_detail(item_name: str):
         return context.item_detail(item_name)
+
+    @router.get("/items/{item_name}/outputs/{filename}")
+    def output_image(item_name: str, filename: str):
+        # Serves actual image/jpeg (not a JSON payload) so a browser <img>
+        # can consume it; filename must be a basename the item's own
+        # task_outputs listing names — the context refuses anything else.
+        result = context.output_image(item_name, filename)
+        jpeg = result.get("jpeg")
+        if jpeg is None:
+            detail: Dict[str, Any] = {
+                "error_type": "not_found",
+                "message": result.get("error", "No such output image."),
+            }
+            if "filenames" in result:
+                detail["filenames"] = result["filenames"]
+            raise HTTPException(status_code=404, detail=detail)
+        return Response(content=jpeg, media_type="image/jpeg")
 
     @router.get("/recent_experiments")
     def recent_experiments():

--- a/tests/autolamella/test_agent_context.py
+++ b/tests/autolamella/test_agent_context.py
@@ -129,6 +129,51 @@ def test_task_outputs_for_a_real_item_and_a_missing_one(experiment):
     assert "no-such-item" in missing["error"]
 
 
+def test_output_image_renders_recorded_outputs_only(experiment):
+    import numpy as np
+    import tifffile
+
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskState
+
+    host = Host()
+    host.experiment = experiment
+    ctx = AgentContext(host)
+    lamella = experiment.positions[0]
+    os.makedirs(lamella.path, exist_ok=True)
+    fname = "ref_Rough Milling_final_res_01_ib.tif"
+    tifffile.imwrite(
+        os.path.join(lamella.path, fname),
+        (np.random.rand(48, 64) * 65535).astype(np.uint16),
+    )
+    # A z-stack fluorescence output: projected, not rejected.
+    zname = "fm_stack.tif"
+    tifffile.imwrite(
+        os.path.join(lamella.path, zname),
+        (np.random.rand(5, 48, 64) * 65535).astype(np.uint16),
+        photometric="minisblack",
+    )
+    lamella.task_history.append(
+        AutoLamellaTaskState(
+            name="Rough Milling",
+            outputs={"final_fib": [fname], "fluorescence": [zname]},
+        )
+    )
+
+    served = ctx.output_image(lamella.name, fname)
+    assert served["jpeg"][:2] == b"\xff\xd8"
+    assert (served["width"], served["height"]) == (64, 48)
+
+    stack = ctx.output_image(lamella.name, zname)
+    assert stack["jpeg"][:2] == b"\xff\xd8"
+
+    unknown = ctx.output_image(lamella.name, "not-listed.tif")
+    assert unknown["jpeg"] is None
+    assert sorted(unknown["filenames"]) == [zname, fname]
+
+    missing = ctx.output_image("no-such-item", fname)
+    assert missing["available"] is False
+
+
 def test_item_detail_serves_the_durable_item_facts(experiment):
     """One read for what a supervisor judges an item by — the exemplar-mode
     seam: after the operator answers, the accepted POI/alignment area are

--- a/tests/server/test_app_router.py
+++ b/tests/server/test_app_router.py
@@ -102,6 +102,38 @@ def test_task_outputs_round_trip(client, host):
     assert missing["available"] is False
 
 
+def test_output_images_serve_jpeg_and_refuse_unknown_names(client, host):
+    import numpy as np
+    import tifffile
+
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskState
+
+    lamella = host.experiment.positions[0]
+    os.makedirs(lamella.path, exist_ok=True)
+    fname = "ref_Rough Milling_final_res_01_ib.tif"
+    tifffile.imwrite(
+        os.path.join(lamella.path, fname),
+        (np.random.rand(64, 96) * 65535).astype(np.uint16),
+    )
+    lamella.task_history.append(
+        AutoLamellaTaskState(name="Rough Milling", outputs={"final_fib": [fname]})
+    )
+
+    served = client.get(f"/app/items/{lamella.name}/outputs/{fname}", headers=AUTH)
+    assert served.status_code == 200
+    assert served.headers["content-type"] == "image/jpeg"
+    assert served.content[:2] == b"\xff\xd8"  # JPEG magic
+
+    # An unlisted name is refused with the valid ones — never resolved as a path.
+    refused = client.get(
+        f"/app/items/{lamella.name}/outputs/../../etc/passwd", headers=AUTH
+    )
+    assert refused.status_code in (404, 422)
+    unknown = client.get(f"/app/items/{lamella.name}/outputs/nope.tif", headers=AUTH)
+    assert unknown.status_code == 404
+    assert unknown.json()["detail"]["filenames"] == [fname]
+
+
 def test_summaries_and_protocol_over_http(client):
     for path in ("/app/experiment_summary", "/app/task_history", "/app/protocol"):
         body = client.get(path, headers=AUTH).json()


### PR DESCRIPTION
One new read-scope route: `GET /app/items/{item}/outputs/{filename}` returns a recorded task output as actual `image/jpeg` (through the existing 768 px preview encoder), so a browser `<img>` can consume it directly.

This is the read side of `task_outputs` for clients that cannot touch the disk — the monitor dashboard's thumbnails (next PR). Agents on the same machine read the TIFFs directly and never needed it.

Safety shape: `filename` must be a basename that the item's own `task_outputs` listing names — an unlisted name is refused 404 carrying the valid names, and nothing client-supplied is ever resolved as a path (the traversal test drives `../../etc/passwd` at it). Fluorescence stacks are max-projected on their leading axes; a trailing RGB(A) axis is colour and stays.

Tests: context-level (real experiment, real TIFFs on disk, stack projection, refusals) and HTTP-level (JPEG magic + content-type, traversal, 404 shape).