### PR TITLE
[server] Task configs become readable, with a version token

### DIFF
--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -352,6 +352,82 @@ class AgentContext:
             "poses": poses,
         }
 
+    # --- task configs (FIB-864, read side) --------------------------------------
+
+    def protocol_task_config(self, task_name: str) -> Dict[str, Any]:
+        """One task's protocol-level defaults document — what new items copy."""
+        experiment = self._experiment
+        protocol = getattr(experiment, "task_protocol", None) if experiment else None
+        config_map = getattr(protocol, "task_config", None) if protocol else None
+        if config_map is None:
+            return {"available": False, "task_name": task_name}
+        config = dict(config_map).get(task_name)
+        if config is None:
+            return {
+                "available": True,
+                "task_name": task_name,
+                "error": f"No task named {task_name!r} in the protocol.",
+                "task_names": list(config_map.keys()),
+            }
+        return self._config_document(task_name, config, level="protocol")
+
+    def item_task_config(self, item_name: str, task_name: str) -> Dict[str, Any]:
+        """One item's own copy of a task config — what its run executes."""
+        experiment = self._experiment
+        if experiment is None:
+            return {
+                "available": False,
+                "item_name": item_name,
+                "task_name": task_name,
+            }
+        lamella = experiment.get_lamella_by_name(item_name)
+        if lamella is None:
+            return {
+                "available": False,
+                "item_name": item_name,
+                "task_name": task_name,
+                "error": f"No item named {item_name!r} in this experiment.",
+            }
+        config = dict(lamella.task_config).get(task_name)
+        if config is None:
+            return {
+                "available": True,
+                "item_name": item_name,
+                "task_name": task_name,
+                "error": f"No task config named {task_name!r} on {item_name!r}.",
+                "task_names": list(lamella.task_config.keys()),
+            }
+        document = self._config_document(task_name, config, level="item")
+        document["item_name"] = item_name
+        return document
+
+    @staticmethod
+    def _config_document(task_name: str, config, level: str) -> Dict[str, Any]:
+        """One config as a wire document with its version token.
+
+        The full ``to_dict``, not a curated snapshot — the document is the
+        contract for editing (you cannot patch what you cannot read). The
+        ``version`` hashes the serialized content, so a later write can name
+        exactly the state it read: the config's nonce, refused as stale on
+        mismatch once the write side lands.
+        """
+        import hashlib
+        import json
+
+        from fibsem.applications.autolamella.server.events import to_plain
+
+        data = to_plain(config.to_dict())
+        version = hashlib.sha256(
+            json.dumps(data, sort_keys=True, default=str).encode()
+        ).hexdigest()[:16]
+        return {
+            "available": True,
+            "task_name": task_name,
+            "level": level,
+            "version": version,
+            "config": data,
+        }
+
     # --- instrument-adjacent (cached only, never a hardware call) --------------
 
     def stage_position(self) -> Dict[str, Any]:

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -252,6 +252,12 @@ def build_sidecar(client, capabilities):
     def get_item_detail(item_name: str):
         return _app_get(f"/app/items/{item_name}")
 
+    def get_protocol_task_config(task_name: str):
+        return _app_get(f"/app/protocol/task_config/{task_name}")
+
+    def get_item_task_config(item_name: str, task_name: str):
+        return _app_get(f"/app/items/{item_name}/task_config/{task_name}")
+
     def list_recent_experiments():
         return _app_get("/app/recent_experiments")
 
@@ -337,6 +343,8 @@ def build_sidecar(client, capabilities):
             get_protocol,
             get_task_outputs,
             get_item_detail,
+            get_protocol_task_config,
+            get_item_task_config,
             list_recent_experiments,
             get_events,
             get_display_images,

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -45,6 +45,10 @@ class AppContext(Protocol):
 
     def output_image(self, item_name: str, filename: str) -> Dict[str, Any]: ...
 
+    def protocol_task_config(self, task_name: str) -> Dict[str, Any]: ...
+
+    def item_task_config(self, item_name: str, task_name: str) -> Dict[str, Any]: ...
+
     def recent_experiments(self) -> List[Dict[str, Any]]: ...
 
     def events(self, since: int = 0, timeout: float = 0.0) -> Dict[str, Any]: ...
@@ -109,6 +113,14 @@ def build_app_router(context: AppContext) -> APIRouter:
     @router.get("/items/{item_name}")
     def item_detail(item_name: str):
         return context.item_detail(item_name)
+
+    @router.get("/protocol/task_config/{task_name}")
+    def protocol_task_config(task_name: str):
+        return context.protocol_task_config(task_name)
+
+    @router.get("/items/{item_name}/task_config/{task_name}")
+    def item_task_config(item_name: str, task_name: str):
+        return context.item_task_config(item_name, task_name)
 
     @router.get("/items/{item_name}/outputs/{filename}")
     def output_image(item_name: str, filename: str):

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -223,6 +223,27 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         params={"item_name": "the item (lamella) name"},
     ),
     ToolSpec(
+        name="get_protocol_task_config",
+        description="One task's protocol-level configuration document (the defaults new items copy), with a version token naming exactly this state of it. Full document, not a summary.",
+        method="GET",
+        path="/app/protocol/task_config/{task_name}",
+        scope="read",
+        router="app",
+        params={"task_name": "the task name, as listed by get_protocol"},
+    ),
+    ToolSpec(
+        name="get_item_task_config",
+        description="One item's own copy of a task configuration (what its run actually executes — tasks may have rewritten it mid-run), with a version token naming exactly this state of it.",
+        method="GET",
+        path="/app/items/{item_name}/task_config/{task_name}",
+        scope="read",
+        router="app",
+        params={
+            "item_name": "the item (lamella) name",
+            "task_name": "the task name, as listed by get_protocol",
+        },
+    ),
+    ToolSpec(
         name="get_events",
         description="Events after a sequence number: milling/acquisition progress, stage moves, task lifecycle. Long-polls up to timeout seconds.",
         method="GET",

--- a/tests/autolamella/test_agent_context.py
+++ b/tests/autolamella/test_agent_context.py
@@ -183,6 +183,46 @@ def test_output_image_renders_recorded_outputs_only(experiment):
     ]
 
 
