### PR TITLE
[autolamella] GridRecord: the workflow's record of a grid, on the Experiment

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -876,6 +876,10 @@ class Lamella:
         default_factory=lambda: Point(0, 0)
     )  # point of interest within lamella area (milling coordinate system)
     description: str = ""  # free-text note about the lamella
+    # The grid this lamella sits on: GridRecord.id, or None when the experiment
+    # does not track grids (every experiment before grid records existed). A
+    # back-reference only; grid -> lamella is derived by filtering on it.
+    grid_id: Optional[str] = None
 
     def __post_init__(self):
         # Deliberately does not create ``path``. Constructing a Lamella is not a
@@ -1060,6 +1064,7 @@ class Lamella:
             "milling_angle": self.milling_angle,
             "poi": self.poi.to_dict(),
             "description": self.description,
+            "grid_id": self.grid_id,
         }
 
     @property
@@ -1115,6 +1120,7 @@ class Lamella:
             milling_angle=data.get("milling_angle", None),
             poi=Point.from_dict(data.get("poi", {"x": 0, "y": 0})),
             description=data.get("description", ""),
+            grid_id=data.get("grid_id"),
         )
 
     def load_reference_image(self, fname) -> FibsemImage:
@@ -1246,6 +1252,95 @@ class Lamella:
         return synced_tasks
 
 
+class GridQuality(Enum):
+    """A human's verdict on a grid, set by hand and never by automation.
+
+    Kept apart from task status on purpose: a task that failed on a grid says
+    nothing about whether the grid is any good, and a good grid can have a failed
+    overview. Same discipline as a lamella's defect state.
+    """
+
+    UNASSESSED = auto()
+    GOOD = auto()
+    POOR = auto()
+
+
+@evented
+@dataclass
+class GridRecord:
+    """A grid as the workflow knows it, distinct from the hardware's `SampleGrid`.
+
+    Linked to the hardware by name and to lamellae by `Lamella.grid_id -> id`.
+    Deliberately holds no slot, stage position, loaded state or copy of the
+    hardware grid: all of that is resolved live against the stage, so a record
+    stays valid when its grid changes slot or leaves the magazine. A record exists
+    from the moment a grid is *available* (present in the inventory), so twelve
+    grids can be queued before any has been in the beam.
+
+    `task_state` and `task_history` are the same types the lamella side uses,
+    and the same rule applies: never replace `task_state` wholesale, mutate it.
+    """
+
+    name: str
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    description: str = ""
+    quality: GridQuality = GridQuality.UNASSESSED
+    task_state: AutoLamellaTaskState = field(default_factory=AutoLamellaTaskState)
+    task_history: List[AutoLamellaTaskState] = field(default_factory=list)
+    created_at: float = field(
+        default_factory=lambda: datetime.timestamp(datetime.now())
+    )
+
+    def __post_init__(self) -> None:
+        if not self.id:
+            self.id = str(uuid.uuid4())
+
+    def has_completed_task(self, task_name: str) -> bool:
+        return any(
+            t.name == task_name and t.status is AutoLamellaTaskStatus.Completed
+            for t in self.task_history
+        )
+
+    @property
+    def is_failure(self) -> bool:
+        """Whether the latest run on this grid ended in failure. Not a verdict on
+        the grid -- see `quality` for that."""
+        return self.task_state.status is AutoLamellaTaskStatus.Failed
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "_id": self.id,
+            "description": self.description,
+            "quality": self.quality.name,
+            "task_state": self.task_state.to_dict(),
+            "task_history": [t.to_dict() for t in self.task_history],
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "GridRecord":
+        quality = data.get("quality", GridQuality.UNASSESSED.name)
+        try:
+            quality = GridQuality[quality]
+        except KeyError:
+            quality = GridQuality.UNASSESSED
+        return cls(
+            name=data["name"],
+            id=data.get("_id") or str(uuid.uuid4()),
+            description=data.get("description", ""),
+            quality=quality,
+            task_state=AutoLamellaTaskState.from_dict(data.get("task_state", {})),
+            task_history=[
+                AutoLamellaTaskState.from_dict(t) for t in data.get("task_history", [])
+            ],
+            created_at=data.get("created_at", datetime.timestamp(datetime.now())),
+        )
+
+    def __repr__(self) -> str:
+        return f"GridRecord(name={self.name!r}, quality={self.quality.name}, tasks={len(self.task_history)})"
+
+
 @evented
 @dataclass
 class Experiment:
