### PR TITLE
[alignment] Coincidence alignment can keep the FIB view; the Demo boots at the SEM orientation

### DIFF
--- a/fibsem/alignment/coincidence.py
+++ b/fibsem/alignment/coincidence.py
@@ -79,6 +79,9 @@ class CoincidenceMeasurement:
     seeded: bool = False
     method: str = "crossbeam-xcorr"
     coarse: bool = False  # taken at the wide coarse field of view
+    # the FIB->SEM y stretch the pair was measured with: dy is in the FIB
+    # plane, dy * y_stretch is the same displacement seen in the SEM plane
+    y_stretch: float = 1.0
     # the pair this was measured from, kept for diagnostics (check_coincidence
     # fills them in; the pure array path leaves them None)
     sem_image: Optional[FibsemImage] = field(default=None, repr=False)
@@ -299,6 +302,7 @@ def measure_coincidence(
     measurement = CoincidenceMeasurement(
         dx=float(dx),
         dy=float(dy),
+        y_stretch=float(stretch),
         dz=float(dz),
         band_disagreement=float(disagreement),
         is_reliable=refusal is None,
@@ -499,8 +503,17 @@ def ensure_coincident(
     coarse_capture_range: float = DEFAULT_COARSE_CAPTURE_RANGE,
     coarse_agreement_tolerance: float = DEFAULT_COARSE_AGREEMENT_TOLERANCE,
     on_progress: Optional[ProgressCallback] = None,
+    reference: "BeamType" = None,
 ) -> CoincidenceAlignment:
     """Measure the SEM/FIB coincidence and correct it until within tolerance.
+
+    `reference` says which view keeps its centre. ELECTRON (the default):
+    the height correction moves the stage along the SEM axis, so what sits
+    at the SEM centre stays there and the FIB view slides onto it. ION: what
+    sits at the FIB centre stays there - the case in the workflow, where the
+    operator chose the site in the FIB view - achieved by first recentring
+    the SEM on the FIB-centred feature with a stable move, then applying the
+    same height correction.
 
     The loop: measure -> vertical move by the measured residual -> re-measure,
     stopping when a FRESH measurement is within tolerance, an iteration limit
@@ -541,12 +554,20 @@ def ensure_coincident(
         on_progress: called with a CoincidenceProgress before every
             acquisition, after every measurement and before every move, from
             the calling thread - a GUI must marshal it across itself.
+        reference: the view whose centre is preserved (ELECTRON or ION).
 
     Returns:
         CoincidenceAlignment with the full measurement history (coarse
         measurements included) and whether the coarse pass was needed.
     """
     from copy import deepcopy
+
+    from fibsem.structures import BeamType
+
+    if reference is None:
+        reference = BeamType.ELECTRON
+    if reference not in (BeamType.ELECTRON, BeamType.ION):
+        raise ValueError(f"reference must be ELECTRON or ION, got {reference}")
 
     measurements: List[CoincidenceMeasurement] = []
     coarse_used = False
@@ -613,6 +634,16 @@ def ensure_coincident(
             # a coarse move only needs to land within the fine pass's reach
 
         report(PROGRESS_MOVING, coarse=measurement.coarse, measurement=measurement)
+        if reference is BeamType.ION:
+            # bring the FIB-centred feature to the SEM centre first: the
+            # height correction preserves the SEM centre, so this is what
+            # leaves the FIB view where the operator put it. A stable move
+            # follows the surface and leaves the height error unchanged
+            microscope.stable_move(
+                dx=-measurement.dx,
+                dy=-measurement.dy * measurement.y_stretch,
+                beam_type=BeamType.ELECTRON,
+            )
         microscope.vertical_move(dy=measurement.dy, dx=0, relaxation=relaxation)
         moves += 1
 

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -748,9 +748,24 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             "Measure the SEM/FIB coincidence at the current position and "
             "correct it with vertical moves until within tolerance (FIB-868)"
         )
-        self.action_ensure_coincidence.triggered.connect(self._on_ensure_coincidence)
-        self.coincidence_progress.connect(self._on_coincidence_progress)
+        self.action_ensure_coincidence.triggered.connect(
+            lambda: self._on_ensure_coincidence(reference=BeamType.ELECTRON)
+        )
         dev_menu.addAction(self.action_ensure_coincidence)
+
+        self.action_ensure_coincidence_fib = QAction(
+            "Run SEM/FIB Coincidence Alignment (keep FIB view)", self
+        )
+        self.action_ensure_coincidence_fib.setToolTip(
+            "As above, but what is centred in the FIB view stays put and the "
+            "SEM view is the one corrected - the case after choosing a site "
+            "in the FIB view"
+        )
+        self.action_ensure_coincidence_fib.triggered.connect(
+            lambda: self._on_ensure_coincidence(reference=BeamType.ION)
+        )
+        dev_menu.addAction(self.action_ensure_coincidence_fib)
+        self.coincidence_progress.connect(self._on_coincidence_progress)
 
         self._dev_menu = dev_menu
         self._dev_menu.menuAction().setVisible(self.dev_mode)
@@ -1213,23 +1228,26 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if self.autolamella_ui is not None:
             self.autolamella_ui.export_fm_configuration()
 
-    def _on_ensure_coincidence(self) -> None:
+    def _on_ensure_coincidence(self, reference: BeamType = BeamType.ELECTRON) -> None:
         """Run the coincidence align loop at the current position (dev tool).
 
         The loop acquires its own image pairs and may move the stage
-        vertically several times; runs off the GUI thread, reports by toast.
+        several times; runs off the GUI thread, reports by toast. `reference`
+        is the view whose centre is preserved.
         """
         microscope = getattr(self.autolamella_ui, "microscope", None)
         if microscope is None:
             self.show_toast("Not connected to a microscope.", "warning")
             return
-        self.action_ensure_coincidence.setEnabled(False)
-        worker = self._ensure_coincidence_worker()
+        actions = (self.action_ensure_coincidence, self.action_ensure_coincidence_fib)
+        for action in actions:
+            action.setEnabled(False)
+        worker = self._ensure_coincidence_worker(reference)
         worker.returned.connect(self._on_ensure_coincidence_finished)
         worker.errored.connect(
             lambda exc: self.show_toast(f"Coincidence alignment failed: {exc}", "error")
         )
-        worker.finished.connect(lambda: self.action_ensure_coincidence.setEnabled(True))
+        worker.finished.connect(lambda: [a.setEnabled(True) for a in actions])
         worker.start()
 
     def _coincidence_diagnostics_path(self) -> str:
@@ -1241,7 +1259,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         base = experiment.path if experiment is not None else cfg.LOG_PATH
         return os.path.join(base, ALIGNMENT_SUBDIR)
 
-    def _ensure_coincidence_worker(self):
+    def _ensure_coincidence_worker(self, reference: BeamType):
         from fibsem.ui.qt.threading import thread_worker
 
         microscope = self.autolamella_ui.microscope
@@ -1254,7 +1272,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             from fibsem.alignment.coincidence import ensure_coincident
             from fibsem.alignment.plotting import save_coincidence_diagnostics
 
-            result = ensure_coincident(microscope, on_progress=on_progress)
+            result = ensure_coincident(
+                microscope, on_progress=on_progress, reference=reference
+            )
             save_coincidence_diagnostics(result, diagnostics_path)
             return result
 

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -442,6 +442,16 @@ class DemoMicroscope(FibsemMicroscope):
             scanning_mode_value=None,
         )
         self.stage_is_compustage: bool = self.system.sim.get("is_compustage", False)
+        if not self.stage_is_compustage:
+            # boot at the SEM orientation, as a loaded shuttle sits: at t=0 a
+            # pre-tilted shuttle presents the FIB a grazing 3 deg view, a pose
+            # no real session starts in. A compustage is flat at t=0 already
+            self.stage_system.position.r = np.radians(
+                self.system.stage.rotation_reference
+            )
+            self.stage_system.position.t = np.radians(
+                self.system.stage.shuttle_pre_tilt
+            )
         self.milling_system = MillingSystem(patterns=[])
         self.imaging_system = ImagingSystem()
 

--- a/tests/fm/conftest.py
+++ b/tests/fm/conftest.py
@@ -4,12 +4,20 @@ import pytest
 
 import fibsem.config as fconfig
 
-SIM_ARCTIS_CONFIG_PATH = os.path.join(fconfig.CONFIG_PATH, "sim-arctis-configuration.yaml")
+SIM_ARCTIS_CONFIG_PATH = os.path.join(
+    fconfig.CONFIG_PATH, "sim-arctis-configuration.yaml"
+)
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True, scope="package")
 def use_sim_arctis_config():
