### PR TITLE
[app] Ensure Coincidence action in the Development menu

### DIFF
--- a/fibsem/alignment/coincidence.py
+++ b/fibsem/alignment/coincidence.py
@@ -30,8 +30,8 @@ full findings.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
 import numpy as np
 from scipy import ndimage as ndi
@@ -78,6 +78,11 @@ class CoincidenceMeasurement:
     refusal_reason: Optional[str] = None  # set when is_reliable is False
     seeded: bool = False
     method: str = "crossbeam-xcorr"
+    coarse: bool = False  # taken at the wide coarse field of view
+    # the pair this was measured from, kept for diagnostics (check_coincidence
+    # fills them in; the pure array path leaves them None)
+    sem_image: Optional[FibsemImage] = field(default=None, repr=False)
+    fib_image: Optional[FibsemImage] = field(default=None, repr=False)
 
 
 @dataclass
@@ -379,14 +384,62 @@ class CoincidenceAlignment:
     converged: bool
     reason: str  # REASON_CONVERGED, REASON_MAX_ITERATIONS, or a refusal_reason
     coarse_used: bool = False
+    # counted, not derived from the history: a coarse measurement adds an
+    # entry without a move
+    moves_applied: int = 0
 
     @property
     def final(self) -> "CoincidenceMeasurement":
         return self.measurements[-1]
 
-    @property
-    def moves_applied(self) -> int:
-        return len(self.measurements) - 1
+
+PROGRESS_MEASURING = "measuring"
+PROGRESS_MEASURED = "measured"
+PROGRESS_MOVING = "moving"
+
+
+@dataclass
+class CoincidenceProgress:
+    """One step of an ensure_coincident run, as reported to `on_progress`.
+
+    Emitted before each acquisition (MEASURING), after each measurement
+    (MEASURED, with the measurement) and before each corrective move
+    (MOVING, with the measurement driving it). `iteration` counts the
+    corrective moves applied so far.
+    """
+
+    stage: str
+    iteration: int
+    max_iterations: int
+    coarse: bool = False
+    measurement: Optional[CoincidenceMeasurement] = None
+
+    def describe(self) -> str:
+        """A one-line, operator-facing description of the step."""
+        pass_name = "coarse" if self.coarse else "fine"
+        if self.stage == PROGRESS_MEASURING:
+            if self.coarse:
+                return "Fine pass refused - measuring at the coarse field of view..."
+            return f"Measuring coincidence ({pass_name}, {self.iteration}/{self.max_iterations} moves so far)..."
+        m = self.measurement
+        assert m is not None
+        if self.stage == PROGRESS_MEASURED:
+            if not m.is_reliable:
+                return (
+                    f"{pass_name.capitalize()} measurement refused: "
+                    f"{m.refusal_reason} (band disagreement {m.band_disagreement * 1e6:.2f} um)."
+                )
+            return (
+                f"{pass_name.capitalize()} measurement: dz {m.dz * 1e6:+.2f} um "
+                f"(dx {m.dx * 1e6:+.2f} um)."
+            )
+        return (
+            f"Correcting height by {m.dz * 1e6:+.2f} um "
+            f"(move {self.iteration + 1}/{self.max_iterations})..."
+        )
+
+
+ProgressCallback = Callable[[CoincidenceProgress], None]
 
 
 def _default_image_settings() -> "ImageSettings":
