### PR TITLE
[app] Tools menu creates the desktop shortcut the docs walk through by hand

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -95,6 +95,12 @@ This resolves the same dependencies from `pyproject.toml` as `pip`, just faster.
 No lockfile or additional configuration is required.
 
 ### Create a desktop shortcut
+The easiest way: launch the application once (`fibsem-autolamella-ui`) and select
+**Tools → Create Desktop Shortcut...** — it locates the entry point in the current
+environment and writes the shortcut to a location you choose, defaulting to your
+Desktop (Windows `.lnk`, Linux `.desktop`, macOS `.command`).
+
+To create one manually instead:
 1. Create a script file:
     Activate the environment then run the following command to create the script:
     - **Windows**

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -690,6 +690,18 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.action_show_plugins.triggered.connect(self._on_show_plugins)
         tools_menu.addAction(self.action_show_plugins)
 
+        self.action_create_desktop_shortcut = QAction(
+            "Create Desktop Shortcut...", self
+        )
+        self.action_create_desktop_shortcut.setToolTip(
+            "Place a shortcut on your desktop that launches AutoLamella from this "
+            "environment"
+        )
+        self.action_create_desktop_shortcut.triggered.connect(
+            self._on_create_desktop_shortcut
+        )
+        tools_menu.addAction(self.action_create_desktop_shortcut)
+
         # add help menu
         help_menu = menu_bar.addMenu("Help")
         if help_menu is None:
@@ -1040,6 +1052,57 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         from fibsem.ui.widgets.plugins_dialog import PluginsDialog
 
         PluginsDialog(parent=self).exec_()
