### PR TITLE
[docs] Developer onboarding: the goal-path guide and a guide skill

### DIFF
--- a/.claude/skills/getting-started-dev/SKILL.md
+++ b/.claude/skills/getting-started-dev/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: getting-started-dev
+description: Guide a developer who is new to fibsem-os — find out what they want to build, route them down the right extension path, and get them to a running, verified starting point. Use when someone asks how to get started, where to begin, how the repo is organised, or how to build X against fibsem-os.
+---
+
+# Onboarding a developer
+
+You are the guide, not the manual. The knowledge lives in
+[docs/developers/getting-started.md](../../../docs/developers/getting-started.md)
+(the goal→path routes), [CONTRIBUTING.md](../../../CONTRIBUTING.md) and
+[AGENTS.md](../../../AGENTS.md) (the rules) — read them before answering,
+and route to them rather than restating them from memory. If the doc and
+the code disagree, the code is right: say so, and note the doc needs
+fixing.
+
+## Conduct
+
+1. **Ask what they want to build before explaining anything.** One
+   question, their words: supporting an instrument, automating a
+   procedure, a model, a new task, an agent client, UI work — or just
+   looking around. Their goal picks the path; do not tour the whole repo
+   at someone who needs one seam.
+2. **Get them running first.** Whatever the goal, a working
+   `fibsem-autolamella-ui` with the Demo microscope connected is the
+   ground truth everything else builds on. Do it with them, not for them:
+   they run the commands, you explain what each did and interpret any
+   failure.
+3. **Route, then walk the path together.** Open the files the path names,
+   read the template alongside them (DemoMicroscope, a task module,
+   ScriptContext), and turn the path's "verify" step into commands they
+   actually run.
+4. **Explain failures as they hit them.** A traceback is a teaching
+   moment: name the trap if it is a known one (py3.8 syntax, offscreen Qt,
+   a stale cached reference), show where the rule is written down, then
+   fix it with them.
+5. **Paved road only.** If their goal has no path in the doc, say so
+   honestly, suggest the nearest paved road, and recommend opening an
+   issue — do not improvise an unsupported route through internals.
+6. **Leave them self-sufficient.** End by pointing at where answers live
+   (the doc, CONTRIBUTING, AGENTS, the test directory that mirrors their
+   area) rather than at yourself.
+
+## What you must not do
+
+- Do not run the full test suite, commit, push, or open PRs during
+  onboarding unless they ask — this is their session, their pace.
+- Do not present simulator behaviour as hardware truth: the Demo
+  microscope always succeeds; real instruments do not. Say which one your
+  evidence comes from.

