### PR TITLE
[autoscript] AutoscriptSampleLoader: the Arctis autoloader as a grid loader

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -321,8 +321,11 @@ class FibsemMicroscope(ABC):
 
         self._stage = _create_sample_stage(self)
 
-    def _create_grid_loader(self) -> "SampleGridLoader":
-        """The grid loader for a compustage system. Backends wrap their own hardware."""
+    def _create_grid_loader(self) -> Optional["SampleGridLoader"]:
+        """The grid loader for a compustage system, or None when it has no autoloader.
+
+        Backends wrap their own hardware; this default is the in-memory model.
+        """
         from fibsem.microscopes._stage import SampleGridLoader
 
         return SampleGridLoader(parent=self)
@@ -3007,6 +3010,22 @@ class ThermoMicroscope(FibsemMicroscope):
             self._create_sample_stage()
         except Exception as e:
             logging.warning(f"Could not create sample stage: {e}")
+
+    def _create_grid_loader(self) -> Optional["SampleGridLoader"]:
+        """The AutoScript autoloader, when the microscope has one.
+
+        A compustage without an autoloader gets no loader at all: its grids are
+        exchanged by hand, and a phantom twelve-slot magazine would only mislead.
+        """
+        from fibsem.microscopes.autoscript import AutoscriptSampleLoader
+
+        loader = AutoscriptSampleLoader(parent=self)
+        if not loader.is_installed:
+            logging.info(
+                "Compustage without an autoloader: grids are exchanged by hand."
+            )
+            return None
+        return loader
 
     def set_channel(self, channel: BeamType) -> None:
         """

--- a/fibsem/microscopes/autoscript.py
+++ b/fibsem/microscopes/autoscript.py
@@ -3,12 +3,22 @@
 This module contains all ThermoFisher AutoScript-specific conversion functions,
 isolated from the general fibsem data structures.
 """
+
 from __future__ import annotations
 
+import logging
 import sys
 from typing import TYPE_CHECKING, Optional, Union
 
-from fibsem.microscopes._stage import SampleGridLoader, SampleHolder, Stage
+from fibsem.microscopes._stage import (
+    GridExchangeError,
+    GridSlot,
+    SampleGrid,
+    SampleGridLoader,
+    SampleHolder,
+    Stage,
+    _slot_name,
+)
 
 if TYPE_CHECKING:
     from fibsem.microscope import ThermoMicroscope
@@ -25,7 +35,9 @@ THERMO_API_AVAILABLE = False
 
 try:
     sys.path.append(r"C:\Program Files\Thermo Scientific AutoScript")
-    sys.path.append(r"C:\Program Files\Enthought\Python\envs\AutoScript\Lib\site-packages")
+    sys.path.append(
+        r"C:\Program Files\Enthought\Python\envs\AutoScript\Lib\site-packages"
+    )
     sys.path.append(r"C:\Program Files\Python36\envs\AutoScript")
     sys.path.append(r"C:\Program Files\Python36\envs\AutoScript\Lib\site-packages")
     from autoscript_sdb_microscope_client.enumerations import CoordinateSystem
@@ -35,6 +47,7 @@ try:
         ManipulatorPosition,
         StagePosition,
     )
+
     THERMO_API_AVAILABLE = True
 except ImportError:
     pass