-    """Use sim-arctis-configuration.yaml for all fm tests (required for FM support)."""
+    """Use sim-arctis-configuration.yaml for all fm tests (required for FM support).
+
+    Package scope, not session: a session-scoped swap is only torn down when
+    the whole run ends, so every test collected after the first fm test - in
+    any other directory, on any xdist worker - silently ran on the compustage
+    configuration too (pre-tilt 0, flat boot pose).
+    """
     original = fconfig.DEFAULT_CONFIGURATION_PATH
     fconfig.DEFAULT_CONFIGURATION_PATH = SIM_ARCTIS_CONFIG_PATH
     yield

--- a/tests/test_align_loop.py
+++ b/tests/test_align_loop.py
@@ -14,7 +14,7 @@ from fibsem.alignment.coincidence import (
     REASON_MAX_ITERATIONS,
     ensure_coincident,
 )
-from fibsem.structures import FibsemStagePosition
+from fibsem.structures import BeamType, FibsemStagePosition
 
 
 @pytest.fixture
@@ -168,3 +168,36 @@ def test_coarse_measurements_do_not_count_as_moves(microscope):
     # refused fine + coarse + post-move fine (+ maybe a fine refinement):
     # the history is longer than the moves by the extra measurements
     assert result.moves_applied == len(result.measurements) - 2
