### PR TITLE
[sim] The fiducial cross is off by default

### DIFF
--- a/docs/developers/render_simulator_examples.py
+++ b/docs/developers/render_simulator_examples.py
@@ -62,7 +62,7 @@ DESCRIPTIONS = {
     "rip_fraction": "fraction of squares with the film torn; neighbours rip more readily",
     "ice_density": "ice crystals per 100 x 100 um",
     "ice_size": "ice plate radius range (m)",
-    "fiducial": "a cross at each grid centre, handy for navigation; absent on a real grid",
+    "fiducial": "a cross at each grid centre, a navigation landmark; absent on a real grid, so off by default",
     "grid_radius": "usable film radius (m); past it the rim, then the holder",
     "grid_rim_width": "the metal rim's width (m)",
     "noise_sigma": "gaussian noise on the final image",
@@ -222,7 +222,8 @@ def main():
     rng = np.random.default_rng(1)
 
     def scene(**kwargs):
-        scene = SampleScene(**kwargs)
+        # the figures keep the fiducial as a landmark; it is off by default
+        scene = SampleScene(**{"fiducial": True, **kwargs})
         scene.anchor(pose)
         microscope._sample_scene = scene
         return scene
@@ -299,7 +300,7 @@ def main():
     arctis, _ = utils.setup_session(
         config_path=os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
     )
-    fm_scene = SampleScene(seed=5)
+    fm_scene = SampleScene(seed=5, fiducial=True)
     fm_scene.anchor(arctis.get_stage_position())
     fm = arctis.fm
     camera = fm.camera

--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -153,7 +153,7 @@ are in degrees, ranges are two-element lists, lengths in metres.
 | `hole_diameter` | 2e-06 | holey film: hole diameter (m) |
 | `hole_pitch` | 4e-06 | holey film: hole pitch (m) |
 | `broken_hole_fraction` | 0.02 | holey film: fraction of holes broken into larger openings |
-| `fiducial` | True | a cross at each grid centre, handy for navigation; absent on a real grid |
+| `fiducial` | False | a cross at each grid centre, a navigation landmark; absent on a real grid, so off by default |
 
 ### Cells
 
@@ -219,7 +219,8 @@ are in degrees, ranges are two-element lists, lengths in metres.
 - The scene is generated fresh from its seed on every connect. The same seed gives the
   same grid; milled trenches do not survive a reconnect.
 
-The figures on this page are rendered by
+The figures on this page are rendered with `fiducial: true` (a landmark for the eye;
+off by default) by
 [`render_simulator_examples.py`](developers/render_simulator_examples.py) from the current
 code, and the key tables are read from the scene's defaults; rerun it after changing the
 simulator.

--- a/fibsem/config/sim-arctis-configuration.yaml
+++ b/fibsem/config/sim-arctis-configuration.yaml
@@ -78,7 +78,7 @@ sim:
     #     noise_sigma: 12.0                                  # gaussian noise on the beam images
     #     noise_fraction: 0.15                               # uniform-noise blend on the beam images
     #     grid_rotation: null                                # degrees; null = random within +/- 45
-    #     fiducial: true                                     # the central X at the world origin; off for realistic imaging
+    #     fiducial: false                                    # a cross at each grid centre, a navigation landmark; absent on a real grid
     #     contamination_density: 15.0                        # specks per 100 x 100 um (aperiodic content on film and bars)
     #     film: continuous                                   # continuous | holey (Quantifoil-style lattice: hole_diameter, hole_pitch; the coincidence measurement does not handle the lattice yet)
     #     rip_fraction: 0.03                                 # squares with the film torn away

--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -102,7 +102,7 @@ sim:
     #     noise_sigma: 12.0                                  # gaussian noise on the beam images
     #     noise_fraction: 0.15                               # uniform-noise blend on the beam images
     #     grid_rotation: null                                # degrees; null = random within +/- 45
-    #     fiducial: true                                     # the central X at the world origin; off for realistic imaging
+    #     fiducial: false                                    # a cross at each grid centre, a navigation landmark; absent on a real grid
     #     contamination_density: 15.0                        # specks per 100 x 100 um (aperiodic content on film and bars)
     #     film: continuous                                   # continuous | holey (Quantifoil-style lattice: hole_diameter, hole_pitch; the coincidence measurement does not handle the lattice yet)
     #     rip_fraction: 0.03                                 # squares with the film torn away

--- a/fibsem/microscopes/sim_scene.py
+++ b/fibsem/microscopes/sim_scene.py
@@ -526,9 +526,9 @@ class SampleScene:
     # ice crystals: flat bright plates with a bright rim, per 100 x 100 um
     ice_density: float = 0.4
     ice_size: Tuple[float, float] = (6e-6, 16e-6)  # m, plate radius
-    # the fiducial-like cross at the world origin: handy for eyeballing
-    # navigation, absent on a real grid - off for realistic imaging
-    fiducial: bool = True
+    # a fiducial-like cross at each grid centre: a landmark for eyeballing
+    # navigation and for tests, absent on a real grid - off by default
+    fiducial: bool = False
     # the grid's usable radius; beyond it the metal rim, then the holder
     grid_radius: float = 1.4e-3  # m
     grid_rim_width: float = 150e-6  # m

--- a/tests/autolamella/test_select_position_coincidence.py
+++ b/tests/autolamella/test_select_position_coincidence.py
@@ -45,6 +45,7 @@ def _anchor_scene(microscope, coincidence_offset: float) -> None:
     scene = SampleScene(
         coincidence_offset=coincidence_offset,
         tilt_axis_offset=NON_EUCENTRIC,
+        fiducial=True,
         noise_sigma=0.0,
         noise_fraction=0.0,
     )

--- a/tests/fm/test_sample_scene_fm.py
+++ b/tests/fm/test_sample_scene_fm.py
@@ -34,7 +34,11 @@ BLUE = ChannelSettings(
 def microscope():
     microscope, _ = utils.setup_session(manufacturer="Demo")
     assert microscope.fm is not None, "the fm package config must carry an FM"
-    microscope.system.sim["sample"] = {"enabled": True, "coincidence_offset": 0.0}
+    microscope.system.sim["sample"] = {
+        "enabled": True,
+        "coincidence_offset": 0.0,
+        "fiducial": True,
+    }
     microscope._setup_sample_scene()
     microscope.move_to_device("FM")
     # the FM images with the objective inserted and at focus; it boots retracted
@@ -46,6 +50,7 @@ def microscope():
 def _fiducial_only(microscope) -> SampleScene:
     scene = SampleScene(
         coincidence_offset=0.0,
+        fiducial=True,
         cell_type="none",
         grid_intensity=0.0,
         noise_sigma=0.0,

--- a/tests/test_align_loop.py
+++ b/tests/test_align_loop.py
@@ -35,7 +35,9 @@ def microscope():
     from fibsem.microscopes.sim_scene import SampleScene
 
     # deterministic scene: the loop is about control flow and geometry
-    scene = SampleScene(coincidence_offset=8e-6, noise_sigma=0.0, noise_fraction=0.0)
+    scene = SampleScene(
+        coincidence_offset=8e-6, fiducial=True, noise_sigma=0.0, noise_fraction=0.0
+    )
     scene.anchor(microscope.get_stage_position())
     microscope._sample_scene = scene
     pose = microscope.get_stage_position()

--- a/tests/test_sim_coincidence.py
+++ b/tests/test_sim_coincidence.py
@@ -54,12 +54,12 @@ def _enable_projection(microscope, offset: float = COINCIDENCE_OFFSET, **scene_k
     microscope.system.sim["coincidence_projection"] = True
     microscope.system.sim["coincidence_offset"] = offset
     microscope._setup_sample_scene()
-    if scene_kwargs:
-        from fibsem.microscopes.sim_scene import SampleScene
+    from fibsem.microscopes.sim_scene import SampleScene
 
-        microscope._sample_scene = SampleScene(
-            coincidence_offset=offset, **scene_kwargs
-        )
+    # the fiducial is the landmark these tests navigate by
+    microscope._sample_scene = SampleScene(
+        coincidence_offset=offset, **{"fiducial": True, **scene_kwargs}
+    )
     # a realistic milling pose: stage tilt 12 deg -> milling angle 15 deg
     # (the Demo boots at the SEM orientation, tilt 35; set the tilt
     # absolutely so the pose does not depend on where it booted)
@@ -207,7 +207,9 @@ def test_views_share_the_scene_but_not_the_contrast():
     from fibsem.projection import BeamStageProjection
     from fibsem.structures import FibsemHardwareGeometry
 
-    scene = SampleScene(coincidence_offset=0.0, noise_sigma=0.0, noise_fraction=0.0)
+    scene = SampleScene(
+        coincidence_offset=0.0, fiducial=True, noise_sigma=0.0, noise_fraction=0.0
+    )
     geometry = FibsemHardwareGeometry(
         column_tilt=0, fib_column_tilt=52.0, shuttle_pre_tilt=35.0
     )

--- a/tests/test_sim_scene_holder.py
+++ b/tests/test_sim_scene_holder.py
@@ -26,6 +26,7 @@ def microscope():
     microscope._setup_sample_scene()
     scene = microscope._sample_scene
     # a quiet scene: the fiducial is the landmark, nothing else in the way
+    scene.fiducial = True
     scene.cell_type = "none"
     scene.contamination_density = 0.0
     scene.ice_density = 0.0

--- a/tests/test_sim_scene_realism.py
+++ b/tests/test_sim_scene_realism.py
@@ -33,7 +33,11 @@ def microscope():
     microscope, _ = utils.setup_session(
         manufacturer="Demo", config_path=TFS_SHUTTLE_CONFIG
     )
-    microscope.system.sim["sample"] = {"enabled": True, "coincidence_offset": 8e-6}
+    microscope.system.sim["sample"] = {
+        "enabled": True,
+        "coincidence_offset": 8e-6,
+        "fiducial": True,
+    }
     microscope._setup_sample_scene()
     pose = microscope.get_stage_position()
     pose.t = MILLING_TILT
@@ -45,7 +49,7 @@ def microscope():
 def _scene(microscope, **kwargs) -> SampleScene:
     """A deterministic scene: no noise, and no ice or rips unless asked -
     the fiducial finders here look for the darkest/brightest pixels."""
-    kwargs = {"ice_density": 0.0, "rip_fraction": 0.0, **kwargs}
+    kwargs = {"ice_density": 0.0, "rip_fraction": 0.0, "fiducial": True, **kwargs}
     scene = SampleScene(noise_sigma=0.0, noise_fraction=0.0, **kwargs)
     scene.anchor(microscope.get_stage_position())
     microscope._sample_scene = scene
@@ -522,10 +526,11 @@ def test_milled_patterns_persist_in_the_world(microscope):
 
 
 def test_the_fiducial_can_be_switched_off():
-    assert any(f.kind == "fiducial" for f in SampleScene().features)
-    scene = SampleScene(fiducial=False)
-    assert not any(f.kind == "fiducial" for f in scene.features)
-    assert SampleScene.from_config({"fiducial": False}).fiducial is False
+    # off by default - no real grid has one - and on when asked
+    assert not any(f.kind == "fiducial" for f in SampleScene().features)
+    scene = SampleScene(fiducial=True)
+    assert any(f.kind == "fiducial" for f in scene.features)
+    assert SampleScene.from_config({"fiducial": True}).fiducial is True
 
 
 def test_a_rotated_pattern_mills_the_footprint_it_was_drawn_with(microscope):

--- a/tests/test_tilt_coincident.py
+++ b/tests/test_tilt_coincident.py
@@ -47,6 +47,7 @@ def _anchor_scene(microscope, tilt_axis_offset: float) -> None:
     scene = SampleScene(
         coincidence_offset=0.0,
         tilt_axis_offset=tilt_axis_offset,
+        fiducial=True,
         noise_sigma=0.0,
         noise_fraction=0.0,
     )

--- a/tests/test_vertical_move.py
+++ b/tests/test_vertical_move.py
@@ -43,6 +43,7 @@ def microscope():
 
     microscope._sample_scene = SampleScene(
         coincidence_offset=0.0,
+        fiducial=True,
         cell_type="none",
         grid_intensity=0.0,
         contamination_density=0.0,


### PR DESCRIPTION
## Summary

No real grid carries a cross at its centre, so the scene's fiducial is now off by default. It stays as a switch (`fiducial: true`), a landmark for the eye and for tests; the tests that navigate by it now ask for it explicitly rather than inheriting it, and the docs figures keep it and say so.

Measured before flipping: the alignment loop still converges on the mammalian default without it (one move, residual under 0.05 µm at 8 and 40 µm), but the rival-peak ratio rises from ~0.5 to 0.73–0.79 against the 0.80 gate — the scene's real content sits right at the fine pass's acceptance edge. The loop tests keep the landmark until that margin is understood on the bench.

## Testing

Scene suites (realism, texture, holder, coincidence, vertical-move, FM) and loop/tilt/task suites green locally with the explicit landmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)