### PR TITLE
[stage] assign_grid / run_inventory on a fixed holder

### DIFF
--- a/fibsem/microscopes/_stage.py
+++ b/fibsem/microscopes/_stage.py
@@ -610,6 +610,38 @@ class Stage:
             return
         self.loader.unload_grid()
 
+    # -- naming and refreshing the inventory, on either shape --------------
+
+    def run_inventory(self) -> List[GridInventoryEntry]:
+        """Refresh what the hardware knows and return the inventory.
+
+        A magazine scan with a loader. On a fixed holder there is nothing to scan:
+        occupancy is what the operator declared, so this is a plain refresh.
+        """
+        if self.loader is not None:
+            self.loader.run_inventory()
+        return self.grid_inventory()
+
+    def assign_grid(
+        self, slot_name: str, grid: Optional[SampleGrid], persist: bool = True
+    ) -> None:
+        """Name (or clear) the grid in an inventory slot, and keep it.
+
+        With a loader the slot is a magazine slot and the name goes to the hardware's
+        slot description. On a fixed holder the slot is a holder slot and the name is
+        saved to the sample holder configuration, so it is there next session. Pass
+        ``persist=False`` to change only the in-memory holder.
+        """
+        if self.loader is not None:
+            self.loader.assign_grid(slot_name, grid)
+            return
+        slot = self.holder.slots.get(slot_name)
+        if slot is None:
+            raise ValueError(f"Slot '{slot_name}' not found in sample holder.")
+        slot.loaded_grid = grid
+        if persist:
+            self.holder.save(SAMPLE_HOLDER_CONFIGURATION_PATH)
+
 
 def _create_sample_stage(microscope: "FibsemMicroscope") -> "Stage":
 

--- a/tests/test_grid_inventory.py
+++ b/tests/test_grid_inventory.py
@@ -368,3 +368,76 @@ class TestEnsureLoadedOnFixedHolder:
         microscope = _fixed_demo()
         with pytest.raises(ValueError):
             microscope._stage.move_to_grid("grid-nowhere")
+
+
+# ---------------------------------------------------------------------------
+# Stage.assign_grid / run_inventory: naming on either shape
+# ---------------------------------------------------------------------------
+
+
+class TestAssignGrid:
+    def test_with_loader_names_the_magazine_slot(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        microscope._stage.assign_grid("Slot-03", SampleGrid(name="grid-cedar"))
+        assert loader.slots["Slot-03"].loaded_grid.name == "grid-cedar"
+        assert _entry(microscope, "Slot-03").present is True
+
+    def test_on_fixed_holder_names_the_slot_and_saves_the_config(
+        self, tmp_path, monkeypatch
+    ):
+        import fibsem.microscopes._stage as stage_module
+
+        path = tmp_path / "holder.yaml"
+        monkeypatch.setattr(stage_module, "SAMPLE_HOLDER_CONFIGURATION_PATH", str(path))
+        microscope = _fixed_demo()
+        microscope._stage.assign_grid("Slot-02", SampleGrid(name="grid-birch"))
+        assert _entry(microscope, "Slot-02").name == "grid-birch"
+        from fibsem.microscopes._stage import SampleHolder
+
+        assert SampleHolder.load(path).slots["Slot-02"].loaded_grid.name == "grid-birch"
+
+    def test_on_fixed_holder_can_skip_persisting(self, tmp_path, monkeypatch):
+        import fibsem.microscopes._stage as stage_module
+
+        path = tmp_path / "holder.yaml"
+        monkeypatch.setattr(stage_module, "SAMPLE_HOLDER_CONFIGURATION_PATH", str(path))
+        microscope = _fixed_demo()
+        microscope._stage.assign_grid("Slot-01", SampleGrid(name="g"), persist=False)
+        assert not path.exists()
+
+    def test_on_fixed_holder_clearing_persists_too(self, tmp_path, monkeypatch):
+        import fibsem.microscopes._stage as stage_module
+
+        path = tmp_path / "holder.yaml"
+        monkeypatch.setattr(stage_module, "SAMPLE_HOLDER_CONFIGURATION_PATH", str(path))
+        microscope = _fixed_demo()
+        microscope._stage.assign_grid("Slot-01", SampleGrid(name="g"))
+        microscope._stage.assign_grid("Slot-01", None)
+        from fibsem.microscopes._stage import SampleHolder
+
+        assert SampleHolder.load(path).slots["Slot-01"].loaded_grid is None
+
+    def test_unknown_holder_slot_raises(self):
+        microscope = _fixed_demo()
+        with pytest.raises(ValueError):
+            microscope._stage.assign_grid(
+                "Slot-99", SampleGrid(name="g"), persist=False
+            )
+
+
+class TestRunInventory:
+    def test_with_loader_scans_and_returns_rows(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        scanned = []
+        loader._scan_magazine = lambda: scanned.append(True)  # type: ignore[assignment]
+        rows = microscope._stage.run_inventory()
+        assert scanned == [True]
+        assert [r.name for r in rows if r.present] == ["Grid-01", "Grid-02", "Grid-05"]
+
+    def test_on_fixed_holder_is_a_refresh(self):
+        microscope = _fixed_demo()
+        microscope._stage.holder.slots["Slot-01"].loaded_grid = SampleGrid(name="g")
+        rows = microscope._stage.run_inventory()
+        assert [r.name for r in rows if r.present] == ["g"]


### PR DESCRIPTION
## Summary

Stacked on #725. Small: the fixed-holder half of the inventory, so that naming a grid and refreshing the inventory are one gesture on both hardware shapes.

- **`Stage.assign_grid(slot_name, grid, persist=True)`** — with a loader, names a magazine slot (and, once the AutoScript driver lands, the hardware's slot description); on a fixed holder, names a holder slot and saves `sample-holder.yaml` so it is there next session. `persist=False` for in-memory-only changes.
- **`Stage.run_inventory()`** — a magazine scan with a loader; a plain refresh on a fixed holder, where occupancy is whatever the operator declared. Returns the same rows as `grid_inventory()`.

The holder already serialised which grid sits in each slot, so most of FIB-884 was already true; this is the entry point the Grids tab and the Sample sub-tab will call without branching on hardware.

## Tests

7 new tests: naming a magazine slot; naming a holder slot writes the config (path monkeypatched, so the real `sample-holder.yaml` is untouched); `persist=False` writes nothing; clearing persists; unknown slot raises; `run_inventory` scans with a loader and refreshes without one.

## Refs

Closes FIB-884 (Grid Workflow, milestone 1).