+
+
+def _anchor_in_view(microscope, beam_type) -> tuple:
+    """Where the scene's world anchor projects into one beam's view (m).
+
+    Read straight off the projection the scene renders with, so it is
+    exact and immune to the periodic mesh's correlation aliases.
+    """
+    from fibsem.projection import BeamStageProjection
+
+    projection = BeamStageProjection.from_microscope(microscope, beam_type)
+    return projection.to_plane(
+        microscope._coincidence_scene.reference_position,
+        microscope.get_stage_position(),
+    )
+
+
+@pytest.mark.parametrize("reference", [BeamType.ELECTRON, BeamType.ION])
+def test_reference_view_keeps_its_centre(microscope, reference):
+    """Whichever view is the reference sees the same scene after the
+    alignment; the other view is the one that moved onto it."""
+    before = {b: _anchor_in_view(microscope, b) for b in BeamType}
+
+    result = ensure_coincident(microscope, tolerance=1e-6, reference=reference)
+    assert result.converged, result.reason
+    assert result.moves_applied == 1
+
+    after = {b: _anchor_in_view(microscope, b) for b in BeamType}
+    other = BeamType.ION if reference is BeamType.ELECTRON else BeamType.ELECTRON
+    kept = np.hypot(*(np.subtract(after[reference], before[reference])))
+    moved = np.hypot(*(np.subtract(after[other], before[other])))
+    assert kept < 1e-6, f"{reference.name} view moved by {kept * 1e6:.2f} um"
+    assert moved > 3e-6, f"{other.name} view only moved {moved * 1e6:.2f} um"

--- a/tests/test_align_loop.py
+++ b/tests/test_align_loop.py
@@ -5,9 +5,12 @@ loop (measurement geometry, vertical_move decomposition, scene rendering)
 shares BeamStageProjection, so convergence here is a real end-to-end fact.
 """
 
+import os
+
 import numpy as np
 import pytest
 
+import fibsem.config as cfg
 from fibsem import utils
 from fibsem.alignment.coincidence import (
     REASON_CONVERGED,
@@ -16,10 +19,16 @@ from fibsem.alignment.coincidence import (
 )
 from fibsem.structures import BeamType, FibsemStagePosition
 
+# The geometry under test is a pre-tilted TFS shuttle; pin it rather than
+# inherit whatever configuration an earlier test left as the default
+TFS_SHUTTLE_CONFIG = os.path.join(cfg.CONFIG_PATH, "microscope-configuration.yaml")
+
 
 @pytest.fixture
 def microscope():
-    microscope, settings = utils.setup_session(manufacturer="Demo")
+    microscope, settings = utils.setup_session(
+        manufacturer="Demo", config_path=TFS_SHUTTLE_CONFIG
+    )
     microscope.system.sim["coincidence_projection"] = True
     microscope.system.sim["coincidence_offset"] = 8e-6
     microscope._setup_coincidence_projection()

--- a/tests/test_align_loop.py
+++ b/tests/test_align_loop.py
@@ -31,9 +31,9 @@ def microscope():
     )
     scene.anchor(microscope.get_stage_position())
     microscope._coincidence_scene = scene
-    microscope.move_stage_relative(
-        FibsemStagePosition(x=0, y=0, z=0, r=0, t=np.deg2rad(12.0))
-    )
+    pose = microscope.get_stage_position()
+    pose.t = np.deg2rad(12.0)
+    microscope.move_stage_absolute(pose)
     yield microscope
     microscope.disconnect()
 

--- a/tests/test_sim_coincidence.py
+++ b/tests/test_sim_coincidence.py
@@ -17,9 +17,12 @@ misleading answers:
    they must agree.
 """
 
