### PR TITLE
[stage] ensure_loaded / unload: the one "make reachable" primitive

### DIFF
--- a/fibsem/microscopes/_stage.py
+++ b/fibsem/microscopes/_stage.py
@@ -561,8 +561,54 @@ class Stage:
         return self.parent.move_to_orientation(orientation)
 
     def move_to_grid(self, grid_name: str) -> FibsemStagePosition:
-        """Alias for move_to_slot for backward compatibility."""
-        return self.move_to_slot(grid_name)
+        """Move the stage to the holder slot that holds this grid."""
+        slot = self.holder.find_slot_by_grid_name(grid_name)
+        if slot is None:
+            raise ValueError(f"Grid '{grid_name}' is not in any holder slot.")
+        return self.move_to_slot(slot.name)
+
+    # -- the one "make reachable" primitive --------------------------------
+
+    @property
+    def loaded_grids(self) -> List[SampleGrid]:
+        """The grids in the beam right now, read from the holder every time."""
+        return [s.loaded_grid for s in self.holder.occupied_slots]  # type: ignore[misc]
+
+    def ensure_loaded(self, grid_name: str) -> GridSlot:
+        """Make a grid reachable, and return the working slot it occupies.
+
+        A no-op when the grid is already in a working slot. With a loader it is a
+        magazine exchange (the current grid is retracted first); without one every
+        present grid already sits in a holder slot, so there is nothing to do but
+        confirm it is there. Raises ``GridExchangeError`` when the grid is not in the
+        inventory or the hardware refuses.
+
+        This does not move the stage: how the grid gets under the beam is the
+        hardware's business, and where on the grid to go is the caller's. Follow it
+        with ``move_to_slot(slot.name)`` (or a task's own positioning).
+        """
+        working = self.holder.find_slot_by_grid_name(grid_name)
+        if working is not None:
+            return working
+        if self.loader is None:
+            raise GridExchangeError(
+                f"Grid '{grid_name}' is not in any holder slot. Place it in the "
+                "holder and update the sample holder configuration."
+            )
+        home = self.loader.find_grid(grid_name)
+        if home is None:
+            raise GridExchangeError(
+                f"Grid '{grid_name}' is not in the magazine. Run an inventory."
+            )
+        self.loader.load_grid(home.name)
+        return self.loader.working_slot
+
+    def unload(self) -> None:
+        """Retract the working slot. Nothing to do on a fixed holder."""
+        if self.loader is None:
+            logging.debug("No loader: nothing to unload from a fixed holder.")
+            return
+        self.loader.unload_grid()
 
 
 def _create_sample_stage(microscope: "FibsemMicroscope") -> "Stage":

--- a/tests/test_grid_inventory.py
+++ b/tests/test_grid_inventory.py
@@ -279,3 +279,92 @@ class TestCreateSampleStage:
     def test_fixed_holder_has_no_loader(self):
         microscope = _fixed_demo()
         assert microscope._stage.loader is None