--- a/docs/developers/getting-started.md
+++ b/docs/developers/getting-started.md
@@ -1,0 +1,141 @@
+# Getting started as a developer
+
+This is a router, not a manual: find your goal below and follow its path.
+The rules of the road live in [CONTRIBUTING.md](../../CONTRIBUTING.md) (PR
+size, py3.8 floor, format-on-touch, tests) and [AGENTS.md](../../AGENTS.md);
+read those once before your first change. This document covers the paved
+roads — the extension points we recommend and keep stable. Other routes
+exist in the code; if you need one, open an issue first.
+
+## The lay of the land
+
+```
+fibsem/                     the instrument library (no app logic)
+  microscope.py             FibsemMicroscope — the ABC every microscope implements
+  microscopes/              implementations: autoscript (TFS), tescan, odemis,
+                            simulator (DemoMicroscope — the reference)
+  structures.py             the shared vocabulary: FibsemImage, Point,
+                            FibsemRectangle, stage positions, settings
+  milling/, imaging/        beam operations built on the ABC
+  segmentation/             detection models (see "your own model")
+  ui/                       shared Qt widgets, tokens.py palette, canvases
+  server/                   the agent/bench HTTP server (build_server)
+  mcp/                      the fibsem-mcp sidecar (MCP → HTTP)
+  plugins/                  entry-point loading: fibsem.patterns,
+                            fibsem.strategies, fibsem.tasks
+
+fibsem/applications/autolamella/
+  structures.py             Experiment, Lamella, AutoLamellaTaskProtocol
+  workflows/tasks/          the task system: base.py (AutoLamellaTask),
+                            registration, one module per task
+  workflows/interaction.py  how tasks ask questions (ask(), Request types)
+  ui/                       the application windows
+  server/                   AgentContext — what remote agents see
+  scripting.py              ScriptContext — what user scripts see
+
+tests/                      mirrors the layout; tests/ui needs
+                            QT_QPA_PLATFORM=offscreen
+```
+
+## First: get it running
+
+```bash
+pip install -e .[ui,test,dev]
+fibsem-autolamella-ui
+```
+
+In the app, connect with the **Demo** (simulator) configuration — no
+hardware needed; every workflow runs against it. That launch-and-click
+loop is the ground truth here: green tests are weaker evidence than usual
+(see AGENTS.md), so run the app for anything about wiring.
+
+Run tests per affected file, never the whole suite by default:
+
+```bash
+QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_something.py -q
+```
+
+## "I want to support my microscope"
+
+The seam is `FibsemMicroscope` (`fibsem/microscope.py`) — an ABC covering
+acquisition, movement, milling, and state. Implement it and everything
+above (workflows, UI, server) works unchanged.
+
+- **Template**: `DemoMicroscope` in `fibsem/microscopes/simulator.py` is
+  the reference implementation — complete, hardware-free, and the shape to
+  copy. `fibsem/microscopes/tescan.py` shows a real vendor SDK behind the
+  same interface.
+- **Configuration**: microscopes are described by a configuration YAML
+  (see `fibsem/config/`); `fibsem-generate-config` scaffolds one.
+- **Verify**: point `utils.setup_session()` at your implementation and run
+  the same imaging/movement calls the Demo tests exercise; then connect
+  through the app.
+
+## "I want to automate something" (three tiers)
+
+1. **A plain script against the library** — no app at all:
+   `utils.setup_session()` gives you a connected microscope; the
+   `fibsem.milling` and `fibsem.imaging` modules do the rest. Right for
+   acquisition sweeps and offline analysis.
+2. **A user script inside AutoLamella** — a Python file in the scripts
+   folder (`fibsem/applications/autolamella/scripting.py`:
+   `discover_scripts` finds them, the app lists them). Your script
+   receives a **`ScriptContext`** — the experiment, microscope, and
+   protocol as a stable, documented surface. Use it rather than reaching
+   into the UI object: the GUI's internals are still moving and its
+   `experiment` attribute is rebound on load, so a cached `ui` reference
+   goes stale silently.
+3. **A real workflow task** — when the automation should live in the
+   queue, with supervision and history. Next section.
+
+## "I want to add or extend a workflow task"
+
+Subclass `AutoLamellaTask` (`workflows/tasks/base.py`) with a matching
+`AutoLamellaTaskConfig`, and register both with `register_task()`
+(`workflows/tasks/__init__.py` — docstring shows the pattern). Read one
+existing task module end to end first; `fiducial.py` is a good
+mid-complexity example.
+
+Two contracts to respect:
+
+- **Questions go through `ask()`** (`workflows/interaction.py`): build a
+  `Request` carrying everything needed to answer it, and block on the
+  responder. Never reach into widgets from the workflow thread — the
+  request/responder seam is what keeps the GUI, the operator, and remote
+  agents all able to answer the same question.
+- **Record what you produce** on the task's history entry
+  (`task_state.outputs`, role → files): that is what the review panel,
+  `task_outputs`, and the dashboard read. Unrecorded files are invisible.
+
+Third parties can ship tasks as plugins via the `fibsem.tasks` entry-point
+group (`fibsem/plugins/loader.py` documents loading and its failure
+reporting); patterns and milling strategies have their own groups.
+
+## "I want to use my own detection model"
+
+`fibsem/segmentation/` is the home: `SegmentationModelHuggingFace` loads
+checkpoints from the Hub, and the local-checkpoint paths sit beside it.
+The honest caveat: a general model-library design (sidecar metadata,
+local/HF resolution) is planned but not built — for now, match the loading
+shape the existing models use, and expect this area to firm up.
+
+## "I want to build against the agent server"
+
+Start with [docs/agent-server.md](../agent-server.md) — what the server
+exposes, the security model, and how agents connect (MCP sidecar or plain
+HTTP). The tool catalog (`fibsem/server/catalog.py`) is the contract: a
+catalog entry without a sidecar implementation fails loudly at startup, so
+extend both together. The supervision skill in
+`.claude/skills/supervise-autolamella/` shows what a well-behaved agent
+client looks like.
+
+## "I want to work on the UI"
+
+Use the role-named palette tokens (`fibsem/ui/tokens.py`) and prebuilt
+stylesheets — never pasted hex. Two rules with history behind them: UI
+event handlers never read the microscope (push updates or cached state
+only — an observer must not make the app poll hardware), and anything
+cross-thread goes through signals or the responder seam, never direct
+widget access. Check layout with an offscreen screenshot
+(`widget.grab().save(...)`) before calling a widget done, and remember CI
+does not run the Qt tests — launch the app.