@@ -56,7 +69,9 @@ def stage_position_to_autoscript(
         ImportError: If AutoScript libraries are not available.
     """
     if not THERMO_API_AVAILABLE:
-        raise ImportError("AutoScript libraries not available. Cannot convert to AutoScript position.")
+        raise ImportError(
+            "AutoScript libraries not available. Cannot convert to AutoScript position."
+        )
 
     if compustage:
         return CompustagePosition(
@@ -92,7 +107,9 @@ def stage_position_from_autoscript(
         ImportError: If AutoScript libraries are not available.
     """
     if not THERMO_API_AVAILABLE:
-        raise ImportError("AutoScript libraries not available. Cannot convert from AutoScript position.")
+        raise ImportError(
+            "AutoScript libraries not available. Cannot convert from AutoScript position."
+        )
 
     from fibsem.structures import FibsemStagePosition
 
@@ -131,7 +148,9 @@ def manipulator_position_to_autoscript(
         ImportError: If AutoScript libraries are not available.
     """
     if not THERMO_API_AVAILABLE:
-        raise ImportError("AutoScript libraries not available. Cannot convert to AutoScript position.")
+        raise ImportError(
+            "AutoScript libraries not available. Cannot convert to AutoScript position."
+        )
 
     if position.coordinate_system == "RAW":
         coordinate_system = "Raw"
@@ -164,7 +183,9 @@ def manipulator_position_from_autoscript(
         ImportError: If AutoScript libraries are not available.
     """
     if not THERMO_API_AVAILABLE:
-        raise ImportError("AutoScript libraries not available. Cannot convert from AutoScript position.")
+        raise ImportError(
+            "AutoScript libraries not available. Cannot convert from AutoScript position."
+        )
 
     from fibsem.structures import FibsemManipulatorPosition
 
@@ -193,7 +214,9 @@ def image_settings_from_adorned_image(
         ImportError: If AutoScript libraries are not available.
     """
     if not THERMO_API_AVAILABLE:
-        raise ImportError("AutoScript libraries not available. Cannot convert from AdornedImage.")
+        raise ImportError(
+            "AutoScript libraries not available. Cannot convert from AdornedImage."
+        )
 
     from fibsem.structures import BeamType, ImageSettings
     from fibsem.utils import current_timestamp
@@ -235,7 +258,9 @@ def fibsem_image_from_adorned_image(
         ImportError: If AutoScript libraries are not available.
     """
     if not THERMO_API_AVAILABLE:
-        raise ImportError("AutoScript libraries not available. Cannot convert from AdornedImage.")
+        raise ImportError(
+            "AutoScript libraries not available. Cannot convert from AdornedImage."
+        )
 
     from fibsem.structures import (
         BeamSettings,
@@ -306,13 +331,19 @@ class AutoscriptManipulator:
         """Retract the manipulator."""
         self.parent.retract_manipulator()
 
-    def move_absolute(self, position: FibsemManipulatorPosition) -> FibsemManipulatorPosition:
+    def move_absolute(
+        self, position: FibsemManipulatorPosition
+    ) -> FibsemManipulatorPosition:
         pass
 
-    def move_relative(self, position: FibsemManipulatorPosition) -> FibsemManipulatorPosition:
+    def move_relative(
+        self, position: FibsemManipulatorPosition
+    ) -> FibsemManipulatorPosition:
         pass
 
-    def move_corrected(self, dx: float, dy: float, beam_type: BeamType) -> FibsemManipulatorPosition:
+    def move_corrected(
+        self, dx: float, dy: float, beam_type: BeamType
+    ) -> FibsemManipulatorPosition:
         pass
 
 
@@ -340,9 +371,125 @@ class AutoscriptCompustage(Stage):
         super().__init__(parent, holder, loader)
 
 
+class AutoscriptSampleLoader(SampleGridLoader):
+    """The AutoScript autoloader (Arctis, xT 28.x, AutoScript >= 4.10) as a grid loader.
+
+    Wraps ``connection.specimen.autoloader``. Magazine slots mirror ``get_slots()``
+    and are addressed by the 1-based ``AutoloaderSlot.id``; ``load(id)`` blocks until
+    the exchange is done and ``unload()`` takes nothing. Grid names live in each
+    slot's ``sample_description``, read on inventory and written back on rename.
+
+    Two things the hardware does that the in-memory model must absorb:
+
+    - A grid that is on the stage makes its magazine slot read ``Empty``. The slot
+      is still that grid's home, so a rescan keeps the grid there while our working
+      slot holds it, and the inventory keeps saying "present, in beam".
+    - ``get_slots(False)`` returns last-known states, which may all be ``Unknown``
+      before any scan. Then, and only then, ``get_slots(True)`` runs a physical scan.
+
+    Confirmed from operator code: the ``get_slots(bool)`` shape, the state strings,
+    ``load(id)`` / ``unload()``, and ``autoloader.stage`` reporting what is on the
+    microscope. Not verified on hardware: whether ``sample_description`` is writable
+    (a refusal is logged, not raised). The magazine is not queried on construction;
+    call ``run_inventory()``.
+    """
+
+    @property
+    def _autoloader(self):
+        return self.parent.connection.specimen.autoloader
+
+    @property
+    def is_installed(self) -> bool:
+        try:
+            return bool(self._autoloader.is_installed)
+        except Exception:  # noqa: BLE001 - device absent, or not ready
+            return False
+
+    # -- inventory -----------------------------------------------------------
+
+    def _scan_magazine(self) -> None:
+        hw_slots = list(self._autoloader.get_slots(False))
+        if hw_slots and all(_slot_state(s) == "Unknown" for s in hw_slots):
+            hw_slots = list(self._autoloader.get_slots(True))
+        if hw_slots:
+            self.capacity = len(hw_slots)
+
+        in_beam = {s.loaded_grid.name for s in self.holder.occupied_slots}
+        slots: dict = {}
+        for hw in hw_slots:
+            number = int(hw.id)
+            name = _slot_name(number - 1)
+            previous = self.slots.get(name)
+            state = _slot_state(hw)
+            grid: Optional[SampleGrid] = None
+            if state == "Occupied":
+                described = (getattr(hw, "sample_description", "") or "").strip()
+                grid_name = described or f"Grid-{number:02d}"
+                if previous is not None and previous.loaded_grid is not None:
+                    if previous.loaded_grid.name == grid_name:
+                        grid = previous.loaded_grid  # keep identity across scans
+                if grid is None:
+                    grid = SampleGrid(name=grid_name)
+            elif (
+                previous is not None
+                and previous.loaded_grid is not None
+                and previous.loaded_grid.name in in_beam
+            ):
+                grid = (
+                    previous.loaded_grid
+                )  # its home; it reads Empty while in the beam
+            elif state == "Unknown":
+                logging.warning(f"Autoloader slot {number} has not been scanned.")
+            slots[name] = GridSlot(name=name, index=number - 1, loaded_grid=grid)
+        self.slots = slots
+
+        # Something may be on the stage that we did not load: reflect the hardware.
+        stage = getattr(self._autoloader, "stage", None)
+        working = self.working_slot
+        if stage is not None:
+            if working.loaded_grid is None and _slot_state(stage) == "Occupied":
+                described = (getattr(stage, "sample_description", "") or "").strip()
+                working.loaded_grid = SampleGrid(name=described or "Grid-on-stage")
+            elif working.loaded_grid is not None and _slot_state(stage) == "Empty":
+                working.loaded_grid = None
+
+    def _write_slot_description(self, slot: GridSlot) -> None:
+        description = slot.loaded_grid.name if slot.loaded_grid is not None else ""
+        try:
+            for hw in self._autoloader.get_slots(False):
+                if int(hw.id) == slot.index + 1:
+                    hw.sample_description = description
+                    return
+            logging.warning(f"Autoloader reported no slot {slot.index + 1} to name.")
+        except Exception as e:  # noqa: BLE001 - not verified writable on hardware
+            logging.warning(f"Could not write the autoloader slot description: {e}")
+
+    # -- exchange ------------------------------------------------------------
+
+    def _do_load(self, slot: GridSlot) -> None:
+        try:
+            self._autoloader.load(slot.index + 1)
+        except Exception as e:
+            raise GridExchangeError(
+                f"Autoloader could not load {slot.name}: {e}"
+            ) from e
+
+    def _do_unload(self, working_slot: GridSlot) -> None:
+        try:
+            self._autoloader.unload()
+        except Exception as e:
+            raise GridExchangeError(f"Autoloader could not unload: {e}") from e
+
+
+def _slot_state(hw_slot) -> str:
+    """``AutoloaderSlot.state`` as a plain string; enum members stringify to it."""
+    state = getattr(hw_slot, "state", "Unknown")
+    text = str(state)
+    return text.rsplit(".", 1)[-1] if "." in text else text
+
+
 class AutoscriptSputterCoater:
     pass
-
 
 
 import time
@@ -355,9 +502,9 @@ from fibsem.structures import FibsemStagePosition
 
 class AutoscriptGISPort:
     port_name: str = "Pt dep"
-    zlimit: float = 4.0e-3 # RAW_COORDINATES
+    zlimit: float = 4.0e-3  # RAW_COORDINATES
 
-    def __init__(self, parent: 'ThermoMicroscope'):
+    def __init__(self, parent: "ThermoMicroscope"):
         self.parent = parent
 
         available_ports = self.parent.connection.gas.list_all_gis_ports()
@@ -376,13 +523,15 @@ class AutoscriptGISPort:
 
     def _move_to_safe_gis_position(self):
 
-        self.parent.move_stage_absolute(FibsemStagePosition(z=self.zlimit-500e-6))
+        self.parent.move_stage_absolute(FibsemStagePosition(z=self.zlimit - 500e-6))
 
     def _run_safety_check(self):
 
         stage_position = self.parent.get_stage_position()
         if stage_position.z > self.zlimit:
-            raise ValueError(f"Unable to insert gis at current z-position{stage_position.pretty}, {self.zlimit*1e3}mm")
+            raise ValueError(
+                f"Unable to insert gis at current z-position{stage_position.pretty}, {self.zlimit * 1e3}mm"
+            )
 
     def open(self):
         self._port.open()

--- a/tests/test_autoscript_sample_loader.py
+++ b/tests/test_autoscript_sample_loader.py
@@ -1,0 +1,257 @@
+"""``AutoscriptSampleLoader`` against a fake of the AutoScript autoloader API.
+
+The fake mirrors what operator code confirmed on an Arctis: ``get_slots(run_inventory)``
+returns ``AutoloaderSlot``-like objects with a 1-based ``id``, a ``state`` in
+``{"Unknown", "Occupied", "Empty"}`` and a ``sample_description``; ``load(id)``
+blocks; ``unload()`` takes nothing; ``stage`` reports what is on the microscope.
+Nothing here has run on hardware -- that is the Arctis bench issue.
+"""
+
+from typing import List, Optional
+
+import pytest
+
+from fibsem import utils
+from fibsem.microscopes._stage import (
+    GridExchangeError,
+    SampleGrid,
+    _create_sample_stage,
+)
+from fibsem.microscopes.autoscript import AutoscriptSampleLoader
+
+# ---------------------------------------------------------------------------
+# A fake autoloader, shaped like the vendor API
+# ---------------------------------------------------------------------------
+
+
+class FakeAutoloaderSlot:
+    def __init__(self, id: int, state: str = "Empty", sample_description: str = ""):
+        self.id = id
+        self.state = state
+        self.sample_description = sample_description
+
+
+class FakeAutoloaderStage:
+    def __init__(self) -> None:
+        self.sample_description = ""
+        self.state = "Empty"
+
+
+class FakeAutoloader:
+    """Twelve slots; loading moves a grid onto ``stage`` and empties its slot."""
+
+    def __init__(self, occupied: Optional[dict] = None, scanned: bool = True) -> None:
+        self.is_installed = True
+        self.stage = FakeAutoloaderStage()
+        self._slots: List[FakeAutoloaderSlot] = [
+            FakeAutoloaderSlot(i, "Empty" if scanned else "Unknown")
+            for i in range(1, 13)
+        ]
+        for number, name in (occupied or {}).items():
+            slot = self._slots[number - 1]
+            slot.state = "Occupied" if scanned else "Unknown"
+            slot.sample_description = name
+        self._pending_occupied = dict(occupied or {}) if not scanned else {}
+        self.calls: List[tuple] = []
+        self.fail_load = False
+        self._loaded_from: Optional[int] = None
+
+    def get_slots(self, run_inventory: bool) -> List[FakeAutoloaderSlot]:
+        self.calls.append(("get_slots", run_inventory))
+        if run_inventory:
+            for slot in self._slots:
+                if slot.state == "Unknown":
+                    slot.state = (
+                        "Occupied" if slot.id in self._pending_occupied else "Empty"
+                    )
+        return list(self._slots)
+
+    def load(self, grid_id: int) -> None:
+        self.calls.append(("load", grid_id))
+        if self.fail_load:
+            raise RuntimeError("Autoloader: gripper fault")
+        slot = self._slots[grid_id - 1]
+        self.stage.sample_description = slot.sample_description
+        self.stage.state = "Occupied"
+        slot.state = "Empty"  # what the hardware reports for a grid on the stage
+        self._loaded_from = grid_id
+
+    def unload(self) -> None:
+        self.calls.append(("unload",))
+        if self._loaded_from is not None:
+            self._slots[self._loaded_from - 1].state = "Occupied"
+        self.stage.sample_description = ""
+        self.stage.state = "Empty"
+        self._loaded_from = None
+
+
+class FakeSpecimen:
+    def __init__(self, autoloader: FakeAutoloader) -> None:
+        self.autoloader = autoloader
+
+
+class FakeConnection:
+    def __init__(self, autoloader: FakeAutoloader) -> None:
+        self.specimen = FakeSpecimen(autoloader)
+
+
+def _microscope_with(autoloader: FakeAutoloader):
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    microscope.stage_is_compustage = True
+    microscope._stage = _create_sample_stage(microscope)
+    microscope.connection = FakeConnection(autoloader)
+    loader = AutoscriptSampleLoader(parent=microscope)
+    microscope._stage.loader = loader
+    return microscope, loader
+
+
+# ---------------------------------------------------------------------------
+# Inventory
+# ---------------------------------------------------------------------------
+
+
+class TestInventory:
+    def test_mirrors_occupied_slots_and_names(self):
+        hw = FakeAutoloader(occupied={1: "grid-cedar", 3: "", 5: "grid-elm"})
+        microscope, loader = _microscope_with(hw)
+        slots = loader.run_inventory()
+        assert [s.name for s in slots] == ["Slot-01", "Slot-03", "Slot-05"]
+        names = {s.name: s.loaded_grid.name for s in slots}
+        # an occupied slot with a blank description gets the default name
+        assert names == {
+            "Slot-01": "grid-cedar",
+            "Slot-03": "Grid-03",
+            "Slot-05": "grid-elm",
+        }
+        assert loader.slots["Slot-02"].loaded_grid is None
+
+    def test_uses_last_known_states_unless_all_unknown(self):
+        hw = FakeAutoloader(occupied={2: "g"})
+        _, loader = _microscope_with(hw)
+        loader.run_inventory()
+        assert hw.calls == [("get_slots", False)]
+
+    def test_forces_a_scan_when_nothing_is_known(self):
+        hw = FakeAutoloader(occupied={2: "g"}, scanned=False)
+        _, loader = _microscope_with(hw)
+        slots = loader.run_inventory()
+        assert hw.calls == [("get_slots", False), ("get_slots", True)]
+        assert [s.name for s in slots] == ["Slot-02"]
+
+    def test_capacity_follows_the_hardware(self):
+        hw = FakeAutoloader()
+        hw._slots = hw._slots[:6]
+        _, loader = _microscope_with(hw)
+        loader.run_inventory()
+        assert loader.capacity == 6
+        assert list(loader.slots) == [f"Slot-{i:02d}" for i in range(1, 7)]
+
+    def test_a_grid_already_on_the_stage_is_reported_in_beam(self):
+        hw = FakeAutoloader(occupied={4: "grid-birch"})
+        hw.load(4)  # someone loaded it from the vendor UI before we connected
+        microscope, loader = _microscope_with(hw)
+        loader.run_inventory()
+        assert [g.name for g in microscope._stage.loaded_grids] == ["grid-birch"]
+
+    def test_inventory_rows_come_from_the_magazine(self):
+        hw = FakeAutoloader(occupied={1: "a", 2: "b"})
+        microscope, loader = _microscope_with(hw)
+        loader.run_inventory()
+        rows = microscope._stage.grid_inventory()
+        assert [r.name for r in rows if r.present] == ["a", "b"]
+        assert all(r.source == "magazine" for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Exchange
+# ---------------------------------------------------------------------------
+
+
+class TestExchange:
+    def test_load_calls_the_hardware_by_slot_id_and_fills_the_working_slot(self):
+        hw = FakeAutoloader(occupied={3: "grid-cedar"})
+        microscope, loader = _microscope_with(hw)
+        loader.run_inventory()
+        microscope._stage.ensure_loaded("grid-cedar")
+        assert ("load", 3) in hw.calls
+        assert microscope._stage.loaded_grids[0].name == "grid-cedar"
+        # the magazine slot stays the grid's home, whatever the hardware reads
+        assert loader.slots["Slot-03"].loaded_grid.name == "grid-cedar"
+
+    def test_the_home_slot_survives_a_rescan_while_loaded(self):
+        hw = FakeAutoloader(occupied={3: "grid-cedar", 4: "grid-elm"})
+        microscope, loader = _microscope_with(hw)
+        loader.run_inventory()
+        microscope._stage.ensure_loaded("grid-cedar")
+        loader.run_inventory()  # hardware now reads slot 3 as Empty
+        assert loader.slots["Slot-03"].loaded_grid.name == "grid-cedar"
+        assert microscope._stage.grid_inventory()[2].in_beam is True
+
+    def test_exchange_unloads_then_loads(self):
+        hw = FakeAutoloader(occupied={1: "a", 2: "b"})
+        microscope, loader = _microscope_with(hw)
+        loader.run_inventory()
+        microscope._stage.ensure_loaded("a")
+        microscope._stage.ensure_loaded("b")
+        assert hw.calls[-2:] == [("unload",), ("load", 2)]
+        assert microscope._stage.loaded_grids[0].name == "b"
+
+    def test_unload_calls_the_hardware(self):
+        hw = FakeAutoloader(occupied={1: "a"})
+        microscope, loader = _microscope_with(hw)
+        loader.run_inventory()
+        microscope._stage.ensure_loaded("a")
+        microscope._stage.unload()
+        assert hw.calls[-1] == ("unload",)
+        assert microscope._stage.loaded_grids == []
+
+    def test_hardware_failure_becomes_a_grid_exchange_error(self):
+        hw = FakeAutoloader(occupied={1: "a"})
+        microscope, loader = _microscope_with(hw)
+        loader.run_inventory()
+        hw.fail_load = True
+        with pytest.raises(GridExchangeError, match="gripper fault"):
+            microscope._stage.ensure_loaded("a")
+        assert microscope._stage.loaded_grids == []
+
+
+# ---------------------------------------------------------------------------
+# Naming writes back to the slot description
+# ---------------------------------------------------------------------------
+
+
+class TestNaming:
+    def test_assign_grid_writes_the_slot_description(self):
+        hw = FakeAutoloader(occupied={2: "Grid-02"})
+        microscope, loader = _microscope_with(hw)
+        loader.run_inventory()
+        microscope._stage.assign_grid("Slot-02", SampleGrid(name="grid-birch"))
+        assert hw._slots[1].sample_description == "grid-birch"
+        assert loader.find_grid("grid-birch") is loader.slots["Slot-02"]
+
+    def test_clearing_a_slot_clears_the_description(self):
+        hw = FakeAutoloader(occupied={2: "grid-birch"})
+        microscope, loader = _microscope_with(hw)
+        loader.run_inventory()
+        microscope._stage.assign_grid("Slot-02", None)
+        assert hw._slots[1].sample_description == ""
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+class TestIsInstalled:
+    def test_reports_the_hardware_flag(self):
+        hw = FakeAutoloader()
+        _, loader = _microscope_with(hw)
+        assert loader.is_installed is True
+        hw.is_installed = False
+        assert loader.is_installed is False
+
+    def test_absent_device_reads_as_not_installed(self):
+        microscope, _ = utils.setup_session(manufacturer="Demo")
+        microscope.connection = FakeConnection(FakeAutoloader())
+        del microscope.connection.specimen.autoloader
+        assert AutoscriptSampleLoader(parent=microscope).is_installed is False


### PR DESCRIPTION
## Summary

Stacked on #726. The real autoloader driver: `AutoscriptSampleLoader` maps `connection.specimen.autoloader` onto the loader's hardware hooks from #724.

- **Inventory** — `get_slots(False)` for last-known states; if every slot reads `Unknown`, `get_slots(True)` runs a physical scan. Magazine slots mirror the hardware by 1-based `id`; capacity follows the hardware. An occupied slot with a blank `sample_description` reads as `Grid-NN`.
- **A grid on the stage reads its magazine slot as `Empty`** (confirmed operator behaviour). The slot is still the grid's home, so a rescan keeps the grid there while our working slot holds it, and the inventory keeps saying present + in beam. A grid already on the stage at connect time is picked up from `autoloader.stage`.
- **Exchange** — `load(id)` / `unload()`; any vendor exception becomes a `GridExchangeError`, so the run loop's failure path is identical on every backend.
- **Naming writes back** to the slot's `sample_description` on rename (decided 2026-09-02). Whether that attribute is writable is **not verified on hardware**; a refusal is logged, not raised.
- **`ThermoMicroscope._create_grid_loader`** returns the driver when `is_installed`, and **None** otherwise — a compustage without an autoloader gets no phantom twelve-slot magazine.

`ruff format` also touched two pre-existing lines in `autoscript.py` (the `sys.path.append` wrapping); CI's format check requires it.

## Tests

`tests/test_autoscript_sample_loader.py` (15 tests) against a class-based fake of the vendor API that reproduces the confirmed behaviours: last-known vs forced scan, capacity from hardware, default names, grid-on-stage at connect, home slot surviving a rescan while loaded, unload-then-load ordering, vendor failure → `GridExchangeError` with state untouched, description write-back, `is_installed` with and without the device.

**Not run on hardware.** That is FIB-893 (Arctis bench session), which should also settle the slot-description write.

## Refs

Part of FIB-6 (Grid Workflow, milestone 1). Hardware verification: FIB-893.