+def test_task_config_documents_carry_the_full_config_and_a_version(experiment):
+    from fibsem.applications.autolamella.workflows.tasks.rough import (
+        MillRoughTaskConfig,
+    )
+
+    host = Host()
+    host.experiment = experiment
+    ctx = AgentContext(host)
+    config = MillRoughTaskConfig(task_name="Rough Milling")
+    experiment.task_protocol.task_config["Rough Milling"] = config
+    lamella = experiment.positions[0]
+    lamella.task_config["Rough Milling"] = config
+
+    doc = ctx.protocol_task_config("Rough Milling")
+    assert doc["available"] is True
+    assert doc["level"] == "protocol"
+    assert doc["config"]["task_type"] == config.to_dict()["task_type"]
+    assert len(doc["version"]) == 16
+    _assert_json_safe(doc)
+
+    item_doc = ctx.item_task_config(lamella.name, "Rough Milling")
+    assert item_doc["level"] == "item"
+    assert item_doc["item_name"] == lamella.name
+    # Same content hashes to the same version: the token names the state.
+    assert item_doc["version"] == doc["version"]
+    _assert_json_safe(item_doc)
+
+    # A content change changes the version — the write side's stale check.
+    config.sync_polishing_position = not config.sync_polishing_position
+    assert ctx.protocol_task_config("Rough Milling")["version"] != doc["version"]
+
+    unknown = ctx.protocol_task_config("No Such Task")
+    assert unknown["available"] is True
+    assert "task_names" in unknown
+    missing_item = ctx.item_task_config("no-such-item", "Rough Milling")
+    assert missing_item["available"] is False
+    no_config = ctx.item_task_config(lamella.name, "No Such Task")
+    assert no_config["task_names"] == ["Rough Milling"]
+
+
 def test_item_detail_serves_the_durable_item_facts(experiment):
     """One read for what a supervisor judges an item by — the exemplar-mode
     seam: after the operator answers, the accepted POI/alignment area are

--- a/tests/server/test_app_router.py
+++ b/tests/server/test_app_router.py
@@ -134,6 +134,30 @@ def test_output_images_serve_jpeg_and_refuse_unknown_names(client, host):
     assert unknown.json()["detail"]["filenames"] == [fname]
 
 
+def test_task_config_reads_over_http(client, host):
+    from fibsem.applications.autolamella.workflows.tasks.rough import (
+        MillRoughTaskConfig,
+    )
+
+    config = MillRoughTaskConfig(task_name="Rough Milling")
+    host.experiment.task_protocol.task_config["Rough Milling"] = config
+    item = host.experiment.positions[0]
+    item.task_config["Rough Milling"] = config
+
+    doc = client.get("/app/protocol/task_config/Rough Milling", headers=AUTH).json()
+    assert doc["available"] is True and doc["level"] == "protocol"
+    assert "version" in doc and "config" in doc
+
+    item_doc = client.get(
+        f"/app/items/{item.name}/task_config/Rough Milling", headers=AUTH
+    ).json()
+    assert item_doc["level"] == "item"
+    assert item_doc["version"] == doc["version"]
+
+    unknown = client.get("/app/protocol/task_config/Nope", headers=AUTH).json()
+    assert "task_names" in unknown
+
+
 def test_summaries_and_protocol_over_http(client):
     for path in ("/app/experiment_summary", "/app/task_history", "/app/protocol"):
         body = client.get(path, headers=AUTH).json()


### PR DESCRIPTION
PR 1 of the protocol-editing plan (read side only — no writes, no new scope yet).

Two read-scope routes:

- `GET /app/protocol/task_config/{task}` — the protocol-level defaults document (what new items copy).
- `GET /app/items/{item}/task_config/{task}` — that item's own copy (what its run actually executes; tasks rewrite these mid-run, e.g. the fiducial task writing the alignment rect into rough/polishing).

Both serve the **full `to_dict`**, deliberately unlike `item_detail`'s curated snapshot: the document is the contract for editing, and you can't patch what you can't read. Each response carries a `version` token (content hash) — the config's nonce: the coming write side echoes it and refuses `409 stale_config` on mismatch, so a patch can never apply against a state its author didn't see. The tests pin the semantics: same content → same version across levels, any field change → new version.

Unknown task/item → structured refusals listing valid names, matching the rest of the surface. Two sidecar tools (`get_protocol_task_config`, `get_item_task_config`) ride the existing catalog↔sidecar contract check.

Scoped to lamella task configs; the new grid protocol's configs are a noted follow-up once that surface settles.