--- a/docs/developers/getting-started.md
+++ b/docs/developers/getting-started.md
@@ -11,9 +11,13 @@ exist in the code; if you need one, open an issue first.
 
 ```
 fibsem/                     the instrument library (no app logic)
-  microscope.py             FibsemMicroscope — the ABC every microscope implements
-  microscopes/              implementations: autoscript (TFS), tescan, odemis,
-                            simulator (DemoMicroscope — the reference)
+  microscope.py             FibsemMicroscope — the ABC every microscope
+                            implements (plus, historically, the TFS
+                            implementation itself — ThermoMicroscope lives
+                            in this file, not in microscopes/)
+  microscopes/              tescan, odemis, simulator (DemoMicroscope — the
+                            reference); autoscript.py is TFS helper
+                            subsystems, not the microscope class
   structures.py             the shared vocabulary: FibsemImage, Point,
                             FibsemRectangle, stage positions, settings
   milling/, imaging/        beam operations built on the ABC
@@ -58,18 +62,33 @@ QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_something.py -q
 ## "I want to support my microscope"
 
 The seam is `FibsemMicroscope` (`fibsem/microscope.py`) — an ABC covering
-acquisition, movement, milling, and state. Implement it and everything
-above (workflows, UI, server) works unchanged.
+acquisition, movement, milling, and state. Once implemented **and
+registered** (below), everything above — workflows, UI, server — works
+unchanged.
 
 - **Template**: `DemoMicroscope` in `fibsem/microscopes/simulator.py` is
   the reference implementation — complete, hardware-free, and the shape to
   copy. `fibsem/microscopes/tescan.py` shows a real vendor SDK behind the
-  same interface.
+  same interface. (`microscopes/zeiss.py` is an empty placeholder awaiting
+  a SerialFIB migration — if Zeiss is your goal, fill it in rather than
+  starting a new file.)
+- **Register it** — implementing the ABC alone is not enough; the
+  manufacturer dispatch is hardcoded in a few places, and missing one
+  gives `NotImplementedError` at connect, not at import:
+  `fibsem/manufacturers.py` (the constant and alias — Zeiss already has
+  one), `fibsem/utils.py` `setup_session()` (the if/elif that constructs
+  your class), `fibsem/configuration.py` (the generator's accepted
+  manufacturers), and the manufacturer gates in
+  `fibsem/ui/widgets/microscope_config_widget.py`.
 - **Configuration**: microscopes are described by a configuration YAML
-  (see `fibsem/config/`); `fibsem-generate-config` scaffolds one.
-- **Verify**: point `utils.setup_session()` at your implementation and run
-  the same imaging/movement calls the Demo tests exercise; then connect
-  through the app.
+  (see `fibsem/config/`); `fibsem-generate-config` scaffolds one — for a
+  manufacturer it does not know yet, scaffold a Demo config and hand-edit.
+- **Verify**: connect via `utils.setup_session()` and run the tests that
+  exercise Demo through the same interface (`tests/test_acquire.py`,
+  `tests/test_movement.py`, `tests/test_microscope.py`); then connect
+  through the app. You do not need all ~45 abstract methods working to
+  start — get acquisition and stage movement right first and let the rest
+  raise until their subsystem's turn.
 
 ## "I want to automate something" (three tiers)
 


### PR DESCRIPTION
Phase 1 of the tutor arc, dev-first: the audience (Dev Partners) and the knowledge (codebase + conventions) both exist today, so this ships as pure extraction — no new code.

**docs/developers/getting-started.md** — a router, not a manual. A short repo map, a get-it-running section (sim app as ground truth), then one paved-road path per goal: support a microscope, automate (three tiers), add a workflow task (including the two contracts: questions via `ask()`/Responder, outputs recorded on task history), bring your own model (honest about the unbuilt model-library), build an agent client, UI work. Rules are not duplicated — CONTRIBUTING/AGENTS remain the single source and the doc routes to them. Every referenced path is existence-checked.

**.claude/skills/getting-started-dev/SKILL.md** — the conduct half: interview the goal before explaining anything, run the sim app *with* them, walk the named files together, teach from failures, paved road only, and never present simulator behaviour as hardware truth. Instructs code-over-doc when they disagree.

Two files, both new — nothing in the tree changes behaviour.