### PR TITLE
[autolamella] Grids tab: a card per grid record, behind the grid_workflow flag

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -56,6 +56,7 @@ from fibsem.applications.autolamella.ui.autolamella_task_config_editor import (
     AutoLamellaProtocolTaskConfigEditor,
 )
 from fibsem.applications.autolamella.ui.AutoLamellaUI import INSTRUCTIONS, AutoLamellaUI
+from fibsem.applications.autolamella.ui.grids_tab_widget import GridsTabWidget
 from fibsem.applications.autolamella.ui.lamella_card_widget import LamellaCardContainer
 from fibsem.applications.autolamella.ui.lamella_task_image_widget import (
     LamellaTaskImageWidget,
@@ -993,6 +994,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # ships to everyone, and which of its modalities can be reached follows the
         # instrument rather than a flag.
         self._apply_napari_overview_visibility()
+        self._apply_grid_workflow_visibility()
         # Toggle Tools -> Scripts. Hiding the menu hides the whole feature: it is the
         # only route to the manager dialog, and the dialog is the only thing that runs
         # a script. If a script is mid-run, leave it visible -- taking away the only
@@ -1663,6 +1665,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if message and self.status_bar is not None:
             self.status_bar.showMessage(message)
         self._set_minimap_workflow_enabled(False)
+        # A run owns the loader: no manual exchange from the Grids tab meanwhile.
+        if getattr(self, "grids_tab", None) is not None:
+            self.grids_tab.set_controls_enabled(False)
         # A live run is exactly when there is a queue to edit, so the actions come
         # on with it — and go off again in hide_workflow_running.
         if hasattr(self, "workflow_timeline"):
@@ -2148,6 +2153,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.add_overview_tab()
         self.add_protocol_editor_tab()
         self.add_lamella_editor_tab()
+        self.add_grids_tab()
         self.add_workflow_tab()
 
         # add notification button to tab bar
@@ -2166,6 +2172,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.beam_overview_tab.refresh_experiment()
         self.task_widget.set_experiment(self.autolamella_ui.experiment)
         self.lamella_widget.set_experiment()
+        self.grids_tab.set_experiment(self.autolamella_ui.experiment)
         experiment = self.autolamella_ui.experiment
         if experiment is not None and experiment.task_protocol is not None:
             self.lamella_workflow_widget.set_experiment(experiment)
@@ -2521,6 +2528,44 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.tab_widget.setTabToolTip(index, "Add lamella positions to enable this tab")
 
         self._on_lamella_card_selected(None)
+
+    def add_grids_tab(self):
+        """The Grids tab, between Lamella and Workflow: the experiment's grid records.
+
+        Behind `features.grid_workflow` (visibility only, like the old Minimap tab)
+        until the screening flow has run on the Arctis and a fixed holder.
+        """
+        self.grids_tab = GridsTabWidget()
+        # Fires on disconnect too, with microscope None; the tab redraws its chips
+        # from whatever stage there is.
+        self.autolamella_ui.system_widget.connected_signal.connect(
+            self._refresh_grids_tab_microscope
+        )
+        self.tab_widget.addTab(
+            self.grids_tab,
+            fibsem_icon("mdi:view-grid-outline", color=GRAY_ICON_COLOR),
+            "Grids",
+        )
+        self.tab_widget.setTabEnabled(self.tab_widget.indexOf(self.grids_tab), False)
+        self._apply_grid_workflow_visibility()
+
+    def _refresh_grids_tab_microscope(self):
+        if getattr(self, "grids_tab", None) is None or self.autolamella_ui is None:
+            return
+        self.grids_tab.set_microscope(self.autolamella_ui.microscope)
+
+    def _apply_grid_workflow_visibility(self) -> None:
+        """`features.grid_workflow` shows or hides the Grids tab.
+
+        Read straight off `self._preferences`, like the Minimap flag: a method on
+        the window that owns them needs no module global.
+        """
+        tab = getattr(self, "grids_tab", None)
+        if tab is None:
+            return
+        self.tab_widget.setTabVisible(
+            self.tab_widget.indexOf(tab), self._preferences.features.grid_workflow
+        )
 
     def add_workflow_tab(self):
         """Add the workflow tab with the combined lamella + workflow widget."""
@@ -3294,6 +3339,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.workflow_timeline.clear_steps()
         self.hide_workflow_running()
         self.lamella_widget.set_active_lamella_name(None)
+        if getattr(self, "grids_tab", None) is not None:
+            self.grids_tab.set_controls_enabled(True)
         self.user_attention_btn.hide()
         self.lamella_list_widget.refresh_all()
         self.lamella_card_container.refresh_all()
@@ -3349,6 +3396,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # disable the tab by default
         self.tab_widget.setTabEnabled(self.tab_widget.indexOf(container), False)
         self._apply_napari_overview_visibility()
+        self._apply_grid_workflow_visibility()
 
     def add_overview_tab(self):
         """Reserve the Overview tab: both modalities, one tab.

--- a/fibsem/applications/autolamella/ui/grid_card_widget.py
+++ b/fibsem/applications/autolamella/ui/grid_card_widget.py
@@ -1,0 +1,583 @@
+"""A card per grid record: the experiment's view of a grid.
+
+The same card as a lamella's, so the two tabs read alike: a thumbnail, the name
+over a status line, a small icon for the person's verdict, and an actions menu.
+What the hardware says (in the beam, or gone from the magazine) is a chip. The
+card's object is the ``GridRecord``, not a hardware slot: the inventory entry
+arrives on every refresh and is only drawn.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import OrderedDict
+from typing import Dict, List, Optional, Tuple
+
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtGui import QImage, QPixmap
+from PyQt5.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QMenu,
+    QMessageBox,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskStatus,
+    Experiment,
+    GridQuality,
+    GridRecord,
+)
+from fibsem.applications.autolamella.task_outputs import latest_grid_output
+from fibsem.config import CARD_MODES, MODE_COMPACT, MODE_COZY, MODE_STANDARD
+from fibsem.microscopes._stage import GridInventoryEntry
+from fibsem.ui import stylesheets
+from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.tokens import (
+    ACCENT_COLOR,
+    ERROR_COLOR,
+    NEUTRAL_200,
+    NEUTRAL_550,
+    NEUTRAL_700,
+    NEUTRAL_900,
+    OK_COLOR,
+    PRIMARY_COLOR,
+    SURFACE_COLOR,
+)
+from fibsem.ui.widgets.custom_widgets import ElidedLabel, chip
+from fibsem.ui.widgets.sample_loader_widget import ICON_LOAD, ICON_UNLOAD
+
+_CARD_WIDTH = 300
+_THUMB_PADDING = 6
+# The lamella card's sizes, so the two strips line up: a small thumbnail beside
+# the name in the standard row, a big one above it in the cozy tile.
+_THUMB_W, _THUMB_H = 66, 44
+_COZY_THUMB_W = _CARD_WIDTH - 8 - _THUMB_PADDING * 2
+_COZY_THUMB_H = 170
+_BTN_SIZE = 24
+# The load step's history entry, as the grid manager writes it.
+_LOAD_ENTRY_NAME = "load"
+# Which overview a card shows, in order of preference.
+_THUMBNAIL_ROLES = (
+    "overview_sem_thumbnail",
+    "overview_fib_thumbnail",
+    "overview_fm_thumbnail",
+)
+
+_CARD_STYLE = f"""
+QFrame#GridCard {{
+    background: {SURFACE_COLOR};
+    border: 1px solid #3a3d42;
+    border-radius: 8px;
+}}
+"""
+_CARD_SELECTED_STYLE = f"""
+QFrame#GridCard {{
+    background: {SURFACE_COLOR};
+    border: 2px solid {PRIMARY_COLOR};
+    border-radius: 8px;
+}}
+"""
+_BTN_STYLE = """
+QToolButton {
+    background: transparent;
+    border: none;
+    border-radius: 4px;
+    padding: 1px;
+}
+QToolButton:hover { background: rgba(255, 255, 255, 30); }
+QToolButton:pressed { background: rgba(255, 255, 255, 15); }
+QToolButton::menu-indicator { image: none; }
+"""
+
+_QUALITY_ICON = {
+    GridQuality.UNASSESSED: ("mdi:help-circle-outline", NEUTRAL_550, "Unassessed"),
+    GridQuality.GOOD: ("mdi:check-circle", stylesheets.GREEN_COLOR, "Good"),
+    GridQuality.POOR: ("mdi:close-circle", stylesheets.DEFECT_RED_COLOR, "Poor"),
+}
+
+
+def grid_headline(grid: GridRecord) -> Tuple[str, str]:
+    """One line on how the grid's last run went, and its colour.
+
+    Read off the history, never off the quality: whether the tasks ran is a
+    different question from whether the grid is any good. The most recent load
+    entry starts the run being described; task entries after it are the run.
+    """
+    state = grid.task_state
+    if state.status is AutoLamellaTaskStatus.InProgress:
+        return f"Running {state.name}", ACCENT_COLOR
+    history = grid.task_history
+    if not history:
+        return "Not run", NEUTRAL_550
+    start = 0
+    for i in range(len(history) - 1, -1, -1):
+        if history[i].name == _LOAD_ENTRY_NAME:
+            start = i
+            break
+    load = history[start] if history[start].name == _LOAD_ENTRY_NAME else None
+    tasks = [t for t in history[start:] if t.name != _LOAD_ENTRY_NAME]
+    if load is not None and load.status is AutoLamellaTaskStatus.Failed:
+        return "Load failed", ERROR_COLOR
+    if not tasks:
+        return "Not run", NEUTRAL_550
+    failed = sum(1 for t in tasks if t.status is AutoLamellaTaskStatus.Failed)
+    cancelled = sum(1 for t in tasks if t.status is AutoLamellaTaskStatus.Cancelled)
+    if failed:
+        return f"{failed} task{'s' if failed != 1 else ''} failed", ERROR_COLOR
+    if cancelled:
+        return "Cancelled", stylesheets.DEFECT_ORANGE_COLOR
+    return "Complete", OK_COLOR
+
+
+# -- thumbnails, decoded once per file -----------------------------------------
+
+_THUMBNAIL_CACHE: "OrderedDict[tuple, QImage]" = OrderedDict()
+_THUMBNAIL_CACHE_MAX = 200
+
+
+def _stamp(path: str) -> Optional[tuple]:
+    try:
+        st = os.stat(path)
+    except OSError:
+        return None
+    return (st.st_mtime_ns, st.st_size)
+
+
+def grid_thumbnail_path(experiment: Experiment, grid: GridRecord) -> Optional[str]:
+    """The latest overview thumbnail a run recorded for the grid, SEM first."""
+    for role in _THUMBNAIL_ROLES:
+        path = latest_grid_output(experiment, grid, role)
+        if path is not None:
+            return path
+    return None
+
+
+def _thumbnail_image(path: Optional[str], w: int, h: int) -> Optional[QImage]:
+    """The thumbnail scaled for a `w` x `h` label, decoded at most once per file
+    (the lamella card's lesson, FIB-681: a strip of cards must not re-decode on
+    every refresh)."""
+    if path is None:
+        return None
+    key = (path, _stamp(path), w, h)
+    image = _THUMBNAIL_CACHE.get(key)
+    if image is not None:
+        _THUMBNAIL_CACHE.move_to_end(key)
+        return image
+    image = QImage(path)
+    if image.isNull():
+        return None
+    image = image.scaled(
+        w,
+        h,
+        Qt.AspectRatioMode.KeepAspectRatioByExpanding,
+        Qt.TransformationMode.SmoothTransformation,
+    )
+    _THUMBNAIL_CACHE[key] = image
+    if len(_THUMBNAIL_CACHE) > _THUMBNAIL_CACHE_MAX:
+        _THUMBNAIL_CACHE.popitem(last=False)
+    return image
+
+
+class GridCardWidget(QWidget):
+    """One grid record: thumbnail | name over status, chips | quality | actions."""
+
+    clicked = pyqtSignal(object)  # GridRecord
+    quality_changed = pyqtSignal(object)  # GridRecord
+    load_requested = pyqtSignal(object)  # GridRecord
+    unload_requested = pyqtSignal(object)  # GridRecord
+    rename_requested = pyqtSignal(object, str)  # GridRecord, new name
+    remove_requested = pyqtSignal(object)  # GridRecord
+
+    def __init__(
+        self,
+        grid: GridRecord,
+        experiment: Optional[Experiment] = None,
+        mode: str = MODE_COZY,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.grid = grid
+        self.experiment = experiment
+        self._mode = mode if mode in CARD_MODES else MODE_COZY
+        self._entry: Optional[GridInventoryEntry] = None
+        self._has_loader = False
+        self._controls_enabled = True
+        self.setFixedWidth(_CARD_WIDTH)
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(4, 4, 4, 4)
+        outer.setSpacing(0)
+        self._card = QFrame()
+        self._card.setObjectName("GridCard")
+        self._card.setStyleSheet(_CARD_STYLE)
+        self._card.setFixedWidth(_CARD_WIDTH - 8)
+        # One content widget the arrangement swaps; the children below are built
+        # once and re-parented, so signals and menus survive a mode switch.
+        self._frame_layout = QVBoxLayout(self._card)
+        self._frame_layout.setContentsMargins(0, 0, 0, 0)
+        self._frame_layout.setSpacing(0)
+        self._content: Optional[QWidget] = None
+
+        self._thumb_label = QLabel()
+        self._thumb_label.setAlignment(Qt.AlignCenter)
+        self._thumb_label.setStyleSheet(
+            f"background: {NEUTRAL_900}; border-radius: 4px;"
+        )
+        self._name_label = ElidedLabel()
+        self._status_label = ElidedLabel()
+        self._chips = QHBoxLayout()
+        self._chips.setSpacing(4)
+        self._chip_widgets: List[QLabel] = []
+
+        self._btn_quality = QToolButton()
+        self._btn_quality.setFixedSize(_BTN_SIZE, _BTN_SIZE)
+        self._btn_quality.setStyleSheet(_BTN_STYLE)
+        self._btn_quality.clicked.connect(self._on_quality_clicked)
+
+        self._btn_actions = QToolButton()
+        self._btn_actions.setFixedSize(_BTN_SIZE, _BTN_SIZE)
+        self._btn_actions.setStyleSheet(_BTN_STYLE)
+        self._btn_actions.setIcon(
+            fibsem_icon("mdi:dots-horizontal", color=stylesheets.GRAY_ICON_COLOR)
+        )
+        self._btn_actions.setToolTip("Actions")
+        self._btn_actions.setPopupMode(QToolButton.InstantPopup)
+        menu = QMenu(self)
+        self._action_load = menu.addAction(
+            fibsem_icon(ICON_LOAD, color=stylesheets.GRAY_ICON_COLOR), "Load"
+        )
+        self._action_unload = menu.addAction(
+            fibsem_icon(ICON_UNLOAD, color=stylesheets.GRAY_ICON_COLOR), "Unload"
+        )
+        self._action_rename = menu.addAction(
+            fibsem_icon("mdi:pencil-outline", color=stylesheets.GRAY_ICON_COLOR),
+            "Rename…",
+        )
+        self._action_remove = menu.addAction(
+            fibsem_icon("mdi:trash-can-outline", color=stylesheets.GRAY_ICON_COLOR),
+            "Remove",
+        )
+        self._action_load.triggered.connect(lambda: self.load_requested.emit(self.grid))
+        self._action_unload.triggered.connect(
+            lambda: self.unload_requested.emit(self.grid)
+        )
+        self._action_rename.triggered.connect(self._on_rename)
+        self._action_remove.triggered.connect(self._on_remove)
+        self._btn_actions.setMenu(menu)
+
+        outer.addWidget(self._card)
+        self._apply_layout()
+        self.refresh()
+
+    # -- arrangement -----------------------------------------------------------
+
+    def set_mode(self, mode: str) -> None:
+        """Cozy tile (big thumbnail), standard row, or compact line."""
+        if mode not in CARD_MODES or mode == self._mode:
+            return
+        self._mode = mode
+        self._apply_layout()
+        self.refresh()
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    def _info_block(self) -> QWidget:
+        """Name over status and chips; the same block in every arrangement."""
+        info = QWidget()
+        info.setStyleSheet("background: transparent;")
+        layout = QVBoxLayout(info)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(2)
+        layout.addStretch(1)
+        layout.addWidget(self._name_label)
+        status_row = QHBoxLayout()
+        status_row.setSpacing(6)
+        status_row.addWidget(self._status_label, 1)
+        status_row.addLayout(self._chips)
+        layout.addLayout(status_row)
+        layout.addStretch(1)
+        return info
+
+    def _apply_layout(self) -> None:
+        if self._content is not None:
+            self._frame_layout.removeWidget(self._content)
+            self._content.setParent(None)
+            self._content.deleteLater()
+        if self._mode == MODE_COZY:
+            self._thumb_label.setFixedSize(_COZY_THUMB_W, _COZY_THUMB_H)
+            content = QWidget()
+            layout = QVBoxLayout(content)
+            layout.setContentsMargins(
+                _THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING
+            )
+            layout.setSpacing(6)
+            layout.addWidget(self._thumb_label)
+            row = QHBoxLayout()
+            row.setSpacing(6)
+            row.addWidget(self._info_block(), 1)
+            row.addWidget(self._btn_quality, 0, Qt.AlignVCenter)
+            row.addWidget(self._btn_actions, 0, Qt.AlignVCenter)
+            layout.addLayout(row)
+        else:
+            self._thumb_label.setFixedSize(_THUMB_W, _THUMB_H)
+            self._thumb_label.setVisible(self._mode != MODE_COMPACT)
+            content = QWidget()
+            row = QHBoxLayout(content)
+            row.setContentsMargins(
+                _THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING, _THUMB_PADDING
+            )
+            row.setSpacing(6)
+            row.addWidget(self._thumb_label)
+            row.addWidget(self._info_block(), 1)
+            row.addWidget(self._btn_quality, 0, Qt.AlignVCenter)
+            row.addWidget(self._btn_actions, 0, Qt.AlignVCenter)
+        self._thumb_label.setVisible(self._mode != MODE_COMPACT)
+        content.setStyleSheet("background: transparent;")
+        self._content = content
+        self._frame_layout.addWidget(content)
+
+    # -- what the hardware says ------------------------------------------------
+
+    def set_inventory(
+        self, entry: Optional[GridInventoryEntry], has_loader: bool
+    ) -> None:
+        """The inventory's row for this grid, or None when the hardware has no
+        grid of this name any more."""
+        self._entry = entry
+        self._has_loader = has_loader
+        self.refresh()
+
+    @property
+    def is_present(self) -> bool:
+        return self._entry is not None and self._entry.present
+
+    @property
+    def in_beam(self) -> bool:
+        return self._entry is not None and self._entry.in_beam
+
+    def set_controls_enabled(self, enabled: bool) -> None:
+        """The host's lockout while a workflow owns the loader."""
+        self._controls_enabled = enabled
+        self.refresh()
+
+    # -- drawing ---------------------------------------------------------------
+
+    def refresh(self) -> None:
+        grid = self.grid
+        present = self.is_present
+        self._name_label.setText(grid.name)
+        self._name_label.setStyleSheet(
+            f"font-size: 13px; font-weight: bold; background: transparent; "
+            f"color: {NEUTRAL_200 if present else NEUTRAL_550};"
+        )
+        self._card.setToolTip(grid.description or "")
+
+        text, colour = grid_headline(grid)
+        self._status_label.setText(text)
+        self._status_label.setStyleSheet(
+            f"font-size: 11px; color: {colour}; background: transparent;"
+        )
+
+        for old in self._chip_widgets:
+            self._chips.removeWidget(old)
+            old.deleteLater()
+        self._chip_widgets = []
+        chips: List[Tuple[str, str]] = []
+        if not present:
+            chips.append(("not present", NEUTRAL_700))
+        elif self.in_beam:
+            chips.append(("in beam", OK_COLOR))
+        for label, chip_colour in chips:
+            widget = chip(label, chip_colour, font_size=10)
+            self._chips.addWidget(widget)
+            self._chip_widgets.append(widget)
+        slot = f"slot {self._entry.index + 1:02d}" if present else "not in the holder"
+        self._status_label.setToolTip(f"{text} · {slot}")
+
+        icon, icon_colour, verdict = _QUALITY_ICON[grid.quality]
+        self._btn_quality.setIcon(fibsem_icon(icon, color=icon_colour))
+        self._btn_quality.setToolTip(
+            f"Quality: {verdict}. A person's verdict; no task sets it."
+        )
+
+        image = _thumbnail_image(
+            grid_thumbnail_path(self.experiment, grid) if self.experiment else None,
+            self._thumb_label.width(),
+            self._thumb_label.height(),
+        )
+        if image is not None:
+            self._thumb_label.setText("")
+            self._thumb_label.setPixmap(QPixmap.fromImage(image))
+        else:
+            self._thumb_label.setPixmap(QPixmap())
+            self._thumb_label.setText("")
+
+        # Load brings a grid into the beam; only with a loader, and only for a grid
+        # that is present and not already there. Unload for the one that is.
+        can = self._controls_enabled
+        self._action_load.setVisible(self._has_loader and not self.in_beam)
+        self._action_load.setEnabled(present and can)
+        self._action_unload.setVisible(self._has_loader and self.in_beam)
+        self._action_unload.setEnabled(can)
+        self._action_rename.setEnabled(can)
+
+    @property
+    def status_text(self) -> str:
+        return self._status_label.text()
+
+    def set_selected(self, selected: bool) -> None:
+        self._card.setStyleSheet(_CARD_SELECTED_STYLE if selected else _CARD_STYLE)
+
+    # -- events ----------------------------------------------------------------
+
+    def mousePressEvent(self, event) -> None:
+        self.clicked.emit(self.grid)
+        super().mousePressEvent(event)
+
+    def _on_quality_clicked(self) -> None:
+        menu = QMenu(self)
+        actions = {}
+        for quality, (icon, colour, verdict) in _QUALITY_ICON.items():
+            actions[menu.addAction(fibsem_icon(icon, color=colour), verdict)] = quality
+        chosen = menu.exec_(
+            self._btn_quality.mapToGlobal(self._btn_quality.rect().bottomLeft())
+        )
+        if chosen in actions:
+            self.set_quality(actions[chosen])
+
+    def set_quality(self, quality: GridQuality) -> None:
+        if quality is self.grid.quality:
+            return
+        self.grid.quality = quality
+        self.refresh()
+        self.quality_changed.emit(self.grid)
+
+    def _on_rename(self) -> None:
+        name, ok = QInputDialog.getText(
+            self, "Rename grid", "Name:", text=self.grid.name
+        )
+        name = name.strip()
+        if ok and name and name != self.grid.name:
+            self.rename_requested.emit(self.grid, name)
+
+    def _on_remove(self) -> None:
+        reply = QMessageBox.question(
+            self,
+            "Remove grid",
+            f"Remove '{self.grid.name}' from the experiment? Its files are kept; "
+            "its lamellae lose their grid.",
+            QMessageBox.Yes,
+            QMessageBox.No,
+        )
+        if reply == QMessageBox.Yes:
+            self.remove_requested.emit(self.grid)
+
+
+class GridCardContainer(QWidget):
+    """A one-column strip of grid cards, in the order the records were added."""
+
+    grid_selected = pyqtSignal(object)  # GridRecord | None
+    quality_changed = pyqtSignal(object)  # GridRecord
+    load_requested = pyqtSignal(object)  # GridRecord
+    unload_requested = pyqtSignal(object)  # GridRecord
+    rename_requested = pyqtSignal(object, str)  # GridRecord, new name
+    remove_requested = pyqtSignal(object)  # GridRecord
+
+    def __init__(self, parent: Optional[QWidget] = None, mode: str = MODE_COZY) -> None:
+        super().__init__(parent)
+        self._cards: Dict[str, GridCardWidget] = {}  # grid.id -> card
+        self._selected_id: Optional[str] = None
+        self._mode = mode if mode in CARD_MODES else MODE_COZY
+        self._layout = QVBoxLayout(self)
+        self._layout.setSpacing(8)
+        self._layout.setContentsMargins(8, 8, 8, 8)
+        self._layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+
+    def add_grid(
+        self, grid: GridRecord, experiment: Optional[Experiment] = None
+    ) -> GridCardWidget:
+        card = GridCardWidget(grid, experiment, mode=self._mode)
+        card.clicked.connect(self._on_card_clicked)
+        card.quality_changed.connect(self.quality_changed)
+        card.load_requested.connect(self.load_requested)
+        card.unload_requested.connect(self.unload_requested)
+        card.rename_requested.connect(self.rename_requested)
+        card.remove_requested.connect(self.remove_requested)
+        self._cards[grid.id] = card
+        self._layout.addWidget(card)
+        return card
+
+    def set_mode(self, mode: str) -> None:
+        """Switch every card, and any added later."""
+        if mode not in CARD_MODES:
+            return
+        self._mode = mode
+        for card in self._cards.values():
+            card.set_mode(mode)
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    def remove_grid(self, grid: GridRecord) -> None:
+        card = self._cards.pop(grid.id, None)
+        if card is not None:
+            self._layout.removeWidget(card)
+            card.deleteLater()
+            if self._selected_id == grid.id:
+                self._selected_id = None
+
+    def card_for(self, grid: GridRecord) -> Optional[GridCardWidget]:
+        return self._cards.get(grid.id)
+
+    @property
+    def cards(self) -> List[GridCardWidget]:
+        return list(self._cards.values())
+
+    @property
+    def selected_grid(self) -> Optional[GridRecord]:
+        card = self._cards.get(self._selected_id) if self._selected_id else None
+        return card.grid if card is not None else None
+
+    def clear(self) -> None:
+        for card in self._cards.values():
+            self._layout.removeWidget(card)
+            card.deleteLater()
+        self._cards.clear()
+        # Ids are stable and the host clears then re-adds the same set, so a
+        # surviving id would name a card drawn unselected while this thinks it is
+        # selected (the lamella strip's FIB-578).
+        self._selected_id = None
+
+    def select_grid(self, grid: Optional[GridRecord]) -> None:
+        """Select programmatically. Does not emit grid_selected."""
+        if self._selected_id and self._selected_id in self._cards:
+            self._cards[self._selected_id].set_selected(False)
+        self._selected_id = None
+        if grid is not None and grid.id in self._cards:
+            self._selected_id = grid.id
+            self._cards[grid.id].set_selected(True)
+
+    def refresh_all(self) -> None:
+        for card in self._cards.values():
+            card.refresh()
+
+    def set_controls_enabled(self, enabled: bool) -> None:
+        for card in self._cards.values():
+            card.set_controls_enabled(enabled)
+
+    def _on_card_clicked(self, grid: GridRecord) -> None:
+        if self._selected_id == grid.id:
+            self.select_grid(None)
+            self.grid_selected.emit(None)
+        else:
+            self.select_grid(grid)
+            self.grid_selected.emit(grid)

--- a/fibsem/applications/autolamella/ui/grids_tab_widget.py
+++ b/fibsem/applications/autolamella/ui/grids_tab_widget.py
@@ -1,0 +1,396 @@
+"""The Grids tab: the experiment's grid records, one card each.
+
+Mirrors the Lamella tab: cards on the left, Protocol and Results sub-tabs on the
+right. The tab's object is what grids are *available to this experiment*, not
+what the hardware holds; empty magazine slots never appear here (that is
+Microscope → Sample). Slot, present and in-beam are read from the stage's
+inventory on every refresh and drawn as chips.
+
+Run inventory, Load and Unload are conveniences over the same ``Stage``
+primitives the Sample view uses, run off the GUI thread. Running tasks is not on
+this tab; that is Workflow → Grids.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Dict, Optional
+
+from PyQt5.QtCore import QSize, Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QScrollArea,
+    QSplitter,
+    QTabWidget,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.applications.autolamella.structures import Experiment, GridRecord
+from fibsem.applications.autolamella.ui.grid_card_widget import GridCardContainer
+from fibsem.microscopes._stage import GridInventoryEntry, SampleGrid
+from fibsem.ui import stylesheets
+from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.qt.threading import thread_worker
+from fibsem.ui.tokens import ERROR_COLOR, NEUTRAL_200, TEXT_MUTED_COLOR
+from fibsem.ui.widgets.sample_loader_widget import _ICON_BTN_STYLE, ICON_INVENTORY
+
+_STRIP_WIDTH = 340
+
+
+class GridsTabWidget(QWidget):
+    """Cards for the experiment's grids, with Protocol and Results beside them."""
+
+    grid_selected = pyqtSignal(object)  # GridRecord | None
+    # The experiment's grid records changed here (inventory, a rename, a quality),
+    # and were saved; hosts drawing them elsewhere should refresh.
+    experiment_changed = pyqtSignal()
+
+    def __init__(self, parent: Optional[QWidget] = None, synchronous: bool = False):
+        super().__init__(parent)
+        self._experiment: Optional[Experiment] = None
+        self._microscope = None
+        self._synchronous = synchronous
+        self._busy = False
+        self._controls_enabled = True
+        self._worker = None
+        self._inventory: Dict[str, GridInventoryEntry] = {}
+        self._setup_ui()
+        self.refresh()
+
+    # -- layout ----------------------------------------------------------------
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        splitter = QSplitter(Qt.Horizontal)
+        splitter.setChildrenCollapsible(True)
+
+        # -- left: the strip -----------------------------------------------------
+        strip = QWidget()
+        strip_layout = QVBoxLayout(strip)
+        strip_layout.setContentsMargins(8, 8, 4, 4)
+        strip_layout.setSpacing(4)
+
+        header = QHBoxLayout()
+        header.setSpacing(6)
+        title = QLabel("Grids")
+        title.setStyleSheet(
+            f"font-size: 14px; font-weight: bold; color: {NEUTRAL_200}; "
+            "background: transparent;"
+        )
+        header.addWidget(title)
+        header.addStretch(1)
+        self.btn_inventory = QToolButton()
+        self.btn_inventory.setFixedSize(26, 26)
+        self.btn_inventory.setIconSize(QSize(18, 18))
+        self.btn_inventory.setStyleSheet(_ICON_BTN_STYLE)
+        self.btn_inventory.setIcon(
+            fibsem_icon(ICON_INVENTORY, color=stylesheets.GRAY_ICON_COLOR)
+        )
+        self.btn_inventory.setToolTip(
+            "Run inventory: refresh what the hardware holds and add a record for "
+            "every grid it finds"
+        )
+        self.btn_inventory.clicked.connect(self._on_run_inventory)
+        header.addWidget(self.btn_inventory)
+        strip_layout.addLayout(header)
+
+        self.summary_label = QLabel()
+        self.summary_label.setStyleSheet(
+            f"font-size: 11px; color: {TEXT_MUTED_COLOR}; background: transparent;"
+        )
+        strip_layout.addWidget(self.summary_label)
+
+        self.cards = GridCardContainer()
+        self.cards.grid_selected.connect(self.grid_selected)
+        self.cards.quality_changed.connect(self._on_quality_changed)
+        self.cards.load_requested.connect(self._on_load)
+        self.cards.unload_requested.connect(self._on_unload)
+        self.cards.rename_requested.connect(self._on_rename)
+        self.cards.remove_requested.connect(self._on_remove)
+        scroll = QScrollArea()
+        scroll.setWidget(self.cards)
+        scroll.setWidgetResizable(True)
+        scroll.setStyleSheet("QScrollArea { border: none; background: transparent; }")
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        strip_layout.addWidget(scroll, 1)
+
+        self.status_label = QLabel()
+        self.status_label.setWordWrap(True)
+        self.status_label.setStyleSheet(
+            f"font-size: 11px; color: {TEXT_MUTED_COLOR}; background: transparent;"
+        )
+        strip_layout.addWidget(self.status_label)
+
+        strip.setMaximumWidth(_STRIP_WIDTH)
+        splitter.addWidget(strip)
+        splitter.setStretchFactor(0, 0)
+
+        # -- right: sub-tabs -----------------------------------------------------
+        self.sub_tabs = QTabWidget()
+        self.protocol_tab = _placeholder(
+            "Grid task settings: the tasks in the experiment's grid protocol and "
+            "each one's settings. Coming next."
+        )
+        self.results_tab = _placeholder(
+            "The selected grid's overviews and history. Coming next."
+        )
+        self.sub_tabs.addTab(self.protocol_tab, "Protocol")
+        self.sub_tabs.addTab(self.results_tab, "Results")
+        splitter.addWidget(self.sub_tabs)
+        splitter.setStretchFactor(1, 1)
+        splitter.setSizes([_STRIP_WIDTH, 99999])
+        layout.addWidget(splitter)
+
+    # -- model -----------------------------------------------------------------
+
+    def set_experiment(self, experiment: Optional[Experiment]) -> None:
+        self._experiment = experiment
+        self._rebuild()
+
+    def set_microscope(self, microscope) -> None:
+        self._microscope = microscope
+        self.refresh()
+
+    @property
+    def stage(self):
+        return getattr(self._microscope, "_stage", None)
+
+    @property
+    def selected_grid(self) -> Optional[GridRecord]:
+        return self.cards.selected_grid
+
+    @property
+    def busy(self) -> bool:
+        return self._busy
+
+    def _rebuild(self) -> None:
+        """A new experiment: new cards. Everything else is a refresh."""
+        selected = self.cards.selected_grid
+        self.cards.clear()
+        if self._experiment is not None:
+            for grid in self._experiment.grids:
+                self.cards.add_grid(grid, self._experiment)
+            if selected is not None:
+                again = self._experiment.get_grid_by_id(selected.id)
+                self.cards.select_grid(again)
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Re-read the inventory and redraw every card from it and its record.
+        No hardware call: the stage answers from what it already knows."""
+        stage = self.stage
+        self._inventory = {}
+        has_loader = False
+        if stage is not None:
+            try:
+                self._inventory = {e.name: e for e in stage.grid_inventory() if e.name}
+            except Exception as e:  # noqa: BLE001 - drawn as "not present", said once
+                logging.warning(f"Could not read the grid inventory: {e}")
+            has_loader = stage.loader is not None
+
+        # A record added since the last rebuild (an inventory just created it)
+        # needs a card; one removed needs its card gone.
+        if self._experiment is not None:
+            known = {card.grid.id for card in self.cards.cards}
+            for grid in self._experiment.grids:
+                if grid.id not in known:
+                    self.cards.add_grid(grid, self._experiment)
+        for card in self.cards.cards:
+            card.set_inventory(self._inventory.get(card.grid.name), has_loader)
+            card.set_controls_enabled(self._controls_enabled and not self._busy)
+
+        n = len(self.cards.cards)
+        present = sum(1 for c in self.cards.cards if c.is_present)
+        if self._experiment is None:
+            self.summary_label.setText("No experiment loaded.")
+        elif n == 0:
+            self.summary_label.setText(
+                "No grids yet. Run inventory to add a record for every grid the "
+                "hardware holds."
+            )
+        else:
+            self.summary_label.setText(f"{n} in this experiment · {present} present")
+        self.btn_inventory.setEnabled(
+            self._experiment is not None
+            and stage is not None
+            and self._controls_enabled
+            and not self._busy
+        )
+
+    def set_controls_enabled(self, enabled: bool) -> None:
+        """The host's lockout while a workflow owns the loader."""
+        self._controls_enabled = enabled
+        self.refresh()
+
+    # -- edits -----------------------------------------------------------------
+
+    def _on_quality_changed(self, grid: GridRecord) -> None:
+        self._save()
+        self.experiment_changed.emit()
+
+    def _on_rename(self, grid: GridRecord, name: str) -> None:
+        experiment = self._experiment
+        if experiment is None:
+            return
+        if experiment.get_grid_by_name(name) is not None:
+            self._say(f"There is already a grid named {name}.", error=True)
+            return
+        old = grid.name
+        entry = self._inventory.get(old)
+        grid.name = name
+        # The record links to the hardware by name, so the hardware follows: on the
+        # autoloader that writes the slot description, on a fixed holder the
+        # occupancy file.
+        if entry is not None and entry.present and self.stage is not None:
+            try:
+                self.stage.assign_grid(entry.slot_name, SampleGrid(name=name))
+            except Exception as e:  # noqa: BLE001 - the record is renamed; say so
+                logging.warning(f"Renamed the record but not the hardware slot: {e}")
+                self._say(
+                    f"Renamed, but the slot could not be updated: {e}", error=True
+                )
+        self._save()
+        self.refresh()
+        self.experiment_changed.emit()
+
+    def _on_remove(self, grid: GridRecord) -> None:
+        """Stop tracking a grid. Its files stay; its lamellae are orphaned, not
+        deleted (Experiment.remove_grid)."""
+        if self._experiment is None:
+            return
+        self._experiment.remove_grid(grid.name)
+        self.cards.remove_grid(grid)
+        self._save()
+        self.refresh()
+        self.experiment_changed.emit()
+
+    def _save(self) -> None:
+        if self._experiment is None:
+            return
+        try:
+            self._experiment.save()
+        except Exception as e:  # noqa: BLE001 - a failed save is worth a line
+            logging.warning(f"Could not save the experiment: {e}")
+
+    # -- hardware, off the GUI thread --------------------------------------------
+
+    def _on_run_inventory(self) -> None:
+        stage = self.stage
+        if stage is None or self._experiment is None:
+            return
+        if stage.loader is not None and not self._confirm(
+            "Run inventory",
+            "Scan the magazine? The autoloader checks every slot for a grid and "
+            "reads the names on the slot descriptions; it takes a moment and the "
+            "magazine must not be opened while it runs.",
+        ):
+            return
+        experiment = self._experiment
+
+        def job() -> None:
+            stage.run_inventory()
+            experiment.sync_grids_from_inventory(stage)
+
+        self._start(job, "Running inventory…", "Inventory complete.")
+
+    def _on_load(self, grid: GridRecord) -> None:
+        stage = self.stage
+        if stage is None:
+            return
+
+        def job() -> None:
+            stage.ensure_loaded(grid.name)
+
+        self._start(job, f"Loading {grid.name}…", f"{grid.name} is in the beam.")
+
+    def _on_unload(self, grid: GridRecord) -> None:
+        stage = self.stage
+        if stage is None:
+            return
+
+        def job() -> None:
+            stage.unload()
+
+        self._start(
+            job, f"Unloading {grid.name}…", f"{grid.name} returned to the magazine."
+        )
+
+    def _confirm(self, title: str, text: str) -> bool:
+        if self._synchronous:
+            return True
+        return (
+            QMessageBox.question(
+                self, title, text, QMessageBox.Yes | QMessageBox.No, QMessageBox.No
+            )
+            == QMessageBox.Yes
+        )
+
+    def _start(self, job: Callable[[], None], doing: str, done: str) -> None:
+        if self._busy:
+            return
+        self._set_busy(True)
+        self._say(doing)
+        self._done_text = done
+        if self._synchronous:
+            try:
+                job()
+                self._on_returned()
+            except Exception as e:  # noqa: BLE001 - reported on the strip
+                self._on_errored(e)
+            finally:
+                self._on_finished()
+            return
+        worker = self._job_worker(job)
+        worker.returned.connect(self._on_returned)
+        worker.errored.connect(self._on_errored)
+        worker.finished.connect(self._on_finished)
+        self._worker = worker
+        worker.start()
+
+    @thread_worker
+    def _job_worker(self, job: Callable[[], None]) -> None:
+        job()
+
+    def _on_returned(self, _result: object = None) -> None:
+        self._say(self._done_text)
+
+    def _on_errored(self, error: Exception) -> None:
+        logging.warning(f"Grid operation failed: {error}")
+        self._say(str(error), error=True)
+
+    def _on_finished(self) -> None:
+        self._worker = None
+        self._set_busy(False)
+        self._save()
+        self.refresh()
+        self.experiment_changed.emit()
+
+    def _set_busy(self, busy: bool) -> None:
+        self._busy = busy
+        self.refresh()
+
+    def _say(self, text: str, error: bool = False) -> None:
+        colour = ERROR_COLOR if error else TEXT_MUTED_COLOR
+        self.status_label.setStyleSheet(
+            f"font-size: 11px; color: {colour}; background: transparent;"
+        )
+        self.status_label.setText(text)
+
+
+def _placeholder(text: str) -> QWidget:
+    widget = QWidget()
+    layout = QVBoxLayout(widget)
+    label = QLabel(text)
+    label.setWordWrap(True)
+    label.setAlignment(Qt.AlignTop)
+    label.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; background: transparent;")
+    layout.addWidget(label)
+    layout.addStretch(1)
+    return widget

--- a/fibsem/ui/widgets/sample_loader_widget.py
+++ b/fibsem/ui/widgets/sample_loader_widget.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from typing import Callable, List, Optional
 
 from PyQt5.QtCore import QSize, Qt, pyqtSignal
+from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import (
     QHBoxLayout,
     QLabel,
@@ -192,7 +193,10 @@ class _MagazineRow(QWidget):
                 if self.state == "occupied"
                 else "Nothing to load"
             )
-        self.btn_action.setVisible(self.state != "empty")
+        # An empty slot keeps the icon's space, blank, so the state column lines
+        # up down the list.
+        if self.state == "empty":
+            self.btn_action.setIcon(QIcon())
         self.btn_action.setEnabled(self.state != "empty" and controls_enabled)
 
     def _on_action(self) -> None:

--- a/tests/ui/test_grids_tab.py
+++ b/tests/ui/test_grids_tab.py
@@ -1,0 +1,308 @@
+"""The Grids tab: cards for the experiment's records, chips from the hardware."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskState,
+    AutoLamellaTaskStatus,
+    Experiment,
+    GridQuality,
+    GridRecord,
+)
+from fibsem.applications.autolamella.ui.grid_card_widget import grid_headline
+from fibsem.applications.autolamella.ui.grids_tab_widget import GridsTabWidget
+from fibsem.microscopes._stage import SampleGrid, _create_sample_stage
+
+
+@pytest.fixture
+def arctis():
+    microscope, _ = utils.setup_session(
+        manufacturer="Demo",
+        config_path=os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml"),
+    )
+    return microscope
+
+
+@pytest.fixture
+def experiment(tmp_path):
+    exp = Experiment(path=tmp_path, name="exp")
+    (tmp_path / "exp").mkdir()
+    return exp
+
+
+@pytest.fixture
+def tab(qapp, arctis, experiment):
+    widget = GridsTabWidget(synchronous=True)
+    widget.set_microscope(arctis)
+    widget.set_experiment(experiment)
+    return widget
+
+
+def entry(status, name="overview_sem"):
+    state = AutoLamellaTaskState(name=name, status=status)
+    state.end_timestamp = state.start_timestamp + 1
+    return state
+
+
+class TestHeadline:
+    def test_nothing_yet(self):
+        assert grid_headline(GridRecord(name="g"))[0] == "Not run"
+
+    def test_complete_after_a_load(self):
+        grid = GridRecord(name="g")
+        grid.task_history += [
+            entry(AutoLamellaTaskStatus.Completed, "load"),
+            entry(AutoLamellaTaskStatus.Completed),
+            entry(AutoLamellaTaskStatus.Completed, "overview_fib"),
+        ]
+        assert grid_headline(grid)[0] == "Complete"
+
+    def test_failed_tasks_are_counted(self):
+        grid = GridRecord(name="g")
+        grid.task_history += [
+            entry(AutoLamellaTaskStatus.Completed, "load"),
+            entry(AutoLamellaTaskStatus.Failed),
+            entry(AutoLamellaTaskStatus.Completed, "overview_fib"),
+        ]
+        assert grid_headline(grid)[0] == "1 task failed"
+
+    def test_a_failed_load_with_nothing_after_it(self):
+        grid = GridRecord(name="g")
+        grid.task_history += [
+            entry(AutoLamellaTaskStatus.Completed, "load"),
+            entry(AutoLamellaTaskStatus.Completed),
+            entry(AutoLamellaTaskStatus.Failed, "load"),
+        ]
+        assert grid_headline(grid)[0] == "Load failed"
+
+    def test_a_run_in_progress(self):
+        grid = GridRecord(name="g")
+        grid.task_state.name = "overview_fm"
+        grid.task_state.status = AutoLamellaTaskStatus.InProgress
+        assert grid_headline(grid)[0] == "Running overview_fm"
+
+
+class TestCards:
+    def test_empty_experiment_invites_an_inventory(self, tab):
+        assert tab.cards.cards == []
+        assert "Run inventory" in tab.summary_label.text()
+        assert tab.btn_inventory.isEnabled()
+
+    def test_inventory_creates_a_card_per_present_grid(self, tab, experiment):
+        tab.btn_inventory.click()
+        assert [c.grid.name for c in tab.cards.cards] == [
+            "Grid-01",
+            "Grid-02",
+            "Grid-03",
+        ]
+        assert tab.summary_label.text() == "3 in this experiment · 3 present"
+        card = tab.cards.cards[0]
+        assert [c.text() for c in card._chip_widgets] == []  # present, not in beam
+        assert "slot 01" in card._status_label.toolTip()
+        assert card.is_present and card.status_text == "Not run"
+        assert card._action_load.isVisible() and card._action_load.isEnabled()
+        assert not card._action_unload.isVisible()
+        assert tab.status_label.text() == "Inventory complete."
+        # saved as it went
+        assert (
+            len(Experiment.load(Path(experiment.path) / "experiment.yaml").grids) == 3
+        )
+
+    def test_a_record_whose_hardware_has_gone_is_kept_dimmed(self, tab, experiment):
+        experiment.add_grid(GridRecord(name="grid-oak"))
+        tab.set_experiment(experiment)
+        (card,) = tab.cards.cards
+        assert [c.text() for c in card._chip_widgets] == ["not present"]
+        assert not card._action_load.isEnabled()
+        assert tab.summary_label.text() == "1 in this experiment · 0 present"
+
+    def test_load_and_unload_follow_the_card(self, tab, arctis):
+        tab.btn_inventory.click()
+        card = tab.cards.cards[1]
+        card._action_load.trigger()
+        assert arctis._stage.loaded_grids[0].name == "Grid-02"
+        assert [c.text() for c in card._chip_widgets] == ["in beam"]
+        assert card._action_unload.isVisible() and not card._action_load.isVisible()
+        assert tab.status_label.text() == "Grid-02 is in the beam."
+        card._action_unload.trigger()
+        assert arctis._stage.loaded_grids == []
+        assert [c.text() for c in card._chip_widgets] == []
+
+    def test_a_refused_exchange_is_reported(self, tab, arctis):
+        tab.btn_inventory.click()
+        arctis._stage.loader.fail_next_exchange = True
+        tab.cards.cards[0]._action_load.trigger()
+        assert "Simulated autoloader exchange failure" in tab.status_label.text()
+        assert tab.cards.cards[0]._action_load.isEnabled()
+
+    def test_quality_is_set_on_the_record_and_saved(self, tab, experiment):
+        tab.btn_inventory.click()
+        changed = []
+        tab.experiment_changed.connect(lambda: changed.append(True))
+        card = tab.cards.cards[0]
+        card.set_quality(GridQuality.GOOD)
+        assert card.grid.quality is GridQuality.GOOD
+        assert "Good" in card._btn_quality.toolTip()
+        assert changed == [True]
+        loaded = Experiment.load(Path(experiment.path) / "experiment.yaml")
+        assert loaded.get_grid_by_name("Grid-01").quality is GridQuality.GOOD
+        # a task outcome does not touch it
+        assert grid_headline(card.grid)[0] == "Not run"
+
+    def test_rename_writes_through_to_the_slot(self, tab, arctis, experiment):
+        tab.btn_inventory.click()
+        card = tab.cards.cards[2]
+        tab._on_rename(card.grid, "grid-cedar")
+        assert card.grid.name == "grid-cedar"
+        assert arctis._stage.loader.slots["Slot-03"].loaded_grid.name == "grid-cedar"
+        assert card._name_label.text() == "grid-cedar"
+        assert "slot 03" in card._status_label.toolTip()
+        assert experiment.get_grid_by_name("grid-cedar") is card.grid
+
+    def test_rename_refuses_a_duplicate(self, tab):
+        tab.btn_inventory.click()
+        tab._on_rename(tab.cards.cards[0].grid, "Grid-02")
+        assert tab.cards.cards[0].grid.name == "Grid-01"
+        assert "already a grid named" in tab.status_label.text()
+
+    def test_selection_toggles_and_is_announced(self, tab):
+        tab.btn_inventory.click()
+        picked = []
+        tab.grid_selected.connect(picked.append)
+        tab.cards._on_card_clicked(tab.cards.cards[0].grid)
+        assert tab.selected_grid.name == "Grid-01"
+        tab.cards._on_card_clicked(tab.cards.cards[0].grid)
+        assert tab.selected_grid is None
+        assert [p.name if p else None for p in picked] == ["Grid-01", None]
+
+    def test_the_host_can_lock_the_hardware_conveniences(self, tab):
+        tab.btn_inventory.click()
+        tab.set_controls_enabled(False)
+        assert not tab.btn_inventory.isEnabled()
+        assert not tab.cards.cards[0]._action_load.isEnabled()
+        assert not tab.cards.cards[0]._action_rename.isEnabled()
+
+    def test_remove_stops_tracking_the_grid(self, tab, experiment):
+        tab.btn_inventory.click()
+        tab.cards.remove_requested.emit(tab.cards.cards[0].grid)
+        assert [g.name for g in experiment.grids] == ["Grid-02", "Grid-03"]
+        assert [c.grid.name for c in tab.cards.cards] == ["Grid-02", "Grid-03"]
+        assert tab.summary_label.text() == "2 in this experiment · 2 present"
+        # still in the magazine: an inventory brings it back as a fresh record
+        tab.btn_inventory.click()
+        assert [g.name for g in experiment.grids] == ["Grid-02", "Grid-03", "Grid-01"]
+
+    def test_a_card_shows_the_latest_overview_thumbnail(self, tab, experiment):
+        import numpy as np
+
+        from fibsem.applications.autolamella.structures import AutoLamellaTaskState
+        from fibsem.imaging.thumbnail import write_thumbnail
+
+        tab.btn_inventory.click()
+        grid = experiment.get_grid_by_name("Grid-01")
+        root = experiment.grid_path(grid)
+        write_thumbnail(
+            (np.random.rand(200, 300) * 255).astype(np.uint8),
+            root / "overview_sem" / "overview-thumbnail.png",
+        )
+        state = AutoLamellaTaskState(
+            name="overview_sem", status=AutoLamellaTaskStatus.Completed
+        )
+        state.outputs = {
+            "overview_sem_thumbnail": ["overview_sem/overview-thumbnail.png"]
+        }
+        grid.task_history.append(state)
+        card = tab.cards.card_for(grid)
+        assert card._thumb_label.pixmap() is None or card._thumb_label.pixmap().isNull()
+        card.refresh()
+        assert not card._thumb_label.pixmap().isNull()
+        assert card.status_text == "Complete"
+        # cozy by default: the big thumbnail; the standard row keeps the small one
+        assert card.mode == "cozy" and card._thumb_label.height() == 170
+        tab.cards.set_mode("standard")
+        assert (
+            card._thumb_label.height() == 44 and not card._thumb_label.pixmap().isNull()
+        )
+        tab.cards.set_mode("cozy")
+
+
+def test_on_a_fixed_holder_there_is_nothing_to_load(qapp, experiment):
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    microscope.stage_is_compustage = False
+    microscope._stage = _create_sample_stage(microscope)
+    microscope._stage.holder.slots["Slot-01"].loaded_grid = SampleGrid(
+        name="grid-aspen"
+    )
+    tab = GridsTabWidget(synchronous=True)
+    tab.set_microscope(microscope)
+    tab.set_experiment(experiment)
+    tab.btn_inventory.click()  # a plain refresh: no scan, no confirmation
+    (card,) = tab.cards.cards
+    assert card.grid.name == "grid-aspen"
+    assert [c.text() for c in card._chip_widgets] == ["in beam"]
+    assert not card._action_load.isVisible() and not card._action_unload.isVisible()
+
+
+@pytest.fixture
+def main_ui(qapp):
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
+    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
+    try:
+        window = module.AutoLamellaSingleWindowUI()
+    finally:
+        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    yield window
+    if window.autolamella_ui.microscope is not None:
+        window.autolamella_ui.microscope.disconnect()
+    original_quit = qapp.quit
+    qapp.quit = lambda: None
+    try:
+        window.close()
+    finally:
+        qapp.quit = original_quit
+
+
+class _NoMinimap:
+    def set_experiment(self) -> None:
+        pass
+
+
+def test_the_tab_sits_behind_the_flag_between_lamella_and_workflow(main_ui):
+    tabs = main_ui.tab_widget
+    index = tabs.indexOf(main_ui.grids_tab)
+    labels = [tabs.tabText(i) for i in range(tabs.count())]
+    assert labels[index - 1] == "Lamella" and labels[index + 1] == "Workflow"
+    assert not tabs.isTabVisible(index)  # off by default
+    main_ui._preferences.features.grid_workflow = True
+    main_ui._apply_grid_workflow_visibility()
+    assert tabs.isTabVisible(index)
+
+
+def test_the_tab_follows_the_connection_and_the_experiment(main_ui, tmp_path):
+    ui = main_ui.autolamella_ui
+    assert main_ui.grids_tab.stage is None
+    ui.system_widget.connect_to_microscope()
+    assert main_ui.grids_tab.stage is ui.microscope._stage
+    exp = Experiment(path=tmp_path, name="exp")
+    (tmp_path / "exp").mkdir()
+    exp.add_grid(GridRecord(name="grid-oak"))
+    ui.experiment = exp
+    # The fixture leaves the napari Minimap tab unbuilt (it owns a viewer that
+    # cannot live in a test), so the one call the update makes on it is stood in
+    # for. Called rather than emitted: an exception inside a Qt slot aborts the
+    # process under PyQt5, and a traceback is worth more than a core dump.
+    main_ui.minimap_widget = _NoMinimap()
+    main_ui._on_experiment_update()
+    assert [c.grid.name for c in main_ui.grids_tab.cards.cards] == ["grid-oak"]
+    assert main_ui.tab_widget.isTabEnabled(
+        main_ui.tab_widget.indexOf(main_ui.grids_tab)
+    )

--- a/tests/ui/test_sample_loader_widget.py
+++ b/tests/ui/test_sample_loader_widget.py
@@ -42,7 +42,7 @@ def test_every_magazine_slot_has_a_row(widget):
     )
     assert not first.name_edit.isReadOnly()
     assert empty.name_edit.text() == "" and empty.name_edit.isReadOnly()
-    assert not empty.btn_action.isEnabled()  # nothing to load, and no button shown
+    assert not empty.btn_action.isEnabled() and empty.btn_action.icon().isNull()
 
 
 def test_load_brings_the_grid_into_the_beam(widget, arctis):


### PR DESCRIPTION
Milestone 5, second PR: the Grids tab with its cards (FIB-199). Stacked on #742. Flag-gated: `features.grid_workflow`, off by default, hides the tab.

## The tab

Between Lamella and Workflow, the same shape as the Lamella tab: a card strip on the left, Protocol and Results sub-tabs on the right. The tab's object is the **experiment's grid records**, what grids are available to this experiment, not hardware slots; empty magazine slots never appear here (that is Microscope → Sample).

**A card per `GridRecord`**, the lamella card's own anatomy so the two strips read alike:
- the latest overview **thumbnail** the grid's runs recorded (SEM first), decoded once per file and cached like the lamella strip's; **cozy** tile by default with the big thumbnail above the name, and the standard row and compact line available through `set_mode`
- the **name** over a **headline** derived from the history: *Not run*, *Running <task>*, *Complete*, *N tasks failed*, *Load failed*, *Cancelled*. Read off the entries after the most recent `load`, never off the quality
- a **chip** only when the hardware has something to say: `in beam`, or `not present`; the slot is in the status tooltip. Read from `Stage.grid_inventory()` on every refresh, no hardware call
- a small **quality** icon (Unassessed / Good / Poor) with a menu to change it, a person's verdict that no task sets, saved on change
- an **actions** menu: Load or Unload (contextual, only with a loader, the same `Stage.ensure_loaded` / `unload` the Sample view calls), Rename (goes through to the hardware, since the record links to its grid by name), Remove (the record only; files stay, lamellae are orphaned)
- a grid whose hardware has gone keeps its card and history, dimmed, with nothing to load

**Header:** the grid count and how many are present, and Run inventory (refresh icon; on a loader it confirms first, like the Sample view), which scans, records every present grid on the experiment, and saves.

Hardware calls run off the GUI thread with the panel locked and a status line saying what is happening; a refused exchange is reported on the strip. `set_controls_enabled` is called from the window's run start and finish, so a workflow that owns the loader blocks manual exchanges here.

The Protocol and Results sub-tabs are labelled placeholders; they are the next two PRs.

## Wiring

`add_grids_tab` in the main window, `features.grid_workflow` applied as tab visibility (the Minimap pattern: read off the window's preferences, no module global), the tab handed the microscope on every connect and the experiment on every experiment update.

Also in here, from review of #742: loader rows keep the icon's space on an empty slot so the state column lines up.

**Tests** (`tests/ui/test_grids_tab.py`): the headline derivation; on the Arctis simulator, inventory creating a card per present grid and saving, a record whose hardware has gone, load and unload following the card, a refused exchange, quality set and saved, rename writing through to the slot and refusing a duplicate, selection, the lockout; a fixed holder with nothing to load; and in the real main window, the tab's position and flag, and following the connection and the experiment.
