### PR TITLE
[autolamella] Grids · Results: the selected grid's overviews and history

### DIFF
--- a/fibsem/applications/autolamella/ui/grid_results_widget.py
+++ b/fibsem/applications/autolamella/ui/grid_results_widget.py
@@ -1,0 +1,342 @@
+"""Grids tab · Results: the selected grid's overviews and history.
+
+Follows card selection. Everything here is read off the grid's task history and
+the outputs recorded on it, never by globbing the grid's directory: a task that
+recorded nothing shows a labelled placeholder saying why, which is the whole
+difference between "failed" and "never ran".
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtWidgets import (
+    QAbstractItemView,
+    QGridLayout,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QScrollArea,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskState,
+    AutoLamellaTaskStatus,
+    Experiment,
+    GridRecord,
+)
+from fibsem.applications.autolamella.ui.lamella_task_image_widget import (
+    ClickableLabel,
+    ExpandedImageDialog,
+)
+from fibsem.constants import TIME_DISPLAY_AMPM_SHORT
+from fibsem.ui import stylesheets
+from fibsem.ui.tokens import (
+    ERROR_COLOR,
+    NEUTRAL_200,
+    NEUTRAL_400,
+    NEUTRAL_550,
+    NEUTRAL_900,
+    OK_COLOR,
+    TEXT_MUTED_COLOR,
+)
+from fibsem.ui.widgets.custom_widgets import ElidedLabel
+
+_LOAD_ENTRY_NAME = "load"
+_TILE_W, _TILE_H = 220, 150
+_TILES_PER_LINE = 3
+
+_STATUS_COLOUR = {
+    AutoLamellaTaskStatus.Completed: OK_COLOR,
+    AutoLamellaTaskStatus.Failed: ERROR_COLOR,
+    AutoLamellaTaskStatus.Cancelled: stylesheets.DEFECT_ORANGE_COLOR,
+    AutoLamellaTaskStatus.Skipped: NEUTRAL_550,
+    AutoLamellaTaskStatus.InProgress: stylesheets.GREEN_COLOR,
+}
+
+
+def _when(state: AutoLamellaTaskState) -> str:
+    stamp = state.end_timestamp or state.start_timestamp
+    return datetime.fromtimestamp(stamp).strftime(TIME_DISPLAY_AMPM_SHORT)
+
+
+def thumbnail_for(
+    experiment: Experiment, grid: GridRecord, state: AutoLamellaTaskState
+) -> Optional[str]:
+    """The thumbnail a task run recorded, if the file is still there."""
+    root = experiment.grid_path(grid)
+    for role, relpaths in state.outputs.items():
+        if not role.endswith("_thumbnail"):
+            continue
+        for relpath in reversed(relpaths):
+            path = os.path.join(root, relpath)
+            if os.path.isfile(path):
+                return path
+    return None
+
+
+def latest_runs(grid: GridRecord) -> Dict[str, AutoLamellaTaskState]:
+    """The most recent history entry per task, in first-run order. The load step
+    is not a task and is reported separately."""
+    latest: Dict[str, AutoLamellaTaskState] = {}
+    for state in grid.task_history:
+        if state.name != _LOAD_ENTRY_NAME:
+            latest[state.name] = state
+    return latest
+
+
+class _OverviewTile(QWidget):
+    """One task's latest result: its thumbnail, or a placeholder that says why not."""
+
+    def __init__(
+        self,
+        title: str,
+        state: Optional[AutoLamellaTaskState],
+        thumbnail: Optional[str],
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.thumbnail = thumbnail
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(3)
+
+        self.image = ClickableLabel(thumbnail or "")
+        self.image.setFixedSize(_TILE_W, _TILE_H)
+        self.image.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.image.setStyleSheet(f"background: {NEUTRAL_900}; border-radius: 4px;")
+        if thumbnail is not None:
+            pixmap = QPixmap(thumbnail)
+            if not pixmap.isNull():
+                self.image.setPixmap(
+                    pixmap.scaled(
+                        _TILE_W, _TILE_H, Qt.KeepAspectRatio, Qt.SmoothTransformation
+                    )
+                )
+            self.image.clicked.connect(self._open)
+        else:
+            self.image.setWordWrap(True)
+            if state is None:
+                text, colour = "not run", NEUTRAL_550
+            elif state.status is AutoLamellaTaskStatus.Completed:
+                text, colour = "no image recorded", NEUTRAL_550
+            else:
+                text = state.status.name.lower()
+                if state.status_message:
+                    text += f"\n{state.status_message}"
+                colour = _STATUS_COLOUR.get(state.status, NEUTRAL_550)
+            self.image.setText(text)
+            self.image.setStyleSheet(
+                f"background: {NEUTRAL_900}; border-radius: 4px; color: {colour}; "
+                "font-size: 11px; padding: 6px;"
+            )
+        layout.addWidget(self.image)
+
+        caption = title if state is None else f"{title} · {_when(state)}"
+        self.caption = ElidedLabel(caption)
+        self.caption.setStyleSheet(
+            f"font-size: 11px; color: {NEUTRAL_400}; background: transparent;"
+        )
+        layout.addWidget(self.caption)
+
+    def _open(self, path: str) -> None:
+        dialog = ExpandedImageDialog(path, title=self.caption.text(), parent=self)
+        dialog.show()
+
+
+class GridResultsWidget(QWidget):
+    """The selected grid: its overviews by task, the load, and the history."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._experiment: Optional[Experiment] = None
+        self._grid: Optional[GridRecord] = None
+        self._tiles: List[_OverviewTile] = []
+        self._setup_ui()
+        self.refresh()
+
+    def _setup_ui(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.NoFrame)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        content = QWidget()
+        layout = QVBoxLayout(content)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(8)
+
+        self.name_label = QLabel()
+        self.name_label.setStyleSheet(
+            f"font-size: 14px; font-weight: bold; color: {NEUTRAL_200}; "
+            "background: transparent;"
+        )
+        layout.addWidget(self.name_label)
+        self.path_label = ElidedLabel("", mode=Qt.ElideLeft)
+        self.path_label.setStyleSheet(
+            f"font-size: 11px; color: {TEXT_MUTED_COLOR}; background: transparent;"
+        )
+        layout.addWidget(self.path_label)
+        self.description_label = QLabel()
+        self.description_label.setWordWrap(True)
+        self.description_label.setStyleSheet(
+            f"font-size: 11px; color: {NEUTRAL_400}; background: transparent;"
+        )
+        layout.addWidget(self.description_label)
+
+        self.tiles_widget = QWidget()
+        self.tiles_widget.setStyleSheet("background: transparent;")
+        self._tiles_layout = QGridLayout(self.tiles_widget)
+        self._tiles_layout.setContentsMargins(0, 4, 0, 4)
+        self._tiles_layout.setSpacing(10)
+        self._tiles_layout.setColumnStretch(_TILES_PER_LINE, 1)
+        layout.addWidget(self.tiles_widget)
+
+        self.load_label = QLabel()
+        self.load_label.setWordWrap(True)
+        self.load_label.setStyleSheet(
+            f"font-size: 11px; color: {NEUTRAL_400}; background: transparent;"
+        )
+        layout.addWidget(self.load_label)
+
+        history_title = QLabel("History")
+        history_title.setStyleSheet(
+            f"font-size: 12px; font-weight: 600; color: {NEUTRAL_400}; "
+            "background: transparent;"
+        )
+        layout.addWidget(history_title)
+        self.history = QTableWidget(0, 4)
+        self.history.setHorizontalHeaderLabels(["Task", "When", "Status", "Details"])
+        self.history.verticalHeader().setVisible(False)
+        self.history.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.history.setSelectionMode(QAbstractItemView.NoSelection)
+        self.history.horizontalHeader().setSectionResizeMode(3, QHeaderView.Stretch)
+        layout.addWidget(self.history)
+
+        self.empty_label = QLabel("Select a grid card to see its results.")
+        self.empty_label.setStyleSheet(
+            f"color: {NEUTRAL_550}; font-size: 12px; background: transparent;"
+        )
+        self.empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.empty_label)
+        layout.addStretch(1)
+        scroll.setWidget(content)
+        outer.addWidget(scroll)
+
+    # -- model -----------------------------------------------------------------
+
+    def set_experiment(self, experiment: Optional[Experiment]) -> None:
+        self._experiment = experiment
+        self.refresh()
+
+    def set_grid(self, grid: Optional[GridRecord]) -> None:
+        self._grid = grid
+        self.refresh()
+
+    @property
+    def grid(self) -> Optional[GridRecord]:
+        return self._grid
+
+    def refresh(self) -> None:
+        for tile in self._tiles:
+            self._tiles_layout.removeWidget(tile)
+            tile.deleteLater()
+        self._tiles = []
+        self.history.setRowCount(0)
+
+        grid, experiment = self._grid, self._experiment
+        has_grid = grid is not None and experiment is not None
+        for widget in (
+            self.name_label,
+            self.path_label,
+            self.description_label,
+            self.tiles_widget,
+            self.load_label,
+            self.history,
+        ):
+            widget.setVisible(has_grid)
+        self.empty_label.setVisible(not has_grid)
+        if not has_grid:
+            return
+
+        self.name_label.setText(grid.name)
+        self.path_label.setText(str(experiment.grid_path(grid)))
+        self.description_label.setText(grid.description)
+        self.description_label.setVisible(bool(grid.description))
+
+        # One tile per task: the protocol's tasks in its order, then anything the
+        # history knows that the protocol no longer names.
+        names: List[str] = []
+        try:
+            names = list(experiment.grid_protocol.ordered_task_names)
+        except ValueError:  # no task protocol on this experiment
+            pass
+        runs = latest_runs(grid)
+        for name in runs:
+            if name not in names:
+                names.append(name)
+        for index, name in enumerate(names):
+            state = runs.get(name)
+            thumbnail = (
+                thumbnail_for(experiment, grid, state) if state is not None else None
+            )
+            tile = _OverviewTile(name, state, thumbnail)
+            row, column = divmod(index, _TILES_PER_LINE)
+            self._tiles_layout.addWidget(tile, row, column)
+            self._tiles.append(tile)
+        self.tiles_widget.setVisible(bool(names))
+
+        loads = [t for t in grid.task_history if t.name == _LOAD_ENTRY_NAME]
+        if loads:
+            load = loads[-1]
+            if load.status is AutoLamellaTaskStatus.Completed:
+                text = f"Loaded {_when(load)} · {load.status_message}"
+                if load.duration:
+                    text += f" · {load.duration:.0f} s"
+            else:
+                text = f"Load {load.status.name.lower()} {_when(load)} · {load.status_message}"
+            self.load_label.setText(text)
+        else:
+            self.load_label.setText("Not loaded by a run yet.")
+
+        for state in grid.task_history:
+            row = self.history.rowCount()
+            self.history.insertRow(row)
+            status = QTableWidgetItem(state.status.name)
+            status.setForeground(
+                Qt.GlobalColor.white
+                if state.status not in _STATUS_COLOUR
+                else _brush(_STATUS_COLOUR[state.status])
+            )
+            for column, item in enumerate(
+                [
+                    QTableWidgetItem(state.name),
+                    QTableWidgetItem(_when(state)),
+                    status,
+                    QTableWidgetItem(self._details(state)),
+                ]
+            ):
+                self.history.setItem(row, column, item)
+        self.history.resizeRowsToContents()
+
+    @staticmethod
+    def _details(state: AutoLamellaTaskState) -> str:
+        if state.status_message:
+            return state.status_message
+        roles = [r for r in state.outputs if not r.endswith("_thumbnail")]
+        return ", ".join(roles)
+
+
+def _brush(colour: str):
+    from PyQt5.QtGui import QBrush, QColor
+
+    return QBrush(QColor(colour))

--- a/fibsem/applications/autolamella/ui/grids_tab_widget.py
+++ b/fibsem/applications/autolamella/ui/grids_tab_widget.py
@@ -32,6 +32,7 @@ from PyQt5.QtWidgets import (
 from fibsem.applications.autolamella.structures import Experiment, GridRecord
 from fibsem.applications.autolamella.ui.grid_card_widget import GridCardContainer
 from fibsem.applications.autolamella.ui.grid_protocol_widget import GridProtocolWidget
+from fibsem.applications.autolamella.ui.grid_results_widget import GridResultsWidget
 from fibsem.microscopes._stage import GridInventoryEntry, SampleGrid
 from fibsem.ui import stylesheets
 from fibsem.ui.icon import fibsem_icon
@@ -136,11 +137,11 @@ class GridsTabWidget(QWidget):
         # -- right: sub-tabs -----------------------------------------------------
         self.sub_tabs = QTabWidget()
         self.protocol_widget = GridProtocolWidget()
-        self.results_tab = _placeholder(
-            "The selected grid's overviews and history. Coming next."
-        )
+        self.results_widget = GridResultsWidget()
         self.sub_tabs.addTab(self.protocol_widget, "Protocol")
-        self.sub_tabs.addTab(self.results_tab, "Results")
+        self.sub_tabs.addTab(self.results_widget, "Results")
+        # Results follows card selection; Protocol does not (one shared protocol).
+        self.cards.grid_selected.connect(self.results_widget.set_grid)
         splitter.addWidget(self.sub_tabs)
         splitter.setStretchFactor(1, 1)
         splitter.setSizes([_STRIP_WIDTH, 99999])
@@ -151,6 +152,7 @@ class GridsTabWidget(QWidget):
     def set_experiment(self, experiment: Optional[Experiment]) -> None:
         self._experiment = experiment
         self.protocol_widget.set_experiment(experiment)
+        self.results_widget.set_experiment(experiment)
         self._rebuild()
 
     def set_microscope(self, microscope) -> None:
@@ -205,6 +207,7 @@ class GridsTabWidget(QWidget):
         for card in self.cards.cards:
             card.set_inventory(self._inventory.get(card.grid.name), has_loader)
             card.set_controls_enabled(self._controls_enabled and not self._busy)
+        self.results_widget.refresh()
 
         n = len(self.cards.cards)
         present = sum(1 for c in self.cards.cards if c.is_present)
@@ -382,15 +385,3 @@ class GridsTabWidget(QWidget):
             f"font-size: 11px; color: {colour}; background: transparent;"
         )
         self.status_label.setText(text)
-
-
-def _placeholder(text: str) -> QWidget:
-    widget = QWidget()
-    layout = QVBoxLayout(widget)
-    label = QLabel(text)
-    label.setWordWrap(True)
-    label.setAlignment(Qt.AlignTop)
-    label.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; background: transparent;")
-    layout.addWidget(label)
-    layout.addStretch(1)
-    return widget

--- a/tests/ui/test_grid_results_widget.py
+++ b/tests/ui/test_grid_results_widget.py
@@ -1,0 +1,155 @@
+"""Grids · Results: what a grid's runs recorded, read off its history."""
+
+import os
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    AutoLamellaTaskState,
+    AutoLamellaTaskStatus,
+    Experiment,
+    GridRecord,
+)
+from fibsem.applications.autolamella.ui.grid_results_widget import (
+    GridResultsWidget,
+    latest_runs,
+    thumbnail_for,
+)
+from fibsem.applications.autolamella.ui.grids_tab_widget import GridsTabWidget
+from fibsem.applications.autolamella.workflows.tasks.grid import (
+    BeamOverviewGridTaskConfig,
+    FluorescenceOverviewGridTaskConfig,
+)
+from fibsem.imaging.thumbnail import write_thumbnail
+
+
+def entry(name, status, message="", outputs=None, seconds=60):
+    state = AutoLamellaTaskState(name=name, status=status, status_message=message)
+    state.end_timestamp = state.start_timestamp + seconds
+    state.outputs = outputs or {}
+    return state
+
+
+@pytest.fixture
+def experiment(tmp_path):
+    exp = Experiment(path=tmp_path, name="exp")
+    (tmp_path / "exp").mkdir()
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    exp.grid_protocol.add(BeamOverviewGridTaskConfig(task_name="overview_sem"))
+    exp.grid_protocol.add(
+        BeamOverviewGridTaskConfig(task_name="overview_fib", orientation="FIB")
+    )
+    exp.grid_protocol.add(FluorescenceOverviewGridTaskConfig(task_name="overview_fm"))
+    return exp
+
+
+@pytest.fixture
+def grid(experiment):
+    """A grid with a load, a recorded SEM overview, a failed FM overview, and the FIB
+    overview never run."""
+    grid = experiment.add_grid(GridRecord(name="grid-elm", description="HeLa, batch B"))
+    root = experiment.grid_path(grid)
+    thumb = write_thumbnail(
+        (np.random.rand(300, 450) * 255).astype(np.uint8),
+        root / "overview_sem" / "overview-thumbnail.png",
+    )
+    assert os.path.isfile(thumb)
+    grid.task_history += [
+        entry(
+            "load", AutoLamellaTaskStatus.Completed, "Loaded into Slot-01.", seconds=218
+        ),
+        entry(
+            "overview_sem",
+            AutoLamellaTaskStatus.Completed,
+            outputs={
+                "overview_sem": ["overview_sem/overview.tif"],
+                "overview_sem_thumbnail": ["overview_sem/overview-thumbnail.png"],
+            },
+        ),
+        entry(
+            "overview_fm", AutoLamellaTaskStatus.Failed, "autofocus timeout on tile 7"
+        ),
+    ]
+    return grid
+
+
+def test_latest_run_per_task_leaves_the_load_out(grid):
+    assert list(latest_runs(grid)) == ["overview_sem", "overview_fm"]
+
+
+def test_thumbnail_is_read_off_the_recorded_outputs(experiment, grid):
+    sem = latest_runs(grid)["overview_sem"]
+    assert thumbnail_for(experiment, grid, sem).endswith("overview-thumbnail.png")
+    assert thumbnail_for(experiment, grid, latest_runs(grid)["overview_fm"]) is None
+
+
+def test_nothing_selected(qapp, experiment):
+    widget = GridResultsWidget()
+    widget.set_experiment(experiment)
+    assert not widget.empty_label.isHidden()
+    assert widget.name_label.isHidden()
+
+
+def test_tiles_thumbnail_placeholder_and_not_run(qapp, experiment, grid):
+    widget = GridResultsWidget()
+    widget.set_experiment(experiment)
+    widget.set_grid(grid)
+    assert widget.name_label.text() == "grid-elm"
+    assert widget.path_label.text().endswith("grid-elm")
+    assert widget.description_label.text() == "HeLa, batch B"
+
+    sem, fib, fm = widget._tiles  # the protocol's order
+    assert sem.thumbnail is not None and sem.image.pixmap() is not None
+    assert sem.caption.text().startswith("overview_sem · ")
+    assert fib.thumbnail is None and fib.image.text() == "not run"
+    assert fib.caption.text() == "overview_fib"
+    assert fm.image.text() == "failed\nautofocus timeout on tile 7"
+
+    assert widget.load_label.text().startswith("Loaded ")
+    assert "Loaded into Slot-01." in widget.load_label.text()
+    assert widget.load_label.text().endswith("· 218 s")
+
+    assert widget.history.rowCount() == 3
+    assert [widget.history.item(r, 0).text() for r in range(3)] == [
+        "load",
+        "overview_sem",
+        "overview_fm",
+    ]
+    assert widget.history.item(1, 3).text() == "overview_sem"
+    assert widget.history.item(2, 3).text() == "autofocus timeout on tile 7"
+
+
+def test_a_task_the_protocol_forgot_still_shows(qapp, experiment, grid):
+    experiment.grid_protocol.remove("overview_fm")
+    widget = GridResultsWidget()
+    widget.set_experiment(experiment)
+    widget.set_grid(grid)
+    assert [t.caption.text().split(" · ")[0] for t in widget._tiles] == [
+        "overview_sem",
+        "overview_fib",
+        "overview_fm",
+    ]
+
+
+def test_a_grid_never_loaded(qapp, experiment):
+    grid = experiment.add_grid(GridRecord(name="grid-oak"))
+    widget = GridResultsWidget()
+    widget.set_experiment(experiment)
+    widget.set_grid(grid)
+    assert widget.load_label.text() == "Not loaded by a run yet."
+    assert widget.history.rowCount() == 0
+    assert [t.image.text() for t in widget._tiles] == ["not run"] * 3
+
+
+def test_the_grids_tab_follows_card_selection(qapp, experiment, grid):
+    tab = GridsTabWidget(synchronous=True)
+    tab.set_experiment(experiment)
+    tab.cards._on_card_clicked(grid)
+    assert tab.results_widget.grid is grid
+    assert tab.sub_tabs.tabText(1) == "Results"
+    tab.cards._on_card_clicked(grid)
+    assert tab.results_widget.grid is None


