### PR TITLE
[autolamella] GridTaskManager: grid-outer, and a grid that will not load is skipped

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/grid/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid/manager.py
@@ -1,0 +1,417 @@
+"""The grid workflow's run loop: grid-outer, and a grid that will not load is skipped.
+
+Grid-outer and dumb. For each grid in turn: make it reachable, run the selected
+tasks on it in order, save, next grid. Reaching a grid is the one expensive step
+-- on an autoloader it is a magazine exchange -- so the queue is built item-outer
+and a grid is exchanged once for all of its tasks.
+
+Three questions with three separate answers, never collapsed into one:
+
+* *Did the grid load?* A ``load`` entry on the grid's history, Completed or Failed
+  with the hardware's message, written here per attempt.
+* *Did each task complete?* One history entry per task, written by the task's own
+  lifecycle: Completed, Failed, Cancelled, or (from here) Skipped.
+* *Is the grid any good?* ``GridRecord.quality``, set by a person, never here.
+
+A failed load records the failure, skips the grid's remaining tasks as "grid not
+loaded", and the run continues with the next grid: an overnight run must not stop
+on grid 3 of 12. A failed task fails only itself; the next task on the same grid
+still runs, since an SEM overview failing says nothing about the FM one.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+import pandas as pd
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskState,
+    AutoLamellaTaskStatus,
+    GridRecord,
+)
+from fibsem.applications.autolamella.workflows.tasks.grid.registry import (
+    run_grid_task,
+)
+from fibsem.applications.autolamella.workflows.tasks.manager import BaseTaskManager
+from fibsem.applications.autolamella.workflows.tasks.queue import WorkItem
+from fibsem.applications.autolamella.workflows.tasks.status import WorkflowStatusEvent
+from fibsem.cancellation import OperationCancelledError
+from fibsem.hooks import HookEvent, HookManager
+from fibsem.microscopes._stage import GridExchangeError
+
+if TYPE_CHECKING:
+    from fibsem.applications.autolamella.structures import Experiment
+    from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+    from fibsem.microscope import FibsemMicroscope
+
+# The load step: a queue item ahead of each grid's tasks, so the plan shows where
+# the exchanges fall and the timeline shows how each one went, and the history
+# entry the exchange leaves on the grid. Not a task in the protocol: loading is
+# the manager's job. It is in the queue so it can be *seen*, not so it can be
+# switched off -- a task whose grid is not in the beam loads it anyway, so
+# removing or reordering a load item changes what is shown, never what runs.
+LOAD_ENTRY_NAME = "load"
+LOAD_TASK_TYPE = "LOAD_GRID"
+
+# Skip reasons, in the vocabulary TASK_SKIPPED hooks and status reports carry.
+SKIP_GRID_NOT_FOUND = "grid_not_found"
+SKIP_GRID_NOT_LOADED = "grid_not_loaded"
+
+
+def plan_grid_run(
+    task_names: List[str], grid_names: List[str]
+) -> List[Tuple[str, str]]:
+    """The ``(grid, step)`` sequence a run would execute: grid-outer, each grid's
+    load first, then its tasks in order. What a run preview shows."""
+    return [
+        (grid, step) for grid in grid_names for step in [LOAD_ENTRY_NAME, *task_names]
+    ]
+
+
+class GridTaskManager(BaseTaskManager):
+    """Runs grid tasks over the experiment's grids, one grid at a time."""
+
+    def __init__(
+        self,
+        microscope: "FibsemMicroscope",
+        experiment: "Experiment",
+        parent_ui: Optional["AutoLamellaUI"] = None,
+        hook_manager: Optional[HookManager] = None,
+    ):
+        super().__init__(microscope, experiment, parent_ui, hook_manager)
+        # Grids this run could not bring into the beam, and why. One attempt per
+        # grid per run: an exchange that failed once is not retried on the next
+        # task, which would only re-run the same failure in front of a queue of
+        # grids that might load fine.
+        self._not_loaded: Dict[str, str] = {}
+
+    # --- Public API ---
+
+    def run(
+        self, task_names: List[str], grid_names: Optional[List[str]] = None
+    ) -> None:
+        """Run ``task_names``, in order, on each of ``grid_names`` (all grids if None)."""
+        if grid_names is None:
+            grid_names = [g.name for g in self.experiment.grids]
+        self.queue.build_from_pairs(
+            plan_grid_run(task_names, grid_names),
+            task_names=task_names,
+            item_names=grid_names,
+        )
+        self._run_queue()
+
+    def build_run_summary_dataframe(self) -> pd.DataFrame:
+        """One row per (grid, task) attempted in this run, skipped tasks included.
+
+        ``loaded`` is the answer to the first question: whether the grid was in
+        the beam for this row's task. Completion time and duration come from the
+        grid's history where a task ran, and are blank where it did not.
+        """
+        rows: List[dict] = []
+        for item in self.queue.items:
+            grid = self.experiment.get_grid_by_name(item.item_name)
+            completed_at = ""
+            duration = None
+            if grid is not None and item.status not in (
+                AutoLamellaTaskStatus.Skipped,
+                AutoLamellaTaskStatus.NotStarted,
+            ):
+                for task in reversed(grid.task_history):
+                    if task.name == item.task_name:
+                        completed_at = task.completed_at
+                        duration = task.duration
+                        break
+            rows.append(
+                {
+                    "grid_name": item.item_name,
+                    "task_name": item.task_name,
+                    "task_status": item.status.name,
+                    "loaded": item.item_name not in self._not_loaded,
+                    "completed_at": completed_at,
+                    "duration": duration,
+                }
+            )
+        return pd.DataFrame(rows)
+
+    # --- The run loop ---
+
+    def _run_queue(self) -> None:
+        self._fire_workflow_hook(HookEvent.WORKFLOW_STARTED)
+        while not self.is_stopped:
+            item = self.queue.next()
+            if item is None:
+                break
+
+            # A stop_task click that landed between two tasks was aimed at the one
+            # that has just finished, not at this one.
+            self._task_stop_event.clear()
+
+            grid = self.experiment.get_grid_by_name(item.item_name)
+            if grid is None:
+                msg = (
+                    f"Skipping {item.task_name}: no grid named {item.item_name} "
+                    "in the experiment."
+                )
+                logging.warning(msg)
+                self.queue.mark_done(item, AutoLamellaTaskStatus.Skipped)
+                self._emit_report(
+                    item=item,
+                    item_name=item.item_name,
+                    status=AutoLamellaTaskStatus.Skipped,
+                    msg=msg,
+                    skip_reason=SKIP_GRID_NOT_FOUND,
+                )
+                self._fire_skipped_hook(
+                    item.task_name, item.item_name, SKIP_GRID_NOT_FOUND
+                )
+                continue
+
+            if item.task_name == LOAD_ENTRY_NAME:
+                self._run_load_step(item, grid)
+                continue
+
+            if not self._ensure_loaded(grid):
+                reason = self._not_loaded[grid.name]
+                msg = f"Skipping {item.task_name} on {grid.name}: grid not loaded."
+                logging.info(f"{msg} {reason}")
+                self.queue.mark_done(item, AutoLamellaTaskStatus.Skipped)
+                self._emit_report(
+                    item=item,
+                    item_name=grid.name,
+                    status=AutoLamellaTaskStatus.Skipped,
+                    msg=msg,
+                    error_message=reason,
+                    skip_reason=SKIP_GRID_NOT_LOADED,
+                )
+                self._fire_skipped_hook(
+                    item.task_name,
+                    grid.name,
+                    SKIP_GRID_NOT_LOADED,
+                    task_type=self._task_type(item.task_name),
+                    item_id=grid.id,
+                )
+                continue
+
+            self._emit_report(
+                item=item,
+                item_name=grid.name,
+                status=AutoLamellaTaskStatus.InProgress,
+                msg=f"Starting {item.task_name} on grid {grid.name}.",
+            )
+            err = self._run_single_task(item.task_name, grid)
+            final_status = grid.task_state.status
+            self.queue.mark_done(item, final_status)
+            if err is None:
+                msg = f"Completed {item.task_name} on grid {grid.name}."
+            else:
+                msg = f"Error in {item.task_name} on grid {grid.name}."
+            self._emit_report(
+                item=item,
+                item_name=grid.name,
+                status=final_status,
+                error_message=grid.task_state.status_message,
+                task_duration=grid.task_state.duration,
+                msg=msg,
+            )
+
+        # The loop exits when the queue drains *or* on Stop; only one of those is a
+        # finished workflow.
+        if self.is_stopped:
+            self._fire_workflow_hook(HookEvent.WORKFLOW_CANCELLED)
+            self._say(workflow_info="Grid workflow cancelled.")
+        else:
+            self._fire_workflow_hook(HookEvent.WORKFLOW_COMPLETED)
+            self._say(workflow_info=self._completion_message())
+        for line in self._grid_summary_lines():
+            logging.info(line)
+
+    def _run_load_step(self, item: WorkItem, grid: GridRecord) -> None:
+        """The planned exchange. Its outcome is the queue item's status, so the
+        timeline shows a grid that would not load where it failed."""
+        self._emit_report(
+            item=item,
+            item_name=grid.name,
+            status=AutoLamellaTaskStatus.InProgress,
+            msg=f"Loading grid {grid.name}.",
+        )
+        loaded = self._ensure_loaded(grid)
+        status = (
+            AutoLamellaTaskStatus.Completed if loaded else AutoLamellaTaskStatus.Failed
+        )
+        self.queue.mark_done(item, status)
+        self._emit_report(
+            item=item,
+            item_name=grid.name,
+            status=status,
+            error_message=None if loaded else self._not_loaded[grid.name],
+            msg=(
+                f"Grid {grid.name} is in the beam."
+                if loaded
+                else f"Grid {grid.name} could not be loaded."
+            ),
+        )
+
+    def _ensure_loaded(self, grid: GridRecord) -> bool:
+        """Bring the grid into the beam, recording the attempt when it costs one.
+
+        A grid already in a holder slot is confirmed, not exchanged, and leaves no
+        entry: the second task on a grid is not a second load. An exchange, or a
+        refusal, is recorded on the grid's history as a ``load`` entry with how
+        long it took or why it did not happen. A failure is remembered for the
+        rest of the run so the grid's other tasks skip without retrying it.
+        """
+        if grid.name in self._not_loaded:
+            return False
+        stage = self.microscope._stage
+        in_beam = stage.holder.find_slot_by_grid_name(grid.name) is not None
+        entry = AutoLamellaTaskState(
+            name=LOAD_ENTRY_NAME,
+            task_type=LOAD_TASK_TYPE,
+            status=AutoLamellaTaskStatus.InProgress,
+        )
+        if not in_beam:
+            logging.info(f"Loading grid {grid.name}.")
+            self._say(status_bar=f"Loading grid {grid.name}...")
+        try:
+            slot = stage.ensure_loaded(grid.name)
+        except GridExchangeError as e:
+            self._not_loaded[grid.name] = str(e)
+            entry.status = AutoLamellaTaskStatus.Failed
+            entry.status_message = str(e)
+            entry.end_timestamp = datetime.timestamp(datetime.now())
+            grid.task_history.append(entry)
+            self.experiment.save()
+            logging.warning(
+                f"Grid {grid.name} could not be loaded: {e} "
+                "Its remaining tasks in this run are skipped."
+            )
+            return False
+        if not in_beam:
+            entry.status = AutoLamellaTaskStatus.Completed
+            entry.status_message = f"Loaded into {slot.name}."
+            entry.end_timestamp = datetime.timestamp(datetime.now())
+            grid.task_history.append(entry)
+            self.experiment.save()
+            logging.info(
+                f"Grid {grid.name} loaded into {slot.name} in {entry.duration:.1f} s."
+            )
+        return True
+
+    def _run_single_task(self, task_name: str, grid: GridRecord) -> Optional[Exception]:
+        """Execute one task on one grid. Returns the exception, or None."""
+        try:
+            run_grid_task(
+                self.microscope,
+                task_name,
+                self.experiment,
+                grid,
+                parent_ui=self.parent_ui,
+                task_manager=self,
+            )
+            self.experiment.save()
+            return None
+        except Exception as e:
+            # The task records its own outcome before re-raising; this is the
+            # fallback for what fails before a task exists -- an unknown task name,
+            # a construction failure. Same cancellation predicate as GridTask, so
+            # the live state and the frozen history entry cannot disagree.
+            if self.should_abort or isinstance(
+                e, (OperationCancelledError, InterruptedError)
+            ):
+                logging.info(f"Task {task_name} on grid {grid.name} cancelled by user.")
+                grid.task_state.status = AutoLamellaTaskStatus.Cancelled
+                grid.task_state.status_message = "Cancelled by user."
+            else:
+                logging.warning(f"Error running {task_name} on grid {grid.name}: {e}")
+                grid.task_state.status = AutoLamellaTaskStatus.Failed
+                grid.task_state.status_message = str(e)
+            self.experiment.save()
+            return e
+
+    # --- Reporting ---
+
+    def _say(
+        self, workflow_info: Optional[str] = None, status_bar: Optional[str] = None
+    ) -> None:
+        """A line for the workflow-information label or the status bar.
+
+        Straight onto the status channel rather than through `update_status_ui`:
+        that helper re-checks for abort and raises once Stop has been pressed,
+        which is exactly when the closing "cancelled" line has to get out.
+        """
+        text = workflow_info or status_bar or ""
+        if self.parent_ui is None:
+            logging.info(text)
+            return
+        self.parent_ui.workflow_status_signal.emit(
+            WorkflowStatusEvent(workflow_info=workflow_info, status_bar=status_bar)
+        )
+
+    def _task_type(self, task_name: str) -> str:
+        try:
+            config = self.experiment.grid_protocol.task_config.get(task_name)
+        except ValueError:  # no task protocol on this experiment
+            return ""
+        return config.task_type if config is not None else ""
+
+    def _grids_in_run(self) -> List[str]:
+        """Every grid the queue holds, in run order: the launch plan plus anything
+        added mid-run."""
+        return list(dict.fromkeys(i.item_name for i in self.queue.items))
+
+    def _completion_message(self) -> str:
+        items = self.queue.items
+        if not items:
+            return "No tasks to run."
+        grids = self._grids_in_run()
+        not_loaded = [g for g in grids if g in self._not_loaded]
+        failed = sum(
+            1
+            for i in items
+            if i.status is AutoLamellaTaskStatus.Failed
+            and i.task_name != LOAD_ENTRY_NAME
+        )
+        parts = [f"{len(grids) - len(not_loaded)} of {len(grids)} grids run"]
+        if not_loaded:
+            parts.append(f"{len(not_loaded)} could not be loaded")
+        if failed:
+            parts.append(f"{failed} task{'s' if failed != 1 else ''} failed")
+        return "Grid workflow complete: " + ", ".join(parts) + "."
+
+    def _grid_summary_lines(self) -> List[str]:
+        """One line per grid: whether it loaded, and how its tasks ended."""
+        lines = []
+        items = self.queue.items
+        for name in self._grids_in_run():
+            if name in self._not_loaded:
+                lines.append(f"{name}: not loaded ({self._not_loaded[name]})")
+                continue
+            outcomes = [
+                i.status.name
+                for i in items
+                if i.item_name == name and i.task_name != LOAD_ENTRY_NAME
+            ]
+            counts = {s: outcomes.count(s) for s in dict.fromkeys(outcomes)}
+            summary = ", ".join(f"{n} {s.lower()}" for s, n in counts.items())
+            lines.append(f"{name}: {summary}")
+        return lines
+
+
+def run_grid_tasks(
+    microscope: "FibsemMicroscope",
+    experiment: "Experiment",
+    task_names: Optional[List[str]] = None,
+    grid_names: Optional[List[str]] = None,
+    parent_ui: Optional["AutoLamellaUI"] = None,
+    hook_manager: Optional[HookManager] = None,
+) -> GridTaskManager:
+    """Run grid tasks headless: the protocol's tasks in its order, on every grid,
+    unless told otherwise. Returns the manager, for its queue and run summary."""
+    if task_names is None:
+        task_names = experiment.grid_protocol.ordered_task_names
+    manager = GridTaskManager(microscope, experiment, parent_ui, hook_manager)
+    manager.run(task_names, grid_names)
+    return manager

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -57,8 +57,15 @@ def run_task(
     task.run()
 
 
-class TaskManager:
-    """Manages execution of autolamella tasks across lamellas."""
+class BaseTaskManager:
+    """What running a queue of (item, task) work needs, whatever the item is.
+
+    The lamella and grid workflows share everything here: the queue, the two stop
+    intents and the token tasks poll, the queue-changed and status channels to the
+    UI, and the hook run context. What they do not share is the run loop, which
+    each subclass writes: what an item is, how it is looked up, when it is skipped
+    and what it costs to reach are the whole difference between the two.
+    """
 
     def __init__(
         self,
@@ -86,12 +93,215 @@ class TaskManager:
         # the app also calls it when it adopts an experiment, and repeating it just
         # re-sets the same two attributes. See FIB-449.
         self.experiment.register_metadata(self.microscope)
+
+    # --- Public API ---
+
+    def stop(self) -> None:
+        """Signal the manager to stop after current task completes."""
+        self._stop_event.set()
+
+    def stop_task(self) -> None:
+        """Abandon the task now running and carry on with the rest of the queue.
+
+        The task unwinds through the same path a run-wide Stop uses, so it ends
+        Cancelled and whatever it was doing to the hardware is undone the same
+        way. Only the loop's reaction differs: is_stopped is untouched, so
+        _run_queue moves to the next item instead of ending the run.
+
+        Cleared at the top of each task, so a click that lands between two tasks
+        is discarded rather than killing the next one.
+        """
+        self._task_stop_event.set()
+
+    @property
+    def is_stopped(self) -> bool:
+        """Whether the *run* should end. Only _run_queue's loop asks this.
+
+        Deliberately narrow. "Should this task unwind?" is a different question
+        with a different answer -- see `should_abort` -- and conflating the two
+        is what makes any cancel end the whole run.
+        """
+        return self._stop_event.is_set()
+
+    @property
+    def should_abort(self) -> bool:
+        """Whether the task now running should unwind.
+
+        For the one caller with no token to poll: workflows.ui._check_for_abort
+        only ever gets a parent_ui. Everything task-side reads `abort_token`
+        instead, which answers the same question without a second route to it.
+        """
+        return self.abort_token.is_set()
+
+    @property
+    def abort_token(self) -> AnyStopEvent:
+        """What anything inside a task polls to know it has been cancelled.
+
+        Captured by AutoLamellaTask and GridTask, handed on to milling and
+        autofocus via `raise_if_cancelled`, and read directly by the fluorescence,
+        coincidence-milling and grid tasks. Only `is_set()` is ever called on it,
+        which is what lets it widen beyond a bare Event without touching any of
+        those call sites.
+        """
+        return self._abort_token
+
+    def notify_queue_changed(self) -> None:
+        """Tell the UI the queue's contents changed, outside the task lifecycle.
+
+        Status updates only fire when a task starts, finishes or is skipped, so
+        an edit made between two tasks would otherwise stay invisible until the
+        next one began.
+
+        Deliberately its own signal rather than the status channel: a queue
+        edit is not a step in the task lifecycle, and the status handler
+        repaints run chrome an edit must not touch.
+        """
+        if self.parent_ui is None:
+            return
+        self.parent_ui.queue_changed_signal.emit(
+            {
+                "queue_items": self.queue.items,  # thread-safe snapshot
+                "version": self.queue.version,
+            }
+        )
+
+    def hook_run_context(self) -> dict:
+        """The fields every hook event from this run carries: which experiment, and
+        how much of the queue is left.
+
+        Public because AutoLamellaTask fires task events itself and needs the same
+        fields; a task reaches this through its task_manager.
+
+        tasks_remaining excludes the task the event is about: queue.next() marks an
+        item InProgress before the task runs, so the one in flight is already out of
+        the pending set on every path, skips included.
+        """
+        pending, total = self.queue.counts
+        return {
+            "experiment_id": self.experiment.id,
+            "experiment_name": self.experiment.name,
+            "tasks_remaining": pending,
+            "tasks_total": total,
+        }
+
+    def _fire_workflow_hook(self, event: HookEvent) -> None:
+        # Workflow events used to carry nothing at all, so workflow_completed reached a
+        # webhook with no way to tell which experiment had finished.
+        fire_event(self.hook_manager, event, **self.hook_run_context())
+
+    def _fire_skipped_hook(
+        self,
+        task_name: str,
+        item_name: str,
+        skip_reason: str,
+        task_type: str = "",
+        item_id: str = "",
+    ) -> None:
+        """Fire TASK_SKIPPED. Unlike the other task events this cannot come from
+        AutoLamellaTask, because the skip is decided before any task object exists —
+        so there is no task_state to attach, and no task_id: nothing ran to have one.
+        item_id is empty on the lamella-not-found path, where there is no lamella."""
+        fire_event(
+            self.hook_manager,
+            HookEvent.TASK_SKIPPED,
+            task_name=task_name,
+            task_type=task_type,
+            item_name=item_name,
+            item_id=item_id,
+            skip_reason=skip_reason,
+            **self.hook_run_context(),
+        )
+
+    # --- Internal helpers ---
+
+    def _set_workflow_pending(self, pending: bool) -> None:
+        """Tell the UI a run is active but nothing is executing.
+
+        Read by the workflow border, which would otherwise show the running
+        colour throughout a scheduled wait that can last hours. Set on the worker
+        thread and read on the GUI thread, the same way WAITING_FOR_USER_INTERACTION
+        already is.
+        """
+        if self.parent_ui is not None:
+            self.parent_ui.WORKFLOW_PENDING = pending
+
+    def _emit_report(
+        self,
+        item: WorkItem,
+        item_name: str,
+        status: "AutoLamellaTaskStatus",
+        msg: str = "",
+        error_message: Optional[str] = None,
+        task_duration: Optional[float] = None,
+        skip_reason: Optional[str] = None,
+    ) -> None:
+        """Emit one lifecycle report on workflow_status_signal, for any kind of item.
+
+        Fire-and-forget on the status channel: a report that a task started is
+        not a step in any request's handshake, so it must not be able to touch
+        one — questions and instructions live on the responder's futures.
+
+        This stream and the hook stream describe the same lifecycle from two different
+        brackets — the manager brackets the task *call*, the task brackets its own
+        *execution* — and they are deliberately not merged. Hooks run user-configurable
+        code synchronously on the worker thread and HookManager.fire swallows what it
+        raises; the UI needs neither of those properties. See FIB-464.
+
+        What the two must agree on is vocabulary: the item is item_name here as it is in
+        HookContext. The queue position fields below have no hook counterpart and stay —
+        they are timeline positioning, not lifecycle facts.
+        """
+        if self.parent_ui is None:
+            return
+
+        # Progress is measured against the live queue rather than the launch
+        # plan. A position in the original task x lamella matrix has no answer
+        # for an item the user added mid-run, and stops being meaningful for
+        # everything else as soon as the queue is reordered.
+        items = self.queue.items
+        position = next((i for i, it in enumerate(items) if it.id == item.id), None)
+
+        # `lamella_name` is no longer a field: `WorkflowStatusUpdate` derives it from
+        # `item_name` as a property, so the deprecated alias cannot drift from the name
+        # it aliases, and drops cleanly with the HookContext shims after v0.6.
+        update = WorkflowStatusUpdate(
+            task_name=item.task_name,
+            item_name=item_name,
+            status=status,
+            timestamp=time.time(),
+            error_message=error_message,
+            task_duration=task_duration,
+            skip_reason=skip_reason,
+            # Already 1-based on the wire. Consumers render it as-is.
+            queue_position=position + 1 if position is not None else None,
+            queue_total=len(items),
+            queue_items=items,  # thread-safe snapshot: Queue.items returns copies
+            # The plan this run was launched with. Informational only — the live
+            # queue may since have diverged from it.
+            task_names=self.queue.task_names,
+            lamella_names=self.queue.item_names,
+        )
+
+        self.parent_ui.workflow_status_signal.emit(
+            WorkflowStatusEvent(message=msg, report=update)
+        )
+
+
+class TaskManager(BaseTaskManager):
+    """Manages execution of autolamella tasks across lamellas."""
+
+    def __init__(
+        self,
+        microscope: FibsemMicroscope,
+        experiment: "Experiment",
+        parent_ui: Optional["AutoLamellaUI"] = None,
+        hook_manager: Optional[HookManager] = None,
+    ):
+        super().__init__(microscope, experiment, parent_ui, hook_manager)
         # Lamellae already finished when the run started, so re-running a task on
         # finished work does not re-announce it. Seeded in _run_queue.
         self._completed_lamella: Set[str] = set()
         self._experiment_was_complete = False
-
-    # --- Public API ---
 
     def run(
         self, task_names: List[str], required_lamella: Optional[List[str]] = None
@@ -248,99 +458,6 @@ class TaskManager:
             )
         return pd.DataFrame(rows)
 
-    def stop(self) -> None:
-        """Signal the manager to stop after current task completes."""
-        self._stop_event.set()
-
-    def stop_task(self) -> None:
-        """Abandon the task now running and carry on with the rest of the queue.
-
-        The task unwinds through the same path a run-wide Stop uses, so it ends
-        Cancelled and whatever it was doing to the hardware is undone the same
-        way. Only the loop's reaction differs: is_stopped is untouched, so
-        _run_queue moves to the next item instead of ending the run.
-
-        Cleared at the top of each task, so a click that lands between two tasks
-        is discarded rather than killing the next one.
-        """
-        self._task_stop_event.set()
-
-    @property
-    def is_stopped(self) -> bool:
-        """Whether the *run* should end. Only _run_queue's loop asks this.
-
-        Deliberately narrow. "Should this task unwind?" is a different question
-        with a different answer -- see `should_abort` -- and conflating the two
-        is what makes any cancel end the whole run.
-        """
-        return self._stop_event.is_set()
-
-    @property
-    def should_abort(self) -> bool:
-        """Whether the task now running should unwind.
-
-        For the one caller with no token to poll: workflows.ui._check_for_abort
-        only ever gets a parent_ui. Everything task-side reads `abort_token`
-        instead, which answers the same question without a second route to it.
-        """
-        return self.abort_token.is_set()
-
-    @property
-    def abort_token(self) -> AnyStopEvent:
-        """What anything inside a task polls to know it has been cancelled.
-
-        Captured by AutoLamellaTask and GridTask, handed on to milling and
-        autofocus via `raise_if_cancelled`, and read directly by the fluorescence,
-        coincidence-milling and grid tasks. Only `is_set()` is ever called on it,
-        which is what lets it widen beyond a bare Event without touching any of
-        those call sites.
-        """
-        return self._abort_token
-
-    def notify_queue_changed(self) -> None:
-        """Tell the UI the queue's contents changed, outside the task lifecycle.
-
-        Status updates only fire when a task starts, finishes or is skipped, so
-        an edit made between two tasks would otherwise stay invisible until the
-        next one began.
-
-        Deliberately its own signal rather than the status channel: a queue
-        edit is not a step in the task lifecycle, and the status handler
-        repaints run chrome an edit must not touch.
-        """
-        if self.parent_ui is None:
-            return
-        self.parent_ui.queue_changed_signal.emit(
-            {
-                "queue_items": self.queue.items,  # thread-safe snapshot
-                "version": self.queue.version,
-            }
-        )
-
-    def hook_run_context(self) -> dict:
-        """The fields every hook event from this run carries: which experiment, and
-        how much of the queue is left.
-
-        Public because AutoLamellaTask fires task events itself and needs the same
-        fields; a task reaches this through its task_manager.
-
-        tasks_remaining excludes the task the event is about: queue.next() marks an
-        item InProgress before the task runs, so the one in flight is already out of
-        the pending set on every path, skips included.
-        """
-        pending, total = self.queue.counts
-        return {
-            "experiment_id": self.experiment.id,
-            "experiment_name": self.experiment.name,
-            "tasks_remaining": pending,
-            "tasks_total": total,
-        }
-
-    def _fire_workflow_hook(self, event: HookEvent) -> None:
-        # Workflow events used to carry nothing at all, so workflow_completed reached a
-        # webhook with no way to tell which experiment had finished.
-        fire_event(self.hook_manager, event, **self.hook_run_context())
-
     def _is_complete(self, lamella: "Lamella") -> bool:
         """Whether a lamella has completed every task the workflow requires of it."""
         # task_protocol is None until one is loaded ("must be set externally").
@@ -437,31 +554,6 @@ class TaskManager:
             return f"All tasks completed ({skipped} skipped)."
         return "All tasks completed."
 
-    def _fire_skipped_hook(
-        self,
-        task_name: str,
-        item_name: str,
-        skip_reason: str,
-        task_type: str = "",
-        item_id: str = "",
-    ) -> None:
-        """Fire TASK_SKIPPED. Unlike the other task events this cannot come from
-        AutoLamellaTask, because the skip is decided before any task object exists —
-        so there is no task_state to attach, and no task_id: nothing ran to have one.
-        item_id is empty on the lamella-not-found path, where there is no lamella."""
-        fire_event(
-            self.hook_manager,
-            HookEvent.TASK_SKIPPED,
-            task_name=task_name,
-            task_type=task_type,
-            item_name=item_name,
-            item_id=item_id,
-            skip_reason=skip_reason,
-            **self.hook_run_context(),
-        )
-
-    # --- Internal helpers ---
-
     def _wait_until_scheduled(
         self, scheduled_at: datetime, task_name: str, lamella: "Lamella"
     ) -> None:
@@ -504,17 +596,6 @@ class TaskManager:
             # for the rest of the run.
             self._set_workflow_pending(False)
 
-    def _set_workflow_pending(self, pending: bool) -> None:
-        """Tell the UI a run is active but nothing is executing.
-
-        Read by the workflow border, which would otherwise show the running
-        colour throughout a scheduled wait that can last hours. Set on the worker
-        thread and read on the GUI thread, the same way WAITING_FOR_USER_INTERACTION
-        already is.
-        """
-        if self.parent_ui is not None:
-            self.parent_ui.WORKFLOW_PENDING = pending
-
     def _should_skip(self, lamella: "Lamella", task_name: str) -> Optional[str]:
         """Return skip reason string, or None if task should run.
 
@@ -552,55 +633,15 @@ class TaskManager:
         task_duration: Optional[float] = None,
         skip_reason: Optional[str] = None,
     ) -> None:
-        """Emit one lifecycle report on workflow_status_signal.
-
-        Fire-and-forget on the status channel: a report that a task started is
-        not a step in any request's handshake, so it must not be able to touch
-        one — questions and instructions live on the responder's futures.
-
-        This stream and the hook stream describe the same lifecycle from two different
-        brackets — the manager brackets the task *call*, the task brackets its own
-        *execution* — and they are deliberately not merged. Hooks run user-configurable
-        code synchronously on the worker thread and HookManager.fire swallows what it
-        raises; the UI needs neither of those properties. See FIB-464.
-
-        What the two must agree on is vocabulary: the item is item_name here as it is in
-        HookContext. The queue position fields below have no hook counterpart and stay —
-        they are timeline positioning, not lifecycle facts.
-        """
-        if self.parent_ui is None:
-            return
-
-        # Progress is measured against the live queue rather than the launch
-        # plan. A position in the original task x lamella matrix has no answer
-        # for an item the user added mid-run, and stops being meaningful for
-        # everything else as soon as the queue is reordered.
-        items = self.queue.items
-        position = next((i for i, it in enumerate(items) if it.id == item.id), None)
-
-        # `lamella_name` is no longer a field: `WorkflowStatusUpdate` derives it from
-        # `item_name` as a property, so the deprecated alias cannot drift from the name
-        # it aliases, and drops cleanly with the HookContext shims after v0.6.
-        update = WorkflowStatusUpdate(
-            task_name=item.task_name,
+        """The lamella spelling of `_emit_report`: the item is the lamella."""
+        self._emit_report(
+            item=item,
             item_name=lamella.name,
             status=status,
-            timestamp=time.time(),
+            msg=msg,
             error_message=error_message,
             task_duration=task_duration,
             skip_reason=skip_reason,
-            # Already 1-based on the wire. Consumers render it as-is.
-            queue_position=position + 1 if position is not None else None,
-            queue_total=len(items),
-            queue_items=items,  # thread-safe snapshot: Queue.items returns copies
-            # The plan this run was launched with. Informational only — the live
-            # queue may since have diverged from it.
-            task_names=self.queue.task_names,
-            lamella_names=self.queue.item_names,
-        )
-
-        self.parent_ui.workflow_status_signal.emit(
-            WorkflowStatusEvent(message=msg, report=update)
         )
 
     def _run_single_task(

--- a/fibsem/applications/autolamella/workflows/tasks/queue.py
+++ b/fibsem/applications/autolamella/workflows/tasks/queue.py
@@ -125,6 +125,35 @@ class TaskQueue:
             self._version += 1
             return [copy.copy(i) for i in self._items]
 
+    def build_from_pairs(
+        self,
+        pairs: List[Tuple[str, str]],
+        task_names: Optional[List[str]] = None,
+        item_names: Optional[List[str]] = None,
+    ) -> List[WorkItem]:
+        """Populate the queue from an explicit ``(item_name, task_name)`` plan.
+
+        For a run whose steps are not a plain matrix -- the grid workflow puts a
+        load step ahead of each grid's tasks. ``task_names`` and ``item_names``
+        are the launch plan the status payload reports; by default they are read
+        off the pairs in first-seen order.
+        """
+        with self._lock:
+            self._task_names = (
+                list(task_names)
+                if task_names is not None
+                else list(dict.fromkeys(t for _, t in pairs))
+            )
+            self._item_names = (
+                list(item_names)
+                if item_names is not None
+                else list(dict.fromkeys(n for n, _ in pairs))
+            )
+            self._items = [WorkItem(item_name=n, task_name=t) for n, t in pairs]
+            self._active = None
+            self._version += 1
+            return [copy.copy(i) for i in self._items]
+
     # --- Internal helpers (caller must hold self._lock) ---
 
     def _find(self, item_id: str) -> Optional[WorkItem]:

--- a/tests/autolamella/test_grid_task_manager.py
+++ b/tests/autolamella/test_grid_task_manager.py
@@ -1,0 +1,389 @@
+"""The grid run loop, on the Arctis simulator (a compustage with a Demo autoloader).
+
+Grid-outer: a grid is exchanged once and all of its tasks run while it is in the
+beam. A grid that will not load is recorded, skipped, and the run continues; a
+task that fails fails only itself. Most tests stub the task itself, as the lamella
+manager's tests do, so they exercise the loop and not the microscope; the last
+runs real overview tasks end to end.
+"""
+
+import os
+from typing import List
+
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    Experiment,
+    GridRecord,
+)
+from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus as Status
+from fibsem.applications.autolamella.task_outputs import grid_outputs
+from fibsem.applications.autolamella.workflows.tasks.grid import (
+    BeamOverviewGridTaskConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.grid.manager import (
+    LOAD_ENTRY_NAME,
+    SKIP_GRID_NOT_FOUND,
+    SKIP_GRID_NOT_LOADED,
+    GridTaskManager,
+    plan_grid_run,
+    run_grid_tasks,
+)
+from fibsem.applications.autolamella.workflows.tasks.status import WorkflowStatusEvent
+from fibsem.structures import BeamType, ImageSettings, OverviewAcquisitionSettings
+
+GRIDS = ["Grid-01", "Grid-02", "Grid-03"]  # what the sim magazine holds
+
+
+class _Recorder:
+    def __init__(self):
+        self.emitted: List = []
+
+    def emit(self, payload) -> None:
+        self.emitted.append(payload)
+
+
+class RecordingUI:
+    """A recorder in place of AutoLamellaUI, which needs a live viewer."""
+
+    def __init__(self):
+        self.workflow_status_signal = _Recorder()
+        self._task_manager = None  # _check_for_abort reads this
+
+    @property
+    def reports(self):
+        return [
+            e.report
+            for e in self.workflow_status_signal.emitted
+            if isinstance(e, WorkflowStatusEvent) and e.report is not None
+        ]
+
+    @property
+    def workflow_info(self):
+        return [
+            e.workflow_info
+            for e in self.workflow_status_signal.emitted
+            if isinstance(e, WorkflowStatusEvent) and e.workflow_info is not None
+        ]
+
+
+def _small_settings(beam=BeamType.ELECTRON) -> OverviewAcquisitionSettings:
+    return OverviewAcquisitionSettings(
+        image_settings=ImageSettings(resolution=(128, 128), hfw=200e-6, beam_type=beam),
+        nrows=1,
+        ncols=1,
+    )
+
+
+@pytest.fixture
+def microscope():
+    microscope, _ = utils.setup_session(
+        manufacturer="Demo",
+        config_path=os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml"),
+    )
+    assert microscope._stage.loader is not None
+    assert [e.name for e in microscope._stage.grid_inventory() if e.present] == GRIDS
+    return microscope
+
+
+@pytest.fixture
+def experiment(tmp_path, microscope):
+    exp = Experiment(path=tmp_path, name="exp")
+    (tmp_path / "exp").mkdir()
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    exp.grid_protocol.add(
+        BeamOverviewGridTaskConfig(task_name="overview_sem", settings=_small_settings())
+    )
+    exp.grid_protocol.add(
+        BeamOverviewGridTaskConfig(
+            task_name="overview_fib",
+            orientation="FIB",
+            settings=_small_settings(BeamType.ION),
+        )
+    )
+    exp.sync_grids_from_inventory(microscope._stage)
+    assert [g.name for g in exp.grids] == GRIDS
+    return exp
+
+
+def run_with_stub(manager: GridTaskManager, task_names, grid_names, on_task=None):
+    """Drive the loop with the task itself stubbed out.
+
+    ``on_task(task_name, grid)`` runs in place of the real task; it may raise, or
+    stop the manager, which are the paths under test.
+    """
+    executed = []
+
+    def _run_single_task(task_name, grid):
+        executed.append((grid.name, task_name))
+        grid.task_state.name = task_name
+        try:
+            if on_task is not None:
+                on_task(task_name, grid)
+        except Exception as e:
+            grid.task_state.status = Status.Failed
+            grid.task_state.status_message = str(e)
+            return e
+        grid.task_state.status = Status.Completed
+        grid.task_state.status_message = ""
+        return None
+
+    manager.parent_ui._task_manager = manager
+    manager._run_single_task = _run_single_task
+    manager.run(task_names, grid_names)
+    return executed
+
+
+@pytest.fixture
+def manager(microscope, experiment) -> GridTaskManager:
+    return GridTaskManager(microscope, experiment, parent_ui=RecordingUI())
+
+
+def load_entries(grid: GridRecord):
+    return [t for t in grid.task_history if t.name == LOAD_ENTRY_NAME]
+
+
+class TestOrderAndLoading:
+    def test_the_plan_shows_each_load_ahead_of_that_grids_tasks(self):
+        assert plan_grid_run(
+            ["overview_sem", "overview_fib"], ["Grid-01", "Grid-02"]
+        ) == [
+            ("Grid-01", "load"),
+            ("Grid-01", "overview_sem"),
+            ("Grid-01", "overview_fib"),
+            ("Grid-02", "load"),
+            ("Grid-02", "overview_sem"),
+            ("Grid-02", "overview_fib"),
+        ]
+
+    def test_the_queue_is_the_plan(self, manager):
+        run_with_stub(manager, ["overview_sem"], ["Grid-01", "Grid-02"])
+        assert [(i.item_name, i.task_name) for i in manager.queue.items] == [
+            ("Grid-01", "load"),
+            ("Grid-01", "overview_sem"),
+            ("Grid-02", "load"),
+            ("Grid-02", "overview_sem"),
+        ]
+        assert manager.queue.task_names == ["overview_sem"]
+        assert manager.queue.item_names == ["Grid-01", "Grid-02"]
+
+    def test_runs_grid_outer(self, manager):
+        executed = run_with_stub(
+            manager, ["overview_sem", "overview_fib"], ["Grid-01", "Grid-02"]
+        )
+        assert executed == [
+            ("Grid-01", "overview_sem"),
+            ("Grid-01", "overview_fib"),
+            ("Grid-02", "overview_sem"),
+            ("Grid-02", "overview_fib"),
+        ]
+
+    def test_each_grid_is_exchanged_once_and_the_exchange_is_recorded(
+        self, manager, experiment, microscope
+    ):
+        run_with_stub(manager, ["overview_sem", "overview_fib"], ["Grid-01", "Grid-02"])
+        for name in ("Grid-01", "Grid-02"):
+            (entry,) = load_entries(experiment.get_grid_by_name(name))
+            assert entry.status is Status.Completed
+            assert "Slot-01" in entry.status_message
+            assert entry.end_timestamp is not None
+        # the last grid is left in the beam; nothing unloads at the end of a run
+        assert microscope._stage.loaded_grids[0].name == "Grid-02"
+
+    def test_a_grid_already_in_the_beam_is_not_loaded_again(
+        self, manager, experiment, microscope
+    ):
+        microscope._stage.ensure_loaded("Grid-03")
+        run_with_stub(manager, ["overview_sem"], ["Grid-03"])
+        assert load_entries(experiment.get_grid_by_name("Grid-03")) == []
+        # the planned load step still completes: the grid is where it needs to be
+        load, _ = manager.queue.items
+        assert (load.task_name, load.status) == ("load", Status.Completed)
+
+    def test_a_task_loads_its_grid_even_if_the_load_step_was_removed(
+        self, manager, experiment, microscope
+    ):
+        def on_task(task_name, grid):
+            assert microscope._stage.loaded_grids[0].name == grid.name
+
+        # remove Grid-02's planned load before the run reaches it
+        def drop_second_load(task_name, grid):
+            on_task(task_name, grid)
+            if grid.name == "Grid-01":
+                load = next(
+                    i for i in manager.queue.pending if i.item_name == "Grid-02"
+                )
+                assert manager.queue.remove(load.id).ok
+
+        run_with_stub(
+            manager, ["overview_sem"], ["Grid-01", "Grid-02"], drop_second_load
+        )
+        (entry,) = load_entries(experiment.get_grid_by_name("Grid-02"))
+        assert entry.status is Status.Completed
+
+    def test_defaults_to_every_grid_in_the_experiment(self, manager):
+        executed = run_with_stub(manager, ["overview_sem"], None)
+        assert [g for g, _ in executed] == GRIDS
+
+
+class TestFailureIsolation:
+    def test_a_failed_load_skips_that_grids_tasks_and_the_run_continues(
+        self, manager, experiment, microscope
+    ):
+        microscope._stage.loader.fail_next_exchange = True  # Grid-01's exchange
+        executed = run_with_stub(
+            manager, ["overview_sem", "overview_fib"], ["Grid-01", "Grid-02"]
+        )
+        assert executed == [("Grid-02", "overview_sem"), ("Grid-02", "overview_fib")]
+
+        failed = experiment.get_grid_by_name("Grid-01")
+        (entry,) = load_entries(failed)
+        assert entry.status is Status.Failed
+        assert "Simulated" in entry.status_message
+        # the grid's own tasks never ran, so it has no task entries at all
+        assert [t.name for t in failed.task_history] == [LOAD_ENTRY_NAME]
+
+        statuses = [(i.item_name, i.task_name, i.status) for i in manager.queue.items]
+        assert statuses == [
+            ("Grid-01", "load", Status.Failed),
+            ("Grid-01", "overview_sem", Status.Skipped),
+            ("Grid-01", "overview_fib", Status.Skipped),
+            ("Grid-02", "load", Status.Completed),
+            ("Grid-02", "overview_sem", Status.Completed),
+            ("Grid-02", "overview_fib", Status.Completed),
+        ]
+        (load_report,) = [
+            r
+            for r in manager.parent_ui.reports
+            if r.task_name == "load" and r.status is Status.Failed
+        ]
+        assert load_report.item_name == "Grid-01"
+        assert "Simulated" in load_report.error_message
+        skipped = [r for r in manager.parent_ui.reports if r.status is Status.Skipped]
+        assert {r.skip_reason for r in skipped} == {SKIP_GRID_NOT_LOADED}
+        assert all("Simulated" in r.error_message for r in skipped)
+        assert manager.parent_ui.workflow_info[-1] == (
+            "Grid workflow complete: 1 of 2 grids run, 1 could not be loaded."
+        )
+
+    def test_a_failed_load_is_not_retried_within_the_run(self, manager, microscope):
+        attempts = []
+        stage = microscope._stage
+        original = stage.ensure_loaded
+
+        def counting(name):
+            attempts.append(name)
+            return original(name)
+
+        stage.ensure_loaded = counting
+        stage.loader.fail_next_exchange = True
+        run_with_stub(manager, ["overview_sem", "overview_fib"], ["Grid-01"])
+        assert attempts == ["Grid-01"]
+
+    def test_a_failed_task_does_not_fail_the_grid(self, manager, experiment):
+        def on_task(task_name, grid):
+            if task_name == "overview_sem":
+                raise RuntimeError("beam off")
+
+        executed = run_with_stub(
+            manager, ["overview_sem", "overview_fib"], ["Grid-01"], on_task
+        )
+        assert executed == [("Grid-01", "overview_sem"), ("Grid-01", "overview_fib")]
+        assert [i.status for i in manager.queue.items] == [
+            Status.Completed,  # load
+            Status.Failed,
+            Status.Completed,
+        ]
+        assert manager.parent_ui.workflow_info[-1] == (
+            "Grid workflow complete: 1 of 1 grids run, 1 task failed."
+        )
+
+    def test_an_unknown_grid_is_skipped_with_a_reason(self, manager):
+        executed = run_with_stub(manager, ["overview_sem"], ["Grid-99", "Grid-01"])
+        assert executed == [("Grid-01", "overview_sem")]
+        skipped = [r for r in manager.parent_ui.reports if r.status is Status.Skipped]
+        assert [(r.item_name, r.task_name) for r in skipped] == [
+            ("Grid-99", "load"),
+            ("Grid-99", "overview_sem"),
+        ]
+        assert {r.skip_reason for r in skipped} == {SKIP_GRID_NOT_FOUND}
+
+
+class TestStopAndStatus:
+    def test_stop_ends_the_run_at_the_next_task_boundary(self, manager):
+        def on_task(task_name, grid):
+            manager.stop()
+
+        executed = run_with_stub(
+            manager, ["overview_sem", "overview_fib"], ["Grid-01", "Grid-02"], on_task
+        )
+        assert executed == [("Grid-01", "overview_sem")]
+        # load + first task consumed; the other four still pending
+        assert manager.queue.counts == (4, 6)
+        assert manager.parent_ui.workflow_info[-1] == "Grid workflow cancelled."
+
+    def test_reports_name_the_grid_and_track_the_queue(self, manager):
+        run_with_stub(manager, ["overview_sem"], ["Grid-01", "Grid-02"])
+        reports = [r for r in manager.parent_ui.reports if r.task_name != "load"]
+        assert [(r.item_name, r.status) for r in reports] == [
+            ("Grid-01", Status.InProgress),
+            ("Grid-01", Status.Completed),
+            ("Grid-02", Status.InProgress),
+            ("Grid-02", Status.Completed),
+        ]
+        assert [r.queue_position for r in reports] == [2, 2, 4, 4]
+        assert reports[-1].queue_total == 4
+        assert [i.task_name for i in reports[-1].queue_items] == [
+            "load",
+            "overview_sem",
+            "load",
+            "overview_sem",
+        ]
+
+    def test_run_summary_has_one_row_per_attempt(self, manager, microscope):
+        microscope._stage.loader.fail_next_exchange = True
+        run_with_stub(manager, ["overview_sem"], ["Grid-01", "Grid-02"])
+        df = manager.build_run_summary_dataframe()
+        assert list(df.columns) == [
+            "grid_name",
+            "task_name",
+            "task_status",
+            "loaded",
+            "completed_at",
+            "duration",
+        ]
+        assert df["grid_name"].tolist() == ["Grid-01", "Grid-01", "Grid-02", "Grid-02"]
+        assert df["task_name"].tolist() == ["load", "overview_sem"] * 2
+        assert df["task_status"].tolist() == [
+            "Failed",
+            "Skipped",
+            "Completed",
+            "Completed",
+        ]
+        assert df["loaded"].tolist() == [False, False, True, True]
+
+
+class TestEndToEnd:
+    def test_real_overviews_land_under_each_grid(
+        self, microscope, experiment, tmp_path
+    ):
+        manager = run_grid_tasks(
+            microscope, experiment, grid_names=["Grid-01", "Grid-02"]
+        )
+        assert all(i.status is Status.Completed for i in manager.queue.items)
+        for name in ("Grid-01", "Grid-02"):
+            grid = experiment.get_grid_by_name(name)
+            assert [t.name for t in grid.task_history] == [
+                LOAD_ENTRY_NAME,
+                "overview_sem",
+                "overview_fib",
+            ]
+            for role in ("overview_sem", "overview_fib"):
+                (path,) = grid_outputs(experiment, grid, role)
+                assert path.startswith(str(tmp_path / "exp" / "grids" / name / role))
+        # the run saved as it went: the record on disk carries the history
+        loaded = Experiment.load(tmp_path / "exp" / "experiment.yaml")
+        assert len(loaded.get_grid_by_name("Grid-02").task_history) == 3


### PR DESCRIPTION
Milestone 4 of the grid workflow: the run loop (FIB-17). Stacked on #738.

## What the run does

For each selected grid: bring it into the beam, run the selected tasks on it in order, save, next grid. Reaching a grid is the one expensive step (a magazine exchange on the autoloader), so the run is **grid-outer** and a grid is exchanged once for all of its tasks.

**The queue is the plan.** Selecting grids 1, 2, 3 and two tasks builds:

```
Grid-01 load · Grid-01 overview_sem · Grid-01 overview_fib · Grid-02 load · …
```

so the timeline shows where the exchanges fall before the run starts and how each one went while it runs. The load step is the manager's, not a protocol task: a task whose grid is not in the beam loads it anyway, so removing or reordering a load item in the queue changes what is shown, never what runs. `plan_grid_run(task_names, grid_names)` is the same sequence for a preview.

**Three questions, three separate answers** (agreed earlier, not collapsed into one enum):

| Question | Where | Who sets it |
| -- | -- | -- |
| Did the grid load? | a `load` entry on the grid's history: Completed with the slot and the exchange time, or Failed with the hardware's message; only written when there was an exchange | the manager, per attempt |
| Did each task complete? | the task's own history entry | the task lifecycle |
| Is the grid any good? | `GridRecord.quality` | a person, never automation |

**Failure isolation.** A failed load (`GridExchangeError`) records the failure, marks that grid's remaining tasks in this run *Skipped: grid not loaded*, and continues with the next grid; the exchange is not retried task after task. A failed task fails only itself, so the FM overview still runs after a failed SEM one. Stop ends the run at the next item boundary; an exchange in flight finishes. Nothing unloads at the end of a run.

**Status** goes out on `workflow_status_signal` as the same typed `WorkflowStatusUpdate` the lamella run sends, with the grid as `item_name`, so the timeline can show it unchanged in milestone 5. `run_grid_tasks(microscope, experiment)` runs the protocol's tasks in its order over every grid, for scripts and the agent server.

## Shape

- **`BaseTaskManager`** (first commit): the queue, the two stop intents and the abort token, the queue-changed and status channels, and the hook run context move verbatim off the lamella `TaskManager`; it keeps everything that is about lamellae (run loop, skip predicate, scheduled waits, completion events, summary). The only generalisation is `_emit_report(item, item_name, …)`, of which the lamella `_emit_status(item, lamella, …)` is now the spelling that takes a lamella. Every other method body is unchanged, checked at the AST level. Lamella manager, stop, hooks, scheduling, agent-context and timeline suites pass unchanged.
- **`GridTaskManager(BaseTaskManager)`** in `workflows/tasks/grid/manager.py`, with its own loop and summary (`grid_name`, `task_name`, `task_status`, `loaded`, …).
- **`TaskQueue.build_from_pairs`** takes the explicit plan; the matrix builder is untouched.

One thing found on the way, left alone: the shared `update_status_ui` re-checks for abort and raises once Stop has been pressed, so the lamella run's closing "Workflow cancelled." line never reaches the label (the worker swallows the `InterruptedError`). The grid manager emits its own closing line directly. Worth a separate look.

## Tests

`tests/autolamella/test_grid_task_manager.py`, on the Arctis simulator (compustage + Demo autoloader, three grids in the magazine): the plan, grid-outer order, one recorded exchange per grid and none for a grid already in the beam, a task loading its grid after the load item was removed, load failure isolation with `fail_next_exchange` (skips, reports, the Failed load entry, no retry), a failed task not failing the grid, an unknown grid, stop at the boundary, the status reports, the run summary, and one end-to-end run of real SEM and FIB overviews on two grids with the history surviving a reload from disk.
