### PR TITLE
[stage] Grid loader magazine, Demo autoloader, and Stage.grid_inventory()

### DIFF
--- a/fibsem/config/sim-arctis-configuration.yaml
+++ b/fibsem/config/sim-arctis-configuration.yaml
@@ -63,5 +63,9 @@ milling:
 sim:
     sem: null # "/path/to/sem/image/data"                   
     fib: null # "/path/to/fib/image/data"                   
-    use_cycle: true                                         
-    is_compustage: true                                   
+    use_cycle: true
+    is_compustage: true
+    loader:                                               # the simulated autoloader magazine
+        capacity: 12
+        occupied: [1, 2, 3]                               # 1-based slot numbers holding a grid
+        names: {}                                         # slot number -> grid name; unnamed slots read as Grid-NN

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -321,6 +321,12 @@ class FibsemMicroscope(ABC):
 
         self._stage = _create_sample_stage(self)
 
+    def _create_grid_loader(self) -> "SampleGridLoader":
+        """The grid loader for a compustage system. Backends wrap their own hardware."""
+        from fibsem.microscopes._stage import SampleGridLoader
+
+        return SampleGridLoader(parent=self)
+
     def _get_axis_limits(self) -> Dict[str, RangeLimit]:
         """Get the stage axis limits from the microscope."""
 

--- a/fibsem/microscopes/_stage.py
+++ b/fibsem/microscopes/_stage.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Tuple, Union
 
 import numpy as np
 import yaml
@@ -50,18 +51,22 @@ class SampleGrid:
 
 @dataclass
 class GridSlot:
-    """A fixed physical slot on a SampleHolder. May have a SampleGrid loaded into it."""
+    """A slot that may hold one SampleGrid.
+
+    A holder *working* slot has a calibrated stage ``position``. A loader *magazine*
+    slot is storage and has none, so ``position`` is optional.
+    """
 
     name: str
     index: int
-    position: FibsemStagePosition
+    position: Optional[FibsemStagePosition] = None
     loaded_grid: Optional[SampleGrid] = None
 
     def to_dict(self) -> dict:
         return {
             "name": self.name,
             "index": self.index,
-            "position": self.position.to_dict(),
+            "position": self.position.to_dict() if self.position is not None else None,
             "loaded_grid": self.loaded_grid.to_dict()
             if self.loaded_grid is not None
             else None,
@@ -75,13 +80,18 @@ class GridSlot:
             if loaded_grid_data is not None
             else None
         )
+        position_data = data.get("position")
+        position = (
+            FibsemStagePosition(**position_data) if position_data is not None else None
+        )
         slot = GridSlot(
             name=data.get("name", ""),
             index=data.get("index", 0),
-            position=FibsemStagePosition(**data.get("position", {})),
+            position=position,
             loaded_grid=loaded_grid,
         )
-        slot.position.name = slot.name
+        if slot.position is not None:
+            slot.position.name = slot.name
         return slot
 
 
@@ -131,6 +141,15 @@ class SampleHolder:
             if slot.loaded_grid is not None and slot.loaded_grid.name == grid_name:
                 return slot
         return None
+
+    @property
+    def occupied_slots(self) -> List["GridSlot"]:
+        """The working slots that hold a grid: what is in the beam right now."""
+        return [
+            s
+            for s in sorted(self.slots.values(), key=lambda s: s.index)
+            if s.loaded_grid is not None
+        ]
 
     def _ensure_slots(self) -> None:
         """Ensure exactly `capacity` slots exist; add empty ones for missing indices."""
@@ -186,35 +205,218 @@ class SampleHolder:
             yaml.dump(self.to_dict(), f, default_flow_style=False, sort_keys=False)
 
 
+class GridExchangeError(RuntimeError):
+    """A grid could not be moved into, or out of, the holder's working slot."""
+
+
 @dataclass
+class GridInventoryEntry:
+    """One row of ``Stage.grid_inventory()``: a slot, and what it holds.
+
+    ``source`` says which hardware answered -- ``"magazine"`` on a system with a
+    loader, ``"holder"`` otherwise. ``present`` is whether the slot holds a grid;
+    ``in_beam`` whether that grid is in a holder working slot right now. The two
+    are kept apart on purpose: *available* is what a run can select from, *in beam*
+    is what it can act on without an exchange.
+    """
+
+    slot_name: str
+    index: int
+    source: str
+    name: Optional[str]
+    present: bool
+    in_beam: bool
+
+
 class SampleGridLoader:
-    parent: "FibsemMicroscope"
+    """The robotic actuator that exchanges grids between its magazine and the beam.
 
-    def __init__(self, parent: "FibsemMicroscope") -> None:
+    The loader owns a **magazine** -- its own storage slots, filled by hand -- which
+    is distinct from the holder's working slot(s). ``load_grid`` moves a grid from a
+    magazine slot into the working slot and ``unload_grid`` retracts it.
+
+    A magazine slot keeps its grid while that grid is in the beam: the slot is the
+    grid's home, and the working slot references the *same* ``SampleGrid``. So
+    "present" is read from the magazine and "in beam" from the holder, and neither
+    is cached anywhere else.
+
+    Subclasses talk to hardware through ``_do_load`` / ``_do_unload`` /
+    ``_scan_magazine`` / ``_write_slot_description``; this base class is the in-memory
+    model they all share.
+    """
+
+    def __init__(self, parent: "FibsemMicroscope", capacity: int = 12) -> None:
         self.parent = parent
+        self.capacity = capacity
+        self.slots: dict[str, GridSlot] = {}
+        self._ensure_slots()
 
-    def load_grid(self, slot_name: str, grid: SampleGrid) -> None:
-        """Load a SampleGrid into the named slot."""
-        slot = self.parent._stage.holder.slots.get(slot_name)
-        if slot is not None:
-            slot.loaded_grid = grid
+    def _ensure_slots(self) -> None:
+        """Ensure exactly ``capacity`` magazine slots exist, named like holder slots."""
+        for i in range(self.capacity):
+            name = _slot_name(i)
+            if name not in self.slots:
+                self.slots[name] = GridSlot(name=name, index=i, position=None)
+        for name in [
+            n for n, s in list(self.slots.items()) if s.index >= self.capacity
+        ]:
+            del self.slots[name]
 
-    def unload_grid(self, slot_name: str) -> None:
-        """Remove the SampleGrid from the named slot."""
-        slot = self.parent._stage.holder.slots.get(slot_name)
-        if slot is not None:
-            slot.loaded_grid = None
+    # -- the holder side ---------------------------------------------------
+
+    @property
+    def holder(self) -> SampleHolder:
+        return self.parent._stage.holder
+
+    @property
+    def working_slot(self) -> GridSlot:
+        """The holder slot an exchange loads into (the first one; an autoloader has one)."""
+        slots = sorted(self.holder.slots.values(), key=lambda s: s.index)
+        if not slots:
+            raise GridExchangeError("The sample holder has no working slot.")
+        return slots[0]
 
     @property
     def loaded_slots(self) -> List[GridSlot]:
-        """Return all slots that currently have a grid loaded."""
-        if self.parent._stage.holder is None:
-            return []
+        """The holder slots that hold a grid. Kept for callers of the old loader."""
+        return self.holder.occupied_slots
+
+    # -- the magazine side -------------------------------------------------
+
+    @property
+    def loaded_magazine_slots(self) -> List[GridSlot]:
+        """Magazine slots that hold a grid: the grids available to load."""
         return [
             s
-            for s in self.parent._stage.holder.slots.values()
+            for s in sorted(self.slots.values(), key=lambda s: s.index)
             if s.loaded_grid is not None
         ]
