### PR TITLE
[docs] Note the grid workflow preview and the overlay default in the changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,21 @@ correctness work landed in correlation and in what the experiment record remembe
 - A task's dependency gets its own column; the experiment completion predicate was
   corrected.
 
+### Grids (preview)
+
+- **A grid workflow, behind a preference.** Preferences → Enable Grid Workflow adds a
+  Grids tab (a card per grid the inventory found, with its overviews and history), a
+  Grid page beside Lamella on the Protocol tab, and a Workflow → Grids view that runs the
+  grid tasks over the selected grids, loading each from the magazine as it comes up, or
+  screens every grid in the magazine in one go. Off by default; it has run end to end on
+  the simulator and is waiting on bench time.
+- **The sample holder and magazine controls are a Sample tab** under Microscope, always
+  shown, in place of the block on the Movement tab and the preference that gated it.
+  Load and unload are icons on the grid's row; inventory is a refresh icon that asks
+  first.
+- The protocol's name, description and version panel on the Protocol tab is now one
+  line with a pencil that opens a dialog, and the settings columns are wider.
+
 ### Overview acquisition
 
 - **One Overview tab**, with the imaging modality chosen on the canvas chrome. The
@@ -81,10 +96,12 @@ correctness work landed in correlation and in what the experiment record remembe
 - Tiles the stage cannot reach are flagged while the grid is dragged, and an unreachable
   grid is refused in the pre-flight dialog.
 - A marked position is boxed with the field of view it stands for.
-- **Grid boundaries and holder slot markers are no longer drawn by default.** Both
-  describe a cryo sample holder, so on a system without one they drew a holder that was
-  not there. Turn them back on under the overlays button on the canvas. Stage travel
-  limits are unchanged and still shown — those are a property of the stage itself.
+- **Grid boundaries and holder slot markers are drawn only when the holder has a
+  calibrated slot.** Both describe a cryo sample holder, so on a system without one they
+  drew a holder that was not there; on an Arctis, whose working slot is always
+  calibrated, they stay on. Either way they toggle under the overlays button on the
+  canvas. Stage travel limits are unchanged and still shown — those are a property of
+  the stage itself.
 - Cancelled overviews no longer report "Done"; one overview can no longer drive the
   stage while the other acquires; stitching and saving now say so.
 - A tab-page key no longer shadows the imaging modality carried on the progress payload,


### PR DESCRIPTION
Follow-up to the #738–#748 chain, kept as its own docs PR.

- The v0.5.2 overlay bullet said grid boundaries and holder slot markers are no longer drawn by default. Since #748 they are drawn when the holder has a calibrated slot (always, on an Arctis) and not otherwise; the bullet now says that.
- A **Grids (preview)** section: the grid workflow behind the Enable Grid Workflow preference, the Sample tab under Microscope that replaced the Movement-tab holder block and the preference that gated it, and the protocol name/description/version panel giving way to a header line with a pencil.

Text only.