### PR TITLE
[autolamella] Fluorescence overview grid task over the FM tiled runner

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/grid/__init__.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid/__init__.py
@@ -9,12 +9,17 @@ later without going through the grid manager.
 """
 
 # The built-in tasks register themselves on import.
-from fibsem.applications.autolamella.workflows.tasks.grid import (
-    imaging,  # noqa: E402,F401
+from fibsem.applications.autolamella.workflows.tasks.grid import (  # noqa: E402,F401
+    fluorescence,
+    imaging,
 )
 from fibsem.applications.autolamella.workflows.tasks.grid.base import (
     GridTask,
     GridTaskConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.grid.fluorescence import (  # noqa: E402
+    FluorescenceOverviewGridTask,
+    FluorescenceOverviewGridTaskConfig,
 )
 from fibsem.applications.autolamella.workflows.tasks.grid.imaging import (  # noqa: E402
     BeamOverviewGridTask,
@@ -33,6 +38,8 @@ __all__ = [
     "GRID_TASK_REGISTRY",
     "BeamOverviewGridTask",
     "BeamOverviewGridTaskConfig",
+    "FluorescenceOverviewGridTask",
+    "FluorescenceOverviewGridTaskConfig",
     "GridTask",
     "GridTaskConfig",
     "get_grid_tasks",

--- a/fibsem/applications/autolamella/workflows/tasks/grid/base.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid/base.py
@@ -23,6 +23,7 @@ from typing import (
     Any,
     ClassVar,
     Dict,
+    List,
     Optional,
     Tuple,
     Type,
@@ -115,6 +116,9 @@ def _deserialise(hint: Any, value: Any) -> Any:
     if origin is Union:  # Optional[X]
         inner = [a for a in hint.__args__ if a is not type(None)]
         return _deserialise(inner[0], value) if len(inner) == 1 else value
+    if origin in (list, List) and isinstance(value, list):  # List[X]
+        (item_hint,) = getattr(hint, "__args__", (None,))
+        return [_deserialise(item_hint, v) for v in value]
     if isinstance(hint, type):
         if issubclass(hint, Enum) and isinstance(value, str):
             return hint[value]

--- a/fibsem/applications/autolamella/workflows/tasks/grid/fluorescence.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid/fluorescence.py
@@ -1,0 +1,174 @@
+"""The fluorescence overview grid task: a thin wrapper over the FM tiled runner.
+
+The operation -- `acquire_fluorescence_overview` -- is a plain function over
+`FMTiledAcquisitionRunner` and `OverviewDestination`, laying files out as the FM
+Overview tab does. The task adds the travel to the FM, the objective, the grid's
+own directory, and the record: the mosaic and a channel-composite thumbnail.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar, List, Optional, Tuple, Type, Union
+
+from fibsem.applications.autolamella.workflows.tasks.grid.base import (
+    GridTask,
+    GridTaskConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.grid.registry import (
+    register_grid_task,
+)
+from fibsem.autofunctions.autofocus import AutoFocusSettings
+from fibsem.fm.acquisition import FMTiledAcquisitionRunner, OverviewDestination
+from fibsem.fm.preview import composite_projection
+from fibsem.fm.structures import ChannelSettings, OverviewParameters, ZParameters
+from fibsem.imaging.thumbnail import write_thumbnail
+from fibsem.imaging.tiled import stamped_overview_name
+from fibsem.microscopes._stage import uncalibrated_message
+from fibsem.structures import FibsemStagePosition
+
+if TYPE_CHECKING:
+    from fibsem.fm.structures import FluorescenceImage
+    from fibsem.microscope import FibsemMicroscope
+
+# ---------------------------------------------------------------------------
+
+
+def acquire_fluorescence_overview(
+    microscope: "FibsemMicroscope",
+    channels: List[ChannelSettings],
+    parameters: OverviewParameters,
+    centre: FibsemStagePosition,
+    directory: Union[str, Path],
+    stem: str = "overview",
+    zparams: Optional[ZParameters] = None,
+    autofocus_settings: Optional[AutoFocusSettings] = None,
+    stop_event=None,
+) -> Tuple["FluorescenceImage", Optional[str]]:
+    """Acquire a fluorescence tileset centred on `centre`, saved under `directory`.
+
+    Returns the stitched mosaic and where it was written (None if the write
+    failed; the mosaic is still returned). The tiles land in a directory of the
+    run's name beside the mosaic, as the FM Overview tab lays them out.
+    """
+    Path(directory).mkdir(parents=True, exist_ok=True)
+    destination = OverviewDestination.create(
+        str(directory), stamped_overview_name(stem)
+    )
+    runner = FMTiledAcquisitionRunner(
+        microscope=microscope,
+        channel_settings=list(channels),
+        overview_parameters=parameters,
+        zparams=zparams if parameters.use_zstack else None,
+        autofocus_settings=autofocus_settings,
+        save_directory=destination.tiles_directory,
+        stop_event=stop_event,
+        centre_position=centre,
+    )
+    mosaic = runner.run_and_stitch()
+    return mosaic, destination.save_mosaic(mosaic)
+
+
+@dataclass
+class FluorescenceOverviewGridTaskConfig(GridTaskConfig):
+    """A tiled fluorescence overview of the grid: the FM Overview tab's inputs."""
+
+    task_type: ClassVar[str] = "FM_OVERVIEW_GRID"
+    display_name: ClassVar[str] = "Fluorescence overview"
+    channels: List[ChannelSettings] = field(
+        default_factory=lambda: [ChannelSettings(name="Channel-01")]
+    )
+    # `overview`, not `parameters`: the base config's `parameters` is the list
+    # of a form's fields, and a field of that name would shadow it.
+    overview: OverviewParameters = field(default_factory=OverviewParameters)
+    zparams: ZParameters = field(default_factory=ZParameters)
+    autofocus_settings: Optional[AutoFocusSettings] = None
+    filename: str = "overview"
+
+    role: ClassVar[str] = "overview_fm"
+
+
+@register_grid_task
+class FluorescenceOverviewGridTask(GridTask):
+    """Move to the FM, put the objective in, acquire, record, and put things back.
+
+    The objective is inserted for the run if it was not already, and returned to
+    how it was found afterwards: a grid exchange with the objective in is not a
+    thing to leave possible by accident.
+    """
+
+    config_cls: ClassVar[Type[GridTaskConfig]] = FluorescenceOverviewGridTaskConfig
+    config: FluorescenceOverviewGridTaskConfig
+
+    def grid_centre(self) -> FibsemStagePosition:
+        """The grid's calibrated slot position, at the FM.
+
+        On a compustage the FM is an orientation (a flip); on an offset mount it is
+        a device the stage travels to with its pose kept. `get_target_position`
+        spells the two differently, and refuses the wrong one, so the branch is here.
+        """
+        slot = self.slot
+        if slot is None:
+            raise RuntimeError(
+                f"Grid '{self.grid.name}' is not in a holder slot. Load it first."
+            )
+        if slot.position is None:
+            raise RuntimeError(uncalibrated_message(slot.name))
+        if self.microscope.stage_is_compustage:
+            return self.microscope.get_target_position(slot.position, "FM")
+        return self.microscope.get_target_position(slot.position, target_device="FM")
+
+    def _run(self) -> None:
+        fm = getattr(self.microscope, "fm", None)
+        if fm is None:
+            raise RuntimeError("This system has no fluorescence microscope.")
+        centre = self.grid_centre()
+
+        # Read before the travel: on a compustage `move_to_device("FM")` inserts the
+        # objective itself, and "how it was found" means before any of this ran.
+        objective = fm.objective
+        was_inserted = objective.state == "Inserted"
+
+        self.log_status_message("MOVE_TO_FM", f"Moving {self.grid.name} to the FM")
+        self.microscope.move_to_device("FM")
+        self._check_for_abort()
+
+        if objective.state != "Inserted":
+            self.log_status_message("INSERT_OBJECTIVE", "Inserting the objective")
+            objective.insert()
+        try:
+            self.log_status_message(
+                "ACQUIRE",
+                f"Acquiring fluorescence overview: {self.config.overview.rows} x "
+                f"{self.config.overview.cols} tiles, "
+                f"{len(self.config.channels)} channel(s)",
+            )
+            mosaic, saved = acquire_fluorescence_overview(
+                self.microscope,
+                self.config.channels,
+                self.config.overview,
+                centre,
+                self.output_dir,
+                stem=self.config.filename,
+                zparams=self.config.zparams,
+                autofocus_settings=self.config.autofocus_settings,
+                stop_event=self._stop_event,
+            )
+            if saved is None:
+                raise RuntimeError("The fluorescence overview could not be saved.")
+            self.record_output(self.config.role, saved)
+            try:
+                thumbnail = write_thumbnail(
+                    composite_projection(mosaic),
+                    self.output_dir / f"{Path(saved).name.split('.')[0]}-thumbnail.png",
+                )
+                self.record_output(f"{self.config.role}_thumbnail", thumbnail)
+            except Exception as e:  # noqa: BLE001 - the overview is already recorded
+                logging.warning(f"Could not write the fluorescence thumbnail: {e}")
+        finally:
+            if not was_inserted:
+                self.log_status_message("RETRACT_OBJECTIVE", "Retracting the objective")
+                objective.retract()
+        self.log_status_message("ACQUIRED", "Fluorescence overview recorded")

--- a/fibsem/applications/autolamella/workflows/tasks/grid/imaging.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid/imaging.py
@@ -1,4 +1,4 @@
-"""Overview grid tasks: thin wrappers over the tiled runners on main.
+"""The beam overview grid task: a thin wrapper over the FIB/SEM tiled runner.
 
 The operation -- `acquire_beam_overview` -- is a plain function over
 `TiledAcquisitionRunner`, callable from the Overview tab or a script. The task

--- a/fibsem/fm/preview.py
+++ b/fibsem/fm/preview.py
@@ -20,12 +20,41 @@ def is_fluorescence_image(filepath: str) -> bool:
     return os.fspath(filepath).lower().endswith((".ome.tiff", ".ome.tif"))
 
 
-def load_projection(filepath: str) -> Tuple[np.ndarray, float]:
-    """Composite a fluorescence z-stack into one RGB image.
+def composite_projection(image: FluorescenceImage) -> np.ndarray:
+    """Max-project each channel over z, tint by its colour, blend: an (H, W, 3) RGB.
 
-    Max-projects each channel over z, tints it by the channel's colour and blends
-    additively — the same composite the FM canvas shows, so a stack looks the same
-    in the review panel as it did live.
+    The same composite the FM canvas shows, from an image in hand -- a mosaic just
+    stitched, say -- so a thumbnail need not re-read a file that was just written.
+    """
+    data = np.asarray(image.data)
+    if data.ndim == 5:  # TCZYX: one time point
+        data = data[0]
+    projected = data.max(axis=1)  # (C, Z, Y, X) -> (C, Y, X)
+    channels = list(image.metadata.channels)
+
+    layers = []
+    for index, plane in enumerate(projected):
+        # metadata should describe every channel, but never drop a plane when it
+        # doesn't — an unnamed channel is better than a silently missing one.
+        if index < len(channels):
+            name = channels[index].name
+            color = (
+                getattr(channels[index], "color", None)
+                or AVAILABLE_COLORS[index % len(AVAILABLE_COLORS)]
+            )
+        else:
+            name = f"Channel-{index + 1:02d}"
+            color = AVAILABLE_COLORS[index % len(AVAILABLE_COLORS)]
+        layers.append(FMLayer(name=name, data=plane, color=color))
+
+    rgb = composite_fm_layers(layers)
+    if rgb is None:
+        raise ValueError("fluorescence image has no displayable channels")
+    return rgb
+
+
+def load_projection(filepath: str) -> Tuple[np.ndarray, float]:
+    """Composite a fluorescence z-stack file into one RGB image.
 
     The volume is released before compositing: a real METEOR stack is ~530 MB in
     memory where its projection is ~25 MB, and callers may load several in a row.
@@ -34,23 +63,11 @@ def load_projection(filepath: str) -> Tuple[np.ndarray, float]:
         (H, W, 3) uint8 RGB, and the pixel size in metres.
     """
     image = FluorescenceImage.load(filepath)
-    projected = image.data.max(axis=1)        # (C, Z, Y, X) -> (C, Y, X), a new array
-    channels = list(image.metadata.channels)
     pixel_size_x = image.metadata.pixel_size_x
-    del image                                  # drop the volume, keep the projection
-
-    layers = []
-    for index, plane in enumerate(projected):
-        # metadata should describe every channel, but never drop a plane when it
-        # doesn't — an unnamed channel is better than a silently missing one.
-        if index < len(channels):
-            name, color = channels[index].name, channels[index].color
-        else:
-            name = f"Channel-{index + 1:02d}"
-            color = AVAILABLE_COLORS[index % len(AVAILABLE_COLORS)]
-        layers.append(FMLayer(name=name, data=plane, color=color))
-
-    rgb = composite_fm_layers(layers)
-    if rgb is None:
-        raise ValueError(f"fluorescence image has no displayable channels: {filepath}")
+    try:
+        rgb = composite_projection(image)
+    except ValueError as e:
+        raise ValueError(f"{e}: {filepath}") from e
+    finally:
+        del image  # drop the volume, keep the projection
     return rgb, pixel_size_x

--- a/tests/autolamella/test_grid_fm_overview_task.py
+++ b/tests/autolamella/test_grid_fm_overview_task.py
@@ -1,0 +1,146 @@
+"""The fluorescence overview grid task, on the Arctis simulator (a compustage with an FM).
+
+It travels to the FM, inserts the objective if it has to, acquires the tileset
+centred on the grid's slot re-expressed for the FM, records the mosaic and a
+channel-composite thumbnail, and puts the objective back how it found it.
+"""
+
+import os
+
+import pytest
+import yaml
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    AutoLamellaTaskStatus,
+    Experiment,
+    GridRecord,
+)
+from fibsem.applications.autolamella.task_outputs import (
+    grid_outputs,
+    latest_grid_output,
+)
+from fibsem.applications.autolamella.workflows.tasks.grid import (
+    GRID_TASK_REGISTRY,
+    FluorescenceOverviewGridTask,
+    FluorescenceOverviewGridTaskConfig,
+    run_grid_task,
+)
+from fibsem.fm.structures import ChannelSettings, OverviewParameters, ZParameters
+from fibsem.microscopes._stage import SampleGrid
+
+
+@pytest.fixture
+def microscope():
+    microscope, _ = utils.setup_session(
+        manufacturer="Demo",
+        config_path=os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml"),
+    )
+    assert microscope.stage_is_compustage and microscope.fm is not None
+    # the working slot is the origin by construction; put a grid in it
+    microscope._stage.holder.slots["Slot-01"].loaded_grid = SampleGrid(
+        name="grid-aspen"
+    )
+    return microscope
+
+
+@pytest.fixture
+def experiment(tmp_path):
+    exp = Experiment(path=tmp_path, name="exp")
+    (tmp_path / "exp").mkdir()
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    exp.grid_protocol.add(
+        FluorescenceOverviewGridTaskConfig(
+            task_name="overview_fm",
+            channels=[
+                ChannelSettings(name="GFP", color="green"),
+                ChannelSettings(name="mCherry", color="red"),
+            ],
+            overview=OverviewParameters(rows=1, cols=2),
+        )
+    )
+    exp.add_grid(GridRecord(name="grid-aspen"))
+    return exp
+
+
+class TestConfig:
+    def test_registered(self):
+        assert GRID_TASK_REGISTRY["FM_OVERVIEW_GRID"] is FluorescenceOverviewGridTask
+
+    def test_round_trips_through_protocol_yaml_with_a_channel_list(
+        self, experiment, tmp_path
+    ):
+        config = experiment.grid_protocol.task_config["overview_fm"]
+        config.overview.use_zstack = True
+        config.zparams = ZParameters(zmin=-2e-6, zmax=2e-6, zstep=1e-6)
+        experiment.save(save_protocol=True)
+        data = yaml.safe_load((tmp_path / "exp" / "protocol.yaml").read_text())
+        saved = data["grid_tasks"]["tasks"]["overview_fm"]
+        assert [c["name"] for c in saved["channels"]] == ["GFP", "mCherry"]
+        assert saved["overview"]["rows"] == 1
+
+        loaded = Experiment.load(tmp_path / "exp" / "experiment.yaml")
+        again = loaded.grid_protocol.task_config["overview_fm"]
+        assert isinstance(again, FluorescenceOverviewGridTaskConfig)
+        assert [type(c).__name__ for c in again.channels] == ["ChannelSettings"] * 2
+        assert again.channels[1].color == "red"
+        assert again.overview.use_zstack is True
+        assert again.zparams.zstep == 1e-6
+
+
+class TestRun:
+    def test_records_mosaic_and_composite_thumbnail(
+        self, microscope, experiment, tmp_path
+    ):
+        grid = experiment.get_grid_by_name("grid-aspen")
+        run_grid_task(microscope, "overview_fm", experiment, grid)
+
+        entry = grid.task_history[-1]
+        assert entry.status is AutoLamellaTaskStatus.Completed
+        assert set(entry.outputs) == {"overview_fm", "overview_fm_thumbnail"}
+        (mosaic,) = grid_outputs(experiment, grid, "overview_fm")
+        assert mosaic.startswith(
+            str(tmp_path / "exp" / "grids" / "grid-aspen" / "overview_fm")
+        )
+        assert mosaic.endswith(".ome.tiff")
+        thumbnail = latest_grid_output(experiment, grid, "overview_fm_thumbnail")
+        from PIL import Image
+
+        with Image.open(thumbnail) as im:
+            assert im.mode == "RGB" and max(im.size) <= 512
+
+    def test_objective_is_inserted_for_the_run_and_returned(
+        self, microscope, experiment
+    ):
+        grid = experiment.get_grid_by_name("grid-aspen")
+        assert microscope.fm.objective.state != "Inserted"
+        run_grid_task(microscope, "overview_fm", experiment, grid)
+        assert microscope.fm.objective.state != "Inserted"  # put back how it was found
+
+    def test_an_already_inserted_objective_is_left_in(self, microscope, experiment):
+        microscope.fm.objective.insert()
+        grid = experiment.get_grid_by_name("grid-aspen")
+        run_grid_task(microscope, "overview_fm", experiment, grid)
+        assert microscope.fm.objective.state == "Inserted"
+
+    def test_centre_is_the_slot_at_the_fm(self, microscope, experiment):
+        grid = experiment.get_grid_by_name("grid-aspen")
+        task = FluorescenceOverviewGridTask(
+            microscope,
+            experiment.grid_protocol.task_config["overview_fm"],
+            grid,
+            experiment,
+        )
+        centre = task.grid_centre()
+        fm = microscope.get_orientation("FM")
+        assert centre.t == pytest.approx(fm.t)
+
+    def test_refuses_without_an_fm(self, experiment, tmp_path):
+        plain, _ = utils.setup_session(manufacturer="Demo")
+        assert plain.fm is None
+        grid = experiment.get_grid_by_name("grid-aspen")
+        with pytest.raises(RuntimeError, match="no fluorescence microscope"):
+            run_grid_task(plain, "overview_fm", experiment, grid)
+        assert grid.task_state.status is AutoLamellaTaskStatus.Failed


### PR DESCRIPTION
## Summary

Milestone 3, PR 2 of 2 (stacked on #734). The fluorescence overview as a grid task, over the FM tiled runner already proven on hardware.

- **`FluorescenceOverviewGridTaskConfig`** (in its own module, `grid/fluorescence.py`, beside the beam task's `imaging.py`) — the FM Overview tab's inputs: `channels` (a list of `ChannelSettings`), `overview` (`OverviewParameters`: rows, cols, overlap, z-stack on/off, autofocus mode, tile order), `zparams`, optional `autofocus_settings`, a filename stem. Named `overview` rather than `parameters` because the base config's `parameters` is the list of a form's fields.
- **The operation is standalone**: `acquire_fluorescence_overview(...)` over `FMTiledAcquisitionRunner` + `OverviewDestination`, laying files out as the tab does (tiles in a directory of the run's name, the `.ome.tiff` mosaic beside it, time-stamped names).
- **The task**: grid centre = the calibrated slot at the FM (an orientation on a compustage, a device on an offset mount, since `get_target_position` spells the two differently and refuses the wrong one); `move_to_device("FM")`; insert the objective if it was not already in — read **before** the travel, since on a compustage the device move inserts it; acquire; record `overview_fm` and a **channel-composite thumbnail** via `fm.preview.composite_projection` — the FM canvas's own composite, now one function that `load_projection` uses too, built here from the mosaic in hand rather than re-reading the file; then return the objective to how it was found, so a grid exchange with the objective in is never left possible by accident. No FM → refused up front.
- The config deserialiser learned typed lists (`List[ChannelSettings]`).

## Tests

`tests/autolamella/test_grid_fm_overview_task.py` (7, on the Arctis simulator): registration; round trip through `protocol.yaml` with the channel list, z-stack and `ZParameters`; a run records the `.ome.tiff` under `grids/<name>/overview_fm/` and an RGB thumbnail ≤ 512 px; the objective is inserted for the run and put back, and left in if it already was; the centre is at the FM orientation; a plain Demo without an FM is refused and recorded Failed. The beam and framework suites still pass (41 total across the three).

## Refs

Closes FIB-888 (Grid Workflow, milestone 3). Builds on #734.
