### PR TITLE
[fm] Drop the remote OME schema validation from FluorescenceImage.save

### DIFF
--- a/fibsem/fm/structures.py
+++ b/fibsem/fm/structures.py
@@ -357,10 +357,12 @@ class FluorescenceImage:
             self.data = self.data.reshape(1, 1, *self.data.shape)
 
         ome_md = self.get_ome_metadata()
+        # No schema validation here: ome_types builds the XML from typed
+        # models, and tff.OmeXml.validate fetches the OME XSD over HTTP on
+        # first use. An offline microscope PC (the normal case) blocked on the
+        # socket timeout and then raised on every FM save. Outbound network
+        # calls are opt-in and must never sit on the acquisition path.
         ome_xml = ome_md.to_xml()
-
-        # Validate OME XML
-        assert tff.OmeXml.validate(ome_xml), "OME XML is not valid"
 
         # Reshape image to 5D for tifffile (CZYX -> TCZYX)
         if self.data.ndim != 5:

--- a/tests/fm/test_structures.py
+++ b/tests/fm/test_structures.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import numpy as np
 import pytest
+import tifffile as tff
 import yaml
 
 from fibsem.fm.structures import (
@@ -563,6 +564,56 @@ def test_fluorescence_image_save_creates_the_directory(tmp_path):
     assert written == str(filename)
 
 
+def test_fluorescence_image_save_load_is_offline(tmp_path, monkeypatch):
+    """save() and load() must not touch the network.
+
+    save() used to validate the OME XML with tff.OmeXml.validate, which
+    downloads the OME XSD over HTTP on first use. On an offline microscope
+    PC every FM save blocked until the socket timed out and then raised; on
+    CI it failed with URLError. Block every outbound socket and the urllib
+    entry point tifffile uses, and check the roundtrip still works.
+    """
+    import socket
+    import urllib.request
+
+    def _no_network(*args, **kwargs):
+        raise AssertionError("network access attempted during FM save/load")
+
+    monkeypatch.setattr(socket, "create_connection", _no_network)
+    monkeypatch.setattr(socket.socket, "connect", _no_network)
+    monkeypatch.setattr(urllib.request, "urlopen", _no_network)
+    # Drop any XSD tifffile cached earlier in the session so the fetch would
+    # actually be attempted if save() still validated.
+    monkeypatch.setattr(tff.OmeXml, "_schema", [])
+
+    channel = FluorescenceChannelMetadata(
+        name="GFP",
+        excitation_wavelength=488.0,
+        emission_wavelength=520.0,
+        power=0.3,
+        exposure_time=0.05,
+        gain=1.0,
+        offset=0.0,
+    )
+    metadata = FluorescenceImageMetadata(
+        acquisition_date=datetime.now().isoformat(),
+        pixel_size_x=100e-9,
+        pixel_size_y=100e-9,
+        resolution=(16, 16),
+        channels=[channel],
+    )
+    image = FluorescenceImage(
+        data=np.zeros((1, 1, 16, 16), dtype=np.uint8), metadata=metadata
+    )
+    filename = tmp_path / "offline.ome.tiff"
+
+    image.save(str(filename))
+    loaded = FluorescenceImage.load(str(filename))
+
+    assert loaded.metadata.channels[0].name == "GFP"
+    assert loaded.data.shape == (1, 1, 16, 16)
+
+
 def test_fluorescence_image_save_load_roundtrip():
     """Test save/load roundtrip with structured annotations."""
     # Create test data
@@ -740,7 +791,7 @@ def test_safe_ome_from_tiff_strips_channel_filters():
         '<Filter ID="Filter:0:0" Type="pass-through" /></Channel>'
         '<Channel ID="Channel:0:1" SamplesPerPixel="1">'
         '<Filter ID="Filter:0:1" Type="pass-through" /></Channel>'
-        '<TiffData /></Pixels></Image></OME>'
+        "<TiffData /></Pixels></Image></OME>"
     )
     data = np.zeros((2, 4, 4), dtype=np.uint8)
 
@@ -1859,7 +1910,9 @@ def test_estimate_acquisition_time_edge_cases():
     # Single z-plane (no z-movement)
     zparams_single = ZParameters(zmin=0, zmax=0, zstep=1e-6)
     time_single = estimate_acquisition_time(channel, zparams_single)
-    expected_single = 0.01 + DEFAULT_OVERHEAD_PER_IMAGE  # exposure + overhead, no z-moves
+    expected_single = (
+        0.01 + DEFAULT_OVERHEAD_PER_IMAGE
+    )  # exposure + overhead, no z-moves
     assert time_single == expected_single
 
     # Note: Timing constants are now fixed in the timing module
@@ -2107,7 +2160,9 @@ def test_estimate_tileset_acquisition_time_counts_only_enabled_tiles():
     plus = [[(i == 2 or j == 2) for j in range(5)] for i in range(5)]
 
     full = estimate_tileset_acquisition_time(channel, grid_size=(5, 5))
-    sparse = estimate_tileset_acquisition_time(channel, grid_size=(5, 5), tile_mask=plus)
+    sparse = estimate_tileset_acquisition_time(
+        channel, grid_size=(5, 5), tile_mask=plus
+    )
 
     assert full["tiles"] == 25
     assert sparse["tiles"] == 9
