### PR TITLE
[sim] The Arctis and iFLM development configurations ship with the sample scene on

### DIFF
--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -6,8 +6,7 @@ same geometry model as the hardware drivers (pre-tilted shuttle or compustage), 
 holder with slots and, when configured, an autoloader magazine. Every workflow, task and
 UI runs against it unchanged, which is how most of fibsem-os is developed and tested.
 
-By default the beams return random noise. Turn on the **sample scene** and they image a
-synthetic cryo-grid instead: a mesh of bars and film with cells, contamination, ice and
+With the **sample scene** on, the beams image a synthetic cryo-grid instead of noise: a mesh of bars and film with cells, contamination, ice and
 rips on it, that both beams and the fluorescence camera see through their own
 projections. The same world persists across stage moves, tilts, scan rotations and beam
 shifts, so navigation, tiling, alignment and milling can be exercised for real.
@@ -21,10 +20,11 @@ sim:
         coincidence_offset: 8.0e-6      # height error at boot (m)
 ```
 
-Everything else has a default. The two example configurations that ship,
-`sim-arctis-configuration.yaml` (compustage, with FM) and `sim-iflm-configuration.yaml`,
-carry a commented `sample:` block listing every key ([sim-arctis](../fibsem/config/sim-arctis-configuration.yaml),
-[sim-iflm](../fibsem/config/sim-iflm-configuration.yaml)).
+Everything else has a default. The two development configurations that ship,
+[sim-arctis](../fibsem/config/sim-arctis-configuration.yaml) (compustage, with FM) and
+[sim-iflm](../fibsem/config/sim-iflm-configuration.yaml), have the scene on with the
+common keys spelled out; `microscope-configuration.yaml` (the shuttle Demo the tests run
+on) leaves it off, so its beams return noise.
 
 ## What the beams see
 

--- a/fibsem/config/sim-arctis-configuration.yaml
+++ b/fibsem/config/sim-arctis-configuration.yaml
@@ -64,28 +64,28 @@ sim:
     sem: null # "/path/to/sem/image/data"                   
     fib: null # "/path/to/fib/image/data"                   
     use_cycle: true
-    # sample:                                               # synthetic cryo-grid both beams (and the FM) image through their projections (FIB-874); default off
-    #     grids_from_holder: false                          # grids at the holder's calibrated, occupied slots (content seeded by grid name; the holder file is shared by every configuration here); off: one grid at the boot position
-    #     enabled: true
-    #     coincidence_offset: 10.0e-6                        # height error at boot (m) - what the coincidence alignment corrects
-    #     tilt_axis_offset: 0.0                              # surface height above the tilt axis (m); >0 makes the stage non-eucentric
-    #     grid_pitch: 125.0e-6                               # mesh pitch (m)
-    #     grid_bar_width: 35.0e-6                            # bar width (m)
-    #     cell_type: mammalian                               # mammalian (adherent, fried-egg) | yeast | bacteria | mixed | none
-    #     mammalian_density: 7.0                             # cells per 150 x 150 um; mammalian_radius / nucleus_radius set the sizes
-    #     n_clusters: 35                                     # yeast: cell clusters over the extent
-    #     cell_size: [4.5e-6, 12.0e-6]                       # cell radius range (m)
-    #     noise_sigma: 12.0                                  # gaussian noise on the beam images
-    #     noise_fraction: 0.15                               # uniform-noise blend on the beam images
-    #     grid_rotation: null                                # degrees; null = random within +/- 45
-    #     fiducial: false                                    # a cross at each grid centre, a navigation landmark; absent on a real grid
-    #     contamination_density: 15.0                        # specks per 100 x 100 um (aperiodic content on film and bars)
-    #     film: continuous                                   # continuous | holey (Quantifoil-style lattice: hole_diameter, hole_pitch; the coincidence measurement does not handle the lattice yet)
-    #     rip_fraction: 0.03                                 # squares with the film torn away
-    #     ice_density: 0.4                                   # ice plates per 100 x 100 um
-    #     grid_radius: 1.4e-3                                # usable radius (m); beyond it the rim, then the holder
-    #     beam_offset: {ion: [1.3e-6, 0.0]}                  # fixed per-beam misalignment (m): the coincidence measurement's dx
-    #     current_offset_scale: 1.5e-6                       # sigma (m) of a seeded per-beam-current offset; 0 = off
+    sample:                                                 # synthetic cryo-grid both beams (and the FM) image through their projections (FIB-874); on for development
+        grids_from_holder: false                          # grids at the holder's calibrated, occupied slots (content seeded by grid name; the holder file is shared by every configuration here); off: one grid at the boot position
+        enabled: true
+        coincidence_offset: 10.0e-6                        # height error at boot (m) - what the coincidence alignment corrects
+        tilt_axis_offset: 0.0                              # surface height above the tilt axis (m); >0 makes the stage non-eucentric
+        grid_pitch: 125.0e-6                               # mesh pitch (m)
+        grid_bar_width: 35.0e-6                            # bar width (m)
+        cell_type: mammalian                               # mammalian (adherent, fried-egg) | yeast | bacteria | mixed | none
+        mammalian_density: 7.0                             # cells per 150 x 150 um; mammalian_radius / nucleus_radius set the sizes
+        n_clusters: 35                                     # yeast: cell clusters over the extent
+        cell_size: [4.5e-6, 12.0e-6]                       # cell radius range (m)
+        noise_sigma: 12.0                                  # gaussian noise on the beam images
+        noise_fraction: 0.15                               # uniform-noise blend on the beam images
+        grid_rotation: null                                # degrees; null = random within +/- 45
+        fiducial: false                                    # a cross at each grid centre, a navigation landmark; absent on a real grid
+        contamination_density: 15.0                        # specks per 100 x 100 um (aperiodic content on film and bars)
+        film: continuous                                   # continuous | holey (Quantifoil-style lattice: hole_diameter, hole_pitch; the coincidence measurement does not handle the lattice yet)
+        rip_fraction: 0.03                                 # squares with the film torn away
+        ice_density: 0.4                                   # ice plates per 100 x 100 um
+        grid_radius: 1.4e-3                                # usable radius (m); beyond it the rim, then the holder
+        beam_offset: {ion: [1.3e-6, 0.0]}                  # fixed per-beam misalignment (m): the coincidence measurement's dx
+        current_offset_scale: 1.5e-6                       # sigma (m) of a seeded per-beam-current offset; 0 = off
     is_compustage: true
     loader:                                               # the simulated autoloader magazine
         capacity: 12

--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -88,28 +88,28 @@ sim:
     sem: null # "/path/to/sem/image/data"                   # the path to the SEM image data for simulation                 [USER]
     fib: null # "/path/to/fib/image/data"                   # the path to the FIB image data for simulation                 [USER]
     use_cycle: true                                         # infinitely cycle sem/fib dataset                              [USER]
-    # sample:                                               # synthetic cryo-grid both beams (and the FM) image through their projections (FIB-874); default off
-    #     grids_from_holder: false                          # grids at the holder's calibrated, occupied slots (content seeded by grid name; the holder file is shared by every configuration here); off: one grid at the boot position
-    #     enabled: true
-    #     coincidence_offset: 10.0e-6                        # height error at boot (m) - what the coincidence alignment corrects
-    #     tilt_axis_offset: 0.0                              # surface height above the tilt axis (m); >0 makes the stage non-eucentric
-    #     grid_pitch: 125.0e-6                               # mesh pitch (m)
-    #     grid_bar_width: 35.0e-6                            # bar width (m)
-    #     cell_type: mammalian                               # mammalian (adherent, fried-egg) | yeast | bacteria | mixed | none
-    #     mammalian_density: 7.0                             # cells per 150 x 150 um; mammalian_radius / nucleus_radius set the sizes
-    #     n_clusters: 35                                     # yeast: cell clusters over the extent
-    #     cell_size: [4.5e-6, 12.0e-6]                       # cell radius range (m)
-    #     noise_sigma: 12.0                                  # gaussian noise on the beam images
-    #     noise_fraction: 0.15                               # uniform-noise blend on the beam images
-    #     grid_rotation: null                                # degrees; null = random within +/- 45
-    #     fiducial: false                                    # a cross at each grid centre, a navigation landmark; absent on a real grid
-    #     contamination_density: 15.0                        # specks per 100 x 100 um (aperiodic content on film and bars)
-    #     film: continuous                                   # continuous | holey (Quantifoil-style lattice: hole_diameter, hole_pitch; the coincidence measurement does not handle the lattice yet)
-    #     rip_fraction: 0.03                                 # squares with the film torn away
-    #     ice_density: 0.4                                   # ice plates per 100 x 100 um
-    #     grid_radius: 1.4e-3                                # usable radius (m); beyond it the rim, then the holder
-    #     beam_offset: {ion: [1.3e-6, 0.0]}                  # fixed per-beam misalignment (m): the coincidence measurement's dx
-    #     current_offset_scale: 1.5e-6                       # sigma (m) of a seeded per-beam-current offset; 0 = off
+    sample:                                                 # synthetic cryo-grid both beams (and the FM) image through their projections (FIB-874); on for development
+        grids_from_holder: false                          # grids at the holder's calibrated, occupied slots (content seeded by grid name; the holder file is shared by every configuration here); off: one grid at the boot position
+        enabled: true
+        coincidence_offset: 10.0e-6                        # height error at boot (m) - what the coincidence alignment corrects
+        tilt_axis_offset: 0.0                              # surface height above the tilt axis (m); >0 makes the stage non-eucentric
+        grid_pitch: 125.0e-6                               # mesh pitch (m)
+        grid_bar_width: 35.0e-6                            # bar width (m)
+        cell_type: mammalian                               # mammalian (adherent, fried-egg) | yeast | bacteria | mixed | none
+        mammalian_density: 7.0                             # cells per 150 x 150 um; mammalian_radius / nucleus_radius set the sizes
+        n_clusters: 35                                     # yeast: cell clusters over the extent
+        cell_size: [4.5e-6, 12.0e-6]                       # cell radius range (m)
+        noise_sigma: 12.0                                  # gaussian noise on the beam images
+        noise_fraction: 0.15                               # uniform-noise blend on the beam images
+        grid_rotation: null                                # degrees; null = random within +/- 45
+        fiducial: false                                    # a cross at each grid centre, a navigation landmark; absent on a real grid
+        contamination_density: 15.0                        # specks per 100 x 100 um (aperiodic content on film and bars)
+        film: continuous                                   # continuous | holey (Quantifoil-style lattice: hole_diameter, hole_pitch; the coincidence measurement does not handle the lattice yet)
+        rip_fraction: 0.03                                 # squares with the film torn away
+        ice_density: 0.4                                   # ice plates per 100 x 100 um
+        grid_radius: 1.4e-3                                # usable radius (m); beyond it the rim, then the holder
+        beam_offset: {ion: [1.3e-6, 0.0]}                  # fixed per-beam misalignment (m): the coincidence measurement's dx
+        current_offset_scale: 1.5e-6                       # sigma (m) of a seeded per-beam-current offset; 0 = off
     is_compustage: false                                    # this stage rotates; the objective is off to the side          [USER]
     has_fm: true                                            # stand in for the hardware probe -- see below                  [USER]
 

--- a/fibsem/microscopes/sim_scene.py
+++ b/fibsem/microscopes/sim_scene.py
@@ -40,6 +40,7 @@ import numpy as np
 from scipy.ndimage import binary_dilation as ndi_binary_dilation
 from scipy.ndimage import gaussian_filter as ndi_gaussian
 from scipy.ndimage import map_coordinates as ndi_map_coordinates
+from scipy.ndimage import zoom as ndi_zoom
 
 from fibsem.projection import (
     BeamStageProjection,
@@ -123,6 +124,24 @@ def fm_channel_weights(emission, excitation=None) -> Tuple[float, float, float, 
         SUBSET_DYE.response(excitation, emission),
         FIDUCIAL_DYE.response(excitation, emission),
     )
+
+
+def _blur(image: np.ndarray, sigma_px: float) -> np.ndarray:
+    """A gaussian blur that stays cheap when it is wide: past a few pixels the
+    frame is block-averaged by `step`, blurred at sigma / step, and scaled
+    back with a linear zoom, which is indistinguishable from the direct blur
+    at that width and costs step^2 less."""
+    step = int(min(8, sigma_px // 4)) if sigma_px >= 12 else 1
+    if step == 1:
+        return ndi_gaussian(image, sigma_px)
+    h, w = image.shape
+    hh, ww = (h // step) * step, (w // step) * step
+    small = (
+        image[:hh, :ww].reshape(hh // step, step, ww // step, step).mean(axis=(1, 3))
+    )
+    small = ndi_gaussian(small, sigma_px / step)
+    back = ndi_zoom(small, (h / small.shape[0], w / small.shape[1]), order=1)
+    return back[:h, :w]
 
 
 def _lattice_draw(i: np.ndarray, j: np.ndarray, seed: int) -> np.ndarray:
@@ -1497,10 +1516,13 @@ class SampleScene:
 
         if defocus:
             # a retracted objective is millimetres from focus: cap the blur so
-            # the render stays cheap and the frame reads as "out of focus"
+            # the frame reads as "out of focus" without costing more than the
+            # rest of the render. A wide blur is done on a decimated frame and
+            # scaled back - what a 40 px gaussian removes, decimating by 8
+            # already removed
             sigma_px = min(abs(defocus) * 1e6 * self.fm_blur_px_per_um, 40.0)
             if sigma_px > 0.3:
-                canvas = ndi_gaussian(canvas, sigma_px)
+                canvas = _blur(canvas, sigma_px)
 
         if rng is None:
             rng = np.random.default_rng()

--- a/tests/fm/conftest.py
+++ b/tests/fm/conftest.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import yaml
 
 import fibsem.config as fconfig
 
@@ -10,15 +11,26 @@ SIM_ARCTIS_CONFIG_PATH = os.path.join(
 
 
 @pytest.fixture(autouse=True, scope="package")
-def use_sim_arctis_config():
+def use_sim_arctis_config(tmp_path_factory):
     """Use sim-arctis-configuration.yaml for all fm tests (required for FM support).
 
     Package scope, not session: a session-scoped swap is only torn down when
     the whole run ends, so every test collected after the first fm test - in
     any other directory, on any xdist worker - silently ran on the compustage
     configuration too (pre-tilt 0, flat boot pose).
+
+    The shipped configuration has the sample scene on, for development; the
+    tests here run on a copy with it off, so an FM frame is noise rather than
+    a render (a 220-frame tileset went from 8 s to 150 s with the scene on).
+    A test that wants the scene enables it itself.
     """
+    with open(SIM_ARCTIS_CONFIG_PATH) as f:
+        config = yaml.safe_load(f)
+    config.setdefault("sim", {}).setdefault("sample", {})["enabled"] = False
+    path = tmp_path_factory.mktemp("fm-config") / "sim-arctis-configuration.yaml"
+    with open(path, "w") as f:
+        yaml.safe_dump(config, f, sort_keys=False)
     original = fconfig.DEFAULT_CONFIGURATION_PATH
-    fconfig.DEFAULT_CONFIGURATION_PATH = SIM_ARCTIS_CONFIG_PATH
+    fconfig.DEFAULT_CONFIGURATION_PATH = str(path)
     yield
     fconfig.DEFAULT_CONFIGURATION_PATH = original


### PR DESCRIPTION
## Summary

`sim-arctis-configuration.yaml` and `sim-iflm-configuration.yaml`, the simulator configurations meant for development, now have the sample scene **on** out of the box: mammalian cells on continuous film, rips, ice and contamination, a 10 µm height error at boot, the 1.3 µm FIB lateral offset and a per-current beam offset, with the common keys spelled out in the file. `microscope-configuration.yaml` (the shuttle Demo the tests run on) keeps its beams on noise.

**Tests stay on noise.** The FM tests run on a scene-off copy of the Arctis configuration written by the package fixture: with the scene on, a 220-frame tileset test went from 8 s to 150 s. A test that wants the scene enables it itself (`tests/fm/test_sample_scene_fm.py` already does). The FM suite is back at ~4 min.

**Cheap defocus blur.** Half of that 150 s was the defocus blur, a 40-pixel gaussian on every large frame. From sigma 12 the blur is now done on a decimated frame and scaled back (what a 40-pixel gaussian removes, decimating by 8 already removed): 0.92 s → 0.08 s at 2048², correlation 0.997 with the direct blur. Below sigma 12 the direct blur is kept.

The docs page now says which configurations ship with the scene on.

## Testing

`tests/fm` 717 passed (4:08); the Arctis/iFLM-loading suites (`test_movement`, `test_projection_paths_agree`, `test_beam_stage_projection`, `test_guided_setup`, texture) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)