+
+
+# ---------------------------------------------------------------------------
+# Stage.ensure_loaded / unload: the one "make reachable" primitive
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureLoadedWithLoader:
+    def test_exchange_when_not_in_beam(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope, names={2: "grid-birch"})
+        slot = microscope._stage.ensure_loaded("grid-birch")
+        assert slot is loader.working_slot
+        assert slot.loaded_grid.name == "grid-birch"
+        assert [g.name for g in microscope._stage.loaded_grids] == ["grid-birch"]
+
+    def test_noop_when_already_in_beam(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope, names={2: "grid-birch"})
+        microscope._stage.ensure_loaded("grid-birch")
+        loader.fail_next_exchange = True  # would raise if anything moved
+        microscope._stage.ensure_loaded("grid-birch")
+        assert loader.fail_next_exchange is True
+
+    def test_unknown_grid_raises(self):
+        microscope = _compustage_demo()
+        _with_magazine(microscope)
+        with pytest.raises(GridExchangeError, match="not in the magazine"):
+            microscope._stage.ensure_loaded("grid-nowhere")
+
+    def test_hardware_failure_propagates(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        loader.fail_next_exchange = True
+        with pytest.raises(GridExchangeError):
+            microscope._stage.ensure_loaded("Grid-01")
+        assert microscope._stage.loaded_grids == []
+
+    def test_does_not_move_the_stage(self):
+        microscope = _compustage_demo()
+        _with_magazine(microscope)
+        before = microscope.get_stage_position()
+        microscope._stage.ensure_loaded("Grid-01")
+        assert microscope.get_stage_position().is_close2(before, tol=1e-9)
+
+    def test_unload_retracts(self):
+        microscope = _compustage_demo()
+        _with_magazine(microscope)
+        microscope._stage.ensure_loaded("Grid-01")
+        microscope._stage.unload()
+        assert microscope._stage.loaded_grids == []
+
+
+class TestEnsureLoadedOnFixedHolder:
+    def test_present_grid_is_already_reachable(self):
+        microscope = _fixed_demo()
+        holder = microscope._stage.holder
+        holder.slots["Slot-02"].loaded_grid = SampleGrid(name="grid-aspen")
+        before = microscope.get_stage_position()
+        slot = microscope._stage.ensure_loaded("grid-aspen")
+        assert slot is holder.slots["Slot-02"]
+        assert microscope.get_stage_position().is_close2(before, tol=1e-9)
+
+    def test_absent_grid_raises_with_a_manual_instruction(self):
+        microscope = _fixed_demo()
+        with pytest.raises(GridExchangeError, match="Place it in the holder"):
+            microscope._stage.ensure_loaded("grid-aspen")
+
+    def test_unload_is_a_noop(self):
+        microscope = _fixed_demo()
+        microscope._stage.holder.slots["Slot-01"].loaded_grid = SampleGrid(name="g")
+        microscope._stage.unload()
+        assert microscope._stage.holder.slots["Slot-01"].loaded_grid is not None
+
+    def test_move_to_grid_resolves_the_slot(self):
+        microscope = _fixed_demo()
+        holder = microscope._stage.holder
+        holder.slots["Slot-02"].loaded_grid = SampleGrid(name="grid-aspen")
+        holder.slots["Slot-02"].position = FibsemStagePosition(
+            name="Slot-02", x=3e-3, y=-2e-3, z=4e-3, r=0.0, t=0.0
+        )
+        microscope._stage.move_to_grid("grid-aspen")
+        pos = microscope.get_stage_position()
+        assert abs(pos.x - 3e-3) < 1e-9 and abs(pos.y + 2e-3) < 1e-9
+
+    def test_move_to_grid_unknown_raises(self):
+        microscope = _fixed_demo()
+        with pytest.raises(ValueError):
+            microscope._stage.move_to_grid("grid-nowhere")


### PR DESCRIPTION
## Summary

Stacked on #724. Adds the one "make reachable" primitive the grid workflow will call, so no caller ever branches on loader-vs-fixed-holder.

- **`Stage.ensure_loaded(grid_name) -> GridSlot`** — no-op when the grid is already in a working slot; with a loader, a magazine exchange (the current grid is retracted first); on a fixed holder, every present grid already sits in a slot, so an absent grid is a `GridExchangeError` carrying a "place it in the holder" instruction rather than a silent no-op. Hardware failures propagate as `GridExchangeError` and leave state untouched.
- **It does not move the stage.** How the grid gets under the beam is the hardware's business; where on the grid to go is the caller's. A task follows it with `move_to_slot(slot.name)` or its own positioning. (FIB-885's text said "a stage move on a fixed holder"; this is the cleaner contract and the issue is updated to match.)
- **`Stage.unload()`** — retracts the working slot; no-op without a loader.
- **`Stage.loaded_grids`** — the grids in the beam, read from the holder every call.
- **`move_to_grid`** now resolves the grid's slot instead of treating the grid name as a slot name (it was an alias to `move_to_slot`, which only worked when the two names coincided).

## Tests

11 new tests in `tests/test_grid_inventory.py`: exchange when not in beam, no-op when in beam (a failure switch that would fire proves nothing moved), unknown grid, hardware failure propagates with state untouched, the stage does not move, unload; and on a fixed holder: present grid is reachable without moving, absent grid raises with the manual instruction, unload is a no-op, `move_to_grid` resolves the slot and rejects unknown grids.

## Refs

Closes FIB-885 (Grid Workflow, milestone 1).
