### PR TITLE
[autolamella] Workflow · Grids: select grids and tasks, confirm, run; Screen all grids

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -56,6 +56,10 @@ from fibsem.applications.autolamella.ui.autolamella_task_config_editor import (
     AutoLamellaProtocolTaskConfigEditor,
 )
 from fibsem.applications.autolamella.ui.AutoLamellaUI import INSTRUCTIONS, AutoLamellaUI
+from fibsem.applications.autolamella.ui.grid_workflow_widget import (
+    GridRunPreflightDialog,
+    GridWorkflowWidget,
+)
 from fibsem.applications.autolamella.ui.grids_tab_widget import GridsTabWidget
 from fibsem.applications.autolamella.ui.lamella_card_widget import LamellaCardContainer
 from fibsem.applications.autolamella.ui.lamella_task_image_widget import (
@@ -1597,6 +1601,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         ):
             return
 
+        if self._grid_workflow_active():
+            self._run_grid_workflow()
+            return
+
         selected_tasks = self.lamella_workflow_widget.get_selected_tasks()
         selected_lamella = self.lamella_workflow_widget.get_selected_lamella()
 
@@ -1626,8 +1634,82 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.lamella_workflow_widget.lamella_list.set_all_selected(False)
         self.lamella_workflow_widget.workflow.set_all_selected(False)
 
+    def _grid_workflow_active(self) -> bool:
+        """Whether the Workflow tab's Grids view is the one showing: Run acts on it."""
+        left = getattr(self, "workflow_left_tabs", None)
+        view = getattr(self, "grid_workflow_widget", None)
+        return left is not None and view is not None and left.currentWidget() is view
+
+    def _run_grid_workflow(self) -> None:
+        """The Run click on the Grids view: confirm, then the grid run."""
+        ui = self.autolamella_ui
+        grids = self.grid_workflow_widget.get_selected_grids()
+        task_names = self.grid_workflow_widget.get_selected_task_names()
+        if not grids or not task_names or ui.experiment is None:
+            return
+        grid_names = [g.name for g in grids]
+        dialog = GridRunPreflightDialog(
+            task_names,
+            grid_names,
+            self.grid_workflow_widget.exchanges_for(grids),
+            str(ui.experiment.path),
+            parent=self,
+        )
+        if dialog.exec_() != QDialog.Accepted:
+            return
+        self._start_grid_run(task_names, grid_names, inventory_first=False)
+
+    def _on_screen_all_grids(self) -> None:
+        """One click: inventory, every present grid, the ticked tasks (FIB-898)."""
+        ui = self.autolamella_ui
+        if ui is None or ui.is_workflow_running or ui.experiment is None:
+            return
+        if ui.microscope is None or ui.experiment.task_protocol is None:
+            return
+        task_names = self.grid_workflow_widget.get_selected_task_names()
+        if not task_names:
+            return
+        known = [g.name for g in ui.experiment.grids]
+        dialog = GridRunPreflightDialog(
+            task_names,
+            known,
+            self.grid_workflow_widget.exchanges_for(list(ui.experiment.grids)),
+            str(ui.experiment.path),
+            screen_all=True,
+            parent=self,
+        )
+        if dialog.exec_() != QDialog.Accepted:
+            return
+        self._start_grid_run(task_names, None, inventory_first=True)
+
+    def _start_grid_run(
+        self, task_names: list, grid_names, inventory_first: bool
+    ) -> None:
+        ui = self.autolamella_ui
+        self._set_border_state("automated")
+        # One writer (FIB-683): land any edit still in the editors first.
+        self.lamella_widget.flush_pending_save()
+        ui._start_run_grid_workflow_thread(task_names, grid_names, inventory_first)
+        self.set_workflow_running()
+
     def _on_workflow_selection_changed(self, _=None) -> None:
         """Enable the run button only when at least one lamella and one task are selected."""
+        if self._grid_workflow_active():
+            n_grid = len(self.grid_workflow_widget.get_selected_grids())
+            n_task = len(self.grid_workflow_widget.get_selected_task_names())
+            valid = n_grid > 0 and n_task > 0
+            self.run_workflow_btn.setEnabled(valid)
+            self.run_workflow_btn.setToolTip(
+                f"Run grid workflow: {n_grid} grid{'s' if n_grid != 1 else ''}, "
+                f"{n_task} task{'s' if n_task != 1 else ''}"
+                if valid
+                else "Select a present grid and a task to run the grid workflow"
+            )
+            if hasattr(self, "workflow_timeline"):
+                self.workflow_timeline.set_add_enabled(
+                    False, "Adding to a grid run mid-way is not supported yet"
+                )
+            return
         n_lam = len(self.lamella_workflow_widget.get_selected_lamella())
         n_task = len(self.lamella_workflow_widget.get_selected_tasks())
         valid = n_lam > 0 and n_task > 0
@@ -1668,6 +1750,8 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # A run owns the loader: no manual exchange from the Grids tab meanwhile.
         if getattr(self, "grids_tab", None) is not None:
             self.grids_tab.set_controls_enabled(False)
+        if getattr(self, "grid_workflow_widget", None) is not None:
+            self.grid_workflow_widget.set_controls_enabled(False)
         # A live run is exactly when there is a queue to edit, so the actions come
         # on with it — and go off again in hide_workflow_running.
         if hasattr(self, "workflow_timeline"):
@@ -2155,6 +2239,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.add_lamella_editor_tab()
         self.add_grids_tab()
         self.add_workflow_tab()
+        self._apply_grid_workflow_visibility()
 
         # add notification button to tab bar
         self.create_notification_button()
@@ -2173,6 +2258,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.task_widget.set_experiment(self.autolamella_ui.experiment)
         self.lamella_widget.set_experiment()
         self.grids_tab.set_experiment(self.autolamella_ui.experiment)
+        self.grid_workflow_widget.set_experiment(self.autolamella_ui.experiment)
         experiment = self.autolamella_ui.experiment
         if experiment is not None and experiment.task_protocol is not None:
             self.lamella_workflow_widget.set_experiment(experiment)
@@ -2553,6 +2639,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if getattr(self, "grids_tab", None) is None or self.autolamella_ui is None:
             return
         self.grids_tab.set_microscope(self.autolamella_ui.microscope)
+        self.grid_workflow_widget.set_microscope(self.autolamella_ui.microscope)
 
     def _apply_grid_workflow_visibility(self) -> None:
         """`features.grid_workflow` shows or hides the Grids tab.
@@ -2560,12 +2647,14 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         Read straight off `self._preferences`, like the Minimap flag: a method on
         the window that owns them needs no module global.
         """
+        enabled = self._preferences.features.grid_workflow
         tab = getattr(self, "grids_tab", None)
