### PR TITLE
[ui] Microscope · Sample: the holder and the magazine as a control tab; a grid_workflow flag

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -463,7 +463,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         # Load user preferences
         self._preferences = fibsem_cfg.load_user_preferences()
-        fibsem_cfg.apply_feature_flags(self._preferences)
 
         # Read once, here, because both the menu entry and the header chip are gated
         # on it and the menu is built before the tabs are.
@@ -959,7 +958,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if dialog.exec_() == QDialog.Accepted:
             self._preferences = dialog.get_preferences()
             fibsem_cfg.save_user_preferences(self._preferences)
-            fibsem_cfg.apply_feature_flags(self._preferences)
             self._apply_preferences()
 
     def _apply_preferences(self):

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -57,6 +57,7 @@ from fibsem.ui import (
 )
 from fibsem.ui import utils as fui
 from fibsem.ui.FibsemMinimapWidget import FibsemMinimapWidget
+from fibsem.ui.FibsemSampleWidget import FibsemSampleWidget
 from fibsem.ui.fm.widgets import FMImageViewerWidget
 from fibsem.ui.qt.threading import FunctionWorker
 
@@ -222,6 +223,7 @@ class AutoLamellaUI(QMainWindow):
         self.movement_widget: Optional[FibsemMovementWidget] = None
         self.spot_burn_widget: Optional[FibsemSpotBurnWidget] = None
         self.fm_control_widget: Optional[FMControlWidget] = None
+        self.sample_widget: Optional[FibsemSampleWidget] = None
         self.milling_task_config_widget: Optional[MillingTaskViewerWidget] = None
         self.det_widget: Optional["FibsemEmbeddedDetectionWidget"] = None
 
@@ -709,6 +711,17 @@ class AutoLamellaUI(QMainWindow):
             )
             self.tabWidget.addTab(self.milling_task_config_widget, "Milling")
 