@@ -422,13 +475,16 @@ def check_coincidence(
     sem_image = microscope.acquire_image(image_settings=settings)
     settings.beam_type = BeamType.ION
     fib_image = microscope.acquire_image(image_settings=settings)
-    return measure_coincidence_from_images(
+    measurement = measure_coincidence_from_images(
         sem_image,
         fib_image,
         prior=prior,
         capture_range=capture_range,
         agreement_tolerance=agreement_tolerance,
     )
+    measurement.sem_image = sem_image
+    measurement.fib_image = fib_image
+    return measurement
 
 
 def ensure_coincident(
@@ -442,6 +498,7 @@ def ensure_coincident(
     coarse_hfw: Optional[float] = DEFAULT_COARSE_HFW,
     coarse_capture_range: float = DEFAULT_COARSE_CAPTURE_RANGE,
     coarse_agreement_tolerance: float = DEFAULT_COARSE_AGREEMENT_TOLERANCE,
+    on_progress: Optional[ProgressCallback] = None,
 ) -> CoincidenceAlignment:
     """Measure the SEM/FIB coincidence and correct it until within tolerance.
 
@@ -481,6 +538,9 @@ def ensure_coincident(
             pitch apart.
         coarse_agreement_tolerance: band-agreement gate for the coarse pass
             (looser: its pixels are ~4x larger).
+        on_progress: called with a CoincidenceProgress before every
+            acquisition, after every measurement and before every move, from
+            the calling thread - a GUI must marshal it across itself.
 
     Returns:
         CoincidenceAlignment with the full measurement history (coarse
@@ -490,8 +550,23 @@ def ensure_coincident(
 
     measurements: List[CoincidenceMeasurement] = []
     coarse_used = False
+    moves = 0
+
+    def report(stage: str, coarse: bool = False, measurement=None) -> None:
+        if on_progress is None:
+            return
+        on_progress(
+            CoincidenceProgress(
+                stage=stage,
+                iteration=moves,
+                max_iterations=max_iterations,
+                coarse=coarse,
+                measurement=measurement,
+            )
+        )
 
     def fine_check(prior: Optional[Tuple[float, float]] = None):
+        report(PROGRESS_MEASURING)
         measurement = check_coincidence(
             microscope,
             image_settings=image_settings,
@@ -500,9 +575,11 @@ def ensure_coincident(
             agreement_tolerance=agreement_tolerance,
         )
         measurements.append(measurement)
+        report(PROGRESS_MEASURED, measurement=measurement)
         return measurement
 
     def coarse_check():
+        report(PROGRESS_MEASURING, coarse=True)
         settings = deepcopy(image_settings or _default_image_settings())
         settings.hfw = coarse_hfw
         measurement = check_coincidence(
@@ -511,7 +588,9 @@ def ensure_coincident(
             capture_range=coarse_capture_range,
             agreement_tolerance=coarse_agreement_tolerance,
         )
+        measurement.coarse = True
         measurements.append(measurement)
+        report(PROGRESS_MEASURED, coarse=True, measurement=measurement)
         return measurement
 
     measurement = fine_check()
@@ -533,7 +612,9 @@ def ensure_coincident(
                 break
             # a coarse move only needs to land within the fine pass's reach
 
+        report(PROGRESS_MOVING, coarse=measurement.coarse, measurement=measurement)
         microscope.vertical_move(dy=measurement.dy, dx=0, relaxation=relaxation)
+        moves += 1
 
         # after a correction the residual should be near zero in y; dx is
         # uncorrected and persists, so seed the fine window there
@@ -550,6 +631,7 @@ def ensure_coincident(
         converged=reason == REASON_CONVERGED,
         reason=reason,
         coarse_used=coarse_used,
+        moves_applied=moves,
     )
     logging.info(
         {

--- a/fibsem/alignment/plotting.py
+++ b/fibsem/alignment/plotting.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import numpy as np
 
@@ -13,7 +13,10 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
     from fibsem.alignment import AlignmentDifferential, AlignmentIteration
-    from fibsem.alignment.coincidence import CoincidenceMeasurement
+    from fibsem.alignment.coincidence import (
+        CoincidenceAlignment,
+        CoincidenceMeasurement,
+    )
     from fibsem.structures import FibsemImage
 
 
@@ -279,3 +282,40 @@ def plot_coincidence_measurement(
         save_path = os.path.join(ref_path, f"{prefix}coincidence_{ts}.png")
         fig.savefig(save_path, dpi=80)
     return fig
+
+
+def save_coincidence_diagnostics(
+    result: "CoincidenceAlignment", path: str, prefix: str = ""
+) -> List[str]:
+    """Save one diagnostic figure per measurement of an ensure_coincident run.
+
+    Files are numbered in run order (`<prefix>coincidence_<ts>_01_fine.png`,
+    `..._02_coarse.png`, ...) so a run reads as a sequence: the refusal that
+    escalated, the coarse lock, the post-move residual. Measurements without
+    their image pair (the pure array path) are skipped.
+
+    Returns:
+        the saved file paths, in order.
+    """
+    from datetime import datetime
+
+    os.makedirs(path, exist_ok=True)
+    ts = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    saved: List[str] = []
+    for i, m in enumerate(result.measurements, start=1):
+        if m.sem_image is None or m.fib_image is None:
+            continue
+        pass_name = "coarse" if m.coarse else "fine"
+        fig = plot_coincidence_measurement(
+            m.sem_image,
+            m.fib_image,
+            m,
+            title=f"Coincidence {i}/{len(result.measurements)} ({pass_name})",
+            save=False,
+        )
+        save_path = os.path.join(
+            path, f"{prefix}coincidence_{ts}_{i:02d}_{pass_name}.png"
+        )
+        fig.savefig(save_path, dpi=80)
+        saved.append(save_path)
+    return saved

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import html
 import logging
+import os
 import sys
 import time
 from typing import List, Optional, Tuple
@@ -16,7 +17,7 @@ import warnings
 from datetime import datetime
 
 import napari
-from PyQt5.QtCore import QSize, Qt, QTimer
+from PyQt5.QtCore import QSize, Qt, QTimer, pyqtSignal
 from PyQt5.QtGui import QIcon, QKeySequence, QPainter, QPixmap
 from PyQt5.QtWidgets import (
     QAction,
@@ -419,6 +420,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
     # control from their own half of the truth is how a control gets stuck on.
     _overviews_allowed = True
 
+    # CoincidenceProgress from the align-loop worker, delivered on the GUI thread
+    coincidence_progress = pyqtSignal(object)
+
     def __init__(self):
         super().__init__()
         # The last words a producer supplied, so a backend's messageless tick still
@@ -737,12 +741,15 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         )
         dev_menu.addAction(self.action_open_coincidence_viewer)
 
-        self.action_ensure_coincidence = QAction("Run SEM/FIB Coincidence Alignment", self)
+        self.action_ensure_coincidence = QAction(
+            "Run SEM/FIB Coincidence Alignment", self
+        )
         self.action_ensure_coincidence.setToolTip(
             "Measure the SEM/FIB coincidence at the current position and "
             "correct it with vertical moves until within tolerance (FIB-868)"
         )
         self.action_ensure_coincidence.triggered.connect(self._on_ensure_coincidence)
+        self.coincidence_progress.connect(self._on_coincidence_progress)
         dev_menu.addAction(self.action_ensure_coincidence)
 
         self._dev_menu = dev_menu
@@ -1217,39 +1224,72 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             self.show_toast("Not connected to a microscope.", "warning")
             return
         self.action_ensure_coincidence.setEnabled(False)
-        self.show_toast("Measuring coincidence…", "info")
         worker = self._ensure_coincidence_worker()
         worker.returned.connect(self._on_ensure_coincidence_finished)
+        worker.errored.connect(
+            lambda exc: self.show_toast(f"Coincidence alignment failed: {exc}", "error")
+        )
         worker.finished.connect(lambda: self.action_ensure_coincidence.setEnabled(True))
         worker.start()
+
+    def _coincidence_diagnostics_path(self) -> str:
+        """Where a run's diagnostic figures go: the open experiment, else the log."""
+        from fibsem import config as cfg
+        from fibsem.alignment import ALIGNMENT_SUBDIR
+
+        experiment = getattr(self.autolamella_ui, "experiment", None)
+        base = experiment.path if experiment is not None else cfg.LOG_PATH
+        return os.path.join(base, ALIGNMENT_SUBDIR)
 
     def _ensure_coincidence_worker(self):
         from fibsem.ui.qt.threading import thread_worker
 
         microscope = self.autolamella_ui.microscope
+        diagnostics_path = self._coincidence_diagnostics_path()
+        # progress crosses back to the GUI thread as a signal, never a call
+        on_progress = self.coincidence_progress.emit
 
         @thread_worker
         def _run():
             from fibsem.alignment.coincidence import ensure_coincident
+            from fibsem.alignment.plotting import save_coincidence_diagnostics
 
-            return ensure_coincident(microscope)
+            result = ensure_coincident(microscope, on_progress=on_progress)
+            save_coincidence_diagnostics(result, diagnostics_path)
+            return result
 
         return _run()
 
+    def _on_coincidence_progress(self, progress) -> None:
+        self.show_toast(progress.describe(), "info", temporary=True)
+        # show each measured pair in the views as it lands, the same way a
+        # spot burn pushes its post-burn image: the acquisition signals are
+        # what the image widget listens to
+        m = progress.measurement
+        if m is None or m.sem_image is None or m.fib_image is None:
+            return
+        microscope = self.autolamella_ui.microscope
+        microscope.sem_acquisition_signal.emit(m.sem_image)
+        microscope.fib_acquisition_signal.emit(m.fib_image)
+
     def _on_ensure_coincidence_finished(self, result) -> None:
         final_dz = result.final.dz * 1e6
+        where = f" Diagnostics in {self._coincidence_diagnostics_path()}"
         if result.converged:
             self.show_toast(
                 f"Coincident: residual {final_dz:+.2f} um after "
-                f"{result.moves_applied} corrective move(s).",
+                f"{result.moves_applied} corrective move(s)."
+                f"{' Coarse pass used.' if result.coarse_used else ''}{where}",
                 "success",
+                duration=10000,
             )
         else:
             self.show_toast(
                 f"Not coincident: {result.reason} "
                 f"(last measured dz {final_dz:+.2f} um, "
-                f"{result.moves_applied} move(s) applied).",
+                f"{result.moves_applied} move(s) applied).{where}",
                 "warning",
+                duration=10000,
             )
 
     def _open_coincidence_milling_viewer(self):

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -737,6 +737,14 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         )
         dev_menu.addAction(self.action_open_coincidence_viewer)
 
+        self.action_ensure_coincidence = QAction("Run SEM/FIB Coincidence Alignment", self)
+        self.action_ensure_coincidence.setToolTip(
+            "Measure the SEM/FIB coincidence at the current position and "
+            "correct it with vertical moves until within tolerance (FIB-868)"
+        )
+        self.action_ensure_coincidence.triggered.connect(self._on_ensure_coincidence)
+        dev_menu.addAction(self.action_ensure_coincidence)
+
         self._dev_menu = dev_menu
         self._dev_menu.menuAction().setVisible(self.dev_mode)
 
@@ -1197,6 +1205,52 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         """Save the current fluorescence microscope configuration."""
         if self.autolamella_ui is not None:
             self.autolamella_ui.export_fm_configuration()
+
+    def _on_ensure_coincidence(self) -> None:
+        """Run the coincidence align loop at the current position (dev tool).
+
+        The loop acquires its own image pairs and may move the stage
+        vertically several times; runs off the GUI thread, reports by toast.
+        """
+        microscope = getattr(self.autolamella_ui, "microscope", None)
+        if microscope is None:
+            self.show_toast("Not connected to a microscope.", "warning")
+            return
+        self.action_ensure_coincidence.setEnabled(False)
+        self.show_toast("Measuring coincidence…", "info")
+        worker = self._ensure_coincidence_worker()
+        worker.returned.connect(self._on_ensure_coincidence_finished)
+        worker.finished.connect(lambda: self.action_ensure_coincidence.setEnabled(True))
+        worker.start()
+
+    def _ensure_coincidence_worker(self):
+        from fibsem.ui.qt.threading import thread_worker
+
+        microscope = self.autolamella_ui.microscope
+
+        @thread_worker
+        def _run():
+            from fibsem.alignment.coincidence import ensure_coincident
+
+            return ensure_coincident(microscope)
+
+        return _run()
+
+    def _on_ensure_coincidence_finished(self, result) -> None:
+        final_dz = result.final.dz * 1e6
+        if result.converged:
+            self.show_toast(
+                f"Coincident: residual {final_dz:+.2f} um after "
+                f"{result.moves_applied} corrective move(s).",
+                "success",
+            )
+        else:
+            self.show_toast(
+                f"Not coincident: {result.reason} "
+                f"(last measured dz {final_dz:+.2f} um, "
+                f"{result.moves_applied} move(s) applied).",
+                "warning",
+            )
 
     def _open_coincidence_milling_viewer(self):
         """Open the Coincidence Milling Viewer dialog."""

--- a/tests/test_align_loop.py
+++ b/tests/test_align_loop.py
@@ -122,3 +122,49 @@ def test_error_beyond_the_coarse_window_does_not_claim_success(microscope):
 
     assert not result.converged
     assert result.coarse_used  # it tried
+
+
+def test_progress_reports_every_step_and_moves_are_counted(microscope, tmp_path):
+    from fibsem.alignment.coincidence import (
+        PROGRESS_MEASURED,
+        PROGRESS_MEASURING,
+        PROGRESS_MOVING,
+    )
+    from fibsem.alignment.plotting import save_coincidence_diagnostics
+
+    steps = []
+    result = ensure_coincident(microscope, tolerance=1e-6, on_progress=steps.append)
+
+    assert result.converged
+    assert result.moves_applied == 1
+    # measure, report, move, measure, report - and every step describes itself
+    assert [s.stage for s in steps] == [
+        PROGRESS_MEASURING,
+        PROGRESS_MEASURED,
+        PROGRESS_MOVING,
+        PROGRESS_MEASURING,
+        PROGRESS_MEASURED,
+    ]
+    assert steps[2].measurement is result.measurements[0]
+    assert steps[2].iteration == 0 and steps[3].iteration == 1
+    assert all(s.describe() for s in steps)
+
+    # each measurement keeps its pair, so the run is fully re-plottable
+    saved = save_coincidence_diagnostics(result, str(tmp_path))
+    assert len(saved) == len(result.measurements) == 2
+    assert saved[0].endswith("_01_fine.png")
+
+
+def test_coarse_measurements_do_not_count_as_moves(microscope):
+    microscope._coincidence_scene.coincidence_offset = 40e-6
+    microscope._coincidence_scene.reference_position = None
+    microscope._coincidence_scene.anchor(microscope.get_stage_position())
+
+    result = ensure_coincident(microscope, tolerance=1e-6)
+
+    assert result.converged and result.coarse_used
+    assert result.measurements[1].coarse
+    assert not result.measurements[0].coarse
+    # refused fine + coarse + post-move fine (+ maybe a fine refinement):
+    # the history is longer than the moves by the extra measurements
+    assert result.moves_applied == len(result.measurements) - 2


### PR DESCRIPTION
Stacked on #721 (needs `ensure_coincident`; retarget as the stack merges).

One Development-menu action to drive the align loop from the app: runs `ensure_coincident` at the current position off the GUI thread, and toasts the outcome — residual and move count on convergence, otherwise the reason (refusal / iteration limit) plus the last measured residual. The action disables while a run is in flight.

Dev-menu only, deliberately: the workflow-task and stage-control integrations come once the loop has bench time. With the simulator scene enabled this gives a one-click end-to-end demo: boot 8 µm off-coincidence → Development → Ensure Coincidence → coincident in one move.