-        if tab is None:
-            return
-        self.tab_widget.setTabVisible(
-            self.tab_widget.indexOf(tab), self._preferences.features.grid_workflow
-        )
+        if tab is not None:
+            self.tab_widget.setTabVisible(self.tab_widget.indexOf(tab), enabled)
+        left = getattr(self, "workflow_left_tabs", None)
+        view = getattr(self, "grid_workflow_widget", None)
+        if left is not None and view is not None:
+            left.setTabVisible(left.indexOf(view), enabled)
 
     def add_workflow_tab(self):
         """Add the workflow tab with the combined lamella + workflow widget."""
@@ -2637,7 +2726,26 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.workflow_timeline.add_to_queue_requested.connect(self._on_add_to_queue)
         _rp_layout.addWidget(self.workflow_timeline)
 
-        splitter.addWidget(self.lamella_workflow_widget)
+        # Lamella and Grids side by side on the left, one timeline on the right:
+        # the queue is generic over items now, and the two runs share the worker
+        # slot, so there is one run at a time and one place to watch it.
+        self.workflow_left_tabs = QTabWidget()
+        self.workflow_left_tabs.addTab(self.lamella_workflow_widget, "Lamella")
+        self.grid_workflow_widget = GridWorkflowWidget()
+        self.grid_workflow_widget.selection_changed.connect(
+            self._on_workflow_selection_changed
+        )
+        self.grid_workflow_widget.screen_all_requested.connect(
+            self._on_screen_all_grids
+        )
+        self.grid_workflow_widget.protocol_changed.connect(
+            lambda: self.grids_tab.protocol_widget.refresh()
+        )
+        self.workflow_left_tabs.addTab(self.grid_workflow_widget, "Grids")
+        self.workflow_left_tabs.currentChanged.connect(
+            self._on_workflow_selection_changed
+        )
+        splitter.addWidget(self.workflow_left_tabs)
         splitter.addWidget(self.workflow_right_panel)
         splitter.setStretchFactor(0, 0)
         splitter.setStretchFactor(1, 1)
@@ -3093,7 +3201,20 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # (`RuntimeError: wrapped C/C++ object of type QLabel has been deleted`).
         # It joins the other two on the same named-lamella path, so it costs one row
         # -- unlike them, though, nothing else was refreshing this list mid-workflow.
-        if lamella is not None:
+        grid = (
+            experiment.get_grid_by_name(lamella_name)
+            if experiment is not None and lamella_name is not None
+            else None
+        )
+        if grid is not None:
+            # A grid run's report: the grid's card and its row follow it. The
+            # lamella lists have nothing to redraw.
+            card = self.grids_tab.cards.card_for(grid)
+            if card is not None:
+                card.refresh()
+            self.grid_workflow_widget.refresh_grid(grid)
+            self.grids_tab.results_widget.refresh()
+        elif lamella is not None:
             self.lamella_list_widget.refresh_lamella(lamella)
             self.lamella_card_container.refresh_lamella(lamella)
             self.autolamella_ui.lamella_list.refresh_lamella(lamella)
@@ -3341,6 +3462,9 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.lamella_widget.set_active_lamella_name(None)
         if getattr(self, "grids_tab", None) is not None:
             self.grids_tab.set_controls_enabled(True)
+        if getattr(self, "grid_workflow_widget", None) is not None:
+            self.grid_workflow_widget.set_controls_enabled(True)
+            self.grid_workflow_widget.refresh()
         self.user_attention_btn.hide()
         self.lamella_list_widget.refresh_all()
         self.lamella_card_container.refresh_all()

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1063,6 +1063,83 @@ class AutoLamellaUI(QMainWindow):
         )
         self._task_worker_thread.start()
 
+    def _start_run_grid_workflow_thread(
+        self,
+        task_names: List[str],
+        grid_names: Optional[List[str]],
+        inventory_first: bool = False,
+    ) -> None:
+        """Start a grid run on the workflow thread: the lamella run's twin.
+
+        `grid_names` None with `inventory_first` is "Screen all grids": the worker
+        runs the inventory, records every present grid, and runs over them all.
+        Shares the worker slot, the manager slot and the finished signal with the
+        lamella run, so Stop, the timeline and the run summary work unchanged and
+        the two cannot overlap.
+        """
+        if self._script_runner_is_busy():
+            msg = "A microscope script is running. Stop it before starting a workflow."
+            logging.warning(msg)
+            notification_service.show_toast(msg, "warning")
+            return
+        self._task_worker_thread = FunctionWorker(
+            self._run_grid_tasks_worker, task_names, grid_names, inventory_first
+        )
+        self._task_worker_thread.start()
+
+    def _run_grid_tasks_worker(
+        self,
+        task_names: List[str],
+        grid_names: Optional[List[str]],
+        inventory_first: bool,
+    ) -> None:
+        """Worker thread for a grid run."""
+        from fibsem.applications.autolamella.workflows.tasks.grid.manager import (
+            GridTaskManager,
+        )
+        from fibsem.applications.autolamella.workflows.tasks.grid.screening import (
+            present_grids,
+        )
+
+        try:
+            self._workflow_stop_event.clear()
+            if self.microscope is None or self.experiment is None:
+                logging.error("No microscope or experiment loaded.")
+                return
+            if not self.microscope.is_on(BeamType.ELECTRON):
+                self.microscope.turn_on(BeamType.ELECTRON)
+            if not self.microscope.is_on(BeamType.ION):
+                self.microscope.turn_on(BeamType.ION)
+            if inventory_first:
+                grid_names = present_grids(self.microscope, self.experiment)
+            logging.info(f"Starting grid tasks: {task_names}, for grids: {grid_names}")
+            self._task_manager = GridTaskManager(
+                microscope=self.microscope,
+                experiment=self.experiment,
+                parent_ui=self,
+                hook_manager=self.setup_hooks(),
+            )
+            if self._workflow_stop_event.is_set():
+                self._task_manager.stop()
+            self._task_manager.run(task_names, grid_names)
+        except (InterruptedError, OperationCancelledError) as e:
+            logging.info(f"Grid workflow cancelled: {e}")
+        except Exception as e:
+            logging.error(f"Error during grid workflow: {e}")
+        finally:
+            cancelled = self._task_manager is not None and self._task_manager.is_stopped
+            if self._task_manager is not None:
+                try:
+                    self._last_run_summary = (
+                        self._task_manager.build_run_summary_dataframe()
+                    )
+                except Exception as e:
+                    logging.warning(f"Failed to build grid run summary: {e}")
+                    self._last_run_summary = None
+            self._task_manager = None
+            self._task_worker_thread = None
+            self._workflow_finished_signal.emit(cancelled)  # type: ignore
+
     def request_start_workflow(
         self, task_names: List[str], item_names: Optional[List[str]] = None
     ) -> "Future":

