### PR TITLE
[movement] vertical_move is actually vertical

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -3589,6 +3589,7 @@ class ThermoMicroscope(FibsemMicroscope):
         dy: float,
         dx: float = 0.0,
         beam_type: BeamType = BeamType.ION,
+        relaxation: float = 1.0,
     ) -> FibsemStagePosition:
         """Restore the coincidence point from an offset measured in one beam view.
 
@@ -3597,16 +3598,25 @@ class ThermoMicroscope(FibsemMicroscope):
             dx (float, optional): distance along the x-axis (image coordinates). Defaults to 0.0.
             beam_type (BeamType, optional): the view the offset was measured in.
                 Defaults to ION.
+            relaxation (float, optional): under-relaxation of the correction.
+                1.0 applies the geometrically exact height change; a value
+                below 1.0 deliberately undershoots, which keeps a manual
+                look-correct-look loop convergent where a slight model error
+                would otherwise make it oscillate. This replaces the old
+                hard-coded 0.9, which was found to be absorbing a
+                decomposition error rather than correcting perspective
+                (FIB-773).
         """
         self._check_vertical_move_supported(beam_type)
         if beam_type is BeamType.ELECTRON:
-            return self._vertical_move_from_sem(dx=dx, dy=dy)
-        return self._vertical_move_from_fib(dx=dx, dy=dy)
+            return self._vertical_move_from_sem(dx=dx, dy=dy, relaxation=relaxation)
+        return self._vertical_move_from_fib(dx=dx, dy=dy, relaxation=relaxation)
 
     def _vertical_move_from_fib(
         self,
         dy: float,
         dx: float = 0.0,
+        relaxation: float = 1.0,
     ) -> FibsemStagePosition:
         """Move the stage vertically to correct coincidence point
 
@@ -3634,20 +3644,19 @@ class ThermoMicroscope(FibsemMicroscope):
             if stage_tilt >= np.deg2rad(-90):
                 dy *= -1.0
 
-        # TODO: implement perspective correction
-        PERSPECTIVE_CORRECTION = 0.9
-        z_move = dy
-        if True:  # use_perspective:
-            z_move = (
-                dy
-                / np.cos(np.deg2rad(90 - self.system.ion.column_tilt))
-                * PERSPECTIVE_CORRECTION
-            )  # TODO: MAGIC NUMBER, 90 - fib tilt
+        # a chamber-vertical displacement of dz appears in the FIB view as
+        # dz * sin(column_tilt), independent of stage tilt - so the height
+        # change that cancels an observed dy is dy / sin(column_tilt)
+        z_move = dy / np.sin(np.deg2rad(self.system.ion.column_tilt)) * relaxation
 
-        # manually calculate the dx, dy, dz
+        # decompose the chamber-vertical into the tilted stage axes:
+        # y = m*sin(t), z = m*cos(t). The old form used z = m/cos(t), which
+        # is only vertical at t=0 - at every tilted pose it dragged the
+        # feature sideways in the SEM view, partially undoing the SEM
+        # centring this operation exists to preserve (FIB-773).
         theta = self.get_stage_position().t  # rad
         dy = z_move * np.sin(theta)
-        dz = z_move / np.cos(theta)
+        dz = z_move * np.cos(theta)
         stage_position = FibsemStagePosition(x=dx, y=dy, z=dz, coordinate_system="RAW")
         logging.info(f"Vertical movement: {stage_position}")
         self.move_stage_relative(
@@ -3688,16 +3697,14 @@ class ThermoMicroscope(FibsemMicroscope):
         """
         return self.vertical_move(dy=dy, dx=dx, beam_type=BeamType.ELECTRON)
 
-    def _vertical_move_from_sem(self, dx: float, dy: float) -> FibsemStagePosition:
+    def _vertical_move_from_sem(
+        self, dx: float, dy: float, relaxation: float = 1.0
+    ) -> FibsemStagePosition:
         """Correct the coincidence point from an offset measured in the SEM view.
 
         Not the mirror image of the FIB path but a superset: a stable move first
         brings the feature to the centre of the SEM, and the height correction
         that follows puts the FIB back.
-
-        NOTE: the geometry here is known to be wrong away from the flat pose, and
-        the two constants below cancel each other -- see FIB-773. Moved verbatim
-        from ``move_coincident_from_sem``; correcting it needs bench time.
         """
 
         # NOTE:
@@ -3724,10 +3731,10 @@ class ThermoMicroscope(FibsemMicroscope):
         if np.isclose(scan_rotation, 0):
             dy *= -1.0
 