+
+    def find_grid(self, grid_name: str) -> Optional[GridSlot]:
+        """The magazine slot holding the grid of this name, or None."""
+        for slot in self.slots.values():
+            if slot.loaded_grid is not None and slot.loaded_grid.name == grid_name:
+                return slot
+        return None
+
+    def assign_grid(self, slot_name: str, grid: Optional[SampleGrid]) -> None:
+        """Name (or clear) the grid in a magazine slot, and tell the hardware."""
+        slot = self._magazine_slot(slot_name)
+        slot.loaded_grid = grid
+        self._write_slot_description(slot)
+
+    def run_inventory(self) -> List[GridSlot]:
+        """Ask the hardware which magazine slots hold a grid, then report them."""
+        self._scan_magazine()
+        return self.loaded_magazine_slots
+
+    # -- exchange ----------------------------------------------------------
+
+    def load_grid(self, slot_name: str) -> SampleGrid:
+        """Bring the grid in a magazine slot into the working slot.
+
+        A no-op when that grid is already there; otherwise the working slot is
+        emptied first. Raises ``GridExchangeError`` when the slot is empty or the
+        hardware refuses.
+        """
+        slot = self._magazine_slot(slot_name)
+        grid = slot.loaded_grid
+        if grid is None:
+            raise GridExchangeError(f"Magazine slot '{slot_name}' holds no grid.")
+        working = self.working_slot
+        if working.loaded_grid is not None and working.loaded_grid.name == grid.name:
+            return grid
+        if working.loaded_grid is not None:
+            self.unload_grid()
+        self._do_load(slot)
+        working.loaded_grid = grid
+        logging.info(f"Loaded grid '{grid.name}' from {slot_name} into {working.name}.")
+        return grid
+
+    def unload_grid(self) -> None:
+        """Retract whatever is in the working slot back into the magazine."""
+        working = self.working_slot
+        if working.loaded_grid is None:
+            return
+        name = working.loaded_grid.name
+        self._do_unload(working)
+        working.loaded_grid = None
+        logging.info(f"Unloaded grid '{name}' from {working.name}.")
+
+    # -- hardware hooks ----------------------------------------------------
+
+    def _do_load(self, slot: GridSlot) -> None:
+        """Physically move the grid in ``slot`` into the working slot."""
+
+    def _do_unload(self, working_slot: GridSlot) -> None:
+        """Physically retract the grid in the working slot."""
+
+    def _scan_magazine(self) -> None:
+        """Refresh ``self.slots`` from the hardware. Nothing to scan in memory."""
+
+    def _write_slot_description(self, slot: GridSlot) -> None:
+        """Persist a slot's grid name where the hardware keeps it."""
+
+    def _magazine_slot(self, slot_name: str) -> GridSlot:
+        try:
+            return self.slots[slot_name]
+        except KeyError:
+            raise GridExchangeError(
+                f"No magazine slot '{slot_name}' (capacity {self.capacity})."
+            ) from None
+
+
+class DemoSampleLoader(SampleGridLoader):
+    """An in-memory autoloader for the simulator.
+
+    ``occupied`` lists the 1-based magazine slot numbers that hold a grid, as printed
+    on a real magazine; ``names`` maps a slot number to a grid name, and any occupied
+    slot without one gets ``Grid-NN`` (what a scan reports for an unnamed grid).
+
+    Set ``fail_next_exchange`` to make the next load or unload raise
+    ``GridExchangeError`` and leave the state untouched, so the run loop's
+    load-failure path can be exercised. ``exchange_delay`` is honoured only when
+    non-zero; tests leave it at zero.
+    """
+
+    def __init__(
+        self,
+        parent: "FibsemMicroscope",
+        capacity: int = 12,
+        occupied: Iterable[int] = (),
+        names: Optional[Mapping[Union[int, str], str]] = None,
+        exchange_delay: float = 0.0,
+    ) -> None:
+        super().__init__(parent, capacity)
+        self.exchange_delay = exchange_delay
+        self.fail_next_exchange = False
+        names = names or {}
+        for number in occupied:
+            number = int(number)
+            slot = self.slots.get(_slot_name(number - 1))
+            if slot is None:
+                raise ValueError(
+                    f"Magazine slot {number} is outside capacity {capacity}."
+                )
+            name = names.get(number, names.get(str(number))) or f"Grid-{number:02d}"
+            slot.loaded_grid = SampleGrid(name=str(name))
+
+    def _do_load(self, slot: GridSlot) -> None:
+        self._exchange()
+
+    def _do_unload(self, working_slot: GridSlot) -> None:
+        self._exchange()
+
+    def _exchange(self) -> None:
+        if self.fail_next_exchange:
+            self.fail_next_exchange = False
+            raise GridExchangeError("Simulated autoloader exchange failure.")
+        if self.exchange_delay > 0:
+            time.sleep(self.exchange_delay)
+
+
+def _slot_name(index: int) -> str:
+    return f"Slot-{index + 1:02d}"
 
 
 class Stage:
@@ -262,6 +464,8 @@ class Stage:
             return None
         stage_position = self.parent._stage_position
         for slot in self.holder.slots.values():
+            if slot.position is None:
+                continue
             if stage_position.is_close2(
                 slot.position, tol=GRID_RADIUS, axes=["x", "y"]
             ):
@@ -273,6 +477,39 @@ class Stage:
         """Get the loaded SampleGrid at the current slot, if any."""
         slot = self.current_slot
         return slot.loaded_grid if slot is not None else None
+
+    def grid_inventory(self) -> List[GridInventoryEntry]:
+        """Which grids exist this session, and which are in the beam. Derived, not stored.
+
+        With a loader the rows are the magazine slots and "in beam" means the grid is
+        in a holder working slot. Without one the rows are the holder slots, and every
+        present grid is in the beam, because reaching it is only a stage move. Callers
+        never need to know which case they got.
+        """
+        if self.loader is not None:
+            in_beam = {s.loaded_grid.name for s in self.holder.occupied_slots}
+            slots = sorted(self.loader.slots.values(), key=lambda s: s.index)
+            source = "magazine"
+        else:
+            in_beam = None
+            slots = sorted(self.holder.slots.values(), key=lambda s: s.index)
+            source = "holder"
+
+        entries: List[GridInventoryEntry] = []
+        for slot in slots:
+            grid = slot.loaded_grid
+            present = grid is not None
+            entries.append(
+                GridInventoryEntry(
+                    slot_name=slot.name,
+                    index=slot.index,
+                    source=source,
+                    name=grid.name if grid is not None else None,
+                    present=present,
+                    in_beam=present and (in_beam is None or grid.name in in_beam),  # type: ignore[union-attr]
+                )
+            )
+        return entries
 
     @property
     def is_homed(self) -> bool:
@@ -341,7 +578,10 @@ def _create_sample_stage(microscope: "FibsemMicroscope") -> "Stage":
         holder = SampleHolder(
             name="CompuStage Holder", capacity=1, slots={"Slot-01": slot01}
         )
-        loader: Optional[SampleGridLoader] = SampleGridLoader(parent=microscope)
+        # The compustage is the autoloader stage, so it is also what says "this system
+        # has a loader". Which loader is the backend's call: the simulator builds one
+        # from its config, a real system wraps its autoloader.
+        loader: Optional[SampleGridLoader] = microscope._create_grid_loader()
     else:
         path = Path(SAMPLE_HOLDER_CONFIGURATION_PATH)
         if not path.exists():

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -1045,6 +1045,24 @@ class DemoMicroscope(FibsemMicroscope):
             return STAGE_LIMITS_COMPUSTAGE
         return STAGE_LIMITS_DEFAULT
 
+    def _create_grid_loader(self) -> "DemoSampleLoader":
+        """An in-memory autoloader, populated from the ``sim.loader`` block.
+
+        Only reached on a compustage configuration (the Arctis simulator). Keys:
+        ``capacity`` (default 12), ``occupied`` (1-based slot numbers), ``names``
+        (slot number -> grid name), ``exchange_delay`` (seconds, default 0).
+        """
+        from fibsem.microscopes._stage import DemoSampleLoader
+
+        cfg = self.system.sim.get("loader") or {}
+        return DemoSampleLoader(
+            parent=self,
+            capacity=int(cfg.get("capacity", 12)),
+            occupied=cfg.get("occupied") or (),
+            names=cfg.get("names") or {},
+            exchange_delay=float(cfg.get("exchange_delay", 0.0)),
+        )
+
     def move_stage_absolute(self, position: FibsemStagePosition) -> FibsemStagePosition:
         """Move the stage to the specified position."""
         # Before the position is assigned, not after: a stage that is moving has not

