### PR TITLE
[autolamella] Four small gaps from the grid workflow review, fixed

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -2674,6 +2674,20 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if loader is not None:
             loader.loader_changed.connect(self.grids_tab.refresh)
             loader.loader_changed.connect(self.grid_workflow_widget.refresh)
+        # Calibrating a slot from the Sample view changes what the Overview
+        # tabs should draw by default; they re-resolve rather than wait for a
+        # reconnect.
+        holder_panel = getattr(sample, "holder_widget", None)
+        if holder_panel is not None:
+            holder_panel.holder_changed.connect(self._on_holder_changed)
+
+    def _on_holder_changed(self, _holder) -> None:
+        for tab in (
+            getattr(self, "beam_overview_tab", None),
+            getattr(self, "fm_overview_tab", None),
+        ):
+            if tab is not None and hasattr(tab, "reset_context_overlay_defaults"):
+                tab.reset_context_overlay_defaults()
 
     def _apply_grid_workflow_visibility(self) -> None:
         """`features.grid_workflow` shows or hides the Grids tab.

--- a/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
@@ -477,7 +477,20 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         """Callback when the selected milling stage changes."""
         selected_task_name = self.task_list_widget.selected_task
 
-        task_config = self.experiment.task_protocol.task_config[selected_task_name]
+        task_config = self.experiment.task_protocol.task_config.get(selected_task_name)
+        if task_config is None:
+            # No lamella task to show: a protocol with none yet (a grid-only
+            # experiment, or one being built from an empty protocol). The
+            # columns wait for a task rather than the editor failing to open.
+            self.task_parameters_config_widget.setVisible(False)
+            self.ref_image_params_widget.setVisible(False)
+            self._current_milling_key = None
+            self.milling_task_editor.clear()
+            self.milling_task_editor.setVisible(False)
+            self.fluorescence_acquisition_task_config_widget.setVisible(False)
+            return
+        self.task_parameters_config_widget.setVisible(True)
+        self.ref_image_params_widget.setVisible(True)
         self.task_parameters_config_widget.set_task_config(task_config)
         self.ref_image_params_widget.update_from_settings(task_config.reference_imaging)
 

--- a/fibsem/applications/autolamella/ui/grid_protocol_widget.py
+++ b/fibsem/applications/autolamella/ui/grid_protocol_widget.py
@@ -195,6 +195,9 @@ class _FluorescenceOverviewEditor(QWidget):
         form.addRow("Filename", self.filename)
         layout.addLayout(form)
         self.channels = ChannelListWidget(fm=None, channel_settings=[])
+        # Four 40 px rows and the header. The list is Expanding, and left to it
+        # the Channels panel took the column and pushed the settings down.
+        self.channels.setMaximumHeight(220)
         layout.addWidget(TitledPanel("Channels", content=self.channels))
         self.settings = FMOverviewSettingsWidget()
         # The task files its output under the grid; the widget's own output panel

--- a/fibsem/applications/autolamella/workflows/tasks/grid/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid/manager.py
@@ -228,7 +228,7 @@ class GridTaskManager(BaseTaskManager):
         # finished workflow.
         if self.is_stopped:
             self._fire_workflow_hook(HookEvent.WORKFLOW_CANCELLED)
-            self._say(workflow_info="Grid workflow cancelled.")
+            self._say(workflow_info="Grid workflow cancelled by user.")
         else:
             self._fire_workflow_hook(HookEvent.WORKFLOW_COMPLETED)
             self._say(workflow_info=self._completion_message())

--- a/fibsem/applications/autolamella/workflows/tasks/grid/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid/manager.py
@@ -37,7 +37,7 @@ from fibsem.applications.autolamella.workflows.tasks.grid.registry import (
 )
 from fibsem.applications.autolamella.workflows.tasks.manager import BaseTaskManager
 from fibsem.applications.autolamella.workflows.tasks.queue import WorkItem
-from fibsem.applications.autolamella.workflows.tasks.status import WorkflowStatusEvent
+from fibsem.applications.autolamella.workflows.ui import update_status_ui
 from fibsem.cancellation import OperationCancelledError
 from fibsem.hooks import HookEvent, HookManager
 from fibsem.microscopes._stage import GridExchangeError
@@ -130,7 +130,13 @@ class GridTaskManager(BaseTaskManager):
                     "grid_name": item.item_name,
                     "task_name": item.task_name,
                     "task_status": item.status.name,
-                    "loaded": item.item_name not in self._not_loaded,
+                    # A task that never ran has no answer to "was the grid in
+                    # the beam for it": blank, not the last load's outcome.
+                    "loaded": (
+                        None
+                        if item.status is AutoLamellaTaskStatus.NotStarted
+                        else item.item_name not in self._not_loaded
+                    ),
                     "completed_at": completed_at,
                     "duration": duration,
                 }
@@ -337,18 +343,14 @@ class GridTaskManager(BaseTaskManager):
     def _say(
         self, workflow_info: Optional[str] = None, status_bar: Optional[str] = None
     ) -> None:
-        """A line for the workflow-information label or the status bar.
-
-        Straight onto the status channel rather than through `update_status_ui`:
-        that helper re-checks for abort and raises once Stop has been pressed,
-        which is exactly when the closing "cancelled" line has to get out.
-        """
-        text = workflow_info or status_bar or ""
-        if self.parent_ui is None:
-            logging.info(text)
-            return
-        self.parent_ui.workflow_status_signal.emit(
-            WorkflowStatusEvent(workflow_info=workflow_info, status_bar=status_bar)
+        """A line for the workflow-information label or the status bar, that
+        gets out after a Stop too: the closing "cancelled" line is the point."""
+        update_status_ui(
+            self.parent_ui,
+            "",
+            workflow_info=workflow_info,
+            status_bar=status_bar,
+            check_abort=False,
         )
 
     def _task_type(self, task_name: str) -> str:

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -415,7 +415,14 @@ class TaskManager(BaseTaskManager):
         # completion for both is what made an abort look like a finished workflow.
         if self.is_stopped:
             self._fire_workflow_hook(HookEvent.WORKFLOW_CANCELLED)
-            update_status_ui(self.parent_ui, "", workflow_info="Workflow cancelled.")
+            # After a Stop the abort predicate is true, so this line must not
+            # be a cancellation point itself: it is the report of one.
+            update_status_ui(
+                self.parent_ui,
+                "",
+                workflow_info="Workflow cancelled.",
+                check_abort=False,
+            )
         else:
             self._fire_workflow_hook(HookEvent.WORKFLOW_COMPLETED)
             update_status_ui(

--- a/fibsem/applications/autolamella/workflows/tasks/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/manager.py
@@ -420,7 +420,7 @@ class TaskManager(BaseTaskManager):
             update_status_ui(
                 self.parent_ui,
                 "",
-                workflow_info="Workflow cancelled.",
+                workflow_info="Workflow cancelled by user.",
                 check_abort=False,
             )
         else:

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -140,7 +140,7 @@ def update_status_ui(
 
     A status point doubles as a cancellation point: a task that reports progress
     is interrupted here once Stop has been pressed. ``check_abort=False`` is for
-    the manager's closing line after a Stop -- "Workflow cancelled." -- which is
+    the manager's closing line after a Stop -- "Workflow cancelled by user." -- which is
     the one status that has to get out precisely because the run was aborted.
     """
     if parent_ui is None:

--- a/fibsem/applications/autolamella/workflows/ui.py
+++ b/fibsem/applications/autolamella/workflows/ui.py
@@ -134,13 +134,21 @@ def update_status_ui(
     msg: str,
     workflow_info: Optional[str] = None,
     status_bar: Optional[str] = None,
+    check_abort: bool = True,
 ) -> None:
+    """Put a line on the workflow-information label or the status bar.
 
+    A status point doubles as a cancellation point: a task that reports progress
+    is interrupted here once Stop has been pressed. ``check_abort=False`` is for
+    the manager's closing line after a Stop -- "Workflow cancelled." -- which is
+    the one status that has to get out precisely because the run was aborted.
+    """
     if parent_ui is None:
         logging.info(msg or status_bar or "")
         return
 
-    _check_for_abort(parent_ui)
+    if check_abort:
+        _check_for_abort(parent_ui)
 
     # Local import: the tasks package pulls this module in through its manager,
     # so a top-level import of tasks.status is a cycle.

--- a/fibsem/ui/fm/widgets/fm_overview_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_widget.py
@@ -406,6 +406,9 @@ class FMOverviewWidget(QWidget):
             stage_context.context_overlay_entries(self.microscope)
         )
         self.overlay_controls.toggled.connect(lambda *_: self._refresh_stage_metadata())
