### PR TITLE
[autolamella] Beam overview grid task over the tiled runner

### DIFF
--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -900,7 +900,10 @@ class DefectState:
 # 512 rather than 280: it leaves the largest card headroom on a HiDPI display, still
 # decodes in ~3 ms, and is a tenth of the bytes. Only ever shrinks -- a frame already
 # smaller than this is written through untouched.
-_THUMBNAIL_MAX_EDGE = 512
+# The bound lives with the writer; kept here by name for anything that imports it.
+from fibsem.imaging.thumbnail import (
+    THUMBNAIL_MAX_EDGE as _THUMBNAIL_MAX_EDGE,  # noqa: E402
+)
 
 
 def _make_thumbnail_placeholder():
@@ -1252,39 +1255,9 @@ class Lamella:
         `_THUMBNAIL_MAX_EDGE`. This is a thumbnail, not a copy of the frame; the frame
         itself is saved separately by the task that acquired it.
         """
-        import tempfile
+        from fibsem.imaging.thumbnail import write_thumbnail
 
-        import numpy as np
-        from PIL import Image
-
-        data = image.filtered_data
-        if data.ndim == 2:
-            data = np.stack([data, data, data], axis=2)
-        # writes directly rather than through FibsemImage.save, so it makes its
-        # own directory -- construction no longer does (FIB-420).
-        os.makedirs(self.path, exist_ok=True)
-        destination = os.path.join(self.path, "thumbnail.png")
-        handle, staged = tempfile.mkstemp(
-            dir=self.path, prefix=".thumbnail-", suffix=".png"
-        )
-        os.close(handle)
-        try:
-            thumbnail = Image.fromarray(data.astype(np.uint8))
-            # In place, and never upscales: a frame smaller than the bound keeps its
-            # own size, which is what a caller passing an already-small image expects.
-            thumbnail.thumbnail(
-                (_THUMBNAIL_MAX_EDGE, _THUMBNAIL_MAX_EDGE), Image.LANCZOS
-            )
-            thumbnail.save(staged)
-            os.replace(staged, destination)
-        except BaseException:
-            # Including cancellation: a staged file left behind would accumulate in the
-            # lamella directory, and it is hidden, so nobody would notice it doing so.
-            try:
-                os.remove(staged)
-            except OSError:
-                pass
-            raise
+        write_thumbnail(image.filtered_data, os.path.join(self.path, "thumbnail.png"))
 
     # def get_task_config_by_type(self, task_type: Type['AutoLamellaTaskConfig']) -> Dict[str, AutoLamellaTaskConfig]:
     #     """Get the task configuration by type."""

--- a/fibsem/applications/autolamella/workflows/tasks/grid/__init__.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid/__init__.py
@@ -8,9 +8,17 @@ stop token. That split is what lets a lamella workflow call the same operation
 later without going through the grid manager.
 """
 