@@ -1253,6 +1348,7 @@ class Experiment:
     id: str
     path: Path
     positions: EventedList[Lamella] = field(default_factory=EventedList)
+    grids: EventedList[GridRecord] = field(default_factory=EventedList)
     landing_positions: List[FibsemStagePosition] = field(default_factory=list)
     created_at: float = field(
         default_factory=lambda: datetime.timestamp(datetime.now())
@@ -1282,6 +1378,7 @@ class Experiment:
         self.created_at: float = datetime.timestamp(datetime.now())
 
         self.positions: EventedList[Lamella] = EventedList()
+        self.grids: EventedList[GridRecord] = EventedList()
         self.landing_positions: List[FibsemStagePosition] = []
 
         self.task_protocol: AutoLamellaTaskProtocol = None  # must be set externally
@@ -1299,6 +1396,7 @@ class Experiment:
             "_id": self.id,
             "path": self.path,
             "positions": [deepcopy(lamella.to_dict()) for lamella in self.positions],
+            "grids": [grid.to_dict() for grid in self.grids],
             "landing_positions": [pos.to_dict() for pos in self.landing_positions],
             "created_at": self.created_at,
             "metadata": self.metadata,
@@ -1333,6 +1431,11 @@ class Experiment:
         for lamella_dict in ddict["positions"]:
             lamella = Lamella.from_dict(data=lamella_dict)
             experiment.positions.append(lamella)
+
+        # Experiments written before grid records existed have no "grids" key and
+        # load with none; nothing else about them changes.
+        for grid_dict in ddict.get("grids", []):
+            experiment.grids.append(GridRecord.from_dict(grid_dict))
 
         # load landing positions
         for landing_dict in ddict.get("landing_positions", []):
@@ -1384,6 +1487,55 @@ class Experiment:
     def get_lamella_by_name(self, name: str) -> Optional["Lamella"]:
         """Return the Lamella with the given name, or None if not found."""
         return next((p for p in self.positions if p.name == name), None)
+
+    # -- grids ---------------------------------------------------------------
+
+    def get_grid_by_name(self, name: str) -> Optional[GridRecord]:
+        return next((g for g in self.grids if g.name == name), None)
+
+    def get_grid_by_id(self, grid_id: Optional[str]) -> Optional[GridRecord]:
+        if grid_id is None:
+            return None
+        return next((g for g in self.grids if g.id == grid_id), None)
+
+    def add_grid(self, grid: GridRecord) -> GridRecord:
+        """Track a grid. Names are the link to the hardware, so they are unique."""
+        if self.get_grid_by_name(grid.name) is not None:
+            raise ValueError(f"Grid '{grid.name}' already exists in the experiment.")
+        self.grids.append(grid)
+        return grid
+
+    def remove_grid(self, name: str) -> Optional[GridRecord]:
+        """Stop tracking a grid. Its lamellae are orphaned, not deleted."""
+        grid = self.get_grid_by_name(name)
+        if grid is None:
+            return None
+        for lamella in self.get_lamellae_for_grid(grid):
+            lamella.grid_id = None
+        self.grids.remove(grid)
+        return grid
+
+    def sync_grids_from_inventory(self, stage) -> List[GridRecord]:
+        """Create a record for every grid the inventory reports present.
+
+        Idempotent, matched by name: a grid already tracked is left alone, with its
+        history; a grid whose hardware has gone keeps its record too, and the UI
+        reads "not present" for it from the inventory. Returns the records added.
+        """
+        added: List[GridRecord] = []
+        for entry in stage.grid_inventory():
+            if not entry.present or not entry.name:
+                continue
+            if self.get_grid_by_name(entry.name) is None:
+                added.append(self.add_grid(GridRecord(name=entry.name)))
+        return added
+
+    def get_lamellae_for_grid(self, grid: GridRecord) -> List["Lamella"]:
+        """Derived from `Lamella.grid_id`; nothing stores the reverse."""
+        return [p for p in self.positions if p.grid_id == grid.id]
+
+    def get_grid_for_lamella(self, lamella: "Lamella") -> Optional[GridRecord]:
+        return self.get_grid_by_id(lamella.grid_id)
 
     def save(self, save_protocol: bool = False) -> None:
         """Save the sample data to yaml file"""

--- a/tests/autolamella/test_grid_record.py
+++ b/tests/autolamella/test_grid_record.py
@@ -1,0 +1,215 @@
+"""GridRecord: the workflow's record of a grid, and its place on the Experiment.
+
+A record is linked to the hardware by name and to lamellae by `Lamella.grid_id`;
+it holds no slot, position or loaded state, so it stays valid when the grid moves
+or leaves the magazine. Experiments written before records existed load with none.
+"""
+
+import yaml
+
+from fibsem import utils
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskState,
+    AutoLamellaTaskStatus,
+    Experiment,
+    GridQuality,
+    GridRecord,
+    Lamella,
+)
+from fibsem.microscopes._stage import DemoSampleLoader, SampleGrid, _create_sample_stage
+
+
+def _experiment(tmp_path) -> Experiment:
+    return Experiment(path=tmp_path, name="exp")
+
+
+def _lamella(tmp_path, name="lam-01", grid_id=None) -> Lamella:
+    return Lamella(path=tmp_path / name, number=1, petname=name, grid_id=grid_id)
+
+
+# ---------------------------------------------------------------------------
+# The record
+# ---------------------------------------------------------------------------
+
+
+class TestGridRecord:
+    def test_defaults(self):
+        grid = GridRecord(name="grid-aspen")
+        assert grid.id
+        assert grid.quality is GridQuality.UNASSESSED
+        assert grid.task_history == []
+        assert not grid.is_failure
+
+    def test_round_trip(self):
+        grid = GridRecord(name="grid-aspen", description="HeLa, batch B")
+        grid.quality = GridQuality.GOOD
+        done = AutoLamellaTaskState(
+            name="overview_sem", status=AutoLamellaTaskStatus.Completed
+        )
+        grid.task_history.append(done)
+        again = GridRecord.from_dict(yaml.safe_load(yaml.safe_dump(grid.to_dict())))
+        assert again.id == grid.id
+        assert again.name == "grid-aspen"
+        assert again.description == "HeLa, batch B"
+        assert again.quality is GridQuality.GOOD
+        assert again.has_completed_task("overview_sem")
+        assert again.created_at == grid.created_at
+
+    def test_unknown_quality_reads_as_unassessed(self):
+        again = GridRecord.from_dict({"name": "g", "quality": "SPLENDID"})
+        assert again.quality is GridQuality.UNASSESSED
+
+    def test_missing_id_gets_one(self):
+        again = GridRecord.from_dict({"name": "g"})
+        assert again.id
+
+    def test_task_state_is_mutated_not_replaced(self):
+        grid = GridRecord(name="g")
+        state = grid.task_state
+        state.status = AutoLamellaTaskStatus.Failed
+        assert grid.is_failure
+        assert grid.task_state is state
+
+
+# ---------------------------------------------------------------------------
+# On the experiment
+# ---------------------------------------------------------------------------
+
+
+class TestExperimentGrids:
+    def test_new_experiment_has_no_grids(self, tmp_path):
+        assert list(_experiment(tmp_path).grids) == []
+
+    def test_add_and_lookup(self, tmp_path):
+        exp = _experiment(tmp_path)
+        grid = exp.add_grid(GridRecord(name="grid-aspen"))
+        assert exp.get_grid_by_name("grid-aspen") is grid
+        assert exp.get_grid_by_id(grid.id) is grid
+        assert exp.get_grid_by_id(None) is None
+
+    def test_names_are_unique(self, tmp_path):
+        exp = _experiment(tmp_path)
+        exp.add_grid(GridRecord(name="grid-aspen"))
+        try:
+            exp.add_grid(GridRecord(name="grid-aspen"))
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("a duplicate grid name was accepted")
+
+    def test_persists_and_old_files_load_with_none(self, tmp_path):
+        exp = _experiment(tmp_path)
+        grid = exp.add_grid(GridRecord(name="grid-aspen"))
+        grid.quality = GridQuality.POOR
+        data = exp.to_dict()
+        again = Experiment.from_dict(yaml.safe_load(yaml.safe_dump(data)))
+        assert [g.name for g in again.grids] == ["grid-aspen"]
+        assert again.grids[0].quality is GridQuality.POOR
+        assert again.grids[0].id == grid.id
+
+        del data["grids"]  # an experiment written before grid records existed
+        older = Experiment.from_dict(data)
+        assert list(older.grids) == []
+
+    def test_save_and_load_round_trip(self, tmp_path):
+        exp = _experiment(tmp_path)
+        exp.add_grid(GridRecord(name="grid-birch"))
+        (tmp_path / "exp").mkdir()
+        exp.save()
+        loaded = Experiment.load(tmp_path / "exp" / "experiment.yaml")
+        assert [g.name for g in loaded.grids] == ["grid-birch"]
+
+
+class TestLamellaLink:
+    def test_grid_id_round_trips_and_defaults_to_none(self, tmp_path):
+        exp = _experiment(tmp_path)
+        grid = exp.add_grid(GridRecord(name="grid-aspen"))
+        lamella = _lamella(tmp_path, grid_id=grid.id)
+        again = Lamella.from_dict(yaml.safe_load(yaml.safe_dump(lamella.to_dict())))
+        assert again.grid_id == grid.id
+        data = lamella.to_dict()
+        del data["grid_id"]
+        assert Lamella.from_dict(data).grid_id is None
+
+    def test_grid_to_lamella_is_derived(self, tmp_path):
+        exp = _experiment(tmp_path)
+        aspen = exp.add_grid(GridRecord(name="grid-aspen"))
+        birch = exp.add_grid(GridRecord(name="grid-birch"))
+        exp.positions.append(_lamella(tmp_path, "a1", grid_id=aspen.id))
+        exp.positions.append(_lamella(tmp_path, "a2", grid_id=aspen.id))
+        exp.positions.append(_lamella(tmp_path, "b1", grid_id=birch.id))
+        exp.positions.append(_lamella(tmp_path, "legacy"))
+        assert [p.name for p in exp.get_lamellae_for_grid(aspen)] == ["a1", "a2"]
+        assert exp.get_grid_for_lamella(exp.positions[2]) is birch
+        assert exp.get_grid_for_lamella(exp.positions[3]) is None
+
+    def test_removing_a_grid_orphans_its_lamellae(self, tmp_path):
+        exp = _experiment(tmp_path)
+        aspen = exp.add_grid(GridRecord(name="grid-aspen"))
+        exp.positions.append(_lamella(tmp_path, "a1", grid_id=aspen.id))
+        removed = exp.remove_grid("grid-aspen")
+        assert removed is aspen
+        assert list(exp.grids) == []
+        assert len(exp.positions) == 1 and exp.positions[0].grid_id is None
+        assert exp.remove_grid("grid-aspen") is None
+
+
+# ---------------------------------------------------------------------------
+# Sync from the inventory
+# ---------------------------------------------------------------------------
+
+
+class TestSyncFromInventory:
+    def _compustage(self):
+        microscope, _ = utils.setup_session(manufacturer="Demo")
+        microscope.stage_is_compustage = True
+        microscope._stage = _create_sample_stage(microscope)
+        microscope._stage.loader = DemoSampleLoader(
+            microscope, occupied=(1, 3), names={3: "grid-cedar"}
+        )
+        return microscope
+
+    def test_creates_a_record_per_present_grid(self, tmp_path):
+        microscope = self._compustage()
+        exp = _experiment(tmp_path)
+        added = exp.sync_grids_from_inventory(microscope._stage)
+        assert [g.name for g in added] == ["Grid-01", "grid-cedar"]
+        assert [g.name for g in exp.grids] == ["Grid-01", "grid-cedar"]
+
+    def test_is_idempotent_and_keeps_history(self, tmp_path):
+        microscope = self._compustage()
+        exp = _experiment(tmp_path)
+        exp.sync_grids_from_inventory(microscope._stage)
+        exp.get_grid_by_name("Grid-01").quality = GridQuality.GOOD
+        assert exp.sync_grids_from_inventory(microscope._stage) == []
+        assert exp.get_grid_by_name("Grid-01").quality is GridQuality.GOOD
+
+    def test_a_record_exists_before_its_grid_is_in_the_beam(self, tmp_path):
+        microscope = self._compustage()
+        exp = _experiment(tmp_path)
+        exp.sync_grids_from_inventory(microscope._stage)
+        assert microscope._stage.loaded_grids == []
+        assert exp.get_grid_by_name("grid-cedar") is not None
+
+    def test_fixed_holder_syncs_named_slots(self, tmp_path):
+        microscope, _ = utils.setup_session(manufacturer="Demo")
+        microscope.stage_is_compustage = False
+        microscope._stage = _create_sample_stage(microscope)
+        microscope._stage.assign_grid(
+            "Slot-02", SampleGrid(name="grid-birch"), persist=False
+        )
+        exp = _experiment(tmp_path)
+        exp.sync_grids_from_inventory(microscope._stage)
+        assert [g.name for g in exp.grids] == ["grid-birch"]
+
+    def test_a_grid_that_leaves_keeps_its_record(self, tmp_path):
+        microscope = self._compustage()
+        exp = _experiment(tmp_path)
+        exp.sync_grids_from_inventory(microscope._stage)
+        microscope._stage.loader.assign_grid(
+            "Slot-01", None
+        )  # taken out of the magazine
+        exp.sync_grids_from_inventory(microscope._stage)
+        assert exp.get_grid_by_name("Grid-01") is not None
+        present = {e.name for e in microscope._stage.grid_inventory() if e.present}
+        assert "Grid-01" not in present


