### PR TITLE
[autolamella] Workflow · Grids: rows fit the panel, a long reason elides, Screen all is secondary

### DIFF
--- a/fibsem/applications/autolamella/ui/grid_workflow_widget.py
+++ b/fibsem/applications/autolamella/ui/grid_workflow_widget.py
@@ -27,6 +27,7 @@ from PyQt5.QtWidgets import (
     QListWidget,
     QListWidgetItem,
     QPushButton,
+    QSizePolicy,
     QToolButton,
     QVBoxLayout,
     QWidget,
@@ -71,7 +72,10 @@ from fibsem.ui.widgets.preflight import (
 # The lamella list's metrics, so the two run views read alike.
 _ROW_HEIGHT = 40
 _NAME_MIN_WIDTH = 160
-_SIDE_COLUMN_WIDTH = 170  # the muted right-hand column: the slot, or the task's kind
+_SIDE_COLUMN_WIDTH = 170  # the muted right-hand column: the task's kind, or why not
+# The slot column is narrower: "slot 02" is all it ever says, and at the task
+# column's width a row carrying the Loaded pill overran the list and lost it.
+_SLOT_COLUMN_WIDTH = 56
 _SIDE_FONT_PX = 10
 _HEADER_STYLE = "font-weight: bold; background: transparent;"
 
@@ -124,7 +128,7 @@ class _GridRow(QWidget):
         # The slot, in its own right-aligned column like the lamella list's
         # dependencies: read down the list, not hunted for after each name.
         self.slot_label = QLabel()
-        self.slot_label.setFixedWidth(_SIDE_COLUMN_WIDTH)
+        self.slot_label.setFixedWidth(_SLOT_COLUMN_WIDTH)
         self.slot_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         self.slot_label.setStyleSheet(
             f"background: transparent; color: {NEUTRAL_700}; "
@@ -208,18 +212,25 @@ class _TaskRow(QWidget):
         self.name_label.setTextFormat(Qt.PlainText)
         layout.addWidget(self.name_label)
         layout.addStretch(1)
-        # The kind, or why this system cannot run it: the muted right column.
-        self.detail_label = QLabel()
+        # The kind, or why this system cannot run it: the muted right column. A
+        # reason can be longer than the column; elided from the right it keeps
+        # its start, where a plain right-aligned label lost it off the left edge.
+        self.detail_label = ElidedLabel()
         self.detail_label.setFixedWidth(_SIDE_COLUMN_WIDTH)
+        # ElidedLabel is Ignored horizontally so a stretching column cannot be
+        # driven wide by its text. This column is fixed, and left Ignored the
+        # layout placed it as if it had no width and let the stretch push it
+        # past the row's edge; Fixed makes it a proper 170 px column.
+        self.detail_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Preferred)
         self.detail_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         layout.addWidget(self.detail_label)
         # Reordered by dragging the handle, as the lamella task list is.
-        handle = QLabel()
-        handle.setFixedSize(DRAG_HANDLE_WIDTH, DRAG_HANDLE_HEIGHT)
-        handle.setPixmap(drag_handle_pixmap())
-        handle.setStyleSheet("background: transparent;")
-        handle.setCursor(Qt.CursorShape.OpenHandCursor)
-        layout.addWidget(handle)
+        self.drag_handle = QLabel()
+        self.drag_handle.setFixedSize(DRAG_HANDLE_WIDTH, DRAG_HANDLE_HEIGHT)
+        self.drag_handle.setPixmap(drag_handle_pixmap())
+        self.drag_handle.setStyleSheet("background: transparent;")
+        self.drag_handle.setCursor(Qt.CursorShape.OpenHandCursor)
+        layout.addWidget(self.drag_handle)
         self.refresh()
 
     @property
@@ -406,7 +417,8 @@ class GridWorkflowWidget(QWidget):
 
         bottom = QHBoxLayout()
         self.btn_screen_all = QPushButton("Screen all grids")
-        self.btn_screen_all.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        # Secondary: Run, on the shared footer, is the primary action of the tab.
+        self.btn_screen_all.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
         self.btn_screen_all.setIcon(
             fibsem_icon("mdi:play-circle", color=stylesheets.GRAY_ICON_COLOR)
         )

--- a/tests/ui/test_grid_workflow_widget.py
+++ b/tests/ui/test_grid_workflow_widget.py
@@ -8,8 +8,9 @@ import pytest
 
 pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
 
+from PyQt5.QtGui import QFontMetrics
 from PyQt5.QtTest import QTest
-from PyQt5.QtWidgets import QDialog
+from PyQt5.QtWidgets import QDialog, QLabel
 
 import fibsem.config as cfg
 from fibsem import utils
@@ -124,6 +125,15 @@ class TestSelection:
         assert [c.text() for c in row._chip_widgets] == ["Loaded"]
         assert row.slot_label.text() == "slot 02"
 
+    def test_a_loaded_row_keeps_its_slot_inside_the_list(self, view, arctis):
+        """The Loaded pill once pushed the slot column past the list's edge, and
+        the slot read as "s". The row must ask for less than the panel gives."""
+        arctis._stage.ensure_loaded("Grid-02")
+        view.refresh()
+        row = view._grid_rows["Grid-02"]
+        assert [c.text() for c in row._chip_widgets] == ["Loaded"]
+        assert row.sizeHint().width() <= 380
+
     def test_the_fm_task_is_greyed_without_a_fluorescence_microscope(
         self, qapp, experiment
     ):
@@ -139,6 +149,23 @@ class TestSelection:
         assert not row.checkbox.isEnabled()
         assert "no fluorescence microscope" in row.detail_label.text()
         assert widget.get_selected_task_names() == ["overview_sem"]
+        # The reason is longer than its column. It is elided from the right so
+        # the start survives; a plain right-aligned label lost it off the left.
+        widget.resize(420, 600)  # the Workflow tab's left panel, near enough
+        widget.show()
+        QTest.qWait(50)
+        drawn = QLabel.text(row.detail_label)
+        assert drawn != row.detail_label.text() and drawn.endswith("\u2026")
+        assert drawn.startswith(row.detail_label.text()[:8])
+        assert (
+            QFontMetrics(row.detail_label.font()).horizontalAdvance(drawn)
+            <= row.detail_label.width()
+        )
+        # And the column sits inside the row, before the drag handle: left to
+        # its Ignored policy the layout pushed it past the row's right edge.
+        assert row.detail_label.geometry().right() <= row.drag_handle.geometry().left()
+        assert row.drag_handle.geometry().right() <= row.width()
+        widget.close()
 
     def test_reordering_tasks_writes_the_protocol(self, view, experiment):
         view._on_reordered(["overview_fm", "overview_sem"])  # what a drop reports


### PR DESCRIPTION
Three things a screenshot of the Workflow → Grids view showed, taken for the bench doc.

- **A grid row with the Loaded pill overran the list**, and its slot column read as "s". The slot column shared the task column's 170 px; "slot 02" is all it ever says, so it is 56 px now and the row asks for less than the panel gives.
- **A task's reason for being unavailable was clipped from the left.** "This system has no fluorescence microscope" is longer than the 170 px column and, right-aligned in a plain QLabel, lost its start. The column is an `ElidedLabel` now, elided from the right so the start survives, with the whole reason on the tooltip. It needs an explicit Fixed size policy: `ElidedLabel` is Ignored horizontally by design, and left that way the layout placed the column past the row's right edge.
- **Screen all grids is a secondary button.** Run, on the shared footer, is the tab's primary action.

**Tests** (`tests/ui/test_grid_workflow_widget.py`): a loaded row's size hint fits a 380 px panel; the FM row's reason is drawn elided from the right, within its column, and the column sits before the drag handle inside the row. Both fail on the old code. 13 in the file pass.