### PR TITLE
[workflow] The task queue is over items, and can run item-outer

### DIFF
--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -119,7 +119,7 @@ class AgentContext:
             )
             if active is not None:
                 payload["workflow"]["current_task"] = active.task_name
-                payload["workflow"]["current_item"] = active.lamella_name
+                payload["workflow"]["current_item"] = active.item_name
         return payload
 
     def queue(self) -> Dict[str, Any]:
@@ -134,7 +134,7 @@ class AgentContext:
             "items": [
                 {
                     "id": item.id,
-                    "item_name": item.lamella_name,
+                    "item_name": item.item_name,
                     "task_name": item.task_name,
                     "status": item.status.name,
                 }

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -2703,7 +2703,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         lamella_names = [lam.name for lam in lamellae]
         task_names = [t.name for t in tasks]
 
-        pending = {(i.lamella_name, i.task_name) for i in manager.queue.pending}
+        pending = {(i.item_name, i.task_name) for i in manager.queue.pending}
         already = [
             f"{t} for {ln}"
             for t in task_names
@@ -2768,7 +2768,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         items = info.get("queue_items", [])
         # An added item can be a (lamella, task) pair the launch matrix never held, so
         # the estimates are recomputed here rather than only at the start.
-        self._push_timeline_estimates([(i.lamella_name, i.task_name) for i in items])
+        self._push_timeline_estimates([(i.item_name, i.task_name) for i in items])
         self.workflow_timeline.refresh_queue(items)
 
     def _estimate_addition(self, manager, pairs: list, run_next: bool):
@@ -2785,7 +2785,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         lamella_by_name = {lam.name: lam for lam in experiment.positions}
 
         def seconds_for(item):
-            lamella = lamella_by_name.get(item.lamella_name)
+            lamella = lamella_by_name.get(item.item_name)
             if lamella is None:
                 return None
             config = lamella.task_config.get(item.task_name)
@@ -2800,7 +2800,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
                 logging.warning(
                     "Could not estimate duration for %s on %s.",
                     item.task_name,
-                    item.lamella_name,
+                    item.item_name,
                     exc_info=True,
                 )
                 return None
@@ -2820,7 +2820,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         active_elapsed = None
         active = manager.queue.active
         if active is not None:
-            lamella = lamella_by_name.get(active.lamella_name)
+            lamella = lamella_by_name.get(active.item_name)
             if lamella is not None and lamella.task_state.start_timestamp:
                 active_elapsed = max(
                     0.0, time.time() - lamella.task_state.start_timestamp
@@ -2904,7 +2904,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if item is None:
             self._show_queue_message("That task is no longer in the queue.")
             return
-        label = f"{item.task_name} for {item.lamella_name}"
+        label = f"{item.task_name} for {item.item_name}"
 
         if action == "stop_task":
             # Confirmed, unlike Remove: that edits a list, this interrupts an
@@ -2937,7 +2937,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if action == "run_again":
             # A fresh item rather than a rewind: the original attempt still
             # happened and stays in the run record.
-            added = queue.add(item.lamella_name, item.task_name, front=True)
+            added = queue.add(item.item_name, item.task_name, front=True)
             message = (
                 f"Queued {label} to run next."
                 if added is not None

--- a/fibsem/applications/autolamella/ui/tests/test_workflow_timeline_animation.py
+++ b/fibsem/applications/autolamella/ui/tests/test_workflow_timeline_animation.py
@@ -29,7 +29,7 @@ from fibsem.ui import stylesheets
 
 # ── Fake workflow data ────────────────────────────────────────────────────────
 LAMELLA_NAMES = ["Lamella-01", "Lamella-02"]
-TASK_NAMES    = ["Trench Milling", "Rough Milling", "Polishing"]
+TASK_NAMES = ["Trench Milling", "Rough Milling", "Polishing"]
 
 # Inner steps per task type
 TASK_STEPS: Dict[str, List[str]] = {
@@ -55,7 +55,7 @@ TASK_STEPS: Dict[str, List[str]] = {
     ],
 }
 
-_FAIL_CHANCE = 0.15   # probability any inner step fails
+_FAIL_CHANCE = 0.15  # probability any inner step fails
 
 
 class AnimatedDemo(QWidget):
@@ -71,9 +71,9 @@ class AnimatedDemo(QWidget):
             for tn in TASK_NAMES
             for ln in LAMELLA_NAMES
         ]
-        self._outer_idx   = -1   # which outer item is active
+        self._outer_idx = -1  # which outer item is active
         self._inner_steps: List[str] = []
-        self._inner_idx   = -1   # which inner step is active
+        self._inner_idx = -1  # which inner step is active
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -115,7 +115,7 @@ class AnimatedDemo(QWidget):
         self._btn_restart.clicked.connect(self._restart)
         self._btn_stop.clicked.connect(self._stop)
 
-        self._timer.start(400)   # short initial delay
+        self._timer.start(400)  # short initial delay
 
     # ── Timer tick ────────────────────────────────────────────────────────
     def _tick(self):
@@ -138,7 +138,7 @@ class AnimatedDemo(QWidget):
 
         item = self._outer_items[self._outer_idx]
         self._inner_steps = TASK_STEPS[item.task_name]
-        self._inner_idx   = -1
+        self._inner_idx = -1
 
         # Drive the outer timeline directly
         for i in range(len(self._outer_items)):
@@ -192,7 +192,6 @@ class AnimatedDemo(QWidget):
         else:
             self._timer.start(random.randint(1_000, 2_000))
 
-
     def _restart(self):
         self._timer.stop()
         self._outer_items = [
@@ -200,9 +199,9 @@ class AnimatedDemo(QWidget):
             for tn in TASK_NAMES
             for ln in LAMELLA_NAMES
         ]
-        self._outer_idx  = -1
+        self._outer_idx = -1
         self._inner_steps = []
-        self._inner_idx  = -1
+        self._inner_idx = -1
         self._progress.set_workflow(self._outer_items)
         self._status_label.setText("Restarted.")
         self._timer.start(400)
@@ -210,7 +209,7 @@ class AnimatedDemo(QWidget):
     def _stop(self):
         self._timer.stop()
         self._inner_steps = []
-        self._inner_idx   = -1
+        self._inner_idx = -1
         self._status_label.setText("Stopped.")
 
 

--- a/fibsem/applications/autolamella/ui/tests/test_workflow_timeline_animation.py
+++ b/fibsem/applications/autolamella/ui/tests/test_workflow_timeline_animation.py
@@ -67,7 +67,7 @@ class AnimatedDemo(QWidget):
 
         # Build flat list of (lamella, task) pairs matching run_tasks loop order
         self._outer_items: List[WorkItem] = [
-            WorkItem(lamella_name=ln, task_name=tn)
+            WorkItem(item_name=ln, task_name=tn)
             for tn in TASK_NAMES
             for ln in LAMELLA_NAMES
         ]
@@ -196,7 +196,7 @@ class AnimatedDemo(QWidget):
     def _restart(self):
         self._timer.stop()
         self._outer_items = [
-            WorkItem(lamella_name=ln, task_name=tn)
+            WorkItem(item_name=ln, task_name=tn)
             for tn in TASK_NAMES
             for ln in LAMELLA_NAMES
         ]

--- a/fibsem/applications/autolamella/ui/workflow_timeline_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_timeline_widget.py
@@ -949,7 +949,7 @@ class WorkflowProgressWidget(QWidget):
             item_name = report.item_name
             reason_str = _SKIP_REASON_LABELS.get(skip_reason, skip_reason or "Skipped")
             for i, item in enumerate(self._items):
-                if item.lamella_name == item_name and item.task_name == task_name:
+                if item.item_name == item_name and item.task_name == task_name:
                     self._outer._steps[i].subtitle = reason_str
                     self._outer._rows[i].refresh(self._outer._steps[i])
                     break
@@ -971,7 +971,7 @@ class WorkflowProgressWidget(QWidget):
             [i.id for i in self._items],
             [
                 TimelineStep(
-                    label=i.lamella_name,
+                    label=i.item_name,
                     subtitle=i.task_name,
                     status=_queue_status_to_step_status(i.status),
                 )
@@ -1146,7 +1146,7 @@ class WorkflowProgressWidget(QWidget):
         """This item's estimate, or None if there is none to offer."""
         if item is None:
             return None
-        return self._estimates.get((item.lamella_name, item.task_name))
+        return self._estimates.get((item.item_name, item.task_name))
 
     def _machine_elapsed(self, elapsed: float) -> float:
         """`elapsed` less any time the task spent waiting for a human.

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -120,16 +120,16 @@ class TaskManager:
             # that has just finished, not at this one.
             self._task_stop_event.clear()
 
-            lamella = self.experiment.get_lamella_by_name(item.lamella_name)
+            lamella = self.experiment.get_lamella_by_name(item.item_name)
             if lamella is None:
                 # No lamella to build a status dict from, so this used to leave no trace
                 # anywhere — not in the log, the UI, or a hook.
                 logging.warning(
-                    f"Skipping {item.task_name}: no lamella named {item.lamella_name} in the experiment."
+                    f"Skipping {item.task_name}: no lamella named {item.item_name} in the experiment."
                 )
                 self.queue.mark_done(item, AutoLamellaTaskStatus.Skipped)
                 self._fire_skipped_hook(
-                    item.task_name, item.lamella_name, "lamella_not_found"
+                    item.task_name, item.item_name, "lamella_not_found"
                 )
                 continue
 
@@ -227,7 +227,7 @@ class TaskManager:
         """
         rows: List[dict] = []
         for item in self.queue.items:
-            lamella = self.experiment.get_lamella_by_name(item.lamella_name)
+            lamella = self.experiment.get_lamella_by_name(item.item_name)
             completed_at = ""
             duration = None
             if lamella is not None:
@@ -239,7 +239,7 @@ class TaskManager:
                         break
             rows.append(
                 {
-                    "lamella_name": item.lamella_name,
+                    "lamella_name": item.item_name,
                     "task_name": item.task_name,
                     "task_status": item.status.name,
                     "completed_at": completed_at,
@@ -596,7 +596,7 @@ class TaskManager:
             # The plan this run was launched with. Informational only — the live
             # queue may since have diverged from it.
             task_names=self.queue.task_names,
-            lamella_names=self.queue.lamella_names,
+            lamella_names=self.queue.item_names,
         )
 
         self.parent_ui.workflow_status_signal.emit(

--- a/fibsem/applications/autolamella/workflows/tasks/queue.py
+++ b/fibsem/applications/autolamella/workflows/tasks/queue.py
@@ -34,6 +34,7 @@ class WorkItem:
     grid on the grid workflow. ``item_name`` is the vocabulary the hooks, the
     status payload and the timeline already speak.
     """
+
     item_name: str
     task_name: str
     status: AutoLamellaTaskStatus = AutoLamellaTaskStatus.NotStarted
@@ -52,11 +53,12 @@ class WorkItem:
 
 class QueueOp(Enum):
     """Outcome of a queue mutation."""
+
     OK = auto()
-    NOT_FOUND = auto()    # no item with that id
+    NOT_FOUND = auto()  # no item with that id
     NOT_PENDING = auto()  # item is active, already run, or removed
-    BAD_ANCHOR = auto()   # the target item is missing or not pending
-    NO_OP = auto()        # already in the requested position
+    BAD_ANCHOR = auto()  # the target item is missing or not pending
+    NO_OP = auto()  # already in the requested position
 
 
 @dataclass(frozen=True)
@@ -66,6 +68,7 @@ class QueueResult:
     The distinct :class:`QueueOp` values exist so the UI can explain a refusal
     ("already running") instead of failing silently.
     """
+
     op: QueueOp
     version: int
 
@@ -93,9 +96,9 @@ class TaskQueue:
 
     # --- Build ---
 
-    def build_from_matrix(self, task_names: List[str],
-                          item_names: List[str],
-                          item_outer: bool = False) -> List[WorkItem]:
+    def build_from_matrix(
+        self, task_names: List[str], item_names: List[str], item_outer: bool = False
+    ) -> List[WorkItem]:
         """Populate queue from a task x item matrix.
 
         Task-outer by default (every item's Trench, then every item's Undercut),
@@ -181,9 +184,15 @@ class TaskQueue:
 
     # --- Mutation (all thread-safe) ---
 
-    def add(self, item_name: str, task_name: str, *,
-            before: Optional[str] = None, after: Optional[str] = None,
-            front: bool = False) -> Optional[WorkItem]:
+    def add(
+        self,
+        item_name: str,
+        task_name: str,
+        *,
+        before: Optional[str] = None,
+        after: Optional[str] = None,
+        front: bool = False,
+    ) -> Optional[WorkItem]:
         """Add a work item, anchored to an existing item or to the queue ends.
 
         Position is one of: ``before``/``after`` an existing *pending* item,

--- a/fibsem/applications/autolamella/workflows/tasks/queue.py
+++ b/fibsem/applications/autolamella/workflows/tasks/queue.py
@@ -28,11 +28,21 @@ from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
 
 @dataclass
 class WorkItem:
-    """A single (lamella, task) work unit."""
-    lamella_name: str
+    """A single (item, task) work unit.
+
+    The item is whatever the run is over: a lamella on the lamella workflow, a
+    grid on the grid workflow. ``item_name`` is the vocabulary the hooks, the
+    status payload and the timeline already speak.
+    """
+    item_name: str
     task_name: str
     status: AutoLamellaTaskStatus = AutoLamellaTaskStatus.NotStarted
     id: str = field(default_factory=lambda: str(uuid4()))
+
+    @property
+    def lamella_name(self) -> str:
+        """Deprecated alias for :attr:`item_name`; drop with the v0.6 shims."""
+        return self.item_name
 
     @property
     def is_pending(self) -> bool:
@@ -79,21 +89,35 @@ class TaskQueue:
         self._version = 0
         # Original matrix dimensions for status dict compat
         self._task_names: List[str] = []
-        self._lamella_names: List[str] = []
+        self._item_names: List[str] = []
 
     # --- Build ---
 
     def build_from_matrix(self, task_names: List[str],
-                          lamella_names: List[str]) -> List[WorkItem]:
-        """Populate queue from task x lamella matrix (task-outer, lamella-inner)."""
+                          item_names: List[str],
+                          item_outer: bool = False) -> List[WorkItem]:
+        """Populate queue from a task x item matrix.
+
+        Task-outer by default (every item's Trench, then every item's Undercut),
+        which is the lamella workflow's order. ``item_outer`` runs every task on
+        one item before moving to the next -- the grid workflow's order, where
+        an item costs a grid exchange to reach and is exchanged once.
+        """
         with self._lock:
             self._task_names = list(task_names)
-            self._lamella_names = list(lamella_names)
-            self._items = [
-                WorkItem(lamella_name=ln, task_name=tn)
-                for tn in task_names
-                for ln in lamella_names
-            ]
+            self._item_names = list(item_names)
+            if item_outer:
+                self._items = [
+                    WorkItem(item_name=name, task_name=tn)
+                    for name in item_names
+                    for tn in task_names
+                ]
+            else:
+                self._items = [
+                    WorkItem(item_name=name, task_name=tn)
+                    for tn in task_names
+                    for name in item_names
+                ]
             self._active = None
             self._version += 1
             return [copy.copy(i) for i in self._items]
@@ -157,7 +181,7 @@ class TaskQueue:
 
     # --- Mutation (all thread-safe) ---
 
-    def add(self, lamella_name: str, task_name: str, *,
+    def add(self, item_name: str, task_name: str, *,
             before: Optional[str] = None, after: Optional[str] = None,
             front: bool = False) -> Optional[WorkItem]:
         """Add a work item, anchored to an existing item or to the queue ends.
@@ -169,14 +193,14 @@ class TaskQueue:
         or no longer pending. Adding a duplicate of an already-completed pair is
         allowed: that is how a task is re-run.
         """
-        item = WorkItem(lamella_name=lamella_name, task_name=task_name)
+        item = WorkItem(item_name=item_name, task_name=task_name)
         with self._lock:
             if before is not None or after is not None:
                 anchor_id = before if before is not None else after
                 anchor = self._find(anchor_id)  # type: ignore[arg-type]
                 if anchor is None or not anchor.is_pending:
                     logging.warning(
-                        f"Cannot add {task_name} for {lamella_name}: anchor "
+                        f"Cannot add {task_name} for {item_name}: anchor "
                         f"{anchor_id} is missing or no longer pending."
                     )
                     return None
@@ -342,6 +366,11 @@ class TaskQueue:
         return list(self._task_names)
 
     @property
+    def item_names(self) -> List[str]:
+        """Original item names list (for status dict compat)."""
+        return list(self._item_names)
+
+    @property
     def lamella_names(self) -> List[str]:
-        """Original lamella names list (for status dict compat)."""
-        return list(self._lamella_names)
+        """Deprecated alias for :attr:`item_names`; drop with the v0.6 shims."""
+        return self.item_names

--- a/fibsem/applications/autolamella/workflows/workflow_estimate.py
+++ b/fibsem/applications/autolamella/workflows/workflow_estimate.py
@@ -378,7 +378,7 @@ def estimate_addition(
     from fibsem.applications.autolamella.workflows.tasks.queue import WorkItem
 
     clock = now if now is not None else datetime.now()
-    added = [WorkItem(lamella_name=ln, task_name=tn) for ln, tn in pairs]
+    added = [WorkItem(item_name=ln, task_name=tn) for ln, tn in pairs]
     proposed = _with_addition(items, added, run_next)
 
     before = estimate_queue(items, seconds_for, schedule, clock, active_elapsed)

--- a/fibsem/applications/autolamella/workflows/workflow_estimate.py
+++ b/fibsem/applications/autolamella/workflows/workflow_estimate.py
@@ -120,9 +120,7 @@ def estimate_workflow(
     started_at = clock
 
     workflow_config = experiment.task_protocol.workflow_config
-    lamellae = [
-        lam for lam in experiment.positions if lam.name in set(lamella_names)
-    ]
+    lamellae = [lam for lam in experiment.positions if lam.name in set(lamella_names)]
 
     rows: List[TaskEstimate] = []
     work_seconds = 0.0
@@ -389,7 +387,9 @@ def estimate_addition(
         work_seconds=after.work_seconds - before.work_seconds,
         # Never negative: adding work cannot bring a finish forward, and floating-point
         # dust on two large sums should not render as "-0s".
-        delay_seconds=max(0.0, (after.expected_finish - before.expected_finish).total_seconds()),
+        delay_seconds=max(
+            0.0, (after.expected_finish - before.expected_finish).total_seconds()
+        ),
         finish_before=before.expected_finish,
         finish_after=after.expected_finish,
         hold_seconds=after.hold_seconds,

--- a/tests/autolamella/test_workflow_estimate.py
+++ b/tests/autolamella/test_workflow_estimate.py
@@ -28,12 +28,18 @@ from fibsem.applications.autolamella.workflows.workflow_estimate import (
 NOW = datetime(2026, 8, 18, 14, 0, 0)
 
 
-def _experiment(tmp_path, n_lamella: int = 2, scheduled=None, supervised=()) -> Experiment:
+def _experiment(
+    tmp_path, n_lamella: int = 2, scheduled=None, supervised=()
+) -> Experiment:
     """Two tasks over n lamella, with the protocol wired to match."""
     exp = Experiment(path=str(tmp_path), name="estimate-test")
     for i in range(n_lamella):
-        lamella = Lamella(path=str(tmp_path), number=i + 1, petname=f"{i + 1:02d}-lamella")
-        lamella.task_config["Setup Lamella Position"] = SelectMillingPositionTaskConfig()
+        lamella = Lamella(
+            path=str(tmp_path), number=i + 1, petname=f"{i + 1:02d}-lamella"
+        )
+        lamella.task_config["Setup Lamella Position"] = (
+            SelectMillingPositionTaskConfig()
+        )
         lamella.task_config["Mill Fiducial"] = MillFiducialTaskConfig()
         exp.add_lamella(lamella)
 
@@ -59,9 +65,12 @@ def _names(exp) -> list:
 
 # ── the breakdown ────────────────────────────────────────────────────────────
 
+
 def test_a_row_per_task_in_the_order_given(tmp_path):
     exp = _experiment(tmp_path)
-    est = estimate_workflow(exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW)
+    est = estimate_workflow(
+        exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW
+    )
     assert [t.name for t in est.tasks] == ["Mill Fiducial", "Setup Lamella Position"]
 
 
@@ -77,7 +86,9 @@ def test_a_row_totals_every_lamella_it_runs_on(tmp_path):
 def test_step_count_matches_the_queue(tmp_path):
     """One item per (task, lamella), the same shape build_from_matrix produces."""
     exp = _experiment(tmp_path, n_lamella=3)
-    est = estimate_workflow(exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW)
+    est = estimate_workflow(
+        exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW
+    )
     assert est.step_count == 6
 
 
@@ -97,9 +108,12 @@ def test_only_the_named_lamella_are_included(tmp_path):
 
 # ── the totals ───────────────────────────────────────────────────────────────
 
+
 def test_work_seconds_is_the_sum_of_the_rows(tmp_path):
     exp = _experiment(tmp_path)
-    est = estimate_workflow(exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW)
+    est = estimate_workflow(
+        exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW
+    )
     assert est.work_seconds == pytest.approx(sum(t.seconds for t in est.tasks))
 
 
@@ -116,14 +130,20 @@ def test_supervised_work_still_counts_towards_the_total(tmp_path):
     plain = _experiment(tmp_path)
     supervised = _experiment(tmp_path, supervised=("Mill Fiducial",))
     tasks = ["Mill Fiducial"]
-    assert estimate_workflow(supervised, tasks, _names(supervised), now=NOW).work_seconds == (
-        pytest.approx(estimate_workflow(plain, tasks, _names(plain), now=NOW).work_seconds)
+    assert estimate_workflow(
+        supervised, tasks, _names(supervised), now=NOW
+    ).work_seconds == (
+        pytest.approx(
+            estimate_workflow(plain, tasks, _names(plain), now=NOW).work_seconds
+        )
     )
 
 
 def test_supervised_rows_are_flagged_and_countable(tmp_path):
     exp = _experiment(tmp_path, supervised=("Mill Fiducial",))
-    est = estimate_workflow(exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW)
+    est = estimate_workflow(
+        exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW
+    )
     assert [t.name for t in est.supervised_tasks] == ["Mill Fiducial"]
     assert est.waits_for_a_human is True
 
@@ -136,6 +156,7 @@ def test_a_workflow_with_no_supervision_says_so(tmp_path):
 
 
 # ── scheduling makes it a walk, not a sum ────────────────────────────────────
+
 
 def test_a_scheduled_task_holds_the_workflow_until_its_time(tmp_path):
     """now + Σ would be wrong by the length of the wait."""
@@ -152,8 +173,14 @@ def test_the_hold_is_not_counted_as_work(tmp_path):
     at = NOW + timedelta(hours=4)
     scheduled = _experiment(tmp_path, scheduled={"Mill Fiducial": at})
     plain = _experiment(tmp_path)
-    assert estimate_workflow(scheduled, ["Mill Fiducial"], _names(scheduled), now=NOW).work_seconds == (
-        pytest.approx(estimate_workflow(plain, ["Mill Fiducial"], _names(plain), now=NOW).work_seconds)
+    assert estimate_workflow(
+        scheduled, ["Mill Fiducial"], _names(scheduled), now=NOW
+    ).work_seconds == (
+        pytest.approx(
+            estimate_workflow(
+                plain, ["Mill Fiducial"], _names(plain), now=NOW
+            ).work_seconds
+        )
     )
 
 
@@ -168,7 +195,9 @@ def test_the_hold_is_measured_from_where_the_earlier_tasks_left_the_clock(tmp_pa
     """The task ahead of it has already consumed part of the wait."""
     at = NOW + timedelta(hours=4)
     exp = _experiment(tmp_path, scheduled={"Mill Fiducial": at})
-    est = estimate_workflow(exp, ["Setup Lamella Position", "Mill Fiducial"], _names(exp), now=NOW)
+    est = estimate_workflow(
+        exp, ["Setup Lamella Position", "Mill Fiducial"], _names(exp), now=NOW
+    )
     setup_seconds = est.tasks[0].seconds
     assert est.hold_seconds == pytest.approx(4 * 3600 - setup_seconds)
 
@@ -176,7 +205,9 @@ def test_the_hold_is_measured_from_where_the_earlier_tasks_left_the_clock(tmp_pa
 def test_scheduled_rows_are_flagged(tmp_path):
     at = NOW + timedelta(hours=4)
     exp = _experiment(tmp_path, scheduled={"Mill Fiducial": at})
-    est = estimate_workflow(exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW)
+    est = estimate_workflow(
+        exp, ["Mill Fiducial", "Setup Lamella Position"], _names(exp), now=NOW
+    )
     assert [t.name for t in est.scheduled_tasks] == ["Mill Fiducial"]
     assert est.tasks[0].scheduled_at == at
 
@@ -192,6 +223,7 @@ def test_a_timezone_aware_schedule_does_not_raise(tmp_path):
 
 
 # ── nothing to do ────────────────────────────────────────────────────────────
+
 
 def test_an_empty_workflow_finishes_now(tmp_path):
     exp = _experiment(tmp_path)
@@ -218,8 +250,11 @@ from fibsem.applications.autolamella.workflows.workflow_estimate import (  # noq
 def _items(*spec) -> list:
     """(lamella, task) or (lamella, task, status) triples, in queue order."""
     return [
-        WorkItem(item_name=s[0], task_name=s[1],
-                 status=s[2] if len(s) > 2 else AutoLamellaTaskStatus.NotStarted)
+        WorkItem(
+            item_name=s[0],
+            task_name=s[1],
+            status=s[2] if len(s) > 2 else AutoLamellaTaskStatus.NotStarted,
+        )
         for s in spec
     ]
 
@@ -243,11 +278,13 @@ def test_pending_items_are_summed():
 def test_work_already_done_costs_nothing():
     """The whole point of asking again mid-workflow: the finish converges on its own,
     without anything being re-learned from how the finished rows actually went."""
-    items = _items(("01", "A", AutoLamellaTaskStatus.Completed),
-                   ("02", "A", AutoLamellaTaskStatus.Failed),
-                   ("03", "A", AutoLamellaTaskStatus.Skipped),
-                   ("04", "A", AutoLamellaTaskStatus.Cancelled),
-                   ("05", "A"))
+    items = _items(
+        ("01", "A", AutoLamellaTaskStatus.Completed),
+        ("02", "A", AutoLamellaTaskStatus.Failed),
+        ("03", "A", AutoLamellaTaskStatus.Skipped),
+        ("04", "A", AutoLamellaTaskStatus.Cancelled),
+        ("05", "A"),
+    )
     est = estimate_queue(items, _flat(60.0), now=NOW)
     assert est.remaining_seconds == pytest.approx(60.0)
 
@@ -257,10 +294,13 @@ def test_an_item_with_no_estimate_contributes_nothing():
     one would be worse than leaving it out."""
     items = _items(("01", "A"), ("02", "A"))
     seconds_for = lambda item: 60.0 if item.lamella_name == "01" else None
-    assert estimate_queue(items, seconds_for, now=NOW).remaining_seconds == pytest.approx(60.0)
+    assert estimate_queue(
+        items, seconds_for, now=NOW
+    ).remaining_seconds == pytest.approx(60.0)
 
 
 # ── the running task ──────────────────────────────────────────────────────────
+
 
 def test_the_running_task_contributes_only_what_is_left_of_it():
     items = _items(("01", "A", AutoLamellaTaskStatus.InProgress), ("02", "A"))
@@ -278,7 +318,9 @@ def test_a_task_past_its_estimate_contributes_zero_not_a_negative():
     est = estimate_queue(items, _flat(100.0), now=NOW, active_elapsed=250.0)
     assert est.active_remaining == 0.0
     assert est.active_estimate_spent is True
-    assert est.remaining_seconds == pytest.approx(100.0)  # the pending item, and no more
+    assert est.remaining_seconds == pytest.approx(
+        100.0
+    )  # the pending item, and no more
 
 
 def test_nothing_running_reports_no_active_remaining():
@@ -295,6 +337,7 @@ def test_a_running_task_with_no_elapsed_yet_is_not_guessed_at():
 
 
 # ── holds ─────────────────────────────────────────────────────────────────────
+
 
 def test_a_scheduled_task_pushes_the_finish_out():
     at = NOW + timedelta(hours=4)
@@ -334,16 +377,20 @@ def test_the_hold_is_measured_from_where_the_queue_has_got_to():
 
 def test_a_queue_scheduled_time_already_past_holds_nothing():
     items = _items(("01", "A"))
-    est = estimate_queue(items, _flat(60.0),
-                         schedule={"A": NOW - timedelta(hours=1)}, now=NOW)
+    est = estimate_queue(
+        items, _flat(60.0), schedule={"A": NOW - timedelta(hours=1)}, now=NOW
+    )
     assert est.hold_seconds == 0.0
     assert est.expected_finish == NOW + timedelta(seconds=60)
 
 
 def test_a_timezone_aware_schedule_in_the_queue_does_not_raise():
     from datetime import timezone
+
     aware = (NOW + timedelta(hours=4)).replace(tzinfo=timezone.utc)
-    est = estimate_queue(_items(("01", "A")), _flat(60.0), schedule={"A": aware}, now=NOW)
+    est = estimate_queue(
+        _items(("01", "A")), _flat(60.0), schedule={"A": aware}, now=NOW
+    )
     assert est.expected_finish is not None
 
 
@@ -365,8 +412,12 @@ def test_adding_work_to_a_plain_queue_delays_it_by_exactly_that_work():
 
 def test_the_work_added_does_not_depend_on_where_it_lands():
     items = _items(("01", "A"), ("02", "B"))
-    at_end = estimate_addition(items, [("03", "A")], _flat(60.0), run_next=False, now=NOW)
-    up_next = estimate_addition(items, [("03", "A")], _flat(60.0), run_next=True, now=NOW)
+    at_end = estimate_addition(
+        items, [("03", "A")], _flat(60.0), run_next=False, now=NOW
+    )
+    up_next = estimate_addition(
+        items, [("03", "A")], _flat(60.0), run_next=True, now=NOW
+    )
     assert at_end.work_seconds == pytest.approx(up_next.work_seconds)
 
 
@@ -376,8 +427,14 @@ def test_work_that_fits_inside_a_scheduled_hold_costs_no_delay():
     finish by nothing. Summing the addition instead of differencing would say an hour."""
     at = NOW + timedelta(hours=4)
     items = _items(("01", "Scheduled"))
-    est = estimate_addition(items, [("02", "Earlier")], _flat(3600.0),
-                            run_next=True, schedule={"Scheduled": at}, now=NOW)
+    est = estimate_addition(
+        items,
+        [("02", "Earlier")],
+        _flat(3600.0),
+        run_next=True,
+        schedule={"Scheduled": at},
+        now=NOW,
+    )
     assert est.work_seconds == pytest.approx(3600.0)
     assert est.delay_seconds == 0.0
     assert est.finish_after == est.finish_before
@@ -388,8 +445,14 @@ def test_the_same_work_after_the_hold_does_delay_it():
     is a property of the hold, not of the work, which is why this cannot be a sum."""
     at = NOW + timedelta(hours=4)
     items = _items(("01", "Scheduled"))
-    est = estimate_addition(items, [("02", "Later")], _flat(3600.0),
-                            run_next=False, schedule={"Scheduled": at}, now=NOW)
+    est = estimate_addition(
+        items,
+        [("02", "Later")],
+        _flat(3600.0),
+        run_next=False,
+        schedule={"Scheduled": at},
+        now=NOW,
+    )
     assert est.delay_seconds == pytest.approx(3600.0)
 
 
@@ -399,18 +462,24 @@ def test_run_next_lands_the_batch_ahead_of_the_pending_work_not_of_history():
     from fibsem.applications.autolamella.workflows.workflow_estimate import (
         _with_addition,
     )
-    items = _items(("01", "A", AutoLamellaTaskStatus.Completed),
-                   ("02", "A", AutoLamellaTaskStatus.InProgress),
-                   ("03", "A"))
-    order = [(i.lamella_name, i.task_name) for i in
-             _with_addition(items, _items(("09", "New")), run_next=True)]
+
+    items = _items(
+        ("01", "A", AutoLamellaTaskStatus.Completed),
+        ("02", "A", AutoLamellaTaskStatus.InProgress),
+        ("03", "A"),
+    )
+    order = [
+        (i.lamella_name, i.task_name)
+        for i in _with_addition(items, _items(("09", "New")), run_next=True)
+    ]
     assert order == [("01", "A"), ("02", "A"), ("09", "New"), ("03", "A")]
 
 
 def test_added_items_with_no_estimate_are_counted_but_not_priced():
     """The dialog needs to know the difference between "no delay" and "cannot say"."""
-    est = estimate_addition(_items(("01", "A")), [("02", "A"), ("03", "A")],
-                            lambda item: None, now=NOW)
+    est = estimate_addition(
+        _items(("01", "A")), [("02", "A"), ("03", "A")], lambda item: None, now=NOW
+    )
     assert est.total_count == 2
     assert est.priced_count == 0
     assert est.is_priced is False
@@ -419,8 +488,9 @@ def test_added_items_with_no_estimate_are_counted_but_not_priced():
 
 def test_a_partly_priced_addition_still_says_so():
     seconds_for = lambda item: 60.0 if item.lamella_name == "02" else None
-    est = estimate_addition(_items(("01", "A")), [("02", "A"), ("03", "A")],
-                            seconds_for, now=NOW)
+    est = estimate_addition(
+        _items(("01", "A")), [("02", "A"), ("03", "A")], seconds_for, now=NOW
+    )
     assert (est.priced_count, est.total_count) == (1, 2)
     assert est.is_priced is True
     assert est.work_seconds == pytest.approx(60.0)
@@ -444,8 +514,9 @@ def test_the_delay_is_exact_even_when_the_running_task_cannot_be_priced():
     to account for cancels in the subtraction. The absolute finish may be optimistic;
     the delay is not."""
     items = _items(("01", "A", AutoLamellaTaskStatus.InProgress), ("02", "A"))
-    known = estimate_addition(items, [("03", "A")], _flat(60.0), now=NOW,
-                              active_elapsed=10.0)
+    known = estimate_addition(
+        items, [("03", "A")], _flat(60.0), now=NOW, active_elapsed=10.0
+    )
     unknown = estimate_addition(items, [("03", "A")], _flat(60.0), now=NOW)
     assert known.delay_seconds == pytest.approx(unknown.delay_seconds)
     assert known.finish_after != unknown.finish_after

--- a/tests/autolamella/test_workflow_estimate.py
+++ b/tests/autolamella/test_workflow_estimate.py
@@ -218,7 +218,7 @@ from fibsem.applications.autolamella.workflows.workflow_estimate import (  # noq
 def _items(*spec) -> list:
     """(lamella, task) or (lamella, task, status) triples, in queue order."""
     return [
-        WorkItem(lamella_name=s[0], task_name=s[1],
+        WorkItem(item_name=s[0], task_name=s[1],
                  status=s[2] if len(s) > 2 else AutoLamellaTaskStatus.NotStarted)
         for s in spec
     ]

--- a/tests/autolamella/test_workflow_status_update.py
+++ b/tests/autolamella/test_workflow_status_update.py
@@ -57,7 +57,7 @@ class TestTheShape:
         tiled contract's reason is what you came looking for, this is not it.
         """
         report = WorkflowStatusUpdate(
-            queue_items=[WorkItem(lamella_name="L1", task_name="Trench")]
+            queue_items=[WorkItem(item_name="L1", task_name="Trench")]
         )
 
         assert {report, report} == {report}
@@ -66,7 +66,7 @@ class TestTheShape:
         """The hazard lives in `WorkItem`, not in this test's imagination. If this ever
         stops raising, `eq=False` has lost its reason and the comment is wrong."""
         with pytest.raises(TypeError):
-            hash(WorkItem(lamella_name="L1", task_name="Trench"))
+            hash(WorkItem(item_name="L1", task_name="Trench"))
 
     def test_a_report_cannot_be_written_to(self):
         report = WorkflowStatusUpdate()

--- a/tests/ui/test_add_to_queue_dialog.py
+++ b/tests/ui/test_add_to_queue_dialog.py
@@ -74,7 +74,7 @@ def joined(dialog) -> str:
 
 
 def queue(*spec) -> list:
-    return [WorkItem(lamella_name=ln, task_name=tn) for ln, tn in spec]
+    return [WorkItem(item_name=ln, task_name=tn) for ln, tn in spec]
 
 
 def estimate(items, seconds=600.0, run_next=False, schedule=None):

--- a/tests/ui/test_add_to_queue_dialog.py
+++ b/tests/ui/test_add_to_queue_dialog.py
@@ -11,6 +11,7 @@ without it cannot show a label painting a block onto the panel behind it.
 Run directly (no display needed):
     QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_add_to_queue_dialog.py
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -56,8 +57,9 @@ def show(app, monkeypatch):
     monkeypatch.setattr(QDialog, "exec_", fake_exec)
 
     def open_it(estimate=None, already=(), run_next=False):
-        confirm_add_to_queue_dialog(LAMELLA, TASKS, run_next, list(already),
-                                    estimate=estimate)
+        confirm_add_to_queue_dialog(
+            LAMELLA, TASKS, run_next, list(already), estimate=estimate
+        )
         return built[-1]
 
     yield open_it
@@ -78,25 +80,28 @@ def queue(*spec) -> list:
 
 
 def estimate(items, seconds=600.0, run_next=False, schedule=None):
-    return estimate_addition(items, PAIRS, lambda i: seconds, run_next=run_next,
-                             schedule=schedule, now=NOW)
+    return estimate_addition(
+        items, PAIRS, lambda i: seconds, run_next=run_next, schedule=schedule, now=NOW
+    )
 
 
 # ── the two figures ───────────────────────────────────────────────────────────
+
 
 def test_it_shows_what_the_addition_costs_and_where_it_lands(show):
     dialog = show(estimate(queue(("03-lamella", "Rough Milling"))))
     body = joined(dialog)
     assert "Adds" in body
-    assert "40m 00s" in body       # 4 added tasks x 600 s
+    assert "40m 00s" in body  # 4 added tasks x 600 s
     assert "Expected finish" in body
-    assert "was " in body          # the finish it moved from
+    assert "was " in body  # the finish it moved from
 
 
 def test_the_finish_it_quotes_is_the_one_after_the_addition(show):
     est = estimate(queue(("03-lamella", "Rough Milling")))
     dialog = show(est)
     from fibsem.ui.widgets.preflight import format_clock
+
     after = format_clock(est.finish_after, est.finish_before)
     before = format_clock(est.finish_before, est.finish_before)
     assert after in joined(dialog)
@@ -110,13 +115,19 @@ def test_the_task_count_sits_under_the_duration(show):
 
 # ── when the two figures disagree ─────────────────────────────────────────────
 
+
 def test_work_absorbed_by_a_scheduled_wait_says_why_it_costs_nothing(show):
     """An hour of work that moves the finish by nothing is the right answer and reads
     as a bug, so the reason goes on screen beside it."""
     at = NOW + timedelta(hours=6)
-    est = estimate_addition(queue(("03-lamella", "Polishing")), [("04-lamella", "Setup")],
-                            lambda i: 600.0, run_next=True,
-                            schedule={"Polishing": at}, now=NOW)
+    est = estimate_addition(
+        queue(("03-lamella", "Polishing")),
+        [("04-lamella", "Setup")],
+        lambda i: 600.0,
+        run_next=True,
+        schedule={"Polishing": at},
+        now=NOW,
+    )
     assert est.work_seconds > 0 and est.delay_seconds == 0
     assert "costs no extra time overall" in joined(show(est))
 
@@ -124,8 +135,12 @@ def test_work_absorbed_by_a_scheduled_wait_says_why_it_costs_nothing(show):
 def test_partly_absorbed_work_says_how_much_actually_lands_late(show):
     at = NOW + timedelta(hours=6)
     est = estimate_addition(
-        queue(("03-lamella", "Polishing")), PAIRS, lambda i: 600.0,
-        run_next=True, schedule={"Polishing": at}, now=NOW,
+        queue(("03-lamella", "Polishing")),
+        PAIRS,
+        lambda i: 600.0,
+        run_next=True,
+        schedule={"Polishing": at},
+        now=NOW,
     )
     assert 0 < est.delay_seconds < est.work_seconds
     assert "fits inside it" in joined(show(est))
@@ -141,17 +156,19 @@ def test_an_ordinary_addition_explains_nothing(show):
 
 # ── degrading ─────────────────────────────────────────────────────────────────
 
+
 def test_with_no_estimate_at_all_the_figures_are_dropped_not_faked(show):
     """A protocol whose configs cannot be priced still has to be able to queue work."""
     body = joined(show(None))
     assert "Adds" not in body
     assert "Expected finish" not in body
-    assert "Rough Milling, Polishing" in body      # the dialog still does its job
+    assert "Rough Milling, Polishing" in body  # the dialog still does its job
 
 
 def test_an_unpriced_estimate_is_treated_as_no_estimate(show):
-    est = estimate_addition(queue(("03-lamella", "Rough Milling")), PAIRS,
-                            lambda i: None, now=NOW)
+    est = estimate_addition(
+        queue(("03-lamella", "Rough Milling")), PAIRS, lambda i: None, now=NOW
+    )
     assert est.is_priced is False
     assert "Expected finish" not in joined(show(est))
 
@@ -159,18 +176,22 @@ def test_an_unpriced_estimate_is_treated_as_no_estimate(show):
 def test_a_partly_priced_addition_admits_how_much_it_covers(show):
     """Otherwise it reads as a complete estimate that happens to be quick."""
     seconds_for = lambda i: 600.0 if i.lamella_name == "01-lamella" else None
-    est = estimate_addition(queue(("03-lamella", "Rough Milling")), PAIRS,
-                            seconds_for, now=NOW)
+    est = estimate_addition(
+        queue(("03-lamella", "Rough Milling")), PAIRS, seconds_for, now=NOW
+    )
     assert "2 estimated" in joined(show(est))
 
 
 # ── what the dialog said before, and still must ───────────────────────────────
 
+
 def test_the_already_queued_warning_survives(show):
     """The one thing this dialog says that nothing else does: a task queued twice mills
     twice. It is stated rather than acted on, so it has to stay stated."""
-    dialog = show(estimate(queue(("03-lamella", "Rough Milling"))),
-                  already=["Polishing for 01-lamella", "Polishing for 02-lamella"])
+    dialog = show(
+        estimate(queue(("03-lamella", "Rough Milling"))),
+        already=["Polishing for 01-lamella", "Polishing for 02-lamella"],
+    )
     body = joined(dialog)
     assert "2 already queued" in body
     assert "run twice" in body
@@ -182,10 +203,13 @@ def test_the_duplicate_notice_carries_no_accent_colour(show):
     Cancel is right there; three lines of body text beat three orange ones out-shouting
     the two figures that lead the dialog."""
     from fibsem.ui.tokens import DEFECT_ORANGE_COLOR
+
     dialog = show(None, already=["Polishing for 01-lamella"])
-    warning = next(lab for lab in dialog.findChildren(QLabel)
-                   if "already queued" in lab.text())
+    warning = next(
+        lab for lab in dialog.findChildren(QLabel) if "already queued" in lab.text()
+    )
     from fibsem.ui.widgets.preflight import TEXT, TEXT_MUTED
+
     assert DEFECT_ORANGE_COLOR not in warning.text()
     assert DEFECT_ORANGE_COLOR not in warning.styleSheet()
     # Body, not the secondary shade: this is content, not a detail-block label.
@@ -208,6 +232,7 @@ def test_the_position_is_named_both_ways(show):
 
 def test_the_count_in_the_button_matches_what_will_be_queued(show):
     from PyQt5.QtWidgets import QPushButton
+
     dialog = show(None)
     labels = [b.text() for b in dialog.findChildren(QPushButton)]
     assert "Add 4 task(s)" in labels
@@ -217,6 +242,7 @@ def test_the_count_in_the_button_matches_what_will_be_queued(show):
 def test_cancel_is_the_default_button(show):
     """Adding work to a running queue is not the safe outcome of a stray Return."""
     from PyQt5.QtWidgets import QPushButton
+
     dialog = show(None)
     default = [b.text() for b in dialog.findChildren(QPushButton) if b.isDefault()]
     assert default == ["Cancel"]
@@ -227,11 +253,13 @@ def test_all_three_dialogs_quote_time_the_same_way(show):
     they cannot use different formatters and stay believable."""
     from fibsem.applications.autolamella.ui import AutoLamellaMainUI as main_ui
     from fibsem.ui.widgets import preflight
+
     assert main_ui.preflight.format_duration is preflight.format_duration
     assert main_ui.preflight.format_clock is preflight.format_clock
 
 
 # ── the note must not invent a wait ───────────────────────────────────────────
+
 
 def test_a_queue_with_nothing_scheduled_never_mentions_a_scheduled_wait(show):
     """Regression. `delay_seconds` comes back through a datetime and `work_seconds` is a
@@ -241,8 +269,9 @@ def test_a_queue_with_nothing_scheduled_never_mentions_a_scheduled_wait(show):
     """
     lamella = [f"{i:02d}-lamella" for i in range(1, 7)]
     pairs = [(ln, tn) for tn in TASKS for ln in lamella]
-    est = estimate_addition(queue(("07-lamella", "Polishing")), pairs,
-                            lambda i: 505.3, now=NOW)   # nothing scheduled anywhere
+    est = estimate_addition(
+        queue(("07-lamella", "Polishing")), pairs, lambda i: 505.3, now=NOW
+    )  # nothing scheduled anywhere
     assert est.work_seconds != est.delay_seconds, "the float gap this guards is gone"
     assert est.hold_seconds == 0.0
     assert "scheduled wait" not in joined(show(est))
@@ -252,8 +281,13 @@ def test_a_difference_too_small_to_render_is_not_explained(show):
     """Both figures go through `format_duration`, so a gap that rounds away leaves two
     identical numbers with a paragraph between them saying they differ."""
     at = NOW + timedelta(hours=6)
-    est = estimate_addition(queue(("03-lamella", "Polishing")), [("04-lamella", "Setup")],
-                            lambda i: 600.0, schedule={"Polishing": at}, now=NOW)
+    est = estimate_addition(
+        queue(("03-lamella", "Polishing")),
+        [("04-lamella", "Setup")],
+        lambda i: 600.0,
+        schedule={"Polishing": at},
+        now=NOW,
+    )
     object.__setattr__(est, "delay_seconds", est.work_seconds - 0.2)
     assert est.hold_seconds > 0
     assert "fits inside it" not in joined(show(est))
@@ -262,8 +296,14 @@ def test_a_difference_too_small_to_render_is_not_explained(show):
 def test_a_real_partial_absorption_is_still_explained(show):
     """The guards must not silence the case the note exists for."""
     at = NOW + timedelta(hours=6)
-    est = estimate_addition(queue(("03-lamella", "Polishing")), PAIRS, lambda i: 600.0,
-                            run_next=True, schedule={"Polishing": at}, now=NOW)
+    est = estimate_addition(
+        queue(("03-lamella", "Polishing")),
+        PAIRS,
+        lambda i: 600.0,
+        run_next=True,
+        schedule={"Polishing": at},
+        now=NOW,
+    )
     assert est.hold_seconds > 0
     assert 0 < est.delay_seconds < est.work_seconds
     assert "fits inside it" in joined(show(est))

--- a/tests/ui/test_mainui_workflow_status.py
+++ b/tests/ui/test_mainui_workflow_status.py
@@ -118,11 +118,11 @@ def test_a_status_event_snapshot_reaches_the_windows_own_timeline(main_ui):
 
     items = [
         WorkItem(
-            lamella_name="lamella-03",
+            item_name="lamella-03",
             task_name="Trench",
             status=AutoLamellaTaskStatus.InProgress,
         ),
-        WorkItem(lamella_name="lamella-04", task_name="Trench"),
+        WorkItem(item_name="lamella-04", task_name="Trench"),
     ]
     report = WorkflowStatusUpdate(
         task_name="Trench",


### PR DESCRIPTION
Groundwork for the grid workflow's run loop (FIB-17). Stacked on #735.

The shared `TaskQueue` was written over lamellae: `WorkItem.lamella_name`, `build_from_matrix(task_names, lamella_names)`, `queue.lamella_names`. The grid manager runs the same queue over grids, so the queue now speaks `item_name`, the vocabulary the hooks (`HookContext.item_name`), the status payload (`WorkflowStatusUpdate.item_name`) and the timeline already use.

- **`WorkItem.item_name`** replaces `lamella_name` as the field. `lamella_name` stays as a read-only alias, to drop with the other v0.6 shims, so out-of-tree readers keep working; every in-tree reader (manager, timeline, agent context, main UI) now says `item_name`.
- **`build_from_matrix(task_names, item_names, item_outer=False)`.** Task-outer is unchanged and remains the default: every lamella's Trench, then every lamella's Undercut. `item_outer=True` runs every task on one item before moving to the next. That is the grid order: a grid costs an exchange to reach, so it is exchanged once and all of its overviews are taken while it is in the beam.
- **`queue.item_names`**, with `lamella_names` as the alias.

No behaviour change for the lamella workflow: the matrix it builds is identical, and the status payload's deprecated `lamella_names` field is fed from the renamed property.

The second commit is format-on-touch for the five files the rename edited that had not yet been converted, kept separate so the rename diff reads on its own.

**Tests:** the queue, manager status, workflow estimate, add-to-queue and timeline suites pass locally (302 tests across the two Qt-owning groups).