@@ -2116,7 +2171,9 @@ def test_estimate_tileset_acquisition_time_counts_only_enabled_tiles():
     # per-row autofocus fires once per row that actually gets visited
     masked_rows = [[(i == 0) for j in range(4)] for i in range(4)]
     one_row = estimate_tileset_acquisition_time(
-        channel, grid_size=(4, 4), autofocus_mode=AutoFocusMode.EACH_ROW,
+        channel,
+        grid_size=(4, 4),
+        autofocus_mode=AutoFocusMode.EACH_ROW,
         tile_mask=masked_rows,
     )
     assert one_row["breakdown"]["autofocus"]["operations"] == 1
@@ -2281,6 +2338,7 @@ def test_estimate_tileset_acquisition_time_scaling():
 # FluorescenceConfiguration tests
 # ---------------------------------------------------------------------------
 
+
 def _make_minimal_config(**kwargs) -> FluorescenceConfiguration:
     """Helper: build a FluorescenceConfiguration with minimal required fields."""
     channel = ChannelSettings(
@@ -2346,6 +2404,7 @@ def test_fluorescence_configuration_yaml_roundtrip():
         assert loaded.default_orientation == "SEM"
     finally:
         import os
+
         if os.path.exists(filename):
             os.unlink(filename)
 
@@ -2361,6 +2420,7 @@ def test_fluorescence_configuration_yaml_roundtrip_fm():
         assert loaded.default_orientation == "FM"
     finally:
         import os
+
         if os.path.exists(filename):
             os.unlink(filename)
 
@@ -2449,15 +2509,17 @@ class TestCombiningImagesKeepsTheirMetadata:
             acquisition_date="2026-07-31T12:00:00",
             pixel_size_x=1e-7,
             pixel_size_y=1e-7,
-            channels=[FluorescenceChannelMetadata(
-                name=overrides.pop("name", "GFP"),
-                excitation_wavelength=488.0,
-                power=0.5,
-                exposure_time=0.1,
-                gain=1.0,
-                offset=0.0,
-                objective_position=1e-3,
-            )],
+            channels=[
+                FluorescenceChannelMetadata(
+                    name=overrides.pop("name", "GFP"),
+                    excitation_wavelength=488.0,
+                    power=0.5,
+                    exposure_time=0.1,
+                    gain=1.0,
+                    offset=0.0,
+                    objective_position=1e-3,
+                )
+            ],
             geometry=FibsemHardwareGeometry(
                 transform=CameraImageTransform.FLIP_XY,
                 camera_tilt=180.0,
@@ -2466,7 +2528,9 @@ class TestCombiningImagesKeepsTheirMetadata:
             description="carried through",
             **overrides,
         )
-        return FluorescenceImage(data=np.zeros((1, 8, 8), dtype=np.uint16), metadata=metadata)
+        return FluorescenceImage(
+            data=np.zeros((1, 8, 8), dtype=np.uint16), metadata=metadata
+        )
 
     def test_a_z_stack_keeps_the_geometry(self):
         from fibsem.fm.structures import FluorescenceImage

--- a/tests/fm/test_structures.py
+++ b/tests/fm/test_structures.py
@@ -583,8 +583,9 @@ def test_fluorescence_image_save_load_is_offline(tmp_path, monkeypatch):
     monkeypatch.setattr(socket.socket, "connect", _no_network)
     monkeypatch.setattr(urllib.request, "urlopen", _no_network)
     # Drop any XSD tifffile cached earlier in the session so the fetch would
-    # actually be attempted if save() still validated.
-    monkeypatch.setattr(tff.OmeXml, "_schema", [])
+    # actually be attempted if save() still validated. Older tifffile (the
+    # 3.8 pin on CI) has no cache attribute at all; raising=False skips it.
+    monkeypatch.setattr(tff.OmeXml, "_schema", [], raising=False)
 
     channel = FluorescenceChannelMetadata(
         name="GFP",


### PR DESCRIPTION
## Problem

`FluorescenceImage.save` asserted `tff.OmeXml.validate(ome_xml)`. tifffile's `validate` downloads the OME XSD from openmicroscopy.org over HTTP on first use (there is no vendored copy). So every FM image save made a network request:

- on an offline microscope PC (the normal case) the save blocked until the socket timed out, then the assert raised
- on CI, `tests/fm/test_structures.py::test_fluorescence_image_save_creates_the_directory` failed with `urllib.error.URLError: <urlopen error [Errno 110] Connection timed out>` (run 33604612148, ubuntu 3.12)

Outbound network calls are opt-in and must never sit on the acquisition path.

## Fix

Remove the validate call. It could not catch anything: ome_types builds the XML from pydantic models generated from the same 2016-06 schema, with validate_assignment on, so wrong-typed, out-of-range, or unknown values are rejected before `to_xml()` runs. I confirmed the current output also passes ome_types' offline `validate_xml` against its vendored XSD. The load path (`from_tiff` / `from_xml`) already parses offline with validation off.

## Test

`test_fluorescence_image_save_load_is_offline` monkeypatches `socket.create_connection`, `socket.socket.connect` and `urllib.request.urlopen` to raise, clears tifffile's cached schema list, and checks a save/load roundtrip. Reverting the fix makes it fail.

The rest of the test-file diff is `ruff format`, which the lint job requires on any changed file.