### PR TITLE
[sim] SampleScene: configurable synthetic sample, imaged by the FM too; FIB-orientation coincidence measured

### DIFF
--- a/fibsem/alignment/coincidence.py
+++ b/fibsem/alignment/coincidence.py
@@ -134,12 +134,13 @@ def geometry_from_images(
     the projections the images record - so a saved pair is self-sufficient,
     usable offline with no microscope connection.
 
+    A pair taken nearer the flipped (rotation_180 / FIB-orientation) side
+    than the reference side is measured - the projections carry the
+    half-turn - but logged: validated on the simulator only, where the loop
+    converges exactly at the FIB orientation, and not yet on hardware.
+
     Raises:
-        ValueError: when the pair's metadata cannot supply the projections,
-            or the stage rotation is nearer the flipped (rotation_180 /
-            FIB-orientation) side than the reference side - unvalidated
-            territory where the measurement should refuse rather than
-            silently mis-scale (FIB-868 follow-up).
+        ValueError: when the pair's metadata cannot supply the projections.
     """
     from copy import deepcopy
 
@@ -156,9 +157,9 @@ def geometry_from_images(
     if angle_difference(stage_rotation, rotation_180) < angle_difference(
         stage_rotation, rotation_reference
     ):
-        raise ValueError(
-            "Stage rotation is on the flipped (FIB-orientation) side; "
-            "coincidence measurement there is not validated yet (FIB-868)."
+        logging.warning(
+            "Coincidence measurement on the flipped (FIB-orientation) side: "
+            "validated on the simulator only, not yet on hardware (FIB-868)."
         )
 
     sem_projection = BeamStageProjection.from_image(sem_image)

--- a/fibsem/alignment/coincidence.py
+++ b/fibsem/alignment/coincidence.py
@@ -51,10 +51,23 @@ AGREEMENT_BANDS: Tuple[Tuple[float, float], Tuple[float, float]] = ((2, 8), (4, 
 DEFAULT_AGREEMENT_TOLERANCE = 0.75e-6  # m
 DEFAULT_CAPTURE_RANGE = 20e-6  # m
 WINDOW_EDGE_MARGIN_PX = 3
+RIVAL_LOBE_BANDS = 2.0  # lobe radius, in units of the band's wide sigma
 
 REFUSAL_BAND_DISAGREEMENT = "band-disagreement"
 REFUSAL_WINDOW_EDGE = "window-edge"
 REFUSAL_LATERAL_OFFSET = "lateral-offset"
+REFUSAL_RIVAL_PEAK = "rival-peak"
+# A second correlation candidate outside the chosen peak's lobe that is
+# nearly as good as the lock: on the simulator every false lock that
+# passed the other gates measured 0.98-1.00 here, every correct fine lock
+# 0.53-0.85 and every correct coarse lock at most 0.94. Calibrated on the
+# simulator only; the bench pairs (FIB-872) are the check.
+DEFAULT_MAX_RIVAL_RATIO = 0.96
+# ...but not at the coarse field of view: there a correct lock can read
+# 0.99 (the wide, smooth structure of large cells) while the wrong ones
+# were all caught by the band and lateral gates, and the fine pass that
+# follows re-verifies under the strict gate. Disabled (1.0) for coarse.
+DEFAULT_COARSE_MAX_RIVAL_RATIO = 1.0
 # A height error cannot produce dx, and a real beam misalignment is a few
 # microns at most (FIB-873 measured ~1.3 um) - a lock further out in x is a
 # rival peak, and both bands agreeing on it does not make it right. On the
@@ -83,6 +96,9 @@ class CoincidenceMeasurement:
     dz: float  # m, inferred height error
     band_disagreement: float  # m, distance between the two band estimates
     is_reliable: bool
+    # best correlation outside the chosen peak's lobe, relative to it (max
+    # over bands); a rival near 1 is a second candidate as good as the lock
+    rival_ratio: float = 0.0
     refusal_reason: Optional[str] = None  # set when is_reliable is False
     seeded: bool = False
     method: str = "crossbeam-xcorr"
@@ -95,6 +111,7 @@ class CoincidenceMeasurement:
     capture_range: float = DEFAULT_CAPTURE_RANGE
     agreement_tolerance: float = DEFAULT_AGREEMENT_TOLERANCE
     max_lateral_offset: float = DEFAULT_MAX_LATERAL_OFFSET
+    max_rival_ratio: float = DEFAULT_MAX_RIVAL_RATIO
     prior: Optional[Tuple[float, float]] = None
     # the pair this was measured from, kept for diagnostics (check_coincidence
     # fills them in; the pure array path leaves them None)
@@ -220,12 +237,18 @@ def _windowed_xcorr(
     other: np.ndarray,
     center_yx: Tuple[float, float],
     half_yx: Tuple[float, float],
-) -> Tuple[Tuple[int, int], bool]:
+    lobe_px: float = 0.0,
+) -> Tuple[Tuple[int, int], bool, float]:
     """Cross-correlate with a Hann window, peak restricted near center_yx.
 
-    Returns ((dy, dx) in pixels, peak_on_window_edge). The Hann window also
-    centre-weights the measurement, so structure near the frame centre (the
-    point whose height matters) dominates over peripheral features.
+    Returns ((dy, dx) in pixels, peak_on_window_edge, rival_ratio). The
+    Hann window also centre-weights the measurement, so structure near the
+    frame centre (the point whose height matters) dominates over peripheral
+    features. `rival_ratio` is the best correlation OUTSIDE the primary
+    peak's own lobe (radius `lobe_px`) relative to the primary - 1 means a
+    second candidate as good as the chosen one, 0 means none. Excluding
+    the lobe is what makes it meaningful in a tight window, where the
+    second-highest pixel is otherwise the primary's own shoulder.
     """
     window = np.outer(np.hanning(ref.shape[0]), np.hanning(ref.shape[1]))
     corr = fftconvolve(ref * window, (other * window)[::-1, ::-1], mode="same")
@@ -242,7 +265,14 @@ def _windowed_xcorr(
         or py >= search.shape[0] - WINDOW_EDGE_MARGIN_PX
         or px >= search.shape[1] - WINDOW_EDGE_MARGIN_PX
     )
-    return (py + y0 - cy, px + x0 - cx), on_edge
+    rival_ratio = 0.0
+    primary = float(search[py, px])
+    if lobe_px > 0 and primary > 0:
+        yy, xx = np.ogrid[0 : search.shape[0], 0 : search.shape[1]]
+        outside = (yy - py) ** 2 + (xx - px) ** 2 > lobe_px**2
+        if outside.any():
+            rival_ratio = max(0.0, float(search[outside].max()) / primary)
+    return (py + y0 - cy, px + x0 - cx), on_edge, rival_ratio
 
 
 def measure_coincidence(
@@ -255,6 +285,7 @@ def measure_coincidence(
     capture_range: float = DEFAULT_CAPTURE_RANGE,
     agreement_tolerance: float = DEFAULT_AGREEMENT_TOLERANCE,
     max_lateral_offset: float = DEFAULT_MAX_LATERAL_OFFSET,
+    max_rival_ratio: float = DEFAULT_MAX_RIVAL_RATIO,
 ) -> CoincidenceMeasurement:
     """Measure the SEM/FIB coincidence residual from one image pair.
 
@@ -277,6 +308,8 @@ def measure_coincidence(
             band estimates for the result to be reliable.
         max_lateral_offset: |dx| (m) beyond which a lock is refused as a
             rival peak - a height error cannot move x.
+        max_rival_ratio: refuse when a second candidate outside the chosen
+            peak's lobe correlates at least this fraction as well.
 
     Returns:
         CoincidenceMeasurement. When is_reliable is False the residuals are
@@ -298,12 +331,17 @@ def measure_coincidence(
 
     shifts = []
     on_edge_any = False
+    rival_ratio = 0.0
     for s1, s2 in AGREEMENT_BANDS:
         ref = _preprocess(sem, s1, s2)
         other = _preprocess(fib_stretched, s1, s2)
-        (dy_px, dx_px), on_edge = _windowed_xcorr(ref, other, center, half_yx)
+        # a correlation peak's own lobe is a few band widths across
+        (dy_px, dx_px), on_edge, ratio = _windowed_xcorr(
+            ref, other, center, half_yx, lobe_px=RIVAL_LOBE_BANDS * s2
+        )
         shifts.append((dy_px, dx_px))
         on_edge_any = on_edge_any or on_edge
+        rival_ratio = max(rival_ratio, ratio)
 
     (dy_a, dx_a), (dy_b, dx_b) = shifts
     disagreement = np.hypot((dy_a - dy_b) / stretch, dx_a - dx_b) * pixel_size
@@ -318,6 +356,8 @@ def measure_coincidence(
         refusal = REFUSAL_BAND_DISAGREEMENT
     elif abs(dx) > max_lateral_offset:
         refusal = REFUSAL_LATERAL_OFFSET
+    elif rival_ratio > max_rival_ratio:
+        refusal = REFUSAL_RIVAL_PEAK
 
     measurement = CoincidenceMeasurement(
         dx=float(dx),
@@ -325,12 +365,14 @@ def measure_coincidence(
         y_stretch=float(stretch),
         dz=float(dz),
         band_disagreement=float(disagreement),
+        rival_ratio=float(rival_ratio),
         is_reliable=refusal is None,
         refusal_reason=refusal,
         seeded=prior is not None,
         capture_range=capture_range,
         agreement_tolerance=agreement_tolerance,
         max_lateral_offset=max_lateral_offset,
+        max_rival_ratio=max_rival_ratio,
         prior=None if prior is None else (float(prior[0]), float(prior[1])),
     )
     logging.debug(
@@ -340,6 +382,7 @@ def measure_coincidence(
             "dy": measurement.dy,
             "dz": measurement.dz,
             "band_disagreement": measurement.band_disagreement,
+            "rival_ratio": measurement.rival_ratio,
             "is_reliable": measurement.is_reliable,
             "refusal_reason": measurement.refusal_reason,
             "seeded": measurement.seeded,
@@ -356,6 +399,7 @@ def measure_coincidence_from_images(
     capture_range: float = DEFAULT_CAPTURE_RANGE,
     agreement_tolerance: float = DEFAULT_AGREEMENT_TOLERANCE,
     max_lateral_offset: float = DEFAULT_MAX_LATERAL_OFFSET,
+    max_rival_ratio: float = DEFAULT_MAX_RIVAL_RATIO,
 ) -> CoincidenceMeasurement:
     """measure_coincidence for a FibsemImage pair.
 
@@ -375,6 +419,7 @@ def measure_coincidence_from_images(
         capture_range=capture_range,
         agreement_tolerance=agreement_tolerance,
         max_lateral_offset=max_lateral_offset,
+        max_rival_ratio=max_rival_ratio,
     )
 
 
@@ -492,6 +537,7 @@ def check_coincidence(
     capture_range: float = DEFAULT_CAPTURE_RANGE,
     agreement_tolerance: float = DEFAULT_AGREEMENT_TOLERANCE,
     max_lateral_offset: float = DEFAULT_MAX_LATERAL_OFFSET,
+    max_rival_ratio: float = DEFAULT_MAX_RIVAL_RATIO,
 ) -> CoincidenceMeasurement:
     """Acquire an eb/ib pair at the current position and measure coincidence.
 
@@ -514,6 +560,7 @@ def check_coincidence(
         capture_range=capture_range,
         agreement_tolerance=agreement_tolerance,
         max_lateral_offset=max_lateral_offset,
+        max_rival_ratio=max_rival_ratio,
     )
     measurement.sem_image = sem_image
     measurement.fib_image = fib_image
@@ -532,6 +579,7 @@ def ensure_coincident(
     coarse_capture_range: float = DEFAULT_COARSE_CAPTURE_RANGE,
     coarse_agreement_tolerance: float = DEFAULT_COARSE_AGREEMENT_TOLERANCE,
     coarse_max_lateral_offset: float = DEFAULT_COARSE_MAX_LATERAL_OFFSET,
+    coarse_max_rival_ratio: float = DEFAULT_COARSE_MAX_RIVAL_RATIO,
     on_progress: Optional[ProgressCallback] = None,
     reference: "BeamType" = None,
 ) -> CoincidenceAlignment:
@@ -584,6 +632,8 @@ def ensure_coincident(
         coarse_max_lateral_offset: |dx| bound for the coarse pass (looser:
             it only has to land within the fine pass's reach, and the fine
             measurement that follows re-verifies under the strict bound).
+        coarse_max_rival_ratio: rival-peak bound for the coarse pass; 1.0
+            (the default) disables it there - see DEFAULT_COARSE_MAX_RIVAL_RATIO.
         on_progress: called with a CoincidenceProgress before every
             acquisition, after every measurement and before every move, from
             the calling thread - a GUI must marshal it across itself.
@@ -642,6 +692,7 @@ def ensure_coincident(
             capture_range=coarse_capture_range,
             agreement_tolerance=coarse_agreement_tolerance,
             max_lateral_offset=coarse_max_lateral_offset,
+            max_rival_ratio=coarse_max_rival_ratio,
         )
         measurement.coarse = True
         measurements.append(measurement)

--- a/fibsem/alignment/coincidence.py
+++ b/fibsem/alignment/coincidence.py
@@ -66,10 +66,11 @@ DEFAULT_MAX_LATERAL_OFFSET = 5e-6  # m
 class CoincidenceMeasurement:
     """Result of one coincidence measurement.
 
-    Sign convention: dx/dy are where the FIB-view scene sits relative to the
-    SEM-view scene, in the SEM image convention (x right, y down), after the
-    geometric perspective correction. dz is the inferred height error along
-    the chamber-vertical axis (dz = dy / sin(column_tilt)).
+    Sign convention: dx/dy are the shift that brings the FIB-view scene onto
+    the SEM-view scene - minus the FIB scene's displacement - in the SEM
+    image convention (x right, y down), after the geometric perspective
+    correction; dy is what vertical_move is handed. dz is the inferred
+    height error along the chamber-vertical axis (the z move to apply).
 
     dx is diagnostic only: a height error cannot produce it. A persistent dx
     indicates beam misalignment (correctable by beam shift, see FIB-873),

--- a/fibsem/alignment/plotting.py
+++ b/fibsem/alignment/plotting.py
@@ -382,7 +382,7 @@ def plot_coincidence_alignment(
             0.04,
             ("RELIABLE" if m.is_reliable else f"REFUSED ({m.refusal_reason})")
             + f"\ndx={m.dx * 1e6:+.2f}  dy={m.dy * 1e6:+.2f}  dz={m.dz * 1e6:+.2f} um"
-            + f"\nband-disagreement={m.band_disagreement * 1e6:.2f} um",
+            + f"\nband-disagreement={m.band_disagreement * 1e6:.2f} um  rival={m.rival_ratio:.2f}",
             transform=ax.transAxes,
             color=colour,
             fontsize=6.5,
@@ -461,6 +461,8 @@ def save_coincidence_diagnostics(
             "capture_range": m.capture_range,
             "agreement_tolerance": m.agreement_tolerance,
             "max_lateral_offset": m.max_lateral_offset,
+            "max_rival_ratio": m.max_rival_ratio,
+            "rival_ratio": m.rival_ratio,
             "prior": m.prior,
         }
         if m.sem_image is not None and m.fib_image is not None:
@@ -502,6 +504,7 @@ def load_coincidence_run(run_dir: str) -> list:
         DEFAULT_AGREEMENT_TOLERANCE,
         DEFAULT_CAPTURE_RANGE,
         DEFAULT_MAX_LATERAL_OFFSET,
+        DEFAULT_MAX_RIVAL_RATIO,
         measure_coincidence_from_images,
     )
     from fibsem.structures import FibsemImage
@@ -527,6 +530,7 @@ def load_coincidence_run(run_dir: str) -> list:
             max_lateral_offset=record.get(
                 "max_lateral_offset", DEFAULT_MAX_LATERAL_OFFSET
             ),
+            max_rival_ratio=record.get("max_rival_ratio", DEFAULT_MAX_RIVAL_RATIO),
         )
         measurement.coarse = record["pass"] == "coarse"
         measurement.sem_image = sem_image

--- a/fibsem/config/sim-arctis-configuration.yaml
+++ b/fibsem/config/sim-arctis-configuration.yaml
@@ -70,7 +70,9 @@ sim:
     #     tilt_axis_offset: 0.0                              # surface height above the tilt axis (m); >0 makes the stage non-eucentric
     #     grid_pitch: 125.0e-6                               # mesh pitch (m)
     #     grid_bar_width: 35.0e-6                            # bar width (m)
-    #     n_clusters: 35                                     # cell clusters over the extent
+    #     cell_type: mammalian                               # mammalian (adherent, fried-egg) | yeast | bacteria | mixed | none
+    #     mammalian_density: 7.0                             # cells per 150 x 150 um; mammalian_radius / nucleus_radius set the sizes
+    #     n_clusters: 35                                     # yeast: cell clusters over the extent
     #     cell_size: [4.5e-6, 12.0e-6]                       # cell radius range (m)
     #     noise_sigma: 12.0                                  # gaussian noise on the beam images
     #     noise_fraction: 0.15                               # uniform-noise blend on the beam images

--- a/fibsem/config/sim-arctis-configuration.yaml
+++ b/fibsem/config/sim-arctis-configuration.yaml
@@ -75,6 +75,9 @@ sim:
     #     noise_sigma: 12.0                                  # gaussian noise on the beam images
     #     noise_fraction: 0.15                               # uniform-noise blend on the beam images
     #     grid_rotation: null                                # degrees; null = random within +/- 45
+    #     contamination_density: 15.0                        # specks per 100 x 100 um (aperiodic content on film and bars)
+    #     beam_offset: {ion: [1.3e-6, 0.0]}                  # fixed per-beam misalignment (m): the coincidence measurement's dx
+    #     current_offset_scale: 1.5e-6                       # sigma (m) of a seeded per-beam-current offset; 0 = off
     is_compustage: true
     loader:                                               # the simulated autoloader magazine
         capacity: 12

--- a/fibsem/config/sim-arctis-configuration.yaml
+++ b/fibsem/config/sim-arctis-configuration.yaml
@@ -64,6 +64,17 @@ sim:
     sem: null # "/path/to/sem/image/data"                   
     fib: null # "/path/to/fib/image/data"                   
     use_cycle: true
+    # sample:                                               # synthetic cryo-grid both beams (and the FM) image through their projections (FIB-874); default off
+    #     enabled: true
+    #     coincidence_offset: 10.0e-6                        # height error at boot (m) - what the coincidence alignment corrects
+    #     tilt_axis_offset: 0.0                              # surface height above the tilt axis (m); >0 makes the stage non-eucentric
+    #     grid_pitch: 125.0e-6                               # mesh pitch (m)
+    #     grid_bar_width: 35.0e-6                            # bar width (m)
+    #     n_clusters: 35                                     # cell clusters over the extent
+    #     cell_size: [4.5e-6, 12.0e-6]                       # cell radius range (m)
+    #     noise_sigma: 12.0                                  # gaussian noise on the beam images
+    #     noise_fraction: 0.15                               # uniform-noise blend on the beam images
+    #     grid_rotation: null                                # degrees; null = random within +/- 45
     is_compustage: true
     loader:                                               # the simulated autoloader magazine
         capacity: 12

--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -88,6 +88,17 @@ sim:
     sem: null # "/path/to/sem/image/data"                   # the path to the SEM image data for simulation                 [USER]
     fib: null # "/path/to/fib/image/data"                   # the path to the FIB image data for simulation                 [USER]
     use_cycle: true                                         # infinitely cycle sem/fib dataset                              [USER]
+    # sample:                                               # synthetic cryo-grid both beams (and the FM) image through their projections (FIB-874); default off
+    #     enabled: true
+    #     coincidence_offset: 10.0e-6                        # height error at boot (m) - what the coincidence alignment corrects
+    #     tilt_axis_offset: 0.0                              # surface height above the tilt axis (m); >0 makes the stage non-eucentric
+    #     grid_pitch: 125.0e-6                               # mesh pitch (m)
+    #     grid_bar_width: 35.0e-6                            # bar width (m)
+    #     n_clusters: 35                                     # cell clusters over the extent
+    #     cell_size: [4.5e-6, 12.0e-6]                       # cell radius range (m)
+    #     noise_sigma: 12.0                                  # gaussian noise on the beam images
+    #     noise_fraction: 0.15                               # uniform-noise blend on the beam images
+    #     grid_rotation: null                                # degrees; null = random within +/- 45
     is_compustage: false                                    # this stage rotates; the objective is off to the side          [USER]
     has_fm: true                                            # stand in for the hardware probe -- see below                  [USER]
 

--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -99,6 +99,9 @@ sim:
     #     noise_sigma: 12.0                                  # gaussian noise on the beam images
     #     noise_fraction: 0.15                               # uniform-noise blend on the beam images
     #     grid_rotation: null                                # degrees; null = random within +/- 45
+    #     contamination_density: 15.0                        # specks per 100 x 100 um (aperiodic content on film and bars)
+    #     beam_offset: {ion: [1.3e-6, 0.0]}                  # fixed per-beam misalignment (m): the coincidence measurement's dx
+    #     current_offset_scale: 1.5e-6                       # sigma (m) of a seeded per-beam-current offset; 0 = off
     is_compustage: false                                    # this stage rotates; the objective is off to the side          [USER]
     has_fm: true                                            # stand in for the hardware probe -- see below                  [USER]
 

--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -94,7 +94,9 @@ sim:
     #     tilt_axis_offset: 0.0                              # surface height above the tilt axis (m); >0 makes the stage non-eucentric
     #     grid_pitch: 125.0e-6                               # mesh pitch (m)
     #     grid_bar_width: 35.0e-6                            # bar width (m)
-    #     n_clusters: 35                                     # cell clusters over the extent
+    #     cell_type: mammalian                               # mammalian (adherent, fried-egg) | yeast | bacteria | mixed | none
+    #     mammalian_density: 7.0                             # cells per 150 x 150 um; mammalian_radius / nucleus_radius set the sizes
+    #     n_clusters: 35                                     # yeast: cell clusters over the extent
     #     cell_size: [4.5e-6, 12.0e-6]                       # cell radius range (m)
     #     noise_sigma: 12.0                                  # gaussian noise on the beam images
     #     noise_fraction: 0.15                               # uniform-noise blend on the beam images

--- a/fibsem/microscopes/sim_scene.py
+++ b/fibsem/microscopes/sim_scene.py
@@ -1,4 +1,4 @@
-"""Shared-scene projection rendering for the simulated microscope (FIB-874).
+"""A synthetic sample the simulated microscope images through its projections (FIB-874).
 
 The simulator's default imaging (file sequences, or the SEM/FIB text cards)
 serves unrelated pictures per beam: nothing about them reflects the stage
@@ -20,9 +20,11 @@ configured initial offset, so the simulator boots off-coincidence by that
 amount and a vertical move that changes stage z visibly corrects the FIB
 view, exactly as on hardware.
 
-Opt-in via the simulator config (`sim: coincidence_projection: true`),
+Opt-in via the simulator config (`sim: sample: {enabled: true, ...}`),
 defaulting off - the file-sequence and text-card modes remain the default
-for workflow/UI simulation.
+for workflow/UI simulation. The `sample` block also carries the scene's
+options (grid pitch, cell size and count, noise, the height offsets); see
+SampleScene for the fields and `SampleScene.from_config`.
 """
 
 from __future__ import annotations
@@ -33,13 +35,88 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 import numpy as np
+from scipy.ndimage import gaussian_filter as ndi_gaussian
 
-from fibsem.projection import BeamStageProjection, surface_foreshortening
+from fibsem.projection import (
+    BeamStageProjection,
+    FMStageProjection,
+    surface_foreshortening,
+)
 from fibsem.structures import BeamType, FibsemStagePosition
 
 # Keep the render well-defined at any pose: below this foreshortening the
 # view is a degenerate grazing projection (features smear to infinity).
 MIN_FORESHORTENING = 0.035  # ~ sin(2 deg)
+
+
+@dataclass(frozen=True)
+class Fluorophore:
+    """A dye on part of the sample: excitation and emission peaks (nm) with
+    the widths a channel's excitation line and emission band are matched
+    against."""
+
+    name: str
+    excitation_peak: float
+    emission_peak: float
+    excitation_width: float = 25.0  # nm, sigma
+    emission_width: float = 35.0  # nm, sigma
+
+    def response(self, excitation, emission) -> float:
+        """How strongly this dye shows in a channel: the product of how well
+        the excitation line drives it and how much of its emission the
+        collected band admits. Either missing counts as fully open."""
+
+        def gauss(value, peak, width):
+            # None, or a non-numeric name ("Fluorescence": a generic
+            # multi-band filter), is an open band - the other side decides
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                return 1.0
+            return float(np.exp(-0.5 * ((value - peak) / width) ** 2))
+
+        return gauss(excitation, self.excitation_peak, self.excitation_width) * gauss(
+            emission, self.emission_peak, self.emission_width
+        )
+
+
+# what carries which dye: the fiducial a DAPI-like blue, every cell a
+# GFP-like green, a seeded subset of cells an mCherry-like red as well
+# peaks sit on real dyes and on the simulated light source's lines (365,
+# 450, 550, 635 nm): 365 drives the fiducial, 450 and 488 the cells, 550 and
+# 561 the subset, 635 nothing on this sample
+FIDUCIAL_DYE = Fluorophore("dapi-like", 365.0, 460.0, excitation_width=30.0)
+CELL_DYE = Fluorophore("gfp-like", 470.0, 510.0, excitation_width=30.0)
+SUBSET_DYE = Fluorophore("mcherry-like", 560.0, 610.0, excitation_width=30.0)
+# in reflection the bars dominate, the fiducial reflects, cells are faint
+REFLECTION_WEIGHTS = (1.0, 0.25, 0.0, 0.6)
+# a faint outline of the bars leaks into every fluorescence channel
+BARS_IN_FLUORESCENCE = 0.05
+
+
+def fm_channel_weights(emission, excitation=None) -> Tuple[float, float, float, float]:
+    """(bars, cells, red subset, fiducial) intensity weights for a channel.
+
+    Reflection is an emission of None (or named so): the excitation light
+    imaged straight back, so the grid bars dominate. Otherwise each dye
+    responds to the excitation line AND the collected emission band - a
+    non-numeric band such as "Fluorescence" is open, and the excitation
+    line alone decides. So 450 or 488 excitation shows the cells, 550/561
+    the red subset, 365 the fiducial, 635 nothing; a mismatched pair (488
+    excitation collected at 610, say) shows a weak bleed rather than
+    nothing.
+    """
+    if emission is None or (
+        isinstance(emission, str) and "reflect" in emission.lower()
+    ):
+        return REFLECTION_WEIGHTS
+    return (
+        BARS_IN_FLUORESCENCE,
+        CELL_DYE.response(excitation, emission),
+        SUBSET_DYE.response(excitation, emission),
+        FIDUCIAL_DYE.response(excitation, emission),
+    )
+
 
 FIDUCIAL_ARM_LENGTH = 8e-6  # m, half-length of each fiducial cross arm
 FIDUCIAL_POINT_SPACING = 0.5e-6  # m
@@ -61,7 +138,7 @@ class SceneFeature:
 
 
 @dataclass
-class CoincidenceScene:
+class SampleScene:
     """A synthetic cryo-grid scene rendered per-beam by projection.
 
     The sample is a regular grid mesh (bars at a known pitch, a hole centred
@@ -74,6 +151,8 @@ class CoincidenceScene:
     coincidence_offset: float = 10e-6  # m, initial height error at boot
     seed: int = 24
     n_clusters: int = 35  # cell clusters scattered over the extent
+    cells_per_cluster: Tuple[int, int] = (3, 8)  # inclusive range
+    cell_size: Tuple[float, float] = (4.5e-6, 12.0e-6)  # m, sigma range per cell
     cluster_spread: float = 15e-6  # m, how far blobs scatter around a cluster
     extent: float = 400e-6  # m, features are scattered over +/- extent/2
     grid_pitch: float = 125e-6  # m, mesh pitch (~200 mesh)
@@ -95,6 +174,11 @@ class CoincidenceScene:
     # as the beam projection of the scene relative to this reference
     reference_position: Optional[FibsemStagePosition] = None
     features: List[SceneFeature] = field(default_factory=list)
+    # fraction of cells that also carry the red fluorophore (seeded subset)
+    red_fraction: float = 0.4
+    # defocus model for the FM: blur sigma grows by this many pixels per
+    # micron the objective sits away from its focus position
+    fm_blur_px_per_um: float = 0.6
 
     def __post_init__(self) -> None:
         if self.features:
@@ -107,12 +191,13 @@ class CoincidenceScene:
         half = self.extent / 2
         for _ in range(self.n_clusters):
             cx, cy = rng.uniform(-half, half, size=2)
-            for _ in range(int(rng.integers(3, 9))):
+            lo, hi = self.cells_per_cluster
+            for _ in range(int(rng.integers(lo, hi + 1))):
                 self.features.append(
                     SceneFeature(
                         x=float(cx + rng.normal(0, self.cluster_spread)),
                         y=float(cy + rng.normal(0, self.cluster_spread)),
-                        sigma=float(rng.uniform(4.5e-6, 12.0e-6)),
+                        sigma=float(rng.uniform(*self.cell_size)),
                         intensity=float(rng.uniform(40, 110)),
                         sharpness=3.0,
                     )
@@ -129,6 +214,48 @@ class CoincidenceScene:
                 self.features.append(
                     SceneFeature(x=x, y=y, sigma=0.4e-6, intensity=220.0)
                 )
+
+    # the configuration keys `sim: sample:` accepts, with their units
+    CONFIG_KEYS = (
+        "coincidence_offset",  # m
+        "tilt_axis_offset",  # m
+        "seed",
+        "n_clusters",
+        "cells_per_cluster",  # [min, max]
+        "cell_size",  # [min, max] m
+        "cluster_spread",  # m
+        "extent",  # m
+        "grid_pitch",  # m
+        "grid_bar_width",  # m
+        "grid_intensity",
+        "noise_sigma",
+        "noise_fraction",
+        "grid_rotation",  # degrees; null = random within grid_rotation_range
+        "grid_rotation_range",  # degrees
+    )
+
+    @classmethod
+    def from_config(cls, config: dict) -> "SampleScene":
+        """Build a scene from the `sim: sample:` block (unknown keys rejected,
+        angles in degrees, ranges as two-element lists)."""
+        unknown = set(config) - set(cls.CONFIG_KEYS) - {"enabled"}
+        if unknown:
+            raise ValueError(f"Unknown sim.sample keys: {sorted(unknown)}")
+        kwargs = {k: v for k, v in config.items() if k in cls.CONFIG_KEYS}
+        for key in ("cells_per_cluster", "cell_size"):
+            if key in kwargs:
+                kwargs[key] = tuple(kwargs[key])
+        if "cells_per_cluster" in kwargs:
+            kwargs["cells_per_cluster"] = tuple(
+                int(v) for v in kwargs["cells_per_cluster"]
+            )
+        if kwargs.get("grid_rotation") is not None:
+            kwargs["grid_rotation"] = float(np.deg2rad(kwargs["grid_rotation"]))
+        if "grid_rotation_range" in kwargs:
+            kwargs["grid_rotation_range"] = float(
+                np.deg2rad(kwargs["grid_rotation_range"])
+            )
+        return cls(**kwargs)
 
     def anchor(self, stage_position: FibsemStagePosition) -> None:
         """Fix the world at a stage position (with the boot height error).
@@ -246,6 +373,98 @@ class CoincidenceScene:
             uniform = rng.uniform(0, 255, canvas.shape)
             data = (1 - self.noise_fraction) * data + self.noise_fraction * uniform
         return np.clip(data, 0, 255).astype(np.uint8)
+
+    def render_fm(
+        self,
+        stage_position: FibsemStagePosition,
+        resolution: Tuple[int, int],
+        projection: FMStageProjection,
+        weights: Tuple[float, float, float, float] = (0.05, 1.0, 0.0, 0.0),
+        defocus: float = 0.0,
+        rng: Optional[np.random.Generator] = None,
+    ) -> np.ndarray:
+        """Render the fluorescence camera's view of the scene.
+
+        The same world the beams image, through the FM's own projection
+        (camera tilt, image transform, pixel size), so a feature the SEM
+        shows sits where the FM projection says it does. Channels are what
+        a cryo-CLEM grid looks like: `reflection` shows the grid bars (and
+        the cells faintly), `green` the cells, `red` a seeded subset of them,
+        `blue` the fiducial; anything else renders dark. `defocus` (m, the
+        objective's distance from its focus position) blurs the image.
+
+        Args:
+            stage_position: current stage position.
+            resolution: (width, height) in pixels, after binning.
+            projection: the FM stage projection (from the live geometry).
+            weights: per-structure intensities (see fm_channel_weights).
+            defocus: objective distance from focus, in metres.
+            rng: noise source; a fresh default generator when omitted.
+
+        Returns:
+            uint16 image of shape (height, width).
+        """
+        width, height = int(resolution[0]), int(resolution[1])
+        pixel_size = projection.pixel_size
+        cx, cy = width / 2, height / 2
+        if self.reference_position is None:
+            self.anchor(stage_position)
+
+        reference = self.reference_position
+        if self.tilt_axis_offset:
+            reference = self._non_eucentric_reference(stage_position, projection)
+        ax, ay = projection.to_plane(reference, stage_position)
+        fs = max(surface_foreshortening(projection, stage_position), MIN_FORESHORTENING)
+
+        bars, cells, red, fiducial = weights
+        canvas = np.zeros((height, width), dtype=np.float32)
+
+        if bars > 0:
+            xs_world = (np.arange(width, dtype=np.float32) - cx) * pixel_size - ax
+            ys_world = (
+                (np.arange(height, dtype=np.float32) - cy) * pixel_size - ay
+            ) / fs
+            cos_r, sin_r = np.cos(self.grid_rotation), np.sin(self.grid_rotation)
+            xw = xs_world[None, :]
+            yw = ys_world[:, None]
+            x_rot = xw * cos_r + yw * sin_r
+            y_rot = -xw * sin_r + yw * cos_r
+            half = self.grid_bar_width / 2
+            bar_mask = (
+                np.abs((x_rot % self.grid_pitch) - self.grid_pitch / 2) < half
+            ) | (np.abs((y_rot % self.grid_pitch) - self.grid_pitch / 2) < half)
+            canvas[bar_mask] += bars * self.grid_intensity
+
+        red_rng = np.random.default_rng(self.seed + 1)
+        for f in self.features:
+            is_fiducial = f.sharpness == 1.0 and f.sigma < 1e-6
+            if is_fiducial:
+                weight = fiducial
+            else:
+                in_subset = red_rng.random() < self.red_fraction
+                weight = cells + (red if in_subset else 0.0)
+            if weight <= 0:
+                continue
+            u = cx + (f.x + ax) / pixel_size
+            v = cy + (f.y * fs + ay) / pixel_size
+            sigma_x = f.sigma / pixel_size
+            self._stamp_blob(
+                canvas, u, v, sigma_x, sigma_x * fs, weight * f.intensity, f.sharpness
+            )
+
+        if defocus:
+            # a retracted objective is millimetres from focus: cap the blur so
+            # the render stays cheap and the frame reads as "out of focus"
+            sigma_px = min(abs(defocus) * 1e6 * self.fm_blur_px_per_um, 40.0)
+            if sigma_px > 0.3:
+                canvas = ndi_gaussian(canvas, sigma_px)
+
+        if rng is None:
+            rng = np.random.default_rng()
+        # 16-bit camera: a dim background, shot-noise-like gaussian noise
+        data = 400.0 + canvas * 120.0
+        data += rng.normal(0, 40.0 + 0.05 * np.sqrt(np.maximum(data, 0)), canvas.shape)
+        return np.clip(data, 0, 65535).astype(np.uint16)
 
     def _non_eucentric_reference(
         self, stage_position: FibsemStagePosition, projection: BeamStageProjection

--- a/fibsem/microscopes/sim_scene.py
+++ b/fibsem/microscopes/sim_scene.py
@@ -91,6 +91,9 @@ CELL_DYE = Fluorophore("gfp-like", 470.0, 510.0, excitation_width=30.0)
 SUBSET_DYE = Fluorophore("mcherry-like", 560.0, 610.0, excitation_width=30.0)
 # in reflection the bars dominate, the fiducial reflects, cells are faint
 REFLECTION_WEIGHTS = (1.0, 0.25, 0.0, 0.6)
+# the FM's fluorescence intensity for a fully-dyed part, on the beam
+# intensity scale the stamper uses
+FM_INTENSITY = 90.0
 # a faint outline of the bars leaks into every fluorescence channel
 BARS_IN_FLUORESCENCE = 0.05
 
@@ -133,10 +136,19 @@ class SceneFeature:
 
     x: float  # m
     y: float  # m
-    sigma: float  # m
+    sigma: float  # m, along the feature's long axis
     intensity: float
     sharpness: float = 1.0
     kind: str = "cell"  # "cell" | "fiducial" | "contamination"
+    # shape: minor/major axis ratio, orientation in the world plane, and an
+    # outline wobble (0 = a clean ellipse) with its own phase
+    eccentricity: float = 1.0
+    angle: float = 0.0  # rad
+    wobble: float = 0.0
+    wobble_phase: float = 0.0
+    # which part of a cell this is - the FM dyes by part
+    part: str = "body"  # "body" | "nucleus" | "organelle" | "bud"
+    cell_id: int = -1
 
 
 @dataclass
@@ -152,10 +164,23 @@ class SampleScene:
 
     coincidence_offset: float = 10e-6  # m, initial height error at boot
     seed: int = 24
+    # what grows on the film: "mammalian" (adherent, fried-egg: a wide flat
+    # body with an off-centre nuclear mound and organelle speckle, sparse),
+    # "yeast" (compact bright ovoids in clusters, some budding), "bacteria"
+    # (dense small rods), "mixed", or "none" for bare film
+    cell_type: str = "mammalian"
+    # yeast: clusters over the extent
     n_clusters: int = 35  # cell clusters scattered over the extent
     cells_per_cluster: Tuple[int, int] = (3, 8)  # inclusive range
     cell_size: Tuple[float, float] = (4.5e-6, 12.0e-6)  # m, sigma range per cell
     cluster_spread: float = 15e-6  # m, how far blobs scatter around a cluster
+    # mammalian: count per 150 x 150 um, body and nucleus radii
+    mammalian_density: float = 7.0
+    mammalian_radius: Tuple[float, float] = (18e-6, 30e-6)  # m
+    nucleus_radius: Tuple[float, float] = (5e-6, 7e-6)  # m
+    # bacteria: count per 150 x 150 um, rod length
+    bacteria_density: float = 160.0
+    bacteria_length: Tuple[float, float] = (2.0e-6, 3.5e-6)  # m
     extent: float = 400e-6  # m, features are scattered over +/- extent/2
     grid_pitch: float = 125e-6  # m, mesh pitch (~200 mesh)
     grid_bar_width: float = 35e-6  # m
@@ -208,19 +233,7 @@ class SampleScene:
                 rng.uniform(-self.grid_rotation_range, self.grid_rotation_range)
             )
         half = self.extent / 2
-        for _ in range(self.n_clusters):
-            cx, cy = rng.uniform(-half, half, size=2)
-            lo, hi = self.cells_per_cluster
-            for _ in range(int(rng.integers(lo, hi + 1))):
-                self.features.append(
-                    SceneFeature(
-                        x=float(cx + rng.normal(0, self.cluster_spread)),
-                        y=float(cy + rng.normal(0, self.cluster_spread)),
-                        sigma=float(rng.uniform(*self.cell_size)),
-                        intensity=float(rng.uniform(40, 110)),
-                        sharpness=3.0,
-                    )
-                )
+        self._generate_cells(rng, half)
         # fiducial-like cross at the world origin: a dense line of small
         # blobs along each arm, so it goes through the same projection as
         # every other feature
@@ -250,15 +263,183 @@ class SampleScene:
                 )
             )
 
+    def _generate_cells(self, rng: np.random.Generator, half: float) -> None:
+        kinds = {
+            "yeast": [("yeast", 1.0)],
+            "mammalian": [("mammalian", 1.0)],
+            "bacteria": [("bacteria", 1.0)],
+            "mixed": [("yeast", 0.5), ("mammalian", 0.4), ("bacteria", 0.3)],
+            "none": [],  # bare film: fiducial, bars and contamination only
+        }
+        if self.cell_type not in kinds:
+            raise ValueError(
+                f"cell_type must be one of {sorted(kinds)}, got {self.cell_type!r}"
+            )
+        fields = (self.extent / 150e-6) ** 2  # how many 150 um fields the extent is
+        next_id = 0
+        for kind, fraction in kinds[self.cell_type]:
+            if kind == "yeast":
+                next_id = self._generate_yeast(rng, half, fraction, next_id)
+            elif kind == "mammalian":
+                n = int(round(self.mammalian_density * fields * fraction))
+                next_id = self._generate_mammalian(rng, half, n, next_id)
+            else:
+                n = int(round(self.bacteria_density * fields * fraction))
+                next_id = self._generate_bacteria(rng, half, n, next_id)
+
+    def _generate_yeast(self, rng, half, fraction, next_id) -> int:
+        for _ in range(int(round(self.n_clusters * fraction))):
+            cx, cy = rng.uniform(-half, half, size=2)
+            lo, hi = self.cells_per_cluster
+            for _ in range(int(rng.integers(lo, hi + 1))):
+                x = float(cx + rng.normal(0, self.cluster_spread))
+                y = float(cy + rng.normal(0, self.cluster_spread))
+                sigma = float(rng.uniform(*self.cell_size))
+                angle = float(rng.uniform(0, np.pi))
+                self.features.append(
+                    SceneFeature(
+                        x=x,
+                        y=y,
+                        sigma=sigma,
+                        intensity=float(rng.uniform(40, 110)),
+                        sharpness=3.0,
+                        eccentricity=float(rng.uniform(0.8, 1.0)),
+                        angle=angle,
+                        cell_id=next_id,
+                    )
+                )
+                # a compact nucleus for the FM (the beams barely see it)
+                self.features.append(
+                    SceneFeature(
+                        x=x,
+                        y=y,
+                        sigma=sigma * 0.35,
+                        intensity=8.0,
+                        sharpness=2.0,
+                        part="nucleus",
+                        cell_id=next_id,
+                    )
+                )
+                if rng.random() < 0.3:  # budding daughter
+                    t = rng.uniform(0, 2 * np.pi)
+                    self.features.append(
+                        SceneFeature(
+                            x=x + 1.1 * sigma * np.cos(t),
+                            y=y + 1.1 * sigma * np.sin(t),
+                            sigma=sigma * 0.55,
+                            intensity=70.0,
+                            sharpness=3.0,
+                            part="bud",
+                            cell_id=next_id,
+                        )
+                    )
+                next_id += 1
+        return next_id
+
+    def _generate_mammalian(self, rng, half, n, next_id) -> int:
+        # adherent cells tile the film rather than cluster: keep them apart
+        placed: List[Tuple[float, float]] = []
+        min_distance = 1.6 * self.mammalian_radius[1]
+        for _ in range(60 * max(n, 1)):
+            if len(placed) >= n:
+                break
+            x, y = rng.uniform(-half, half, size=2)
+            if all(np.hypot(x - px_, y - py_) > min_distance for px_, py_ in placed):
+                placed.append((float(x), float(y)))
+        for x, y in placed:
+            radius = float(rng.uniform(*self.mammalian_radius))
+            angle = float(rng.uniform(0, np.pi))
+            ecc = float(rng.uniform(0.6, 1.0))
+            phase = float(rng.uniform(0, 2 * np.pi))
+            # the flat spread body: low, wide, irregular outline
+            self.features.append(
+                SceneFeature(
+                    x=x,
+                    y=y,
+                    sigma=radius,
+                    intensity=28.0,
+                    sharpness=2.5,
+                    eccentricity=ecc,
+                    angle=angle,
+                    wobble=0.25,
+                    wobble_phase=phase,
+                    cell_id=next_id,
+                )
+            )
+            # the nuclear mound, off centre
+            nx = x + float(rng.normal(0, 0.2 * radius))
+            ny = y + float(rng.normal(0, 0.2 * radius))
+            nucleus = float(rng.uniform(*self.nucleus_radius))
+            self.features.append(
+                SceneFeature(
+                    x=nx,
+                    y=ny,
+                    sigma=nucleus,
+                    intensity=75.0,
+                    sharpness=2.0,
+                    eccentricity=0.85,
+                    angle=angle,
+                    part="nucleus",
+                    cell_id=next_id,
+                )
+            )
+            # organelle speckle in the cytoplasm
+            for _ in range(int(rng.integers(15, 30))):
+                t = rng.uniform(0, 2 * np.pi)
+                r = rng.uniform(1.2 * nucleus, 0.9 * radius)
+                self.features.append(
+                    SceneFeature(
+                        x=x
+                        + r * np.cos(t) * np.cos(angle)
+                        - r * np.sin(t) * ecc * np.sin(angle),
+                        y=y
+                        + r * np.cos(t) * np.sin(angle)
+                        + r * np.sin(t) * ecc * np.cos(angle),
+                        sigma=1.2e-6,
+                        intensity=12.0,
+                        sharpness=2.0,
+                        part="organelle",
+                        cell_id=next_id,
+                    )
+                )
+            next_id += 1
+        return next_id
+
+    def _generate_bacteria(self, rng, half, n, next_id) -> int:
+        for _ in range(n):
+            x, y = rng.uniform(-half, half, size=2)
+            length = float(rng.uniform(*self.bacteria_length))
+            width = float(rng.uniform(0.5e-6, 0.7e-6))
+            self.features.append(
+                SceneFeature(
+                    x=float(x),
+                    y=float(y),
+                    sigma=length / 2,
+                    intensity=float(rng.uniform(60, 110)),
+                    sharpness=4.0,
+                    eccentricity=width / (length / 2),
+                    angle=float(rng.uniform(0, np.pi)),
+                    cell_id=next_id,
+                )
+            )
+            next_id += 1
+        return next_id
+
     # the configuration keys `sim: sample:` accepts, with their units
     CONFIG_KEYS = (
         "coincidence_offset",  # m
         "tilt_axis_offset",  # m
         "seed",
+        "cell_type",  # mammalian | yeast | bacteria | mixed
         "n_clusters",
         "cells_per_cluster",  # [min, max]
         "cell_size",  # [min, max] m
         "cluster_spread",  # m
+        "mammalian_density",  # per 150 x 150 um
+        "mammalian_radius",  # [min, max] m
+        "nucleus_radius",  # [min, max] m
+        "bacteria_density",  # per 150 x 150 um
+        "bacteria_length",  # [min, max] m
         "extent",  # m
         "grid_pitch",  # m
         "grid_bar_width",  # m
@@ -281,7 +462,14 @@ class SampleScene:
         if unknown:
             raise ValueError(f"Unknown sim.sample keys: {sorted(unknown)}")
         kwargs = {k: v for k, v in config.items() if k in cls.CONFIG_KEYS}
-        for key in ("cells_per_cluster", "cell_size", "contamination_size"):
+        for key in (
+            "cells_per_cluster",
+            "cell_size",
+            "contamination_size",
+            "mammalian_radius",
+            "nucleus_radius",
+            "bacteria_length",
+        ):
             if key in kwargs:
                 kwargs[key] = tuple(kwargs[key])
         if "beam_offset" in kwargs:
@@ -420,11 +608,7 @@ class SampleScene:
             px_, py_ = f.x, f.y * fs
             u = cx + (px_ * cos_t - py_ * sin_t + ax) / pixel_size
             v = cy + (px_ * sin_t + py_ * cos_t + ay) / pixel_size
-            sigma_x = f.sigma / pixel_size
-            sigma_y = sigma_x * fs
-            self._stamp_blob(
-                canvas, u, v, sigma_x, sigma_y, f.intensity, f.sharpness, angle=theta
-            )
+            self._stamp_feature(canvas, f, u, v, pixel_size, fs, theta)
 
         if rng is None:
             rng = np.random.default_rng()
@@ -504,23 +688,30 @@ class SampleScene:
             ) | (np.abs((y_rot % self.grid_pitch) - self.grid_pitch / 2) < half)
             canvas[bar_mask] += bars * self.grid_intensity
 
-        red_rng = np.random.default_rng(self.seed + 1)
+        subset_rng = np.random.default_rng(self.seed + 1)
+        in_subset: Dict[int, bool] = {}
         for f in self.features:
             if f.kind == "fiducial":
-                weight = fiducial
+                weight = fiducial * f.intensity
             elif f.kind == "contamination":
-                weight = contamination
+                weight = contamination * f.intensity
             else:
-                in_subset = red_rng.random() < self.red_fraction
-                weight = cells + (red if in_subset else 0.0)
+                if f.cell_id not in in_subset:
+                    in_subset[f.cell_id] = subset_rng.random() < self.red_fraction
+                # dyes by part: the DNA dye lives in the nucleus, the
+                # cytoplasmic one everywhere; the subset dye follows the cell
+                body_dye = cells + (red if in_subset[f.cell_id] else 0.0)
+                if f.part == "nucleus":
+                    weight = FM_INTENSITY * (fiducial * 1.0 + body_dye * 0.5)
+                elif f.part == "organelle":
+                    weight = FM_INTENSITY * body_dye * 0.6
+                else:
+                    weight = FM_INTENSITY * body_dye
             if weight <= 0:
                 continue
             u = cx + (f.x + ax) / pixel_size
             v = cy + (f.y * fs + ay) / pixel_size
-            sigma_x = f.sigma / pixel_size
-            self._stamp_blob(
-                canvas, u, v, sigma_x, sigma_x * fs, weight * f.intensity, f.sharpness
-            )
+            self._stamp_feature(canvas, f, u, v, pixel_size, fs, 0.0, intensity=weight)
 
         if defocus:
             # a retracted objective is millimetres from focus: cap the blur so
@@ -598,6 +789,33 @@ class SampleScene:
         reference.z = (reference.z or 0.0) + dz
         return reference
 
+    def _stamp_feature(
+        self,
+        canvas: np.ndarray,
+        f: SceneFeature,
+        u: float,
+        v: float,
+        pixel_size: float,
+        fs: float,
+        scan_rotation: float,
+        intensity: Optional[float] = None,
+    ) -> None:
+        """Stamp one feature at view position (u, v): its ellipse in pixels,
+        foreshortened along the view's y, turned with the scan."""
+        sigma_x = f.sigma / pixel_size
+        self._stamp_blob(
+            canvas,
+            u,
+            v,
+            sigma_x,
+            sigma_x * f.eccentricity * fs,
+            f.intensity if intensity is None else intensity,
+            f.sharpness,
+            angle=f.angle + scan_rotation,
+            wobble=f.wobble,
+            wobble_phase=f.wobble_phase,
+        )
+
     @staticmethod
     def _stamp_blob(
         canvas: np.ndarray,
@@ -608,18 +826,21 @@ class SampleScene:
         intensity: float,
         sharpness: float = 1.0,
         angle: float = 0.0,
+        wobble: float = 0.0,
+        wobble_phase: float = 0.0,
     ) -> None:
         """Add one supergaussian blob, clipped to its bounding box.
 
         sharpness 1 = gaussian; higher = flat top with a sharp rim. `angle`
-        turns the (sigma_x, sigma_y) ellipse, for a scan-rotated view.
+        turns the (sigma_x, sigma_y) ellipse; `wobble` modulates its radius
+        with a few harmonics of the polar angle for an irregular outline.
         """
         height, width = canvas.shape
-        reach = 4 * max(sigma_x, sigma_y) if angle else None
-        x0 = max(0, int(u - (reach or 4 * sigma_x)))
-        x1 = min(width, int(u + (reach or 4 * sigma_x)) + 1)
-        y0 = max(0, int(v - (reach or 4 * sigma_y)))
-        y1 = min(height, int(v + (reach or 4 * sigma_y)) + 1)
+        reach = 4 * max(sigma_x, sigma_y) * (1 + wobble)
+        x0 = max(0, int(u - reach))
+        x1 = min(width, int(u + reach) + 1)
+        y0 = max(0, int(v - reach))
+        y1 = min(height, int(v + reach) + 1)
         if x0 >= x1 or y0 >= y1:
             return
         xs = np.arange(x0, x1, dtype=np.float32)
@@ -632,4 +853,11 @@ class SampleScene:
         rx = dx / max(sigma_x, 0.5)
         ry = dy / max(sigma_y, 0.5)
         r2 = rx**2 + ry**2
+        if wobble:
+            theta = np.arctan2(ry, rx)
+            mod = 1.0 + wobble * (
+                0.6 * np.sin(3 * theta + wobble_phase)
+                + 0.4 * np.sin(5 * theta + 2 * wobble_phase)
+            )
+            r2 = r2 / mod**2
         canvas[y0:y1, x0:x1] += intensity * np.exp(-0.5 * r2**sharpness)

--- a/fibsem/microscopes/sim_scene.py
+++ b/fibsem/microscopes/sim_scene.py
@@ -30,9 +30,10 @@ SampleScene for the fields and `SampleScene.from_config`.
 from __future__ import annotations
 
 import logging
+import zlib
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from scipy.ndimage import gaussian_filter as ndi_gaussian
@@ -135,6 +136,7 @@ class SceneFeature:
     sigma: float  # m
     intensity: float
     sharpness: float = 1.0
+    kind: str = "cell"  # "cell" | "fiducial" | "contamination"
 
 
 @dataclass
@@ -165,6 +167,23 @@ class SampleScene:
     # grids never load perfectly straight; drawn from +/- this range per seed
     grid_rotation: Optional[float] = None  # rad; random when None
     grid_rotation_range: float = np.deg2rad(45.0)
+    # contamination: small specks over film and bars - the aperiodic content
+    # a real grid carries, which is what breaks a mesh-pitch alias
+    contamination_density: float = 15.0  # specks per 100 x 100 um
+    contamination_size: Tuple[float, float] = (0.8e-6, 3.0e-6)  # m, sigma range
+    # a fixed per-beam misalignment ("electron"/"ion" -> (dx, dy) m): the
+    # view shifted as by a beam shift the microscope does not report - the
+    # persistent lateral offset the coincidence measurement calls dx
+    beam_offset: Dict[str, Tuple[float, float]] = field(default_factory=dict)
+    # changing beam current moves the beam a little (aperture/lens
+    # alignment): a seeded per-(beam, current) offset drawn with this sigma
+    # (m), so the milling-current alignment has something real to undo.
+    # Opt-in (0 = off): on, every acquisition carries a current-dependent
+    # lateral offset, which tests with exact expectations must account for
+    current_offset_scale: float = 0.0
+    _current_offsets: Dict[Tuple[str, float], Tuple[float, float]] = field(
+        default_factory=dict, repr=False
+    )
     # how far above the stage tilt axis the sample surface sits (m, along the
     # stage z axis). 0 is a eucentric stage; a real stage is not, and a tilt
     # change then swings the surface about the axis, costing coincidence
@@ -212,8 +231,24 @@ class SampleScene:
                 (float(offset), -float(offset)),
             ):
                 self.features.append(
-                    SceneFeature(x=x, y=y, sigma=0.4e-6, intensity=220.0)
+                    SceneFeature(
+                        x=x, y=y, sigma=0.4e-6, intensity=220.0, kind="fiducial"
+                    )
                 )
+        # contamination: everywhere, film and bars alike
+        n_specks = int(self.contamination_density * (self.extent / 100e-6) ** 2)
+        for _ in range(n_specks):
+            x, y = rng.uniform(-half, half, size=2)
+            self.features.append(
+                SceneFeature(
+                    x=float(x),
+                    y=float(y),
+                    sigma=float(rng.uniform(*self.contamination_size)),
+                    intensity=float(rng.uniform(40, 120)),
+                    sharpness=2.0,
+                    kind="contamination",
+                )
+            )
 
     # the configuration keys `sim: sample:` accepts, with their units
     CONFIG_KEYS = (
@@ -232,6 +267,10 @@ class SampleScene:
         "noise_fraction",
         "grid_rotation",  # degrees; null = random within grid_rotation_range
         "grid_rotation_range",  # degrees
+        "contamination_density",  # specks per 100 x 100 um
+        "contamination_size",  # [min, max] m
+        "beam_offset",  # {electron: [dx, dy], ion: [dx, dy]} m
+        "current_offset_scale",  # m, sigma of the per-current beam offset
     )
 
     @classmethod
@@ -242,9 +281,14 @@ class SampleScene:
         if unknown:
             raise ValueError(f"Unknown sim.sample keys: {sorted(unknown)}")
         kwargs = {k: v for k, v in config.items() if k in cls.CONFIG_KEYS}
-        for key in ("cells_per_cluster", "cell_size"):
+        for key in ("cells_per_cluster", "cell_size", "contamination_size"):
             if key in kwargs:
                 kwargs[key] = tuple(kwargs[key])
+        if "beam_offset" in kwargs:
+            kwargs["beam_offset"] = {
+                str(k).lower(): (float(v[0]), float(v[1]))
+                for k, v in (kwargs["beam_offset"] or {}).items()
+            }
         if "cells_per_cluster" in kwargs:
             kwargs["cells_per_cluster"] = tuple(
                 int(v) for v in kwargs["cells_per_cluster"]
@@ -283,6 +327,8 @@ class SampleScene:
         resolution: Tuple[int, int],
         projection: BeamStageProjection,
         rng: Optional[np.random.Generator] = None,
+        beam_shift: Tuple[float, float] = (0.0, 0.0),
+        beam_current: Optional[float] = None,
     ) -> np.ndarray:
         """Render one beam's view of the scene at the current stage position.
 
@@ -299,6 +345,10 @@ class SampleScene:
             resolution: (width, height) in pixels.
             projection: the beam's stage projection (from the live geometry).
             rng: noise source; a fresh default generator when omitted.
+            beam_shift: the beam's current shift (m); the configured
+                `beam_offset` for the beam is added to it.
+            beam_current: the beam current (A); each distinct current carries
+                its own seeded offset (see current_offset_scale).
 
         Returns:
             uint8 image of shape (height, width).
@@ -325,16 +375,31 @@ class SampleScene:
         ax, ay = projection.to_plane(reference, stage_position)
 
         fs = max(surface_foreshortening(projection, stage_position), MIN_FORESHORTENING)
-        flip = -1.0 if np.isclose(projection.scan_rotation, np.pi) else 1.0
+        # scan rotation turns the raster, so the content turns with it - the
+        # full angle here, not only the half-turn the app's projection models,
+        # so an intermediate rotation shows the app's limitation honestly
+        theta = float(projection.scan_rotation or 0.0)
+        cos_t, sin_t = np.cos(theta), np.sin(theta)
+        # the projection already flips the anchor offset at a half-turn;
+        # undo that and apply the full rotation here so every angle works
+        if np.isclose(theta, np.pi):
+            ax, ay = -ax, -ay
+        ax, ay = ax * cos_t - ay * sin_t, ax * sin_t + ay * cos_t
+        # a beam shift moves the content in the view, in the scan frame
+        offset = self.beam_offset.get(beam_type.name.lower(), (0.0, 0.0))
+        current_offset = self.current_offset(beam_type, beam_current)
+        ax = ax + beam_shift[0] + offset[0] + current_offset[0]
+        ay = ay - (beam_shift[1] + offset[1] + current_offset[1])
 
         canvas = np.zeros((height, width), dtype=np.float32)
 
         # grid mesh bars: world (sample-plane) coordinates per pixel, through
-        # the inverse of the same mapping the features use
-        xs_world = flip * ((np.arange(width, dtype=np.float32) - cx) * pixel_size - ax)
-        ys_world = (
-            flip * ((np.arange(height, dtype=np.float32) - cy) * pixel_size - ay) / fs
-        )
+        # the inverse of the same mapping the features use: un-shift,
+        # un-rotate the scan, un-foreshorten
+        vx = (np.arange(width, dtype=np.float32) - cx)[None, :] * pixel_size - ax
+        vy = (np.arange(height, dtype=np.float32) - cy)[:, None] * pixel_size - ay
+        xs_world = vx * cos_t + vy * sin_t
+        ys_world = (-vx * sin_t + vy * cos_t) / fs
 
         def _near_bar(w: np.ndarray) -> np.ndarray:
             return (
@@ -345,19 +410,21 @@ class SampleScene:
         # the mesh is rotated in the world plane, so the bar test runs on
         # rotated world coordinates (full 2D, no longer separable)
         cos_r, sin_r = np.cos(self.grid_rotation), np.sin(self.grid_rotation)
-        xw = xs_world[None, :]
-        yw = ys_world[:, None]
-        x_rot = xw * cos_r + yw * sin_r
-        y_rot = -xw * sin_r + yw * cos_r
+        x_rot = xs_world * cos_r + ys_world * sin_r
+        y_rot = -xs_world * sin_r + ys_world * cos_r
         bar_mask = _near_bar(x_rot) | _near_bar(y_rot)
         canvas[bar_mask] += self.grid_intensity
 
         for f in self.features:
-            u = cx + (flip * f.x + ax) / pixel_size
-            v = cy + (flip * f.y * fs + ay) / pixel_size
+            # project (foreshorten), rotate with the scan, then shift
+            px_, py_ = f.x, f.y * fs
+            u = cx + (px_ * cos_t - py_ * sin_t + ax) / pixel_size
+            v = cy + (px_ * sin_t + py_ * cos_t + ay) / pixel_size
             sigma_x = f.sigma / pixel_size
             sigma_y = sigma_x * fs
-            self._stamp_blob(canvas, u, v, sigma_x, sigma_y, f.intensity, f.sharpness)
+            self._stamp_blob(
+                canvas, u, v, sigma_x, sigma_y, f.intensity, f.sharpness, angle=theta
+            )
 
         if rng is None:
             rng = np.random.default_rng()
@@ -416,7 +483,9 @@ class SampleScene:
         ax, ay = projection.to_plane(reference, stage_position)
         fs = max(surface_foreshortening(projection, stage_position), MIN_FORESHORTENING)
 
-        bars, cells, red, fiducial = weights
+        bars, cells, red, fiducial = weights[:4]
+        # contamination reflects strongly and autofluoresces faintly
+        contamination = 0.9 if bars >= 1.0 else 0.12
         canvas = np.zeros((height, width), dtype=np.float32)
 
         if bars > 0:
@@ -437,9 +506,10 @@ class SampleScene:
 
         red_rng = np.random.default_rng(self.seed + 1)
         for f in self.features:
-            is_fiducial = f.sharpness == 1.0 and f.sigma < 1e-6
-            if is_fiducial:
+            if f.kind == "fiducial":
                 weight = fiducial
+            elif f.kind == "contamination":
+                weight = contamination
             else:
                 in_subset = red_rng.random() < self.red_fraction
                 weight = cells + (red if in_subset else 0.0)
@@ -465,6 +535,26 @@ class SampleScene:
         data = 400.0 + canvas * 120.0
         data += rng.normal(0, 40.0 + 0.05 * np.sqrt(np.maximum(data, 0)), canvas.shape)
         return np.clip(data, 0, 65535).astype(np.uint16)
+
+    def current_offset(
+        self, beam_type: BeamType, beam_current: Optional[float]
+    ) -> Tuple[float, float]:
+        """The beam offset that goes with a beam current: drawn once per
+        (beam, current) from the scene's seed, so it is reproducible across
+        a session and across sessions with the same seed - a lookup table
+        nobody wrote down, like the real one."""
+        if beam_current is None or self.current_offset_scale <= 0:
+            return (0.0, 0.0)
+        key = (beam_type.name.lower(), float(f"{beam_current:.6g}"))
+        if key not in self._current_offsets:
+            # a deterministic hash - Python's own is salted per process
+            rng = np.random.default_rng(
+                [self.seed, zlib.crc32(key[0].encode()), int(abs(key[1]) * 1e15)]
+            )
+            self._current_offsets[key] = tuple(
+                float(v) for v in rng.normal(0, self.current_offset_scale, size=2)
+            )
+        return self._current_offsets[key]
 
     def _non_eucentric_reference(
         self, stage_position: FibsemStagePosition, projection: BeamStageProjection
@@ -517,21 +607,29 @@ class SampleScene:
         sigma_y: float,
         intensity: float,
         sharpness: float = 1.0,
+        angle: float = 0.0,
     ) -> None:
         """Add one supergaussian blob, clipped to its bounding box.
 
-        sharpness 1 = gaussian; higher = flat top with a sharp rim.
+        sharpness 1 = gaussian; higher = flat top with a sharp rim. `angle`
+        turns the (sigma_x, sigma_y) ellipse, for a scan-rotated view.
         """
         height, width = canvas.shape
-        x0 = max(0, int(u - 4 * sigma_x))
-        x1 = min(width, int(u + 4 * sigma_x) + 1)
-        y0 = max(0, int(v - 4 * sigma_y))
-        y1 = min(height, int(v + 4 * sigma_y) + 1)
+        reach = 4 * max(sigma_x, sigma_y) if angle else None
+        x0 = max(0, int(u - (reach or 4 * sigma_x)))
+        x1 = min(width, int(u + (reach or 4 * sigma_x)) + 1)
+        y0 = max(0, int(v - (reach or 4 * sigma_y)))
+        y1 = min(height, int(v + (reach or 4 * sigma_y)) + 1)
         if x0 >= x1 or y0 >= y1:
             return
         xs = np.arange(x0, x1, dtype=np.float32)
         ys = np.arange(y0, y1, dtype=np.float32)
-        rx = (xs[None, :] - u) / max(sigma_x, 0.5)
-        ry = (ys[:, None] - v) / max(sigma_y, 0.5)
+        dx = xs[None, :] - u
+        dy = ys[:, None] - v
+        if angle:
+            c, s_ = np.cos(angle), np.sin(angle)
+            dx, dy = dx * c + dy * s_, -dx * s_ + dy * c
+        rx = dx / max(sigma_x, 0.5)
+        ry = dy / max(sigma_y, 0.5)
         r2 = rx**2 + ry**2
         canvas[y0:y1, x0:x1] += intensity * np.exp(-0.5 * r2**sharpness)

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -730,12 +730,19 @@ class DemoMicroscope(FibsemMicroscope):
             projection = BeamStageProjection.from_microscope(
                 self, beam_type=effective_beam_type
             )
+            shift = self.get_beam_shift(effective_beam_type)
+            try:
+                current = float(self.get("current", effective_beam_type))
+            except Exception:
+                current = None
             image.data = self._sample_scene.render(
                 beam_type=effective_beam_type,
                 stage_position=self.get_stage_position(),
                 hfw=effective_image_settings.hfw,
                 resolution=effective_image_settings.resolution,
                 projection=projection,
+                beam_shift=(float(shift.x), float(shift.y)),
+                beam_current=current,
             )
         # generate the next image from the sequence iterator
         elif self.use_image_sequence:

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -17,12 +17,14 @@ import numpy as np
 from skimage.transform import resize
 
 from fibsem._timing import sim_sleep
-from fibsem.fm.microscope import FluorescenceMicroscope
+from fibsem.fm.microscope import Camera, FluorescenceMicroscope
 from fibsem.microscope import (
     FibsemMicroscope,
     ThermoMicroscope,
 )
+from fibsem.microscopes.sim_scene import fm_channel_weights
 from fibsem.milling.progress import MillingProgress, MillingProgressStatus
+from fibsem.projection import FMStageProjection
 from fibsem.structures import (
     ACTIVE_MILLING_STATES,
     BeamSettings,
@@ -265,6 +267,52 @@ CHAMBER_ACTIVE_VIEW = 4
 CHAMBER_ACTIVE_DEVICE = 3
 
 
+class SceneCamera(Camera):
+    """The simulated FM camera, imaging the sample scene when there is one.
+
+    Renders the same synthetic sample the beams image, through the FM's
+    projection, for the channel the microscope is configured to and with
+    the objective's defocus; falls back to the stock noise/counter frames
+    when no scene is enabled.
+    """
+
+    def acquire_image(self) -> np.ndarray:
+        fm = self.parent
+        microscope = getattr(fm, "parent", None)
+        scene = getattr(microscope, "_sample_scene", None)
+        if scene is None:
+            return super().acquire_image()
+        projection = FMStageProjection.from_microscope(microscope)
+        if projection is None:
+            return super().acquire_image()
+        sim_sleep(self.exposure_time)
+        weights = fm_channel_weights(
+            fm.filter_set.emission_wavelength, fm.filter_set.excitation_wavelength
+        )
+        focus = fm.objective.focus_position
+        defocus = 0.0 if focus is None else fm.objective.position - focus
+        # the projection carries the unbinned camera shape; render at the
+        # binned resolution with the matching pixel size
+        projection = FMStageProjection(
+            geometry=projection.geometry,
+            pixel_size=self.pixel_size[0],
+            shape=(self.resolution[1], self.resolution[0]),
+        )
+        self._index += 1
+        frame = scene.render_fm(
+            microscope.get_stage_position(),
+            self.resolution,
+            projection,
+            weights=weights,
+            defocus=defocus,
+        )
+        # the projection speaks in displayed-image coordinates, but a camera
+        # frame goes through the mount and user transforms before display:
+        # pre-apply their inverse (flips are self-inverse; reversed order)
+        frame = fm._transform_array(frame, fm._transform)
+        return fm._transform_array(frame, fm.mount_transform)
+
+
 class SimulatedFluorescenceMicroscope(FluorescenceMicroscope):
     """The FM half of the one imaging channel a TFS system shares (FIB-518).
 
@@ -284,6 +332,7 @@ class SimulatedFluorescenceMicroscope(FluorescenceMicroscope):
 
     def __init__(self, parent: Optional["FibsemMicroscope"] = None):
         super().__init__(parent=parent)
+        self.camera = SceneCamera(parent=self)
         self._active_view = FM_ACTIVE_VIEW
         self._active_device = FM_ACTIVE_DEVICE
         # The parent's lock, as the driver takes it: an FM scope and a beam acquisition
@@ -506,7 +555,7 @@ class DemoMicroscope(FibsemMicroscope):
         self._last_imaging_settings: ImageSettings = ImageSettings()
         self.milling_channel: BeamType = BeamType.ION
         self._image_cache: dict = {}
-        self._setup_coincidence_projection()
+        self._setup_sample_scene()
         logging.debug(
             {
                 "msg": "create_microscope_client",
@@ -675,13 +724,13 @@ class DemoMicroscope(FibsemMicroscope):
         )
 
         # shared-scene projection takes precedence when enabled (FIB-874)
-        if self._coincidence_scene is not None:
+        if self._sample_scene is not None:
             from fibsem.projection import BeamStageProjection
 
             projection = BeamStageProjection.from_microscope(
                 self, beam_type=effective_beam_type
             )
-            image.data = self._coincidence_scene.render(
+            image.data = self._sample_scene.render(
                 beam_type=effective_beam_type,
                 stage_position=self.get_stage_position(),
                 hfw=effective_image_settings.hfw,
@@ -736,41 +785,50 @@ class DemoMicroscope(FibsemMicroscope):
 
         return image
 
-    def _setup_coincidence_projection(self) -> None:
-        """Opt-in shared-scene projection rendering (FIB-874), default off.
+    def _setup_sample_scene(self) -> None:
+        """Opt-in synthetic-sample imaging (FIB-874), default off.
 
-        When `sim: coincidence_projection: true`, both beams image one
-        synthetic scene, with the FIB view foreshortened and displaced by the
-        current height error - so SEM/FIB coincidence can be measured and
-        corrected on the simulator. `sim: coincidence_offset` (metres) sets
-        how far off-coincidence the simulator boots (default 10e-6).
+        `sim: sample: {enabled: true, ...}` makes both beams (and the FM,
+        where present) image one synthetic cryo-grid through their
+        projections, so geometry between the views - coincidence above all -
+        is measurable and correctable on the simulator. The block's other
+        keys are the scene's options (see SampleScene.CONFIG_KEYS). The
+        older flat keys `coincidence_projection`, `coincidence_offset` and
+        `tilt_axis_offset` are still honoured when there is no `sample` block.
         """
-        from fibsem.microscopes.sim_scene import CoincidenceScene
+        from fibsem.microscopes.sim_scene import SampleScene
 
-        self._coincidence_scene: Optional[CoincidenceScene] = None
-        if not self.system.sim.get("coincidence_projection", False):
+        self._sample_scene: Optional[SampleScene] = None
+        sim = self.system.sim
+        config = sim.get("sample")
+        if config is None:
+            if not sim.get("coincidence_projection", False):
+                return
+            config = {
+                "coincidence_offset": sim.get("coincidence_offset", 10e-6),
+                "tilt_axis_offset": sim.get("tilt_axis_offset", 0.0),
+            }
+        elif not config.get("enabled", False):
             return
-        offset = float(self.system.sim.get("coincidence_offset", 10e-6))
-        # `sim: tilt_axis_offset` (metres) makes the stage non-eucentric: a
-        # tilt change then costs coincidence, as on real hardware (FIB-899)
-        tilt_axis_offset = float(self.system.sim.get("tilt_axis_offset", 0.0))
-        self._coincidence_scene = CoincidenceScene(
-            coincidence_offset=offset, tilt_axis_offset=tilt_axis_offset
+        self._sample_scene = SampleScene.from_config(
+            {k: v for k, v in config.items() if k != "enabled"}
         )
         try:
             # anchor the world NOW, at the connect pose - so moving straight
             # to a saved position and acquiring shows that position's
             # surroundings rather than anchoring the world there
-            self._coincidence_scene.anchor(self.get_stage_position())
+            self._sample_scene.anchor(self.get_stage_position())
         except Exception as e:
             logging.warning(
-                "Could not anchor the coincidence scene at connect (%s); "
+                "Could not anchor the sample scene at connect (%s); "
                 "it will anchor at the first acquisition instead.",
                 e,
             )
         logging.info(
-            "Simulator coincidence projection enabled (initial offset: %.2f um)",
-            offset * 1e6,
+            "Simulator sample scene enabled (coincidence offset %.2f um, "
+            "tilt axis offset %.1f um)",
+            self._sample_scene.coincidence_offset * 1e6,
+            self._sample_scene.tilt_axis_offset * 1e6,
         )
 
     def _generate_next_image(

--- a/tests/autolamella/test_select_position_coincidence.py
+++ b/tests/autolamella/test_select_position_coincidence.py
@@ -21,7 +21,7 @@ from fibsem.applications.autolamella.workflows.tasks.select_position import (
     SelectMillingPositionTask,
     SelectMillingPositionTaskConfig,
 )
-from fibsem.microscopes.sim_scene import CoincidenceScene
+from fibsem.microscopes.sim_scene import SampleScene
 from fibsem.projection import BeamStageProjection
 from fibsem.structures import BeamType
 
@@ -36,20 +36,20 @@ def microscope():
         manufacturer="Demo", config_path=TFS_SHUTTLE_CONFIG
     )
     microscope.system.sim["coincidence_projection"] = True
-    microscope._setup_coincidence_projection()
+    microscope._setup_sample_scene()
     yield microscope
     microscope.disconnect()
 
 
 def _anchor_scene(microscope, coincidence_offset: float) -> None:
-    scene = CoincidenceScene(
+    scene = SampleScene(
         coincidence_offset=coincidence_offset,
         tilt_axis_offset=NON_EUCENTRIC,
         noise_sigma=0.0,
         noise_fraction=0.0,
     )
     scene.anchor(microscope.get_stage_position())
-    microscope._coincidence_scene = scene
+    microscope._sample_scene = scene
 
 
 def _anchor_in_fib_view(microscope) -> tuple:
@@ -57,7 +57,7 @@ def _anchor_in_fib_view(microscope) -> tuple:
     the invariant: with reference=ION nothing the task does may move what
     the operator centred there - not the alignment, not the tilt."""
     projection = BeamStageProjection.from_microscope(microscope, BeamType.ION)
-    scene = microscope._coincidence_scene
+    scene = microscope._sample_scene
     pose = microscope.get_stage_position()
     return projection.to_plane(scene._non_eucentric_reference(pose, projection), pose)
 

--- a/tests/fm/test_sample_scene_fm.py
+++ b/tests/fm/test_sample_scene_fm.py
@@ -1,0 +1,162 @@
+"""The simulated FM images the same sample scene as the beams (FIB-874).
+
+Runs under the fm package's sim-arctis configuration (compustage, FM
+present). The scene is rendered through FMStageProjection, so where a
+feature lands in the FM image is predicted by the same projection the app
+draws stage positions with - that prediction is the oracle here.
+"""
+
+import numpy as np
+import pytest
+from scipy import ndimage as ndi
+
+from fibsem import utils
+from fibsem.fm.structures import ChannelSettings
+from fibsem.microscopes.sim_scene import SampleScene, fm_channel_weights
+from fibsem.projection import FMStageProjection
+from fibsem.structures import FibsemStagePosition
+
+REFLECTION = ChannelSettings(
+    name="reflection", excitation_wavelength=550, emission_wavelength=None, color="gray"
+)
+GREEN = ChannelSettings(
+    name="green", excitation_wavelength=488, emission_wavelength=520, color="green"
+)
+RED = ChannelSettings(
+    name="red", excitation_wavelength=561, emission_wavelength=610, color="red"
+)
+BLUE = ChannelSettings(
+    name="blue", excitation_wavelength=405, emission_wavelength=450, color="blue"
+)
+
+
+@pytest.fixture
+def microscope():
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    assert microscope.fm is not None, "the fm package config must carry an FM"
+    microscope.system.sim["sample"] = {"enabled": True, "coincidence_offset": 0.0}
+    microscope._setup_sample_scene()
+    microscope.move_to_device("FM")
+    # the FM images with the objective inserted and at focus; it boots retracted
+    microscope.fm.objective.move_absolute(microscope.fm.objective.focus_position)
+    yield microscope
+    microscope.disconnect()
+
+
+def _fiducial_only(microscope) -> SampleScene:
+    scene = SampleScene(
+        coincidence_offset=0.0,
+        n_clusters=0,
+        grid_intensity=0.0,
+        noise_sigma=0.0,
+        noise_fraction=0.0,
+    )
+    scene.anchor(microscope.get_stage_position())
+    microscope._sample_scene = scene
+    return scene
+
+
+def _brightest(image) -> tuple:
+    data = ndi.gaussian_filter(image.data.astype(np.float32), 2)
+    y, x = np.unravel_index(np.argmax(data), data.shape)
+    return float(x), float(y)
+
+
+def _predicted_fiducial(microscope) -> tuple:
+    """Where the world origin (the fiducial) projects into the FM image."""
+    projection = FMStageProjection.from_microscope(microscope)
+    fm = microscope.fm
+    width, height = fm.camera.resolution
+    projection = FMStageProjection(
+        geometry=projection.geometry,
+        pixel_size=fm.camera.pixel_size[0],
+        shape=(height, width),
+    )
+    scene = microscope._sample_scene
+    pose = microscope.get_stage_position()
+    ax, ay = projection.to_plane(scene.reference_position, pose)
+    return (
+        width / 2 + ax / projection.pixel_size,
+        height / 2 + ay / projection.pixel_size,
+    )
+
+
+def test_channels_respond_to_the_excitation_and_emission_pair():
+    bars, cells, subset, fiducial = fm_channel_weights(None, 550)
+    assert bars == 1.0 and fiducial > 0  # reflection: the grid, and the fiducial
+    _, cells, subset, fiducial = fm_channel_weights(520, 488)
+    assert cells > 0.7 and subset < 0.05 and fiducial < 0.05  # GFP channel
+    _, cells, subset, fiducial = fm_channel_weights(610, 561)
+    assert subset > 0.7 and cells < 0.05  # mCherry channel
+    _, cells, subset, fiducial = fm_channel_weights(460, 365)
+    assert fiducial > 0.7 and cells < 0.05  # DAPI channel
+    # a mismatched pair: 488 excitation collected in the red band bleeds
+    # weakly rather than showing nothing or everything
+    _, cells, subset, _ = fm_channel_weights(610, 488)
+    assert 0 < subset < 0.1 and cells < 0.05
+    assert fm_channel_weights("reflection", None) == fm_channel_weights(None, None)
+    # the simulated FM's own filter: emission "Fluorescence" is an open band,
+    # so its excitation lines pick the dye - 365 fiducial, 450 cells, 550
+    # subset, 635 nothing
+    line = {ex: fm_channel_weights("Fluorescence", ex) for ex in (365, 450, 550, 635)}
+    assert line[365][3] > 0.7 and line[365][1] < 0.05
+    assert line[450][1] > 0.7 and line[450][2] < 0.05
+    assert line[550][2] > 0.9 and line[550][1] < 0.05
+    assert max(line[635][1:]) < 0.05
+
+
+def test_channels_show_different_structures(microscope):
+    reflection = microscope.fm.acquire_image(REFLECTION).data.astype(np.float32)
+    green = microscope.fm.acquire_image(GREEN).data.astype(np.float32)
+    red = microscope.fm.acquire_image(RED).data.astype(np.float32)
+
+    # every channel has structure, and they are not the same picture
+    for image in (reflection, green, red):
+        assert ndi.gaussian_filter(image, 3).std() > 20
+    corr = np.corrcoef(reflection.ravel(), green.ravel())[0, 1]
+    assert corr < 0.5, f"reflection and green correlate {corr:.2f}: bars vs cells lost"
+    # the red subset is a subset: where red is bright, green is bright too
+    bright_red = ndi.gaussian_filter(red, 3) > np.percentile(red, 99)
+    assert ndi.gaussian_filter(green, 3)[bright_red].mean() > np.percentile(green, 80)
+
+
+def test_the_fiducial_lands_where_the_fm_projection_says(microscope):
+    _fiducial_only(microscope)
+    image = microscope.fm.acquire_image(BLUE)
+    found = _brightest(image)
+    predicted = _predicted_fiducial(microscope)
+    error = np.hypot(found[0] - predicted[0], found[1] - predicted[1])
+    assert error < 3, f"fiducial {error:.1f} px from the projected position"
+
+    # move the stage: the fiducial follows the projection, not the pixels
+    microscope.move_stage_relative(
+        FibsemStagePosition(x=20e-6, y=-15e-6, z=0, r=0, t=0)
+    )
+    image = microscope.fm.acquire_image(BLUE)
+    found = _brightest(image)
+    predicted = _predicted_fiducial(microscope)
+    moved = np.hypot(
+        found[0] - image.data.shape[1] / 2, found[1] - image.data.shape[0] / 2
+    )
+    assert moved > 20  # it visibly moved off centre
+    error = np.hypot(found[0] - predicted[0], found[1] - predicted[1])
+    assert error < 3, (
+        f"after the move the fiducial is {error:.1f} px off the projection"
+    )
+
+
+def test_defocus_blurs_the_image(microscope):
+    _fiducial_only(microscope)
+    fm = microscope.fm
+    fm.objective.move_absolute(fm.objective.focus_position)
+    sharp = fm.acquire_image(BLUE).data.astype(np.float32)
+    fm.objective.move_absolute(fm.objective.focus_position + 20e-6)
+    blurred = fm.acquire_image(BLUE).data.astype(np.float32)
+
+    # the fiducial's peak over the background: blur spreads it out. Pixel
+    # noise dominates any whole-image edge measure, so look at the peak.
+    def peak_contrast(image):
+        smooth = ndi.gaussian_filter(image, 1)
+        return smooth.max() - np.median(smooth)
+
+    assert peak_contrast(blurred) < 0.5 * peak_contrast(sharp)

--- a/tests/fm/test_sample_scene_fm.py
+++ b/tests/fm/test_sample_scene_fm.py
@@ -46,7 +46,7 @@ def microscope():
 def _fiducial_only(microscope) -> SampleScene:
     scene = SampleScene(
         coincidence_offset=0.0,
-        n_clusters=0,
+        cell_type="none",
         grid_intensity=0.0,
         noise_sigma=0.0,
         noise_fraction=0.0,

--- a/tests/test_align_loop.py
+++ b/tests/test_align_loop.py
@@ -31,15 +31,13 @@ def microscope():
     )
     microscope.system.sim["coincidence_projection"] = True
     microscope.system.sim["coincidence_offset"] = 8e-6
-    microscope._setup_coincidence_projection()
-    from fibsem.microscopes.sim_scene import CoincidenceScene
+    microscope._setup_sample_scene()
+    from fibsem.microscopes.sim_scene import SampleScene
 
     # deterministic scene: the loop is about control flow and geometry
-    scene = CoincidenceScene(
-        coincidence_offset=8e-6, noise_sigma=0.0, noise_fraction=0.0
-    )
+    scene = SampleScene(coincidence_offset=8e-6, noise_sigma=0.0, noise_fraction=0.0)
     scene.anchor(microscope.get_stage_position())
-    microscope._coincidence_scene = scene
+    microscope._sample_scene = scene
     pose = microscope.get_stage_position()
     pose.t = np.deg2rad(12.0)
     microscope.move_stage_absolute(pose)
@@ -101,9 +99,9 @@ def test_coarse_pass_rescues_errors_beyond_the_fine_window(microscope, offset):
     the coarse pass, and still converge. The honest reach on this mesh is
     ~50 um - about half a grid pitch, where rival peaks start to compete;
     an 80 um "rescue" this test once claimed was a false-lock chain."""
-    microscope._coincidence_scene.coincidence_offset = offset
-    microscope._coincidence_scene.reference_position = None
-    microscope._coincidence_scene.anchor(microscope.get_stage_position())
+    microscope._sample_scene.coincidence_offset = offset
+    microscope._sample_scene.reference_position = None
+    microscope._sample_scene.anchor(microscope.get_stage_position())
 
     result = ensure_coincident(microscope, tolerance=1e-6)
 
@@ -120,9 +118,9 @@ def test_error_beyond_the_coarse_window_does_not_claim_success(microscope, offse
     recording that). The alias is caught by its lateral offset instead: a
     height error cannot move x, and on the rotated mesh the rival peak sits
     well off-axis - so the lock is refused rather than acted on."""
-    microscope._coincidence_scene.coincidence_offset = offset
-    microscope._coincidence_scene.reference_position = None
-    microscope._coincidence_scene.anchor(microscope.get_stage_position())
+    microscope._sample_scene.coincidence_offset = offset
+    microscope._sample_scene.reference_position = None
+    microscope._sample_scene.anchor(microscope.get_stage_position())
 
     result = ensure_coincident(microscope, tolerance=1e-6)
 
@@ -189,9 +187,9 @@ def test_a_coarse_run_replays_with_its_own_parameters(microscope, tmp_path):
         save_coincidence_diagnostics,
     )
 
-    microscope._coincidence_scene.coincidence_offset = 40e-6
-    microscope._coincidence_scene.reference_position = None
-    microscope._coincidence_scene.anchor(microscope.get_stage_position())
+    microscope._sample_scene.coincidence_offset = 40e-6
+    microscope._sample_scene.reference_position = None
+    microscope._sample_scene.anchor(microscope.get_stage_position())
     result = ensure_coincident(microscope, tolerance=1e-6)
     assert result.coarse_used
 
@@ -204,9 +202,9 @@ def test_a_coarse_run_replays_with_its_own_parameters(microscope, tmp_path):
 
 
 def test_coarse_measurements_do_not_count_as_moves(microscope):
-    microscope._coincidence_scene.coincidence_offset = 40e-6
-    microscope._coincidence_scene.reference_position = None
-    microscope._coincidence_scene.anchor(microscope.get_stage_position())
+    microscope._sample_scene.coincidence_offset = 40e-6
+    microscope._sample_scene.reference_position = None
+    microscope._sample_scene.anchor(microscope.get_stage_position())
 
     result = ensure_coincident(microscope, tolerance=1e-6)
 
@@ -228,7 +226,7 @@ def _anchor_in_view(microscope, beam_type) -> tuple:
 
     projection = BeamStageProjection.from_microscope(microscope, beam_type)
     return projection.to_plane(
-        microscope._coincidence_scene.reference_position,
+        microscope._sample_scene.reference_position,
         microscope.get_stage_position(),
     )
 
@@ -249,3 +247,24 @@ def test_reference_view_keeps_its_centre(microscope, reference):
     moved = np.hypot(*(np.subtract(after[other], before[other])))
     assert kept < 1e-6, f"{reference.name} view moved by {kept * 1e6:.2f} um"
     assert moved > 3e-6, f"{other.name} view only moved {moved * 1e6:.2f} um"
+
+
+@pytest.mark.parametrize("reference", [BeamType.ELECTRON, BeamType.ION])
+def test_converges_at_the_fib_orientation(microscope, reference):
+    """At the FIB orientation (half a turn round, the FIB looking at the
+    surface face-on) the projections carry the flip; the loop converges
+    exactly. Validated here only - the guard is a logged warning, not a
+    refusal, until hardware confirms it."""
+    fib = microscope.get_orientation("FIB")
+    pose = microscope.get_stage_position()
+    pose.r, pose.t = fib.r, fib.t
+    microscope.move_stage_absolute(pose)
+    microscope._sample_scene.reference_position = None
+    microscope._sample_scene.anchor(microscope.get_stage_position())
+
+    result = ensure_coincident(microscope, tolerance=1e-6, reference=reference)
+
+    assert result.converged, result.reason
+    assert result.moves_applied == 1
+    assert abs(result.measurements[0].dz) == pytest.approx(8e-6, abs=1e-6)
+    assert result.measurements[0].y_stretch < 1  # the FIB is the face-on view here

--- a/tests/test_coincidence.py
+++ b/tests/test_coincidence.py
@@ -246,20 +246,6 @@ def test_measure_from_images_and_diagnostic_plot(tmp_path):
     assert len(pngs) == 1
 
 
-def test_flipped_rotation_is_rejected():
-    from fibsem.alignment.coincidence import geometry_from_images
-
-    blank = np.zeros(SHAPE, dtype=np.uint8)
-    sem_image, fib_image = _image_pair(blank, blank)
-    # stage rotated to the flipped (FIB-orientation) side: unvalidated
-    # territory, so the derivation must refuse loudly
-    for image in (sem_image, fib_image):
-        image.metadata.microscope_state.stage_position.r = np.deg2rad(180.0)
-
-    with pytest.raises(ValueError, match="FIB-orientation"):
-        geometry_from_images(sem_image, fib_image)
-
-
 def test_large_lateral_offset_is_refused_as_a_rival_peak():
     """A height error cannot move x, so a lock far out in x is a wrong peak
     even when both bands agree on it - it must not be acted on."""

--- a/tests/test_coincidence.py
+++ b/tests/test_coincidence.py
@@ -265,3 +265,52 @@ def test_large_lateral_offset_is_refused_as_a_rival_peak():
         sem, fib, PIXEL_SIZE, Y_STRETCH, DZ_PER_DY, max_lateral_offset=20e-6
     )
     assert m.is_reliable
+
+
+def test_a_rival_peak_as_good_as_the_lock_is_refused():
+    """One structure in the SEM, two identical copies of it in the FIB: the
+    correlation has two equal peaks, and the correlator has no business
+    choosing between them."""
+    from fibsem.alignment.coincidence import REFUSAL_RIVAL_PEAK
+
+    rng = np.random.default_rng(3)
+    motif = ndi.gaussian_filter(rng.uniform(0, 1, (60, 60)).astype(np.float32), 2)
+    cy, cx = SHAPE[0] // 2, SHAPE[1] // 2
+    sem = np.zeros(SHAPE, dtype=np.float32)
+    sem[cy - 30 : cy + 30, cx - 30 : cx + 30] = motif * 150
+    # the FIB carries two identical copies, 60 px either side of centre, so
+    # the two candidate shifts are equally weighted by the centre-weighting
+    # window and neither is the better lock
+    left = make_fib_view(np.roll(sem, -60, axis=1), 0.0, 0.0, Y_STRETCH)
+    right = make_fib_view(np.roll(sem, 60, axis=1), 0.0, 0.0, Y_STRETCH)
+    fib = np.minimum(left, right)  # FIB contrast is inverted: darker wins
+
+    window = 150 * PIXEL_SIZE
+    m = measure_coincidence(
+        sem, fib, PIXEL_SIZE, Y_STRETCH, DZ_PER_DY, capture_range=window
+    )
+    assert m.rival_ratio > 0.9
+    assert not m.is_reliable
+    assert m.refusal_reason == REFUSAL_RIVAL_PEAK
+
+    # the bound is a parameter: with it open the same pair measures
+    m = measure_coincidence(
+        sem,
+        fib,
+        PIXEL_SIZE,
+        Y_STRETCH,
+        DZ_PER_DY,
+        capture_range=window,
+        max_rival_ratio=1.0,
+    )
+    assert m.is_reliable
+
+
+def test_a_single_structure_has_no_serious_rival():
+    sem = make_sem_scene()
+    fib = make_fib_view(sem, 12.0, -6.0, Y_STRETCH)
+
+    m = measure_coincidence(sem, fib, PIXEL_SIZE, Y_STRETCH, DZ_PER_DY)
+
+    assert m.is_reliable, m.refusal_reason
+    assert m.rival_ratio < 0.9

--- a/tests/test_sim_coincidence.py
+++ b/tests/test_sim_coincidence.py
@@ -53,11 +53,11 @@ def microscope():
 def _enable_projection(microscope, offset: float = COINCIDENCE_OFFSET, **scene_kwargs):
     microscope.system.sim["coincidence_projection"] = True
     microscope.system.sim["coincidence_offset"] = offset
-    microscope._setup_coincidence_projection()
+    microscope._setup_sample_scene()
     if scene_kwargs:
-        from fibsem.microscopes.sim_scene import CoincidenceScene
+        from fibsem.microscopes.sim_scene import SampleScene
 
-        microscope._coincidence_scene = CoincidenceScene(
+        microscope._sample_scene = SampleScene(
             coincidence_offset=offset, **scene_kwargs
         )
     # a realistic milling pose: stage tilt 12 deg -> milling angle 15 deg
@@ -103,7 +103,7 @@ def _find_fiducial(image):
 
 
 def test_projection_defaults_off(microscope):
-    assert microscope._coincidence_scene is None
+    assert microscope._sample_scene is None
 
 
 @pytest.mark.parametrize("beam_type", [BeamType.ELECTRON, BeamType.ION])
@@ -198,13 +198,11 @@ def test_stitched_overview_matches_single_wide_shot(microscope, beam_type, tmp_p
 def test_views_share_the_scene_but_not_the_contrast():
     """Rendered through identical geometry, the two beams differ only in
     contrast convention - strongly anti-correlated with noise off."""
-    from fibsem.microscopes.sim_scene import CoincidenceScene
+    from fibsem.microscopes.sim_scene import SampleScene
     from fibsem.projection import BeamStageProjection
     from fibsem.structures import FibsemHardwareGeometry
 
-    scene = CoincidenceScene(
-        coincidence_offset=0.0, noise_sigma=0.0, noise_fraction=0.0
-    )
+    scene = SampleScene(coincidence_offset=0.0, noise_sigma=0.0, noise_fraction=0.0)
     geometry = FibsemHardwareGeometry(
         column_tilt=0, fib_column_tilt=52.0, shuttle_pre_tilt=35.0
     )
@@ -303,8 +301,8 @@ def test_world_anchors_at_connect(microscope):
     and acquiring must show that position's surroundings, not anchor the
     fiducial there."""
     microscope.system.sim["coincidence_projection"] = True
-    microscope._setup_coincidence_projection()
-    scene = microscope._coincidence_scene
+    microscope._setup_sample_scene()
+    scene = microscope._sample_scene
     assert scene.reference_position is not None
     boot = microscope.get_stage_position()
     assert scene.reference_position.x == pytest.approx(boot.x or 0.0)

--- a/tests/test_sim_coincidence.py
+++ b/tests/test_sim_coincidence.py
@@ -73,7 +73,7 @@ def _fiducial_only(microscope):
     _enable_projection(
         microscope,
         offset=0.0,
-        n_clusters=0,
+        cell_type="none",
         grid_intensity=0.0,
         noise_sigma=0.0,
         noise_fraction=0.0,

--- a/tests/test_sim_scene_realism.py
+++ b/tests/test_sim_scene_realism.py
@@ -1,0 +1,231 @@
+"""Scene realism: contamination, beam shift and scan rotation (FIB-874).
+
+Each layer exists because it exercises something in the measurement or the
+app: contamination is the aperiodic content that breaks a mesh-pitch
+alias, a beam offset is the only way the sim can produce a real lateral
+dx, and scan rotation turns the content the way a real raster does.
+"""
+
+import dataclasses
+import os
+
+import numpy as np
+import pytest
+from scipy import ndimage as ndi
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.alignment.coincidence import (
+    REFUSAL_LATERAL_OFFSET,
+    check_coincidence,
+    ensure_coincident,
+)
+from fibsem.microscopes.sim_scene import SampleScene
+from fibsem.projection import BeamStageProjection
+from fibsem.structures import BeamType, ImageSettings
+
+TFS_SHUTTLE_CONFIG = os.path.join(cfg.CONFIG_PATH, "microscope-configuration.yaml")
+MILLING_TILT = np.deg2rad(12.0)
+
+
+@pytest.fixture
+def microscope():
+    microscope, _ = utils.setup_session(
+        manufacturer="Demo", config_path=TFS_SHUTTLE_CONFIG
+    )
+    microscope.system.sim["sample"] = {"enabled": True, "coincidence_offset": 8e-6}
+    microscope._setup_sample_scene()
+    pose = microscope.get_stage_position()
+    pose.t = MILLING_TILT
+    microscope.move_stage_absolute(pose)
+    yield microscope
+    microscope.disconnect()
+
+
+def _scene(microscope, **kwargs) -> SampleScene:
+    scene = SampleScene(noise_sigma=0.0, noise_fraction=0.0, **kwargs)
+    scene.anchor(microscope.get_stage_position())
+    microscope._sample_scene = scene
+    return scene
+
+
+def _settings(beam_type, hfw=150e-6):
+    return ImageSettings(
+        resolution=(1536, 1024),
+        hfw=hfw,
+        dwell_time=1e-9,
+        save=False,
+        beam_type=beam_type,
+    )
+
+
+def _fiducial(image):
+    """Centre of the fiducial: the centroid of its pixels. In the FIB view
+    the foreshortened cross is a long dark ridge, and the smoothed minimum
+    wanders along it; the centroid tracks the crossing to a pixel."""
+    data = image.data.astype(np.float32)
+    if image.metadata.image_settings.beam_type is BeamType.ION:
+        mask = data < np.percentile(data, 0.5)
+    else:
+        mask = data > np.percentile(data, 99.5)
+    ys, xs = np.nonzero(mask)
+    return float(xs.mean()), float(ys.mean())
+
+
+def test_contamination_adds_fine_aperiodic_structure(microscope):
+    def speckle(density):
+        _scene(
+            microscope,
+            coincidence_offset=0.0,
+            n_clusters=0,
+            contamination_density=density,
+        )
+        image = microscope.acquire_image(image_settings=_settings(BeamType.ELECTRON))
+        data = image.data.astype(np.float32)
+        # speck-scale blobs: a band-pass at their size, counted as components
+        dog = ndi.gaussian_filter(data, 2) - ndi.gaussian_filter(data, 10)
+        return int(ndi.label(dog > 15)[1])
+
+    clean, dirty = speckle(0.0), speckle(30.0)
+    assert dirty > 3 * clean and dirty - clean > 15, (clean, dirty)
+    scene = microscope._sample_scene
+    assert sum(f.kind == "contamination" for f in scene.features) == int(
+        30.0 * (scene.extent / 100e-6) ** 2
+    )
+
+
+def test_beam_shift_moves_the_content_the_way_the_alignment_expects(microscope):
+    """The oracle is the alignment code itself: displace the stage, align by
+    beam shift against the earlier reference, and the image must be back."""
+    from fibsem.alignment import AlignmentSubsystem, beam_shift_alignment_v2
+
+    _scene(
+        microscope,
+        coincidence_offset=0.0,
+        n_clusters=0,
+        grid_intensity=0.0,
+        contamination_density=0.0,
+    )
+    settings = _settings(BeamType.ION)
+    reference = microscope.acquire_image(image_settings=settings)
+    before = _fiducial(reference)
+
+    microscope.stable_move(dx=3e-6, dy=-2e-6, beam_type=BeamType.ION)
+    displaced = _fiducial(microscope.acquire_image(image_settings=settings))
+    assert np.hypot(displaced[0] - before[0], displaced[1] - before[1]) > 10
+
+    beam_shift_alignment_v2(
+        microscope, reference, subsystem=AlignmentSubsystem.BEAM_SHIFT
+    )
+
+    after = _fiducial(microscope.acquire_image(image_settings=settings))
+    assert np.hypot(after[0] - before[0], after[1] - before[1]) < 2
+    shift = microscope.get_beam_shift(BeamType.ION)
+    assert np.hypot(shift.x, shift.y) > 1e-6  # it really was the beam that moved
+
+
+def test_a_small_beam_offset_is_measured_as_dx_and_tolerated(microscope):
+    _scene(
+        microscope,
+        coincidence_offset=8e-6,
+        beam_offset={"ion": (1.3e-6, 0.0)},
+        current_offset_scale=0.0,
+    )
+
+    result = ensure_coincident(microscope, tolerance=1e-6)
+
+    assert result.converged, result.reason
+    # dx is the shift that brings FIB onto SEM: minus the displacement
+    assert result.measurements[0].dx == pytest.approx(-1.3e-6, abs=0.4e-6)
+    assert abs(result.measurements[0].dz) == pytest.approx(8e-6, abs=1e-6)
+
+
+def test_a_large_beam_offset_is_refused_as_lateral(microscope):
+    _scene(
+        microscope,
+        coincidence_offset=8e-6,
+        beam_offset={"ion": (8e-6, 0.0)},
+        current_offset_scale=0.0,
+    )
+
+    m = check_coincidence(microscope)
+
+    assert not m.is_reliable
+    assert m.refusal_reason == REFUSAL_LATERAL_OFFSET
+    assert m.dx == pytest.approx(-8e-6, abs=0.6e-6)
+
+
+def test_changing_beam_current_moves_the_beam_reproducibly(microscope):
+    """Each ion current carries its own seeded offset: switching current
+    shifts the FIB view, switching back restores it, and the beam-shift
+    alignment can undo the difference - the milling-current alignment."""
+    from fibsem.alignment import AlignmentSubsystem, beam_shift_alignment_v2
+
+    _scene(
+        microscope,
+        coincidence_offset=0.0,
+        n_clusters=0,
+        grid_intensity=0.0,
+        contamination_density=0.0,
+        current_offset_scale=2e-6,
+    )
+    settings = _settings(BeamType.ION)
+    currents = microscope.get_available_values("current", BeamType.ION)
+    low, high = currents[1], currents[-2]
+
+    microscope.set("current", low, BeamType.ION)
+    reference = microscope.acquire_image(image_settings=settings)
+    at_low = _fiducial(reference)
+    microscope.set("current", high, BeamType.ION)
+    at_high = _fiducial(microscope.acquire_image(image_settings=settings))
+    assert np.hypot(at_high[0] - at_low[0], at_high[1] - at_low[1]) > 3
+    microscope.set("current", low, BeamType.ION)
+    again = _fiducial(microscope.acquire_image(image_settings=settings))
+    assert np.hypot(again[0] - at_low[0], again[1] - at_low[1]) < 1.5
+
+    microscope.set("current", high, BeamType.ION)
+    beam_shift_alignment_v2(
+        microscope, reference, subsystem=AlignmentSubsystem.BEAM_SHIFT
+    )
+    aligned = _fiducial(microscope.acquire_image(image_settings=settings))
+    assert np.hypot(aligned[0] - at_low[0], aligned[1] - at_low[1]) < 2
+
+
+def test_scan_rotation_turns_the_content(microscope):
+    """A quarter-turn of the scan puts a feature that sat to the right of
+    centre above or below it, at the same distance."""
+    scene = _scene(
+        microscope,
+        coincidence_offset=0.0,
+        n_clusters=0,
+        grid_intensity=0.0,
+        contamination_density=0.0,
+    )
+    microscope.stable_move(dx=10e-6, dy=0.0, beam_type=BeamType.ELECTRON)
+    pose = microscope.get_stage_position()
+    projection = BeamStageProjection.from_microscope(microscope, BeamType.ELECTRON)
+    resolution = (1536, 1024)
+    hfw = 150e-6
+    px = hfw / resolution[0]
+
+    def fiducial_px(scan_rotation):
+        rotated = dataclasses.replace(projection, scan_rotation=scan_rotation)
+        data = scene.render(
+            BeamType.ELECTRON,
+            pose,
+            hfw,
+            resolution,
+            rotated,
+            rng=np.random.default_rng(0),
+        )
+        y, x = np.unravel_index(
+            np.argmax(ndi.gaussian_filter(data.astype(np.float32), 3)), data.shape
+        )
+        return x - resolution[0] / 2, y - resolution[1] / 2
+
+    x0, y0 = fiducial_px(0.0)
+    assert abs(abs(x0) - 10e-6 / px) < 3 and abs(y0) < 3
+    x90, y90 = fiducial_px(np.pi / 2)
+    assert abs(x90) < 3 and abs(abs(y90) - 10e-6 / px) < 3
+    x180, y180 = fiducial_px(np.pi)
+    assert abs(x180 + x0) < 3 and abs(y180) < 3

--- a/tests/test_sim_scene_realism.py
+++ b/tests/test_sim_scene_realism.py
@@ -77,7 +77,7 @@ def test_contamination_adds_fine_aperiodic_structure(microscope):
         _scene(
             microscope,
             coincidence_offset=0.0,
-            n_clusters=0,
+            cell_type="none",
             contamination_density=density,
         )
         image = microscope.acquire_image(image_settings=_settings(BeamType.ELECTRON))
@@ -102,7 +102,7 @@ def test_beam_shift_moves_the_content_the_way_the_alignment_expects(microscope):
     _scene(
         microscope,
         coincidence_offset=0.0,
-        n_clusters=0,
+        cell_type="none",
         grid_intensity=0.0,
         contamination_density=0.0,
     )
@@ -164,7 +164,7 @@ def test_changing_beam_current_moves_the_beam_reproducibly(microscope):
     _scene(
         microscope,
         coincidence_offset=0.0,
-        n_clusters=0,
+        cell_type="none",
         grid_intensity=0.0,
         contamination_density=0.0,
         current_offset_scale=2e-6,
@@ -197,7 +197,7 @@ def test_scan_rotation_turns_the_content(microscope):
     scene = _scene(
         microscope,
         coincidence_offset=0.0,
-        n_clusters=0,
+        cell_type="none",
         grid_intensity=0.0,
         contamination_density=0.0,
     )
@@ -229,3 +229,82 @@ def test_scan_rotation_turns_the_content(microscope):
     assert abs(x90) < 3 and abs(abs(y90) - 10e-6 / px) < 3
     x180, y180 = fiducial_px(np.pi)
     assert abs(x180 + x0) < 3 and abs(y180) < 3
+
+
+@pytest.mark.parametrize(
+    "cell_type, parts",
+    [
+        ("mammalian", {"body", "nucleus", "organelle"}),
+        ("yeast", {"body", "nucleus", "bud"}),
+        ("bacteria", {"body"}),
+        ("mixed", {"body", "nucleus", "organelle", "bud"}),
+    ],
+)
+def test_cell_types_generate_their_parts(cell_type, parts):
+    scene = SampleScene(cell_type=cell_type, contamination_density=0.0)
+    cells = [f for f in scene.features if f.kind == "cell"]
+    assert {f.part for f in cells} == parts
+    assert all(f.cell_id >= 0 for f in cells)
+
+
+def test_mammalian_is_the_default_and_unknown_types_are_rejected():
+    assert SampleScene().cell_type == "mammalian"
+    with pytest.raises(ValueError):
+        SampleScene(cell_type="tardigrade")
+    assert SampleScene.from_config({"cell_type": "bacteria"}).cell_type == "bacteria"
+
+
+def test_mammalian_cells_are_spread_out_with_the_nucleus_inside_the_body():
+    scene = SampleScene(cell_type="mammalian", contamination_density=0.0)
+    cells = [f for f in scene.features if f.kind == "cell"]
+    bodies = {f.cell_id: f for f in cells if f.part == "body"}
+    nuclei = {f.cell_id: f for f in cells if f.part == "nucleus"}
+    assert set(bodies) == set(nuclei)
+    for cell_id, body in bodies.items():
+        nucleus = nuclei[cell_id]
+        assert np.hypot(nucleus.x - body.x, nucleus.y - body.y) < 0.8 * body.sigma
+        assert nucleus.sigma < 0.5 * body.sigma
+    centres = np.array([(b.x, b.y) for b in bodies.values()])
+    for i, c in enumerate(centres):
+        others = np.delete(centres, i, axis=0)
+        assert np.hypot(*(others - c).T).min() > 1.5 * scene.mammalian_radius[1]
+
+
+def test_the_fm_dyes_the_nucleus_and_the_cytoplasm_differently(microscope):
+    """In the FM the DNA dye (365 excitation) lights the nucleus only; the
+    cytoplasmic dye (450) lights the whole body - so the DAPI image is a
+    subset of the GFP image, brightest where GFP is bright too."""
+    from fibsem.microscopes.sim_scene import fm_channel_weights
+    from fibsem.projection import FMStageProjection
+
+    scene = _scene(
+        microscope,
+        coincidence_offset=0.0,
+        cell_type="mammalian",
+        contamination_density=0.0,
+        grid_intensity=0.0,
+    )
+    res = (512, 512)
+    projection = FMStageProjection(
+        geometry=microscope.hardware_geometry(),
+        pixel_size=150e-6 / res[0],
+        shape=(res[1], res[0]),
+    )
+    pose = microscope.get_stage_position()
+    gfp = scene.render_fm(
+        pose, res, projection, weights=fm_channel_weights("Fluorescence", 450)
+    ).astype(np.float32)
+    dapi = scene.render_fm(
+        pose, res, projection, weights=fm_channel_weights("Fluorescence", 365)
+    ).astype(np.float32)
+
+    dapi_smooth = ndi.gaussian_filter(dapi, 2)
+    gfp_smooth = ndi.gaussian_filter(gfp, 2)
+    background = np.median(dapi_smooth)
+    nuclei = dapi_smooth > background + 0.3 * (dapi_smooth.max() - background)
+    assert 0 < nuclei.mean() < 0.05  # nuclei are small
+    # and they sit in cytoplasm: the GFP there is well above the bare film
+    # (large adherent cells cover most of the field, so the film is the
+    # dim tail of the GFP image, not its median)
+    film = np.percentile(gfp_smooth, 10)
+    assert gfp_smooth[nuclei].mean() > 3 * film

--- a/tests/test_tilt_coincident.py
+++ b/tests/test_tilt_coincident.py
@@ -18,7 +18,7 @@ from fibsem.alignment.coincidence import (
     check_coincidence,
     tilt_coincident,
 )
-from fibsem.microscopes.sim_scene import CoincidenceScene
+from fibsem.microscopes.sim_scene import SampleScene
 
 # The geometry under test is a pre-tilted TFS shuttle; pin it rather than
 # inherit whatever configuration an earlier test left as the default
@@ -37,14 +37,14 @@ def microscope():
         manufacturer="Demo", config_path=TFS_SHUTTLE_CONFIG
     )
     microscope.system.sim["coincidence_projection"] = True
-    microscope._setup_coincidence_projection()
+    microscope._setup_sample_scene()
     yield microscope
     microscope.disconnect()
 
 
 def _anchor_scene(microscope, tilt_axis_offset: float) -> None:
     """A noise-free scene, coincident at the current (SEM) pose."""
-    scene = CoincidenceScene(
+    scene = SampleScene(
         coincidence_offset=0.0,
         tilt_axis_offset=tilt_axis_offset,
         noise_sigma=0.0,
@@ -53,7 +53,7 @@ def _anchor_scene(microscope, tilt_axis_offset: float) -> None:
     pose = microscope.get_stage_position()
     assert pose.t == pytest.approx(SEM_TILT)
     scene.anchor(pose)
-    microscope._coincidence_scene = scene
+    microscope._sample_scene = scene
 
 
 def _tilt_to(microscope, tilt: float) -> None:
@@ -152,7 +152,7 @@ def _anchor_in_sem_view(microscope) -> tuple:
     from fibsem.structures import BeamType
 
     projection = BeamStageProjection.from_microscope(microscope, BeamType.ELECTRON)
-    scene = microscope._coincidence_scene
+    scene = microscope._sample_scene
     pose = microscope.get_stage_position()
     reference = scene._non_eucentric_reference(pose, projection)
     return projection.to_plane(reference, pose)

--- a/tests/test_vertical_move.py
+++ b/tests/test_vertical_move.py
@@ -43,7 +43,7 @@ def microscope():
 
     microscope._sample_scene = SampleScene(
         coincidence_offset=0.0,
-        n_clusters=0,
+        cell_type="none",
         grid_intensity=0.0,
         noise_sigma=0.0,
         noise_fraction=0.0,
@@ -108,7 +108,7 @@ def test_vertical_move_closes_the_measured_coincidence_error(microscope):
     pose = microscope.get_stage_position()
     pose.t = np.deg2rad(12.0)
     microscope.move_stage_absolute(pose)
-    microscope._sample_scene.n_clusters = 35
+    microscope._sample_scene.cell_type = "mammalian"  # cells back on the film
     microscope._sample_scene.grid_intensity = 90.0
     microscope._sample_scene.features = []
     microscope._sample_scene.__post_init__()

--- a/tests/test_vertical_move.py
+++ b/tests/test_vertical_move.py
@@ -38,10 +38,10 @@ def microscope():
     )
     microscope.system.sim["coincidence_projection"] = True
     microscope.system.sim["coincidence_offset"] = 0.0
-    microscope._setup_coincidence_projection()
-    from fibsem.microscopes.sim_scene import CoincidenceScene
+    microscope._setup_sample_scene()
+    from fibsem.microscopes.sim_scene import SampleScene
 
-    microscope._coincidence_scene = CoincidenceScene(
+    microscope._sample_scene = SampleScene(
         coincidence_offset=0.0,
         n_clusters=0,
         grid_intensity=0.0,
@@ -103,15 +103,15 @@ def test_vertical_move_delivers_the_requested_fib_shift(microscope, tilt_deg):
 def test_vertical_move_closes_the_measured_coincidence_error(microscope):
     """The mini align loop: measure the height error, correct it with one
     vertical move, re-measure - the residual must be near zero."""
-    microscope._coincidence_scene.coincidence_offset = 8e-6
-    microscope._coincidence_scene.reference_position = None  # re-anchor with offset
+    microscope._sample_scene.coincidence_offset = 8e-6
+    microscope._sample_scene.reference_position = None  # re-anchor with offset
     pose = microscope.get_stage_position()
     pose.t = np.deg2rad(12.0)
     microscope.move_stage_absolute(pose)
-    microscope._coincidence_scene.n_clusters = 35
-    microscope._coincidence_scene.grid_intensity = 90.0
-    microscope._coincidence_scene.features = []
-    microscope._coincidence_scene.__post_init__()
+    microscope._sample_scene.n_clusters = 35
+    microscope._sample_scene.grid_intensity = 90.0
+    microscope._sample_scene.features = []
+    microscope._sample_scene.__post_init__()
 
     def measure():
         settings = ImageSettings(


### PR DESCRIPTION
## Summary

**The scene is a sample, not a coincidence gadget.** `CoincidenceScene` → `SampleScene`, configured by a `sim: sample:` block (`enabled`, `coincidence_offset`, `tilt_axis_offset`, `grid_pitch`, `grid_bar_width`, `n_clusters`, `cells_per_cluster`, `cell_size`, `cluster_spread`, `extent`, `noise_sigma`, `noise_fraction`, `grid_rotation`) via `SampleScene.from_config` — unknown keys rejected, angles in degrees. The older flat keys (`coincidence_projection`, `coincidence_offset`, `tilt_axis_offset`) still work. Documented as a commented example in the arctis and iFLM configurations.

**The simulated FM images the same scene.** `SceneCamera` renders it through `FMStageProjection`, so a feature the SEM shows sits where the FM projection says it does (the camera's mount/user transforms are pre-inverted so displayed frames match). Channels are dye responses to the excitation line **and** the collected emission band: a DAPI-like dye on the fiducial (365→460), a GFP-like one on every cell (~470→510), an mCherry-like one on a seeded subset (560→610); reflection (emission `None`) shows the grid bars. The simulator's own `"Fluorescence"` band is non-numeric and counts as open, so its excitation lines pick the dye: 365 fiducial, 450 cells, 550 subset, 635 nothing. A mismatched pair bleeds weakly rather than switching off. The objective's distance from its focus position blurs the frame.

**Coincidence at the FIB orientation is measured rather than refused.** The projections carry the half-turn and the loop converges exactly there on the simulator (both references, y_stretch 0.62). Hardware is still unverified, so the guard is now a logged warning.

**Scene realism (second commit).** Contamination (`contamination_density`, per 100×100 µm): world-anchored specks over film and bars — the aperiodic content that breaks a mesh-pitch alias. Beam shift honoured in the render, plus a per-beam `beam_offset` (a fixed misalignment: the only way the sim can produce a real lateral dx); sign settled by the alignment code itself. `current_offset_scale` (opt-in): a seeded, process-deterministic offset per (beam, current), so switching current moves the view and switching back restores it — the milling-current alignment has something real to undo. Scan rotation turns the content by the full angle (the app's projection models only the half-turn; the sim now shows that honestly).

**Cell types (fourth commit)** — `cell_type: mammalian` (default; adherent fried-egg cells: flat wobbled body, off-centre nuclear mound, organelle speckle, spread over the film) | `yeast` (the previous clustered ovoids, plus budding) | `bacteria` (dense rods) | `mixed` | `none`. Parts (body/nucleus/organelle/bud) are dyed separately in the FM.

**Rival-peak gate (third commit)** — the mammalian default found two false locks the other gates missed. A second candidate outside the chosen peak's lobe that correlates nearly as well now refuses the fine measurement (`rival-peak`, > 0.96; calibrated on the sim: false locks 0.98–1.00, correct fine locks 0.53–0.85). The coarse pass is exempt (a correct coarse lock can read 0.99; its wrong locks were all caught by the band/lateral gates and the fine pass re-verifies). Recorded and replayed.

## Testing

- `tests/fm/test_sample_scene_fm.py` (4): dye responses per excitation/emission pair incl. the simulator's own lines; channels differ; the fiducial lands within 3 px of the FM projection before and after a stage move; defocus blurs.
- `tests/test_align_loop.py`: converges at the FIB orientation for both references.
- `tests/test_sim_scene_realism.py` (6): contamination adds speck-scale blobs; beam-shift alignment round trip; 1.3 µm offset measured and tolerated, 8 µm refused; current offsets reproducible and correctable; a quarter-turn scan rotation moves a feature from x to y.
- Full run of every touched suite: 391 passed (first commit), 55 + 6 (second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)