--- a/tests/test_grid_inventory.py
+++ b/tests/test_grid_inventory.py
@@ -1,0 +1,281 @@
+"""The loader magazine, the Demo autoloader, and ``Stage.grid_inventory()``.
+
+Two hardware shapes, one query. On a compustage the inventory is the loader's
+magazine and "in beam" is whichever grid sits in the holder's working slot; on a
+fixed holder the inventory is the holder itself and every present grid is in the
+beam. Nothing here is cached: every answer is re-derived from the slots.
+"""
+
+import pytest
+
+from fibsem import utils
+from fibsem.microscopes._stage import (
+    DemoSampleLoader,
+    GridExchangeError,
+    GridSlot,
+    SampleGrid,
+    SampleGridLoader,
+    _create_sample_stage,
+)
+from fibsem.structures import FibsemStagePosition
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _compustage_demo():
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    microscope.stage_is_compustage = True
+    microscope._stage = _create_sample_stage(microscope)
+    return microscope
+
+
+def _fixed_demo():
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    microscope.stage_is_compustage = False
+    microscope._stage = _create_sample_stage(microscope)
+    for slot in microscope._stage.holder.slots.values():
+        slot.loaded_grid = None
+    return microscope
+
+
+def _with_magazine(microscope, occupied=(1, 2, 5), names=None) -> DemoSampleLoader:
+    loader = DemoSampleLoader(microscope, capacity=12, occupied=occupied, names=names)
+    microscope._stage.loader = loader
+    return loader
+
+
+def _entry(microscope, slot_name):
+    return next(
+        e for e in microscope._stage.grid_inventory() if e.slot_name == slot_name
+    )
+
+
+# ---------------------------------------------------------------------------
+# GridSlot: magazine slots have no position
+# ---------------------------------------------------------------------------
+
+
+class TestGridSlotPosition:
+    def test_position_is_optional(self):
+        slot = GridSlot(name="Slot-01", index=0)
+        assert slot.position is None
+
+    def test_roundtrip_without_position(self):
+        slot = GridSlot(name="Slot-03", index=2, loaded_grid=SampleGrid(name="g"))
+        again = GridSlot.from_dict(slot.to_dict())
+        assert again.position is None
+        assert again.loaded_grid.name == "g"
+
+    def test_roundtrip_with_position_still_names_it(self):
+        slot = GridSlot(
+            name="Slot-01", index=0, position=FibsemStagePosition(x=1e-3, y=0, z=0)
+        )
+        again = GridSlot.from_dict(slot.to_dict())
+        assert again.position.name == "Slot-01"
+
+
+# ---------------------------------------------------------------------------
+# The magazine
+# ---------------------------------------------------------------------------
+
+
+class TestMagazine:
+    def test_capacity_slots_without_positions(self):
+        microscope = _compustage_demo()
+        loader = SampleGridLoader(microscope, capacity=4)
+        assert list(loader.slots) == ["Slot-01", "Slot-02", "Slot-03", "Slot-04"]
+        assert all(s.position is None for s in loader.slots.values())
+        assert loader.loaded_magazine_slots == []
+
+    def test_demo_occupancy_and_default_names(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope, occupied=(1, 2, 5), names={2: "grid-birch"})
+        names = {s.name: s.loaded_grid.name for s in loader.loaded_magazine_slots}
+        assert names == {
+            "Slot-01": "Grid-01",
+            "Slot-02": "grid-birch",
+            "Slot-05": "Grid-05",
+        }
+        assert loader.slots["Slot-03"].loaded_grid is None
+
+    def test_demo_names_accept_string_keys_as_yaml_gives_them(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope, occupied=(7,), names={"7": "grid-fir"})
+        assert loader.slots["Slot-07"].loaded_grid.name == "grid-fir"
+
+    def test_demo_occupied_outside_capacity_refused(self):
+        microscope = _compustage_demo()
+        with pytest.raises(ValueError):
+            DemoSampleLoader(microscope, capacity=4, occupied=(5,))
+
+    def test_run_inventory_reports_occupied_slots(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        assert [s.name for s in loader.run_inventory()] == [
+            "Slot-01",
+            "Slot-02",
+            "Slot-05",
+        ]
+
+    def test_assign_and_find_grid(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        loader.assign_grid("Slot-03", SampleGrid(name="grid-cedar"))
+        assert loader.find_grid("grid-cedar") is loader.slots["Slot-03"]
+        loader.assign_grid("Slot-03", None)
+        assert loader.find_grid("grid-cedar") is None
+
+    def test_assign_to_unknown_slot_raises(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        with pytest.raises(GridExchangeError):
+            loader.assign_grid("Slot-99", SampleGrid(name="x"))
+
+
+# ---------------------------------------------------------------------------
+# Exchange: magazine <-> working slot
+# ---------------------------------------------------------------------------
+
+
+class TestExchange:
+    def test_load_puts_the_same_grid_object_in_the_working_slot(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        grid = loader.load_grid("Slot-02")
+        working = microscope._stage.holder.slots["Slot-01"]
+        assert working.loaded_grid is grid
+        # the magazine slot is the grid's home; it keeps the grid while it is in the beam
+        assert loader.slots["Slot-02"].loaded_grid is grid
+
+    def test_load_another_grid_exchanges(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        loader.load_grid("Slot-01")
+        loader.load_grid("Slot-05")
+        working = microscope._stage.holder.slots["Slot-01"]
+        assert working.loaded_grid.name == "Grid-05"
+        assert loader.slots["Slot-01"].loaded_grid.name == "Grid-01"  # still present
+
+    def test_load_same_grid_is_a_noop(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        loader.load_grid("Slot-02")
+        loader.fail_next_exchange = True  # would raise if an exchange happened
+        loader.load_grid("Slot-02")
+        assert loader.fail_next_exchange is True
+
+    def test_unload_clears_the_working_slot(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        loader.load_grid("Slot-02")
+        loader.unload_grid()
+        assert microscope._stage.holder.slots["Slot-01"].loaded_grid is None
+        assert loader.slots["Slot-02"].loaded_grid is not None
+
+    def test_unload_when_empty_is_a_noop(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        loader.fail_next_exchange = True
+        loader.unload_grid()
+        assert loader.fail_next_exchange is True
+
+    def test_load_empty_slot_raises(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        with pytest.raises(GridExchangeError):
+            loader.load_grid("Slot-03")
+
+    def test_failed_exchange_raises_and_leaves_state_untouched(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        loader.load_grid("Slot-01")
+        loader.fail_next_exchange = True
+        with pytest.raises(GridExchangeError):
+            loader.load_grid("Slot-02")
+        working = microscope._stage.holder.slots["Slot-01"]
+        # the unload half of the exchange failed, so Grid-01 is still in the beam
+        assert working.loaded_grid.name == "Grid-01"
+        assert loader.fail_next_exchange is False
+
+
+# ---------------------------------------------------------------------------
+# Stage.grid_inventory()
+# ---------------------------------------------------------------------------
+
+
+class TestInventoryWithLoader:
+    def test_one_row_per_magazine_slot(self):
+        microscope = _compustage_demo()
+        _with_magazine(microscope)
+        rows = microscope._stage.grid_inventory()
+        assert len(rows) == 12
+        assert {r.source for r in rows} == {"magazine"}
+        assert [r.slot_name for r in rows[:3]] == ["Slot-01", "Slot-02", "Slot-03"]
+
+    def test_present_and_in_beam_are_separate(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        loader.load_grid("Slot-02")
+        one, two, three = (_entry(microscope, f"Slot-0{i}") for i in (1, 2, 3))
+        assert (one.present, one.in_beam) == (True, False)
+        assert (two.present, two.in_beam) == (True, True)
+        assert (three.present, three.in_beam, three.name) == (False, False, None)
+
+    def test_in_beam_follows_the_holder_not_a_cache(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        loader.load_grid("Slot-02")
+        # an operator hand-loads something else: the inventory must say so
+        microscope._stage.holder.slots["Slot-01"].loaded_grid = loader.slots[
+            "Slot-05"
+        ].loaded_grid
+        assert _entry(microscope, "Slot-02").in_beam is False
+        assert _entry(microscope, "Slot-05").in_beam is True
+
+
+class TestInventoryOnFixedHolder:
+    def test_rows_are_holder_slots_and_present_means_in_beam(self):
+        microscope = _fixed_demo()
+        holder = microscope._stage.holder
+        holder.slots["Slot-01"].loaded_grid = SampleGrid(name="grid-aspen")
+        rows = microscope._stage.grid_inventory()
+        assert len(rows) == len(holder.slots)
+        assert {r.source for r in rows} == {"holder"}
+        first = _entry(microscope, "Slot-01")
+        assert (first.name, first.present, first.in_beam) == ("grid-aspen", True, True)
+        second = _entry(microscope, "Slot-02")
+        assert (second.name, second.present, second.in_beam) == (None, False, False)
+
+
+# ---------------------------------------------------------------------------
+# _create_sample_stage wires the right loader
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSampleStage:
+    def test_compustage_demo_builds_the_loader_from_sim_config(self):
+        microscope, _ = utils.setup_session(manufacturer="Demo")
+        microscope.stage_is_compustage = True
+        # a copy, not a mutation: `system.sim` may be shared with other sessions
+        microscope.system.sim = dict(
+            microscope.system.sim,
+            loader={"capacity": 6, "occupied": [1, 4], "names": {4: "grid-elm"}},
+        )
+        stage = _create_sample_stage(microscope)
+        assert isinstance(stage.loader, DemoSampleLoader)
+        assert stage.loader.capacity == 6
+        assert [s.loaded_grid.name for s in stage.loader.loaded_magazine_slots] == [
+            "Grid-01",
+            "grid-elm",
+        ]
+
+    def test_compustage_demo_without_loader_block_has_an_empty_magazine(self):
+        microscope = _compustage_demo()
+        assert isinstance(microscope._stage.loader, DemoSampleLoader)
+        assert microscope._stage.loader.loaded_magazine_slots == []
+
+    def test_fixed_holder_has_no_loader(self):
+        microscope = _fixed_demo()
+        assert microscope._stage.loader is None


### PR DESCRIPTION
## Summary

First PR of the Grid Workflow (screening) project, milestone 1. Gives the grid loader a magazine, adds the Demo autoloader for the Arctis simulator, and adds the one inventory query the workflow layer will read.

- **`SampleGridLoader` owns a magazine** — its own storage slots (no stage position), filled by hand, distinct from the holder's working slot. `load_grid(slot_name)` moves a grid from a magazine slot into the working slot (emptying it first), `unload_grid()` retracts it, `assign_grid` / `find_grid` / `run_inventory` manage the magazine. Hardware talks through four hooks (`_do_load`, `_do_unload`, `_scan_magazine`, `_write_slot_description`); the base class is the in-memory model.
- A magazine slot **keeps its grid while that grid is in the beam** — the slot is the grid's home and the working slot references the same `SampleGrid`. So *present* is read from the magazine and *in beam* from the holder (`SampleHolder.occupied_slots`), never from a cache.
- **`Stage.grid_inventory()`** — one row per magazine slot (with a loader) or per holder slot (without), each with `present` and `in_beam` kept apart. On a fixed holder every present grid is in the beam. Callers never branch on hardware shape.
- **`DemoSampleLoader`** — built from a `sim.loader` block (`capacity`, 1-based `occupied`, `names`; unnamed slots read as `Grid-NN`). `fail_next_exchange` makes the next exchange raise `GridExchangeError` and leave state untouched, so the run loop's load-failure path can be exercised. The Arctis sim config now ships three occupied slots.
- Which loader a compustage system gets is the backend's call via `FibsemMicroscope._create_grid_loader()` (Demo overrides it; a real autoloader driver follows in a later PR). Per the design decision, the compustage flag is what says "this system has a loader".
- `GridSlot.position` becomes optional (magazine slots have none); `current_slot` skips positionless slots.

No callers of the old `load_grid(slot, grid)` signature existed outside `_stage.py`.

## Tests

`tests/test_grid_inventory.py` (new, 22 tests): magazine construction, Demo occupancy and default names, assign/find, load/exchange/unload/no-op, failure leaves state untouched, inventory on both hardware shapes, in-beam follows the holder rather than a cache, `_create_sample_stage` wiring from sim config. `tests/test_sample_holder.py` still passes. Smoke-ran the Arctis sim config end to end: inventory shows three grids, `load_grid("Slot-02")` puts Grid-02 in the beam.

Not touched: FIB-242 (compustage state leaking across tests). The new tests set the flag on the instance and rebuild the stage explicitly, like the existing ones.

## Refs

Part of FIB-883 (Grid Workflow, milestone 1). Design: the Linear project description.
