### PR TITLE
[alignment] SEM/FIB coincidence measurement primitive

### DIFF
--- a/fibsem/alignment/coincidence.py
+++ b/fibsem/alignment/coincidence.py
@@ -1,0 +1,302 @@
+"""SEM/FIB coincidence measurement (FIB-868).
+
+Coincidence error is a height error: the sample surface sitting above or below
+the fixed intersection point of the two beam axes. Because the beams are
+separated by a tilt about a horizontal axis, that height error projects into
+the FIB view along image-y only, while leaving the SEM view stationary. This
+module measures that residual by cross-beam correlation and reports it as a
+height error in metres, refusing rather than guessing when the measurement
+cannot be trusted.
+
+The measurement is a pure image computation: no hardware access, no stage
+motion. Correction (vertical_move) is layered on top by callers.
+
+Method: both images are contrast-normalised locally, band-passed (difference
+of Gaussians) and reduced to gradient magnitude, so only structure that
+survives the SEM->FIB modality change contributes (topography: milled edges,
+fiducials, cracks, contamination). The FIB image is stretched along y by the
+geometric foreshortening ratio so both views share the SEM projection, then a
+windowed cross-correlation finds the residual shift. The estimate is computed
+twice with independent band-pass scales and accepted only when the two agree
+(a window-size-invariant validity gate; a top-2-peak ratio degenerates when
+the search window is tight). A peak on the search-window boundary is refused
+outright.
+
+Validated offline on a reference cryo-lamella dataset: sub-micron
+repeatability when topographic features are present. See FIB-868 for the
+full findings.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+from scipy import ndimage as ndi
+from scipy.signal import fftconvolve
+
+from fibsem.structures import FibsemImage
+from fibsem.transformations import convert_stage_tilt_to_milling_angle
+
+DEFAULT_FIB_COLUMN_TILT = np.deg2rad(52.0)
+
+# Independent band-pass scales (sigma pairs, px) for the agreement gate.
+AGREEMENT_BANDS: Tuple[Tuple[float, float], Tuple[float, float]] = ((2, 8), (4, 16))
+DEFAULT_AGREEMENT_TOLERANCE = 0.75e-6  # m
+DEFAULT_CAPTURE_RANGE = 20e-6  # m
+WINDOW_EDGE_MARGIN_PX = 3
+
+REFUSAL_BAND_DISAGREEMENT = "band-disagreement"
+REFUSAL_WINDOW_EDGE = "window-edge"
+
+
+@dataclass
+class CoincidenceMeasurement:
+    """Result of one coincidence measurement.
+
+    Sign convention: dx/dy are where the FIB-view scene sits relative to the
+    SEM-view scene, in the SEM image convention (x right, y down), after the
+    geometric perspective correction. dz is the inferred height error along
+    the chamber-vertical axis (dz = dy / sin(column_tilt)).
+
+    dx is diagnostic only: a height error cannot produce it. A persistent dx
+    indicates beam misalignment (correctable by beam shift, see FIB-873),
+    scan-rotation mismatch, or a failed SEM centring - never fold it into a
+    vertical correction.
+    """
+
+    dx: float  # m, lateral residual (diagnostic)
+    dy: float  # m, vertical residual in the FIB image plane
+    dz: float  # m, inferred height error
+    band_disagreement: float  # m, distance between the two band estimates
+    is_reliable: bool
+    refusal_reason: Optional[str] = None  # set when is_reliable is False
+    seeded: bool = False
+    method: str = "crossbeam-xcorr"
+
+
+def fib_view_y_stretch(
+    milling_angle: float, column_tilt: float = DEFAULT_FIB_COLUMN_TILT
+) -> float:
+    """Foreshortening ratio mapping the FIB view onto the SEM projection.
+
+    For a locally flat surface at the given milling angle (FIB glancing
+    angle), the two views of the surface differ by a y-only scale of
+    sin(column_tilt - milling_angle) / sin(milling_angle).
+
+    Args:
+        milling_angle: angle between the FIB beam and the sample surface, in
+            RADIANS.
+        column_tilt: angle between the SEM and FIB columns, in RADIANS.
+    """
+    if not 0 < milling_angle < column_tilt:
+        raise ValueError(
+            f"milling_angle must be in (0, column_tilt) radians, "
+            f"got {milling_angle}. (Degrees passed by mistake?)"
+        )
+    return np.sin(column_tilt - milling_angle) / np.sin(milling_angle)
+
+
+def height_error_from_fib_shift(
+    dy: float, column_tilt: float = DEFAULT_FIB_COLUMN_TILT
+) -> float:
+    """Convert a FIB-view vertical residual (m) to a height error (m).
+
+    A chamber-vertical displacement dz appears in the FIB view displaced by
+    dz * sin(column_tilt) along image-y, and is invisible to a vertical SEM.
+    """
+    return dy / np.sin(column_tilt)
+
+
+def _local_normalise(image: np.ndarray, sigma: float = 32) -> np.ndarray:
+    mean = ndi.gaussian_filter(image, sigma)
+    var = ndi.gaussian_filter((image - mean) ** 2, sigma)
+    return (image - mean) / (np.sqrt(var) + 1e-6)
+
+
+def _preprocess(image: np.ndarray, s1: float, s2: float) -> np.ndarray:
+    """Local normalise -> DoG band-pass -> gradient magnitude, zero-mean."""
+    x = _local_normalise(image.astype(np.float32))
+    x = ndi.gaussian_filter(x, s1) - ndi.gaussian_filter(x, s2)
+    x = np.hypot(ndi.sobel(x, axis=1), ndi.sobel(x, axis=0))
+    return (x - x.mean()) / (x.std() + 1e-6)
+
+
+def _stretch_y(image: np.ndarray, scale: float) -> np.ndarray:
+    """Scale an image about its centre along y only."""
+    h, w = image.shape
+    yy, xx = np.mgrid[0:h, 0:w].astype(np.float32)
+    cy = h / 2
+    src_y = (yy - cy) / scale + cy
+    return ndi.map_coordinates(image, [src_y, xx], order=1, mode="constant", cval=0)
+
+
+def _windowed_xcorr(
+    ref: np.ndarray,
+    other: np.ndarray,
+    center_yx: Tuple[float, float],
+    half_yx: Tuple[float, float],
+) -> Tuple[Tuple[int, int], bool]:
+    """Cross-correlate with a Hann window, peak restricted near center_yx.
+
+    Returns ((dy, dx) in pixels, peak_on_window_edge). The Hann window also
+    centre-weights the measurement, so structure near the frame centre (the
+    point whose height matters) dominates over peripheral features.
+    """
+    window = np.outer(np.hanning(ref.shape[0]), np.hanning(ref.shape[1]))
+    corr = fftconvolve(ref * window, (other * window)[::-1, ::-1], mode="same")
+    cy, cx = np.array(corr.shape) // 2
+    oy, ox = int(round(center_yx[0])), int(round(center_yx[1]))
+    hy, hx = int(round(half_yx[0])), int(round(half_yx[1]))
+    y0, y1 = max(0, cy + oy - hy), min(corr.shape[0], cy + oy + hy + 1)
+    x0, x1 = max(0, cx + ox - hx), min(corr.shape[1], cx + ox + hx + 1)
+    search = corr[y0:y1, x0:x1]
+    py, px = np.unravel_index(np.argmax(search), search.shape)
+    on_edge = (
+        py < WINDOW_EDGE_MARGIN_PX
+        or px < WINDOW_EDGE_MARGIN_PX
+        or py >= search.shape[0] - WINDOW_EDGE_MARGIN_PX
+        or px >= search.shape[1] - WINDOW_EDGE_MARGIN_PX
+    )
+    return (py + y0 - cy, px + x0 - cx), on_edge
+
+
+def measure_coincidence(
+    sem: np.ndarray,
+    fib: np.ndarray,
+    pixel_size: float,
+    milling_angle: float,
+    column_tilt: float = DEFAULT_FIB_COLUMN_TILT,
+    prior: Optional[Tuple[float, float]] = None,
+    capture_range: float = DEFAULT_CAPTURE_RANGE,
+    agreement_tolerance: float = DEFAULT_AGREEMENT_TOLERANCE,
+) -> CoincidenceMeasurement:
+    """Measure the SEM/FIB coincidence residual from one image pair.
+
+    Pure image computation; performs no acquisition and no motion.
+
+    Args:
+        sem: SEM (electron) image, 2D.
+        fib: FIB (ion) image of the same scene, 2D, same shape and pixel size.
+        pixel_size: metres per pixel (shared by both images).
+        milling_angle: FIB-beam-to-surface angle in RADIANS.
+        column_tilt: SEM-to-FIB column angle in RADIANS.
+        prior: expected (dx, dy) residual in metres, e.g. the previous
+            measurement at this site. Centres the search window.
+        capture_range: half-width of the search window in metres. Keep well
+            under one grid pitch: periodic structure creates rival
+            correlation peaks one pitch apart (FIB-711).
+        agreement_tolerance: max distance (m) between the two independent
+            band estimates for the result to be reliable.
+
+    Returns:
+        CoincidenceMeasurement. When is_reliable is False the residuals are
+        the (untrustworthy) mean estimate and refusal_reason says why; act on
+        reliable measurements only.
+    """
+    if sem.shape != fib.shape:
+        raise ValueError(f"image shapes differ: {sem.shape} vs {fib.shape}")
+
+    stretch = fib_view_y_stretch(milling_angle, column_tilt)
+    fib_stretched = _stretch_y(fib.astype(np.float32), stretch)
+
+    if prior is not None:
+        center = (prior[1] / pixel_size * stretch, prior[0] / pixel_size)
+    else:
+        center = (0.0, 0.0)
+    half_px = capture_range / pixel_size
+    half_yx = (half_px * stretch, half_px)
+
+    shifts = []
+    on_edge_any = False
+    for s1, s2 in AGREEMENT_BANDS:
+        ref = _preprocess(sem, s1, s2)
+        other = _preprocess(fib_stretched, s1, s2)
+        (dy_px, dx_px), on_edge = _windowed_xcorr(ref, other, center, half_yx)
+        shifts.append((dy_px, dx_px))
+        on_edge_any = on_edge_any or on_edge
+
+    (dy_a, dx_a), (dy_b, dx_b) = shifts
+    disagreement = np.hypot((dy_a - dy_b) / stretch, dx_a - dx_b) * pixel_size
+    dy = ((dy_a + dy_b) / 2 / stretch) * pixel_size
+    dx = ((dx_a + dx_b) / 2) * pixel_size
+    dz = height_error_from_fib_shift(dy, column_tilt)
+
+    refusal: Optional[str] = None
+    if on_edge_any:
+        refusal = REFUSAL_WINDOW_EDGE
+    elif disagreement > agreement_tolerance:
+        refusal = REFUSAL_BAND_DISAGREEMENT
+
+    measurement = CoincidenceMeasurement(
+        dx=float(dx),
+        dy=float(dy),
+        dz=float(dz),
+        band_disagreement=float(disagreement),
+        is_reliable=refusal is None,
+        refusal_reason=refusal,
+        seeded=prior is not None,
+    )
+    logging.debug(
+        {
+            "msg": "measure_coincidence",
+            "dx": measurement.dx,
+            "dy": measurement.dy,
+            "dz": measurement.dz,
+            "band_disagreement": measurement.band_disagreement,
+            "is_reliable": measurement.is_reliable,
+            "refusal_reason": measurement.refusal_reason,
+            "seeded": measurement.seeded,
+        }
+    )
+    return measurement
+
+
+def geometry_from_metadata(image: FibsemImage) -> Tuple[float, float, float]:
+    """Extract (pixel_size, milling_angle, column_tilt) from image metadata.
+
+    Pixel size is per-image (hfw varies between workflow stages - never share
+    one value across a dataset). The milling angle is derived from the
+    recorded stage tilt plus the hardware geometry (shuttle pre-tilt, ion
+    column tilt), so a saved pair is self-sufficient - usable offline with no
+    microscope connection.
+    """
+    md = image.metadata
+    pixel_size = md.pixel_size.x
+    column_tilt = np.deg2rad(md.hardware_geometry.fib_column_tilt)
+    pretilt = np.deg2rad(md.hardware_geometry.shuttle_pre_tilt)
+    stage_tilt = md.microscope_state.stage_position.t
+    milling_angle = convert_stage_tilt_to_milling_angle(
+        stage_tilt=stage_tilt, pretilt=pretilt, column_tilt=column_tilt
+    )
+    return pixel_size, milling_angle, column_tilt
+
+
+def measure_coincidence_from_images(
+    sem_image: FibsemImage,
+    fib_image: FibsemImage,
+    milling_angle: Optional[float] = None,
+    column_tilt: Optional[float] = None,
+    prior: Optional[Tuple[float, float]] = None,
+    capture_range: float = DEFAULT_CAPTURE_RANGE,
+    agreement_tolerance: float = DEFAULT_AGREEMENT_TOLERANCE,
+) -> CoincidenceMeasurement:
+    """measure_coincidence for a FibsemImage pair.
+
+    Pixel size, milling angle, and column tilt default to values derived from
+    the SEM image's metadata (see geometry_from_metadata); pass milling_angle
+    or column_tilt (RADIANS) only to override the recorded geometry.
+    """
+    pixel_size, md_milling_angle, md_column_tilt = geometry_from_metadata(sem_image)
+    return measure_coincidence(
+        sem=sem_image.data,
+        fib=fib_image.data,
+        pixel_size=pixel_size,
+        milling_angle=md_milling_angle if milling_angle is None else milling_angle,
+        column_tilt=md_column_tilt if column_tilt is None else column_tilt,
+        prior=prior,
+        capture_range=capture_range,
+        agreement_tolerance=agreement_tolerance,
+    )

--- a/fibsem/alignment/plotting.py
+++ b/fibsem/alignment/plotting.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
     from fibsem.alignment import AlignmentDifferential, AlignmentIteration
+    from fibsem.alignment.coincidence import CoincidenceMeasurement
     from fibsem.structures import FibsemImage
 
 
@@ -186,5 +187,98 @@ def plot_multi_step_alignment(
     fig.tight_layout()
     if save:
         save_path = os.path.join(ref_path, "figure.png")
+        fig.savefig(save_path, dpi=80)
+    return fig
+
+
+def plot_coincidence_measurement(
+    sem_image: "FibsemImage",
+    fib_image: "FibsemImage",
+    measurement: "CoincidenceMeasurement",
+    title: Optional[str] = None,
+    save: bool = True,
+    path: Optional[str] = None,
+):
+    """Diagnostic figure for one coincidence measurement (FIB-868).
+
+    Three panels: the SEM view, the raw FIB view, and an overlay of the SEM
+    (green) against the perspective-corrected FIB shifted by the measured
+    residual (red) - on a correct measurement the shared structure coincides.
+    The annotation carries the residuals and the reliability verdict.
+
+    Returns:
+        matplotlib.figure.Figure
+    """
+    from datetime import datetime
+
+    from matplotlib.figure import Figure
+    from scipy import ndimage as ndi
+
+    from fibsem.alignment.coincidence import (
+        _stretch_y,
+        fib_view_y_stretch,
+        geometry_from_metadata,
+    )
+
+    pixel_size, milling_angle, column_tilt = geometry_from_metadata(sem_image)
+    stretch = fib_view_y_stretch(milling_angle, column_tilt)
+    fib_stretched = _stretch_y(fib_image.data.astype(np.float32), stretch)
+    dy_px = measurement.dy / pixel_size * stretch
+    dx_px = measurement.dx / pixel_size
+    fib_aligned = ndi.shift(fib_stretched, (dy_px, dx_px), order=1, mode="constant")
+
+    def _normalise(data: np.ndarray) -> np.ndarray:
+        valid = data[data > 0] if (data > 0).any() else data
+        lo, hi = np.percentile(valid, [1, 99])
+        return np.clip((data - lo) / (hi - lo + 1e-6), 0, 1)
+
+    overlay = np.zeros((*sem_image.data.shape, 3))
+    overlay[..., 1] = _normalise(sem_image.data.astype(np.float32))
+    overlay[..., 0] = _normalise(fib_aligned)
+
+    timestamp_str = datetime.now().strftime(DATETIME_DISPLAY)
+    if title is None:
+        title = f"Coincidence Measurement — {timestamp_str}"
+    else:
+        title = f"{title} — {timestamp_str}"
+
+    fig = Figure(figsize=(12, 4.2))
+    axes = fig.subplots(1, 3)
+    fig.suptitle(title)
+    _plot_image_with_crosshair(axes[0], sem_image.data, "SEM")
+    _plot_image_with_crosshair(axes[1], fib_image.data, "FIB")
+    axes[2].imshow(overlay)
+    axes[2].set_title("Overlay (SEM green, aligned FIB red)")
+    axes[2].axis("off")
+
+    verdict = (
+        "RELIABLE"
+        if measurement.is_reliable
+        else (f"REFUSED ({measurement.refusal_reason})")
+    )
+    colour = "lime" if measurement.is_reliable else "red"
+    axes[2].text(
+        0.04,
+        0.04,
+        f"{verdict}\n"
+        f"dx={measurement.dx * 1e6:+.2f}um  dy={measurement.dy * 1e6:+.2f}um\n"
+        f"dz={measurement.dz * 1e6:+.2f}um  "
+        f"band-disagreement={measurement.band_disagreement * 1e6:.2f}um",
+        transform=axes[2].transAxes,
+        color=colour,
+        fontsize=7,
+        va="bottom",
+        fontfamily="monospace",
+        bbox=dict(
+            boxstyle="round,pad=0.2", facecolor="black", alpha=0.6, edgecolor="none"
+        ),
+    )
+
+    fig.tight_layout()
+    if save:
+        ref_path, prefix, ts = _alignment_save_path(sem_image)
+        if path is not None:
+            ref_path = path
+        save_path = os.path.join(ref_path, f"{prefix}coincidence_{ts}.png")
         fig.savefig(save_path, dpi=80)
     return fig

--- a/tests/test_coincidence.py
+++ b/tests/test_coincidence.py
@@ -189,3 +189,68 @@ def test_measurement_dataclass_defaults():
     assert m.refusal_reason is None
     assert m.method == "crossbeam-xcorr"
     assert not m.seeded
+
+
+def _image_with_metadata(data: np.ndarray, pixel_size: float) -> "FibsemImage":
+    from fibsem.structures import (
+        FibsemHardwareGeometry,
+        FibsemImage,
+        FibsemImageMetadata,
+        FibsemStagePosition,
+        ImageSettings,
+        MicroscopeState,
+        Point,
+    )
+
+    # stage tilt for a 15 deg milling angle with 35 deg pretilt, 52 deg column:
+    # stage_tilt = milling + column + pretilt - 90 = 12 deg
+    metadata = FibsemImageMetadata(
+        image_settings=ImageSettings(
+            hfw=pixel_size * data.shape[1], resolution=(data.shape[1], data.shape[0])
+        ),
+        microscope_state=MicroscopeState(
+            stage_position=FibsemStagePosition(t=np.deg2rad(12.0))
+        ),
+        pixel_size=Point(pixel_size, pixel_size),
+        hardware_geometry=FibsemHardwareGeometry(
+            column_tilt=0,
+            fib_column_tilt=52.0,
+            shuttle_pre_tilt=35.0,
+        ),
+    )
+    return FibsemImage(data=data.astype(np.uint8), metadata=metadata)
+
+
+def test_geometry_from_metadata():
+    from fibsem.alignment.coincidence import geometry_from_metadata
+
+    image = _image_with_metadata(np.zeros(SHAPE, dtype=np.uint8), PIXEL_SIZE)
+    pixel_size, milling_angle, column_tilt = geometry_from_metadata(image)
+    assert pixel_size == pytest.approx(PIXEL_SIZE)
+    assert milling_angle == pytest.approx(np.deg2rad(15.0))
+    assert column_tilt == pytest.approx(np.deg2rad(52.0))
+
+
+def test_measure_from_images_and_diagnostic_plot(tmp_path):
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from fibsem.alignment.coincidence import measure_coincidence_from_images
+    from fibsem.alignment.plotting import plot_coincidence_measurement
+
+    stretch = fib_view_y_stretch(np.deg2rad(15.0), np.deg2rad(52.0))
+    sem = np.clip(make_sem_scene(), 0, 255)
+    fib = np.clip(make_fib_view(sem, 20.0, 5.0, stretch), 0, 255)
+    sem_image = _image_with_metadata(sem, PIXEL_SIZE)
+    fib_image = _image_with_metadata(fib, PIXEL_SIZE)
+
+    m = measure_coincidence_from_images(sem_image, fib_image)
+    assert m.is_reliable
+    assert m.dx == pytest.approx(5.0 * PIXEL_SIZE, abs=2 * PIXEL_SIZE)
+
+    fig = plot_coincidence_measurement(
+        sem_image, fib_image, m, save=True, path=str(tmp_path)
+    )
+    assert fig is not None
+    pngs = list(tmp_path.glob("*coincidence*.png"))
+    assert len(pngs) == 1

--- a/tests/test_coincidence.py
+++ b/tests/test_coincidence.py
@@ -1,0 +1,191 @@
+"""Tests for fibsem.alignment.coincidence (FIB-868).
+
+Synthetic scenes: a blob/edge-rich SEM view, and a FIB view built by applying
+the inverse of the geometric transform the measurement is supposed to undo
+(y-compression by the foreshortening ratio, a known shift, contrast change,
+independent noise). The measurement must recover the known offset, and refuse
+on scenes or conditions it cannot trust.
+"""
+
+import numpy as np
+import pytest
+from scipy import ndimage as ndi
+
+from fibsem.alignment.coincidence import (
+    REFUSAL_BAND_DISAGREEMENT,
+    REFUSAL_WINDOW_EDGE,
+    CoincidenceMeasurement,
+    fib_view_y_stretch,
+    height_error_from_fib_shift,
+    measure_coincidence,
+)
+
+PIXEL_SIZE = 65e-9  # ~100 um hfw at 1536 px, typical reference imaging
+MILLING_ANGLE = np.deg2rad(15.0)
+COLUMN_TILT = np.deg2rad(52.0)
+SHAPE = (512, 768)
+
+
+def make_sem_scene(seed: int = 42) -> np.ndarray:
+    """Feature-rich flat scene: sparse blobs and a fiducial-like cross."""
+    rng = np.random.default_rng(seed)
+    scene = np.zeros(SHAPE, dtype=np.float32)
+    ys = rng.integers(60, SHAPE[0] - 60, size=40)
+    xs = rng.integers(60, SHAPE[1] - 60, size=40)
+    for y, x in zip(ys, xs):
+        scene[y, x] = rng.uniform(50, 200)
+    scene = ndi.gaussian_filter(scene, 3)
+    cy, cx = SHAPE[0] // 2, SHAPE[1] // 2
+    scene[cy - 2 : cy + 2, cx - 40 : cx + 40] = 150
+    scene[cy - 40 : cy + 40, cx - 2 : cx + 2] = 150
+    scene += rng.normal(0, 2, SHAPE).astype(np.float32)
+    return scene
+
+
+def make_fib_view(
+    sem_scene: np.ndarray,
+    dy_px: float,
+    dx_px: float,
+    stretch: float,
+    seed: int = 7,
+) -> np.ndarray:
+    """Project the SEM scene into the FIB view with a known residual.
+
+    The measurement stretches the FIB image y by `stretch`; building the view
+    with the inverse mapping (and the shift applied in stretched space) means
+    the known (dy_px, dx_px) is exactly what it should recover.
+    """
+    rng = np.random.default_rng(seed)
+    h, w = sem_scene.shape
+    yy, xx = np.mgrid[0:h, 0:w].astype(np.float32)
+    cy = h / 2
+    src_y = (yy - cy) * stretch + cy + dy_px
+    src_x = xx + dx_px
+    fib = ndi.map_coordinates(
+        sem_scene, [src_y, src_x], order=1, mode="constant", cval=0
+    )
+    fib = 200 - fib  # contrast inversion: intensities differ across modalities
+    fib += rng.normal(0, 2, fib.shape).astype(np.float32)
+    return fib
+
+
+def test_y_stretch_matches_geometry():
+    stretch = fib_view_y_stretch(MILLING_ANGLE, COLUMN_TILT)
+    expected = np.sin(COLUMN_TILT - MILLING_ANGLE) / np.sin(MILLING_ANGLE)
+    assert stretch == pytest.approx(expected)
+    assert stretch == pytest.approx(2.33, abs=0.01)
+
+
+def test_y_stretch_rejects_degrees():
+    with pytest.raises(ValueError):
+        fib_view_y_stretch(15.0)  # degrees passed where radians expected
+
+
+def test_recovers_known_offset():
+    stretch = fib_view_y_stretch(MILLING_ANGLE, COLUMN_TILT)
+    dy_px, dx_px = 30.0, -12.0  # in stretched (SEM-projection) space
+    sem = make_sem_scene()
+    fib = make_fib_view(sem, dy_px, dx_px, stretch)
+
+    m = measure_coincidence(
+        sem, fib, PIXEL_SIZE, MILLING_ANGLE, column_tilt=COLUMN_TILT
+    )
+
+    assert m.is_reliable, m.refusal_reason
+    # dy is reported in the FIB image plane: stretched-space px / stretch
+    assert m.dy == pytest.approx(dy_px / stretch * PIXEL_SIZE, abs=2 * PIXEL_SIZE)
+    assert m.dx == pytest.approx(dx_px * PIXEL_SIZE, abs=2 * PIXEL_SIZE)
+    assert m.dz == pytest.approx(m.dy / np.sin(COLUMN_TILT))
+
+
+def test_zero_offset_measures_near_zero():
+    stretch = fib_view_y_stretch(MILLING_ANGLE, COLUMN_TILT)
+    sem = make_sem_scene()
+    fib = make_fib_view(sem, 0.0, 0.0, stretch)
+
+    m = measure_coincidence(
+        sem, fib, PIXEL_SIZE, MILLING_ANGLE, column_tilt=COLUMN_TILT
+    )
+
+    assert m.is_reliable
+    assert abs(m.dy) <= 2 * PIXEL_SIZE
+    assert abs(m.dx) <= 2 * PIXEL_SIZE
+
+
+def test_prior_narrows_search_and_still_recovers():
+    stretch = fib_view_y_stretch(MILLING_ANGLE, COLUMN_TILT)
+    dy_px, dx_px = 40.0, 8.0
+    sem = make_sem_scene()
+    fib = make_fib_view(sem, dy_px, dx_px, stretch)
+    prior = (dx_px * PIXEL_SIZE, dy_px / stretch * PIXEL_SIZE)
+
+    m = measure_coincidence(
+        sem,
+        fib,
+        PIXEL_SIZE,
+        MILLING_ANGLE,
+        column_tilt=COLUMN_TILT,
+        prior=prior,
+        capture_range=3e-6,
+    )
+
+    assert m.is_reliable
+    assert m.seeded
+    assert m.dx == pytest.approx(dx_px * PIXEL_SIZE, abs=2 * PIXEL_SIZE)
+
+
+def test_featureless_scene_is_refused():
+    rng = np.random.default_rng(0)
+    sem = rng.normal(100, 3, SHAPE).astype(np.float32)
+    fib = rng.normal(100, 3, SHAPE).astype(np.float32)
+
+    m = measure_coincidence(
+        sem, fib, PIXEL_SIZE, MILLING_ANGLE, column_tilt=COLUMN_TILT
+    )
+
+    assert not m.is_reliable
+    assert m.refusal_reason in (REFUSAL_BAND_DISAGREEMENT, REFUSAL_WINDOW_EDGE)
+
+
+def test_offset_beyond_capture_range_is_refused_not_guessed():
+    stretch = fib_view_y_stretch(MILLING_ANGLE, COLUMN_TILT)
+    sem = make_sem_scene()
+    # true offset well outside the search window
+    fib = make_fib_view(sem, 120.0, 90.0, stretch)
+
+    m = measure_coincidence(
+        sem,
+        fib,
+        PIXEL_SIZE,
+        MILLING_ANGLE,
+        column_tilt=COLUMN_TILT,
+        capture_range=2e-6,
+    )
+
+    assert not m.is_reliable
+
+
+def test_height_error_conversion():
+    assert height_error_from_fib_shift(1e-6, np.deg2rad(90)) == pytest.approx(1e-6)
+    assert height_error_from_fib_shift(
+        np.sin(COLUMN_TILT) * 1e-6, COLUMN_TILT
+    ) == pytest.approx(1e-6)
+
+
+def test_shape_mismatch_raises():
+    with pytest.raises(ValueError):
+        measure_coincidence(
+            np.zeros((10, 10), dtype=np.float32),
+            np.zeros((10, 12), dtype=np.float32),
+            PIXEL_SIZE,
+            MILLING_ANGLE,
+        )
+
+
+def test_measurement_dataclass_defaults():
+    m = CoincidenceMeasurement(
+        dx=0.0, dy=0.0, dz=0.0, band_disagreement=0.0, is_reliable=True
+    )
+    assert m.refusal_reason is None
+    assert m.method == "crossbeam-xcorr"
+    assert not m.seeded


### PR DESCRIPTION
Adds `fibsem/alignment/coincidence.py`: measure the SEM/FIB coincidence residual from a single eb/ib image pair, as a pure image computation — no hardware access, no stage motion.

## What it does

- **Geometry-pinned perspective correction**: the FIB view is stretched along y by `sin(column_tilt − milling_angle)/sin(milling_angle)`, derived per image from metadata (stage tilt + shuttle pre-tilt + ion column tilt), never searched or hardcoded. A saved pair is measurable offline with no microscope connection.
- **Modality-robust correlation**: local normalisation → DoG band-pass → gradient magnitude → Hann-windowed FFT correlation, so only topographic structure (fiducials, milled edges, cracks, contamination) contributes.
- **Refuse, don't guess**: the estimate is computed twice with independent band-pass scales and accepted only when the two agree (window-size-invariant gate); a peak on the search-window boundary refuses outright. `CoincidenceMeasurement` carries an explicit `refusal_reason`.
- **Residual decomposition**: dy → height error dz (the one degree of freedom a vertical move can fix); dx reported separately as a lateral diagnostic (beam misalignment — not height-correctable).
- **Diagnostics**: `plot_coincidence_measurement` renders SEM/FIB/overlay panels with residuals and verdict, saved to the same `Alignment/` subdir as the multi-step beam-shift alignment plots.

## Scope

Measurement only. The acquire wrapper and the `vertical_move` correction loop come separately — the loop is blocked on the vertical_move axis-decomposition fix. Part of the Automated Coincidence Alignment project.

## Testing

- 12 unit tests: known-offset recovery on synthetic cross-modality scenes (validates sign conventions and the metres conversions end to end), seeded-window recovery, featureless-scene refusal, out-of-capture-range refusal, metadata-derived geometry, and the diagnostic plot output.
- Validated against a real reference cryo-lamella dataset: sub-µm within-site repeatability; refusals verified visually against overlays.