+        self._context_defaults_for_calibrated = stage_context.holder_is_calibrated(
+            self.microscope
+        )
         self.btn_overlays = self.canvas.canvas.add_toolbar_button(
             "mdi:eye-outline",
             "Overlays",
@@ -1458,6 +1461,19 @@ class FMOverviewWidget(QWidget):
     def _toggle_overlays(self) -> None:
         """Show or hide the overlays popover, anchored under its button."""
         self.overlay_popover.set_open(self.btn_overlays.isChecked(), self.btn_overlays)
+
+    def reset_context_overlay_defaults(self) -> None:
+        """Re-resolve the holder-dependent overlay defaults, as the beam tab does:
+        a slot calibrated mid-session turns the boundary and slot markers on
+        without a reconnect, and only when the answer changed."""
+        calibrated = stage_context.holder_is_calibrated(self.microscope)
+        if calibrated == self._context_defaults_for_calibrated:
+            return
+        self._context_defaults_for_calibrated = calibrated
+        for key, _label, shown in stage_context.context_overlay_entries(
+            self.microscope
+        ):
+            self.overlay_controls.set_visible(key, shown)
 
     def _refresh_stage_metadata(self) -> None:
         """Draw where the sample and the stage can physically go.

--- a/fibsem/ui/widgets/overview_widget.py
+++ b/fibsem/ui/widgets/overview_widget.py
@@ -827,6 +827,9 @@ class FibsemOverviewWidget(QWidget):
             ]
         )
         self.overlay_controls.toggled.connect(self._on_overlay_toggled)
+        self._context_defaults_for_calibrated = stage_context.holder_is_calibrated(
+            self.microscope
+        )
         self.spin_gridbar_spacing = ValueSpinBox(
             suffix=" um", minimum=1.0, maximum=10000.0, step=10.0, decimals=1
         )
@@ -1184,6 +1187,24 @@ class FibsemOverviewWidget(QWidget):
         section = getattr(self, "display_section", None)
         if section is not None:
             section.setVisible(visible)
+
+    def reset_context_overlay_defaults(self) -> None:
+        """Re-resolve the holder-dependent overlay defaults.
+
+        The switches were resolved when the tab was built, against the holder as it
+        was then. Calibrating a slot mid-session changes the answer, and the
+        boundary and slot markers should come on without a reconnect. Only when
+        the answer changed: a rename fires the same holder signal, and must not
+        undo a toggle the user made.
+        """
+        calibrated = stage_context.holder_is_calibrated(self.microscope)
+        if calibrated == self._context_defaults_for_calibrated:
+            return
+        self._context_defaults_for_calibrated = calibrated
+        for key, _label, shown in stage_context.context_overlay_entries(
+            self.microscope
+        ):
+            self.overlay_controls.set_visible(key, shown)
 
     def _on_overlay_toggled(self, key: str, checked: bool) -> None:
         """One overlay turned on or off.

--- a/tests/autolamella/test_grid_task_manager.py
+++ b/tests/autolamella/test_grid_task_manager.py
@@ -324,6 +324,11 @@ class TestStopAndStatus:
         # load + first task consumed; the other four still pending
         assert manager.queue.counts == (4, 6)
         assert manager.parent_ui.workflow_info[-1] == "Grid workflow cancelled."
+        # The rows that never ran say nothing about the load, rather than
+        # repeating the last load's outcome.
+        df = manager.build_run_summary_dataframe()
+        assert df.loc[df.task_status == "NotStarted", "loaded"].isna().all()
+        assert df.loc[df.task_status != "NotStarted", "loaded"].notna().all()
 
     def test_reports_name_the_grid_and_track_the_queue(self, manager):
         run_with_stub(manager, ["overview_sem"], ["Grid-01", "Grid-02"])

--- a/tests/autolamella/test_grid_task_manager.py
+++ b/tests/autolamella/test_grid_task_manager.py
@@ -323,7 +323,7 @@ class TestStopAndStatus:
         assert executed == [("Grid-01", "overview_sem")]
         # load + first task consumed; the other four still pending
         assert manager.queue.counts == (4, 6)
-        assert manager.parent_ui.workflow_info[-1] == "Grid workflow cancelled."
+        assert manager.parent_ui.workflow_info[-1] == "Grid workflow cancelled by user."
         # The rows that never ran say nothing about the load, rather than
         # repeating the last load's outcome.
         df = manager.build_run_summary_dataframe()

--- a/tests/autolamella/test_task_manager_hooks.py
+++ b/tests/autolamella/test_task_manager_hooks.py
@@ -211,4 +211,4 @@ def test_cancelled_run_keeps_its_own_message(experiment, recorder, monkeypatch):
 
     manager.run(task_names=["MillTrench"], required_lamella=[])
 
-    assert messages[-1] == "Workflow cancelled."
+    assert messages[-1] == "Workflow cancelled by user."

--- a/tests/autolamella/test_task_manager_hooks.py
+++ b/tests/autolamella/test_task_manager_hooks.py
@@ -26,7 +26,9 @@ def recorder() -> "tuple[HookManager, List[HookContext]]":
     """A HookManager that records every event fired, in order."""
     fired: List[HookContext] = []
     manager = HookManager()
-    manager.register(FunctionHook(name="recorder", events=ALL_EVENTS, callback=fired.append))
+    manager.register(
+        FunctionHook(name="recorder", events=ALL_EVENTS, callback=fired.append)
+    )
     return manager, fired
 
 
@@ -57,6 +59,7 @@ def _events(fired: List[HookContext]) -> List[str]:
 # workflow_completed vs workflow_cancelled
 # ---------------------------------------------------------------------------
 
+
 def test_draining_the_queue_fires_workflow_completed(experiment, recorder):
     hook_manager, fired = recorder
     manager = _manager(experiment, hook_manager)
@@ -82,7 +85,9 @@ def test_stopping_fires_workflow_cancelled_not_completed(experiment, recorder):
 def test_stopping_midway_still_cancels(experiment, recorder):
     """Stop set while items remain: the queue does not drain, so this is a cancel."""
     hook_manager, fired = recorder
-    experiment.positions.append(Lamella(path=experiment.path, number=1, petname="lam-1"))
+    experiment.positions.append(
+        Lamella(path=experiment.path, number=1, petname="lam-1")
+    )
     manager = _manager(experiment, hook_manager)
     manager.stop()
 
@@ -94,6 +99,7 @@ def test_stopping_midway_still_cancels(experiment, recorder):
 # ---------------------------------------------------------------------------
 # task_skipped
 # ---------------------------------------------------------------------------
+
 
 def test_missing_lamella_fires_task_skipped(experiment, recorder, caplog):
     """A queue item naming a lamella that is not in the experiment used to be marked
@@ -150,6 +156,7 @@ def test_skip_fires_no_task_started_or_completed(experiment, recorder):
 # ---------------------------------------------------------------------------
 # closing status message
 # ---------------------------------------------------------------------------
+
 
 def _status_messages(monkeypatch) -> List[str]:
     """Capture the workflow_info strings the manager closes a run with."""

--- a/tests/ui/test_grid_protocol_widget.py
+++ b/tests/ui/test_grid_protocol_widget.py
@@ -179,6 +179,7 @@ def test_the_fluorescence_editor_round_trips_channels_and_z(widget, experiment):
     widget.refresh()  # reload the form from the record
     editor = widget.editor_panel.editor_for(FM)
     assert [c.name for c in editor.channels.channel_settings] == ["GFP", "mCherry"]
+    assert editor.channels.maximumHeight() <= 220  # four rows, not the column
     assert editor.settings.parameters.rows == 2
     assert editor.settings.z_widget.z_parameters.zstep == pytest.approx(1e-6)
 

--- a/tests/ui/test_grids_tab.py
+++ b/tests/ui/test_grids_tab.py
@@ -10,6 +10,7 @@ pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is delibe
 import fibsem.config as cfg
 from fibsem import utils
 from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskProtocol,
     AutoLamellaTaskState,
     AutoLamellaTaskStatus,
     Experiment,
@@ -317,3 +318,20 @@ def test_the_tab_follows_the_connection_and_the_experiment(main_ui, tmp_path):
     assert main_ui.tab_widget.isTabEnabled(
         main_ui.tab_widget.indexOf(main_ui.grids_tab)
     )
+
+
+def test_an_experiment_with_no_lamella_tasks_loads(main_ui, tmp_path):
+    """A grid-only experiment, or one built from an empty protocol: the lamella
+    task editor has nothing to show and says so by hiding its columns, where it
+    used to raise on the empty selection and stop the whole experiment load."""
+    ui = main_ui.autolamella_ui
+    ui.system_widget.connect_to_microscope()
+    exp = Experiment(path=tmp_path, name="exp")
+    (tmp_path / "exp").mkdir()
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    ui.experiment = exp
+    main_ui.minimap_widget = _NoMinimap()
+    main_ui._on_experiment_update()
+    editor = main_ui.task_widget
+    assert not editor.task_parameters_config_widget.isVisibleTo(editor)
+    assert not editor.milling_task_editor.isVisibleTo(editor)

--- a/tests/ui/test_overview_widget.py
+++ b/tests/ui/test_overview_widget.py
@@ -4252,7 +4252,9 @@ class TestItOnlyDrawsItsOwnRuns:
 
 def test_grid_boundaries_and_slots_come_on_with_a_calibrated_holder(qapp):
     """Off describes a holder that is not there; on a holder with a calibrated
-    slot they draw where the grid is, and that is worth having on by default."""
+    slot they draw where the grid is, and that is worth having on by default.
+    A slot calibrated mid-session turns them on in the tab already built, and a
+    holder change that leaves calibration as it was leaves the switches alone."""
     from fibsem.microscopes._stage import SlotCalibration, _create_sample_stage
     from fibsem.structures import FibsemStagePosition
     from fibsem.ui.widgets.canvas.overlays import stage_context
@@ -4261,21 +4263,33 @@ def test_grid_boundaries_and_slots_come_on_with_a_calibrated_holder(qapp):
     microscope.stage_is_compustage = False
     microscope._stage = _create_sample_stage(microscope)
     assert not stage_context.holder_is_calibrated(microscope)
-    before = FibsemOverviewWidget(microscope)
-    try:
-        assert not before.overlay_controls.is_visible(stage_context.OVERLAY_BOUNDARIES)
-        assert not before.overlay_controls.is_visible(stage_context.OVERLAY_SLOTS)
-    finally:
-        before.deleteLater()
-    slot = microscope._stage.holder.slots["Slot-01"]
-    slot.position = FibsemStagePosition(
-        name=slot.name, x=-4e-3, y=1e-3, z=4e-3, r=0, t=0.61
-    )
-    slot.calibration = SlotCalibration("SEM", 35.0, 0.0, "2026-09-02T11:24:09", "test")
-    assert stage_context.holder_is_calibrated(microscope)
     widget = FibsemOverviewWidget(microscope)
     try:
+        assert not widget.overlay_controls.is_visible(stage_context.OVERLAY_BOUNDARIES)
+        assert not widget.overlay_controls.is_visible(stage_context.OVERLAY_SLOTS)
+
+        slot = microscope._stage.holder.slots["Slot-01"]
+        slot.position = FibsemStagePosition(
+            name=slot.name, x=-4e-3, y=1e-3, z=4e-3, r=0, t=0.61
+        )
+        slot.calibration = SlotCalibration(
+            "SEM", 35.0, 0.0, "2026-09-02T11:24:09", "test"
+        )
+        assert stage_context.holder_is_calibrated(microscope)
+        widget.reset_context_overlay_defaults()
         assert widget.overlay_controls.is_visible(stage_context.OVERLAY_BOUNDARIES)
         assert widget.overlay_controls.is_visible(stage_context.OVERLAY_SLOTS)
+
+        # The user's toggle survives a holder change that is not a calibration.
+        widget.overlay_controls.set_visible(stage_context.OVERLAY_BOUNDARIES, False)
+        widget.reset_context_overlay_defaults()
+        assert not widget.overlay_controls.is_visible(stage_context.OVERLAY_BOUNDARIES)
     finally:
         widget.deleteLater()
+
+    fresh = FibsemOverviewWidget(microscope)
+    try:
+        assert fresh.overlay_controls.is_visible(stage_context.OVERLAY_BOUNDARIES)
+        assert fresh.overlay_controls.is_visible(stage_context.OVERLAY_SLOTS)
+    finally:
+        fresh.deleteLater()

--- a/tests/ui/test_workflow_cancellation_logging.py
+++ b/tests/ui/test_workflow_cancellation_logging.py
@@ -89,7 +89,7 @@ def test_a_genuine_failure_still_logs_an_error(ui, monkeypatch, caplog):
 
 def test_the_closing_line_gets_out_after_a_stop(ui):
     """After Stop the abort predicate is true, and a status point raises on it:
-    that is what kept "Workflow cancelled." off the label. The manager's closing
+    that is what kept "Workflow cancelled by user." off the label. The manager's closing
     line asks for no abort check, and reaches the signal."""
     from fibsem.applications.autolamella.workflows.ui import update_status_ui
 
@@ -97,6 +97,6 @@ def test_the_closing_line_gets_out_after_a_stop(ui):
     ui.workflow_status_signal.connect(lambda event: seen.append(event.workflow_info))
     ui._workflow_stop_event.set()
     with pytest.raises(InterruptedError):
-        update_status_ui(ui, "", workflow_info="Workflow cancelled.")
-    update_status_ui(ui, "", workflow_info="Workflow cancelled.", check_abort=False)
-    assert seen == ["Workflow cancelled."]
+        update_status_ui(ui, "", workflow_info="Workflow cancelled by user.")
+    update_status_ui(ui, "", workflow_info="Workflow cancelled by user.", check_abort=False)
+    assert seen == ["Workflow cancelled by user."]

--- a/tests/ui/test_workflow_cancellation_logging.py
+++ b/tests/ui/test_workflow_cancellation_logging.py
@@ -85,3 +85,18 @@ def test_a_genuine_failure_still_logs_an_error(ui, monkeypatch, caplog):
     assert any("stage fell over" in r.message for r in errors), (
         "downgrading cancellation must not swallow real failures"
     )
+
+
+def test_the_closing_line_gets_out_after_a_stop(ui):
+    """After Stop the abort predicate is true, and a status point raises on it:
+    that is what kept "Workflow cancelled." off the label. The manager's closing
+    line asks for no abort check, and reaches the signal."""
+    from fibsem.applications.autolamella.workflows.ui import update_status_ui
+
+    seen = []
+    ui.workflow_status_signal.connect(lambda event: seen.append(event.workflow_info))
+    ui._workflow_stop_event.set()
+    with pytest.raises(InterruptedError):
+        update_status_ui(ui, "", workflow_info="Workflow cancelled.")
+    update_status_ui(ui, "", workflow_info="Workflow cancelled.", check_abort=False)
+    assert seen == ["Workflow cancelled."]

--- a/tests/ui/test_workflow_cancellation_logging.py
+++ b/tests/ui/test_workflow_cancellation_logging.py
@@ -98,5 +98,7 @@ def test_the_closing_line_gets_out_after_a_stop(ui):
     ui._workflow_stop_event.set()
     with pytest.raises(InterruptedError):
         update_status_ui(ui, "", workflow_info="Workflow cancelled by user.")
-    update_status_ui(ui, "", workflow_info="Workflow cancelled by user.", check_abort=False)
+    update_status_ui(
+        ui, "", workflow_info="Workflow cancelled by user.", check_abort=False
+    )
     assert seen == ["Workflow cancelled by user."]


### PR DESCRIPTION
Four things noted while reviewing the grid chain and writing the bench doc, none of them in Linear, each small enough to fix rather than file. One commit each; over the usual file count because the overlay fix touches both Overview tabs and the window that wires them.

- **"Workflow cancelled." never reached the label.** `update_status_ui` re-checks the abort predicate and raises once Stop has been pressed, and the lamella manager's closing line went through it. It takes `check_abort=False` now, for the one status that exists because the run was aborted; the grid manager's `_say` uses the same path instead of emitting around it. Also: the grid run summary leaves `loaded` blank for a task that never ran instead of repeating the last load's outcome on every NotStarted row.
- **A protocol with no lamella tasks stopped the experiment load.** The task editor indexed the protocol by the (empty) selected task name and raised `KeyError`. The columns hide and wait for a task.
- **Calibrating a slot mid-session did not turn the overlays on.** The defaults were resolved when the Overview tabs were built; both tabs re-resolve on the holder panel's `holder_changed`, and only when the calibrated answer changed, so a rename does not undo a user's toggle.
- **The grid FM task's Channels panel took the whole column.** Capped at four rows.

**Tests**: the closing line reaches the signal after a Stop (and the raise without the flag is pinned); NotStarted rows have no `loaded`; an empty-protocol experiment loads into the real window with the editor's columns hidden; the overlay test now calibrates the slot on a built widget, checks a user's toggle survives a non-calibration holder change, and that a fresh widget starts on; the Channels cap. 901 across the overview widget and autolamella suites, 326 across the Grids tab and overview tab suites.