### PR TITLE
[alignment] Coincident tilt undoes the surface walk; select position aligns coincidence in the workflow

### DIFF
--- a/fibsem/alignment/coincidence.py
+++ b/fibsem/alignment/coincidence.py
@@ -89,6 +89,12 @@ class CoincidenceMeasurement:
     # the FIB->SEM y stretch the pair was measured with: dy is in the FIB
     # plane, dy * y_stretch is the same displacement seen in the SEM plane
     y_stretch: float = 1.0
+    # what the measurement was run with, so a saved pair can be replayed
+    # with the same inputs
+    capture_range: float = DEFAULT_CAPTURE_RANGE
+    agreement_tolerance: float = DEFAULT_AGREEMENT_TOLERANCE
+    max_lateral_offset: float = DEFAULT_MAX_LATERAL_OFFSET
+    prior: Optional[Tuple[float, float]] = None
     # the pair this was measured from, kept for diagnostics (check_coincidence
     # fills them in; the pure array path leaves them None)
     sem_image: Optional[FibsemImage] = field(default=None, repr=False)
@@ -320,6 +326,10 @@ def measure_coincidence(
         is_reliable=refusal is None,
         refusal_reason=refusal,
         seeded=prior is not None,
+        capture_range=capture_range,
+        agreement_tolerance=agreement_tolerance,
+        max_lateral_offset=max_lateral_offset,
+        prior=None if prior is None else (float(prior[0]), float(prior[1])),
     )
     logging.debug(
         {

--- a/fibsem/alignment/coincidence.py
+++ b/fibsem/alignment/coincidence.py
@@ -30,6 +30,7 @@ full findings.
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 
@@ -37,7 +38,7 @@ import numpy as np
 from scipy import ndimage as ndi
 from scipy.signal import fftconvolve
 
-from fibsem.structures import FibsemImage
+from fibsem.structures import FibsemImage, FibsemStagePosition
 
 if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
@@ -712,10 +713,67 @@ class TiltAlignment:
     alignments: List["CoincidenceAlignment"]
     converged: bool  # coincident AT the target tilt
     reason: str
+    # the height of the surface above the tilt axis, estimated from the sag
+    # each tilt segment cost (None when no segment could measure it)
+    tilt_axis_offset: Optional[float] = None
+    # the surface walk h * sin(dt) the tilt produced, and whether it was
+    # undone (a stable move back to the patch that was centred before)
+    walk: float = 0.0
+    walk_undone: bool = False
 
     @property
     def moves_applied(self) -> int:
         return sum(a.moves_applied for a in self.alignments)
+
+
+# a segment must change cos(t - apex) by at least this much to resolve h:
+# below it the height lever is too short and noise dominates (~2 deg near apex)
+MIN_HEIGHT_LEVER = 6e-4
+MIN_WALK_TO_UNDO = 0.2e-6  # m
+
+
+def tilt_swing(
+    tilt_axis_offset: float,
+    tilt_from: float,
+    tilt_to: float,
+    apex: float,
+    pretilt: float,
+) -> Tuple[float, float]:
+    """Where a tilt from `tilt_from` to `tilt_to` carries a surface point
+    sitting `tilt_axis_offset` above the tilt axis, as a (dy, dz)
+    displacement in stage axes.
+
+    The eucentric-height model, anchored at a physical `apex`: the tilt at
+    which the offset vector from axis to surface is vertical - the SEM
+    orientation, where the surface normal points up the column. Relative to
+    it the point sits at height h * cos(t - apex) and lateral h * sin(t -
+    apex); a segment changes those by the difference. Anchoring at an apex
+    rather than at "wherever the segment started" is what keeps h's sign
+    right on the way back: after a correction at the milling angle, the
+    return tilt sees the opposite height change, and a start-relative
+    h * (1 - cos dt) read that as a negative h and undid the walk backwards.
+
+    The walk follows the stable-move direction (cos p, -sin p) in stage y/z
+    for corrected pre-tilt p - not the stage y axis, which leaves the surface
+    plane on a pre-tilted shuttle; the height goes on the stage z axis,
+    where a coincidence height error lives. Shared with the simulator's
+    scene, which renders exactly this.
+    """
+    walk = tilt_axis_offset * (np.sin(tilt_to - apex) - np.sin(tilt_from - apex))
+    rise = tilt_axis_offset * (np.cos(tilt_to - apex) - np.cos(tilt_from - apex))
+    return float(walk * np.cos(pretilt)), float(-walk * np.sin(pretilt) + rise)
+
+
+def tilt_axis_offset_from_height_change(
+    dz: float, tilt_from: float, tilt_to: float, apex: float
+) -> Optional[float]:
+    """h from the height error a tilt segment produced (dz = the z move that
+    cancels it, so the surface moved by -dz). None when the segment is too
+    flat to tell."""
+    dcos = np.cos(tilt_to - apex) - np.cos(tilt_from - apex)
+    if abs(dcos) < MIN_HEIGHT_LEVER:
+        return None
+    return float(-dz / dcos)
 
 
 DEFAULT_MAX_TILT_SPLITS = 2
@@ -727,6 +785,7 @@ def tilt_coincident(
     reference: "BeamType" = None,
     max_splits: int = DEFAULT_MAX_TILT_SPLITS,
     on_progress: Optional[ProgressCallback] = None,
+    undo_walk: bool = True,
     **ensure_kwargs,
 ) -> TiltAlignment:
     """Tilt the stage to `target_tilt` (rad) and restore coincidence there.
@@ -744,9 +803,15 @@ def tilt_coincident(
 
     `reference` is passed through to ensure_coincident; ION (the default
     here, unlike ensure_coincident's) keeps what the operator centred in the
-    FIB view. Note this preserves coincidence, not identity: a large swing can
-    bring a different feature under the crosshair, and tracking the original
-    is a separate problem.
+    FIB view.
+
+    Coincidence is not identity: the same swing that costs the height also
+    walks the surface under the beams by h * sin(dt), so a different patch
+    is centred afterwards. The sag the alignment measures gives h directly
+    (sag = h * (1 - cos dt), assuming the stage was coincident before the
+    tilt), so the walk is known without any image tracking, and with
+    `undo_walk` one stable move at the end brings the original patch back
+    under the crosshair. The estimate is reported as `tilt_axis_offset`.
 
     Args:
         microscope: the microscope connection.
@@ -754,6 +819,8 @@ def tilt_coincident(
         reference: which view keeps its centre (see ensure_coincident).
         max_splits: how many times a refused segment may be halved.
         on_progress: forwarded to every ensure_coincident call.
+        undo_walk: after converging at the target, stable-move back by the
+            walk the tilt produced, so what was centred before stays centred.
         **ensure_kwargs: forwarded to ensure_coincident (tolerance, ranges...).
 
     Returns:
@@ -765,10 +832,14 @@ def tilt_coincident(
     if reference is None:
         reference = BeamType.ION
 
-    last_coincident_tilt = float(microscope.get_stage_position().t or 0.0)
+    start_pose = microscope.get_stage_position()
+    start_tilt = float(start_pose.t or 0.0)
+    last_coincident_tilt = start_tilt
+    apex = _tilt_apex(microscope)
     pending: List[float] = [float(target_tilt)]  # target stays at the bottom
     tilts: List[float] = []
     alignments: List[CoincidenceAlignment] = []
+    offset_estimates: List[float] = []
     splits = 0
 
     while pending:
@@ -784,6 +855,11 @@ def tilt_coincident(
         alignments.append(result)
 
         if result.converged:
+            estimate = _segment_offset_estimate(
+                result, last_coincident_tilt, goal, apex
+            )
+            if estimate is not None:
+                offset_estimates.append(estimate)
             pending.pop()
             last_coincident_tilt = goal
             continue
@@ -795,6 +871,17 @@ def tilt_coincident(
 
     converged = bool(alignments) and not pending and alignments[-1].converged
     reason = REASON_CONVERGED if converged else alignments[-1].reason
+
+    tilt_axis_offset = float(np.mean(offset_estimates)) if offset_estimates else None
+    walk = 0.0
+    walk_undone = False
+    if converged and tilt_axis_offset is not None:
+        walk = tilt_axis_offset * (
+            np.sin(float(target_tilt) - apex) - np.sin(start_tilt - apex)
+        )
+        if undo_walk and abs(walk) > MIN_WALK_TO_UNDO:
+            _undo_surface_walk(microscope, start_pose, tilt_axis_offset)
+            walk_undone = True
     logging.info(
         {
             "msg": "tilt_coincident",
@@ -803,8 +890,72 @@ def tilt_coincident(
             "converged": converged,
             "reason": reason,
             "splits": splits,
+            "tilt_axis_offset": tilt_axis_offset,
+            "walk": walk,
+            "walk_undone": walk_undone,
         }
     )
     return TiltAlignment(
-        tilts=tilts, alignments=alignments, converged=converged, reason=reason
+        tilts=tilts,
+        alignments=alignments,
+        converged=converged,
+        reason=reason,
+        tilt_axis_offset=tilt_axis_offset,
+        walk=walk,
+        walk_undone=walk_undone,
     )
+
+
+def _tilt_apex(microscope: "FibsemMicroscope") -> float:
+    """The tilt at which the surface normal is vertical: the SEM orientation."""
+    return float(microscope.get_orientation("SEM").t or 0.0)
+
+
+def _segment_offset_estimate(
+    alignment: CoincidenceAlignment, tilt_from: float, tilt_to: float, apex: float
+) -> Optional[float]:
+    """h from one tilt segment: the first reliable measurement at the new
+    tilt is the whole height error the segment produced (the stage was
+    coincident before it)."""
+    first = next((m for m in alignment.measurements if m.is_reliable), None)
+    if first is None:
+        return None
+    return tilt_axis_offset_from_height_change(first.dz, tilt_from, tilt_to, apex)
+
+
+def _undo_surface_walk(
+    microscope: "FibsemMicroscope",
+    start_pose: FibsemStagePosition,
+    tilt_axis_offset: float,
+) -> None:
+    """Bring the patch that was centred before the tilt back to the centre.
+
+    The h-model says where that patch now sits in stage coordinates (the
+    start pose carried by the swing); projecting it into the SEM view at the
+    ACTUAL current pose - after every correction the alignment made - gives
+    the displacement to undo, with no image tracking and no bookkeeping of
+    the individual moves. One stable move follows the surface, so it does
+    not cost the coincidence just restored.
+    """
+    from fibsem.projection import BeamStageProjection
+    from fibsem.structures import BeamType
+    from fibsem.transformations import _projection_terms
+
+    projection = BeamStageProjection.from_microscope(microscope, BeamType.ELECTRON)
+    if projection is None:
+        logging.warning("Cannot undo the tilt walk: no SEM projection available")
+        return
+    now = microscope.get_stage_position()
+    _, pretilt, _ = _projection_terms(projection.geometry, now.r or 0.0, now.t or 0.0)
+    dy, dz = tilt_swing(
+        tilt_axis_offset,
+        float(start_pose.t or 0.0),
+        float(now.t or 0.0),
+        _tilt_apex(microscope),
+        pretilt,
+    )
+    patch = deepcopy(start_pose)
+    patch.y = (patch.y or 0.0) + dy
+    patch.z = (patch.z or 0.0) + dz
+    ax, ay = projection.to_plane(patch, now)
+    microscope.stable_move(dx=-ax, dy=-ay, beam_type=BeamType.ELECTRON)

--- a/fibsem/alignment/plotting.py
+++ b/fibsem/alignment/plotting.py
@@ -295,8 +295,8 @@ def plot_coincidence_alignment(
     the FIB stretched to the SEM projection and shifted by the measured
     residual, shown as a checkerboard against the SEM so a good lock reads
     as continuous structure across the tiles and a wrong one as broken
-    edges. A single-panel residual plot at the top right carries the
-    convergence story, and the title the verdict. Measurements without
+    edges. A short residual plot along the bottom carries the convergence
+    story, and the title the verdict. Measurements without
     their image pair are skipped.
 
     Returns:
@@ -321,8 +321,19 @@ def plot_coincidence_alignment(
         if m.sem_image is not None and m.fib_image is not None
     ]
     n = max(len(rows), 1)
-    fig = Figure(figsize=(14.5, 3.3 * n + 0.7))
-    grid = GridSpec(n, 4, figure=fig, width_ratios=[1, 1, 1, 0.85])
+    fig = Figure(figsize=(12, 2.8 * n + 2.4))
+    grid = GridSpec(
+        n + 1,
+        3,
+        figure=fig,
+        height_ratios=[1] * n + [0.6],
+        wspace=0.04,
+        hspace=0.12,
+        left=0.03,
+        right=0.99,
+        top=0.93,
+        bottom=0.06,
+    )
 
     verdict = "CONVERGED" if result.converged else f"NOT COINCIDENT ({result.reason})"
     header = (
@@ -382,8 +393,8 @@ def plot_coincidence_alignment(
             ),
         )
 
-    # one panel's worth of residual plot, not a column-high one
-    ax = fig.add_subplot(grid[0, 3])
+    # a short strip along the bottom, not a column-high panel
+    ax = fig.add_subplot(grid[n, :])
     idx = np.arange(1, len(result.measurements) + 1)
     dz = np.array([m.dz for m in result.measurements]) * 1e6
     dx = np.array([m.dx for m in result.measurements]) * 1e6
@@ -405,10 +416,8 @@ def plot_coincidence_alignment(
     ax.set_xlabel("measurement")
     ax.set_ylabel("um")
     ax.set_title("Residuals", fontsize=10)
-    ax.legend(fontsize="x-small")
+    ax.legend(fontsize="x-small", loc="upper right", ncol=3)
     ax.grid(alpha=0.3)
-
-    fig.tight_layout(rect=(0, 0, 1, 0.95))
     return fig
 
 
@@ -489,7 +498,12 @@ def load_coincidence_run(run_dir: str) -> list:
     """
     import json
 
-    from fibsem.alignment.coincidence import measure_coincidence_from_images
+    from fibsem.alignment.coincidence import (
+        DEFAULT_AGREEMENT_TOLERANCE,
+        DEFAULT_CAPTURE_RANGE,
+        DEFAULT_MAX_LATERAL_OFFSET,
+        measure_coincidence_from_images,
+    )
     from fibsem.structures import FibsemImage
 
     with open(os.path.join(run_dir, "run.json")) as f:
@@ -501,13 +515,18 @@ def load_coincidence_run(run_dir: str) -> list:
         sem_image = FibsemImage.load(os.path.join(run_dir, record["sem"]))
         fib_image = FibsemImage.load(os.path.join(run_dir, record["fib"]))
         prior = record.get("prior")
+        # runs saved before the parameters were recorded replay with defaults
         measurement = measure_coincidence_from_images(
             sem_image,
             fib_image,
             prior=None if prior is None else tuple(prior),
-            capture_range=record["capture_range"],
-            agreement_tolerance=record["agreement_tolerance"],
-            max_lateral_offset=record["max_lateral_offset"],
+            capture_range=record.get("capture_range", DEFAULT_CAPTURE_RANGE),
+            agreement_tolerance=record.get(
+                "agreement_tolerance", DEFAULT_AGREEMENT_TOLERANCE
+            ),
+            max_lateral_offset=record.get(
+                "max_lateral_offset", DEFAULT_MAX_LATERAL_OFFSET
+            ),
         )
         measurement.coarse = record["pass"] == "coarse"
         measurement.sem_image = sem_image

--- a/fibsem/alignment/plotting.py
+++ b/fibsem/alignment/plotting.py
@@ -284,38 +284,233 @@ def plot_coincidence_measurement(
     return fig
 
 
-def save_coincidence_diagnostics(
-    result: "CoincidenceAlignment", path: str, prefix: str = ""
-) -> List[str]:
-    """Save one diagnostic figure per measurement of an ensure_coincident run.
+def plot_coincidence_alignment(
+    result: "CoincidenceAlignment", title: Optional[str] = None
+):
+    """One figure for a whole ensure_coincident run.
 
-    Files are numbered in run order (`<prefix>coincidence_<ts>_01_fine.png`,
-    `..._02_coarse.png`, ...) so a run reads as a sequence: the refusal that
-    escalated, the coarse lock, the post-move residual. Measurements without
-    their image pair (the pure array path) are skipped.
+    A row per measurement: the raw SEM and FIB pair (the context the
+    operator recognises), then what the correlator actually saw - both
+    images local-normalised, band-passed and reduced to gradient magnitude,
+    the FIB stretched to the SEM projection and shifted by the measured
+    residual, shown as a checkerboard against the SEM so a good lock reads
+    as continuous structure across the tiles and a wrong one as broken
+    edges. A single-panel residual plot at the top right carries the
+    convergence story, and the title the verdict. Measurements without
+    their image pair are skipped.
 
     Returns:
-        the saved file paths, in order.
+        matplotlib.figure.Figure
     """
     from datetime import datetime
 
-    os.makedirs(path, exist_ok=True)
-    ts = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-    saved: List[str] = []
-    for i, m in enumerate(result.measurements, start=1):
-        if m.sem_image is None or m.fib_image is None:
-            continue
+    from matplotlib.figure import Figure
+    from matplotlib.gridspec import GridSpec
+    from scipy import ndimage as ndi
+
+    from fibsem.alignment.coincidence import (
+        AGREEMENT_BANDS,
+        _preprocess,
+        _stretch_y,
+        geometry_from_images,
+    )
+
+    rows = [
+        m
+        for m in result.measurements
+        if m.sem_image is not None and m.fib_image is not None
+    ]
+    n = max(len(rows), 1)
+    fig = Figure(figsize=(14.5, 3.3 * n + 0.7))
+    grid = GridSpec(n, 4, figure=fig, width_ratios=[1, 1, 1, 0.85])
+
+    verdict = "CONVERGED" if result.converged else f"NOT COINCIDENT ({result.reason})"
+    header = (
+        f"{title or 'Coincidence alignment'} — {verdict}, "
+        f"{result.moves_applied} move(s)"
+        f"{', coarse pass used' if result.coarse_used else ''} — "
+        f"{datetime.now().strftime(DATETIME_DISPLAY)}"
+    )
+    fig.suptitle(header, fontsize=12, color="lime" if result.converged else "orange")
+
+    s1, s2 = AGREEMENT_BANDS[0]
+    for i, m in enumerate(rows):
+        geometry = geometry_from_images(m.sem_image, m.fib_image)
+        px = geometry.pixel_size
+        stretch = geometry.y_stretch
+        sem = m.sem_image.data.astype(np.float32)
+        fib = m.fib_image.data.astype(np.float32)
         pass_name = "coarse" if m.coarse else "fine"
-        fig = plot_coincidence_measurement(
-            m.sem_image,
-            m.fib_image,
-            m,
-            title=f"Coincidence {i}/{len(result.measurements)} ({pass_name})",
-            save=False,
+        hfw_um = m.sem_image.metadata.image_settings.hfw * 1e6
+
+        ax = fig.add_subplot(grid[i, 0])
+        _plot_image_with_crosshair(
+            ax, sem, f"{i + 1}. SEM ({pass_name}, {hfw_um:.0f} um)"
         )
-        save_path = os.path.join(
-            path, f"{prefix}coincidence_{ts}_{i:02d}_{pass_name}.png"
+        ax = fig.add_subplot(grid[i, 1])
+        _plot_image_with_crosshair(ax, fib, f"{i + 1}. FIB")
+
+        # the correlator's view, FIB shifted by the measured residual
+        ref = _preprocess(sem, s1, s2)
+        other = _preprocess(_stretch_y(fib, stretch), s1, s2)
+        other = ndi.shift(
+            other, (m.dy / px * stretch, m.dx / px), order=1, mode="constant"
         )
-        fig.savefig(save_path, dpi=80)
-        saved.append(save_path)
-    return saved
+        tile = max(16, min(ref.shape) // 8)
+        yy, xx = np.mgrid[0 : ref.shape[0], 0 : ref.shape[1]]
+        checker = ((yy // tile) + (xx // tile)) % 2 == 0
+        board = np.where(checker, ref, other)
+        ax = fig.add_subplot(grid[i, 2])
+        lo, hi = np.percentile(board, [1, 99])
+        ax.imshow(board, cmap="gray", vmin=lo, vmax=hi)
+        ax.set_title("Correlator: SEM / aligned FIB checkerboard", fontsize=8)
+        ax.axis("off")
+        colour = "lime" if m.is_reliable else "red"
+        ax.text(
+            0.03,
+            0.04,
+            ("RELIABLE" if m.is_reliable else f"REFUSED ({m.refusal_reason})")
+            + f"\ndx={m.dx * 1e6:+.2f}  dy={m.dy * 1e6:+.2f}  dz={m.dz * 1e6:+.2f} um"
+            + f"\nband-disagreement={m.band_disagreement * 1e6:.2f} um",
+            transform=ax.transAxes,
+            color=colour,
+            fontsize=6.5,
+            va="bottom",
+            fontfamily="monospace",
+            bbox=dict(
+                boxstyle="round,pad=0.2", facecolor="black", alpha=0.6, edgecolor="none"
+            ),
+        )
+
+    # one panel's worth of residual plot, not a column-high one
+    ax = fig.add_subplot(grid[0, 3])
+    idx = np.arange(1, len(result.measurements) + 1)
+    dz = np.array([m.dz for m in result.measurements]) * 1e6
+    dx = np.array([m.dx for m in result.measurements]) * 1e6
+    reliable = np.array([m.is_reliable for m in result.measurements])
+    ax.plot(idx, dz, "o-", color="tab:blue", label="dz (height)")
+    ax.plot(idx, dx, "s--", color="tab:gray", label="dx (lateral)")
+    if (~reliable).any():
+        ax.plot(
+            idx[~reliable],
+            dz[~reliable],
+            "x",
+            color="red",
+            ms=12,
+            mew=2,
+            label="refused",
+        )
+    ax.axhline(0, color="k", lw=0.8)
+    ax.set_xticks(idx)
+    ax.set_xlabel("measurement")
+    ax.set_ylabel("um")
+    ax.set_title("Residuals", fontsize=10)
+    ax.legend(fontsize="x-small")
+    ax.grid(alpha=0.3)
+
+    fig.tight_layout(rect=(0, 0, 1, 0.95))
+    return fig
+
+
+def save_coincidence_diagnostics(
+    result: "CoincidenceAlignment", path: str, prefix: str = ""
+) -> str:
+    """Save an ensure_coincident run as a replayable case.
+
+    Writes a run directory `<path>/<prefix>coincidence_<ts>/` holding every
+    measured pair as `NN_<pass>_sem.tif` / `NN_<pass>_fib.tif` with full
+    metadata (so `load_coincidence_run` can re-measure them offline with
+    the same inputs), `run.json` with the verdict and every measurement's
+    numbers, and `summary.png`, the figure from plot_coincidence_alignment.
+    Measurements without their image pair (the pure array path) are skipped.
+
+    Returns:
+        the run directory.
+    """
+    import json
+    from datetime import datetime
+
+    ts = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    run_dir = os.path.join(path, f"{prefix}coincidence_{ts}")
+    os.makedirs(run_dir, exist_ok=True)
+
+    records = []
+    for i, m in enumerate(result.measurements, start=1):
+        pass_name = "coarse" if m.coarse else "fine"
+        record = {
+            "index": i,
+            "pass": pass_name,
+            "dx": m.dx,
+            "dy": m.dy,
+            "dz": m.dz,
+            "band_disagreement": m.band_disagreement,
+            "is_reliable": m.is_reliable,
+            "refusal_reason": m.refusal_reason,
+            "seeded": m.seeded,
+            "y_stretch": m.y_stretch,
+            "method": m.method,
+            "capture_range": m.capture_range,
+            "agreement_tolerance": m.agreement_tolerance,
+            "max_lateral_offset": m.max_lateral_offset,
+            "prior": m.prior,
+        }
+        if m.sem_image is not None and m.fib_image is not None:
+            record["sem"] = f"{i:02d}_{pass_name}_sem.tif"
+            record["fib"] = f"{i:02d}_{pass_name}_fib.tif"
+            m.sem_image.save(os.path.join(run_dir, record["sem"]))
+            m.fib_image.save(os.path.join(run_dir, record["fib"]))
+        records.append(record)
+
+    with open(os.path.join(run_dir, "run.json"), "w") as f:
+        json.dump(
+            {
+                "converged": result.converged,
+                "reason": result.reason,
+                "moves_applied": result.moves_applied,
+                "coarse_used": result.coarse_used,
+                "measurements": records,
+            },
+            f,
+            indent=2,
+        )
+
+    fig = plot_coincidence_alignment(result, title=f"{prefix}coincidence")
+    fig.savefig(os.path.join(run_dir, "summary.png"), dpi=80)
+    return run_dir
+
+
+def load_coincidence_run(run_dir: str) -> list:
+    """Replay a saved run: re-measure every saved pair with the same inputs.
+
+    Returns [(record, sem_image, fib_image, measurement)] in run order, where
+    `record` is the saved measurement and `measurement` a fresh one from the
+    current code, run with the saved parameters (window, tolerances, prior)
+    - the two disagreeing is the point of keeping the raw data.
+    """
+    import json
+
+    from fibsem.alignment.coincidence import measure_coincidence_from_images
+    from fibsem.structures import FibsemImage
+
+    with open(os.path.join(run_dir, "run.json")) as f:
+        run = json.load(f)
+    replayed = []
+    for record in run["measurements"]:
+        if "sem" not in record:
+            continue
+        sem_image = FibsemImage.load(os.path.join(run_dir, record["sem"]))
+        fib_image = FibsemImage.load(os.path.join(run_dir, record["fib"]))
+        prior = record.get("prior")
+        measurement = measure_coincidence_from_images(
+            sem_image,
+            fib_image,
+            prior=None if prior is None else tuple(prior),
+            capture_range=record["capture_range"],
+            agreement_tolerance=record["agreement_tolerance"],
+            max_lateral_offset=record["max_lateral_offset"],
+        )
+        measurement.coarse = record["pass"] == "coarse"
+        measurement.sem_image = sem_image
+        measurement.fib_image = fib_image
+        replayed.append((record, sem_image, fib_image, measurement))
+    return replayed

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -1461,9 +1461,17 @@ class AutoLamellaSingleWindowUI(QMainWindow):
     def _on_tilt_coincident_finished(self, result) -> None:
         tilts = ", ".join(f"{np.degrees(t):.1f}" for t in result.tilts)
         if result.converged:
+            offset = (
+                f" Surface {result.tilt_axis_offset * 1e6:+.0f} um off the tilt axis;"
+                f" walk of {abs(result.walk) * 1e6:.0f} um"
+                f"{' undone' if result.walk_undone else ' left'}."
+                if result.tilt_axis_offset is not None
+                else ""
+            )
             self.show_toast(
                 f"Coincident at {np.degrees(result.tilts[-1]):.1f} deg after "
-                f"{result.moves_applied} corrective move(s) (tilts visited: {tilts}).",
+                f"{result.moves_applied} corrective move(s) (tilts visited: {tilts})."
+                f"{offset}",
                 "success",
                 duration=10000,
             )

--- a/fibsem/applications/autolamella/workflows/tasks/select_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_position.py
@@ -27,8 +27,10 @@ class SelectMillingPositionTaskConfig(AutoLamellaTaskConfig):
     auto_milling_alignment: bool = field(
         default=False,
         metadata=field_meta(
-            label="Auto Milling Angle Alignment",
-            tooltip="Whether to automatically align for a milling position",
+            label="Auto Coincidence Alignment",
+            tooltip="Align SEM/FIB coincidence at the current pose, then tilt "
+            "to the milling angle while keeping it (from the SEM orientation "
+            "or the milling angle; other start poses are not validated)",
         ),
     )
     use_autofocus: bool = field(
@@ -84,27 +86,12 @@ class SelectMillingPositionTask(AutoLamellaTask):
             field_of_view=self.config.reference_imaging.field_of_view1,
         )
 
+        if self.config.auto_milling_alignment:
+            self._align_coincident_for_milling(milling_angle, is_close)
+
         if not is_close:
             if self.config.auto_milling_alignment:
-                from fibsem.alignment.coincidence import tilt_coincident
-                from fibsem.transformations import get_stage_tilt_from_milling_angle
-
-                target_stage_tilt = get_stage_tilt_from_milling_angle(
-                    self.microscope, np.radians(milling_angle)
-                )
-                # tilt straight there and restore coincidence by cross-beam
-                # measurement, keeping what the operator centred in the FIB
-                # view; steps only if the measurement refuses at the target
-                tilt = tilt_coincident(
-                    self.microscope, target_stage_tilt, reference=BeamType.ION
-                )
-                if not tilt.converged:
-                    logging.warning(
-                        "Coincidence not restored at the milling angle (%s); "
-                        "continuing at the target tilt",
-                        tilt.reason,
-                    )
-
+                pass  # tilted coincidently above
             elif self.validate:
                 current_milling_angle = self.microscope.get_current_milling_angle()
                 ret = ask_user(
@@ -131,6 +118,91 @@ class SelectMillingPositionTask(AutoLamellaTask):
                 image_settings=self.image_settings,
                 filename=f"ref_{self.task_name}_post_tilt",
                 field_of_view=self.config.reference_imaging.field_of_view1,
+            )
+
+    def _align_coincident_for_milling(
+        self, milling_angle: float, is_close: bool
+    ) -> None:
+        """Make the SEM and FIB coincident at the milling angle.
+
+        Initial scope: the task starts either AT the milling angle (align
+        only) or at the SEM orientation (align there, then tilt to the
+        milling angle keeping coincidence, and undo the surface walk the
+        tilt produced so the site the operator chose is still centred).
+        Aligning BEFORE the tilt is what makes the tilt's height-offset
+        estimate - and so the walk undo - valid. Any other start pose is
+        allowed but unvalidated, and says so in the log.
+
+        A refusal never stops the task: the stage is left where the last
+        reliable correction put it and the refusal is logged (policy for
+        escalation - ask, spot burn - is deliberately not decided here).
+        """
+        import os
+
+        from fibsem.alignment import ALIGNMENT_SUBDIR
+        from fibsem.alignment.coincidence import ensure_coincident, tilt_coincident
+        from fibsem.alignment.plotting import save_coincidence_diagnostics
+        from fibsem.transformations import get_stage_tilt_from_milling_angle
+
+        diagnostics_path = os.path.join(self.lamella.path, ALIGNMENT_SUBDIR)
+
+        def on_progress(progress) -> None:
+            self.update_status_ui(progress.describe())
+
+        self.log_status_message("ALIGN_COINCIDENCE", "Aligning SEM/FIB coincidence...")
+        start = ensure_coincident(
+            self.microscope, reference=BeamType.ION, on_progress=on_progress
+        )
+        save_coincidence_diagnostics(start, diagnostics_path, prefix="start_")
+        if not start.converged:
+            logging.warning(
+                "SEM/FIB coincidence not reached before the tilt (%s); the tilt's "
+                "height-offset estimate will be off",
+                start.reason,
+            )
+        if is_close:
+            return
+
+        orientation = self.microscope.get_stage_orientation()
+        if orientation != "SEM":
+            logging.warning(
+                "Coincident tilt to the milling angle starting from the %s "
+                "orientation is not validated (expected SEM or MILLING)",
+                orientation,
+            )
+        target_stage_tilt = get_stage_tilt_from_milling_angle(
+            self.microscope, np.radians(milling_angle)
+        )
+        self.log_status_message(
+            "TILT_COINCIDENT",
+            f"Tilting to the milling angle ({milling_angle:.1f}"
+            f"{constants.DEGREE_SYMBOL}) keeping coincidence...",
+        )
+        tilt = tilt_coincident(
+            self.microscope,
+            target_stage_tilt,
+            reference=BeamType.ION,
+            on_progress=on_progress,
+        )
+        for i, alignment in enumerate(tilt.alignments, start=1):
+            save_coincidence_diagnostics(
+                alignment, diagnostics_path, prefix=f"tilt{i:02d}_"
+            )
+        if tilt.converged:
+            logging.info(
+                {
+                    "msg": "milling_tilt_coincident",
+                    "tilt_axis_offset": tilt.tilt_axis_offset,
+                    "walk": tilt.walk,
+                    "walk_undone": tilt.walk_undone,
+                    "moves_applied": tilt.moves_applied,
+                }
+            )
+        else:
+            logging.warning(
+                "Coincidence not restored at the milling angle (%s); continuing "
+                "at the target tilt",
+                tilt.reason,
             )
 
         # confirm with user to move to milling position

--- a/fibsem/microscopes/sim_scene.py
+++ b/fibsem/microscopes/sim_scene.py
@@ -255,10 +255,11 @@ class CoincidenceScene:
         The projection tilts the world about the point the stage reports - a
         eucentric stage. On a real stage the surface sits `tilt_axis_offset`
         above the tilt axis, so a tilt change swings it about the axis. The
-        textbook eucentric-height model: a point h above the axis walks
-        h * sin(dt) ALONG THE SURFACE (the same in both views - only which
-        feature is centred changes) and sags h * (1 - cos(dt)) in height,
-        which is what costs coincidence.
+        textbook eucentric-height model, anchored at the SEM orientation
+        (the apex, where the offset vector is vertical): a point h above the
+        axis walks ALONG THE SURFACE (the same in both views - only which
+        feature is centred changes) and changes height, which is what costs
+        coincidence. See tilt_swing for the model.
 
         The walk follows the stable-move direction - on a pre-tilted shuttle
         that is not the stage y axis but (cos p, -sin p) in stage y/z, with p
@@ -267,18 +268,25 @@ class CoincidenceScene:
         The sag goes on the stage z axis exactly as the boot
         `coincidence_offset` does, so the same correction path restores it.
         """
+        from fibsem.alignment.coincidence import tilt_swing
         from fibsem.transformations import _projection_terms
 
-        h = self.tilt_axis_offset
-        dt = (stage_position.t or 0.0) - (self.reference_position.t or 0.0)
         _, pretilt, _ = _projection_terms(
             projection.geometry, stage_position.r or 0.0, stage_position.t or 0.0
         )
-        walk = h * np.sin(dt)
-        sag = h * (1.0 - np.cos(dt))
+        # the apex - where the offset vector is vertical - is the SEM
+        # orientation: tilt = shuttle pre-tilt (0 on a compustage)
+        apex = np.deg2rad(projection.geometry.shuttle_pre_tilt)
+        dy, dz = tilt_swing(
+            self.tilt_axis_offset,
+            self.reference_position.t or 0.0,
+            stage_position.t or 0.0,
+            apex,
+            pretilt,
+        )
         reference = deepcopy(self.reference_position)
-        reference.y = (reference.y or 0.0) + walk * np.cos(pretilt)
-        reference.z = (reference.z or 0.0) - walk * np.sin(pretilt) - sag
+        reference.y = (reference.y or 0.0) + dy
+        reference.z = (reference.z or 0.0) + dz
         return reference
 
     @staticmethod

--- a/tests/autolamella/test_select_position_coincidence.py
+++ b/tests/autolamella/test_select_position_coincidence.py
@@ -1,0 +1,120 @@
+"""SelectMillingPositionTask with auto_milling_alignment: coincidence in the
+workflow (FIB-899, initial scope).
+
+Two supported starts: at the SEM orientation (align, tilt coincidently,
+undo the walk) and at the milling angle (align only). Runs on the Demo's
+projection-true scene with a non-eucentric stage, so the geometry is real.
+"""
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.alignment import ALIGNMENT_SUBDIR
+from fibsem.alignment.coincidence import check_coincidence
+from fibsem.applications.autolamella.structures import Lamella
+from fibsem.applications.autolamella.workflows.tasks.select_position import (
+    SelectMillingPositionTask,
+    SelectMillingPositionTaskConfig,
+)
+from fibsem.microscopes.sim_scene import CoincidenceScene
+from fibsem.projection import BeamStageProjection
+from fibsem.structures import BeamType
+
+TFS_SHUTTLE_CONFIG = os.path.join(cfg.CONFIG_PATH, "microscope-configuration.yaml")
+MILLING_ANGLE = 15.0  # deg -> stage tilt 12 deg on the 35 deg shuttle
+NON_EUCENTRIC = 200e-6  # m
+
+
+@pytest.fixture
+def microscope():
+    microscope, _ = utils.setup_session(
+        manufacturer="Demo", config_path=TFS_SHUTTLE_CONFIG
+    )
+    microscope.system.sim["coincidence_projection"] = True
+    microscope._setup_coincidence_projection()
+    yield microscope
+    microscope.disconnect()
+
+
+def _anchor_scene(microscope, coincidence_offset: float) -> None:
+    scene = CoincidenceScene(
+        coincidence_offset=coincidence_offset,
+        tilt_axis_offset=NON_EUCENTRIC,
+        noise_sigma=0.0,
+        noise_fraction=0.0,
+    )
+    scene.anchor(microscope.get_stage_position())
+    microscope._coincidence_scene = scene
+
+
+def _anchor_in_fib_view(microscope) -> tuple:
+    """Where the world anchor projects into the FIB view (m). The FIB view is
+    the invariant: with reference=ION nothing the task does may move what
+    the operator centred there - not the alignment, not the tilt."""
+    projection = BeamStageProjection.from_microscope(microscope, BeamType.ION)
+    scene = microscope._coincidence_scene
+    pose = microscope.get_stage_position()
+    return projection.to_plane(scene._non_eucentric_reference(pose, projection), pose)
+
+
+def _make_task(microscope, tmp_path: Path) -> SelectMillingPositionTask:
+    lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+    lamella.path.mkdir(parents=True, exist_ok=True)
+    lamella.milling_pose = microscope.get_microscope_state()
+    config = SelectMillingPositionTaskConfig(
+        milling_angle=MILLING_ANGLE,
+        auto_milling_alignment=True,
+        use_autofocus=False,
+        select_poi=False,
+    )
+    return SelectMillingPositionTask(
+        microscope=microscope, config=config, lamella=lamella
+    )
+
+
+def test_from_the_sem_orientation_the_task_ends_coincident_at_the_milling_angle(
+    microscope, tmp_path
+):
+    _anchor_scene(microscope, coincidence_offset=8e-6)
+    task = _make_task(microscope, tmp_path)
+    before = _anchor_in_fib_view(microscope)
+
+    task._run()
+
+    from fibsem.transformations import get_stage_tilt_from_milling_angle
+
+    target = get_stage_tilt_from_milling_angle(microscope, np.radians(MILLING_ANGLE))
+    assert microscope.get_stage_position().t == pytest.approx(target, abs=1e-6)
+    m = check_coincidence(microscope)
+    assert m.is_reliable and abs(m.dz) < 1e-6, (m.refusal_reason, m.dz)
+    # the site the operator chose is still centred: the walk was undone
+    drift = np.hypot(*np.subtract(_anchor_in_fib_view(microscope), before))
+    assert drift < 2e-6, f"site drifted {drift * 1e6:.1f} um"
+    # diagnostics for the pre-tilt alignment and the tilt landed with the lamella
+    saved = os.listdir(task.lamella.path / ALIGNMENT_SUBDIR)
+    assert any(f.startswith("start_") for f in saved)
+    assert any(f.startswith("tilt01_") for f in saved)
+
+
+def test_at_the_milling_angle_the_task_only_aligns(microscope, tmp_path):
+    from fibsem.transformations import get_stage_tilt_from_milling_angle
+
+    pose = microscope.get_stage_position()
+    pose.t = get_stage_tilt_from_milling_angle(microscope, np.radians(MILLING_ANGLE))
+    microscope.move_stage_absolute(pose)
+    _anchor_scene(microscope, coincidence_offset=8e-6)
+    task = _make_task(microscope, tmp_path)
+
+    task._run()
+
+    assert microscope.get_stage_position().t == pytest.approx(pose.t, abs=1e-6)
+    m = check_coincidence(microscope)
+    assert m.is_reliable and abs(m.dz) < 1e-6, (m.refusal_reason, m.dz)
+    saved = os.listdir(task.lamella.path / ALIGNMENT_SUBDIR)
+    assert any(f.startswith("start_") for f in saved)
+    assert not any(f.startswith("tilt") for f in saved)

--- a/tests/test_align_loop.py
+++ b/tests/test_align_loop.py
@@ -156,10 +156,51 @@ def test_progress_reports_every_step_and_moves_are_counted(microscope, tmp_path)
     assert steps[2].iteration == 0 and steps[3].iteration == 1
     assert all(s.describe() for s in steps)
 
-    # each measurement keeps its pair, so the run is fully re-plottable
-    saved = save_coincidence_diagnostics(result, str(tmp_path))
-    assert len(saved) == len(result.measurements) == 2
-    assert saved[0].endswith("_01_fine.png")
+    # each measurement keeps its pair, so the run is saved as a replayable
+    # case: every pair as tif with metadata, the numbers, one summary figure
+    import os
+
+    from fibsem.alignment.plotting import load_coincidence_run
+
+    run_dir = save_coincidence_diagnostics(result, str(tmp_path), prefix="start_")
+    assert os.path.basename(run_dir).startswith("start_coincidence_")
+    saved = sorted(os.listdir(run_dir))
+    assert saved == [
+        "01_fine_fib.tif",
+        "01_fine_sem.tif",
+        "02_fine_fib.tif",
+        "02_fine_sem.tif",
+        "run.json",
+        "summary.png",
+    ]
+    replayed = load_coincidence_run(run_dir)
+    assert len(replayed) == 2
+    for record, _, _, fresh in replayed:
+        assert fresh.is_reliable == record["is_reliable"]
+        assert fresh.dz == pytest.approx(record["dz"], abs=0.5e-6)
+
+
+def test_a_coarse_run_replays_with_its_own_parameters(microscope, tmp_path):
+    """A coarse pair re-measured with the fine window reads differently;
+    the run records what each measurement was run with, and the replay
+    uses it, so the replay reproduces the run."""
+    from fibsem.alignment.plotting import (
+        load_coincidence_run,
+        save_coincidence_diagnostics,
+    )
+
+    microscope._coincidence_scene.coincidence_offset = 40e-6
+    microscope._coincidence_scene.reference_position = None
+    microscope._coincidence_scene.anchor(microscope.get_stage_position())
+    result = ensure_coincident(microscope, tolerance=1e-6)
+    assert result.coarse_used
+
+    replayed = load_coincidence_run(save_coincidence_diagnostics(result, str(tmp_path)))
+    assert [r["pass"] for r, *_ in replayed] == ["fine", "coarse", "fine"]
+    for record, _, _, fresh in replayed:
+        assert fresh.is_reliable == record["is_reliable"]
+        assert fresh.refusal_reason == record["refusal_reason"]
+        assert fresh.dz == pytest.approx(record["dz"], abs=0.5e-6)
 
 
 def test_coarse_measurements_do_not_count_as_moves(microscope):

--- a/tests/test_tilt_coincident.py
+++ b/tests/test_tilt_coincident.py
@@ -143,3 +143,71 @@ def test_out_of_splits_reports_the_refusal_and_stays_at_the_target(microscope):
     assert result.reason != REASON_CONVERGED
     assert result.moves_applied == 0  # refused: nothing was moved
     assert microscope.get_stage_position().t == pytest.approx(MILLING_TILT)
+
+
+def _anchor_in_sem_view(microscope) -> tuple:
+    """Where the world anchor projects into the SEM view (m) - the sim's
+    own projection, so exact and alias-free."""
+    from fibsem.projection import BeamStageProjection
+    from fibsem.structures import BeamType
+
+    projection = BeamStageProjection.from_microscope(microscope, BeamType.ELECTRON)
+    scene = microscope._coincidence_scene
+    pose = microscope.get_stage_position()
+    reference = scene._non_eucentric_reference(pose, projection)
+    return projection.to_plane(reference, pose)
+
+
+def test_the_offset_is_estimated_from_the_sag_and_the_walk_undone(microscope):
+    """One coincident tilt measures h (sag = h(1 - cos dt)), so the walk
+    h sin dt is known and undone: what was centred before is centred after."""
+    _anchor_scene(microscope, tilt_axis_offset=NON_EUCENTRIC)
+    before = _anchor_in_sem_view(microscope)
+
+    result = tilt_coincident(microscope, MILLING_TILT, tolerance=1e-6)
+
+    assert result.converged, result.reason
+    assert result.tilt_axis_offset == pytest.approx(NON_EUCENTRIC, rel=0.1)
+    assert abs(result.walk) == pytest.approx(
+        NON_EUCENTRIC * np.sin(SEM_TILT - MILLING_TILT), rel=0.1
+    )
+    assert result.walk_undone
+    after = _anchor_in_sem_view(microscope)
+    drift = np.hypot(*np.subtract(after, before))
+    assert drift < 2e-6, f"the centred patch drifted {drift * 1e6:.1f} um"
+    # and the stable move back did not cost the coincidence just restored
+    m = check_coincidence(microscope)
+    assert m.is_reliable and abs(m.dz) < 1e-6
+
+
+def test_walk_undo_can_be_declined(microscope):
+    _anchor_scene(microscope, tilt_axis_offset=NON_EUCENTRIC)
+    before = _anchor_in_sem_view(microscope)
+
+    result = tilt_coincident(microscope, MILLING_TILT, tolerance=1e-6, undo_walk=False)
+
+    assert result.converged and not result.walk_undone
+    drift = np.hypot(*np.subtract(_anchor_in_sem_view(microscope), before))
+    assert drift > 10e-6  # the walk is real and was left alone
+
+
+def test_round_trip_estimates_h_with_one_sign_and_returns_to_the_site(microscope):
+    """Tilt down, then back up. The stage is corrected at the milling
+    angle, so the return segment sees the opposite height change - a
+    start-relative model read that as a negative h and undid the walk
+    backwards. Anchored at the apex both segments agree on h and the site
+    is back where it started."""
+    _anchor_scene(microscope, tilt_axis_offset=NON_EUCENTRIC)
+    before = _anchor_in_sem_view(microscope)
+
+    down = tilt_coincident(microscope, MILLING_TILT, tolerance=1e-6)
+    up = tilt_coincident(microscope, SEM_TILT, tolerance=1e-6)
+
+    assert down.converged and up.converged
+    assert down.tilt_axis_offset == pytest.approx(NON_EUCENTRIC, rel=0.1)
+    assert up.tilt_axis_offset == pytest.approx(NON_EUCENTRIC, rel=0.1)
+    assert up.walk_undone
+    drift = np.hypot(*np.subtract(_anchor_in_sem_view(microscope), before))
+    assert drift < 2e-6, f"site drifted {drift * 1e6:.1f} um after the round trip"
+    m = check_coincidence(microscope)
+    assert m.is_reliable and abs(m.dz) < 1e-6


### PR DESCRIPTION
## Summary

**`tilt_coincident` estimates the height offset and undoes the walk.** The sag a coincident tilt measures is the eucentric-height model's own signal: relative to the apex (the SEM orientation, where the offset vector from tilt axis to surface is vertical) the surface sits at `h·cos(t−apex)` / `h·sin(t−apex)`, so one segment's height error gives h, and the walk along the surface follows with no image tracking. `tilt_swing()` is the shared model; the simulator scene renders exactly it. With `undo_walk` (default) the loop brings the patch that was centred before the tilt back under the crosshair: the model places the start-pose patch in stage coordinates, the SEM projection says where it now sits at the *actual* current pose (so the alignment's own recentre moves and the SEM z-leak are included for free), one stable move undoes it. Anchoring at an apex rather than at each segment's start keeps h's sign right on the way back — a start-relative `h(1−cos Δt)` read the return tilt as a negative h and undid the walk backwards (seen live). Precision is bounded by cot(Δt/2): ~5 µm of walk per µm of sag noise at 23°.

**Select position aligns coincidence in the workflow.** `auto_milling_alignment` now means: `ensure_coincident` at the current pose (keeping the FIB view), then if not at the milling angle, `tilt_coincident` there with the walk undone. Initial scope: starting at the SEM orientation or at the milling angle; other start poses run but log that they are unvalidated. A refusal never stops the task (escalation policy deliberately undecided). Progress goes to the status line; diagnostics for the pre-tilt alignment and the tilt land under the lamella's `Alignment/` folder.

**Diagnostics are replayable cases.** `save_coincidence_diagnostics` writes a run directory (`<prefix>coincidence_<ts>/`): every pair as `.tif` with full metadata, `run.json` with the verdict, every measurement's numbers and the parameters it was measured with, and one `summary.png` (raw SEM/FIB per row, the correlator's view as a SEM/aligned-FIB checkerboard, a single-panel residual plot). `load_coincidence_run` re-measures the saved pairs with the saved parameters — a coarse pair replayed with the fine window reads differently, and the test proves the replay reproduces the run.

## Testing

- `tests/test_tilt_coincident.py` (9): h estimated within 10 % from the sag; walk undone with the centred patch drifting < 2 µm and coincidence kept; undo can be declined; down-then-up round trip gives h with one sign and returns to the site.
- `tests/autolamella/test_select_position_coincidence.py` (2): from the SEM orientation the task ends at the milling tilt, coincident, FIB-centred site drift < 2 µm, diagnostics written; at the milling angle it only aligns.
- Live on Demo (`tilt_axis_offset: 50e-6`): a three-lamella workflow run estimated h = 52 / 49.7 / 49.7 µm and undid ~20 µm walks; dev-menu tilts both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)