### PR DESCRIPTION
## Summary

Milestone 2, PR 1 of 3 (Grid Workflow). The workflow's record of a grid, on the experiment.

- **`GridRecord`** — `name` (the link to the hardware `SampleGrid`), a stable `id`, `description`, a human-set **`quality`** (Unassessed / Good / Poor; automation never touches it), `task_state`, `task_history` and `created_at`. Same task-state types as a lamella, same rule: mutate `task_state`, never replace it.
- Deliberately **not** on the record: slot, stage position, loaded state, or a copy of the hardware grid. All resolved live against the stage, so a record survives its grid moving slot or leaving the magazine.
- **`Experiment.grids`** with `to_dict` / `from_dict` (files without the key load with none), `add_grid` (names unique), `get_grid_by_name` / `get_grid_by_id`, `remove_grid` (orphans linked lamellae rather than deleting them), `get_lamellae_for_grid` (derived by filtering) and `get_grid_for_lamella`.
- **`Experiment.sync_grids_from_inventory(stage)`** — a record for every grid the inventory reports *present*, matched by name; idempotent, keeps history, and a grid whose hardware has gone keeps its record (the inventory says "not present" for it). A record exists before its grid has been in the beam.
- **`Lamella.grid_id`** — added now as an additive field defaulting to None; wired up in the follow-ups milestone.

## Tests

`tests/autolamella/test_grid_record.py` (18): round trips incl. unknown quality and missing id, mutation-not-replacement, experiment persistence and old-file loading, save/load through `experiment.yaml`, the lamella link, orphaning on remove, and sync on both a Demo magazine and a fixed holder. Existing structure/forward-compat/session tests pass.

## Refs

Closes FIB-16 (Grid Workflow, milestone 2).