+import os
+
 import numpy as np
 import pytest
 
+import fibsem.config as cfg
 from fibsem import conversions, utils
 from fibsem.alignment.coincidence import measure_coincidence_from_images
 from fibsem.structures import (
@@ -30,13 +33,19 @@ from fibsem.structures import (
     Point,
 )
 
+# The geometry under test is a pre-tilted TFS shuttle; pin it rather than
+# inherit whatever configuration an earlier test left as the default
+TFS_SHUTTLE_CONFIG = os.path.join(cfg.CONFIG_PATH, "microscope-configuration.yaml")
+
 COINCIDENCE_OFFSET = 8e-6
 MILLING_POSE_TILT = np.deg2rad(12.0)
 
 
 @pytest.fixture
 def microscope():
-    microscope, settings = utils.setup_session(manufacturer="Demo")
+    microscope, settings = utils.setup_session(
+        manufacturer="Demo", config_path=TFS_SHUTTLE_CONFIG
+    )
     yield microscope
     microscope.disconnect()
 

--- a/tests/test_sim_coincidence.py
+++ b/tests/test_sim_coincidence.py
@@ -52,11 +52,11 @@ def _enable_projection(microscope, offset: float = COINCIDENCE_OFFSET, **scene_k
             coincidence_offset=offset, **scene_kwargs
         )
     # a realistic milling pose: stage tilt 12 deg -> milling angle 15 deg
-    # (at the Demo's boot tilt of 0 the FIB view is a ~3 deg grazing view,
-    # foreshortened x14 - unmeasurable on hardware too)
-    microscope.move_stage_relative(
-        FibsemStagePosition(x=0, y=0, z=0, r=0, t=MILLING_POSE_TILT)
-    )
+    # (the Demo boots at the SEM orientation, tilt 35; set the tilt
+    # absolutely so the pose does not depend on where it booted)
+    pose = microscope.get_stage_position()
+    pose.t = MILLING_POSE_TILT
+    microscope.move_stage_absolute(pose)
 
 
 def _fiducial_only(microscope):
@@ -278,9 +278,9 @@ def test_tilting_does_not_reset_the_world(microscope):
     assert off_before > 20e-6  # fiducial clearly off-centre at the site
 
     # the workflow tilts to another orientation
-    microscope.move_stage_relative(
-        FibsemStagePosition(x=0, y=0, z=0, r=0, t=np.deg2rad(23.0))
-    )
+    pose = microscope.get_stage_position()
+    pose.t = np.deg2rad(23.0)
+    microscope.move_stage_absolute(pose)
     gx, gy = fiducial()
     off_after = np.hypot(gx - 768, gy - 512) * pixel_size
     # the world persisted: the fiducial is still far from centre, not reset

--- a/tests/test_vertical_move.py
+++ b/tests/test_vertical_move.py
@@ -12,12 +12,19 @@ projection-true scene, at more than one tilt: the bug family being pinned
 here is exact at t=0 and wrong everywhere else.
 """
 
+import os
+
 import numpy as np
 import pytest
 
+import fibsem.config as cfg
 from fibsem import utils
 from fibsem.alignment.coincidence import measure_coincidence_from_images
 from fibsem.structures import BeamType, FibsemStagePosition, ImageSettings
+
+# The geometry under test is a pre-tilted TFS shuttle; pin it rather than
+# inherit whatever configuration an earlier test left as the default
+TFS_SHUTTLE_CONFIG = os.path.join(cfg.CONFIG_PATH, "microscope-configuration.yaml")
 
 HFW = 150e-6
 RESOLUTION = (1536, 1024)
@@ -26,7 +33,9 @@ PIXEL_SIZE = HFW / RESOLUTION[0]
 
 @pytest.fixture
 def microscope():
-    microscope, settings = utils.setup_session(manufacturer="Demo")
+    microscope, settings = utils.setup_session(
+        manufacturer="Demo", config_path=TFS_SHUTTLE_CONFIG
+    )
     microscope.system.sim["coincidence_projection"] = True
     microscope.system.sim["coincidence_offset"] = 0.0
     microscope._setup_coincidence_projection()

--- a/tests/test_vertical_move.py
+++ b/tests/test_vertical_move.py
@@ -61,9 +61,9 @@ def _fiducial(microscope, beam_type):
 @pytest.mark.parametrize("tilt_deg", [12.0, 35.0])
 def test_vertical_move_is_invisible_to_the_sem(microscope, tilt_deg):
     """The whole premise: correcting the FIB view must not drag the SEM."""
-    microscope.move_stage_relative(
-        FibsemStagePosition(x=0, y=0, z=0, r=0, t=np.deg2rad(tilt_deg))
-    )
+    pose = microscope.get_stage_position()
+    pose.t = np.deg2rad(tilt_deg)
+    microscope.move_stage_absolute(pose)
     sx0, sy0 = _fiducial(microscope, BeamType.ELECTRON)
 
     microscope.vertical_move(dy=-20e-6, dx=0)
@@ -76,9 +76,9 @@ def test_vertical_move_is_invisible_to_the_sem(microscope, tilt_deg):
 @pytest.mark.parametrize("tilt_deg", [12.0, 35.0])
 def test_vertical_move_delivers_the_requested_fib_shift(microscope, tilt_deg):
     """The contract: the FIB view shifts by exactly the requested dy."""
-    microscope.move_stage_relative(
-        FibsemStagePosition(x=0, y=0, z=0, r=0, t=np.deg2rad(tilt_deg))
-    )
+    pose = microscope.get_stage_position()
+    pose.t = np.deg2rad(tilt_deg)
+    microscope.move_stage_absolute(pose)
     fx0, fy0 = _fiducial(microscope, BeamType.ION)
 
     requested = -20e-6
@@ -96,9 +96,9 @@ def test_vertical_move_closes_the_measured_coincidence_error(microscope):
     vertical move, re-measure - the residual must be near zero."""
     microscope._coincidence_scene.coincidence_offset = 8e-6
     microscope._coincidence_scene.reference_position = None  # re-anchor with offset
-    microscope.move_stage_relative(
-        FibsemStagePosition(x=0, y=0, z=0, r=0, t=np.deg2rad(12.0))
-    )
+    pose = microscope.get_stage_position()
+    pose.t = np.deg2rad(12.0)
+    microscope.move_stage_absolute(pose)
     microscope._coincidence_scene.n_clusters = 35
     microscope._coincidence_scene.grid_intensity = 90.0
     microscope._coincidence_scene.features = []


### PR DESCRIPTION
## Summary

**\`ensure_coincident(reference=)\`** — which view keeps its centre.
- \`ELECTRON\` (default): unchanged. The height correction moves along the SEM axis, so what is centred in the SEM stays and the FIB view slides onto it.
- \`ION\`: the workflow case — the operator chose the site in the FIB view. The loop first recentres the SEM on the FIB-centred feature with a stable move (\`-dx, -dy * y_stretch\` in the SEM plane; measurements now carry their \`y_stretch\`), then applies the same height correction. What the FIB showed stays under its crosshair; the SEM view is the one corrected.
- Development menu gets a **"Run SEM/FIB Coincidence Alignment (keep FIB view)"** variant. Verified live on Demo.

**The Demo boots at the SEM orientation** (non-compustage). At t=0 a 35° pre-tilted shuttle gives the FIB a 3° grazing view — a pose no real session starts in and one where the coincidence scene is unmeasurable (×14 foreshortening). Now \`r = rotation_reference, t = shuttle_pre_tilt\`; a compustage is flat at t=0 and is left alone. The coincidence tests tilted relatively from the old boot pose and now set the tilt absolutely.

## Testing

- New oracle test \`test_reference_view_keeps_its_centre[ELECTRON|ION]\`: reads where the scene's world anchor projects into each view (\`BeamStageProjection.to_plane\`) before and after — the reference view moves < 1 µm, the other by the correction. A whole-frame phase correlation was tried first as the oracle and returned 0.00 for a view that had moved (the periodic mesh aliases it); the projection is exact.
- Every simulator-using test file run against the new boot pose: 1226 passed, 1 xfail (the pre-existing pitch-alias record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)