-        # apply the vertical move to correct the position
-        self._vertical_move_from_fib(
-            dx=0, dy=dy * 1.11
-        )  # TODO: MAGIC_NUMBER To correct for perspective correction...
+        # apply the vertical move to correct the position. (The old 1.11
+        # here was 1/0.9: it existed to cancel the magic constant inside
+        # vertical_move from the outside, and is gone with it - FIB-773.)
+        self._vertical_move_from_fib(dx=0, dy=dy, relaxation=relaxation)
 
         return self.get_stage_position()
 

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -1085,18 +1085,28 @@ class DemoMicroscope(FibsemMicroscope):
         return ThermoMicroscope.stable_move(self, dx, dy, beam_type, static_wd)
 
     def vertical_move(
-        self, dy: float, dx: float = 0.0, beam_type: BeamType = BeamType.ION
+        self,
+        dy: float,
+        dx: float = 0.0,
+        beam_type: BeamType = BeamType.ION,
+        relaxation: float = 1.0,
     ) -> FibsemStagePosition:
         """Restore the coincidence point from an offset measured in one beam view."""
-        return ThermoMicroscope.vertical_move(self, dy, dx, beam_type)
+        return ThermoMicroscope.vertical_move(self, dy, dx, beam_type, relaxation)
 
     def _vertical_move_from_fib(
-        self, dy: float, dx: float = 0.0
+        self, dy: float, dx: float = 0.0, relaxation: float = 1.0
     ) -> FibsemStagePosition:
-        return ThermoMicroscope._vertical_move_from_fib(self, dy=dy, dx=dx)
+        return ThermoMicroscope._vertical_move_from_fib(
+            self, dy=dy, dx=dx, relaxation=relaxation
+        )
 