### PR DESCRIPTION
Milestone 5, fourth PR: the Grids tab's Results sub-tab (FIB-891). Stacked on #745.

Follows card selection, and reads everything off the grid's task history and the outputs recorded on it; nothing globs the grid's directory.

- **Overviews**: one tile per task, the protocol's tasks in its order and then any task the history knows that the protocol no longer names. A tile is the latest run's thumbnail (the `<role>_thumbnail` output the task recorded; click opens it larger), or a labelled placeholder saying why there is none: *not run*, *failed* with the task's message, *cancelled*, *skipped*, or *no image recorded*. That is the difference between "failed" and "never ran" on one screen. The FM tile is the channel composite the task writes.
- **Load**: the latest `load` entry, with when, which slot, and how long the exchange took, or why it did not happen.
- **History**: every entry with its time, outcome and either its message or the roles it recorded.
- Name, output path and description at the top.

Minimal, as agreed. "Open in Overview tab" from the mock-up is left for when the Overview tab can be handed a grid's overview (FIB-71 territory).

**Tests** (`tests/ui/test_grid_results_widget.py`): the latest-run-per-task read, thumbnail lookup, nothing selected, a grid with a thumbnail, a failed task and a never-run task, a task the protocol forgot, a grid never loaded, and the Grids tab wiring selection to it.
