### PR TITLE
[server] Protocol-level config patches, and no stale form survives one

### DIFF
--- a/.claude/skills/supervise-autolamella/SKILL.md
+++ b/.claude/skills/supervise-autolamella/SKILL.md
@@ -202,6 +202,40 @@ The argument selects a variation on the same loop:
 - `POST /app/queue/requeue {"item_name", "task_name"}` — re-runs a completed
   pair inside a running workflow.
 
+## Editing configuration (configure permission)
+
+A separate permission from *Act* — the operator arms **Configure** in
+Tools → Agent Server. With it you can change task parameters; without it
+you can still read them (`get_protocol_task_config`,
+`get_item_task_config`).
+
+Two levels, one dance:
+
+- **Per-item** (`update_item_task_config`): the config this item's next run
+  of that task will execute.
+- **Protocol** (`update_protocol_task_config`): the defaults new items
+  copy. Never affects existing items — they hold their own copies.
+
+The dance: **read, patch against that read's `version`, report**. A
+`409 stale_config` means the config changed since you read it (often: the
+operator edited) — that refusal is correct; re-read and decide again on
+the current state. A `409 task_running` means the task already copied its
+config for the run in progress — patch after it finishes. Values are SI
+(metres, amps); bounds are validated for you and refusals name the
+failing path.
+
+Etiquette:
+
+- **Change what was asked, exactly.** "Make the fiducial 2 µm deeper" is
+  one dotted path, not an opinion about the neighbouring fields. Patches
+  are small and named; never rewrite a document wholesale.
+- **Unprompted edits follow the trust ladder**: propose in chat first
+  unless the operator has delegated parameter changes to you.
+- **Report every applied change** old → new (the response echoes it; the
+  timeline records it; your report should match both).
+- The operator sees your change land: the open editor rebuilds and a
+  toast names the edit. Nothing you change is silent.
+
 ## Report
 
 Keep the operator oriented without flooding them: say what you answered and

--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -420,6 +420,39 @@ class AgentContext:
         document["item_name"] = item_name
         return document
 