+# The built-in tasks register themselves on import.
+from fibsem.applications.autolamella.workflows.tasks.grid import (
+    imaging,  # noqa: E402,F401
+)
 from fibsem.applications.autolamella.workflows.tasks.grid.base import (
     GridTask,
     GridTaskConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.grid.imaging import (  # noqa: E402
+    BeamOverviewGridTask,
+    BeamOverviewGridTaskConfig,
 )
 from fibsem.applications.autolamella.workflows.tasks.grid.registry import (
     GRID_TASK_REGISTRY,
@@ -23,6 +31,8 @@ from fibsem.applications.autolamella.workflows.tasks.grid.registry import (
 
 __all__ = [
     "GRID_TASK_REGISTRY",
+    "BeamOverviewGridTask",
+    "BeamOverviewGridTaskConfig",
     "GridTask",
     "GridTaskConfig",
     "get_grid_tasks",

--- a/fibsem/applications/autolamella/workflows/tasks/grid/imaging.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid/imaging.py
@@ -1,0 +1,207 @@
+"""Overview grid tasks: thin wrappers over the tiled runners on main.
+
+The operation -- `acquire_beam_overview` -- is a plain function over
+`TiledAcquisitionRunner`, callable from the Overview tab or a script. The task
+adds only what makes it a workflow step: where the grid is (its calibrated slot,
+re-expressed for the requested orientation), where the files go (the grid's own
+directory), and what to record (the stitched image and a thumbnail, by role).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar, Optional, Type, Union
+
+import numpy as np
+
+from fibsem import utils
+from fibsem.applications.autolamella.workflows.tasks.grid.base import (
+    GridTask,
+    GridTaskConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.grid.registry import (
+    register_grid_task,
+)
+from fibsem.imaging.tiled import TiledAcquisitionRunner
+from fibsem.microscopes._stage import uncalibrated_message
+from fibsem.structures import (
+    BeamType,
+    FibsemImage,
+    FibsemStagePosition,
+    OverviewAcquisitionSettings,
+)
+
+if TYPE_CHECKING:
+    from fibsem.microscope import FibsemMicroscope
+
+THUMBNAIL_MAX_EDGE = 512
+
+# The output roles a results card, the Overview tab and the agent server read
+# (FIB-876). One per beam, plus the thumbnail beside it.
+ROLE_BY_BEAM = {BeamType.ELECTRON: "overview_sem", BeamType.ION: "overview_fib"}
+
+
+def stamped_name(stem: str) -> str:
+    """`overview` -> `overview-14-23-05`: the name is a location, and two runs
+    called the same thing land on each other (the Overview tab does the same)."""
+    return f"{stem}-{utils.current_timestamp_v3(timeonly=True)}"
+
+
+def write_thumbnail(data: np.ndarray, destination: Union[str, Path]) -> str:
+    """Write `data` as a display-sized PNG, atomically. Returns the path written.
+
+    Same contract as a lamella's thumbnail: staged in the destination directory
+    and moved into place, so a reader on another thread never sees a partial file.
+    """
+    from PIL import Image
+
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if data.ndim == 2:
+        data = np.stack([data, data, data], axis=2)
+    handle, staged = tempfile.mkstemp(
+        dir=str(destination.parent), prefix=".thumbnail-", suffix=".png"
+    )
+    os.close(handle)
+    try:
+        thumbnail = Image.fromarray(np.asarray(data).astype(np.uint8))
+        thumbnail.thumbnail((THUMBNAIL_MAX_EDGE, THUMBNAIL_MAX_EDGE), Image.LANCZOS)
+        thumbnail.save(staged)
+        os.replace(staged, str(destination))
+    except BaseException:
+        try:
+            os.remove(staged)
+        except OSError:
+            pass
+        raise
+    return str(destination)
+
+
+# ---------------------------------------------------------------------------
+# The operation
+# ---------------------------------------------------------------------------
+
+
+def acquire_beam_overview(
+    microscope: "FibsemMicroscope",
+    settings: OverviewAcquisitionSettings,
+    centre: FibsemStagePosition,
+    directory: Union[str, Path],
+    stem: str = "overview",
+    stop_event=None,
+) -> FibsemImage:
+    """Acquire a tiled SEM or FIB overview centred on `centre`, saved under `directory`.
+
+    A copy of `settings` is used, so the caller's object is not rewritten with the
+    per-run path and stamped name. The beam is `settings.image_settings.beam_type`.
+    The runner restores the stage to where it started; `centre` is the grid's
+    centre, not a new home.
+    """
+    settings = deepcopy(settings)
+    settings.image_settings.save = True
+    settings.image_settings.path = str(directory)
+    settings.image_settings.filename = stamped_name(stem)
+    Path(directory).mkdir(parents=True, exist_ok=True)
+    runner = TiledAcquisitionRunner(
+        microscope, settings, stop_event=stop_event, centre_position=centre
+    )
+    return runner.run_and_stitch()
+
+
+# ---------------------------------------------------------------------------
+# The task
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BeamOverviewGridTaskConfig(GridTaskConfig):
+    """A tiled SEM or FIB overview of the grid.
+
+    One task for both beams: the beam is `settings.image_settings.beam_type`, as it
+    is everywhere else the overview settings are used, so the Overview tab's settings
+    form edits this unchanged. `orientation` is the pose to acquire in; the grid's
+    calibrated slot position is re-expressed for it.
+    """
+
+    task_type: ClassVar[str] = "BEAM_OVERVIEW_GRID"
+    display_name: ClassVar[str] = "Beam overview"
+    orientation: str = "SEM"
+    settings: OverviewAcquisitionSettings = field(
+        default_factory=OverviewAcquisitionSettings
+    )
+    filename: str = "overview"
+
+    @property
+    def beam_type(self) -> BeamType:
+        return self.settings.image_settings.beam_type
+
+    @property
+    def role(self) -> str:
+        return ROLE_BY_BEAM.get(self.beam_type, "overview")
+
+
+@register_grid_task
+class BeamOverviewGridTask(GridTask):
+    config_cls: ClassVar[Type[GridTaskConfig]] = BeamOverviewGridTaskConfig
+    config: BeamOverviewGridTaskConfig
+
+    def grid_centre(self) -> FibsemStagePosition:
+        """The grid's calibrated slot position, in the requested orientation.
+
+        Refuses a grid that is not in a holder slot (nothing has made it reachable)
+        and a slot with no calibrated position, with the same message the stage
+        gives, rather than acquiring an overview of wherever the stage happens to be.
+        """
+        slot = self.slot
+        if slot is None:
+            raise RuntimeError(
+                f"Grid '{self.grid.name}' is not in a holder slot. Load it first."
+            )
+        if slot.position is None:
+            raise RuntimeError(uncalibrated_message(slot.name))
+        return self.microscope.get_target_position(
+            slot.position, self.config.orientation
+        )
+
+    def _run(self) -> None:
+        centre = self.grid_centre()
+        self.log_status_message(
+            "MOVE_TO_GRID",
+            f"Moving to {self.grid.name} at the {self.config.orientation} orientation",
+        )
+        self.microscope.safe_absolute_stage_movement(centre)
+        self._check_for_abort()
+
+        beam = self.config.beam_type.name
+        self.log_status_message(
+            "ACQUIRE",
+            f"Acquiring {beam} overview: {self.config.settings.nrows} x "
+            f"{self.config.settings.ncols} tiles",
+        )
+        image = acquire_beam_overview(
+            self.microscope,
+            self.config.settings,
+            centre,
+            self.output_dir,
+            stem=self.config.filename,
+            stop_event=self._stop_event,
+        )
+        self.record_output(self.config.role, image)
+
+        # Beside the stitched image, named after it, so a card can show it without
+        # decoding a full-resolution overview. A missing thumbnail is worth far less
+        # than a recorded overview, so a failure here is logged, not raised.
+        try:
+            stem = Path(image.filepath).stem if image.filepath else self.config.filename
+            thumbnail = write_thumbnail(
+                image.filtered_data, self.output_dir / f"{stem}-thumbnail.png"
+            )
+            self.record_output(f"{self.config.role}_thumbnail", thumbnail)
+        except Exception as e:  # noqa: BLE001 - the overview is already recorded
+            logging.warning(f"Could not write the overview thumbnail: {e}")
+        self.log_status_message("ACQUIRED", f"{beam} overview recorded")

--- a/fibsem/applications/autolamella/workflows/tasks/grid/imaging.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid/imaging.py
@@ -10,8 +10,6 @@ directory), and what to record (the stitched image and a thumbnail, by role).
 from __future__ import annotations
 
 import logging
-import os
-import tempfile
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -19,7 +17,6 @@ from typing import TYPE_CHECKING, ClassVar, Optional, Type, Union
 
 import numpy as np
 
-from fibsem import utils
 from fibsem.applications.autolamella.workflows.tasks.grid.base import (
     GridTask,
     GridTaskConfig,
@@ -27,7 +24,8 @@ from fibsem.applications.autolamella.workflows.tasks.grid.base import (
 from fibsem.applications.autolamella.workflows.tasks.grid.registry import (
     register_grid_task,
 )
-from fibsem.imaging.tiled import TiledAcquisitionRunner
+from fibsem.imaging.thumbnail import write_thumbnail
+from fibsem.imaging.tiled import TiledAcquisitionRunner, stamped_overview_name
 from fibsem.microscopes._stage import uncalibrated_message
 from fibsem.structures import (
     BeamType,
@@ -39,47 +37,9 @@ from fibsem.structures import (
 if TYPE_CHECKING:
     from fibsem.microscope import FibsemMicroscope
 
-THUMBNAIL_MAX_EDGE = 512
-
 # The output roles a results card, the Overview tab and the agent server read
 # (FIB-876). One per beam, plus the thumbnail beside it.
 ROLE_BY_BEAM = {BeamType.ELECTRON: "overview_sem", BeamType.ION: "overview_fib"}
-
-
-def stamped_name(stem: str) -> str:
-    """`overview` -> `overview-14-23-05`: the name is a location, and two runs
-    called the same thing land on each other (the Overview tab does the same)."""
-    return f"{stem}-{utils.current_timestamp_v3(timeonly=True)}"
-
-
-def write_thumbnail(data: np.ndarray, destination: Union[str, Path]) -> str:
-    """Write `data` as a display-sized PNG, atomically. Returns the path written.
-
-    Same contract as a lamella's thumbnail: staged in the destination directory
-    and moved into place, so a reader on another thread never sees a partial file.
-    """
-    from PIL import Image
-
-    destination = Path(destination)
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    if data.ndim == 2:
-        data = np.stack([data, data, data], axis=2)
-    handle, staged = tempfile.mkstemp(
-        dir=str(destination.parent), prefix=".thumbnail-", suffix=".png"
-    )
-    os.close(handle)
-    try:
-        thumbnail = Image.fromarray(np.asarray(data).astype(np.uint8))
-        thumbnail.thumbnail((THUMBNAIL_MAX_EDGE, THUMBNAIL_MAX_EDGE), Image.LANCZOS)
-        thumbnail.save(staged)
-        os.replace(staged, str(destination))
-    except BaseException:
-        try:
-            os.remove(staged)
-        except OSError:
-            pass
-        raise
-    return str(destination)
 
 
 # ---------------------------------------------------------------------------
@@ -105,7 +65,7 @@ def acquire_beam_overview(
     settings = deepcopy(settings)
     settings.image_settings.save = True
     settings.image_settings.path = str(directory)
-    settings.image_settings.filename = stamped_name(stem)
+    settings.image_settings.filename = stamped_overview_name(stem)
     Path(directory).mkdir(parents=True, exist_ok=True)
     runner = TiledAcquisitionRunner(
         microscope, settings, stop_event=stop_event, centre_position=centre

--- a/fibsem/imaging/thumbnail.py
+++ b/fibsem/imaging/thumbnail.py
@@ -1,0 +1,58 @@
+"""Display-sized copies of acquired frames, written so a reader never sees a partial one.
+
+One writer for every thumbnail the app keeps beside a frame: a lamella's, a grid
+overview's. Written at display size rather than at the acquired resolution -- this
+is a thumbnail, not a copy of the frame, which is saved separately by whatever
+acquired it.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+
+THUMBNAIL_MAX_EDGE = 512
+
+
+def write_thumbnail(
+    data: np.ndarray,
+    destination: Union[str, Path],
+    max_edge: int = THUMBNAIL_MAX_EDGE,
+) -> str:
+    """Write `data` (2-D grey or (H, W, 3) RGB) as a PNG no larger than `max_edge`.
+
+    Staged in the destination's directory and moved into place: `os.replace` is
+    atomic on POSIX and on Windows provided both are on one filesystem, so a
+    reader on another thread sees either the previous thumbnail or the new one,
+    never a partial. Never upscales -- a frame smaller than the bound keeps its
+    size. Returns the path written.
+    """
+    from PIL import Image
+
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    data = np.asarray(data)
+    if data.ndim == 2:
+        data = np.stack([data, data, data], axis=2)
+    handle, staged = tempfile.mkstemp(
+        dir=str(destination.parent), prefix=".thumbnail-", suffix=".png"
+    )
+    os.close(handle)
+    try:
+        thumbnail = Image.fromarray(data.astype(np.uint8))
+        thumbnail.thumbnail((max_edge, max_edge), Image.LANCZOS)
+        thumbnail.save(staged)
+        os.replace(staged, str(destination))
+    except BaseException:
+        # Including cancellation: a staged file left behind would accumulate, and
+        # it is hidden, so nobody would notice it doing so.
+        try:
+            os.remove(staged)
+        except OSError:
+            pass
+        raise
+    return str(destination)

--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -12,7 +12,7 @@ import numpy as np
 from fibsem import acquire, conversions
 from fibsem.autofunctions.autofocus import run_auto_focus
 from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
-from fibsem.constants import DATETIME_FILE, TIME_FILE
+from fibsem.constants import DATETIME_FILE
 
 # Moved to the `tiling` package (FIB-390); re-exported so existing importers and the
 # public API are unaffected. `fibsem/imaging/__init__.py` star-imports this module.
@@ -57,6 +57,7 @@ from fibsem.structures import (
     Point,
     TileOrderStrategy,
 )
+from fibsem.utils import current_timestamp_v3
 
 ##### TILE GRID
 
@@ -87,7 +88,7 @@ def stamped_overview_name(name: str) -> str:
     from another. Applied to whatever a caller asks for, not only to a default: a
     name someone typed is no less prone to being reused.
     """
-    return f"{name}-{datetime.datetime.now().strftime(TIME_FILE)}"
+    return f"{name}-{current_timestamp_v3(timeonly=True)}"
 
 
 class TiledAcquisitionRunner:

--- a/fibsem/imaging/tiled.py
+++ b/fibsem/imaging/tiled.py
@@ -12,7 +12,7 @@ import numpy as np
 from fibsem import acquire, conversions
 from fibsem.autofunctions.autofocus import run_auto_focus
 from fibsem.cancellation import OperationCancelledError, raise_if_cancelled
-from fibsem.constants import DATETIME_FILE
+from fibsem.constants import DATETIME_FILE, TIME_FILE
 
 # Moved to the `tiling` package (FIB-390); re-exported so existing importers and the
 # public API are unaffected. `fibsem/imaging/__init__.py` star-imports this module.
@@ -74,6 +74,20 @@ def _check_cancelled(stop_event: Optional[threading.Event]) -> None:
 
 
 ##### TILED ACQUISITION
+
+
+def stamped_overview_name(name: str) -> str:
+    """`overview-image` -> `overview-image-14-23-05`, the time the run was started.
+
+    The name is not a label, it is a location: both overview runners make the tile
+    sub-folder from it and write the stitch keyed on the same name. Two runs called
+    the same thing therefore land on each other -- the second overwrites the first's
+    tiles *and* its mosaic. Time rather than date and time: the experiment directory
+    is already dated, so inside it the time of day is what distinguishes one run
+    from another. Applied to whatever a caller asks for, not only to a default: a
+    name someone typed is no less prone to being reused.
+    """
+    return f"{name}-{datetime.datetime.now().strftime(TIME_FILE)}"
 
 
 class TiledAcquisitionRunner:

--- a/fibsem/ui/widgets/overview_acquisition_settings_widget.py
+++ b/fibsem/ui/widgets/overview_acquisition_settings_widget.py
@@ -16,6 +16,7 @@ from fibsem.config import (
     DEFAULT_STANDARD_RESOLUTION,
     DEFAULT_STANDARD_RESOLUTION_LIST,
 )
+from fibsem.imaging.tiled import stamped_overview_name as _stamped_overview_name
 from fibsem.structures import (
     AutoFocusMode,
     BeamType,
@@ -32,7 +33,6 @@ from fibsem.ui.widgets.custom_widgets import (
     ValueSpinBox,
 )
 from fibsem.ui.widgets.image_settings_widget import ImageSettingsWidget
-from fibsem.utils import current_timestamp_v3
 
 # What an overview run looks like before anyone touches it.
 #
@@ -49,29 +49,9 @@ OVERVIEW_TILE_DWELL_TIME = 1e-6  # s
 DEFAULT_OVERVIEW_FILENAME = "overview-image"
 
 
-def stamped_overview_name(name: str) -> str:
-    """`overview-image` -> `overview-image-14-23-05`, the time the run was started.
-
-    The name is not a label, it is a location: both overview runners make the tile
-    sub-folder from it and write the stitch keyed on the same name. Two runs called the
-    same thing therefore land on each other -- the second overwrites the first's tiles
-    *and* its mosaic, and only the canvas, holding both in memory, still shows two.
-    Reloading the experiment finds one.
-
-    Time rather than date and time: the experiment directory is already dated, so inside
-    it the time of day is the whole of what distinguishes one run from another.
-
-    Applied to whatever the box says, not only to the default. A name someone typed is
-    no less prone to being reused -- more so, since a memorable name invites it -- and a
-    run that quietly replaced an earlier one is worse than a name with six digits on the
-    end. The box keeps showing the base, and the destination line reports the stamped
-    name, which is what that row is for.
-
-    Shared by both overview tabs. It lived in the FIB/SEM tab, which is 2,000 lines the
-    fluorescence side has no reason to import; here it sits beside
-    `DEFAULT_OVERVIEW_FILENAME`, which is the name it is usually applied to.
-    """
-    return f"{name}-{current_timestamp_v3(timeonly=True)}"
+# Re-exported: it lives with the runners that make the folder from it, and both
+# overview tabs and the grid overview tasks import the same one.
+stamped_overview_name = _stamped_overview_name
 
 
 def default_overview_acquisition_settings() -> OverviewAcquisitionSettings:

--- a/tests/autolamella/test_grid_overview_task.py
+++ b/tests/autolamella/test_grid_overview_task.py
@@ -7,6 +7,7 @@ and a thumbnail by role under the grid's own directory.
 """
 
 import threading
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -171,7 +172,7 @@ class TestRun:
         grid = experiment.get_grid_by_name("grid-aspen")
         run_grid_task(microscope, "overview_fib", experiment, grid)
         (overview,) = grid_outputs(experiment, grid, "overview_fib")
-        assert "/overview_fib/" in overview
+        assert Path(overview).parent.name == "overview_fib"
         assert grid_outputs(experiment, grid, "overview_sem") == []
 
     def test_stage_is_where_it_started_afterwards(self, microscope, experiment):
@@ -224,7 +225,9 @@ class TestRun:
             tmp_path / "standalone",
             stem="ov",
         )
-        assert image.filepath and "/standalone/ov-" in image.filepath
+        assert image.filepath
+        assert Path(image.filepath).parent.name == "standalone"
+        assert Path(image.filepath).name.startswith("ov-")
         assert image.data.ndim == 2
 
 

--- a/tests/autolamella/test_grid_overview_task.py
+++ b/tests/autolamella/test_grid_overview_task.py
@@ -32,8 +32,8 @@ from fibsem.applications.autolamella.workflows.tasks.grid import (
 )
 from fibsem.applications.autolamella.workflows.tasks.grid.imaging import (
     acquire_beam_overview,
-    write_thumbnail,
 )
+from fibsem.imaging.thumbnail import write_thumbnail
 from fibsem.microscopes._stage import SampleGrid, SlotCalibration, _create_sample_stage
 from fibsem.structures import (
     BeamType,

--- a/tests/autolamella/test_grid_overview_task.py
+++ b/tests/autolamella/test_grid_overview_task.py
@@ -1,0 +1,238 @@
+"""The beam overview grid task, end to end on the simulator.
+
+One task for both beams, an orientation to acquire in, the standard overview
+settings. It starts from the grid's calibrated slot position re-expressed for the
+orientation, refuses a grid that is not reachable, and records the stitched image
+and a thumbnail by role under the grid's own directory.
+"""
+
+import threading
+
+import numpy as np
+import pytest
+import yaml
+
+from fibsem import utils
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    AutoLamellaTaskStatus,
+    Experiment,
+    GridRecord,
+)
+from fibsem.applications.autolamella.task_outputs import (
+    grid_outputs,
+    latest_grid_output,
+)
+from fibsem.applications.autolamella.workflows.tasks.grid import (
+    GRID_TASK_REGISTRY,
+    BeamOverviewGridTask,
+    BeamOverviewGridTaskConfig,
+    run_grid_task,
+)
+from fibsem.applications.autolamella.workflows.tasks.grid.imaging import (
+    acquire_beam_overview,
+    write_thumbnail,
+)
+from fibsem.microscopes._stage import SampleGrid, SlotCalibration, _create_sample_stage
+from fibsem.structures import (
+    BeamType,
+    FibsemStagePosition,
+    ImageSettings,
+    OverviewAcquisitionSettings,
+)
+
+
+def _small_settings(
+    beam=BeamType.ELECTRON, rows=2, cols=2
+) -> OverviewAcquisitionSettings:
+    return OverviewAcquisitionSettings(
+        image_settings=ImageSettings(resolution=(128, 128), hfw=200e-6, beam_type=beam),
+        nrows=rows,
+        ncols=cols,
+    )
+
+
+@pytest.fixture
+def microscope():
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    microscope.stage_is_compustage = False
+    microscope._stage = _create_sample_stage(microscope)
+    slot = microscope._stage.holder.slots["Slot-01"]
+    slot.position = FibsemStagePosition(
+        name="Slot-01", x=-4e-3, y=1e-3, z=4e-3, r=0.0, t=0.61
+    )
+    slot.calibration = SlotCalibration("SEM", 35.0, 0.0, "2026-09-02T11:24:09", "test")
+    slot.loaded_grid = SampleGrid(name="grid-aspen")
+    return microscope
+
+
+@pytest.fixture
+def experiment(tmp_path):
+    exp = Experiment(path=tmp_path, name="exp")
+    (tmp_path / "exp").mkdir()
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    exp.grid_protocol.add(
+        BeamOverviewGridTaskConfig(task_name="overview_sem", settings=_small_settings())
+    )
+    exp.grid_protocol.add(
+        BeamOverviewGridTaskConfig(
+            task_name="overview_fib",
+            orientation="FIB",
+            settings=_small_settings(BeamType.ION),
+        )
+    )
+    exp.add_grid(GridRecord(name="grid-aspen"))
+    return exp
+
+
+class TestConfig:
+    def test_registered(self):
+        assert GRID_TASK_REGISTRY["BEAM_OVERVIEW_GRID"] is BeamOverviewGridTask
+
+    def test_role_follows_the_beam_in_the_settings(self):
+        assert BeamOverviewGridTaskConfig().role == "overview_sem"
+        assert (
+            BeamOverviewGridTaskConfig(settings=_small_settings(BeamType.ION)).role
+            == "overview_fib"
+        )
+
+    def test_round_trips_through_protocol_yaml(self, experiment, tmp_path):
+        experiment.save(save_protocol=True)
+        loaded = Experiment.load(tmp_path / "exp" / "experiment.yaml")
+        fib = loaded.grid_protocol.task_config["overview_fib"]
+        assert isinstance(fib, BeamOverviewGridTaskConfig)
+        assert fib.orientation == "FIB"
+        assert fib.beam_type is BeamType.ION
+        assert fib.settings.nrows == 2 and fib.settings.image_settings.hfw == 200e-6
+        data = yaml.safe_load((tmp_path / "exp" / "protocol.yaml").read_text())
+        assert data["grid_tasks"]["order"] == ["overview_sem", "overview_fib"]
+
+
+class TestReachability:
+    def test_refuses_a_grid_that_is_not_in_a_slot(self, microscope, experiment):
+        grid = experiment.add_grid(GridRecord(name="grid-nowhere"))
+        with pytest.raises(RuntimeError, match="not in a holder slot"):
+            run_grid_task(microscope, "overview_sem", experiment, grid)
+        assert grid.task_state.status is AutoLamellaTaskStatus.Failed
+
+    def test_refuses_an_uncalibrated_slot(self, microscope, experiment):
+        slot = microscope._stage.holder.slots["Slot-01"]
+        slot.position = None
+        slot.calibration = None
+        grid = experiment.get_grid_by_name("grid-aspen")
+        with pytest.raises(RuntimeError, match="Calibrate slot positions"):
+            run_grid_task(microscope, "overview_sem", experiment, grid)
+
+    def test_centre_is_the_slot_re_expressed_for_the_orientation(
+        self, microscope, experiment
+    ):
+        grid = experiment.get_grid_by_name("grid-aspen")
+        task = BeamOverviewGridTask(
+            microscope,
+            experiment.grid_protocol.task_config["overview_fib"],
+            grid,
+            experiment,
+        )
+        centre = task.grid_centre()
+        fib = microscope.get_orientation("FIB")
+        assert centre.r == pytest.approx(fib.r) and centre.t == pytest.approx(fib.t)
+        # a half turn about the stage axis mirrors x: the slot at -4 mm is reached at
+        # +4 mm once the stage has rotated to the FIB orientation
+        assert abs(centre.x) == pytest.approx(4e-3, abs=1e-6)
+        sem = task.microscope.get_target_position(task.slot.position, "SEM")
+        assert sem.x == pytest.approx(-4e-3, abs=1e-6)
+
+
+class TestRun:
+    def test_records_the_stitched_image_and_a_thumbnail(
+        self, microscope, experiment, tmp_path
+    ):
+        grid = experiment.get_grid_by_name("grid-aspen")
+        run_grid_task(microscope, "overview_sem", experiment, grid)
+
+        entry = grid.task_history[-1]
+        assert entry.status is AutoLamellaTaskStatus.Completed
+        assert set(entry.outputs) == {"overview_sem", "overview_sem_thumbnail"}
+        (overview,) = grid_outputs(experiment, grid, "overview_sem")
+        assert overview.startswith(
+            str(tmp_path / "exp" / "grids" / "grid-aspen" / "overview_sem")
+        )
+        assert overview.endswith(".tif")
+        thumbnail = latest_grid_output(experiment, grid, "overview_sem_thumbnail")
+        assert thumbnail.endswith("-thumbnail.png")
+        from PIL import Image
+
+        with Image.open(thumbnail) as im:
+            assert max(im.size) <= 512
+
+    def test_fib_overview_lands_under_its_own_role_and_task(
+        self, microscope, experiment
+    ):
+        grid = experiment.get_grid_by_name("grid-aspen")
+        run_grid_task(microscope, "overview_fib", experiment, grid)
+        (overview,) = grid_outputs(experiment, grid, "overview_fib")
+        assert "/overview_fib/" in overview
+        assert grid_outputs(experiment, grid, "overview_sem") == []
+
+    def test_stage_is_where_it_started_afterwards(self, microscope, experiment):
+        before = microscope.get_stage_position()
+        grid = experiment.get_grid_by_name("grid-aspen")
+        run_grid_task(microscope, "overview_sem", experiment, grid)
+        after = microscope.get_stage_position()
+        # the runner restores its start, which is the grid centre the task moved to
+        centre = microscope.get_target_position(
+            microscope._stage.holder.slots["Slot-01"].position, "SEM"
+        )
+        assert after.x == pytest.approx(centre.x, abs=1e-6)
+        assert after.x != pytest.approx(before.x, abs=1e-6)
+
+    def test_two_runs_do_not_overwrite_each_other(self, microscope, experiment):
+        grid = experiment.get_grid_by_name("grid-aspen")
+        run_grid_task(microscope, "overview_sem", experiment, grid)
+        import time
+
+        time.sleep(1.1)  # the name carries the time of day, to the second
+        run_grid_task(microscope, "overview_sem", experiment, grid)
+        assert len(grid_outputs(experiment, grid, "overview_sem")) == 2
+
+    def test_a_stop_before_the_run_is_a_cancellation(self, microscope, experiment):
+        class Manager:
+            abort_token = threading.Event()
+            hook_manager = None
+
+            @property
+            def should_abort(self):
+                return self.abort_token.is_set()
+
+            def hook_run_context(self):
+                return {}
+
+        manager = Manager()
+        manager.abort_token.set()
+        grid = experiment.get_grid_by_name("grid-aspen")
+        with pytest.raises((InterruptedError, Exception)):
+            run_grid_task(
+                microscope, "overview_sem", experiment, grid, task_manager=manager
+            )
+        assert grid.task_state.status is AutoLamellaTaskStatus.Cancelled
+
+    def test_the_operation_is_callable_standalone(self, microscope, tmp_path):
+        image = acquire_beam_overview(
+            microscope,
+            _small_settings(),
+            microscope.get_stage_position(),
+            tmp_path / "standalone",
+            stem="ov",
+        )
+        assert image.filepath and "/standalone/ov-" in image.filepath
+        assert image.data.ndim == 2
+
+
+def test_write_thumbnail_bounds_the_size_and_is_atomic(tmp_path):
+    data = (np.random.rand(1200, 900) * 255).astype(np.uint8)
+    path = write_thumbnail(data, tmp_path / "t" / "thumb.png")
+    from PIL import Image
+
+    with Image.open(path) as im:
+        assert max(im.size) == 512
+    assert [p.name for p in (tmp_path / "t").iterdir()] == ["thumb.png"]

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -3442,10 +3442,11 @@ class TestTwoRunsCannotLandOnEachOther:
         raced: two real runs are minutes apart, and a test that acquires twice in the
         same second would pass for the wrong reason either way.
 
-        The clock is read where the stamping lives, which is now shared with the
-        fluorescence tab rather than private to this one.
+        The clock is read where the stamping lives, `fibsem.imaging.tiled`, which is
+        shared with the fluorescence tab and the grid tasks rather than private to
+        this one.
         """
-        from fibsem.ui.widgets import overview_acquisition_settings_widget as module
+        from fibsem.imaging import tiled as module
 
         times = iter(["14-23-05", "14-31-40"])
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Milestone 3, PR 1 of 2 (stacked on #733). The SEM/FIB overview as a grid task, over the class-based tiled runner on main.

- **One task for both beams** (decided in review): `BeamOverviewGridTaskConfig` has an `orientation` to acquire in, the standard `OverviewAcquisitionSettings` (the beam is `settings.image_settings.beam_type`, as everywhere else, so the Overview tab's settings form edits it unchanged) and a filename stem. The output role follows the beam: `overview_sem` / `overview_fib`, plus `<role>_thumbnail`.
- **Grid centre** = the grid's calibrated slot position re-expressed for the orientation via `get_target_position`. A grid not in a holder slot, or a slot with no calibrated position, is refused with the stage's own message rather than surveyed wherever the stage is. On the Arctis the working slot is the origin by construction, so this needs nothing extra there.
- **The operation is standalone**: `acquire_beam_overview(microscope, settings, centre, directory, stem, stop_event)` is a plain function over `TiledAcquisitionRunner`, using a copy of the settings and a time-stamped name (two runs never land on each other). The task adds the move, the grid's directory (`grids/<name>/<task>/`), and the record.
- **Thumbnail** written display-sized and atomically beside the stitched image; a thumbnail failure is logged, never fails the task. On review, the two helpers this needed got proper homes rather than a second copy: `fibsem.imaging.thumbnail.write_thumbnail` (now also the body of `Lamella.save_thumbnail`) and `stamped_overview_name` moved from the overview settings *widget* into `fibsem.imaging.tiled` beside the runners that make the folder from it (the widget re-exports it, so both overview tabs are unchanged).
- Registered on package import.

## Tests

`tests/autolamella/test_grid_overview_task.py` (13, on the Demo with 2×2 tiles at 128 px): registration, role from beam, round trip through `protocol.yaml`; refusal when not in a slot and when uncalibrated; the FIB orientation mirrors x (a half turn) with SEM unchanged; a run records the `.tif` and a ≤512 px thumbnail under `grids/<name>/overview_sem/`; the FIB task lands under its own role and folder; the stage ends where the run started; two runs a second apart keep both files; a Stop is a cancellation; the operation works standalone; the thumbnail writer bounds size and leaves no staged file.

## Refs

Closes FIB-14 (Grid Workflow, milestone 3). Builds on #733.
