### PR TITLE
[stage] current_slot answers None before the position cache is filled

### DIFF
--- a/fibsem/microscopes/_stage.py
+++ b/fibsem/microscopes/_stage.py
@@ -631,7 +631,12 @@ class Stage:
         """Get the slot the stage is currently positioned at, if any."""
         if self.holder is None:
             return None
+        # The cached position, never a hardware read: this is called from UI
+        # paint paths. It is None until the first read or move after connecting,
+        # and then the answer is "not known to be at any slot", not a crash.
         stage_position = self.parent._stage_position
+        if stage_position is None:
+            return None
         for slot in self.holder.slots.values():
             if slot.position is None:
                 continue

--- a/tests/test_grid_inventory.py
+++ b/tests/test_grid_inventory.py
@@ -446,3 +446,26 @@ class TestRunInventory:
         microscope._stage.holder.slots["Slot-01"].loaded_grid = SampleGrid(name="g")
         rows = microscope._stage.run_inventory()
         assert [r.name for r in rows if r.present] == ["g"]
+
+
+# ---------------------------------------------------------------------------
+# current_slot / current_grid before the position cache is filled
+# ---------------------------------------------------------------------------
+
+
+def test_current_grid_is_none_before_the_first_position_read():
+    """A fresh connection has no cached stage position. Asking which grid the
+    stage is at then means "not known", not an AttributeError."""
+    microscope = _compustage_demo()
+    _with_magazine(microscope)
+    stage = microscope._stage
+    stage.ensure_loaded("Grid-01")
+    microscope._stage_position = None
+
+    assert stage.current_slot is None
+    assert stage.current_grid is None
+
+    stage.position  # the first read fills the cache
+    stage.move_to_slot("Slot-01")
+    assert stage.current_grid is not None
+    assert stage.current_grid.name == "Grid-01"


### PR DESCRIPTION
`Stage.current_slot` reads the cached stage position on purpose: the calibration dialog and the quad view call it from paint paths and must not touch hardware. That cache is empty until the first position read or move after connecting, and `current_slot` (so `current_grid`) raised `AttributeError: 'NoneType' object has no attribute 'is_close2'` on it. Found writing the bench doc: a fresh REPL that connects and asks `stage.current_grid` fell over.

An empty cache now answers "not at any known slot": `current_grid` is None until something fills the cache, and the right grid after a move.

**Test** (`tests/test_grid_inventory.py`): a compustage Demo with a loaded grid and the cache cleared answers None for both, then names the grid after a position read and a move to the slot. Fails on the old code with the AttributeError above. Grid inventory, holder calibration and calibration dialog suites pass.