+    def apply_protocol_task_config_patch(
+        self,
+        task_name: str,
+        patch: Dict[str, Any],
+        version: str,
+        timeout: float = 10.0,
+    ) -> Dict[str, Any]:
+        """Patch a task's protocol-level defaults — what new items copy.
+
+        Same version-guarded, GUI-thread apply as the per-item patch. No
+        running-task guard: a running task holds its item's copy, so a
+        protocol edit can never touch it — the edit reaches items created
+        (or re-copied) after it lands.
+        """
+        host = self._host
+        if not hasattr(host, "request_apply_protocol_task_config_patch"):
+            return {"available": False, "applied": False}
+        outcome = host.request_apply_protocol_task_config_patch(
+            task_name, dict(patch), str(version)
+        )
+        result = outcome.result(timeout=timeout)
+        result["available"] = True
+        if result.get("applied") and self._event_buffer is not None:
+            self._event_buffer.append(
+                "config_edited",
+                {
+                    "level": "protocol",
+                    "task_name": task_name,
+                    "changes": result.get("changes", []),
+                },
+            )
+        return result
+
     @staticmethod
     def _config_document(task_name: str, config, level: str) -> Dict[str, Any]:
         """One config as a wire document with its version token.

--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -566,7 +566,7 @@ class AgentContext:
         manager = self._manager
         if manager is not None:
             running = any(
-                item.lamella_name == item_name
+                item.item_name == item_name
                 and item.task_name == task_name
                 and item.status is AutoLamellaTaskStatus.InProgress
                 for item in manager.queue.items

--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -36,8 +36,10 @@ __all__ = ["AgentContext", "ITEM_PATCH_FIELDS", "config_version", "item_fields_v
 
 # The item-document fields an agent may patch: what a lamella IS — geometry,
 # verdict, notes. Everything else on the object (poses, ids, paths, history)
-# is either derived, hardware-adjacent, or the record itself.
-ITEM_PATCH_FIELDS = ("poi", "alignment_area", "milling_angle", "description", "defect")
+# is either derived, hardware-adjacent, an *outcome* rather than an input
+# (milling_angle is recorded from where Setup put the stage — writing it
+# would move nothing), or the record itself.
+ITEM_PATCH_FIELDS = ("poi", "alignment_area", "description", "defect")
 
 
 def _content_hash(data) -> str:

--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -32,7 +32,36 @@ from typing import Any, Dict, List, Optional
 from fibsem.applications.autolamella import task_outputs as _task_outputs
 from fibsem.applications.autolamella.structures import AutoLamellaTaskStatus
 
-__all__ = ["AgentContext", "config_version"]
+__all__ = ["AgentContext", "ITEM_PATCH_FIELDS", "config_version", "item_fields_version"]
+
+# The item-document fields an agent may patch: what a lamella IS — geometry,
+# verdict, notes. Everything else on the object (poses, ids, paths, history)
+# is either derived, hardware-adjacent, or the record itself.
+ITEM_PATCH_FIELDS = ("poi", "alignment_area", "milling_angle", "description", "defect")
+
+
+def _content_hash(data) -> str:
+    import hashlib
+    import json
+
+    return hashlib.sha256(
+        json.dumps(data, sort_keys=True, default=str).encode()
+    ).hexdigest()[:16]
+
+
+def item_fields_version(lamella) -> str:
+    """A content hash naming the state of an item's patchable fields.
+
+    The item document's nonce, hashing exactly the ITEM_PATCH_FIELDS — so a
+    task re-recording geometry rotates it (stales a pending patch, correctly),
+    while poses moving or history growing does not (they are not patchable,
+    so they cannot invalidate what a patch was written against).
+    """
+    from fibsem.applications.autolamella.server.events import to_plain
+
+    return _content_hash(
+        {name: to_plain(getattr(lamella, name, None)) for name in ITEM_PATCH_FIELDS}
+    )
 
 
 def config_version(config) -> str:
@@ -48,10 +77,7 @@ def config_version(config) -> str:
 
     from fibsem.applications.autolamella.server.events import to_plain
 
-    data = to_plain(config.to_dict())
-    return hashlib.sha256(
-        json.dumps(data, sort_keys=True, default=str).encode()
-    ).hexdigest()[:16]
+    return _content_hash(to_plain(config.to_dict()))
 
 
 def _json_safe(value: Any) -> Any:
@@ -351,6 +377,8 @@ class AgentContext:
                 "item_name": item_name,
                 "error": f"No item named {item_name!r} in this experiment.",
             }
+        from fibsem.applications.autolamella.server.events import to_plain
+
         poses = {}
         for pose_name, pose in dict(lamella.poses).items():
             position = getattr(pose, "stage_position", None)
@@ -368,7 +396,12 @@ class AgentContext:
             if lamella.alignment_area is not None
             else None,
             "milling_angle": lamella.milling_angle,
+            "defect": to_plain(lamella.defect.to_dict())
+            if getattr(lamella, "defect", None) is not None
+            else None,
             "poses": poses,
+            # The item document's nonce: patches echo it (see apply_item_patch).
+            "version": item_fields_version(lamella),
         }
 
     # --- task configs (FIB-864, read side) --------------------------------------
@@ -419,6 +452,41 @@ class AgentContext:
         document = self._config_document(task_name, config, level="item")
         document["item_name"] = item_name
         return document
+
+    def apply_item_patch(
+        self,
+        item_name: str,
+        patch: Dict[str, Any],
+        version: str,
+        timeout: float = 10.0,
+    ) -> Dict[str, Any]:
+        """Patch an item's own document — geometry, verdict, notes.
+
+        The item-level counterpart of the task-config patches: same engine,
+        same version dance (``version`` comes from :meth:`item_detail`), but
+        the document is what the lamella IS rather than how a step runs, and
+        only the ITEM_PATCH_FIELDS are editable. Tasks re-record geometry at
+        their own moments (a fiducial task rewrites the alignment area at its
+        end) — that rotation stales pending patches, which is the correct
+        outcome, and it means an edit here is the value the NEXT run starts
+        from, not a permanent override.
+        """
+        host = self._host
+        if not hasattr(host, "request_apply_item_patch"):
+            return {"available": False, "applied": False}
+        outcome = host.request_apply_item_patch(item_name, dict(patch), str(version))
+        result = outcome.result(timeout=timeout)
+        result["available"] = True
+        if result.get("applied") and self._event_buffer is not None:
+            self._event_buffer.append(
+                "config_edited",
+                {
+                    "level": "item_fields",
+                    "item_name": item_name,
+                    "changes": result.get("changes", []),
+                },
+            )
+        return result
 
     def apply_protocol_task_config_patch(
         self,

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1438,7 +1438,7 @@ class AutoLamellaUI(QMainWindow):
             changes = apply_patch(
                 lamella,
                 patch,
-                none_types={"milling_angle": float, "description": str},
+                none_types={"description": str},
             )
         except PatchError as exc:
             return {"applied": False, "invalid_patch": str(exc), "path": exc.path}

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1350,9 +1350,24 @@ class AutoLamellaUI(QMainWindow):
             f"agent config patch applied ({level}): {where}: "
             + ", ".join(f"{p}: {old!r} -> {new!r}" for p, old, new in changes)
         )
+        # Persist now: an operator edit rides the editor's debounced save, but
+        # a patch has no editor session to coalesce with — without this write
+        # the change lives only in memory and a restart silently reverts it
+        # (observed live). One request, one write; protocol-level edits also
+        # rewrite protocol.yaml, exactly as the protocol editor's saves do.
+        saved = True
+        try:
+            experiment.save(save_protocol=(level == "protocol"))
+        except Exception:
+            saved = False
+            logging.exception(
+                "save after agent config patch failed; the change is applied "
+                "in memory but not yet on disk"
+            )
         self._show_agent_config_patch(level, item_name, task_name, changes)
         result = {
             "applied": True,
+            "saved": saved,
             "task_name": task_name,
             "changes": [
                 {"path": p, "old": to_plain(old), "new": to_plain(new)}

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -190,7 +190,7 @@ class AutoLamellaUI(QMainWindow):
     # way agent answers are: (task_names, item_names, Future[dict]).
     _agent_start_workflow = pyqtSignal(list, object, object)
     # (item_name, task_name, patch, version, Future) — the config-patch marshal
-    _agent_config_patch = pyqtSignal(str, str, object, str, object)
+    _agent_config_patch = pyqtSignal(str, str, str, object, str, object)
 
     def __init__(
         self,
@@ -1238,16 +1238,41 @@ class AutoLamellaUI(QMainWindow):
         from concurrent.futures import Future as _Future
 
         outcome: "_Future" = _Future()
-        self._agent_config_patch.emit(item_name, task_name, patch, version, outcome)
+        self._agent_config_patch.emit(
+            "item", item_name, task_name, patch, version, outcome
+        )
+        return outcome
+
+    def request_apply_protocol_task_config_patch(
+        self, task_name: str, patch: dict, version: str
+    ) -> "Future":
+        """Patch a task's protocol-level defaults; any thread.
+
+        Same marshal and rules as the per-item form; the document edited is
+        what new items copy, so a running task is never affected (it holds
+        its item's copy) and no task-running guard applies.
+        """
+        from concurrent.futures import Future as _Future
+
+        outcome: "_Future" = _Future()
+        self._agent_config_patch.emit(
+            "protocol", "", task_name, patch, version, outcome
+        )
         return outcome
 
     def _apply_agent_config_patch(
-        self, item_name: str, task_name: str, patch, version: str, outcome: "Future"
+        self,
+        level: str,
+        item_name: str,
+        task_name: str,
+        patch,
+        version: str,
+        outcome: "Future",
     ) -> None:
         """GUI thread. Complete ``outcome`` with the patch result."""
         try:
             result = self._apply_task_config_patch_for_agent(
-                item_name, task_name, patch, version
+                level, item_name, task_name, patch, version
             )
         except Exception as exc:  # noqa: BLE001 - the requester owns the failure
             outcome.set_exception(exc)
@@ -1255,16 +1280,19 @@ class AutoLamellaUI(QMainWindow):
         outcome.set_result(result)
 
     def _apply_task_config_patch_for_agent(
-        self, item_name: str, task_name: str, patch: dict, version: str
+        self, level: str, item_name: str, task_name: str, patch: dict, version: str
     ) -> dict:
         """Validate against the live config and apply, all on the GUI thread.
 
         The version check sits beside the apply on the one thread that edits
         configs, so nothing can change between check and set. Before checking,
-        any edit still sitting in the editor is flushed (the FIB-683
+        any edit still sitting in the editors is flushed (the FIB-683
         one-writer rule, same as the agent workflow start): if the operator's
         pending edit changes this config, the agent's version goes stale and
-        the refusal — not a silent merge — resolves the race.
+        the refusal — not a silent merge — resolves the race. After a
+        successful apply, whichever editor is displaying this config is
+        rebuilt (no stale form survives to write old values back) and a toast
+        tells the operator what changed.
         """
         from fibsem.applications.autolamella.server.context import config_version
         from fibsem.applications.autolamella.server.events import to_plain
@@ -1280,20 +1308,33 @@ class AutoLamellaUI(QMainWindow):
         experiment = self.experiment
         if experiment is None:
             return {"applied": False, "error": "no experiment is loaded"}
-        lamella = experiment.get_lamella_by_name(item_name)
-        if lamella is None:
-            return {
-                "applied": False,
-                "error": f"No item named {item_name!r} in this experiment.",
-                "item_names": [p.name for p in experiment.positions],
-            }
-        config = dict(lamella.task_config).get(task_name)
-        if config is None:
-            return {
-                "applied": False,
-                "error": f"No task config named {task_name!r} on {item_name!r}.",
-                "task_names": list(lamella.task_config.keys()),
-            }
+        if level == "protocol":
+            protocol = getattr(experiment, "task_protocol", None)
+            config_map = getattr(protocol, "task_config", None)
+            if config_map is None:
+                return {"applied": False, "error": "no protocol is loaded"}
+            config = dict(config_map).get(task_name)
+            if config is None:
+                return {
+                    "applied": False,
+                    "error": f"No task named {task_name!r} in the protocol.",
+                    "task_names": list(config_map.keys()),
+                }
+        else:
+            lamella = experiment.get_lamella_by_name(item_name)
+            if lamella is None:
+                return {
+                    "applied": False,
+                    "error": f"No item named {item_name!r} in this experiment.",
+                    "item_names": [p.name for p in experiment.positions],
+                }
+            config = dict(lamella.task_config).get(task_name)
+            if config is None:
+                return {
+                    "applied": False,
+                    "error": f"No task config named {task_name!r} on {item_name!r}.",
+                    "task_names": list(lamella.task_config.keys()),
+                }
         if config_version(config) != version:
             return {"applied": False, "stale": True}
         try:
@@ -1304,13 +1345,14 @@ class AutoLamellaUI(QMainWindow):
                 "invalid_patch": str(exc),
                 "path": exc.path,
             }
+        where = f"{item_name} / {task_name}" if level == "item" else task_name
         logging.info(
-            f"agent config patch applied: {item_name} / {task_name}: "
+            f"agent config patch applied ({level}): {where}: "
             + ", ".join(f"{p}: {old!r} -> {new!r}" for p, old, new in changes)
         )
-        return {
+        self._show_agent_config_patch(level, item_name, task_name, changes)
+        result = {
             "applied": True,
-            "item_name": item_name,
             "task_name": task_name,
             "changes": [
                 {"path": p, "old": to_plain(old), "new": to_plain(new)}
@@ -1318,6 +1360,41 @@ class AutoLamellaUI(QMainWindow):
             ],
             "version": config_version(config),
         }
+        if level == "item":
+            result["item_name"] = item_name
+        return result
+
+    def _show_agent_config_patch(
+        self, level: str, item_name: str, task_name: str, changes
+    ) -> None:
+        """Rebuild the editor showing this config and toast the change.
+
+        GUI thread, after a successful apply. The rebuild is what stops a
+        stale open form writing old values back on the operator's next edit;
+        the toast is what stops the form appearing to change by itself.
+        Chrome only — a failure here must never fail the applied patch.
+        """
+        try:
+            leaf = changes[0][0].rsplit(".", 1)[-1]
+            summary = f"{leaf}: {changes[0][1]!r} → {changes[0][2]!r}"
+            if len(changes) > 1:
+                summary += f" (+{len(changes) - 1} more)"
+            target = f"{task_name} for {item_name}" if level == "item" else task_name
+            notification_service.show_toast(
+                f"Agent edited {target} — {summary}", "info"
+            )
+        except Exception:
+            logging.exception("toast after agent config patch failed")
+        parent = self.parent_widget
+        if parent is None:
+            return
+        try:
+            if level == "item":
+                parent.lamella_widget.refresh_if_showing(item_name)
+            else:
+                parent.task_widget.refresh_if_showing_task(task_name)
+        except Exception:
+            logging.exception("editor refresh after agent config patch failed")
 
     def _run_tasks_worker(
         self, task_names: List[str], lamella_names: Optional[List[str]] = None

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1445,7 +1445,9 @@ class AutoLamellaUI(QMainWindow):
         area = lamella.alignment_area
         if area is not None and not area.is_valid_reduced_area:
             for path, old, _new in reversed(changes):
-                apply_patch(lamella, {path: old if not hasattr(old, "name") else old.name})
+                apply_patch(
+                    lamella, {path: old if not hasattr(old, "name") else old.name}
+                )
             return {
                 "applied": False,
                 "invalid_patch": "the patched alignment area is out of bounds "

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -1243,6 +1243,22 @@ class AutoLamellaUI(QMainWindow):
         )
         return outcome
 
+    def request_apply_item_patch(
+        self, item_name: str, patch: dict, version: str
+    ) -> "Future":
+        """Patch an item's own document (geometry, verdict, notes); any thread.
+
+        Same marshal as the config patches; the editable set is
+        ITEM_PATCH_FIELDS, and the version comes from item_detail.
+        """
+        from concurrent.futures import Future as _Future
+
+        outcome: "_Future" = _Future()
+        self._agent_config_patch.emit(
+            "item_fields", item_name, "", patch, version, outcome
+        )
+        return outcome
+
     def request_apply_protocol_task_config_patch(
         self, task_name: str, patch: dict, version: str
     ) -> "Future":
@@ -1308,6 +1324,8 @@ class AutoLamellaUI(QMainWindow):
         experiment = self.experiment
         if experiment is None:
             return {"applied": False, "error": "no experiment is loaded"}
+        if level == "item_fields":
+            return self._apply_item_fields_patch(experiment, item_name, patch, version)
         if level == "protocol":
             protocol = getattr(experiment, "task_protocol", None)
             config_map = getattr(protocol, "task_config", None)
@@ -1379,6 +1397,89 @@ class AutoLamellaUI(QMainWindow):
             result["item_name"] = item_name
         return result
 
+    def _apply_item_fields_patch(
+        self, experiment, item_name: str, patch: dict, version: str
+    ) -> dict:
+        """Patch the lamella's own editable fields. GUI thread.
+
+        Allowlisted to ITEM_PATCH_FIELDS — poses, ids, paths and history are
+        not editable through any agent surface. Alignment validity is checked
+        after the apply and reverted on failure (the engine's own checks are
+        per-field; a rectangle is only judgeable whole). A defect edit stamps
+        ``updated_at``, so the verdict record carries when it was changed.
+        """
+        import time as _time
+
+        from fibsem.applications.autolamella.server.context import (
+            ITEM_PATCH_FIELDS,
+            item_fields_version,
+        )
+        from fibsem.applications.autolamella.server.events import to_plain
+        from fibsem.server.config_patch import PatchError, apply_patch
+
+        lamella = experiment.get_lamella_by_name(item_name)
+        if lamella is None:
+            return {
+                "applied": False,
+                "error": f"No item named {item_name!r} in this experiment.",
+                "item_names": [p.name for p in experiment.positions],
+            }
+        for path in patch:
+            if path.split(".", 1)[0] not in ITEM_PATCH_FIELDS:
+                return {
+                    "applied": False,
+                    "invalid_patch": f"{path!r} is not an editable item field; "
+                    f"editable: {sorted(ITEM_PATCH_FIELDS)}",
+                    "path": path,
+                }
+        if item_fields_version(lamella) != version:
+            return {"applied": False, "stale": True}
+        try:
+            changes = apply_patch(
+                lamella,
+                patch,
+                none_types={"milling_angle": float, "description": str},
+            )
+        except PatchError as exc:
+            return {"applied": False, "invalid_patch": str(exc), "path": exc.path}
+        area = lamella.alignment_area
+        if area is not None and not area.is_valid_reduced_area:
+            for path, old, _new in reversed(changes):
+                apply_patch(lamella, {path: old if not hasattr(old, "name") else old.name})
+            return {
+                "applied": False,
+                "invalid_patch": "the patched alignment area is out of bounds "
+                "(left/top >= 0, width/height > 0, inside the frame); "
+                "nothing was applied.",
+                "path": None,
+            }
+        if any(p.split(".", 1)[0] == "defect" for p, _o, _n in changes):
+            lamella.defect.updated_at = _time.time()
+        logging.info(
+            f"agent item patch applied: {item_name}: "
+            + ", ".join(f"{p}: {old!r} -> {new!r}" for p, old, new in changes)
+        )
+        saved = True
+        try:
+            experiment.save()
+        except Exception:
+            saved = False
+            logging.exception(
+                "save after agent item patch failed; the change is applied "
+                "in memory but not yet on disk"
+            )
+        self._show_agent_config_patch("item_fields", item_name, item_name, changes)
+        return {
+            "applied": True,
+            "saved": saved,
+            "item_name": item_name,
+            "changes": [
+                {"path": p, "old": to_plain(old), "new": to_plain(new)}
+                for p, old, new in changes
+            ],
+            "version": item_fields_version(lamella),
+        }
+
     def _show_agent_config_patch(
         self, level: str, item_name: str, task_name: str, changes
     ) -> None:
@@ -1394,7 +1495,12 @@ class AutoLamellaUI(QMainWindow):
             summary = f"{leaf}: {changes[0][1]!r} → {changes[0][2]!r}"
             if len(changes) > 1:
                 summary += f" (+{len(changes) - 1} more)"
-            target = f"{task_name} for {item_name}" if level == "item" else task_name
+            if level == "item":
+                target = f"{task_name} for {item_name}"
+            elif level == "item_fields":
+                target = item_name
+            else:
+                target = task_name
             notification_service.show_toast(
                 f"Agent edited {target} — {summary}", "info"
             )
@@ -1404,7 +1510,7 @@ class AutoLamellaUI(QMainWindow):
         if parent is None:
             return
         try:
-            if level == "item":
+            if level in ("item", "item_fields"):
                 parent.lamella_widget.refresh_if_showing(item_name)
             else:
                 parent.task_widget.refresh_if_showing_task(task_name)

--- a/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
@@ -87,6 +87,7 @@ _SAVE_DEBOUNCE_MS = 400
 POI_OVERLAY_ID = "poi"
 ALIGNMENT_OVERLAY_ID = "alignment_area"
 
+
 class AutoLamellaProtocolEditorWidget(QWidget):
     """A widget to edit the AutoLamella protocol."""
 
@@ -408,6 +409,19 @@ class AutoLamellaProtocolEditorWidget(QWidget):
             and self.parent_widget.experiment.positions
         ):  # type: ignore
             self._selected_lamella = self.parent_widget.experiment.positions[0]
+            self._on_selected_lamella_changed()
+
+    def refresh_if_showing(self, item_name: str) -> None:
+        """Rebuild the panel if it is displaying ``item_name``.
+
+        Called (on the GUI thread) after an outside writer — the agent's
+        config patch — changed the item's state under an open form. The
+        rebuild is what prevents the stale form writing old values back on
+        the operator's next edit; pending operator edits were flushed before
+        the outside write was allowed to apply.
+        """
+        selected = self._selected_lamella
+        if selected is not None and selected.name == item_name:
             self._on_selected_lamella_changed()
 
     def _refresh_experiment_positions(self):
@@ -1182,7 +1196,9 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         text = self.line_edit_description.text()
         if lamella.description == text:
             return
-        lamella.description = text  # fires events.description -> updates read-only mirrors
+        lamella.description = (
+            text  # fires events.description -> updates read-only mirrors
+        )
         self._save_experiment()
 
     def _save_experiment(self):

--- a/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
@@ -473,6 +473,20 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         task_names = list(self.experiment.task_protocol.task_config.keys())
         self.task_list_widget.set_tasks(task_names)
 
+    def refresh_if_showing_task(self, task_name: str) -> None:
+        """Rebuild the panel if it is displaying ``task_name``.
+
+        Called (on the GUI thread) after an outside writer — the agent's
+        protocol-level config patch — changed the config under an open form,
+        so no stale form survives to write old values back.
+        """
+        try:
+            selected = self.task_list_widget.selected_task
+        except Exception:
+            return
+        if selected == task_name:
+            self._on_selected_task_changed()
+
     def _on_selected_task_changed(self):
         """Callback when the selected milling stage changes."""
         selected_task_name = self.task_list_widget.selected_task

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -258,6 +258,15 @@ def build_sidecar(client, capabilities):
     def get_item_task_config(item_name: str, task_name: str):
         return _app_get(f"/app/items/{item_name}/task_config/{task_name}")
 
+    def update_protocol_task_config(task_name: str, patch: dict, version: str):
+        data, err = _call(
+            client,
+            "POST",
+            f"/app/protocol/task_config/{task_name}",
+            {"patch": dict(patch), "version": str(version)},
+        )
+        return err if err else data
+
     def update_item_task_config(
         item_name: str, task_name: str, patch: dict, version: str
     ):
@@ -357,6 +366,7 @@ def build_sidecar(client, capabilities):
             get_protocol_task_config,
             get_item_task_config,
             update_item_task_config,
+            update_protocol_task_config,
             list_recent_experiments,
             get_events,
             get_display_images,

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -258,6 +258,15 @@ def build_sidecar(client, capabilities):
     def get_item_task_config(item_name: str, task_name: str):
         return _app_get(f"/app/items/{item_name}/task_config/{task_name}")
 
+    def update_item_detail(item_name: str, patch: dict, version: str):
+        data, err = _call(
+            client,
+            "POST",
+            f"/app/items/{item_name}",
+            {"patch": dict(patch), "version": str(version)},
+        )
+        return err if err else data
+
     def update_protocol_task_config(task_name: str, patch: dict, version: str):
         data, err = _call(
             client,
@@ -367,6 +376,7 @@ def build_sidecar(client, capabilities):
             get_item_task_config,
             update_item_task_config,
             update_protocol_task_config,
+            update_item_detail,
             list_recent_experiments,
             get_events,
             get_display_images,

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -58,6 +58,10 @@ class AppContext(Protocol):
         self, item_name: str, task_name: str, patch: Dict[str, Any], version: str
     ) -> Dict[str, Any]: ...
 
+    def apply_protocol_task_config_patch(
+        self, task_name: str, patch: Dict[str, Any], version: str
+    ) -> Dict[str, Any]: ...
+
     def recent_experiments(self) -> List[Dict[str, Any]]: ...
 
     def events(self, since: int = 0, timeout: float = 0.0) -> Dict[str, Any]: ...
@@ -310,8 +314,7 @@ def build_app_config_router(context: AppContext) -> APIRouter:
     """
     router = APIRouter(prefix="/app")
 
-    @router.post("/items/{item_name}/task_config/{task_name}")
-    def patch_item_task_config(item_name: str, task_name: str, body: Dict[str, Any]):
+    def _validated(body: Dict[str, Any]):
         patch = body.get("patch")
         version = body.get("version")
         if (
@@ -329,9 +332,23 @@ def build_app_config_router(context: AppContext) -> APIRouter:
                     "written against).",
                 },
             )
-        result = context.apply_item_task_config_patch(
-            item_name, task_name, patch, version
+        return patch, version
+
+    @router.post("/protocol/task_config/{task_name}")
+    def patch_protocol_task_config(task_name: str, body: Dict[str, Any]):
+        patch, version = _validated(body)
+        return _refused_or(
+            context.apply_protocol_task_config_patch(task_name, patch, version)
         )
+
+    @router.post("/items/{item_name}/task_config/{task_name}")
+    def patch_item_task_config(item_name: str, task_name: str, body: Dict[str, Any]):
+        patch, version = _validated(body)
+        return _refused_or(
+            context.apply_item_task_config_patch(item_name, task_name, patch, version)
+        )
+
+    def _refused_or(result: Dict[str, Any]):
         if result.get("stale"):
             raise HTTPException(
                 status_code=409,

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -62,6 +62,10 @@ class AppContext(Protocol):
         self, task_name: str, patch: Dict[str, Any], version: str
     ) -> Dict[str, Any]: ...
 
+    def apply_item_patch(
+        self, item_name: str, patch: Dict[str, Any], version: str
+    ) -> Dict[str, Any]: ...
+
     def recent_experiments(self) -> List[Dict[str, Any]]: ...
 
     def events(self, since: int = 0, timeout: float = 0.0) -> Dict[str, Any]: ...
@@ -347,6 +351,14 @@ def build_app_config_router(context: AppContext) -> APIRouter:
         return _refused_or(
             context.apply_item_task_config_patch(item_name, task_name, patch, version)
         )
+
+    @router.post("/items/{item_name}")
+    def patch_item(item_name: str, body: Dict[str, Any]):
+        # The item's own document (geometry, verdict, notes) — the write-side
+        # mirror of GET /app/items/{item_name}, whose payload carries the
+        # version this patch must echo.
+        patch, version = _validated(body)
+        return _refused_or(context.apply_item_patch(item_name, patch, version))
 
     def _refused_or(result: Dict[str, Any]):
         if result.get("stale"):

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -244,6 +244,19 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         },
     ),
     ToolSpec(
+        name="update_protocol_task_config",
+        description="Patch a task's protocol-level defaults (what new items copy) with dotted-path edits. Echo the version from get_protocol_task_config — a mismatch is refused (409 stale_config). Running tasks are never affected: they hold their item's copy; the edit reaches items created after. Needs the configure permission.",
+        method="POST",
+        path="/app/protocol/task_config/{task_name}",
+        scope="configure",
+        router="app",
+        params={
+            "task_name": "the task name, as listed by get_protocol",
+            "patch": "object of dotted-path: value entries to set",
+            "version": "the version token from get_protocol_task_config",
+        },
+    ),
+    ToolSpec(
         name="update_item_task_config",
         description="Patch an item's task config with dotted-path edits (e.g. {'milling.mill_rough.stages.0.pattern.depth': 2e-6}). Echo the version from get_item_task_config — a mismatch is refused (409 stale_config): re-read and re-patch. A task currently running for that item is refused (it already copied its config); pending tasks pick the change up at start. Values are validated against the live field's type and declared bounds; the response echoes every change old -> new. Needs the configure permission.",
         method="POST",

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -245,7 +245,7 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
     ),
     ToolSpec(
         name="update_item_detail",
-        description="Patch an item's own document with dotted-path edits: poi.x/poi.y (metres, milling frame), alignment_area.left/top/width/height (frame fractions), milling_angle (degrees), description, defect.state (NONE/FAILURE/REWORK) and defect.description. Echo the version from get_item_detail — a mismatch is refused (409 stale_config). Tasks re-record geometry at their own moments, so an edit here is what the NEXT run starts from, not a permanent override. Needs the configure permission.",
+        description="Patch an item's own document with dotted-path edits: poi.x/poi.y (metres, milling frame), alignment_area.left/top/width/height (frame fractions), description, defect.state (NONE/FAILURE/REWORK) and defect.description. milling_angle is read-only: it is an outcome of the Setup task, not an input. Echo the version from get_item_detail — a mismatch is refused (409 stale_config). Tasks re-record geometry at their own moments, so an edit here is what the NEXT run starts from, not a permanent override. Needs the configure permission.",
         method="POST",
         path="/app/items/{item_name}",
         scope="configure",

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -244,6 +244,19 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         },
     ),
     ToolSpec(
+        name="update_item_detail",
+        description="Patch an item's own document with dotted-path edits: poi.x/poi.y (metres, milling frame), alignment_area.left/top/width/height (frame fractions), milling_angle (degrees), description, defect.state (NONE/FAILURE/REWORK) and defect.description. Echo the version from get_item_detail — a mismatch is refused (409 stale_config). Tasks re-record geometry at their own moments, so an edit here is what the NEXT run starts from, not a permanent override. Needs the configure permission.",
+        method="POST",
+        path="/app/items/{item_name}",
+        scope="configure",
+        router="app",
+        params={
+            "item_name": "the item (lamella) name",
+            "patch": "object of dotted-path: value entries to set",
+            "version": "the version token from get_item_detail",
+        },
+    ),
+    ToolSpec(
         name="update_protocol_task_config",
         description="Patch a task's protocol-level defaults (what new items copy) with dotted-path edits. Echo the version from get_protocol_task_config — a mismatch is refused (409 stale_config). Running tasks are never affected: they hold their item's copy; the edit reaches items created after. Needs the configure permission.",
         method="POST",

--- a/fibsem/server/config_patch.py
+++ b/fibsem/server/config_patch.py
@@ -29,7 +29,7 @@ Qt-free and py3.8-clean; the GUI-thread caller owns marshalling.
 from dataclasses import fields as dataclass_fields
 from dataclasses import is_dataclass
 from enum import Enum
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 __all__ = ["PatchError", "apply_patch"]
 
@@ -42,13 +42,24 @@ class PatchError(ValueError):
         super().__init__(message)
 
 
-def apply_patch(root: Any, patch: Dict[str, Any]) -> List[Tuple[str, Any, Any]]:
+def apply_patch(
+    root: Any,
+    patch: Dict[str, Any],
+    none_types: Optional[Dict[str, type]] = None,
+) -> List[Tuple[str, Any, Any]]:
     """Validate every entry against the live object, then apply them all.
 
     Returns ``[(path, old, new), ...]`` in patch order. Raises
     :class:`PatchError` before anything is set if any entry is invalid.
+
+    ``none_types`` declares the type of fields that may legitimately hold
+    ``None`` (e.g. an unset milling angle): a ``None`` leaf is otherwise
+    refused, because its type cannot be inferred from the value it holds.
     """
-    resolved = [_resolve(root, path, value) for path, value in patch.items()]
+    resolved = [
+        _resolve(root, path, value, (none_types or {}).get(path))
+        for path, value in patch.items()
+    ]
     changes: List[Tuple[str, Any, Any]] = []
     for setter, path, old, new in resolved:
         setter(new)
@@ -56,7 +67,7 @@ def apply_patch(root: Any, patch: Dict[str, Any]) -> List[Tuple[str, Any, Any]]:
     return changes
 
 
-def _resolve(root: Any, path: str, value: Any):
+def _resolve(root: Any, path: str, value: Any, none_type: Optional[type] = None):
     parts = path.split(".")
     if not all(parts):
         raise PatchError(path, f"malformed path {path!r}")
@@ -70,7 +81,11 @@ def _resolve(root: Any, path: str, value: Any):
             path,
             f"{path!r} names a section, not a value; patch the fields inside it.",
         )
