### PR TITLE
[server] Task config patches: the configure scope and the write path

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -77,6 +77,15 @@ In **Tools → Agent Server**, the *Act* switch lets the agent:
   agent-supervised, mid-run;
 - **re-queue a task** — "run 03's fiducial again" during a run.
 
+A separate **Configure** switch lets the agent edit task parameters — an
+item's milling depths, currents, imaging settings — as targeted patches
+against exactly the state it last read (a concurrent edit of yours makes the
+agent's write stale, and it is refused, never merged). A task already
+running has copied its settings and is refused outright; pending tasks pick
+changes up when they start. Every applied change is recorded on the
+timeline, old value and new. It is deliberately its own switch: answering
+questions and rewriting protocols are different levels of trust.
+
 Permissions last the session only. They are granted in the dialog, die when
 the app closes, and never persist — every session starts read-only.
 

--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -32,7 +32,26 @@ from typing import Any, Dict, List, Optional
 from fibsem.applications.autolamella import task_outputs as _task_outputs
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
 
-__all__ = ["AgentContext"]
+__all__ = ["AgentContext", "config_version"]
+
+
+def config_version(config) -> str:
+    """A content hash naming exactly this state of a task config.
+
+    The config's nonce (FIB-864): reads serve it, writes echo it, and a
+    mismatch is refused as stale — a patch can never apply against a state
+    its author did not see. Computed from the serialized document so the
+    same content hashes identically wherever it is held.
+    """
+    import hashlib
+    import json
+
+    from fibsem.applications.autolamella.server.events import to_plain
+
+    data = to_plain(config.to_dict())
+    return hashlib.sha256(
+        json.dumps(data, sort_keys=True, default=str).encode()
+    ).hexdigest()[:16]
 
 
 def _json_safe(value: Any) -> Any:
@@ -407,26 +426,73 @@ class AgentContext:
 
         The full ``to_dict``, not a curated snapshot — the document is the
         contract for editing (you cannot patch what you cannot read). The
-        ``version`` hashes the serialized content, so a later write can name
-        exactly the state it read: the config's nonce, refused as stale on
-        mismatch once the write side lands.
+        ``version`` hashes the serialized content, so a write names exactly
+        the state it read: the config's nonce, refused as stale on mismatch.
         """
-        import hashlib
-        import json
-
         from fibsem.applications.autolamella.server.events import to_plain
 
-        data = to_plain(config.to_dict())
-        version = hashlib.sha256(
-            json.dumps(data, sort_keys=True, default=str).encode()
-        ).hexdigest()[:16]
         return {
             "available": True,
             "task_name": task_name,
             "level": level,
-            "version": version,
-            "config": data,
+            "version": config_version(config),
+            "config": to_plain(config.to_dict()),
         }
+
+    def apply_item_task_config_patch(
+        self,
+        item_name: str,
+        task_name: str,
+        patch: Dict[str, Any],
+        version: str,
+        timeout: float = 10.0,
+    ) -> Dict[str, Any]:
+        """Patch one item's task config, as an operator edit would land.
+
+        The version (from :meth:`item_task_config`) names the state the patch
+        was written against; the check happens on the GUI thread beside the
+        apply, so an edit landing in between is refused as stale, never
+        half-merged. A task currently running for this item is refused too —
+        it already copied its config, so the edit would take effect never,
+        and a refusal is more honest than a silent no-op. Pending tasks pick
+        the change up when they start (the ``set_supervision`` semantics).
+        """
+        host = self._host
+        if not hasattr(host, "request_apply_task_config_patch"):
+            return {"available": False, "applied": False}
+        manager = self._manager
+        if manager is not None:
+            running = any(
+                item.lamella_name == item_name
+                and item.task_name == task_name
+                and item.status is AutoLamellaTaskStatus.InProgress
+                for item in manager.queue.items
+            )
+            if running:
+                return {
+                    "available": True,
+                    "applied": False,
+                    "error_type": "task_running",
+                    "error": f"{task_name!r} is running for {item_name!r} right "
+                    "now and has already copied its config — the edit would "
+                    "never take effect. Patch it after the task finishes.",
+                }
+        outcome = host.request_apply_task_config_patch(
+            item_name, task_name, dict(patch), str(version)
+        )
+        result = outcome.result(timeout=timeout)
+        result["available"] = True
+        if result.get("applied") and self._event_buffer is not None:
+            self._event_buffer.append(
+                "config_edited",
+                {
+                    "level": "item",
+                    "item_name": item_name,
+                    "task_name": task_name,
+                    "changes": result.get("changes", []),
+                },
+            )
+        return result
 
     # --- instrument-adjacent (cached only, never a hardware call) --------------
 

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -189,6 +189,8 @@ class AutoLamellaUI(QMainWindow):
     # A remote (agent) start request, marshalled to the GUI thread the same
     # way agent answers are: (task_names, item_names, Future[dict]).
     _agent_start_workflow = pyqtSignal(list, object, object)
+    # (item_name, task_name, patch, version, Future) — the config-patch marshal
+    _agent_config_patch = pyqtSignal(str, str, object, str, object)
 
     def __init__(
         self,
@@ -206,6 +208,7 @@ class AutoLamellaUI(QMainWindow):
         # widget itself is built in _setup_ui, before the responder exists.
         self.ui_responder.add_question_observer(self.question_timeline.record)
         self._agent_start_workflow.connect(self._apply_agent_start_workflow)
+        self._agent_config_patch.connect(self._apply_agent_config_patch)
 
         self._protocol_lock = threading.RLock()
 
@@ -1221,6 +1224,100 @@ class AutoLamellaUI(QMainWindow):
             except Exception:
                 logging.exception("window chrome after agent start failed")
         return {"started": started}
+
+    def request_apply_task_config_patch(
+        self, item_name: str, task_name: str, patch: dict, version: str
+    ) -> "Future":
+        """Patch an item's task config as an operator edit would land; any thread.
+
+        Marshalled to the GUI thread — the thread that owns the editor and the
+        experiment's writer seat — resolving to a plain dict: the applied
+        changes, or a structured refusal (stale version, invalid patch,
+        unknown names). Configure-scope arming is the consent.
+        """
+        from concurrent.futures import Future as _Future
+
+        outcome: "_Future" = _Future()
+        self._agent_config_patch.emit(item_name, task_name, patch, version, outcome)
+        return outcome
+
+    def _apply_agent_config_patch(
+        self, item_name: str, task_name: str, patch, version: str, outcome: "Future"
+    ) -> None:
+        """GUI thread. Complete ``outcome`` with the patch result."""
+        try:
+            result = self._apply_task_config_patch_for_agent(
+                item_name, task_name, patch, version
+            )
+        except Exception as exc:  # noqa: BLE001 - the requester owns the failure
+            outcome.set_exception(exc)
+            return
+        outcome.set_result(result)
+
+    def _apply_task_config_patch_for_agent(
+        self, item_name: str, task_name: str, patch: dict, version: str
+    ) -> dict:
+        """Validate against the live config and apply, all on the GUI thread.
+
+        The version check sits beside the apply on the one thread that edits
+        configs, so nothing can change between check and set. Before checking,
+        any edit still sitting in the editor is flushed (the FIB-683
+        one-writer rule, same as the agent workflow start): if the operator's
+        pending edit changes this config, the agent's version goes stale and
+        the refusal — not a silent merge — resolves the race.
+        """
+        from fibsem.applications.autolamella.server.context import config_version
+        from fibsem.applications.autolamella.server.events import to_plain
+        from fibsem.server.config_patch import PatchError, apply_patch
+
+        parent = self.parent_widget
+        if parent is not None:
+            try:
+                parent.lamella_widget.flush_pending_save()
+            except Exception:
+                logging.exception("flush before agent config patch failed; continuing")
+
+        experiment = self.experiment
+        if experiment is None:
+            return {"applied": False, "error": "no experiment is loaded"}
+        lamella = experiment.get_lamella_by_name(item_name)
+        if lamella is None:
+            return {
+                "applied": False,
+                "error": f"No item named {item_name!r} in this experiment.",
+                "item_names": [p.name for p in experiment.positions],
+            }
+        config = dict(lamella.task_config).get(task_name)
+        if config is None:
+            return {
+                "applied": False,
+                "error": f"No task config named {task_name!r} on {item_name!r}.",
+                "task_names": list(lamella.task_config.keys()),
+            }
+        if config_version(config) != version:
+            return {"applied": False, "stale": True}
+        try:
+            changes = apply_patch(config, patch)
+        except PatchError as exc:
+            return {
+                "applied": False,
+                "invalid_patch": str(exc),
+                "path": exc.path,
+            }
+        logging.info(
+            f"agent config patch applied: {item_name} / {task_name}: "
+            + ", ".join(f"{p}: {old!r} -> {new!r}" for p, old, new in changes)
+        )
+        return {
+            "applied": True,
+            "item_name": item_name,
+            "task_name": task_name,
+            "changes": [
+                {"path": p, "old": to_plain(old), "new": to_plain(new)}
+                for p, old, new in changes
+            ],
+            "version": config_version(config),
+        }
 
     def _run_tasks_worker(
         self, task_names: List[str], lamella_names: Optional[List[str]] = None

--- a/fibsem/applications/autolamella/ui/agent_server_dialog.py
+++ b/fibsem/applications/autolamella/ui/agent_server_dialog.py
@@ -184,6 +184,15 @@ class AgentServerDialog(QDialog):
         layout.addWidget(self._control_row)
         self._chk_control = self._control_row.toggle  # the arming switch
 
+        self._configure_row = _ScopeRow(
+            "Configure",
+            "Edit task parameters — protocol defaults and per-item configs. "
+            "Every change is recorded on the timeline.",
+            _AGENT_COLOR,
+        )
+        layout.addWidget(self._configure_row)
+        self._chk_configure = self._configure_row.toggle
+
         self._hardware_row = _ScopeRow(
             "Command hardware",
             "Move the stage, acquire, mill. Not yet available.",
@@ -220,6 +229,7 @@ class AgentServerDialog(QDialog):
         self._btn_reveal.toggled.connect(self._on_reveal_toggled)
         self._btn_copy.clicked.connect(self._on_copy_clicked)
         self._chk_control.toggled.connect(self._on_control_toggled)
+        self._chk_configure.toggled.connect(self._on_configure_toggled)
 
         # Keep the status line live while the dialog is open: "last heard
         # from" is only useful if it ticks. Status text only — a full
@@ -272,6 +282,7 @@ class AgentServerDialog(QDialog):
         ):
             widget.setEnabled(running)
         self._chk_control.setEnabled(running)
+        self._chk_configure.setEnabled(running)
         if not running:
             self._status_dot.setStyleSheet(f"color: {TEXT_MUTED_COLOR};")
             self._status_label.setText(
@@ -280,9 +291,10 @@ class AgentServerDialog(QDialog):
             )
             self._status_label.setStyleSheet(f"color: {TEXT_MUTED_COLOR};")
             self._token_edit.setText("")
-            self._chk_control.blockSignals(True)
-            self._chk_control.setChecked(False)
-            self._chk_control.blockSignals(False)
+            for chk in (self._chk_control, self._chk_configure):
+                chk.blockSignals(True)
+                chk.setChecked(False)
+                chk.blockSignals(False)
             return
         from fibsem.server.auth import Scope
 
@@ -295,6 +307,9 @@ class AgentServerDialog(QDialog):
         self._chk_control.blockSignals(True)
         self._chk_control.setChecked(host.auth.is_armed(Scope.CONTROL))
         self._chk_control.blockSignals(False)
+        self._chk_configure.blockSignals(True)
+        self._chk_configure.setChecked(host.auth.is_armed(Scope.CONFIGURE))
+        self._chk_configure.blockSignals(False)
 
     # --- actions --------------------------------------------------------------
 
@@ -340,5 +355,17 @@ class AgentServerDialog(QDialog):
         host.auth.set_armed(Scope.CONTROL, checked)
         logging.warning(
             "agent server: control scope %s via the Agent Server dialog",
+            "ARMED" if checked else "disarmed",
+        )
+
+    def _on_configure_toggled(self, checked: bool) -> None:
+        host = self._host()
+        if host is None:
+            return
+        from fibsem.server.auth import Scope
+
+        host.auth.set_armed(Scope.CONFIGURE, checked)
+        logging.warning(
+            "agent server: configure scope %s via the Agent Server dialog",
             "ARMED" if checked else "disarmed",
         )

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -258,6 +258,17 @@ def build_sidecar(client, capabilities):
     def get_item_task_config(item_name: str, task_name: str):
         return _app_get(f"/app/items/{item_name}/task_config/{task_name}")
 
+    def update_item_task_config(
+        item_name: str, task_name: str, patch: dict, version: str
+    ):
+        data, err = _call(
+            client,
+            "POST",
+            f"/app/items/{item_name}/task_config/{task_name}",
+            {"patch": dict(patch), "version": str(version)},
+        )
+        return err if err else data
+
     def list_recent_experiments():
         return _app_get("/app/recent_experiments")
 
@@ -345,6 +356,7 @@ def build_sidecar(client, capabilities):
             get_item_detail,
             get_protocol_task_config,
             get_item_task_config,
+            update_item_task_config,
             list_recent_experiments,
             get_events,
             get_display_images,

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -21,7 +21,12 @@ try:  # Protocol is typing-only; keep import robust on the 3.8 floor
 except ImportError:  # pragma: no cover
     Protocol = object  # type: ignore[assignment]
 
-__all__ = ["AppContext", "build_app_control_router", "build_app_router"]
+__all__ = [
+    "AppContext",
+    "build_app_config_router",
+    "build_app_control_router",
+    "build_app_router",
+]
 
 
 class AppContext(Protocol):
@@ -48,6 +53,10 @@ class AppContext(Protocol):
     def protocol_task_config(self, task_name: str) -> Dict[str, Any]: ...
 
     def item_task_config(self, item_name: str, task_name: str) -> Dict[str, Any]: ...
+
+    def apply_item_task_config_patch(
+        self, item_name: str, task_name: str, patch: Dict[str, Any], version: str
+    ) -> Dict[str, Any]: ...
 
     def recent_experiments(self) -> List[Dict[str, Any]]: ...
 
@@ -288,5 +297,76 @@ def build_app_control_router(context: AppContext) -> APIRouter:
         return context.requeue_task(
             item_name, task_name, front=bool(body.get("front", False))
         )
+
+    return router
+
+
+def build_app_config_router(context: AppContext) -> APIRouter:
+    """Routes that edit configuration — the ``configure`` scope's own router.
+
+    Deliberately not on the control router: answering a question with
+    geometry (control) and editing protocols (configure) are different
+    grants, and the arming dialog shows them as separate rungs (FIB-864).
+    """
+    router = APIRouter(prefix="/app")
+
+    @router.post("/items/{item_name}/task_config/{task_name}")
+    def patch_item_task_config(item_name: str, task_name: str, body: Dict[str, Any]):
+        patch = body.get("patch")
+        version = body.get("version")
+        if (
+            not isinstance(patch, dict)
+            or not patch
+            or not all(isinstance(k, str) for k in patch)
+            or not isinstance(version, str)
+        ):
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "error_type": "missing_field",
+                    "message": "Pass patch (a non-empty object of dotted-path: "
+                    "value entries) and version (from the config read it was "
+                    "written against).",
+                },
+            )
+        result = context.apply_item_task_config_patch(
+            item_name, task_name, patch, version
+        )
+        if result.get("stale"):
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error_type": "stale_config",
+                    "message": "The config changed since your read; re-read "
+                    "it and write the patch against the current version.",
+                },
+            )
+        if result.get("error_type") == "task_running":
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error_type": "task_running",
+                    "message": result.get("error", "That task is running."),
+                },
+            )
+        if result.get("invalid_patch"):
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "error_type": "invalid_patch",
+                    "message": result["invalid_patch"],
+                    "path": result.get("path"),
+                },
+            )
+        if not result.get("applied") and result.get("error"):
+            detail: Dict[str, Any] = {
+                "error_type": "not_found",
+                "message": result["error"],
+            }
+            for key in ("item_names", "task_names"):
+                if key in result:
+                    detail[key] = result[key]
+            raise HTTPException(status_code=404, detail=detail)
+        return result
 
     return router

--- a/fibsem/server/auth.py
+++ b/fibsem/server/auth.py
@@ -5,6 +5,9 @@ One bearer token per server instance, three scopes:
 - ``read``: granted to every valid token. Observation only.
 - ``control``: app-level workflow control. Armed by the hosting (GUI toggle in
   the embedded app; unused in bench hosting until an app router exists).
+- ``configure``: editing task parameters (protocol and per-item task configs).
+  Its own rung, deliberately separate from ``control``: answering a question
+  with geometry and editing protocols are different grants (FIB-864).
 - ``hardware``: anything that commands or mutates the microscope. Armed
   explicitly by the hosting (GUI toggle, or ``--arm-hardware`` on the CLI).
 
@@ -26,6 +29,7 @@ from fastapi import HTTPException, Request
 class Scope(str, Enum):
     READ = "read"
     CONTROL = "control"
+    CONFIGURE = "configure"
     HARDWARE = "hardware"
 
 
@@ -80,12 +84,15 @@ class AuthConfig:
     def generate(
         cls,
         arm_control: bool = False,
+        arm_configure: bool = False,
         arm_hardware: bool = False,
         token: Optional[str] = None,
     ) -> "AuthConfig":
         armed = set()
         if arm_control:
             armed.add(Scope.CONTROL)
+        if arm_configure:
+            armed.add(Scope.CONFIGURE)
         if arm_hardware:
             armed.add(Scope.HARDWARE)
         return cls(token=token or secrets.token_urlsafe(32), armed=frozenset(armed))

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -244,6 +244,20 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         },
     ),
     ToolSpec(
+        name="update_item_task_config",
+        description="Patch an item's task config with dotted-path edits (e.g. {'milling.mill_rough.stages.0.pattern.depth': 2e-6}). Echo the version from get_item_task_config — a mismatch is refused (409 stale_config): re-read and re-patch. A task currently running for that item is refused (it already copied its config); pending tasks pick the change up at start. Values are validated against the live field's type and declared bounds; the response echoes every change old -> new. Needs the configure permission.",
+        method="POST",
+        path="/app/items/{item_name}/task_config/{task_name}",
+        scope="configure",
+        router="app",
+        params={
+            "item_name": "the item (lamella) name",
+            "task_name": "the task name, as listed by get_protocol",
+            "patch": "object of dotted-path: value entries to set",
+            "version": "the version token from get_item_task_config",
+        },
+    ),
+    ToolSpec(
         name="get_events",
         description="Events after a sequence number: milling/acquisition progress, stage moves, task lifecycle. Long-polls up to timeout seconds.",
         method="GET",

--- a/fibsem/server/config_patch.py
+++ b/fibsem/server/config_patch.py
@@ -166,19 +166,19 @@ def _check_bounds(obj: Any, leaf: str, value: Any, path: str) -> None:
         # Compare in that frame, or every valid SI value would be refused.
         scale = f.metadata.get("scale") or 1.0
         display = value * scale
-        unit = f.metadata.get("unit") or ""
+        # No unit label: metadata's "unit" is the SI unit of the STORED value,
+        # while min/max bound the scaled display value — labelling either
+        # number with it would mislead (2e-3 m scales to 2000.0, not "2000 m").
         if minimum is not None and display < minimum:
             raise PatchError(
                 path,
-                f"{display!r} {unit} is below the minimum {minimum!r} {unit} "
-                f"for {path!r} (values are SI; bounds are checked in display "
-                "units).",
+                f"{value!r} (display value {display!r}) is below the minimum "
+                f"{minimum!r} for {path!r}.",
             )
         if maximum is not None and display > maximum:
             raise PatchError(
                 path,
-                f"{display!r} {unit} is above the maximum {maximum!r} {unit} "
-                f"for {path!r} (values are SI; bounds are checked in display "
-                "units).",
+                f"{value!r} (display value {display!r}) is above the maximum "
+                f"{maximum!r} for {path!r}.",
             )
         return

--- a/fibsem/server/config_patch.py
+++ b/fibsem/server/config_patch.py
@@ -1,0 +1,184 @@
+"""Apply dotted-path patches to typed config objects (FIB-864).
+
+The write half of the config documents: a patch is ``{"a.b.c": value, ...}``
+against the live dataclass tree a read served. Deliberately a *patch*, never a
+document replace — a replace round-trips a possibly-stale read and silently
+reverts concurrent edits, while a patch names its intent, validates per field,
+and reads legibly in the event stream.
+
+Rules, all enforced here so every caller (per-item now, protocol-level next)
+refuses identically:
+
+- Every path segment must already exist: dataclass field, dict key, or list
+  index. A patch edits values; it never creates structure.
+- The leaf must be a value, not a section — patching ``milling`` wholesale is
+  refused; patch the fields inside it.
+- The new value must match the old one's type (bool for bool, number for
+  number, string for string, an enum member's name for an enum). ``None``
+  fields are refused: their type cannot be inferred.
+- Where the enclosing dataclass declares ``minimum``/``maximum`` field
+  metadata (the same vocabulary the GUI's forms clamp by), the value must be
+  in range — otherwise the server stores a number the form then displays
+  differently.
+- All-or-nothing: every entry is resolved and validated before anything is
+  set, so a failing entry leaves the config untouched.
+
+Qt-free and py3.8-clean; the GUI-thread caller owns marshalling.
+"""
+
+from dataclasses import fields as dataclass_fields
+from dataclasses import is_dataclass
+from enum import Enum
+from typing import Any, Dict, List, Tuple
+
+__all__ = ["PatchError", "apply_patch"]
+
+
+class PatchError(ValueError):
+    """One patch entry could not be applied; ``path`` names the entry."""
+
+    def __init__(self, path: str, message: str):
+        self.path = path
+        super().__init__(message)
+
+
+def apply_patch(root: Any, patch: Dict[str, Any]) -> List[Tuple[str, Any, Any]]:
+    """Validate every entry against the live object, then apply them all.
+
+    Returns ``[(path, old, new), ...]`` in patch order. Raises
+    :class:`PatchError` before anything is set if any entry is invalid.
+    """
+    resolved = [_resolve(root, path, value) for path, value in patch.items()]
+    changes: List[Tuple[str, Any, Any]] = []
+    for setter, path, old, new in resolved:
+        setter(new)
+        changes.append((path, old, new))
+    return changes
+
+
+def _resolve(root: Any, path: str, value: Any):
+    parts = path.split(".")
+    if not all(parts):
+        raise PatchError(path, f"malformed path {path!r}")
+    obj = root
+    for part in parts[:-1]:
+        obj = _child(obj, part, path)
+    leaf = parts[-1]
+    old = _child(obj, leaf, path)
+    if isinstance(old, (dict, list)) or is_dataclass(old):
+        raise PatchError(
+            path,
+            f"{path!r} names a section, not a value; patch the fields inside it.",
+        )
+    new = _coerce(old, value, path)
+    _check_bounds(obj, leaf, new, path)
+
+    def setter(coerced: Any, obj=obj, leaf=leaf) -> None:
+        if isinstance(obj, dict):
+            obj[leaf] = coerced
+        elif isinstance(obj, list):
+            obj[int(leaf)] = coerced
+        else:
+            setattr(obj, leaf, coerced)
+
+    return setter, path, old, new
+
+
+def _child(obj: Any, part: str, path: str) -> Any:
+    if isinstance(obj, dict):
+        if part not in obj:
+            raise PatchError(
+                path,
+                f"{part!r} not found under {path!r}; "
+                f"known keys: {sorted(map(str, obj.keys()))}",
+            )
+        return obj[part]
+    if isinstance(obj, list):
+        if not part.lstrip("-").isdigit():
+            raise PatchError(path, f"{part!r} is not a list index in {path!r}")
+        index = int(part)
+        if not (0 <= index < len(obj)):
+            raise PatchError(
+                path, f"index {index} out of range (0..{len(obj) - 1}) in {path!r}"
+            )
+        return obj[index]
+    if is_dataclass(obj):
+        names = {f.name for f in dataclass_fields(obj)}
+        if part not in names:
+            raise PatchError(
+                path,
+                f"{part!r} is not a field of {type(obj).__name__} in {path!r}; "
+                f"fields: {sorted(names)}",
+            )
+        return getattr(obj, part)
+    raise PatchError(
+        path, f"cannot descend into {type(obj).__name__} at {part!r} in {path!r}"
+    )
+
+
+def _coerce(old: Any, value: Any, path: str) -> Any:
+    if isinstance(old, Enum):
+        members = type(old).__members__
+        if isinstance(value, str) and value in members:
+            return members[value]
+        try:
+            return type(old)(value)
+        except (KeyError, ValueError):
+            raise PatchError(
+                path,
+                f"{value!r} is not a {type(old).__name__}; one of: {sorted(members)}",
+            )
+    if isinstance(old, bool):
+        if not isinstance(value, bool):
+            raise PatchError(path, f"{path!r} is a boolean; got {value!r}")
+        return value
+    if isinstance(old, float):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise PatchError(path, f"{path!r} is a number; got {value!r}")
+        return float(value)
+    if isinstance(old, int):
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise PatchError(path, f"{path!r} is an integer; got {value!r}")
+        return value
+    if isinstance(old, str):
+        if not isinstance(value, str):
+            raise PatchError(path, f"{path!r} is a string; got {value!r}")
+        return value
+    if old is None:
+        raise PatchError(
+            path, f"{path!r} is unset; its type cannot be inferred from None."
+        )
+    raise PatchError(
+        path, f"{path!r} holds a {type(old).__name__}, which patches cannot edit."
+    )
+
+
+def _check_bounds(obj: Any, leaf: str, value: Any, path: str) -> None:
+    if not is_dataclass(obj) or not isinstance(value, (int, float)):
+        return
+    for f in dataclass_fields(obj):
+        if f.name != leaf:
+            continue
+        minimum = f.metadata.get("minimum")
+        maximum = f.metadata.get("maximum")
+        # The form metadata states bounds in *display* units (a depth of
+        # 2e-6 m displays as 2.0 with scale 1e6, and min/max bound the 2.0).
+        # Compare in that frame, or every valid SI value would be refused.
+        scale = f.metadata.get("scale") or 1.0
+        display = value * scale
+        unit = f.metadata.get("unit") or ""
+        if minimum is not None and display < minimum:
+            raise PatchError(
+                path,
+                f"{display!r} {unit} is below the minimum {minimum!r} {unit} "
+                f"for {path!r} (values are SI; bounds are checked in display "
+                "units).",
+            )
+        if maximum is not None and display > maximum:
+            raise PatchError(
+                path,
+                f"{display!r} {unit} is above the maximum {maximum!r} {unit} "
+                f"for {path!r} (values are SI; bounds are checked in display "
+                "units).",
+            )
+        return

--- a/fibsem/server/server.py
+++ b/fibsem/server/server.py
@@ -41,7 +41,11 @@ from fastapi.responses import JSONResponse, Response
 
 from fibsem import utils
 from fibsem.microscope import FibsemMicroscope
-from fibsem.server.app_routes import build_app_control_router, build_app_router
+from fibsem.server.app_routes import (
+    build_app_config_router,
+    build_app_control_router,
+    build_app_router,
+)
 from fibsem.server.auth import AuthConfig, Scope, command_slot, require_scope
 from fibsem.server.discovery import (
     DISCOVERY_FILE,
@@ -694,6 +698,10 @@ def build_server(
         app.include_router(
             build_app_control_router(app_context),
             dependencies=[Depends(require_scope(Scope.CONTROL))],
+        )
+        app.include_router(
+            build_app_config_router(app_context),
+            dependencies=[Depends(require_scope(Scope.CONFIGURE))],
         )
     return app
 

--- a/tests/server/test_catalog_discovery.py
+++ b/tests/server/test_catalog_discovery.py
@@ -60,14 +60,16 @@ def test_every_catalog_entry_is_a_real_route(app):
 def test_catalog_names_unique_and_scopes_valid():
     names = [t.name for t in CATALOG]
     assert len(names) == len(set(names))
-    assert set(t.scope for t in CATALOG) <= {"read", "control", "hardware"}
+    assert set(t.scope for t in CATALOG) <= {"read", "control", "configure", "hardware"}
 
 
 def test_tools_for_scopes_filters_hardware():
     read_only = tools_for_scopes({"read": True, "hardware": False})
     assert all(t.scope == "read" for t in read_only)
     assert any(t.name == "stop_milling" for t in read_only)
-    armed = tools_for_scopes({"read": True, "control": True, "hardware": True})
+    armed = tools_for_scopes(
+        {"read": True, "control": True, "configure": True, "hardware": True}
+    )
     assert len(armed) == len(CATALOG)
 
 

--- a/tests/server/test_config_patch.py
+++ b/tests/server/test_config_patch.py
@@ -1,0 +1,87 @@
+"""The dotted-path patch engine, against the real config dataclasses.
+
+Real objects throughout: a MillRoughTaskConfig with its actual TrenchPattern
+stages, so type coercion, enum handling, and the display-unit bounds are
+exercised against exactly the structures the server patches in production.
+"""
+
+import pytest
+
+from fibsem.server.config_patch import PatchError, apply_patch
+
+
+@pytest.fixture
+def config():
+    from fibsem.applications.autolamella.workflows.tasks.rough import (
+        MillRoughTaskConfig,
+    )
+
+    return MillRoughTaskConfig(task_name="Rough Milling")
+
+
+def test_a_float_field_patches_and_reports_old_and_new(config):
+    old = config.milling["mill_rough"].stages[0].pattern.depth
+    changes = apply_patch(config, {"milling.mill_rough.stages.0.pattern.depth": 2.5e-6})
+    assert changes == [("milling.mill_rough.stages.0.pattern.depth", old, 2.5e-6)]
+    assert config.milling["mill_rough"].stages[0].pattern.depth == 2.5e-6
+
+
+def test_enums_patch_by_member_name(config):
+    from fibsem.structures import CrossSectionPattern
+
+    apply_patch(
+        config,
+        {"milling.mill_rough.stages.0.pattern.cross_section": "Rectangle"},
+    )
+    assert (
+        config.milling["mill_rough"].stages[0].pattern.cross_section
+        is CrossSectionPattern.Rectangle
+    )
+    with pytest.raises(PatchError, match="CrossSectionPattern"):
+        apply_patch(
+            config,
+            {"milling.mill_rough.stages.0.pattern.cross_section": "Diagonal"},
+        )
+
+
+def test_type_mismatches_are_refused(config):
+    with pytest.raises(PatchError, match="is a number"):
+        apply_patch(config, {"milling.mill_rough.stages.0.pattern.depth": "deep"})
+    with pytest.raises(PatchError, match="is a boolean"):
+        apply_patch(config, {"sync_polishing_position": 1})
+
+
+def test_unknown_names_are_refused_with_the_valid_ones(config):
+    with pytest.raises(PatchError, match="fields:"):
+        apply_patch(config, {"milling.mill_rough.stages.0.pattern.dept": 1e-6})
+    with pytest.raises(PatchError, match="known keys"):
+        apply_patch(config, {"milling.mill_smooth.stages.0.pattern.depth": 1e-6})
+    with pytest.raises(PatchError, match="out of range"):
+        apply_patch(config, {"milling.mill_rough.stages.9.pattern.depth": 1e-6})
+
+
+def test_sections_cannot_be_replaced_wholesale(config):
+    with pytest.raises(PatchError, match="section, not a value"):
+        apply_patch(config, {"milling.mill_rough.stages.0.pattern": {}})
+
+
+def test_bounds_are_checked_in_display_units(config):
+    # depth metadata: minimum 0.01, maximum 1000 — µm (scale 1e6), not metres.
+    # 2 µm (2e-6 m) is valid; 2 mm (2e-3 m -> 2000 µm) is above the maximum.
+    apply_patch(config, {"milling.mill_rough.stages.0.pattern.depth": 2e-6})
+    with pytest.raises(PatchError, match="above the maximum"):
+        apply_patch(config, {"milling.mill_rough.stages.0.pattern.depth": 2e-3})
+
+
+def test_a_failing_entry_applies_nothing(config):
+    stage = config.milling["mill_rough"].stages[0]
+    depth_before = stage.pattern.depth
+    with pytest.raises(PatchError):
+        apply_patch(
+            config,
+            {
+                "milling.mill_rough.stages.0.pattern.depth": 2.5e-6,
+                "milling.mill_rough.stages.0.pattern.nope": 1.0,
+            },
+        )
+    assert stage.pattern.depth == depth_before

--- a/tests/server/test_hosting.py
+++ b/tests/server/test_hosting.py
@@ -56,7 +56,7 @@ def test_start_serves_read_only_with_the_app_router(host, microscope):
     assert host.running
     body = _get(host, "/capabilities").json()
     assert body["routers"]["app"] is True
-    assert body["scopes"] == {"read": True, "control": False, "hardware": False}
+    assert body["scopes"] == {"read": True, "control": False, "configure": False, "hardware": False}
     # idempotent: a second start is a no-op, not a second server
     assert host.start(microscope) is True
 

--- a/tests/server/test_hosting.py
+++ b/tests/server/test_hosting.py
@@ -56,7 +56,12 @@ def test_start_serves_read_only_with_the_app_router(host, microscope):
     assert host.running
     body = _get(host, "/capabilities").json()
     assert body["routers"]["app"] is True
-    assert body["scopes"] == {"read": True, "control": False, "configure": False, "hardware": False}
+    assert body["scopes"] == {
+        "read": True,
+        "control": False,
+        "configure": False,
+        "hardware": False,
+    }
     # idempotent: a second start is a no-op, not a second server
     assert host.start(microscope) is True
 

--- a/tests/server/test_server_factory.py
+++ b/tests/server/test_server_factory.py
@@ -93,7 +93,12 @@ def test_capabilities_reports_scopes_and_routers(read_client):
     assert resp.status_code == 200
     body = resp.json()
     assert body["routers"] == {"microscope": True, "app": False}
-    assert body["scopes"] == {"read": True, "control": False, "configure": False, "hardware": False}
+    assert body["scopes"] == {
+        "read": True,
+        "control": False,
+        "configure": False,
+        "hardware": False,
+    }
     assert body["manufacturer"] == "DemoMicroscope"
 
 

--- a/tests/server/test_server_factory.py
+++ b/tests/server/test_server_factory.py
@@ -93,7 +93,7 @@ def test_capabilities_reports_scopes_and_routers(read_client):
     assert resp.status_code == 200
     body = resp.json()
     assert body["routers"] == {"microscope": True, "app": False}
-    assert body["scopes"] == {"read": True, "control": False, "hardware": False}
+    assert body["scopes"] == {"read": True, "control": False, "configure": False, "hardware": False}
     assert body["manufacturer"] == "DemoMicroscope"
 
 

--- a/tests/ui/test_agent_config_patch.py
+++ b/tests/ui/test_agent_config_patch.py
@@ -1,0 +1,202 @@
+"""Config patches end to end: HTTP → configure scope → GUI-thread apply.
+
+Same three-thread shape as the prompt-surface tests: the 'agent' speaks HTTP
+from a worker thread, the apply marshals to the GUI thread the test spins.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("PyQt5")
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient
+from psygnal.containers import EventedDict
+
+from fibsem.applications.autolamella.server import AgentContext
+from fibsem.applications.autolamella.server.events import EventBuffer
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI
+from fibsem.applications.autolamella.workflows.tasks.rough import (
+    MillRoughTaskConfig,
+)
+from fibsem.server import AuthConfig, build_server
+from fibsem.structures import MicroscopeState
+
+TOKEN = "test-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+TASK = "Rough Milling"
+DEPTH = "milling.mill_rough.stages.0.pattern.depth"
+
+
+@pytest.fixture
+def ui(qapp, monkeypatch, tmp_path):
+    import fibsem.config as fibsem_config
+
+    arctis_config = os.path.join(
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "sim-arctis-configuration.yaml",
+    )
+    widget = AutoLamellaUI(parent_ui=None)
+    monkeypatch.setattr(
+        widget.system_widget,
+        "load_configuration",
+        lambda configuration_name=None: arctis_config,
+    )
+    widget.system_widget.connect_to_microscope()
+    exp = Experiment(path=tmp_path / "exp", name="config-patch-exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    (tmp_path / "exp").mkdir(parents=True, exist_ok=True)
+    exp.add_new_lamella(MicroscopeState(), EventedDict())
+    exp.positions[0].task_config[TASK] = MillRoughTaskConfig(task_name=TASK)
+    widget.experiment = exp
+    yield widget
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+    widget.deleteLater()
+    qapp.processEvents()
+
+
+def _client(ui, buffer=None, arm_configure=True):
+    app = build_server(
+        ui.microscope,
+        app_context=AgentContext(ui, event_buffer=buffer),
+        auth=AuthConfig.generate(arm_configure=arm_configure, token=TOKEN),
+    )
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _spin_until(qapp, predicate, timeout_s=10.0):
+    deadline = time.monotonic() + timeout_s
+    while not predicate():
+        if time.monotonic() > deadline:
+            raise TimeoutError("condition not reached")
+        qapp.processEvents()
+        time.sleep(0.01)
+
+
+def _post_on_worker(qapp, client, path, body):
+    """POST from a worker thread while the GUI loop spins (the apply marshals)."""
+    posted = {}
+
+    def target():
+        posted["response"] = client.post(path, headers=AUTH, json=body)
+
+    thread = threading.Thread(target=target, daemon=True)
+    thread.start()
+    _spin_until(qapp, lambda: "response" in posted)
+    return posted["response"]
+
+
+def test_a_patch_lands_with_diff_version_and_event(ui, qapp):
+    buffer = EventBuffer()
+    item = ui.experiment.positions[0].name
+    with _client(ui, buffer=buffer) as client:
+        doc = client.get(f"/app/items/{item}/task_config/{TASK}", headers=AUTH).json()
+        old_depth = (
+            ui.experiment.positions[0]
+            .task_config[TASK]
+            .milling["mill_rough"]
+            .stages[0]
+            .pattern.depth
+        )
+
+        resp = _post_on_worker(
+            qapp,
+            client,
+            f"/app/items/{item}/task_config/{TASK}",
+            {"patch": {DEPTH: 2.5e-6}, "version": doc["version"]},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["applied"] is True
+        assert body["changes"] == [{"path": DEPTH, "old": old_depth, "new": 2.5e-6}]
+        # The object actually changed, and the new version names the new state.
+        config = ui.experiment.positions[0].task_config[TASK]
+        assert config.milling["mill_rough"].stages[0].pattern.depth == 2.5e-6
+        assert body["version"] != doc["version"]
+        reread = client.get(
+            f"/app/items/{item}/task_config/{TASK}", headers=AUTH
+        ).json()
+        assert reread["version"] == body["version"]
+        # And the record shows it: config_edited on the event stream.
+        events = client.get("/app/events?since=0", headers=AUTH).json()["events"]
+        edited = [e for e in events if e["kind"] == "config_edited"]
+        assert edited and edited[-1]["payload"]["changes"][0]["path"] == DEPTH
+
+
+def test_a_stale_version_is_refused_and_nothing_changes(ui, qapp):
+    item = ui.experiment.positions[0].name
+    config = ui.experiment.positions[0].task_config[TASK]
+    with _client(ui) as client:
+        doc = client.get(f"/app/items/{item}/task_config/{TASK}", headers=AUTH).json()
+        # The operator edits in between: the agent's version is now stale.
+        config.milling["mill_rough"].stages[0].pattern.depth = 1.9e-6
+        resp = _post_on_worker(
+            qapp,
+            client,
+            f"/app/items/{item}/task_config/{TASK}",
+            {"patch": {DEPTH: 2.5e-6}, "version": doc["version"]},
+        )
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["error_type"] == "stale_config"
+        assert config.milling["mill_rough"].stages[0].pattern.depth == 1.9e-6
+
+
+def test_invalid_patches_and_unknown_names_refuse_structuredly(ui, qapp):
+    item = ui.experiment.positions[0].name
+    with _client(ui) as client:
+        doc = client.get(f"/app/items/{item}/task_config/{TASK}", headers=AUTH).json()
+        bad = _post_on_worker(
+            qapp,
+            client,
+            f"/app/items/{item}/task_config/{TASK}",
+            {"patch": {DEPTH: "deep"}, "version": doc["version"]},
+        )
+        assert bad.status_code == 422
+        assert bad.json()["detail"]["error_type"] == "invalid_patch"
+        assert bad.json()["detail"]["path"] == DEPTH
+
+        missing = _post_on_worker(
+            qapp,
+            client,
+            f"/app/items/no-such-item/task_config/{TASK}",
+            {"patch": {DEPTH: 2e-6}, "version": doc["version"]},
+        )
+        assert missing.status_code == 404
+        assert missing.json()["detail"]["error_type"] == "not_found"
+
+        malformed = client.post(
+            f"/app/items/{item}/task_config/{TASK}",
+            headers=AUTH,
+            json={"patch": {}, "version": doc["version"]},
+        )
+        assert malformed.status_code == 422
+        assert malformed.json()["detail"]["error_type"] == "missing_field"
+
+
+def test_the_configure_scope_gates_the_route(ui, qapp):
+    item = ui.experiment.positions[0].name
+    with _client(ui, arm_configure=False) as client:
+        # Reads stay read-scope; the write needs configure armed.
+        doc = client.get(f"/app/items/{item}/task_config/{TASK}", headers=AUTH).json()
+        assert doc["available"] is True
+        resp = client.post(
+            f"/app/items/{item}/task_config/{TASK}",
+            headers=AUTH,
+            json={"patch": {DEPTH: 2e-6}, "version": doc["version"]},
+        )
+        assert resp.status_code == 403
+        assert resp.json()["detail"]["scope"] == "configure"


### PR DESCRIPTION
PR 2 of the protocol-editing plan, stacked on #754 (the reads it patches against).

`POST /app/items/{item}/task_config/{task}` takes `{"patch": {"dotted.path": value}, "version": "<from the read>"}`, behind a **new third scope, `configure`** — its own rung in the Agent Server dialog, because answering a question with geometry (control) and editing protocols are different grants.

**The patch engine** (`fibsem/server/config_patch.py`, Qt-free, shared with the coming protocol-level PR): paths must already exist (a patch edits values, never creates structure); leaves must be values, not sections; types must match the live field (enums by member name); and numeric bounds from the form metadata are checked **in display units** — the metadata's min/max bound the scaled value the form shows (a depth minimum of 0.01 is micrometres), so the naive SI comparison would have refused every valid value. All-or-nothing: one failing entry applies nothing. Every refusal names the failing path and the valid alternatives.

**Concurrency**: the apply marshals to the GUI thread beside the version check (nothing changes between check and set), and flushes any edit still sitting in the protocol editor first — the FIB-683 one-writer rule the agent workflow start already follows — which turns the operator-vs-agent race into a deterministic `409 stale_config` instead of a silent merge. A task currently running for that item is refused (`409 task_running`): it already copied its config, so the edit would take effect never. Pending tasks pick changes up at start, the `set_supervision` semantics.

**Record**: applied patches echo their diff (old → new per path), rotate the version, emit `config_edited` to the event stream, and log.

Tests: 7 engine tests against the real `MillRoughTaskConfig` tree (types, enums, sections, unknown names, display-unit bounds, all-or-nothing) and 4 end-to-end (HTTP → scope gate → GUI-thread apply → event stream; stale refusal leaves the object untouched). Sidecar grows `update_item_task_config`.

Over the file target as the seam demands: scope (auth) + router + engine + context + GUI applier + dialog rung + catalog/sidecar + docs + tests, each a small piece of one change.

Release-Note: Agents can now edit task parameters over the agent server, behind a new Configure permission in the Agent Server dialog; every change is validated, refused if the config changed under it, and recorded on the timeline.