+
+    def _on_create_desktop_shortcut(self):
+        """Create a launcher shortcut for the AutoLamella UI, confirming overwrites.
+
+        The location is chosen by the user, defaulting to the Desktop.
+        """
+        from pathlib import Path
+
+        from PyQt5.QtWidgets import QFileDialog
+
+        from fibsem.tools import desktop_shortcut
+
+        chosen = QFileDialog.getExistingDirectory(
+            self,
+            "Choose Shortcut Location",
+            str(desktop_shortcut.get_desktop_directory()),
+        )
+        if not chosen:
+            return
+        directory = Path(chosen)
+        try:
+            path = desktop_shortcut.create_desktop_shortcut(directory=directory)
+        except FileExistsError as exc:
+            reply = QMessageBox.question(
+                self,
+                "Create Desktop Shortcut",
+                f"A shortcut already exists at:\n{exc}\n\nReplace it?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if reply != QMessageBox.Yes:
+                return
+            try:
+                path = desktop_shortcut.create_desktop_shortcut(
+                    overwrite=True, directory=directory
+                )
+            except Exception as exc2:
+                self._show_shortcut_error(exc2)
+                return
+        except Exception as exc:
+            self._show_shortcut_error(exc)
+            return
+        self.show_toast(f"Shortcut created: {path}", "info")
+
+    def _show_shortcut_error(self, exc: Exception) -> None:
+        logging.error(f"Failed to create desktop shortcut: {exc}")
+        QMessageBox.warning(
+            self,
+            "Create Desktop Shortcut",
+            f"Could not create the desktop shortcut:\n{exc}",
+        )
 
     def _on_toggle_minimap_widget(self, checked: bool):
         """Toggle the minimap plot widget visibility."""

--- a/fibsem/tools/desktop_shortcut.py
+++ b/fibsem/tools/desktop_shortcut.py
@@ -1,0 +1,183 @@
+"""Create a desktop shortcut that launches the AutoLamella UI.
+
+Replaces the manual steps in INSTALLATION.md ("Create a desktop shortcut"): the
+running application already knows which environment it lives in, so the entry
+point is resolved from ``sys.executable`` rather than relying on ``where``/
+``which`` in an activated shell.
+
+Pure Python, no Qt -- the UI wires this into a menu action, and tests exercise
+it headlessly.
+"""
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+ENTRY_POINT_NAME = "fibsem-autolamella-ui"
+SHORTCUT_BASENAME = "AutoLamella"
+
+
+def find_entry_point(name: str = ENTRY_POINT_NAME) -> Optional[Path]:
+    """Locate the console-script executable for the current environment.
+
+    Looks beside ``sys.executable`` first: a venv on Windows puts entry points
+    in ``Scripts/`` next to ``python.exe``, while conda puts ``python.exe`` in
+    the environment root with entry points in a ``Scripts/`` subdirectory. On
+    POSIX both live in ``bin/`` beside the interpreter. Falls back to PATH,
+    which only helps when the launching shell had the environment activated.
+    """
+    exe_name = name + ".exe" if os.name == "nt" else name
+    interpreter_dir = Path(sys.executable).resolve().parent
+    for directory in (interpreter_dir, interpreter_dir / "Scripts"):
+        candidate = directory / exe_name
+        if candidate.is_file():
+            return candidate
+
+    import shutil
+
+    which = shutil.which(name)
+    return Path(which) if which else None
+
+
+def get_desktop_directory() -> Path:
+    """Return the user's Desktop directory.
+
+    On Windows the Desktop is queried from the shell (SHGetKnownFolderPath) so
+    OneDrive-redirected desktops resolve correctly; ``~/Desktop`` is only the
+    fallback. Elsewhere ``~/Desktop`` is used directly.
+    """
+    if os.name == "nt":
+        known = _windows_known_desktop()
+        if known is not None:
+            return known
+    return Path.home() / "Desktop"
+
+
+def _windows_known_desktop() -> Optional[Path]:
+    """SHGetKnownFolderPath(FOLDERID_Desktop), or None if the query fails."""
+    try:
+        import ctypes
+        from ctypes import windll, wintypes  # type: ignore[attr-defined]
+
+        class GUID(ctypes.Structure):
+            _fields_ = [
+                ("Data1", wintypes.DWORD),
+                ("Data2", wintypes.WORD),
+                ("Data3", wintypes.WORD),
+                ("Data4", wintypes.BYTE * 8),
+            ]
+
+        # FOLDERID_Desktop {B4BFCC3A-DB2C-424C-B029-7FE99A87C641}
+        folder_id = GUID(
+            0xB4BFCC3A,
+            0xDB2C,
+            0x424C,
+            (wintypes.BYTE * 8)(0xB0, 0x29, 0x7F, 0xE9, 0x9A, 0x87, 0xC6, 0x41),
+        )
+        path_ptr = ctypes.c_wchar_p()
+        result = windll.shell32.SHGetKnownFolderPath(
+            ctypes.byref(folder_id), 0, None, ctypes.byref(path_ptr)
+        )
+        if result != 0 or not path_ptr.value:
+            return None
+        try:
+            return Path(path_ptr.value)
+        finally:
+            windll.ole32.CoTaskMemFree(path_ptr)
+    except Exception:
+        return None
+
+
+def shortcut_path(directory: Optional[Path] = None) -> Path:
+    """The path the shortcut will be written to on this platform.
+
+    ``directory`` is where the shortcut goes; the Desktop when omitted.
+    """
+    if directory is None:
+        directory = get_desktop_directory()
+    if os.name == "nt":
+        return directory / (SHORTCUT_BASENAME + ".lnk")
+    if sys.platform == "darwin":
+        return directory / (SHORTCUT_BASENAME + ".command")
+    return directory / (SHORTCUT_BASENAME + ".desktop")
+
+
+def create_desktop_shortcut(
+    overwrite: bool = False, directory: Optional[Path] = None
+) -> Path:
+    """Create a shortcut launching the AutoLamella UI; return its path.
+
+    Written into ``directory``, or the user's Desktop when omitted. Raises
+    FileNotFoundError when the entry point cannot be located (e.g. an
+    editable install whose scripts were never generated), FileExistsError when
+    a shortcut already exists and ``overwrite`` is False, and OSError /
+    subprocess.CalledProcessError when writing fails.
+    """
+    target = find_entry_point()
+    if target is None:
+        raise FileNotFoundError(
+            f"Could not locate the '{ENTRY_POINT_NAME}' executable in this environment."
+        )
+
+    destination = shortcut_path(directory)
+    if destination.exists() and not overwrite:
+        raise FileExistsError(str(destination))
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    if os.name == "nt":
+        _write_windows_lnk(destination, target)
+    elif sys.platform == "darwin":
+        _write_script(
+            destination, "#!/bin/bash\nexec '{}'\n".format(_posix_quote(target))
+        )
+    else:
+        _write_script(
+            destination,
+            "[Desktop Entry]\n"
+            "Type=Application\n"
+            "Name=AutoLamella\n"
+            "Comment=Launch the AutoLamella UI\n"
+            'Exec="{}"\n'
+            "Terminal=false\n".format(str(target)),
+        )
+    return destination
+
+
+def _posix_quote(path: Path) -> str:
+    """Escape a path for inclusion inside single quotes in a shell script."""
+    return str(path).replace("'", "'\\''")
+
+
+def _write_script(destination: Path, content: str) -> None:
+    destination.write_text(content)
+    destination.chmod(
+        destination.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+
+
+def _write_windows_lnk(destination: Path, target: Path) -> None:
+    """Create a real .lnk via WScript.Shell so no console window flashes.
+
+    PowerShell single-quoted strings escape a quote by doubling it, and paths
+    cannot contain double quotes on Windows, so doubling ``'`` is sufficient.
+    """
+
+    def q(p: Path) -> str:
+        return "'" + str(p).replace("'", "''") + "'"
+
+    script = (
+        "$s = (New-Object -ComObject WScript.Shell).CreateShortcut({dest}); "
+        "$s.TargetPath = {target}; "
+        "$s.WorkingDirectory = {workdir}; "
+        "$s.Description = 'Launch the AutoLamella UI'; "
+        "$s.Save()"
+    ).format(dest=q(destination), target=q(target), workdir=q(Path.home()))
+    subprocess.run(
+        ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+        check=True,
+        capture_output=True,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+    )

--- a/tests/test_desktop_shortcut.py
+++ b/tests/test_desktop_shortcut.py
@@ -1,0 +1,42 @@
+import os
+import stat
+import sys
+
+import pytest
+
+from fibsem.tools import desktop_shortcut
+
+
+def test_find_entry_point_resolves_in_this_environment():
+    path = desktop_shortcut.find_entry_point()
+    assert path is not None
+    assert path.is_file()
+    assert path.name.startswith(desktop_shortcut.ENTRY_POINT_NAME)
+
+
+def test_shortcut_path_extension(tmp_path):
+    path = desktop_shortcut.shortcut_path(tmp_path)
+    assert path.parent == tmp_path
+    if os.name == "nt":
+        assert path.suffix == ".lnk"
+    elif sys.platform == "darwin":
+        assert path.suffix == ".command"
+    else:
+        assert path.suffix == ".desktop"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX writes a script; Windows a .lnk")
+def test_create_desktop_shortcut_writes_executable_launcher(tmp_path):
+    created = desktop_shortcut.create_desktop_shortcut(directory=tmp_path)
+    assert created == desktop_shortcut.shortcut_path(tmp_path)
+    assert str(desktop_shortcut.find_entry_point()) in created.read_text()
+    assert created.stat().st_mode & stat.S_IXUSR
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX writes a script; Windows a .lnk")
+def test_create_desktop_shortcut_refuses_then_overwrites(tmp_path):
+    first = desktop_shortcut.create_desktop_shortcut(directory=tmp_path)
+    with pytest.raises(FileExistsError):
+        desktop_shortcut.create_desktop_shortcut(directory=tmp_path)
+    again = desktop_shortcut.create_desktop_shortcut(directory=tmp_path, overwrite=True)
+    assert again == first

--- a/tests/ui/test_create_desktop_shortcut.py
+++ b/tests/ui/test_create_desktop_shortcut.py
@@ -1,0 +1,96 @@
+"""Tools -> Create Desktop Shortcut... on the real main window.
+
+Window construction follows test_mainui_workflow_status.py (the minimap stub is
+the only non-real piece; see that module's docstring). The location dialog is
+the one modal the handler owns, so the tests stand in for the user there —
+QFileDialog.getExistingDirectory returns tmp_path instead of blocking on a
+native dialog — and everything else is the real QAction, handler, and file
+writer. No microscope connection is needed: the action acts on the install,
+not a session.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QFileDialog, QMessageBox
+
+
+@pytest.fixture(scope="module")
+def main_ui(qapp):
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
+    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
+    try:
+        window = module.AutoLamellaSingleWindowUI()
+    finally:
+        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    yield window
+    # closeEvent ends in app.quit(); on the shared test QApplication that latches
+    # and breaks later QEventLoop.exec_() calls — run close with quit stubbed.
+    original_quit = qapp.quit
+    qapp.quit = lambda: None
+    try:
+        window.close()
+    finally:
+        qapp.quit = original_quit
+
+
+@pytest.fixture()
+def chosen_directory(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        QFileDialog, "getExistingDirectory", lambda *args, **kwargs: str(tmp_path)
+    )
+    return tmp_path
+
+
+def test_the_action_lives_in_the_tools_menu(main_ui):
+    tools = [
+        a.menu()
+        for a in main_ui.menuBar().actions()
+        if a.menu() is not None and a.text() == "Tools"
+    ]
+    assert len(tools) == 1
+    assert main_ui.action_create_desktop_shortcut in tools[0].actions()
+
+
+def test_triggering_the_action_writes_the_shortcut_to_the_chosen_directory(
+    main_ui, chosen_directory
+):
+    from fibsem.tools import desktop_shortcut
+
+    main_ui.action_create_desktop_shortcut.trigger()
+
+    created = desktop_shortcut.shortcut_path(chosen_directory)
+    assert created.is_file()
+    assert str(desktop_shortcut.find_entry_point()) in created.read_text()
+
+
+def test_cancelling_the_location_dialog_writes_nothing(main_ui, monkeypatch, tmp_path):
+    monkeypatch.setattr(QFileDialog, "getExistingDirectory", lambda *args, **kwargs: "")
+    main_ui.action_create_desktop_shortcut.trigger()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_declining_the_overwrite_question_leaves_the_file(
+    main_ui, chosen_directory, monkeypatch
+):
+    from fibsem.tools import desktop_shortcut
+
+    existing = desktop_shortcut.shortcut_path(chosen_directory)
+    existing.write_text("pre-existing")
+
+    monkeypatch.setattr(QMessageBox, "question", lambda *args, **kwargs: QMessageBox.No)
+    main_ui.action_create_desktop_shortcut.trigger()
+    assert existing.read_text() == "pre-existing"
+
+    monkeypatch.setattr(
+        QMessageBox, "question", lambda *args, **kwargs: QMessageBox.Yes
+    )
+    main_ui.action_create_desktop_shortcut.trigger()
+    assert str(desktop_shortcut.find_entry_point()) in existing.read_text()


### PR DESCRIPTION
## What

**Tools → Create Desktop Shortcut...** replaces the manual .bat/.sh steps in INSTALLATION.md. The action:

- resolves the `fibsem-autolamella-ui` entry point from the running environment (`sys.executable`, venv and conda `Scripts/` layouts, PATH fallback) — no activated shell or `where`/`which` required
- asks where to put the shortcut, defaulting to the Desktop (resolved via `SHGetKnownFolderPath` on Windows so OneDrive-redirected desktops work)
- writes the platform launcher: `.lnk` via a PowerShell `WScript.Shell` one-liner on Windows (no pywin32 dependency, no console window), `.desktop` on Linux, `.command` on macOS
- confirms before replacing an existing shortcut; cancel in the location dialog does nothing

The writer is pure Python (no Qt) in `fibsem/tools/desktop_shortcut.py`; the menu action and dialogs live in `AutoLamellaMainUI`. INSTALLATION.md now points at the menu item first and keeps the manual steps as fallback.

## Testing

- `tests/test_desktop_shortcut.py`: entry-point resolution against the real environment, launcher content + executable bit, overwrite refusal/overwrite
- `tests/ui/test_create_desktop_shortcut.py`: real main window offscreen — menu placement, trigger writes to the chosen directory, dialog cancel writes nothing, overwrite question No/Yes paths
- Verified live on macOS: launched the app, created the shortcut from the menu, double-clicked it on the Desktop

**Not verified on real machines: Windows and Linux.** The `.lnk`/PowerShell path is tested only by inspection (CI can't exercise it), and on GNOME a new `.desktop` file needs a one-time right-click → "Allow Launching".