-    new = _coerce(old, value, path)
+    if old is None and none_type is not None:
+        old_for_coerce = none_type()  # a stand-in of the declared type
+        new = _coerce(old_for_coerce, value, path)
+    else:
+        new = _coerce(old, value, path)
     _check_bounds(obj, leaf, new, path)
 
     def setter(coerced: Any, obj=obj, leaf=leaf) -> None:

--- a/tests/ui/test_agent_config_editor_refresh.py
+++ b/tests/ui/test_agent_config_editor_refresh.py
@@ -1,0 +1,99 @@
+"""The editors rebuild when an agent patch lands under their open forms.
+
+The real main window, real editors: the refresh hooks are what stop a stale
+open form writing old values back on the operator's next edit.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from psygnal.containers import EventedDict
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.applications.autolamella.workflows.tasks.rough import (
+    MillRoughTaskConfig,
+)
+from fibsem.structures import MicroscopeState
+
+TASK = "Rough Milling"
+
+
+@pytest.fixture(scope="module")
+def window(qapp):
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    original = module.AutoLamellaSingleWindowUI.add_minimap_tab
+    module.AutoLamellaSingleWindowUI.add_minimap_tab = lambda self: None
+    try:
+        win = module.AutoLamellaSingleWindowUI()
+    finally:
+        module.AutoLamellaSingleWindowUI.add_minimap_tab = original
+    win.autolamella_ui.system_widget.connect_to_microscope()
+    win._set_border_state("idle")
+    yield win
+    if win.autolamella_ui.microscope is not None:
+        win.autolamella_ui.microscope.disconnect()
+    original_quit = qapp.quit
+    qapp.quit = lambda: None
+    try:
+        win.close()
+    finally:
+        qapp.quit = original_quit
+
+
+@pytest.fixture
+def experiment(window, tmp_path):
+    exp = Experiment(path=tmp_path / "exp", name="editor-refresh-exp")
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    (tmp_path / "exp").mkdir(parents=True, exist_ok=True)
+    exp.add_new_lamella(MicroscopeState(), EventedDict())
+    exp.positions[0].task_config[TASK] = MillRoughTaskConfig(task_name=TASK)
+    exp.task_protocol.task_config[TASK] = MillRoughTaskConfig(task_name=TASK)
+    window.autolamella_ui.experiment = exp
+    window.lamella_widget.set_experiment()
+    return exp
+
+
+def test_the_item_editor_rebuilds_only_for_the_shown_item(window, experiment):
+    editor = window.lamella_widget
+    lamella = experiment.positions[0]
+    assert editor._selected_lamella is not None
+    assert editor._selected_lamella.name == lamella.name
+
+    # An outside writer changes state under the open panel; the hook rebuilds
+    # the panel from state — observable through any displayed field.
+    lamella.description = "changed by the agent"
+    editor.refresh_if_showing(lamella.name)
+    assert editor.line_edit_description.text() == "changed by the agent"
+
+    # A different item's change leaves the shown panel alone.
+    lamella.description = "changed again"
+    editor.refresh_if_showing("some-other-item")
+    assert editor.line_edit_description.text() == "changed by the agent"
+
+
+def test_the_applier_reaches_the_editor_through_the_window(window, experiment):
+    """The full GUI-side path: patch applied on the main window's embedded UI
+    rebuilds the editor showing that item."""
+    from fibsem.applications.autolamella.server.context import config_version
+
+    ui = window.autolamella_ui
+    lamella = experiment.positions[0]
+    config = lamella.task_config[TASK]
+    result = ui._apply_task_config_patch_for_agent(
+        "item",
+        lamella.name,
+        TASK,
+        {"milling.mill_rough.stages.0.pattern.depth": 2.7e-6},
+        config_version(config),
+    )
+    assert result["applied"] is True
+    assert config.milling["mill_rough"].stages[0].pattern.depth == 2.7e-6

--- a/tests/ui/test_agent_config_patch.py
+++ b/tests/ui/test_agent_config_patch.py
@@ -232,3 +232,27 @@ def test_a_protocol_level_patch_lands_and_is_recorded(ui, qapp):
             {"patch": {DEPTH: 3.1e-6}, "version": doc["version"]},
         )
         assert stale.status_code == 409
+
+
+def test_a_patch_is_durable_on_disk(ui, qapp):
+    import yaml
+
+    item = ui.experiment.positions[0].name
+    with _client(ui) as client:
+        doc = client.get(f"/app/items/{item}/task_config/{TASK}", headers=AUTH).json()
+        resp = _post_on_worker(
+            qapp,
+            client,
+            f"/app/items/{item}/task_config/{TASK}",
+            {"patch": {DEPTH: 2.2e-6}, "version": doc["version"]},
+        )
+        assert resp.json()["saved"] is True
+
+    # The write survives the process: read the file, not the object.
+    with open(os.path.join(ui.experiment.path, "experiment.yaml")) as f:
+        saved = yaml.safe_load(f)
+    lamella = next(p for p in saved["positions"] if p["petname"] == item)
+    depth = lamella["task_config"][TASK]["milling"]["mill_rough"]["stages"][0][
+        "pattern"
+    ]["depth"]
+    assert depth == 2.2e-6

--- a/tests/ui/test_agent_config_patch.py
+++ b/tests/ui/test_agent_config_patch.py
@@ -256,3 +256,70 @@ def test_a_patch_is_durable_on_disk(ui, qapp):
         "pattern"
     ]["depth"]
     assert depth == 2.2e-6
+
+
+def test_item_fields_patch_moves_poi_and_sets_defect(ui, qapp):
+    buffer = EventBuffer()
+    lamella = ui.experiment.positions[0]
+    from fibsem.structures import Point
+
+    lamella.poi = Point(x=1e-6, y=2e-6)
+    item = lamella.name
+    with _client(ui, buffer=buffer) as client:
+        doc = client.get(f"/app/items/{item}", headers=AUTH).json()
+        assert "version" in doc and doc["defect"]["state"] == "NONE"
+        resp = _post_on_worker(
+            qapp,
+            client,
+            f"/app/items/{item}",
+            {
+                "patch": {
+                    "poi.x": 5e-6,
+                    "milling_angle": 17.0,
+                    "defect.state": "REWORK",
+                    "defect.description": "curtained face",
+                },
+                "version": doc["version"],
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["applied"] is True and body["saved"] is True
+        assert lamella.poi.x == 5e-6
+        assert lamella.milling_angle == 17.0
+        assert lamella.defect.state.name == "REWORK"
+        assert lamella.defect.updated_at is not None
+        # New version serves on the next read; the event stream records it.
+        reread = client.get(f"/app/items/{item}", headers=AUTH).json()
+        assert reread["version"] == body["version"] != doc["version"]
+        events = client.get("/app/events?since=0", headers=AUTH).json()["events"]
+        edited = [e for e in events if e["kind"] == "config_edited"][-1]
+        assert edited["payload"]["level"] == "item_fields"
+
+
+def test_item_fields_allowlist_and_alignment_validity(ui, qapp):
+    lamella = ui.experiment.positions[0]
+    from fibsem.structures import FibsemRectangle
+
+    lamella.alignment_area = FibsemRectangle(left=0.6, top=0.3, width=0.3, height=0.4)
+    item = lamella.name
+    with _client(ui) as client:
+        doc = client.get(f"/app/items/{item}", headers=AUTH).json()
+        off_list = _post_on_worker(
+            qapp,
+            client,
+            f"/app/items/{item}",
+            {"patch": {"path": "/tmp/evil"}, "version": doc["version"]},
+        )
+        assert off_list.status_code == 422
+        assert "editable" in off_list.json()["detail"]["message"]
+
+        # A rectangle pushed out of the frame is reverted whole.
+        bad = _post_on_worker(
+            qapp,
+            client,
+            f"/app/items/{item}",
+            {"patch": {"alignment_area.left": 0.9}, "version": doc["version"]},
+        )
+        assert bad.status_code == 422
+        assert lamella.alignment_area.left == 0.6

--- a/tests/ui/test_agent_config_patch.py
+++ b/tests/ui/test_agent_config_patch.py
@@ -60,6 +60,7 @@ def ui(qapp, monkeypatch, tmp_path):
     (tmp_path / "exp").mkdir(parents=True, exist_ok=True)
     exp.add_new_lamella(MicroscopeState(), EventedDict())
     exp.positions[0].task_config[TASK] = MillRoughTaskConfig(task_name=TASK)
+    exp.task_protocol.task_config[TASK] = MillRoughTaskConfig(task_name=TASK)
     widget.experiment = exp
     yield widget
     if widget.microscope is not None:
@@ -200,3 +201,34 @@ def test_the_configure_scope_gates_the_route(ui, qapp):
         )
         assert resp.status_code == 403
         assert resp.json()["detail"]["scope"] == "configure"
+
+
+def test_a_protocol_level_patch_lands_and_is_recorded(ui, qapp):
+    buffer = EventBuffer()
+    with _client(ui, buffer=buffer) as client:
+        doc = client.get(f"/app/protocol/task_config/{TASK}", headers=AUTH).json()
+        resp = _post_on_worker(
+            qapp,
+            client,
+            f"/app/protocol/task_config/{TASK}",
+            {"patch": {DEPTH: 2.8e-6}, "version": doc["version"]},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["applied"] is True and "item_name" not in body
+        config = ui.experiment.task_protocol.task_config[TASK]
+        assert config.milling["mill_rough"].stages[0].pattern.depth == 2.8e-6
+        # The item's own copy is untouched: protocol edits reach future items.
+        item_config = ui.experiment.positions[0].task_config[TASK]
+        assert item_config.milling["mill_rough"].stages[0].pattern.depth != 2.8e-6
+        events = client.get("/app/events?since=0", headers=AUTH).json()["events"]
+        edited = [e for e in events if e["kind"] == "config_edited"][-1]
+        assert edited["payload"]["level"] == "protocol"
+
+        stale = _post_on_worker(
+            qapp,
+            client,
+            f"/app/protocol/task_config/{TASK}",
+            {"patch": {DEPTH: 3.1e-6}, "version": doc["version"]},
+        )
+        assert stale.status_code == 409

--- a/tests/ui/test_agent_config_patch.py
+++ b/tests/ui/test_agent_config_patch.py
@@ -275,7 +275,6 @@ def test_item_fields_patch_moves_poi_and_sets_defect(ui, qapp):
             {
                 "patch": {
                     "poi.x": 5e-6,
-                    "milling_angle": 17.0,
                     "defect.state": "REWORK",
                     "defect.description": "curtained face",
                 },
@@ -286,7 +285,6 @@ def test_item_fields_patch_moves_poi_and_sets_defect(ui, qapp):
         body = resp.json()
         assert body["applied"] is True and body["saved"] is True
         assert lamella.poi.x == 5e-6
-        assert lamella.milling_angle == 17.0
         assert lamella.defect.state.name == "REWORK"
         assert lamella.defect.updated_at is not None
         # New version serves on the next read; the event stream records it.
@@ -313,6 +311,15 @@ def test_item_fields_allowlist_and_alignment_validity(ui, qapp):
         )
         assert off_list.status_code == 422
         assert "editable" in off_list.json()["detail"]["message"]
+
+        # milling_angle is an outcome of Setup, not an input — not editable.
+        angle = _post_on_worker(
+            qapp,
+            client,
+            f"/app/items/{item}",
+            {"patch": {"milling_angle": 17.0}, "version": doc["version"]},
+        )
+        assert angle.status_code == 422
 
         # A rectangle pushed out of the frame is reverted whole.
         bad = _post_on_worker(


### PR DESCRIPTION
PR 3 of FIB-864, stacked on #756.

**Protocol level**: `POST /app/protocol/task_config/{task}` — same patch engine and version guard as per-item; no `task_running` refusal because a running task holds its item's copy, so protocol edits only ever reach items created (or re-copied) after. Refusal translation shared between the two routes so they refuse identically. Sidecar grows `update_protocol_task_config`.

**The staleness fix** (demonstrated live on #756: a patch under an open form left the form showing the old value, and its next save would have written that old value back): after a successful apply, the editor displaying that config is rebuilt — `refresh_if_showing(item)` on the item editor, `refresh_if_showing_task(task)` on the protocol tab. This is race-free by construction: operator edits still sitting in the form were flushed *before* the patch was allowed to apply (and if they touched this config, the patch was refused stale), so the rebuild never discards operator work. A toast names each change (task, field, old → new) — a form that morphs silently would be worse than a stale one.

**Skill**: the supervise playbook grows configuration etiquette — read → patch against that read's version → report old→new; exact requested changes only; unprompted edits follow the trust ladder; 409s are correct behaviour, re-read and re-decide.

Tests: protocol-level end-to-end (applies, records `level: protocol` on the event stream, leaves the item's copy untouched, stale refused) and real-main-window editor tests (the shown item rebuilds, other items don't, the applier reaches the editor through the window).

Release-Note: Agents can edit protocol-level task defaults as well as per-item configs; the open editor follows agent changes instead of going stale, and a toast names every change.