--- a/fibsem/applications/autolamella/ui/grid_workflow_widget.py
+++ b/fibsem/applications/autolamella/ui/grid_workflow_widget.py
@@ -219,13 +219,15 @@ class _TaskRow(QWidget):
 
     def refresh(self) -> None:
         available = self._reason is None
-        self.name_label.setText(self.config.display_name)
+        self.name_label.setText(self.task_name)
         style_with_tooltip(
             self.name_label,
             f"font-weight: bold; background: transparent; "
             f"color: {NEUTRAL_200 if available else NEUTRAL_550};",
         )
-        self.detail_label.setText(self.task_name if available else self._reason)
+        self.detail_label.setText(
+            self.config.display_name if available else self._reason
+        )
         self.detail_label.setStyleSheet(
             f"font-size: 11px; color: {TEXT_MUTED_COLOR}; background: transparent;"
         )

--- a/fibsem/applications/autolamella/ui/grid_workflow_widget.py
+++ b/fibsem/applications/autolamella/ui/grid_workflow_widget.py
@@ -1,0 +1,634 @@
+"""Workflow tab · Grids: pick grids, pick and order tasks, run.
+
+The run view for grids, beside the lamella one and sharing its chrome: the Run
+and Stop buttons, the timeline on the right, the confirmation before a start.
+Grid rows come from the experiment's records with the hardware's word on each
+(slot, in beam) drawn as chips; only a present grid can be ticked. Task rows
+come from the grid protocol in its order, and the order can be changed here.
+Settings live on Grids → Protocol.
+
+"Screen all grids" is the Arctis user's one action: inventory, every present
+grid, the ticked tasks.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional, Tuple
+
+from PyQt5.QtCore import QSize, Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.applications.autolamella.structures import Experiment, GridRecord
+from fibsem.applications.autolamella.ui.grid_card_widget import grid_headline
+from fibsem.applications.autolamella.workflows.tasks.grid import (
+    FluorescenceOverviewGridTaskConfig,
+    GridTaskConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.grid.manager import (
+    LOAD_ENTRY_NAME,
+    plan_grid_run,
+)
+from fibsem.microscopes._stage import GridInventoryEntry
+from fibsem.ui import stylesheets
+from fibsem.ui.icon import fibsem_icon
+from fibsem.ui.tokens import (
+    NEUTRAL_200,
+    NEUTRAL_550,
+    NEUTRAL_700,
+    OK_COLOR,
+    TEXT_MUTED_COLOR,
+)
+from fibsem.ui.widgets.custom_widgets import ElidedLabel, chip, style_with_tooltip
+from fibsem.ui.widgets.preflight import (
+    BACKGROUND,
+    ON_PANEL,
+    TEXT_STRONG,
+    detail_block,
+    meta_label,
+    metric,
+)
+
+_ROW_HEIGHT = 34
+_ICON_BTN = 22
+_HEADER_STYLE = f"font-size: 12px; font-weight: bold; color: {NEUTRAL_200}; background: transparent;"
+_ICON_BTN_STYLE = """
+QToolButton { background: transparent; border: none; border-radius: 4px; }
+QToolButton:hover { background: rgba(255, 255, 255, 30); }
+QToolButton:disabled { background: transparent; }
+"""
+
+
+def task_unavailable_reason(config: GridTaskConfig, microscope) -> Optional[str]:
+    """Why this system cannot run the task, or None when it can (or no system
+    is connected to say)."""
+    if microscope is None:
+        return None
+    if (
+        isinstance(config, FluorescenceOverviewGridTaskConfig)
+        and getattr(microscope, "fm", None) is None
+    ):
+        return "This system has no fluorescence microscope"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Rows
+# ---------------------------------------------------------------------------
+
+
+class _GridRow(QWidget):
+    selection_changed = pyqtSignal(object, bool)  # GridRecord, checked
+
+    def __init__(self, grid: GridRecord, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.grid = grid
+        self._entry: Optional[GridInventoryEntry] = None
+        self._chip_widgets: List[QLabel] = []
+        self.setFixedHeight(_ROW_HEIGHT)
+        self.setAttribute(Qt.WA_TranslucentBackground)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 0, 6, 0)
+        layout.setSpacing(8)
+        self.checkbox = QCheckBox()
+        self.checkbox.setStyleSheet("background: transparent;")
+        self.checkbox.toggled.connect(
+            lambda checked: self.selection_changed.emit(self.grid, checked)
+        )
+        layout.addWidget(self.checkbox)
+        self.name_label = QLabel()
+        layout.addWidget(self.name_label)
+        self.status_label = ElidedLabel()
+        layout.addWidget(self.status_label, 1)
+        self._chips = QHBoxLayout()
+        self._chips.setSpacing(4)
+        layout.addLayout(self._chips)
+        self.refresh()
+
+    @property
+    def is_present(self) -> bool:
+        return self._entry is not None and self._entry.present
+
+    @property
+    def in_beam(self) -> bool:
+        return self._entry is not None and self._entry.in_beam
+
+    def set_inventory(self, entry: Optional[GridInventoryEntry]) -> None:
+        self._entry = entry
+        self.refresh()
+
+    def refresh(self) -> None:
+        self.name_label.setText(self.grid.name)
+        present = self.is_present
+        style_with_tooltip(
+            self.name_label,
+            f"font-weight: bold; background: transparent; "
+            f"color: {NEUTRAL_200 if present else NEUTRAL_550};",
+        )
+        text, colour = grid_headline(self.grid)
+        self.status_label.setText(text)
+        self.status_label.setStyleSheet(
+            f"font-size: 11px; color: {colour}; background: transparent;"
+        )
+        for old in self._chip_widgets:
+            self._chips.removeWidget(old)
+            old.deleteLater()
+        self._chip_widgets = []
+        entry = self._entry
+        chips: List[Tuple[str, str]] = []
+        if entry is None or not entry.present:
+            chips.append(("not present", NEUTRAL_700))
+        else:
+            chips.append((f"slot {entry.index + 1:02d}", NEUTRAL_550))
+            if entry.in_beam:
+                chips.append(("in beam", OK_COLOR))
+        for label, colour in chips:
+            widget = chip(label, colour)
+            self._chips.addWidget(widget)
+            self._chip_widgets.append(widget)
+        # Only a present grid can be run on; an absent one is unticked and stays so.
+        if not present and self.checkbox.isChecked():
+            self.checkbox.setChecked(False)
+        self.checkbox.setEnabled(present)
+        self.checkbox.setToolTip(
+            "" if present else "Not in the magazine or holder; run an inventory"
+        )
+
+
+class _TaskRow(QWidget):
+    selection_changed = pyqtSignal(str, bool)  # task name, checked
+    move_up = pyqtSignal(str)
+    move_down = pyqtSignal(str)
+
+    def __init__(
+        self, config: GridTaskConfig, parent: Optional[QWidget] = None
+    ) -> None:
+        super().__init__(parent)
+        self.config = config
+        self._reason: Optional[str] = None
+        self.setFixedHeight(_ROW_HEIGHT)
+        self.setAttribute(Qt.WA_TranslucentBackground)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 0, 6, 0)
+        layout.setSpacing(8)
+        self.checkbox = QCheckBox()
+        self.checkbox.setStyleSheet("background: transparent;")
+        self.checkbox.toggled.connect(
+            lambda checked: self.selection_changed.emit(self.task_name, checked)
+        )
+        layout.addWidget(self.checkbox)
+        self.name_label = QLabel()
+        layout.addWidget(self.name_label)
+        self.detail_label = ElidedLabel()
+        layout.addWidget(self.detail_label, 1)
+        self.btn_up = QToolButton()
+        self.btn_down = QToolButton()
+        for button, icon, signal in (
+            (self.btn_up, "mdi:chevron-up", self.move_up),
+            (self.btn_down, "mdi:chevron-down", self.move_down),
+        ):
+            button.setFixedSize(_ICON_BTN, _ICON_BTN)
+            button.setIconSize(QSize(16, 16))
+            button.setStyleSheet(_ICON_BTN_STYLE)
+            button.setIcon(fibsem_icon(icon, color=stylesheets.GRAY_ICON_COLOR))
+            button.clicked.connect(lambda _c, s=signal: s.emit(self.task_name))
+            layout.addWidget(button)
+        self.btn_up.setToolTip("Run earlier")
+        self.btn_down.setToolTip("Run later")
+        self.refresh()
+
+    @property
+    def task_name(self) -> str:
+        return self.config.task_name
+
+    def set_unavailable(self, reason: Optional[str]) -> None:
+        self._reason = reason
+        self.refresh()
+
+    def refresh(self) -> None:
+        available = self._reason is None
+        self.name_label.setText(self.config.display_name)
+        style_with_tooltip(
+            self.name_label,
+            f"font-weight: bold; background: transparent; "
+            f"color: {NEUTRAL_200 if available else NEUTRAL_550};",
+        )
+        self.detail_label.setText(self.task_name if available else self._reason)
+        self.detail_label.setStyleSheet(
+            f"font-size: 11px; color: {TEXT_MUTED_COLOR}; background: transparent;"
+        )
+        if not available and self.checkbox.isChecked():
+            self.checkbox.setChecked(False)
+        self.checkbox.setEnabled(available)
+        self.checkbox.setToolTip(self._reason or "")
+
+
+class _ListHeader(QWidget):
+    select_all_changed = pyqtSignal(bool)
+
+    def __init__(self, title: str, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 0, 6, 0)
+        self.select_all = QCheckBox()
+        self.select_all.setStyleSheet("background: transparent;")
+        self.select_all.setToolTip("Select all / none")
+        self.select_all.toggled.connect(self.select_all_changed)
+        layout.addWidget(self.select_all)
+        self.title = QLabel(title)
+        self.title.setStyleSheet(_HEADER_STYLE)
+        layout.addWidget(self.title)
+        layout.addStretch(1)
+        self.trailing = QLabel()
+        self.trailing.setStyleSheet(
+            f"font-size: 11px; color: {TEXT_MUTED_COLOR}; background: transparent;"
+        )
+        layout.addWidget(self.trailing)
+
+
+def _list() -> QListWidget:
+    widget = QListWidget()
+    widget.setStyleSheet(stylesheets.LIST_WIDGET_STYLESHEET)
+    widget.setSelectionMode(QListWidget.NoSelection)
+    widget.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+    widget.setResizeMode(QListWidget.Adjust)
+    widget.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+    return widget
+
+
+def _add_row(widget: QListWidget, row: QWidget) -> None:
+    item = QListWidgetItem(widget)
+    item.setSizeHint(QSize(0, _ROW_HEIGHT))
+    item.setFlags(Qt.ItemFlag.ItemIsEnabled)
+    widget.addItem(item)
+    widget.setItemWidget(item, row)
+
+
+# ---------------------------------------------------------------------------
+# The view
+# ---------------------------------------------------------------------------
+
+
+class GridWorkflowWidget(QWidget):
+    selection_changed = pyqtSignal()
+    # The one-click path. The host runs it: inventory, then the ticked tasks on
+    # every present grid.
+    screen_all_requested = pyqtSignal()
+    # The task order was changed here and saved to the protocol.
+    protocol_changed = pyqtSignal()
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._experiment: Optional[Experiment] = None
+        self._microscope = None
+        self._grid_rows: Dict[str, _GridRow] = {}
+        self._task_rows: Dict[str, _TaskRow] = {}
+        self._controls_enabled = True
+        self._setup_ui()
+        self.refresh()
+
+    def _setup_ui(self) -> None:
+        root = QVBoxLayout(self)
+        root.setContentsMargins(8, 8, 8, 8)
+        root.setSpacing(6)
+
+        self.grid_header = _ListHeader("Grids")
+        self.grid_header.select_all_changed.connect(self.set_all_grids_selected)
+        root.addWidget(self.grid_header)
+        self.grid_list = _list()
+        root.addWidget(self.grid_list, 1)
+
+        sep = QFrame()
+        sep.setFrameShape(QFrame.HLine)
+        sep.setStyleSheet("color: #3a3d42;")
+        root.addWidget(sep)
+
+        self.task_header = _ListHeader("Tasks")
+        self.task_header.select_all_changed.connect(self.set_all_tasks_selected)
+        root.addWidget(self.task_header)
+        self.task_list = _list()
+        root.addWidget(self.task_list, 1)
+        self.task_hint = QLabel(
+            "Settings are on the Grids tab's Protocol view. The order here is the "
+            "order they run on each grid."
+        )
+        self.task_hint.setWordWrap(True)
+        self.task_hint.setStyleSheet(
+            f"font-size: 11px; color: {TEXT_MUTED_COLOR}; background: transparent;"
+        )
+        root.addWidget(self.task_hint)
+
+        self.summary_label = QLabel()
+        self.summary_label.setStyleSheet(
+            f"font-size: 11px; color: {TEXT_MUTED_COLOR}; background: transparent;"
+        )
+        root.addWidget(self.summary_label)
+
+        bottom = QHBoxLayout()
+        self.btn_screen_all = QPushButton("Screen all grids")
+        self.btn_screen_all.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.btn_screen_all.setIcon(
+            fibsem_icon("mdi:play-circle", color=stylesheets.GRAY_ICON_COLOR)
+        )
+        self.btn_screen_all.setToolTip(
+            "Run inventory, then the ticked tasks on every grid it finds present"
+        )
+        self.btn_screen_all.clicked.connect(self.screen_all_requested)
+        bottom.addWidget(self.btn_screen_all)
+        bottom.addStretch(1)
+        root.addLayout(bottom)
+
+    # -- model -----------------------------------------------------------------
+
+    def set_experiment(self, experiment: Optional[Experiment]) -> None:
+        self._experiment = experiment
+        self._rebuild()
+
+    def set_microscope(self, microscope) -> None:
+        self._microscope = microscope
+        self.refresh()
+
+    @property
+    def stage(self):
+        return getattr(self._microscope, "_stage", None)
+
+    def _protocol(self):
+        if self._experiment is None or self._experiment.task_protocol is None:
+            return None
+        return self._experiment.grid_protocol
+
+    def _rebuild(self) -> None:
+        """New experiment, or the protocol's task set changed: new rows."""
+        checked_grids = {
+            n for n, r in self._grid_rows.items() if r.checkbox.isChecked()
+        }
+        checked_tasks = {
+            n for n, r in self._task_rows.items() if r.checkbox.isChecked()
+        }
+        self.grid_list.clear()
+        self._grid_rows = {}
+        self.task_list.clear()
+        self._task_rows = {}
+        if self._experiment is not None:
+            for grid in self._experiment.grids:
+                row = _GridRow(grid)
+                row.selection_changed.connect(lambda *_: self._on_selection())
+                _add_row(self.grid_list, row)
+                self._grid_rows[grid.name] = row
+                row.checkbox.setChecked(grid.name in checked_grids)
+        protocol = self._protocol()
+        if protocol is not None:
+            for name in protocol.ordered_task_names:
+                row = _TaskRow(protocol.task_config[name])
+                row.selection_changed.connect(lambda *_: self._on_selection())
+                row.move_up.connect(lambda n: self._move_task(n, -1))
+                row.move_down.connect(lambda n: self._move_task(n, +1))
+                _add_row(self.task_list, row)
+                self._task_rows[name] = row
+                # Every task ticked by default: the usual run is the whole protocol.
+                row.checkbox.setChecked(name in checked_tasks or not checked_tasks)
+        # The header box reads the rows, so its next click means the opposite.
+        for header, rows in (
+            (self.grid_header, self._grid_rows),
+            (self.task_header, self._task_rows),
+        ):
+            header.select_all.blockSignals(True)
+            header.select_all.setChecked(
+                bool(rows) and all(r.checkbox.isChecked() for r in rows.values())
+            )
+            header.select_all.blockSignals(False)
+        self.refresh()
+
+    def refresh(self) -> None:
+        """Redraw from the inventory and the records; no hardware call."""
+        inventory: Dict[str, GridInventoryEntry] = {}
+        stage = self.stage
+        if stage is not None:
+            try:
+                inventory = {e.name: e for e in stage.grid_inventory() if e.name}
+            except Exception as e:  # noqa: BLE001 - drawn as "not present"
+                logging.warning(f"Could not read the grid inventory: {e}")
+        # Records added since the last rebuild (an inventory just made them) or
+        # tasks added on the Protocol view need rows.
+        if self._experiment is not None:
+            names = [g.name for g in self._experiment.grids]
+            protocol = self._protocol()
+            tasks = list(protocol.ordered_task_names) if protocol is not None else []
+            if names != list(self._grid_rows) or tasks != list(self._task_rows):
+                self._rebuild()
+                return
+        for row in self._grid_rows.values():
+            row.set_inventory(inventory.get(row.grid.name))
+        for row in self._task_rows.values():
+            row.set_unavailable(task_unavailable_reason(row.config, self._microscope))
+        present = sum(1 for r in self._grid_rows.values() if r.is_present)
+        self.grid_header.trailing.setText(
+            f"{present} of {len(self._grid_rows)} present" if self._grid_rows else ""
+        )
+        self._apply_controls()
+        self._update_summary()
+
+    def refresh_grid(self, grid: GridRecord) -> None:
+        row = self._grid_rows.get(grid.name)
+        if row is not None:
+            row.refresh()
+
+    # -- selection -------------------------------------------------------------
+
+    def get_selected_grids(self) -> List[GridRecord]:
+        return [
+            r.grid
+            for r in self._grid_rows.values()
+            if r.checkbox.isChecked() and r.is_present
+        ]
+
+    def get_selected_task_names(self) -> List[str]:
+        """Ticked tasks, in the list's (the protocol's) order."""
+        return [n for n, r in self._task_rows.items() if r.checkbox.isChecked()]
+
+    def set_all_grids_selected(self, checked: bool) -> None:
+        for row in self._grid_rows.values():
+            if row.is_present:
+                row.checkbox.setChecked(checked)
+
+    def set_all_tasks_selected(self, checked: bool) -> None:
+        for row in self._task_rows.values():
+            if row.checkbox.isEnabled():
+                row.checkbox.setChecked(checked)
+
+    def exchanges_for(self, grids: List[GridRecord]) -> int:
+        """How many of these grids are not in the beam now: the exchanges a run
+        would make on a loader, zero on a fixed holder."""
+        stage = self.stage
+        if stage is None or stage.loader is None:
+            return 0
+        count = 0
+        for g in grids:
+            row = self._grid_rows.get(g.name)
+            if row is not None and not row.in_beam:
+                count += 1
+        return count
+
+    def _on_selection(self) -> None:
+        self._update_summary()
+        self._apply_controls()
+        self.selection_changed.emit()
+
+    def _update_summary(self) -> None:
+        grids = self.get_selected_grids()
+        tasks = self.get_selected_task_names()
+        exchanges = self.exchanges_for(grids)
+        text = (
+            f"{len(grids)} grid{'s' if len(grids) != 1 else ''}, "
+            f"{len(tasks)} task{'s' if len(tasks) != 1 else ''} selected"
+        )
+        if grids:
+            text += f" · {exchanges} exchange{'s' if exchanges != 1 else ''}"
+        self.summary_label.setText(text)
+
+    # -- controls --------------------------------------------------------------
+
+    def set_controls_enabled(self, enabled: bool) -> None:
+        """The host's lockout while a run is going."""
+        self._controls_enabled = enabled
+        self._apply_controls()
+
+    def _apply_controls(self) -> None:
+        protocol = self._protocol()
+        can_screen = (
+            self._controls_enabled
+            and self._experiment is not None
+            and protocol is not None
+            and self.stage is not None
+            and bool(self.get_selected_task_names())
+        )
+        self.btn_screen_all.setEnabled(can_screen)
+        for row in self._task_rows.values():
+            row.btn_up.setEnabled(self._controls_enabled)
+            row.btn_down.setEnabled(self._controls_enabled)
+
+    # -- order -----------------------------------------------------------------
+
+    def _move_task(self, name: str, delta: int) -> None:
+        protocol = self._protocol()
+        if protocol is None:
+            return
+        order = list(protocol.ordered_task_names)
+        i = order.index(name)
+        j = i + delta
+        if not 0 <= j < len(order):
+            return
+        order[i], order[j] = order[j], order[i]
+        protocol.order = order
+        if self._experiment is not None:
+            try:
+                self._experiment.save(save_protocol=True)
+            except Exception as e:  # noqa: BLE001 - the order is changed; say so
+                logging.warning(f"Could not save the grid protocol: {e}")
+        self._rebuild()
+        self.protocol_changed.emit()
+
+
+# ---------------------------------------------------------------------------
+# The confirmation
+# ---------------------------------------------------------------------------
+
+
+class GridRunPreflightDialog(QDialog):
+    """What a grid run is about to do: how many grids and tasks, how many
+    exchanges, where the files go, and the first steps of the plan.
+
+    Its own dialog rather than the lamella preflight: that one is built on a
+    lamella estimate with durations, and grid tasks have no duration estimate
+    yet. When they do, this grows a time column.
+    """
+
+    _STEPS_SHOWN = 12
+
+    def __init__(
+        self,
+        task_names: List[str],
+        grid_names: List[str],
+        exchanges: int,
+        output_root: str,
+        screen_all: bool = False,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Screen all grids" if screen_all else "Run grid workflow")
+        self.setMinimumWidth(460)
+        self.setStyleSheet(f"background: {BACKGROUND};")
+        layout = QVBoxLayout(self)
+        layout.setSpacing(10)
+
+        title = QLabel(
+            "Run inventory, then the tasks on every present grid"
+            if screen_all
+            else "Run the tasks on the selected grids"
+        )
+        title.setStyleSheet(
+            f"font-size: 14px; font-weight: bold; color: {TEXT_STRONG}; {ON_PANEL}"
+        )
+        layout.addWidget(title)
+
+        metrics = QHBoxLayout()
+        metrics.addWidget(
+            metric(
+                "Grids",
+                "every present" if screen_all else str(len(grid_names)),
+                f"{len(grid_names)} known now" if screen_all else "",
+            )
+        )
+        metrics.addWidget(metric("Tasks per grid", str(len(task_names))))
+        metrics.addWidget(
+            metric(
+                "Exchanges",
+                "one per grid" if screen_all else str(exchanges),
+                "" if exchanges or screen_all else "all in the beam",
+            )
+        )
+        layout.addLayout(metrics)
+
+        plan = plan_grid_run(task_names, grid_names)
+        lines = [
+            f"{grid}  ·  {'load' if step == LOAD_ENTRY_NAME else step}"
+            for grid, step in plan[: self._STEPS_SHOWN]
+        ]
+        if len(plan) > self._STEPS_SHOWN:
+            lines.append(f"… and {len(plan) - self._STEPS_SHOWN} more steps")
+        if screen_all:
+            lines.insert(0, "inventory")
+        rows = [("Plan", lines[0])] + [("", line) for line in lines[1:]]
+        layout.addWidget(detail_block(rows if lines else [("Plan", "nothing yet")]))
+        layout.addWidget(meta_label(f"Output: {output_root}/grids/<grid>/"))
+        layout.addWidget(
+            meta_label(
+                "A grid that will not load is skipped and the run continues. "
+                "Stop ends the run at the next step."
+            )
+        )
+
+        buttons = QHBoxLayout()
+        buttons.addStretch(1)
+        self.btn_cancel = QPushButton("Cancel")
+        self.btn_cancel.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.btn_cancel.clicked.connect(self.reject)
+        self.btn_run = QPushButton("Run")
+        self.btn_run.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.btn_run.clicked.connect(self.accept)
+        self.btn_run.setDefault(True)
+        buttons.addWidget(self.btn_cancel)
+        buttons.addWidget(self.btn_run)
+        layout.addLayout(buttons)

--- a/tests/ui/test_grid_workflow_widget.py
+++ b/tests/ui/test_grid_workflow_widget.py
@@ -1,0 +1,255 @@
+"""Workflow · Grids: select grids and tasks, confirm, run on the window's worker."""
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtTest import QTest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    AutoLamellaTaskStatus,
+    Experiment,
+    GridRecord,
+)
+from fibsem.applications.autolamella.task_outputs import grid_outputs
+from fibsem.applications.autolamella.ui.grid_workflow_widget import (
+    GridRunPreflightDialog,
+    GridWorkflowWidget,
+)
+from fibsem.applications.autolamella.workflows.tasks.grid import (
+    BeamOverviewGridTaskConfig,
+    FluorescenceOverviewGridTaskConfig,
+)
+from fibsem.microscopes._stage import SampleGrid, SlotCalibration, _create_sample_stage
+from fibsem.structures import (
+    BeamType,
+    FibsemStagePosition,
+    ImageSettings,
+    OverviewAcquisitionSettings,
+)
+
+
+def _small_settings(beam=BeamType.ELECTRON) -> OverviewAcquisitionSettings:
+    return OverviewAcquisitionSettings(
+        image_settings=ImageSettings(resolution=(128, 128), hfw=200e-6, beam_type=beam),
+        nrows=1,
+        ncols=1,
+    )
+
+
+@pytest.fixture
+def arctis():
+    microscope, _ = utils.setup_session(
+        manufacturer="Demo",
+        config_path=os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml"),
+    )
+    return microscope
+
+
+@pytest.fixture
+def experiment(tmp_path):
+    exp = Experiment(path=tmp_path, name="exp")
+    (tmp_path / "exp").mkdir()
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    exp.grid_protocol.add(
+        BeamOverviewGridTaskConfig(task_name="overview_sem", settings=_small_settings())
+    )
+    exp.grid_protocol.add(FluorescenceOverviewGridTaskConfig(task_name="overview_fm"))
+    return exp
+
+
+@pytest.fixture
+def view(qapp, arctis, experiment):
+    experiment.sync_grids_from_inventory(arctis._stage)
+    experiment.add_grid(GridRecord(name="grid-oak"))  # not in the magazine
+    widget = GridWorkflowWidget()
+    widget.set_microscope(arctis)
+    widget.set_experiment(experiment)
+    return widget
+
+
+class TestSelection:
+    def test_rows_and_defaults(self, view):
+        assert list(view._grid_rows) == ["Grid-01", "Grid-02", "Grid-03", "grid-oak"]
+        assert view.grid_header.trailing.text() == "3 of 4 present"
+        assert not view._grid_rows["grid-oak"].checkbox.isEnabled()
+        # every task ticked by default, in the protocol's order
+        assert view.get_selected_task_names() == ["overview_sem", "overview_fm"]
+        assert view.get_selected_grids() == []
+        assert view.summary_label.text() == "0 grids, 2 tasks selected"
+
+    def test_select_all_ticks_only_present_grids(self, view):
+        view.grid_header.select_all.setChecked(True)
+        assert [g.name for g in view.get_selected_grids()] == [
+            "Grid-01",
+            "Grid-02",
+            "Grid-03",
+        ]
+        assert view.summary_label.text() == "3 grids, 2 tasks selected · 3 exchanges"
+
+    def test_a_grid_in_the_beam_costs_no_exchange(self, view, arctis):
+        arctis._stage.ensure_loaded("Grid-02")
+        view.refresh()
+        view.grid_header.select_all.setChecked(True)
+        assert view.exchanges_for(view.get_selected_grids()) == 2
+        assert [c.text() for c in view._grid_rows["Grid-02"]._chip_widgets] == [
+            "slot 02",
+            "in beam",
+        ]
+
+    def test_the_fm_task_is_greyed_without_a_fluorescence_microscope(
+        self, qapp, experiment
+    ):
+        plain, _ = utils.setup_session(manufacturer="Demo")
+        # Said outright: a Demo session set up after an Arctis one in the same
+        # process keeps the Arctis FM (the default configuration is shared), so
+        # the plain Demo is not reliably FM-less by itself.
+        plain.fm = None
+        widget = GridWorkflowWidget()
+        widget.set_microscope(plain)
+        widget.set_experiment(experiment)
+        row = widget._task_rows["overview_fm"]
+        assert not row.checkbox.isEnabled()
+        assert "no fluorescence microscope" in row.detail_label.text()
+        assert widget.get_selected_task_names() == ["overview_sem"]
+
+    def test_reordering_tasks_writes_the_protocol(self, view, experiment):
+        view._task_rows["overview_fm"].btn_up.click()
+        assert view.get_selected_task_names() == ["overview_fm", "overview_sem"]
+        assert experiment.grid_protocol.ordered_task_names == [
+            "overview_fm",
+            "overview_sem",
+        ]
+        again = Experiment.load(Path(experiment.path) / "experiment.yaml")
+        assert again.grid_protocol.ordered_task_names == ["overview_fm", "overview_sem"]
+
+    def test_screen_all_needs_a_task_and_a_stage(self, view):
+        assert view.btn_screen_all.isEnabled()
+        assert view.task_header.select_all.isChecked()  # reads the rows
+        view.task_header.select_all.setChecked(False)
+        assert view.get_selected_task_names() == []
+        assert not view.btn_screen_all.isEnabled()
+        view.set_all_tasks_selected(True)
+        view.set_controls_enabled(False)
+        assert not view.btn_screen_all.isEnabled()
+
+
+def test_the_preflight_says_what_a_run_does(qapp):
+    dialog = GridRunPreflightDialog(
+        ["overview_sem", "overview_fib"], ["Grid-01", "Grid-02"], 2, "/exp"
+    )
+    assert dialog.windowTitle() == "Run grid workflow"
+    dialog = GridRunPreflightDialog(
+        ["overview_sem"], ["Grid-01"], 1, "/exp", screen_all=True
+    )
+    assert dialog.windowTitle() == "Screen all grids"
+
+
+@pytest.fixture
+def main_ui(qapp):
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
+    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
+    try:
+        window = module.AutoLamellaSingleWindowUI()
+    finally:
+        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    yield window
+    if window.autolamella_ui.microscope is not None:
+        window.autolamella_ui.microscope.disconnect()
+    original_quit = qapp.quit
+    qapp.quit = lambda: None
+    try:
+        window.close()
+    finally:
+        qapp.quit = original_quit
+
+
+def _wait_for_run(ui, timeout_s: float = 90.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    while ui.is_workflow_running and time.monotonic() < deadline:
+        QTest.qWait(100)
+    assert not ui.is_workflow_running, "the grid run did not finish in time"
+
+
+def test_the_grids_view_sits_beside_lamella_behind_the_flag(main_ui):
+    left = main_ui.workflow_left_tabs
+    index = left.indexOf(main_ui.grid_workflow_widget)
+    assert left.tabText(index) == "Grids" and left.tabText(0) == "Lamella"
+    assert not left.isTabVisible(index)
+    main_ui._preferences.features.grid_workflow = True
+    main_ui._apply_grid_workflow_visibility()
+    assert left.isTabVisible(index)
+
+
+def test_a_grid_run_from_the_window_on_a_fixed_holder(main_ui, tmp_path, monkeypatch):
+    """End to end: the Run button on the Grids view, the worker, the manager, the
+    shared timeline and the record. A fixed holder, so no exchange."""
+    ui = main_ui.autolamella_ui
+    # The post-run summary is modal; under offscreen it would block forever.
+    from fibsem.applications.autolamella.ui import AutoLamellaUI as ui_module
+
+    class _NoDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def exec_(self):
+            return 0
+
+    monkeypatch.setattr(ui_module, "WorkflowSummaryDialog", _NoDialog)
+    ui.system_widget.connect_to_microscope()
+    microscope = ui.microscope
+    microscope.stage_is_compustage = False
+    microscope._stage = _create_sample_stage(microscope)
+    slot = microscope._stage.holder.slots["Slot-01"]
+    slot.position = FibsemStagePosition(
+        name=slot.name, x=-4e-3, y=1e-3, z=4e-3, r=0, t=0.61
+    )
+    slot.calibration = SlotCalibration("SEM", 35.0, 0.0, "2026-09-02T11:24:09", "test")
+    slot.loaded_grid = SampleGrid(name="grid-aspen")
+    main_ui._refresh_grids_tab_microscope()
+
+    exp = Experiment(path=tmp_path, name="exp")
+    (tmp_path / "exp").mkdir()
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    exp.grid_protocol.add(
+        BeamOverviewGridTaskConfig(task_name="overview_sem", settings=_small_settings())
+    )
+    exp.sync_grids_from_inventory(microscope._stage)
+    ui.experiment = exp
+    # The pieces of _on_experiment_update this test needs. The whole handler also
+    # rebuilds the lamella task editor, which cannot take a protocol with no
+    # lamella tasks (a pre-existing gap; real protocols always have some).
+    main_ui.grids_tab.set_experiment(exp)
+    main_ui.grid_workflow_widget.set_experiment(exp)
+    main_ui.tab_widget.setTabEnabled(
+        main_ui.tab_widget.indexOf(main_ui.grids_tab), True
+    )
+
+    view = main_ui.grid_workflow_widget
+    main_ui.workflow_left_tabs.setCurrentWidget(view)
+    view.grid_header.select_all.setChecked(True)
+    assert main_ui.run_workflow_btn.isEnabled()
+    assert "1 grid, 1 task" in main_ui.run_workflow_btn.toolTip()
+
+    main_ui._start_grid_run(["overview_sem"], ["grid-aspen"], inventory_first=False)
+    assert ui.is_workflow_running
+    assert not main_ui.grids_tab.btn_inventory.isEnabled()  # locked during the run
+    _wait_for_run(ui)
+    QTest.qWait(200)  # let the finished signal land
+
+    grid = exp.get_grid_by_name("grid-aspen")
+    # a fixed holder: the grid was in the beam already, so no load entry
+    assert [t.name for t in grid.task_history] == ["overview_sem"]
+    assert grid.task_history[-1].status is AutoLamellaTaskStatus.Completed
+    assert len(grid_outputs(exp, grid, "overview_sem")) == 1
+    assert main_ui.grids_tab.btn_inventory.isEnabled()
+    assert ui._last_run_summary is not None  # the grid summary, for the agent server

--- a/tests/ui/test_grid_workflow_widget.py
+++ b/tests/ui/test_grid_workflow_widget.py
@@ -184,10 +184,16 @@ def test_the_grids_view_sits_beside_lamella_behind_the_flag(main_ui):
     left = main_ui.workflow_left_tabs
     index = left.indexOf(main_ui.grid_workflow_widget)
     assert left.tabText(index) == "Grids" and left.tabText(0) == "Lamella"
-    assert not left.isTabVisible(index)
-    main_ui._preferences.features.grid_workflow = True
-    main_ui._apply_grid_workflow_visibility()
-    assert left.isTabVisible(index)
+    was = main_ui._preferences.features.grid_workflow
+    try:
+        main_ui._preferences.features.grid_workflow = False
+        main_ui._apply_grid_workflow_visibility()
+        assert not left.isTabVisible(index)
+        main_ui._preferences.features.grid_workflow = True
+        main_ui._apply_grid_workflow_visibility()
+        assert left.isTabVisible(index)
+    finally:
+        main_ui._preferences.features.grid_workflow = was
 
 
 def test_a_grid_run_from_the_window_on_a_fixed_holder(main_ui, tmp_path, monkeypatch):

--- a/tests/ui/test_grids_tab.py
+++ b/tests/ui/test_grids_tab.py
@@ -281,10 +281,18 @@ def test_the_tab_sits_behind_the_flag_between_lamella_and_workflow(main_ui):
     index = tabs.indexOf(main_ui.grids_tab)
     labels = [tabs.tabText(i) for i in range(tabs.count())]
     assert labels[index - 1] == "Lamella" and labels[index + 1] == "Workflow"
-    assert not tabs.isTabVisible(index)  # off by default
-    main_ui._preferences.features.grid_workflow = True
-    main_ui._apply_grid_workflow_visibility()
-    assert tabs.isTabVisible(index)
+    # Both states set outright: the window loads (and on close saves) the
+    # preference file, so "off by default" would read whatever the last run left.
+    was = main_ui._preferences.features.grid_workflow
+    try:
+        main_ui._preferences.features.grid_workflow = False
+        main_ui._apply_grid_workflow_visibility()
+        assert not tabs.isTabVisible(index)
+        main_ui._preferences.features.grid_workflow = True
+        main_ui._apply_grid_workflow_visibility()
+        assert tabs.isTabVisible(index)
+    finally:
+        main_ui._preferences.features.grid_workflow = was
 
 
 def test_the_tab_follows_the_connection_and_the_experiment(main_ui, tmp_path):


### PR DESCRIPTION
Milestone 5, last PR: the run view (FIB-890) and the one-click screening (FIB-898). Stacked on #746. Behind `features.grid_workflow` like the rest.

## Workflow → Grids

The Workflow tab's left panel becomes two views, **Lamella** and **Grids**; the timeline on the right, the status-bar Run and Stop buttons and the window's worker thread are shared. One run at a time, one place to watch it; Run acts on whichever view is showing (as agreed: one timeline).

- **Grids**: checkbox rows over the experiment's grid records, each with the headline from its history and the hardware's word as chips (`slot NN`, `in beam`, or `not present`). Only a present grid can be ticked; select all ticks the present ones. The header counts how many are present.
- **Tasks**: the grid protocol's tasks in its order, every one ticked by default (the usual run is the whole protocol), the order editable with up/down and written to `protocol.yaml`. A task this system cannot run (the fluorescence overview without an FM) is greyed with the reason. Settings stay on Grids → Protocol.
- **Summary**: grids, tasks, and the exchanges the run would make (grids not in the beam; zero on a fixed holder).
- **Preflight**, its own dialog since grid tasks have no duration estimate yet: grids, tasks per grid, exchanges, the first steps of the plan with the loads in it, where the files go, and the two rules (a grid that will not load is skipped; Stop ends the run at the next step).
- **Screen all grids**: inventory on the worker, then the ticked tasks on every grid it finds present, with the same confirmation.

## The run on the window

`_start_run_grid_workflow_thread` / `_run_grid_tasks_worker` are the lamella run's twin: the same worker slot, manager slot (so Stop and the abort check work unchanged), hooks, and finished signal; the run summary lands where the agent server reads it. A grid run's status reports refresh the grid's card, its row and the Results view rather than the lamella lists. `set_workflow_running` locks every manual exchange control (Sample view, Grids tab, this view) and the finish unlocks them and redraws.

Adding to a running grid queue from the timeline is not offered yet (its Add button is disabled on this view); the queue supports it, the estimate path does not.

**Tests** (`tests/ui/test_grid_workflow_widget.py`): rows and defaults on the Arctis simulator, select-all over present grids only, exchange counting with a grid in the beam, the FM task greyed on a system without one, reordering written to disk, the Screen-all gate, both preflight titles; and in the real window, the view's place and flag, and an end-to-end grid run on a fixed holder: Run enabled from the selection, the run locking the Grids tab, the history and outputs recorded, the summary captured, the lockout released.

One thing found on the way and left alone: `_on_experiment_update` rebuilds the lamella task editor, which raises on a task protocol with no lamella tasks (real protocols always have some). The window test drives the grid pieces directly.