-    def _vertical_move_from_sem(self, dx: float, dy: float) -> FibsemStagePosition:
-        return ThermoMicroscope._vertical_move_from_sem(self, dx=dx, dy=dy)
+    def _vertical_move_from_sem(
+        self, dx: float, dy: float, relaxation: float = 1.0
+    ) -> FibsemStagePosition:
+        return ThermoMicroscope._vertical_move_from_sem(
+            self, dx=dx, dy=dy, relaxation=relaxation
+        )
 
     def _y_corrected_stage_movement(
         self, expected_y: float, beam_type: BeamType

--- a/tests/test_vertical_move.py
+++ b/tests/test_vertical_move.py
@@ -1,0 +1,131 @@
+"""vertical_move must be vertical (FIB-773).
+
+The premise of the operation: a chamber-vertical move is invisible to the
+SEM view, which is what lets it correct the FIB view without disturbing the
+SEM centring it started from. The old decomposition used 1/cos(t) where a
+vertical needs cos(t), so the move dragged the feature sideways in the SEM
+at every tilted pose - and two magic constants (0.9, 1.11) partly absorbed
+the error near the milling tilt.
+
+These tests run the real ThermoMicroscope math through the simulator's
+projection-true scene, at more than one tilt: the bug family being pinned
+here is exact at t=0 and wrong everywhere else.
+"""
+
+import numpy as np
+import pytest
+
+from fibsem import utils
+from fibsem.alignment.coincidence import measure_coincidence_from_images
+from fibsem.structures import BeamType, FibsemStagePosition, ImageSettings
+
+HFW = 150e-6
+RESOLUTION = (1536, 1024)
+PIXEL_SIZE = HFW / RESOLUTION[0]
+
+
+@pytest.fixture
+def microscope():
+    microscope, settings = utils.setup_session(manufacturer="Demo")
+    microscope.system.sim["coincidence_projection"] = True
+    microscope.system.sim["coincidence_offset"] = 0.0
+    microscope._setup_coincidence_projection()
+    from fibsem.microscopes.sim_scene import CoincidenceScene
+
+    microscope._coincidence_scene = CoincidenceScene(
+        coincidence_offset=0.0,
+        n_clusters=0,
+        grid_intensity=0.0,
+        noise_sigma=0.0,
+        noise_fraction=0.0,
+    )
+    yield microscope
+    microscope.disconnect()
+
+
+def _fiducial(microscope, beam_type):
+    from scipy import ndimage as ndi
+
+    settings = ImageSettings(
+        resolution=RESOLUTION, hfw=HFW, dwell_time=1e-9, save=False, beam_type=beam_type
+    )
+    image = microscope.acquire_image(image_settings=settings)
+    data = ndi.gaussian_filter(image.data.astype(np.float32), 3)
+    if beam_type is BeamType.ION:
+        y, x = np.unravel_index(np.argmin(data), data.shape)
+    else:
+        y, x = np.unravel_index(np.argmax(data), data.shape)
+    return x, y
+
+
+@pytest.mark.parametrize("tilt_deg", [12.0, 35.0])
+def test_vertical_move_is_invisible_to_the_sem(microscope, tilt_deg):
+    """The whole premise: correcting the FIB view must not drag the SEM."""
+    microscope.move_stage_relative(
+        FibsemStagePosition(x=0, y=0, z=0, r=0, t=np.deg2rad(tilt_deg))
+    )
+    sx0, sy0 = _fiducial(microscope, BeamType.ELECTRON)
+
+    microscope.vertical_move(dy=-20e-6, dx=0)
+
+    sx1, sy1 = _fiducial(microscope, BeamType.ELECTRON)
+    drag = np.hypot(sx1 - sx0, sy1 - sy0) * PIXEL_SIZE
+    assert drag < 1e-6, f"SEM view dragged {drag * 1e6:.2f} um by a 'vertical' move"
+
+
+@pytest.mark.parametrize("tilt_deg", [12.0, 35.0])
+def test_vertical_move_delivers_the_requested_fib_shift(microscope, tilt_deg):
+    """The contract: the FIB view shifts by exactly the requested dy."""
+    microscope.move_stage_relative(
+        FibsemStagePosition(x=0, y=0, z=0, r=0, t=np.deg2rad(tilt_deg))
+    )
+    fx0, fy0 = _fiducial(microscope, BeamType.ION)
+
+    requested = -20e-6
+    microscope.vertical_move(dy=requested, dx=0)
+
+    fx1, fy1 = _fiducial(microscope, BeamType.ION)
+    moved = (fy1 - fy0) * PIXEL_SIZE
+    assert moved == pytest.approx(requested, abs=1e-6), (
+        f"FIB view moved {moved * 1e6:+.2f} um for a {requested * 1e6:+.2f} um request"
+    )
+
+
+def test_vertical_move_closes_the_measured_coincidence_error(microscope):
+    """The mini align loop: measure the height error, correct it with one
+    vertical move, re-measure - the residual must be near zero."""
+    microscope._coincidence_scene.coincidence_offset = 8e-6
+    microscope._coincidence_scene.reference_position = None  # re-anchor with offset
+    microscope.move_stage_relative(
+        FibsemStagePosition(x=0, y=0, z=0, r=0, t=np.deg2rad(12.0))
+    )
+    microscope._coincidence_scene.n_clusters = 35
+    microscope._coincidence_scene.grid_intensity = 90.0
+    microscope._coincidence_scene.features = []
+    microscope._coincidence_scene.__post_init__()
+
+    def measure():
+        settings = ImageSettings(
+            resolution=RESOLUTION,
+            hfw=100e-6,
+            dwell_time=1e-9,
+            save=False,
+            beam_type=BeamType.ELECTRON,
+        )
+        sem_image = microscope.acquire_image(image_settings=settings)
+        settings.beam_type = BeamType.ION
+        fib_image = microscope.acquire_image(image_settings=settings)
+        return measure_coincidence_from_images(sem_image, fib_image)
+
+    m0 = measure()
+    assert m0.is_reliable, m0.refusal_reason
+    assert abs(m0.dz) > 5e-6  # there is an error to correct
+
+    # correct using the measured FIB-plane residual, as the align loop will
+    microscope.vertical_move(dy=m0.dy, dx=0)
+
+    m1 = measure()
+    assert m1.is_reliable, m1.refusal_reason
+    assert abs(m1.dz) < 1e-6, (
+        f"residual {m1.dz * 1e6:+.2f} um after correcting {m0.dz * 1e6:+.2f} um"
+    )


### PR DESCRIPTION
Stacked on #718 (needs the simulator scene for its tests; retarget when that merges).

Fixes the axis decomposition in `vertical_move`: it split the correction as `dy = m·sin(t), dz = m/cos(t)` where a chamber-vertical needs `dz = m·cos(t)`. The two agree only at t=0, so at every tilted pose the move dragged the feature sideways in the SEM view — partially undoing the SEM centring the operation exists to preserve (~5.6% of the correction at the milling pose, ~50% at the FIB pose).

Both magic constants go with it:
- `PERSPECTIVE_CORRECTION = 0.9` was absorbing the decomposition error near the milling tilt, not correcting perspective — the geometric factor is `dy/sin(column_tilt)`, tilt-independent.
- The `×1.11` in the SEM path was `1/0.9`, cancelling the first constant from outside.

Under-relaxation is now an explicit `relaxation` parameter (default 1.0 = exact) for callers that want a deliberately damped manual loop.

## Testing

Failing-first against the simulator's projection-true scene at two tilts (the old code fails the SEM-drag test at t=35 and the delivery test at t=12 — the bug family is exact at t=0 and wrong everywhere else):
- a vertical move leaves the SEM view still (<1 µm)
- delivers the requested FIB-view shift exactly
- closes a measured coincidence error in a single iteration (the mini align loop)

Tescan's implementation was already correct (its stage z is chamber-vertical, own geometry); Odemis delegates to the fixed path. **Bench validation still applies before trusting on hardware** — the constants being removed were hand-tuned against the old behaviour, and the issue's suggested check (command a known correction at MILLING, compare reported stage x/y/z against the decomposition) is queued with the other bench items.