+            # The hardware view of the grids: the holder, and the magazine when
+            # there is one. Slot moves go through the Movement widget, the same
+            # route as a saved position, so the readout and post-move images follow.
+            self.sample_widget = FibsemSampleWidget(
+                microscope=self.microscope, parent=self
+            )
+            self.sample_widget.move_to_requested.connect(
+                self.movement_widget.move_to_position
+            )
+            self.tabWidget.addTab(self.sample_widget, "Sample")
+
             if self.microscope.fm is not None:
                 self.fm_control_widget = FMControlWidget(
                     microscope=self.microscope, parent=self
@@ -753,6 +766,10 @@ class AutoLamellaUI(QMainWindow):
                 return
 
             # remove tabs
+            if self.sample_widget is not None:
+                self.tabWidget.removeTab(self.tabWidget.indexOf(self.sample_widget))
+                self.sample_widget.deleteLater()
+                self.sample_widget = None
             if self.fm_control_widget is not None:
                 # deleteLater fires neither closeEvent nor close_widget, so tear
                 # down the FM widget's external signal connections explicitly

--- a/fibsem/config.py
+++ b/fibsem/config.py
@@ -394,7 +394,9 @@ class DisplayPreferences:
 @dataclass
 class FeatureFlags:
     coincidence_milling_enabled: bool = False
-    sample_holder_widget: bool = False
+    # `sample_holder_widget` retired 2026-09-02: the holder panel is the Microscope
+    # tab's Sample view now, shown on every machine. A saved preferences file that
+    # still names it loads fine; unknown keys are ignored.
     bug_report_enabled: bool = False
     # Tools -> Scripts. A user script runs with the application's own access to the
     # microscope and none of its guard rails, so the menu is not offered to anyone
@@ -435,6 +437,17 @@ class FeatureFlags:
     # A staging flag like `napari_overview_tab`, and it goes the same way: deleted
     # when the chip replaces the tab, not kept as a preference.
     connection_chip: bool = False
+    # The grid screening workflow (FIB-892): the Grids tab and the Workflow tab's
+    # Grids view. Off until the flow has run on the Arctis and on a fixed holder.
+    # The backend beneath it -- inventory, grid records, grid tasks, the grid run
+    # loop -- is not gated and is exercised headless either way. The hardware view,
+    # Microscope -> Sample, is not gated either: a holder reads as uncalibrated
+    # until the wizard has run, which is the safe thing for it to say.
+    #
+    # Off by default. Turning it on for everyone later is a new default, and a
+    # changed default reaches only fresh installs; the release that flips it needs
+    # a note, or a migration, not just this line.
+    grid_workflow: bool = False
 
 
 @dataclass
@@ -752,23 +765,6 @@ def get_last_experiment_file() -> Optional[str]:
     return None
 
 
-def apply_feature_flags(prefs: UserPreferences) -> None:
-    """Update module-level FEATURE_* constants from user preferences.
-
-    Down to one. The others either went away with their features or, in the case of
-    coincidence milling, turned out to have no reader -- that one gates on
-    `prefs.features.coincidence_milling_enabled` directly, which is the simpler
-    thing to do when the caller already holds a preferences object.
-
-    The global survives here because its caller does not: `FibsemMovementWidget`
-    reads it while building a widget, and the alternative is re-reading
-    user-preferences.yaml from disk on every construction.
-    """
-    global FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED
-    f = prefs.features
-    FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED = f.sample_holder_widget
-
-
 ### AUTOLAMELLA APPLICATION PATHS
 AUTOLAMELLA_BASE_PATH: Path = os.path.join(
     os.path.dirname(__file__), "applications", "autolamella"
@@ -784,6 +780,3 @@ AUTOLAMELLA_TASK_PROTOCOL_PATH: Path = os.path.join(
 AUTOLAMELLA_EXPERIMENT_NAME = "AutoLamella"
 
 os.makedirs(AUTOLAMELLA_LOG_PATH, exist_ok=True)
-
-####### FEATURE FLAGS
-FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED = False

--- a/fibsem/ui/FibsemMovementWidget.py
+++ b/fibsem/ui/FibsemMovementWidget.py
@@ -129,16 +129,6 @@ class FibsemMovementWidget(QtWidgets.QWidget):
         self.saved_positions_widget._load_default_positions()
         self.saved_positions_widget.move_to_requested.connect(self.move_to_position)
 
-        if cfg.FEATURE_SAMPLE_HOLDER_WIDGET_ENABLED:
-            from fibsem.ui.widgets.sample_holder_widget import SampleHolderWidget
-
-            self.sample_holder_widget = SampleHolderWidget(microscope=self.microscope)
-            self.sample_holder_widget.set_holder(self.microscope._stage.holder)
-            # Same route as a saved position, so the readout and the post-move
-            # images follow the stage to the slot.
-            self.sample_holder_widget.move_to_requested.connect(self.move_to_position)
-            self.gridLayout_2.addWidget(self.sample_holder_widget, 3, 0)
-
         self.control_widget.update_ui()
 
     # --- the surface other windows reach for ---------------------------------

--- a/fibsem/ui/FibsemSampleWidget.py
+++ b/fibsem/ui/FibsemSampleWidget.py
@@ -1,0 +1,68 @@
+"""Microscope tab · Sample: the hardware view of the grids.
+
+The holder on every machine (its slots, their calibration, which grid is in each,
+Move, and the calibration wizard) and, when the system has an autoloader, the
+magazine beneath it. The Grids tab is the experiment's view of the same grids;
+this one is the instrument's, and it is where the twelve-row slot list lives.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtWidgets import QScrollArea, QVBoxLayout, QWidget
+
+from fibsem.ui.widgets.sample_holder_widget import SampleHolderWidget
+from fibsem.ui.widgets.sample_loader_widget import SampleLoaderWidget
+
+
+class FibsemSampleWidget(QWidget):
+    # A request to drive to a calibrated holder slot, routed by the host through
+    # the Movement widget so the readout and post-move images follow.
+    move_to_requested = pyqtSignal(object)  # FibsemStagePosition
+
+    def __init__(self, microscope, parent=None):
+        super().__init__(parent)
+        self.microscope = microscope
+        stage = microscope._stage
+
+        scroll = QScrollArea(self)
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.NoFrame)
+        # Never wider than the tab: a long facts line wraps rather than pushing
+        # the rows' right-hand column out of view.
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        inner = QWidget()
+        inner_layout = QVBoxLayout(inner)
+        inner_layout.setContentsMargins(6, 6, 6, 6)
+        inner_layout.setSpacing(8)
+
+        self.holder_widget = SampleHolderWidget(microscope=microscope)
+        self.holder_widget.set_holder(stage.holder)
+        self.holder_widget.move_to_requested.connect(self.move_to_requested)
+        inner_layout.addWidget(self.holder_widget)
+
+        self.loader_widget: Optional[SampleLoaderWidget] = None
+        if stage.loader is not None:
+            self.loader_widget = SampleLoaderWidget(microscope=microscope)
+            # An exchange changes what is in the holder's working slot.
+            self.loader_widget.loader_changed.connect(self.holder_widget.refresh)
+            inner_layout.addWidget(self.loader_widget)
+
+        inner_layout.addStretch(1)
+        scroll.setWidget(inner)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(scroll)
+
+    def refresh(self) -> None:
+        self.holder_widget.refresh()
+        if self.loader_widget is not None:
+            self.loader_widget.refresh()
+
+    def set_controls_enabled(self, enabled: bool) -> None:
+        """Lock the exchange controls while a workflow owns the loader."""
+        if self.loader_widget is not None:
+            self.loader_widget.set_controls_enabled(enabled)

--- a/fibsem/ui/FibsemUI.py
+++ b/fibsem/ui/FibsemUI.py
@@ -38,6 +38,7 @@ from fibsem.structures import MicroscopeSettings
 from fibsem.ui.FibsemImageSettingsWidget import FibsemImageSettingsWidget
 from fibsem.ui.FibsemManipulatorWidget import FibsemManipulatorWidget
 from fibsem.ui.FibsemMovementWidget import FibsemMovementWidget
+from fibsem.ui.FibsemSampleWidget import FibsemSampleWidget
 from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.stylesheets import NAPARI_STYLE
@@ -73,6 +74,7 @@ class FibsemUI(QMainWindow):
         self.image_widget: Optional[FibsemImageSettingsWidget] = None
         self.movement_widget: Optional[FibsemMovementWidget] = None
         self.milling_widget: Optional[MillingTaskViewerWidget] = None
+        self.sample_widget: Optional[MillingTaskViewerWidget] = None
         self.manipulator_widget: Optional[FibsemManipulatorWidget] = None
         self.overview_widget: Optional[FibsemOverviewWidget] = None
 
@@ -188,6 +190,7 @@ class FibsemUI(QMainWindow):
         self.image_widget = None
         self.movement_widget = None
         self.milling_widget = None
+        self.sample_widget = None
         self.overview_widget = None
 
     # ── the widgets a connection brings with it ──────────────────────────
@@ -225,10 +228,21 @@ class FibsemUI(QMainWindow):
             else:
                 self.manipulator_widget = None
 
+            # The hardware view of the grids: the holder, and the magazine when
+            # there is one. Slot moves go through the Movement widget, the same
+            # route as a saved position, so the readout and post-move images follow.
+            self.sample_widget = FibsemSampleWidget(
+                microscope=self.microscope, parent=self
+            )
+            self.sample_widget.move_to_requested.connect(
+                self.movement_widget.move_to_position
+            )
+
             # add widgets to tabs
             self._add_control_tab(self.image_widget, "Image")
             self._add_control_tab(self.movement_widget, "Movement")
             self._add_control_tab(self.milling_widget, "Milling")
+            self._add_control_tab(self.sample_widget, "Sample")
 
             if self.microscope.system.manipulator.enabled:
                 self._add_control_tab(self.manipulator_widget, "Manipulator")
@@ -258,6 +272,7 @@ class FibsemUI(QMainWindow):
             self.movement_widget._teardown_connections()
             self.movement_widget.deleteLater()
             self.milling_widget.deleteLater()
+            self.sample_widget.deleteLater()
             if self.manipulator_widget is not None:
                 self.manipulator_widget.deleteLater()
 

--- a/fibsem/ui/widgets/preferences_dialog.py
+++ b/fibsem/ui/widgets/preferences_dialog.py
@@ -51,8 +51,6 @@ _TIP_COINCIDENCE = (
     "Enable the coincidence milling viewer for simultaneous FIB milling and FM acquisition. "
     "Restricted to ThermoFisher Arctis with the modified sample holder."
 )
-_LBL_SAMPLE_HOLDER = "Enable Sample Holder Widget"
-_TIP_SAMPLE_HOLDER = "Show the sample holder navigation widget in the main interface."
 _LBL_BUG_REPORT = "Enable Bug Reporter"
 _TIP_BUG_REPORT = (
     "Show the 'Report an Issue...' option in the Help menu, for reporting bugs and "
@@ -71,6 +69,12 @@ _TIP_CONNECTION_CHIP = (
     "File > Connect to Microscope, which opens a dialog for connecting, "
     "reconnecting and disconnecting. The Connection tab still works and is still "
     "where connecting happens; this is the header half of replacing it."
+)
+_LBL_GRID_WORKFLOW = "Enable Grid Workflow"
+_TIP_GRID_WORKFLOW = (
+    "Show the Grids tab and the Workflow tab's Grids view: inventory the grids in "
+    "the holder or autoloader, and acquire SEM, FIB and fluorescence overviews of "
+    "each. In development; the Microscope tab's Sample view is available either way."
 )
 _LBL_SCRIPTS = "Enable User Scripts"
 _TIP_SCRIPTS = (
@@ -181,8 +185,6 @@ class PreferencesDialog(QDialog):
         features_form = QFormLayout(features_page)
         self._chk_coincidence_milling = QCheckBox()
         self._chk_coincidence_milling.setToolTip(_TIP_COINCIDENCE)
-        self._chk_sample_holder = QCheckBox()
-        self._chk_sample_holder.setToolTip(_TIP_SAMPLE_HOLDER)
         self._chk_bug_report = QCheckBox()
         self._chk_bug_report.setToolTip(_TIP_BUG_REPORT)
         self._chk_scripts = QCheckBox()
@@ -192,11 +194,13 @@ class PreferencesDialog(QDialog):
         self._chk_connection_chip = QCheckBox()
         self._chk_connection_chip.setToolTip(_TIP_CONNECTION_CHIP)
         features_form.addRow(_LBL_COINCIDENCE, self._chk_coincidence_milling)
-        features_form.addRow(_LBL_SAMPLE_HOLDER, self._chk_sample_holder)
         features_form.addRow(_LBL_BUG_REPORT, self._chk_bug_report)
         features_form.addRow(_LBL_SCRIPTS, self._chk_scripts)
         features_form.addRow(_LBL_NAPARI_OVERVIEW, self._chk_napari_overview)
         features_form.addRow(_LBL_CONNECTION_CHIP, self._chk_connection_chip)
+        self._chk_grid_workflow = QCheckBox()
+        self._chk_grid_workflow.setToolTip(_TIP_GRID_WORKFLOW)
+        features_form.addRow(_LBL_GRID_WORKFLOW, self._chk_grid_workflow)
         self._stack.addWidget(features_page)
 
         # --- Experiment Defaults ---
@@ -288,12 +292,12 @@ class PreferencesDialog(QDialog):
 
         f = prefs.features
         self._chk_coincidence_milling.setChecked(f.coincidence_milling_enabled)
-        self._chk_sample_holder.setChecked(f.sample_holder_widget)
         self._chk_bug_report.setChecked(f.bug_report_enabled)
         self._chk_scripts.setChecked(f.scripts_enabled)
         self._chk_agent_server.setChecked(f.agent_server_enabled)
         self._chk_napari_overview.setChecked(f.napari_overview_tab)
         self._chk_connection_chip.setChecked(f.connection_chip)
+        self._chk_grid_workflow.setChecked(f.grid_workflow)
 
         self._spin_watchdog.setValue(prefs.agent.watchdog_minutes)
 
@@ -363,12 +367,12 @@ class PreferencesDialog(QDialog):
             ),
             features=FeatureFlags(
                 coincidence_milling_enabled=self._chk_coincidence_milling.isChecked(),
-                sample_holder_widget=self._chk_sample_holder.isChecked(),
                 bug_report_enabled=self._chk_bug_report.isChecked(),
                 scripts_enabled=self._chk_scripts.isChecked(),
                 agent_server_enabled=self._chk_agent_server.isChecked(),
                 napari_overview_tab=self._chk_napari_overview.isChecked(),
                 connection_chip=self._chk_connection_chip.isChecked(),
+                grid_workflow=self._chk_grid_workflow.isChecked(),
             ),
             movement=MovementPreferences(
                 acquire_sem_after_stage_movement=self._chk_acquire_sem.isChecked(),

--- a/fibsem/ui/widgets/sample_holder_widget.py
+++ b/fibsem/ui/widgets/sample_holder_widget.py
@@ -285,6 +285,7 @@ class SampleHolderWidget(QWidget):
         self.btn_calibrate.clicked.connect(self._on_calibrate)
 
         self.facts_label = QLabel()
+        self.facts_label.setWordWrap(True)
         self.facts_label.setStyleSheet(
             f"color: {TEXT_MUTED_COLOR}; font-size: 11px; background: transparent;"
         )
@@ -293,6 +294,9 @@ class SampleHolderWidget(QWidget):
         self._list = QListWidget()
         self._list.setStyleSheet(stylesheets.LIST_WIDGET_STYLESHEET)
         self._list.setSelectionMode(QListWidget.NoSelection)
+        # Fixed (the default) lays item widgets out once, at whatever width the
+        # list had then; a later resize or restyle leaves them clipped.
+        self._list.setResizeMode(QListWidget.Adjust)
         self._list.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self._list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self._list.setMinimumHeight(2 * _ROW_HEIGHT)

--- a/fibsem/ui/widgets/sample_loader_widget.py
+++ b/fibsem/ui/widgets/sample_loader_widget.py
@@ -23,13 +23,15 @@ from PyQt5.QtWidgets import (
     QLineEdit,
     QListWidget,
     QListWidgetItem,
-    QPushButton,
+    QMessageBox,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
 
 from fibsem.microscopes._stage import GridSlot, SampleGrid, SampleGridLoader
 from fibsem.ui import stylesheets
+from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.qt.threading import thread_worker
 from fibsem.ui.tokens import (
     ERROR_COLOR,
@@ -45,7 +47,23 @@ from fibsem.ui.widgets.sample_holder_widget import _NAME_FIELD_STYLE
 _ROW_HEIGHT = 34
 _SLOT_LABEL_WIDTH = 28
 _STATE_LABEL_WIDTH = 64
-_LOAD_BTN_WIDTH = 60
+_ICON_BTN = 26
+# An arrow into a bracket for load, out of it for unload: the grid going into,
+# and coming out of, the beam.
+ICON_LOAD = "mdi:login"
+ICON_UNLOAD = "mdi:logout"
+ICON_INVENTORY = "mdi:refresh"
+_ICON_BTN_STYLE = """
+QToolButton {
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    padding: 1px;
+}
+QToolButton:hover { background: rgba(255, 255, 255, 30); }
+QToolButton:pressed { background: rgba(255, 255, 255, 15); }
+QToolButton:disabled { background: transparent; }
+"""
 
 # A magazine slot is one of three things. `unknown` (a slot the hardware has not
 # scanned since the magazine was opened) reads as empty until an inventory says
@@ -78,6 +96,7 @@ class _MagazineRow(QWidget):
     its state, and Load."""
 
     load_clicked = pyqtSignal(object)  # GridSlot
+    unload_clicked = pyqtSignal(object)  # GridSlot
     grid_named = pyqtSignal(object, str)  # GridSlot, new name
 
     def __init__(self, slot: GridSlot, in_beam: bool, parent=None) -> None:
@@ -114,11 +133,14 @@ class _MagazineRow(QWidget):
         self.state_label.setFixedWidth(_STATE_LABEL_WIDTH)
         layout.addWidget(self.state_label)
 
-        self.btn_load = QPushButton("Load")
-        self.btn_load.setFixedWidth(_LOAD_BTN_WIDTH)
-        self.btn_load.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
-        self.btn_load.clicked.connect(lambda: self.load_clicked.emit(self.slot))
-        layout.addWidget(self.btn_load)
+        # One action, contextual: load an occupied slot's grid, unload the one in
+        # the beam. Nothing on an empty slot.
+        self.btn_action = QToolButton()
+        self.btn_action.setFixedSize(_ICON_BTN, _ICON_BTN)
+        self.btn_action.setIconSize(QSize(18, 18))
+        self.btn_action.setStyleSheet(_ICON_BTN_STYLE)
+        self.btn_action.clicked.connect(self._on_action)
+        layout.addWidget(self.btn_action)
 
         self.refresh(in_beam)
 
@@ -150,18 +172,34 @@ class _MagazineRow(QWidget):
         self.state_label.setText(_STATE_TEXT[self.state])
         self.state_label.setToolTip(_STATE_TIP[self.state])
 
-        loadable = self.state == "occupied" and controls_enabled
-        self.btn_load.setEnabled(loadable)
         if self.state == "in_beam":
-            self.btn_load.setToolTip("Already in the beam")
-        elif self.state == "empty":
-            self.btn_load.setToolTip("Nothing to load")
-        elif not controls_enabled:
-            self.btn_load.setToolTip(
-                "Not while the loader is busy or a workflow is running"
+            self.btn_action.setIcon(
+                fibsem_icon(ICON_UNLOAD, color=stylesheets.GRAY_ICON_COLOR)
+            )
+            self.btn_action.setToolTip(
+                f"Return {name} to the magazine"
+                if controls_enabled
+                else "Not while the loader is busy or a workflow is running"
             )
         else:
-            self.btn_load.setToolTip(f"Bring {name} into the beam")
+            self.btn_action.setIcon(
+                fibsem_icon(ICON_LOAD, color=stylesheets.GRAY_ICON_COLOR)
+            )
+            self.btn_action.setToolTip(
+                f"Bring {name} into the beam"
+                if self.state == "occupied" and controls_enabled
+                else "Not while the loader is busy or a workflow is running"
+                if self.state == "occupied"
+                else "Nothing to load"
+            )
+        self.btn_action.setVisible(self.state != "empty")
+        self.btn_action.setEnabled(self.state != "empty" and controls_enabled)
+
+    def _on_action(self) -> None:
+        if self.state == "in_beam":
+            self.unload_clicked.emit(self.slot)
+        elif self.state == "occupied":
+            self.load_clicked.emit(self.slot)
 
     def _on_name_edited(self) -> None:
         name = self.name_edit.text().strip()
@@ -211,17 +249,20 @@ class SampleLoaderWidget(QWidget):
         inner_layout.setContentsMargins(6, 6, 6, 6)
         inner_layout.setSpacing(6)
 
-        self.btn_inventory = QPushButton("Run inventory")
-        self.btn_inventory.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        # The scan in the title bar, as an icon, where the app keeps a panel's
+        # actions. It moves the magazine, so it asks first.
+        self.btn_inventory = QToolButton()
+        self.btn_inventory.setFixedSize(_ICON_BTN, _ICON_BTN)
+        self.btn_inventory.setIconSize(QSize(18, 18))
+        self.btn_inventory.setStyleSheet(_ICON_BTN_STYLE)
+        self.btn_inventory.setIcon(
+            fibsem_icon(ICON_INVENTORY, color=stylesheets.GRAY_ICON_COLOR)
+        )
         self.btn_inventory.setToolTip(
-            "Ask the autoloader which magazine slots hold a grid, and read their names"
+            "Run inventory: ask the autoloader which magazine slots hold a grid, "
+            "and read their names"
         )
         self.btn_inventory.clicked.connect(self._on_run_inventory)
-
-        self.btn_unload = QPushButton("Unload")
-        self.btn_unload.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
-        self.btn_unload.setToolTip("Return the grid in the beam to its magazine slot")
-        self.btn_unload.clicked.connect(self._on_unload)
 
         self.facts_label = QLabel()
         self.facts_label.setWordWrap(True)
@@ -249,7 +290,6 @@ class SampleLoaderWidget(QWidget):
 
         self._panel = TitledPanel("Loader", content=inner, collapsible=True)
         self._panel.add_header_widget(self.btn_inventory)
-        self._panel.add_header_widget(self.btn_unload)
         layout.addWidget(self._panel)
 
     # -- model -----------------------------------------------------------------
@@ -299,6 +339,7 @@ class SampleLoaderWidget(QWidget):
             )
             row.refresh(row.state == "in_beam", controls_enabled=controls)
             row.load_clicked.connect(self._on_load)
+            row.unload_clicked.connect(self._on_unload)
             row.grid_named.connect(self._on_grid_named)
             item = QListWidgetItem(self._list)
             item.setSizeHint(QSize(0, _ROW_HEIGHT))
@@ -323,7 +364,6 @@ class SampleLoaderWidget(QWidget):
     def _apply_controls(self) -> None:
         active = self._controls_enabled and not self._busy and self.loader is not None
         self.btn_inventory.setEnabled(active)
-        self.btn_unload.setEnabled(active and bool(self._in_beam_names()))
         for row in self._rows:
             row.refresh(row.state == "in_beam", controls_enabled=active)
 
@@ -348,6 +388,13 @@ class SampleLoaderWidget(QWidget):
         loader = self.loader
         if loader is None:
             return
+        if not self._confirm(
+            "Run inventory",
+            "Scan the magazine? The autoloader checks every slot for a grid and "
+            "reads the names on the slot descriptions; it takes a moment and the "
+            "magazine must not be opened while it runs.",
+        ):
+            return
 
         def job() -> None:
             self._microscope._stage.run_inventory()
@@ -366,17 +413,28 @@ class SampleLoaderWidget(QWidget):
 
         self._start(job, f"Loading {name}…", f"{name} is in the beam.")
 
-    def _on_unload(self) -> None:
+    def _on_unload(self, slot: GridSlot) -> None:
         loader = self.loader
-        if loader is None:
+        if loader is None or slot.loaded_grid is None:
             return
-        names = self._in_beam_names()
-        name = next(iter(names)) if names else "the grid"
+        name = slot.loaded_grid.name
 
         def job() -> None:
             loader.unload_grid()
 
         self._start(job, f"Unloading {name}…", f"{name} returned to the magazine.")
+
+    def _confirm(self, title: str, text: str) -> bool:
+        """Yes/No before an action that moves the loader. Answered without a
+        dialog in synchronous (test) mode."""
+        if self._synchronous:
+            return True
+        return (
+            QMessageBox.question(
+                self, title, text, QMessageBox.Yes | QMessageBox.No, QMessageBox.No
+            )
+            == QMessageBox.Yes
+        )
 
     def _start(self, job: Callable[[], None], doing: str, done: str) -> None:
         if self._busy:

--- a/fibsem/ui/widgets/sample_loader_widget.py
+++ b/fibsem/ui/widgets/sample_loader_widget.py
@@ -1,0 +1,432 @@
+"""The autoloader's magazine: every slot, what is in it, and the exchange controls.
+
+The hardware view of grids on a system with a loader. Empty and unscanned slots
+are shown here and nowhere else: the Grids tab shows the experiment's records,
+and a magazine slot with nothing in it is not one. Names typed here go to the
+autoloader's slot description through ``Stage.assign_grid``, so they survive a
+reconnect and an inventory reads them back.
+
+Every hardware call -- inventory, load, unload -- runs off the GUI thread and the
+panel repaints when it returns. Nothing here polls the loader.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Callable, List, Optional
+
+from PyQt5.QtCore import QSize, Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.microscopes._stage import GridSlot, SampleGrid, SampleGridLoader
+from fibsem.ui import stylesheets
+from fibsem.ui.qt.threading import thread_worker
+from fibsem.ui.tokens import (
+    ERROR_COLOR,
+    NEUTRAL_700,
+    OK_COLOR,
+    TEXT_COLOR,
+    TEXT_MUTED_COLOR,
+    TEXT_STRONG_COLOR,
+)
+from fibsem.ui.widgets.custom_widgets import TitledPanel, style_with_tooltip
+from fibsem.ui.widgets.sample_holder_widget import _NAME_FIELD_STYLE
+
+_ROW_HEIGHT = 34
+_SLOT_LABEL_WIDTH = 28
+_STATE_LABEL_WIDTH = 64
+_LOAD_BTN_WIDTH = 60
+
+# A magazine slot is one of three things. `unknown` (a slot the hardware has not
+# scanned since the magazine was opened) reads as empty until an inventory says
+# otherwise: the loader model does not carry the hardware's Unknown state.
+_STATE_COLOUR = {
+    "in_beam": OK_COLOR,
+    "occupied": TEXT_COLOR,
+    "empty": NEUTRAL_700,
+}
+_STATE_TEXT = {
+    "in_beam": "in beam",
+    "occupied": "occupied",
+    "empty": "empty",
+}
+_STATE_TIP = {
+    "in_beam": "This grid is in the holder's working slot right now",
+    "occupied": "A grid is in this magazine slot; Load brings it into the beam",
+    "empty": "Nothing in this magazine slot (or not scanned since the magazine was opened)",
+}
+
+
+def slot_state(slot: GridSlot, in_beam: bool) -> str:
+    if slot.loaded_grid is None:
+        return "empty"
+    return "in_beam" if in_beam else "occupied"
+
+
+class _MagazineRow(QWidget):
+    """One magazine slot: number, the grid's name (editable when there is one),
+    its state, and Load."""
+
+    load_clicked = pyqtSignal(object)  # GridSlot
+    grid_named = pyqtSignal(object, str)  # GridSlot, new name
+
+    def __init__(self, slot: GridSlot, in_beam: bool, parent=None) -> None:
+        super().__init__(parent)
+        self.slot = slot
+        self.state = "empty"
+        self.setAttribute(Qt.WA_TranslucentBackground)
+        self.setFixedHeight(_ROW_HEIGHT)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 0, 6, 0)
+        layout.setSpacing(8)
+
+        self.dot = QLabel()
+        self.dot.setFixedSize(10, 10)
+        layout.addWidget(self.dot)
+
+        self.slot_label = QLabel(f"{slot.index + 1:02d}")
+        self.slot_label.setFixedWidth(_SLOT_LABEL_WIDTH)
+        style_with_tooltip(
+            self.slot_label,
+            f"font-family: monospace; color: {TEXT_MUTED_COLOR}; background: transparent;",
+        )
+        layout.addWidget(self.slot_label)
+
+        self.name_edit = QLineEdit()
+        self.name_edit.setPlaceholderText("empty")
+        self.name_edit.setStyleSheet(_NAME_FIELD_STYLE)
+        self.name_edit.setFixedHeight(24)
+        self.name_edit.editingFinished.connect(self._on_name_edited)
+        layout.addWidget(self.name_edit, 1)
+
+        self.state_label = QLabel()
+        self.state_label.setFixedWidth(_STATE_LABEL_WIDTH)
+        layout.addWidget(self.state_label)
+
+        self.btn_load = QPushButton("Load")
+        self.btn_load.setFixedWidth(_LOAD_BTN_WIDTH)
+        self.btn_load.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.btn_load.clicked.connect(lambda: self.load_clicked.emit(self.slot))
+        layout.addWidget(self.btn_load)
+
+        self.refresh(in_beam)
+
+    def refresh(self, in_beam: bool, controls_enabled: bool = True) -> None:
+        slot = self.slot
+        self.state = slot_state(slot, in_beam)
+        grid = slot.loaded_grid
+        name = grid.name if grid is not None else ""
+        if self.name_edit.text() != name:
+            self.name_edit.setText(name)
+        # A name means a grid: only a slot with one in it can be named. Naming an
+        # empty slot would be declaring a grid the hardware says is not there.
+        self.name_edit.setReadOnly(grid is None)
+        self.name_edit.setToolTip(
+            "The grid in this slot; written to the autoloader's slot description"
+            if grid is not None
+            else _STATE_TIP["empty"]
+        )
+        style_with_tooltip(
+            self.dot,
+            f"background: {_STATE_COLOUR[self.state]}; border-radius: 5px;",
+        )
+        self.dot.setToolTip(_STATE_TIP[self.state])
+        colour = TEXT_STRONG_COLOR if self.state == "in_beam" else TEXT_MUTED_COLOR
+        style_with_tooltip(
+            self.state_label,
+            f"color: {colour}; font-size: 11px; background: transparent;",
+        )
+        self.state_label.setText(_STATE_TEXT[self.state])
+        self.state_label.setToolTip(_STATE_TIP[self.state])
+
+        loadable = self.state == "occupied" and controls_enabled
+        self.btn_load.setEnabled(loadable)
+        if self.state == "in_beam":
+            self.btn_load.setToolTip("Already in the beam")
+        elif self.state == "empty":
+            self.btn_load.setToolTip("Nothing to load")
+        elif not controls_enabled:
+            self.btn_load.setToolTip(
+                "Not while the loader is busy or a workflow is running"
+            )
+        else:
+            self.btn_load.setToolTip(f"Bring {name} into the beam")
+
+    def _on_name_edited(self) -> None:
+        name = self.name_edit.text().strip()
+        current = self.slot.loaded_grid.name if self.slot.loaded_grid else ""
+        if name and name != current:
+            self.grid_named.emit(self.slot, name)
+        elif not name:
+            # A grid cannot be un-named; put the name back.
+            self.name_edit.setText(current)
+
+
+class SampleLoaderWidget(QWidget):
+    """The magazine, Run inventory, Load per slot, Unload.
+
+    ``loader_changed`` fires after any of those finish, whether or not they
+    succeeded, so a host drawing the holder's working slot repaints. ``busy_changed``
+    tracks an exchange or scan in flight. ``set_controls_enabled(False)`` is the
+    host's lockout while a workflow owns the loader.
+
+    ``synchronous`` runs the hardware calls on the calling thread, for tests.
+    """
+
+    loader_changed = pyqtSignal()
+    busy_changed = pyqtSignal(bool)
+
+    def __init__(self, microscope=None, parent=None, synchronous: bool = False):
+        super().__init__(parent)
+        self._microscope = microscope
+        self._synchronous = synchronous
+        self._rows: List[_MagazineRow] = []
+        self._busy = False
+        self._controls_enabled = True
+        self._scanned_at: Optional[datetime] = None
+        self._worker = None
+        self._setup_ui()
+        self.refresh()
+
+    # -- layout ----------------------------------------------------------------
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        inner = QWidget()
+        inner_layout = QVBoxLayout(inner)
+        inner_layout.setContentsMargins(6, 6, 6, 6)
+        inner_layout.setSpacing(6)
+
+        self.btn_inventory = QPushButton("Run inventory")
+        self.btn_inventory.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.btn_inventory.setToolTip(
+            "Ask the autoloader which magazine slots hold a grid, and read their names"
+        )
+        self.btn_inventory.clicked.connect(self._on_run_inventory)
+
+        self.btn_unload = QPushButton("Unload")
+        self.btn_unload.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.btn_unload.setToolTip("Return the grid in the beam to its magazine slot")
+        self.btn_unload.clicked.connect(self._on_unload)
+
+        self.facts_label = QLabel()
+        self.facts_label.setWordWrap(True)
+        self.facts_label.setStyleSheet(
+            f"color: {TEXT_MUTED_COLOR}; font-size: 11px; background: transparent;"
+        )
+        inner_layout.addWidget(self.facts_label)
+
+        self._list = QListWidget()
+        self._list.setStyleSheet(stylesheets.LIST_WIDGET_STYLESHEET)
+        self._list.setSelectionMode(QListWidget.NoSelection)
+        # Fixed (the default) lays item widgets out once, at whatever width the
+        # list had then; a later resize or restyle leaves them clipped.
+        self._list.setResizeMode(QListWidget.Adjust)
+        self._list.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self._list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        inner_layout.addWidget(self._list)
+
+        self.status_label = QLabel()
+        self.status_label.setWordWrap(True)
+        self.status_label.setStyleSheet(
+            f"color: {TEXT_MUTED_COLOR}; font-size: 11px; background: transparent;"
+        )
+        inner_layout.addWidget(self.status_label)
+
+        self._panel = TitledPanel("Loader", content=inner, collapsible=True)
+        self._panel.add_header_widget(self.btn_inventory)
+        self._panel.add_header_widget(self.btn_unload)
+        layout.addWidget(self._panel)
+
+    # -- model -----------------------------------------------------------------
+
+    @property
+    def loader(self) -> Optional[SampleGridLoader]:
+        stage = getattr(self._microscope, "_stage", None)
+        return getattr(stage, "loader", None)
+
+    @property
+    def busy(self) -> bool:
+        return self._busy
+
+    def _in_beam_names(self) -> set:
+        loader = self.loader
+        if loader is None:
+            return set()
+        return {s.loaded_grid.name for s in loader.holder.occupied_slots}  # type: ignore[union-attr]
+
+    def refresh(self) -> None:
+        loader = self.loader
+        self._list.clear()
+        self._rows = []
+        self.setEnabled(loader is not None)
+        if loader is None:
+            self.facts_label.setText("No autoloader on this system.")
+            return
+
+        in_beam = self._in_beam_names()
+        slots = sorted(loader.slots.values(), key=lambda s: s.index)
+        occupied = sum(1 for s in slots if s.loaded_grid is not None)
+        scanned = (
+            f"scanned {self._scanned_at.strftime('%H:%M')}"
+            if self._scanned_at is not None
+            else "not scanned this session"
+        )
+        plural = "" if occupied == 1 else "s"
+        self.facts_label.setText(
+            f"Magazine · {len(slots)} slots · {occupied} grid{plural} · {scanned}"
+        )
+
+        controls = self._controls_enabled and not self._busy
+        for slot in slots:
+            row = _MagazineRow(
+                slot,
+                in_beam=bool(slot.loaded_grid) and slot.loaded_grid.name in in_beam,
+            )
+            row.refresh(row.state == "in_beam", controls_enabled=controls)
+            row.load_clicked.connect(self._on_load)
+            row.grid_named.connect(self._on_grid_named)
+            item = QListWidgetItem(self._list)
+            item.setSizeHint(QSize(0, _ROW_HEIGHT))
+            item.setFlags(Qt.ItemFlag.ItemIsEnabled)
+            self._list.addItem(item)
+            self._list.setItemWidget(item, row)
+            self._rows.append(row)
+        self._list.setFixedHeight(
+            max(2, len(slots)) * _ROW_HEIGHT + 2 * self._list.frameWidth()
+        )
+        self._apply_controls()
+
+    def _row_widget(self, i: int) -> Optional[_MagazineRow]:
+        return self._rows[i] if 0 <= i < len(self._rows) else None
+
+    def set_controls_enabled(self, enabled: bool) -> None:
+        """The host's lockout: nothing here may touch the loader while a workflow
+        owns it. Names stay editable; they are not hardware motion."""
+        self._controls_enabled = enabled
+        self._apply_controls()
+
+    def _apply_controls(self) -> None:
+        active = self._controls_enabled and not self._busy and self.loader is not None
+        self.btn_inventory.setEnabled(active)
+        self.btn_unload.setEnabled(active and bool(self._in_beam_names()))
+        for row in self._rows:
+            row.refresh(row.state == "in_beam", controls_enabled=active)
+
+    # -- edits -----------------------------------------------------------------
+
+    def _on_grid_named(self, slot: GridSlot, name: str) -> None:
+        grid = slot.loaded_grid
+        if grid is None or self._microscope is None:
+            return
+        grid = SampleGrid(name=name, description=grid.description, radius=grid.radius)
+        try:
+            self._microscope._stage.assign_grid(slot.name, grid)
+        except Exception as e:  # noqa: BLE001 - keep the in-memory change, say so
+            logging.warning(f"Could not write the name of {slot.name}: {e}")
+            slot.loaded_grid = grid
+        self.refresh()
+        self.loader_changed.emit()
+
+    # -- hardware, off the GUI thread --------------------------------------------
+
+    def _on_run_inventory(self) -> None:
+        loader = self.loader
+        if loader is None:
+            return
+
+        def job() -> None:
+            self._microscope._stage.run_inventory()
+            self._scanned_at = datetime.now()
+
+        self._start(job, "Scanning the magazine…", "Inventory complete.")
+
+    def _on_load(self, slot: GridSlot) -> None:
+        loader = self.loader
+        if loader is None or slot.loaded_grid is None:
+            return
+        name = slot.loaded_grid.name
+
+        def job() -> None:
+            loader.load_grid(slot.name)
+
+        self._start(job, f"Loading {name}…", f"{name} is in the beam.")
+
+    def _on_unload(self) -> None:
+        loader = self.loader
+        if loader is None:
+            return
+        names = self._in_beam_names()
+        name = next(iter(names)) if names else "the grid"
+
+        def job() -> None:
+            loader.unload_grid()
+
+        self._start(job, f"Unloading {name}…", f"{name} returned to the magazine.")
+
+    def _start(self, job: Callable[[], None], doing: str, done: str) -> None:
+        if self._busy:
+            return
+        self._set_busy(True)
+        self._say(doing)
+        self._done_text = done
+        if self._synchronous:
+            try:
+                job()
+                self._on_returned()
+            except Exception as e:  # noqa: BLE001 - reported on the panel
+                self._on_errored(e)
+            finally:
+                self._on_finished()
+            return
+        worker = self._job_worker(job)
+        worker.returned.connect(self._on_returned)
+        worker.errored.connect(self._on_errored)
+        worker.finished.connect(self._on_finished)
+        self._worker = worker  # keep it alive; only signals cross back
+        worker.start()
+
+    @thread_worker
+    def _job_worker(self, job: Callable[[], None]) -> None:
+        job()
+
+    def _on_returned(self, _result: object = None) -> None:
+        self._say(self._done_text)
+
+    def _on_errored(self, error: Exception) -> None:
+        logging.warning(f"Autoloader operation failed: {error}")
+        self._say(str(error), error=True)
+
+    def _on_finished(self) -> None:
+        self._worker = None
+        self._set_busy(False)
+        self.refresh()
+        self.loader_changed.emit()
+
+    def _set_busy(self, busy: bool) -> None:
+        if busy == self._busy:
+            return
+        self._busy = busy
+        self._apply_controls()
+        self.busy_changed.emit(busy)
+
+    def _say(self, text: str, error: bool = False) -> None:
+        colour = ERROR_COLOR if error else TEXT_MUTED_COLOR
+        self.status_label.setStyleSheet(
+            f"color: {colour}; font-size: 11px; background: transparent;"
+        )
+        self.status_label.setText(text)

--- a/tests/ui/test_overview_tab_wiring.py
+++ b/tests/ui/test_overview_tab_wiring.py
@@ -305,9 +305,8 @@ def test_the_flag_exists_and_is_off_by_default():
 def test_the_flag_survives_a_preferences_round_trip(tmp_path):
     """A flag that does not persist cannot be turned on by the person who wants it back.
 
-    Through `to_dict`/`from_dict` rather than through `apply_feature_flags`, which does
-    not carry this one — saving and reloading is what the preferences dialog actually
-    does, and it is the step that would silently drop an unknown field.
+    Through `to_dict`/`from_dict`: saving and reloading is what the preferences dialog
+    actually does, and it is the step that would silently drop an unknown field.
     """
     import fibsem.config as fibsem_cfg
 

--- a/tests/ui/test_sample_control_tab.py
+++ b/tests/ui/test_sample_control_tab.py
@@ -1,0 +1,52 @@
+"""The Sample control tab comes and goes with the connection, like the others."""
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+
+@pytest.fixture
+def main_ui(qapp):
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
+    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
+    try:
+        window = module.AutoLamellaSingleWindowUI()
+    finally:
+        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    yield window
+    if window.autolamella_ui.microscope is not None:
+        window.autolamella_ui.microscope.disconnect()
+    # closeEvent ends in app.quit(); on the shared test QApplication that latches
+    # an interrupt. Run the real close cleanup with quit stubbed out.
+    original_quit = qapp.quit
+    qapp.quit = lambda: None
+    try:
+        window.close()
+    finally:
+        qapp.quit = original_quit
+
+
+def _tab_labels(ui):
+    tabs = ui.tabWidget
+    return [tabs.tabText(i) for i in range(tabs.count())]
+
+
+def test_the_sample_tab_lives_for_the_connection(main_ui):
+    ui = main_ui.autolamella_ui
+    assert "Sample" not in _tab_labels(ui)
+    assert ui.sample_widget is None
+
+    ui.system_widget.connect_to_microscope()
+    labels = _tab_labels(ui)
+    assert labels[labels.index("Milling") + 1] == "Sample"
+    assert ui.sample_widget.holder_widget.current_holder is ui.microscope._stage.holder
+    # the holder panel left the Movement sub-tab for good
+    assert not hasattr(ui.movement_widget, "sample_holder_widget")
+
+    ui.microscope.disconnect()
+    ui.microscope = None
+    ui.update_microscope_ui()
+    assert "Sample" not in _tab_labels(ui)
+    assert ui.sample_widget is None

--- a/tests/ui/test_sample_loader_widget.py
+++ b/tests/ui/test_sample_loader_widget.py
@@ -1,0 +1,137 @@
+"""The magazine panel on the Arctis simulator, and the Sample view that holds it."""
+
+import os
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.ui.FibsemSampleWidget import FibsemSampleWidget
+from fibsem.ui.widgets.sample_loader_widget import SampleLoaderWidget
+
+
+@pytest.fixture
+def arctis():
+    microscope, _ = utils.setup_session(
+        manufacturer="Demo",
+        config_path=os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml"),
+    )
+    assert microscope._stage.loader is not None
+    return microscope
+
+
+@pytest.fixture
+def widget(qapp, arctis):
+    return SampleLoaderWidget(microscope=arctis, synchronous=True)
+
+
+def states(widget):
+    return [r.state for r in widget._rows]
+
+
+def test_every_magazine_slot_has_a_row(widget):
+    assert len(widget._rows) == 12
+    assert states(widget)[:4] == ["occupied", "occupied", "occupied", "empty"]
+    assert "12 slots · 3 grids · not scanned this session" in widget.facts_label.text()
+    first, empty = widget._row_widget(0), widget._row_widget(3)
+    assert first.slot_label.text() == "01" and first.name_edit.text() == "Grid-01"
+    assert first.btn_load.isEnabled()
+    assert not first.name_edit.isReadOnly()
+    assert empty.name_edit.text() == "" and empty.name_edit.isReadOnly()
+    assert not empty.btn_load.isEnabled()
+    assert not widget.btn_unload.isEnabled()  # nothing in the beam yet
+
+
+def test_load_brings_the_grid_into_the_beam(widget, arctis):
+    changed = []
+    widget.loader_changed.connect(lambda: changed.append(True))
+    widget._row_widget(1).btn_load.click()
+    assert arctis._stage.loaded_grids[0].name == "Grid-02"
+    assert states(widget)[:3] == ["occupied", "in_beam", "occupied"]
+    assert not widget._row_widget(1).btn_load.isEnabled()
+    assert widget.btn_unload.isEnabled()
+    assert widget.status_label.text() == "Grid-02 is in the beam."
+    assert changed == [True]
+    assert not widget.busy
+
+
+def test_unload_returns_it(widget, arctis):
+    widget._row_widget(0).btn_load.click()
+    widget.btn_unload.click()
+    assert arctis._stage.loaded_grids == []
+    assert states(widget)[0] == "occupied"
+    assert "returned to the magazine" in widget.status_label.text()
+
+
+def test_run_inventory_stamps_the_scan(widget):
+    widget.btn_inventory.click()
+    assert "scanned " in widget.facts_label.text()
+    assert widget.status_label.text() == "Inventory complete."
+
+
+def test_a_refused_exchange_is_reported_and_the_controls_come_back(widget, arctis):
+    arctis._stage.loader.fail_next_exchange = True
+    widget._row_widget(0).btn_load.click()
+    assert arctis._stage.loaded_grids == []
+    assert "Simulated autoloader exchange failure" in widget.status_label.text()
+    assert widget._row_widget(0).btn_load.isEnabled()
+    assert not widget.busy
+
+
+def test_naming_a_grid_goes_through_the_stage(widget, arctis, monkeypatch):
+    written = []
+    monkeypatch.setattr(
+        arctis._stage.loader,
+        "_write_slot_description",
+        lambda slot: written.append((slot.name, slot.loaded_grid.name)),
+    )
+    row = widget._row_widget(2)
+    row.name_edit.setText("grid-cedar")
+    row.name_edit.editingFinished.emit()
+    assert written == [("Slot-03", "grid-cedar")]
+    assert arctis._stage.loader.slots["Slot-03"].loaded_grid.name == "grid-cedar"
+    assert widget._row_widget(2).name_edit.text() == "grid-cedar"
+
+
+def test_a_grid_cannot_be_unnamed(widget, arctis):
+    row = widget._row_widget(0)
+    row.name_edit.setText("")
+    row.name_edit.editingFinished.emit()
+    assert row.name_edit.text() == "Grid-01"
+    assert arctis._stage.loader.slots["Slot-01"].loaded_grid.name == "Grid-01"
+
+
+def test_the_host_can_lock_the_exchange_controls(widget):
+    widget.set_controls_enabled(False)
+    assert not widget.btn_inventory.isEnabled()
+    assert not widget._row_widget(0).btn_load.isEnabled()
+    assert "workflow" in widget._row_widget(0).btn_load.toolTip()
+    widget.set_controls_enabled(True)
+    assert widget._row_widget(0).btn_load.isEnabled()
+
+
+class TestSampleView:
+    def test_has_the_loader_only_when_there_is_one(self, qapp, arctis):
+        view = FibsemSampleWidget(microscope=arctis)
+        assert view.loader_widget is not None
+        assert view.holder_widget.current_holder is arctis._stage.holder
+
+        plain, _ = utils.setup_session(manufacturer="Demo")
+        assert FibsemSampleWidget(microscope=plain).loader_widget is None
+
+    def test_an_exchange_repaints_the_holder(self, qapp, arctis):
+        view = FibsemSampleWidget(microscope=arctis)
+        view.loader_widget._synchronous = True
+        view.loader_widget._row_widget(0).btn_load.click()
+        assert view.holder_widget._row_widget(0).name_edit.text() == "Grid-01"
+
+    def test_move_requests_pass_through(self, qapp, arctis):
+        view = FibsemSampleWidget(microscope=arctis)
+        received = []
+        view.move_to_requested.connect(received.append)
+        view.holder_widget._row_widget(0).btn_move.click()
+        assert (
+            len(received) == 1
+        )  # the compustage working slot is calibrated by construction

--- a/tests/ui/test_sample_loader_widget.py
+++ b/tests/ui/test_sample_loader_widget.py
@@ -37,35 +37,46 @@ def test_every_magazine_slot_has_a_row(widget):
     assert "12 slots · 3 grids · not scanned this session" in widget.facts_label.text()
     first, empty = widget._row_widget(0), widget._row_widget(3)
     assert first.slot_label.text() == "01" and first.name_edit.text() == "Grid-01"
-    assert first.btn_load.isEnabled()
+    assert (
+        first.btn_action.isEnabled() and "into the beam" in first.btn_action.toolTip()
+    )
     assert not first.name_edit.isReadOnly()
     assert empty.name_edit.text() == "" and empty.name_edit.isReadOnly()
-    assert not empty.btn_load.isEnabled()
-    assert not widget.btn_unload.isEnabled()  # nothing in the beam yet
+    assert not empty.btn_action.isEnabled()  # nothing to load, and no button shown
 
 
 def test_load_brings_the_grid_into_the_beam(widget, arctis):
     changed = []
     widget.loader_changed.connect(lambda: changed.append(True))
-    widget._row_widget(1).btn_load.click()
+    widget._row_widget(1).btn_action.click()
     assert arctis._stage.loaded_grids[0].name == "Grid-02"
     assert states(widget)[:3] == ["occupied", "in_beam", "occupied"]
-    assert not widget._row_widget(1).btn_load.isEnabled()
-    assert widget.btn_unload.isEnabled()
+    # the loaded row's action turns into Unload; the others still offer Load
+    assert "Return Grid-02" in widget._row_widget(1).btn_action.toolTip()
+    assert "into the beam" in widget._row_widget(0).btn_action.toolTip()
     assert widget.status_label.text() == "Grid-02 is in the beam."
     assert changed == [True]
     assert not widget.busy
 
 
 def test_unload_returns_it(widget, arctis):
-    widget._row_widget(0).btn_load.click()
-    widget.btn_unload.click()
+    widget._row_widget(0).btn_action.click()
+    widget._row_widget(0).btn_action.click()  # now the unload action
     assert arctis._stage.loaded_grids == []
     assert states(widget)[0] == "occupied"
     assert "returned to the magazine" in widget.status_label.text()
 
 
-def test_run_inventory_stamps_the_scan(widget):
+def test_run_inventory_asks_first_then_stamps_the_scan(widget, monkeypatch):
+    asked = []
+    widget._synchronous = False  # so the confirmation is consulted...
+    monkeypatch.setattr(
+        widget, "_confirm", lambda title, text: asked.append(title) or False
+    )
+    widget.btn_inventory.click()
+    assert asked == ["Run inventory"] and "not scanned" in widget.facts_label.text()
+    monkeypatch.undo()
+    widget._synchronous = True  # ...and answered yes without a dialog
     widget.btn_inventory.click()
     assert "scanned " in widget.facts_label.text()
     assert widget.status_label.text() == "Inventory complete."
@@ -73,10 +84,10 @@ def test_run_inventory_stamps_the_scan(widget):
 
 def test_a_refused_exchange_is_reported_and_the_controls_come_back(widget, arctis):
     arctis._stage.loader.fail_next_exchange = True
-    widget._row_widget(0).btn_load.click()
+    widget._row_widget(0).btn_action.click()
     assert arctis._stage.loaded_grids == []
     assert "Simulated autoloader exchange failure" in widget.status_label.text()
-    assert widget._row_widget(0).btn_load.isEnabled()
+    assert widget._row_widget(0).btn_action.isEnabled()
     assert not widget.busy
 
 
@@ -106,10 +117,10 @@ def test_a_grid_cannot_be_unnamed(widget, arctis):
 def test_the_host_can_lock_the_exchange_controls(widget):
     widget.set_controls_enabled(False)
     assert not widget.btn_inventory.isEnabled()
-    assert not widget._row_widget(0).btn_load.isEnabled()
-    assert "workflow" in widget._row_widget(0).btn_load.toolTip()
+    assert not widget._row_widget(0).btn_action.isEnabled()
+    assert "workflow" in widget._row_widget(0).btn_action.toolTip()
     widget.set_controls_enabled(True)
-    assert widget._row_widget(0).btn_load.isEnabled()
+    assert widget._row_widget(0).btn_action.isEnabled()
 
 
 class TestSampleView:
@@ -124,7 +135,7 @@ class TestSampleView:
     def test_an_exchange_repaints_the_holder(self, qapp, arctis):
         view = FibsemSampleWidget(microscope=arctis)
         view.loader_widget._synchronous = True
-        view.loader_widget._row_widget(0).btn_load.click()
+        view.loader_widget._row_widget(0).btn_action.click()
         assert view.holder_widget._row_widget(0).name_edit.text() == "Grid-01"
 
     def test_move_requests_pass_through(self, qapp, arctis):

--- a/tests/ui/test_scripts_feature_flag.py
+++ b/tests/ui/test_scripts_feature_flag.py
@@ -19,6 +19,7 @@ from fibsem.ui.widgets.preferences_dialog import PreferencesDialog  # noqa: E402
 @pytest.fixture
 def qapp():
     from PyQt5.QtWidgets import QApplication
+
     yield QApplication.instance() or QApplication([])
 
 
@@ -53,6 +54,7 @@ def prefs_file(tmp_path, monkeypatch):
 
 # ── the default ──────────────────────────────────────────────────────────────
 
+
 def test_scripts_are_off_by_default():
     assert cfg.FeatureFlags().scripts_enabled is False
 
@@ -76,6 +78,7 @@ def test_scripts_stay_off_for_a_file_that_predates_the_flag(prefs_file):
 
 # ── persistence ──────────────────────────────────────────────────────────────
 
+
 def test_the_flag_round_trips(prefs_file):
     prefs = cfg.load_user_preferences()
     prefs.features.scripts_enabled = True
@@ -86,17 +89,18 @@ def test_the_flag_round_trips(prefs_file):
 
 def test_enabling_scripts_leaves_the_other_flags_alone(prefs_file):
     prefs = cfg.load_user_preferences()
-    prefs.features.sample_holder_widget = True
+    prefs.features.grid_workflow = True
     prefs.features.scripts_enabled = True
     cfg.save_user_preferences(prefs)
 
     reloaded = cfg.load_user_preferences().features
 
-    assert (reloaded.scripts_enabled, reloaded.sample_holder_widget) == (True, True)
+    assert (reloaded.scripts_enabled, reloaded.grid_workflow) == (True, True)
     assert reloaded.coincidence_milling_enabled is False
 
 
 # ── the Preferences dialog ───────────────────────────────────────────────────
+
 
 def test_the_dialog_shows_the_current_value(qapp):
     prefs = cfg.UserPreferences()


### PR DESCRIPTION
Milestone 5, first PR: the hardware view of the grids, and the flag the rest of the milestone hides behind. Stacked on #740. Two commits, read separately.

## Microscope → Sample (FIB-897)

A `Sample` sub-tab beside Image, Movement and Milling, on every machine:

- **Holder**: the redesigned holder panel from #729, moved here out of the Movement sub-tab. Slot moves still route through the Movement widget, so the readout and post-move images follow.
- **Loader**, only when the system has an autoloader: every magazine slot with a state dot and word (*occupied*, *in beam*, *empty*), the grid's name editable inline and written to the autoloader slot description through `Stage.assign_grid`, one contextual icon per row (load an occupied slot's grid, unload the one in the beam, nothing on an empty slot), a refresh icon in the title bar for **Run inventory** that confirms before it scans, and a facts line (slots, grids, when last scanned). Empty slots appear here and nowhere else; the Grids tab shows the experiment's records.
- Every hardware call runs off the GUI thread and the panel repaints when it returns; nothing polls. While one is in flight the controls lock and the status line says what is happening; a refused exchange (the Demo loader's `fail_next_exchange`) is reported on the panel and the controls come back. `set_controls_enabled(False)` is the host's lockout for when a workflow owns the loader (milestone 5's run view uses it).

A rendering fix that both slot lists needed: `QListView`'s default `Fixed` resize mode lays item widgets out once, at whatever width the list had then, so a restyle after construction left the right-hand column (Move, or state + Load) clipped. Both lists are `Adjust` now.

## The flag (FIB-892)

`features.grid_workflow`, off by default, in Preferences → Features. It will gate the Grids tab and the Workflow tab's Grids view in the following PRs; the backend beneath them is not gated, and neither is this Sample view, which reads as uncalibrated until the wizard has run and is safe to show everyone.

`features.sample_holder_widget` retires with the Movement placement it gated, along with `apply_feature_flags` and the last `FEATURE_*` global, whose only reader was that placement. A saved preferences file that still names the old key loads fine; unknown keys are ignored.

## Files

13 files, over the usual target: the new panel and its host are three, the tab wiring in the AutoLamella window and the standalone FibsemUI two, the flag retirement touches config, the Preferences dialog and the main window, and the rest are tests.

**Tests**: the magazine panel on the Arctis simulator (rows and states, load, unload, inventory, a refused exchange, naming through the stage, the lockout), the Sample view with and without a loader, and the tab coming and going with the connection in the real main window. Preferences, flag and holder suites pass; 107 across the touched areas.
