### PR TITLE
[sim] Per-beam layer contrast; the rival lobe is a physical size, gate 0.80

### DIFF
--- a/fibsem/alignment/coincidence.py
+++ b/fibsem/alignment/coincidence.py
@@ -51,20 +51,24 @@ AGREEMENT_BANDS: Tuple[Tuple[float, float], Tuple[float, float]] = ((2, 8), (4, 
 DEFAULT_AGREEMENT_TOLERANCE = 0.75e-6  # m
 DEFAULT_CAPTURE_RANGE = 20e-6  # m
 WINDOW_EDGE_MARGIN_PX = 3
-RIVAL_LOBE_BANDS = 2.0  # lobe radius, in units of the band's wide sigma
+# the primary peak's own lobe, excluded when looking for a rival: a physical
+# size, so the gate reads the same at any field width (in pixels the lobe
+# would shrink relative to the search window as the field narrows, and the
+# ratio would climb for the same true lock)
+RIVAL_LOBE = 3.2e-6  # m (~2x the wide band sigma at the 150 um alignment field)
 
 REFUSAL_BAND_DISAGREEMENT = "band-disagreement"
 REFUSAL_WINDOW_EDGE = "window-edge"
 REFUSAL_LATERAL_OFFSET = "lateral-offset"
 REFUSAL_RIVAL_PEAK = "rival-peak"
 # A second correlation candidate outside the chosen peak's lobe that is
-# nearly as good as the lock: on the simulator every correct fine lock
-# measured 0.53-0.85 here (mammalian, yeast, bacteria scenes) and every
-# false fine lock that passed the other gates 0.94-1.00 - the 0.94 one
-# moved the stage 15 um the wrong way before the next measurement caught
-# it. Calibrated on the simulator only; the bench pairs (FIB-872) are the
-# check.
-DEFAULT_MAX_RIVAL_RATIO = 0.92
+# nearly as good as the lock. With the lobe a physical size (RIVAL_LOBE)
+# the ratio reads the same at any field width; on the simulator's scenes
+# (mammalian, yeast, bacteria; 80-300 um fields; with and without noise)
+# every correct fine lock measured 0.35-0.72 and every false fine lock
+# 0.86-0.99. Calibrated on the simulator only; the bench pairs (FIB-872)
+# are the check.
+DEFAULT_MAX_RIVAL_RATIO = 0.80
 # ...but not at the coarse field of view: there a correct lock can read
 # 0.99 (the wide, smooth structure of large cells) while the wrong ones
 # were all caught by the band and lateral gates, and the fine pass that
@@ -337,9 +341,8 @@ def measure_coincidence(
     for s1, s2 in AGREEMENT_BANDS:
         ref = _preprocess(sem, s1, s2)
         other = _preprocess(fib_stretched, s1, s2)
-        # a correlation peak's own lobe is a few band widths across
         (dy_px, dx_px), on_edge, ratio = _windowed_xcorr(
-            ref, other, center, half_yx, lobe_px=RIVAL_LOBE_BANDS * s2
+            ref, other, center, half_yx, lobe_px=RIVAL_LOBE / pixel_size
         )
         shifts.append((dy_px, dx_px))
         on_edge_any = on_edge_any or on_edge
@@ -579,6 +582,8 @@ def ensure_coincident(
     relaxation: float = 1.0,
     coarse_hfw: Optional[float] = DEFAULT_COARSE_HFW,
     coarse_capture_range: float = DEFAULT_COARSE_CAPTURE_RANGE,
+    max_lateral_offset: float = DEFAULT_MAX_LATERAL_OFFSET,
+    max_rival_ratio: float = DEFAULT_MAX_RIVAL_RATIO,
     coarse_agreement_tolerance: float = DEFAULT_COARSE_AGREEMENT_TOLERANCE,
     coarse_max_lateral_offset: float = DEFAULT_COARSE_MAX_LATERAL_OFFSET,
     coarse_max_rival_ratio: float = DEFAULT_COARSE_MAX_RIVAL_RATIO,
@@ -623,6 +628,8 @@ def ensure_coincident(
         capture_range: fine search half-width (m), centred on zero every
             iteration - never re-seeded at a previous lock.
         agreement_tolerance: band-agreement gate for fine measurements.
+        max_lateral_offset: |dx| bound for fine measurements.
+        max_rival_ratio: rival-peak bound for fine measurements.
         relaxation: under-relaxation passed to vertical_move; 1.0 is exact.
         coarse_hfw: field width (m) for the coarse escalation; None disables
             it, making a fine refusal terminal.
@@ -679,6 +686,8 @@ def ensure_coincident(
             prior=prior,
             capture_range=capture_range,
             agreement_tolerance=agreement_tolerance,
+            max_lateral_offset=max_lateral_offset,
+            max_rival_ratio=max_rival_ratio,
         )
         measurements.append(measurement)
         report(PROGRESS_MEASURED, measurement=measurement)

--- a/fibsem/microscopes/sim_scene.py
+++ b/fibsem/microscopes/sim_scene.py
@@ -131,12 +131,54 @@ def _lattice_draw(i: np.ndarray, j: np.ndarray, seed: int) -> np.ndarray:
     return ((h * 2654435761) & 0xFFFFFFFF) / 2**32
 
 
-# what the beams see of the support, on the canvas scale
-HOLE_DEPTH = 45.0  # film absent inside a hole
-HOLE_RIM = 25.0  # the bright rim around a hole
-RIP_DEPTH = 80.0  # film torn away
-RIM_INTENSITY = 120.0  # the grid's metal rim
-BEYOND_INTENSITY = -60.0  # the holder, beyond the grid
+# What each beam sees of each layer, on a 0-255 scale. Features carry an
+# SEM-scale intensity; the FIB column is a multiplier on it (negative =
+# darker than the film). The support layers are absolute per beam. The FIB
+# is not an inverted SEM: holes and trenches are dark in both (no material,
+# no signal), cell bodies read slightly darker than film in the FIB with
+# bright outlines from the edge effect, contamination and ice stay bright.
+BEAM_LAYERS = {
+    BeamType.ELECTRON: {
+        "film": 60.0,
+        "film_tilt_gain": 30.0,  # added as (1 - foreshortening): tilt contrast
+        "bars": 90.0,
+        "holes": -45.0,
+        "hole_rim": 25.0,
+        "rips": -70.0,  # absolute offset from film where the film is gone
+        "rim": 120.0,
+        "holder": 0.0,
+        "edge_highlight": 0.0,
+        "trench_floor": 0.25,
+        "cell": {"body": 1.0, "nucleus": 1.0, "organelle": 1.0, "bud": 1.0},
+        "contamination": 1.0,
+        "ice": 1.0,
+        "fiducial": 1.0,
+    },
+    BeamType.ION: {
+        "film": 95.0,
+        "film_tilt_gain": 60.0,
+        "bars": 50.0,
+        "holes": -80.0,
+        "hole_rim": 10.0,
+        "rips": -90.0,
+        "rim": 150.0,
+        "holder": 0.0,
+        "edge_highlight": 1.0,  # x the saturating outline of the structure
+        "trench_floor": 0.25,
+        "cell": {"body": -0.7, "nucleus": 0.15, "organelle": 0.0, "bud": -0.7},
+        "contamination": 0.5,
+        "ice": 0.7,
+        "fiducial": -0.3,
+    },
+}
+# the FIB edge effect: an outline brightens by up to EDGE_INTENSITY once the
+# structure gradient (per pixel, on the canvas scale) passes the scale
+EDGE_INTENSITY = 45.0
+EDGE_GRADIENT_SCALE = 4.0
+# the FM reflection's view of the support, on the same scale
+HOLE_DEPTH = 45.0
+RIP_DEPTH = 80.0
+RIM_INTENSITY = 120.0
 
 FIDUCIAL_ARM_LENGTH = 8e-6  # m, half-length of each fiducial cross arm
 FIDUCIAL_POINT_SPACING = 0.5e-6  # m
@@ -185,7 +227,6 @@ class MilledRegion:
 
 
 MILL_DEPTH = 90.0  # how dark a trench reads in the FM reflection (canvas scale)
-MILL_FLOOR = 0.25  # the fraction of the local beam intensity a trench keeps
 
 
 @dataclass
@@ -847,7 +888,11 @@ class SampleScene:
         ax = ax + beam_shift[0] + offset[0] + current_offset[0]
         ay = ay - (beam_shift[1] + offset[1] + current_offset[1])
 
-        canvas = np.zeros((height, width), dtype=np.float32)
+        # both beams' canvases are drawn together - one profile, one cover,
+        # two intensities - and the requested one is returned. The other is
+        # the "structure" the FIB's edge highlight is taken from
+        canvases = {b: np.zeros((height, width), dtype=np.float32) for b in BEAM_LAYERS}
+        layers = {b: BEAM_LAYERS[b] for b in BEAM_LAYERS}
 
         # grid mesh bars: world (sample-plane) coordinates per pixel, through
         # the inverse of the same mapping the features use: un-shift,
@@ -858,39 +903,54 @@ class SampleScene:
         ys_world = (-vx * sin_t + vy * cos_t) / fs
 
         bars, holes, rips, rim, beyond = self.film_masks(xs_world, ys_world)
-        canvas[bars] += self.grid_intensity
-        # holes: film absent, with a bright rim one pixel-ish wide
-        canvas[holes] -= HOLE_DEPTH
         hole_rim = ndi_binary_dilation(holes, iterations=2) & ~holes & ~bars
-        canvas[hole_rim] += HOLE_RIM
+        for b, canvas in canvases.items():
+            t = layers[b]
+            canvas[bars] += t["bars"] * (self.grid_intensity / 90.0)
+            canvas[holes] += t["holes"]
+            canvas[hole_rim] += t["hole_rim"]
 
         for f in self.features:
             # project (foreshorten), rotate with the scan, then shift
             px_, py_ = f.x, f.y * fs
             u = cx + (px_ * cos_t - py_ * sin_t + ax) / pixel_size
             v = cy + (px_ * sin_t + py_ * cos_t + ay) / pixel_size
-            self._stamp_feature(canvas, f, u, v, pixel_size, fs, theta)
+            targets = [
+                (canvases[b], f.intensity * self._layer_weight(layers[b], f))
+                for b in canvases
+            ]
+            self._stamp_feature(targets, f, u, v, pixel_size, fs, theta)
 
-        # what is torn or off-grid overrides whatever was drawn there
-        canvas[rips] = -RIP_DEPTH
-        canvas[rim] = RIM_INTENSITY
-        canvas[beyond] = BEYOND_INTENSITY
-
+        trench = self.milled_mask(xs_world, ys_world) if self.milled else None
         if rng is None:
             rng = np.random.default_rng()
+
+        t = layers[beam_type]
+        canvas = canvases[beam_type]
         # soft-compress so overlapping cells don't saturate into flat,
         # texture-free regions (hard clipping kills correlatable structure)
         canvas = 180.0 * np.tanh(canvas / 180.0)
-        if beam_type is BeamType.ION:
-            data = 170.0 - 0.6 * canvas
-        else:
-            data = 60.0 + canvas
-        # a trench is dark in BOTH beams - it is not surface contrast but a
-        # hole in the sample - so it goes on after the per-beam mapping
-        if self.milled:
-            trench = self.milled_mask(xs_world, ys_world)
-            data = np.where(trench, data * MILL_FLOOR, data)
-        data += rng.normal(0, self.noise_sigma, canvas.shape)
+        # the film: brighter at grazing incidence (SE yield rises with tilt)
+        data = t["film"] + t["film_tilt_gain"] * (1.0 - fs) + canvas
+        if t["edge_highlight"]:
+            # the FIB's edge effect: outlines light up wherever the
+            # structure changes - cell rims, bar edges, hole and trench lips
+            structure = ndi_gaussian(canvases[BeamType.ELECTRON], 1.0)
+            if trench is not None:
+                structure = structure - 120.0 * trench
+            gy, gx = np.gradient(structure)
+            # a saturating outline: any real edge lights up about the same,
+            # the way an SE edge effect does, without amplifying flat noise
+            edge = np.tanh(np.hypot(gx, gy) / EDGE_GRADIENT_SCALE)
+            data = data + t["edge_highlight"] * EDGE_INTENSITY * edge
+        # what is torn or off-grid overrides whatever was drawn there
+        data = np.where(rips, t["film"] + t["rips"], data)
+        data = np.where(rim, t["rim"], data)
+        data = np.where(beyond, t["holder"], data)
+        # a trench is a hole in the sample, dark in both beams
+        if trench is not None:
+            data = np.where(trench, data * t["trench_floor"], data)
+        data = data + rng.normal(0, self.noise_sigma, canvas.shape)
         if self.noise_fraction > 0:
             uniform = rng.uniform(0, 255, canvas.shape)
             data = (1 - self.noise_fraction) * data + self.noise_fraction * uniform
@@ -1063,9 +1123,15 @@ class SampleScene:
         reference.z = (reference.z or 0.0) + dz
         return reference
 
+    @staticmethod
+    def _layer_weight(table: dict, f: SceneFeature) -> float:
+        if f.kind == "cell":
+            return float(table["cell"].get(f.part, 1.0))
+        return float(table.get(f.kind, 1.0))
+
     def _stamp_feature(
         self,
-        canvas: np.ndarray,
+        targets,
         f: SceneFeature,
         u: float,
         v: float,
@@ -1075,15 +1141,18 @@ class SampleScene:
         intensity: Optional[float] = None,
     ) -> None:
         """Stamp one feature at view position (u, v): its ellipse in pixels,
-        foreshortened along the view's y, turned with the scan."""
+        foreshortened along the view's y, turned with the scan. `targets` is
+        either one canvas (with `intensity`) or a list of (canvas,
+        intensity) pairs drawn with one profile."""
+        if intensity is not None:
+            targets = [(targets, intensity)]
         sigma_x = f.sigma / pixel_size
         self._stamp_blob(
-            canvas,
+            targets,
             u,
             v,
             sigma_x,
             sigma_x * f.eccentricity * fs,
-            f.intensity if intensity is None else intensity,
             f.sharpness,
             angle=f.angle + scan_rotation,
             wobble=f.wobble,
@@ -1093,12 +1162,11 @@ class SampleScene:
 
     @staticmethod
     def _stamp_blob(
-        canvas: np.ndarray,
+        targets,
         u: float,
         v: float,
         sigma_x: float,
         sigma_y: float,
-        intensity: float,
         sharpness: float = 1.0,
         angle: float = 0.0,
         wobble: float = 0.0,
@@ -1111,9 +1179,10 @@ class SampleScene:
         turns the (sigma_x, sigma_y) ellipse; `wobble` modulates its radius
         with a few harmonics of the polar angle for an irregular outline.
         `opacity` composites instead of adding: inside the outline the
-        background (film, holes, bars) is hidden by that fraction.
+        background (film, holes, bars) is hidden by that fraction. `targets`
+        are (canvas, intensity) pairs sharing the one profile.
         """
-        height, width = canvas.shape
+        height, width = targets[0][0].shape
         # a flat-top blob (sharpness >= 2) is already ~0 by 2 sigma; only a
         # plain gaussian needs the 4 sigma box - and a box 4x smaller is
         # what makes a field of 30 um cells affordable
@@ -1150,7 +1219,9 @@ class SampleScene:
             # whatever the intensity profile does - a body hides the film
             # under all of itself, not only under its brightest part
             cover = opacity * np.exp(-0.5 * r2 ** max(sharpness, 6.0))
-            region = canvas[y0:y1, x0:x1]
-            canvas[y0:y1, x0:x1] = region * (1 - cover) + intensity * profile
+            for canvas, intensity in targets:
+                region = canvas[y0:y1, x0:x1]
+                canvas[y0:y1, x0:x1] = region * (1 - cover) + intensity * profile
         else:
-            canvas[y0:y1, x0:x1] += intensity * profile
+            for canvas, intensity in targets:
+                canvas[y0:y1, x0:x1] += intensity * profile

--- a/tests/test_sim_coincidence.py
+++ b/tests/test_sim_coincidence.py
@@ -75,6 +75,9 @@ def _fiducial_only(microscope):
         offset=0.0,
         cell_type="none",
         grid_intensity=0.0,
+        contamination_density=0.0,
+        ice_density=0.0,
+        rip_fraction=0.0,
         noise_sigma=0.0,
         noise_fraction=0.0,
     )
@@ -196,8 +199,10 @@ def test_stitched_overview_matches_single_wide_shot(microscope, beam_type, tmp_p
 
 
 def test_views_share_the_scene_but_not_the_contrast():
-    """Rendered through identical geometry, the two beams differ only in
-    contrast convention - strongly anti-correlated with noise off."""
+    """Rendered through identical geometry, the two beams show the same
+    structure with different contrast: correlated, but not the same
+    picture and not its inverse either (holes and trenches are dark in
+    both; cells are bright in the SEM, outlined in the FIB)."""
     from fibsem.microscopes.sim_scene import SampleScene
     from fibsem.projection import BeamStageProjection
     from fibsem.structures import FibsemHardwareGeometry
@@ -217,7 +222,7 @@ def test_views_share_the_scene_but_not_the_contrast():
     sem = scene.render(beam_type=BeamType.ELECTRON, **kwargs).astype(np.float32)
     fib = scene.render(beam_type=BeamType.ION, **kwargs).astype(np.float32)
     corr = np.corrcoef(sem.ravel(), fib.ravel())[0, 1]
-    assert corr < -0.9
+    assert 0.2 < corr < 0.95, corr
 
 
 def test_measures_configured_offset(microscope):

--- a/tests/test_sim_scene_realism.py
+++ b/tests/test_sim_scene_realism.py
@@ -384,8 +384,10 @@ def test_ice_plates_are_generated_and_render_bright(microscope):
         image_settings=_settings(BeamType.ELECTRON, hfw=300e-6)
     )
     data = image.data.astype(np.float32)
-    # flat plates: large bright connected regions with sharp edges
-    bright = ndi.gaussian_filter(data, 1) > np.percentile(data, 97)
+    # flat plates: large bright connected regions with sharp edges, well
+    # above the film (an absolute step, not a percentile - the plates are
+    # a good fraction of the field)
+    bright = ndi.gaussian_filter(data, 1) > np.median(data) + 40
     labels, n = ndi.label(bright)
     px = 300e-6 / 1536
     areas = ndi.sum(bright, labels, range(1, n + 1)) * px**2
@@ -514,3 +516,79 @@ def test_a_rotated_pattern_mills_the_footprint_it_was_drawn_with(microscope):
     expected = (np.abs(u) <= 12e-6) & (np.abs(v) <= 1.5e-6)
     iou = (trench & expected).sum() / (trench | expected).sum()
     assert iou > 0.8, f"trench footprint IoU {iou:.2f} against the drawn pattern"
+
+
+def _fib_and_sem(microscope, hfw=150e-6):
+    fib = microscope.acquire_image(image_settings=_settings(BeamType.ION, hfw=hfw)).data
+    sem = microscope.acquire_image(
+        image_settings=_settings(BeamType.ELECTRON, hfw=hfw)
+    ).data
+    return fib.astype(np.float32), sem.astype(np.float32)
+
+
+def test_holes_and_trenches_are_dark_in_both_beams(microscope):
+    """No material, no signal: a hole in the film and a milled trench read
+    dark in the FIB as well as the SEM - the FIB is not an inverted SEM."""
+    from fibsem.structures import FibsemRectangleSettings
+
+    scene = _scene(
+        microscope,
+        coincidence_offset=0.0,
+        cell_type="none",
+        contamination_density=0.0,
+        fiducial=False,
+        film="holey",
+    )
+    microscope.draw_rectangle(
+        FibsemRectangleSettings(
+            width=20e-6, height=5e-6, depth=1e-6, centre_x=0.0, centre_y=-25e-6
+        )
+    )
+    microscope.run_milling(milling_current=1e-9, milling_voltage=30e3)
+    fib, sem = _fib_and_sem(microscope, hfw=100e-6)
+    for name, image in (("FIB", fib), ("SEM", sem)):
+        film = np.median(image)
+        # the darkest few percent are holes and the trench, well below the film
+        assert np.percentile(image, 2) < film - 30, f"{name}: no dark holes/trench"
+        assert (image < film - 30).mean() > 0.05, f"{name}: too little dark structure"
+
+
+def test_the_fib_sees_cells_as_outlined_not_inverted(microscope):
+    """In the FIB a cell body is slightly darker than the film with a bright
+    rim (the edge effect); in the SEM it is brighter than the film."""
+    scene = _scene(
+        microscope,
+        coincidence_offset=0.0,
+        cell_type="yeast",
+        contamination_density=0.0,
+        fiducial=False,
+        grid_intensity=0.0,
+    )
+    fib, sem = _fib_and_sem(microscope, hfw=100e-6)
+    film_fib, film_sem = np.median(fib), np.median(sem)
+    # the SEM: cells brighter than the film
+    assert (sem > film_sem + 25).mean() > 0.02
+    # the FIB (its own pixels - the two views are foreshortened differently,
+    # so a mask cannot be carried across): bodies darker than the film...
+    dark = fib < film_fib - 15
+    assert dark.mean() > 0.005
+    interior = ndi.binary_erosion(dark, iterations=3)
+    # ...with a bright outline just outside them: the body's darkening
+    # tapers over several pixels before the edge effect's rim, so look a
+    # little way out from the dark core
+    rim = ndi.binary_dilation(dark, iterations=12) & ~ndi.binary_dilation(
+        dark, iterations=6
+    )
+    assert np.percentile(fib[rim], 90) > film_fib + 8
+    assert np.percentile(fib[rim], 90) > fib[interior].mean() + 20
+
+
+def test_the_film_is_brighter_at_grazing_incidence():
+    """SE yield rises with tilt: the same bare film reads brighter in a
+    view that sees it at a steeper angle."""
+    from fibsem.microscopes.sim_scene import BEAM_LAYERS
+
+    t = BEAM_LAYERS[BeamType.ION]
+    grazing = t["film"] + t["film_tilt_gain"] * (1 - 0.26)
+    face_on = t["film"] + t["film_tilt_gain"] * (1 - 0.95)
+    assert grazing > face_on + 30

--- a/tests/test_vertical_move.py
+++ b/tests/test_vertical_move.py
@@ -45,6 +45,9 @@ def microscope():
         coincidence_offset=0.0,
         cell_type="none",
         grid_intensity=0.0,
+        contamination_density=0.0,
+        ice_density=0.0,
+        rip_fraction=0.0,
         noise_sigma=0.0,
         noise_fraction=0.0,
     )


### PR DESCRIPTION
## Summary

**The FIB is no longer an inverted SEM.** Each beam composes its own canvas from a table of per-layer intensities (`BEAM_LAYERS`): features stamp into both canvases with one profile and one opacity cover; the film masks add per-beam values. Holes, rips and trenches read dark in both beams (no material, no signal — the inversion rendered them bright); cell bodies read slightly darker than the film in the FIB with bright outlines from the edge effect (a saturating outline of the structure's gradient); the film brightens with tilt (SE yield at grazing incidence). Contamination and ice stay bright in both.

**The rival-peak gate is scale-invariant now.** The primary peak's lobe was excluded in pixels while the search window grows in pixels as the field narrows, so the same true lock read 0.62 at 200 µm and 0.99 at 80 µm. With the lobe a physical 3.2 µm the ratio is flat across field widths: on the sim's scenes (mammalian, yeast, bacteria; 80–300 µm; with and without noise) every correct fine lock measures 0.35–0.72 and every false one 0.86–0.99 — the gate comes down from 0.92 to **0.80** with margin both sides. `ensure_coincident` exposes the fine bounds alongside the coarse ones.

## Testing

- `tests/test_sim_scene_realism.py` (+3): holes and trenches dark in both beams; FIB cells darker than film with a bright outline; film brighter at grazing incidence. Scene tests that assumed the inverse relationship updated.
- Full regression across every scene-dependent suite: 81 passed, 1 xfail; loop/tilt/task/unit suites re-run at the 0.80 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)