### PR TITLE
[server] Grid runs get their verbs: plan, start, screen all

### DIFF
--- a/.claude/skills/supervise-autolamella/SKILL.md
+++ b/.claude/skills/supervise-autolamella/SKILL.md
@@ -193,7 +193,13 @@ The argument selects a variation on the same loop:
   source pixels with their status — use it for "which items sit near the
   edge / off the grid" judgments, never re-derive stage geometry yourself.
   `quality` is the operator's verdict, not yours: say what you see, propose,
-  and leave the verdict to them.
+  and leave the verdict to them. Starting a screening run is a control
+  action: `POST /app/workflow/grids/plan` first and show the operator the
+  plan (every step, one load per grid — an exchange is the most physical
+  thing this server commands), then `POST /app/workflow/grids/start` with
+  the same body; `screen_all: true` inventories and runs every present grid.
+  One run at a time: it is refused while a lamella run is live, and a
+  lamella start is refused while a grid run is.
 
 ## Acting beyond answers (control permission)
 

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -96,6 +96,11 @@ questions and rewriting protocols are different levels of trust.
 Permissions last the session only. They are granted in the dialog, die when
 the app closes, and never persist — every session starts read-only.
 
+With Control the agent can also start a **grid screening run** — the Grids
+view's Run or Screen all grids, remotely — over the grid tasks in your
+protocol. It is refused while any run is going, and a good agent shows you
+the plan (every grid, its load, its tasks) before it starts one.
+
 ## What the agent cannot do
 
 Command hardware. There is no permission that lets an agent move the stage,

--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -282,9 +282,19 @@ class AgentContext:
         if task_protocol is None:
             return {"available": False, "tasks": []}
         config = task_protocol.workflow_config
+        grid_protocol = experiment.grid_protocol
         return {
             "available": True,
             "name": config.name,
+            # The grid protocol beside the lamella workflow: what a grid run
+            # can name. Kind is the registered task type (beam vs FM overview).
+            "grid_tasks": [
+                {
+                    "name": name,
+                    "type": getattr(grid_protocol.task_config[name], "task_type", None),
+                }
+                for name in grid_protocol.ordered_task_names
+            ],
             "tasks": [
                 {
                     "name": task.name,
@@ -1101,6 +1111,109 @@ class AgentContext:
         if not hasattr(host, "request_start_workflow"):
             return {"available": False, "started": False}
         outcome = host.request_start_workflow(list(task_names), item_names)
+        result = outcome.result(timeout=timeout)
+        result["available"] = True
+        return result
+
+    def grid_workflow_plan(
+        self,
+        task_names: List[str],
+        grid_names: Optional[List[str]] = None,
+        screen_all: bool = False,
+    ) -> Dict[str, Any]:
+        """What a grid run would execute, for a confirmation — no hardware.
+
+        The ``(grid, step)`` sequence the manager builds, grid-outer with each
+        grid's load first, validated against the grid protocol and the
+        recorded grids exactly as :meth:`start_grid_workflow` will. For
+        ``screen_all`` the grids are whatever the inventory finds at run time,
+        so the plan names the known grids and says so rather than guessing.
+        Exchanges are deliberately not counted: whether a grid is in the beam
+        is a live stage fact this facade does not read.
+        """
+        from fibsem.applications.autolamella.workflows.tasks.grid.manager import (
+            plan_grid_run,
+        )
+
+        experiment = self._experiment
+        if experiment is None or experiment.task_protocol is None:
+            return {
+                "available": False,
+                "valid": False,
+                "reason": "no experiment is loaded",
+            }
+        known_tasks = list(experiment.grid_protocol.ordered_task_names)
+        unknown = [t for t in task_names if t not in known_tasks]
+        if not task_names or unknown:
+            return {
+                "available": True,
+                "valid": False,
+                "reason": f"unknown grid tasks: {unknown!r}" if unknown else "no tasks",
+                "task_names": known_tasks,
+            }
+        known_grids = [g.name for g in experiment.grids]
+        if screen_all:
+            if grid_names is not None:
+                return {
+                    "available": True,
+                    "valid": False,
+                    "reason": "screen_all runs over every present grid; "
+                    "do not name grids with it",
+                }
+            return {
+                "available": True,
+                "valid": True,
+                "screen_all": True,
+                "task_names": list(task_names),
+                "grid_names": known_grids,
+                "note": "inventory first; the grids run are those present at run time",
+                "steps": [
+                    {"grid": grid, "step": step}
+                    for grid, step in plan_grid_run(list(task_names), known_grids)
+                ],
+            }
+        if grid_names is None:
+            grid_names = known_grids
+        missing = [n for n in grid_names if n not in known_grids]
+        if missing:
+            return {
+                "available": True,
+                "valid": False,
+                "reason": f"unknown grids: {missing!r}",
+                "grid_names": known_grids,
+            }
+        return {
+            "available": True,
+            "valid": True,
+            "screen_all": False,
+            "task_names": list(task_names),
+            "grid_names": list(grid_names),
+            "steps": [
+                {"grid": grid, "step": step}
+                for grid, step in plan_grid_run(list(task_names), list(grid_names))
+            ],
+        }
+
+    def start_grid_workflow(
+        self,
+        task_names: List[str],
+        grid_names: Optional[List[str]] = None,
+        screen_all: bool = False,
+        timeout: float = 15.0,
+    ) -> Dict[str, Any]:
+        """Start a grid run as the Grids view's Run (or Screen all grids) would.
+
+        Marshalled to the GUI thread like :meth:`start_workflow`; shares its
+        worker slot, so it is refused while any workflow — lamella or grid —
+        is running. Control-scope arming stands in for the preflight dialog's
+        Run click; :meth:`grid_workflow_plan` is that dialog's content.
+        """
+        host = self._host
+        if not hasattr(host, "request_start_grid_workflow"):
+            return {"available": False, "started": False}
+        outcome = host.request_start_grid_workflow(
+            list(task_names), grid_names, inventory_first=screen_all
+        )
         result = outcome.result(timeout=timeout)
         result["available"] = True
         return result

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -189,6 +189,8 @@ class AutoLamellaUI(QMainWindow):
     # A remote (agent) start request, marshalled to the GUI thread the same
     # way agent answers are: (task_names, item_names, Future[dict]).
     _agent_start_workflow = pyqtSignal(list, object, object)
+    # The grid twin: (task_names, grid_names, inventory_first, Future[dict]).
+    _agent_start_grid_workflow = pyqtSignal(list, object, bool, object)
     # (item_name, task_name, patch, version, Future) — the config-patch marshal
     _agent_config_patch = pyqtSignal(str, str, str, object, str, object)
 
@@ -208,6 +210,7 @@ class AutoLamellaUI(QMainWindow):
         # widget itself is built in _setup_ui, before the responder exists.
         self.ui_responder.add_question_observer(self.question_timeline.record)
         self._agent_start_workflow.connect(self._apply_agent_start_workflow)
+        self._agent_start_grid_workflow.connect(self._apply_agent_start_grid_workflow)
         self._agent_config_patch.connect(self._apply_agent_config_patch)
 
         self._protocol_lock = threading.RLock()
@@ -1224,6 +1227,115 @@ class AutoLamellaUI(QMainWindow):
             except Exception:
                 logging.exception("window chrome after agent start failed")
         return {"started": started}
+
+    def request_start_grid_workflow(
+        self,
+        task_names: List[str],
+        grid_names: Optional[List[str]] = None,
+        inventory_first: bool = False,
+    ) -> "Future":
+        """Start a grid run as the Grids view's Run (or Screen all grids) would;
+        any thread. Same marshal as :meth:`request_start_workflow`."""
+        from concurrent.futures import Future as _Future
+
+        outcome: "_Future" = _Future()
+        self._agent_start_grid_workflow.emit(
+            list(task_names), grid_names, bool(inventory_first), outcome
+        )
+        return outcome
+
+    def _apply_agent_start_grid_workflow(
+        self, task_names: List[str], grid_names, inventory_first: bool, outcome
+    ) -> None:
+        """GUI thread. Complete ``outcome`` with the start result."""
+        try:
+            result = self._start_grid_workflow_for_agent(
+                task_names, grid_names, inventory_first
+            )
+        except Exception as exc:  # noqa: BLE001 - the requester owns the failure
+            outcome.set_exception(exc)
+            return
+        outcome.set_result(result)
+
+    def _start_grid_workflow_for_agent(
+        self,
+        task_names: List[str],
+        grid_names: Optional[List[str]],
+        inventory_first: bool,
+    ) -> dict:
+        """Validate and start, mirroring the Grids view's Run path (GUI thread).
+
+        One worker slot serves lamella and grid runs alike, so "a workflow is
+        already running" refuses either kind. ``inventory_first`` is "Screen
+        all grids": the worker inventories and runs over every present grid,
+        so ``grid_names`` must be omitted; otherwise omitted grids means every
+        grid the experiment records, as the manager's own default does.
+        """
+        from fibsem.applications.autolamella.workflows.tasks.grid.manager import (
+            plan_grid_run,
+        )
+
+        if self.is_workflow_running:
+            return {"started": False, "reason": "a workflow is already running"}
+        if self.microscope is None:
+            return {"started": False, "reason": "no microscope is connected"}
+        experiment = self.experiment
+        if experiment is None or experiment.task_protocol is None:
+            return {"started": False, "reason": "no experiment is loaded"}
+        known_tasks = list(experiment.grid_protocol.ordered_task_names)
+        unknown = [t for t in task_names if t not in known_tasks]
+        if not task_names or unknown:
+            return {
+                "started": False,
+                "reason": f"unknown grid tasks: {unknown!r}" if unknown else "no tasks",
+                "task_names": known_tasks,
+            }
+        known_grids = [g.name for g in experiment.grids]
+        if inventory_first:
+            if grid_names is not None:
+                return {
+                    "started": False,
+                    "reason": "screen_all runs over every present grid; "
+                    "do not name grids with it",
+                }
+        elif grid_names is None:
+            grid_names = known_grids
+        else:
+            missing = [n for n in grid_names if n not in known_grids]
+            if missing:
+                return {
+                    "started": False,
+                    "reason": f"unknown grids: {missing!r}",
+                    "grid_names": known_grids,
+                }
+        if not inventory_first and not grid_names:
+            return {"started": False, "reason": "no grids", "grid_names": known_grids}
+        parent = self.parent_widget
+        if parent is not None:
+            try:
+                # FIB-683 one-writer rule, as the Grids view's Run does.
+                parent.lamella_widget.flush_pending_save()
+            except Exception:
+                logging.exception("flush before agent grid start failed; continuing")
+        self._start_run_grid_workflow_thread(
+            task_names,
+            list(grid_names) if grid_names is not None else None,
+            inventory_first,
+        )
+        started = self.is_workflow_running
+        if started and parent is not None:
+            try:
+                parent._set_border_state("automated")
+                parent.set_workflow_running()
+            except Exception:
+                logging.exception("window chrome after agent grid start failed")
+        result = {"started": started, "screen_all": inventory_first}
+        if not inventory_first:
+            result["plan"] = [
+                {"grid": grid, "step": step}
+                for grid, step in plan_grid_run(task_names, grid_names or [])
+            ]
+        return result
 
     def request_apply_task_config_patch(
         self, item_name: str, task_name: str, patch: dict, version: str

--- a/fibsem/mcp/sidecar.py
+++ b/fibsem/mcp/sidecar.py
@@ -362,6 +362,24 @@ def build_sidecar(client, capabilities):
         data, err = _call(client, "POST", "/app/workflow/start", payload)
         return err if err else data
 
+    def plan_grid_workflow(
+        task_names: list, grid_names: list = None, screen_all: bool = False
+    ):  # noqa: RUF013
+        payload = {"task_names": list(task_names), "screen_all": bool(screen_all)}
+        if grid_names is not None:
+            payload["grid_names"] = list(grid_names)
+        data, err = _call(client, "POST", "/app/workflow/grids/plan", payload)
+        return err if err else data
+
+    def start_grid_workflow(
+        task_names: list, grid_names: list = None, screen_all: bool = False
+    ):  # noqa: RUF013
+        payload = {"task_names": list(task_names), "screen_all": bool(screen_all)}
+        if grid_names is not None:
+            payload["grid_names"] = list(grid_names)
+        data, err = _call(client, "POST", "/app/workflow/grids/start", payload)
+        return err if err else data
+
     def set_task_supervision(task_name: str, supervise: bool, supervisor: str = None):  # noqa: RUF013
         payload = {"task_name": task_name, "supervise": bool(supervise)}
         if supervisor is not None:
@@ -449,6 +467,8 @@ def build_sidecar(client, capabilities):
             get_pending_prompt,
             answer_prompt,
             stop_workflow,
+            plan_grid_workflow,
+            start_grid_workflow,
             set_task_supervision,
             requeue_task,
             start_workflow,

--- a/fibsem/server/app_routes.py
+++ b/fibsem/server/app_routes.py
@@ -114,6 +114,20 @@ class AppContext(Protocol):
         self, task_names: List[str], item_names: Optional[List[str]] = None
     ) -> Dict[str, Any]: ...
 
+    def grid_workflow_plan(
+        self,
+        task_names: List[str],
+        grid_names: Optional[List[str]] = None,
+        screen_all: bool = False,
+    ) -> Dict[str, Any]: ...
+
+    def start_grid_workflow(
+        self,
+        task_names: List[str],
+        grid_names: Optional[List[str]] = None,
+        screen_all: bool = False,
+    ) -> Dict[str, Any]: ...
+
     def set_supervision(
         self,
         task_name: str,
@@ -124,6 +138,38 @@ class AppContext(Protocol):
     def requeue_task(
         self, item_name: str, task_name: str, front: bool = False
     ) -> Dict[str, Any]: ...
+
+
+def _grid_run_body(body: Dict[str, Any]):
+    """Validate the shared body of the grid plan/start verbs, or raise 422."""
+    task_names = body.get("task_names")
+    grid_names = body.get("grid_names")
+    screen_all = body.get("screen_all", False)
+    ok = (
+        isinstance(task_names, list)
+        and bool(task_names)
+        and all(isinstance(t, str) for t in task_names)
+        and (
+            grid_names is None
+            or (
+                isinstance(grid_names, list)
+                and all(isinstance(g, str) for g in grid_names)
+            )
+        )
+        and isinstance(screen_all, bool)
+    )
+    if not ok:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error_type": "missing_field",
+                "message": "Pass task_names (non-empty list of grid task names); "
+                "grid_names (list of strings) is optional — omitted means every "
+                "recorded grid; screen_all (bool) inventories first and runs over "
+                "every present grid, and takes no grid_names.",
+            },
+        )
+    return task_names, grid_names, screen_all
 
 
 def _jpeg_or_404(result: Dict[str, Any]) -> Response:
@@ -219,6 +265,14 @@ def build_app_router(context: AppContext) -> APIRouter:
     @router.get("/prompt")
     def pending_prompt():
         return context.pending_prompt()
+
+    @router.post("/workflow/grids/plan")
+    def grid_workflow_plan(body: Dict[str, Any]):
+        # A POST on the read router because it computes, never acts: the
+        # preflight dialog's content for a grid run, from a body a GET could
+        # not carry cleanly. No hardware is read.
+        task_names, grid_names, screen_all = _grid_run_body(body)
+        return context.grid_workflow_plan(task_names, grid_names, screen_all)
 
     @router.post("/workflow/stop")
     def stop_workflow():
@@ -321,6 +375,13 @@ def build_app_control_router(context: AppContext) -> APIRouter:
                 },
             )
         return context.start_workflow(task_names, item_names)
+
+    @router.post("/workflow/grids/start")
+    def start_grid_workflow(body: Dict[str, Any]):
+        # The Grids view's Run / Screen all grids, remotely. Shares the lamella
+        # run's worker slot, so the context refuses it while any run is live.
+        task_names, grid_names, screen_all = _grid_run_body(body)
+        return context.start_grid_workflow(task_names, grid_names, screen_all)
 
     @router.post("/agent/notes")
     def add_note(body: Dict[str, Any]):

--- a/fibsem/server/catalog.py
+++ b/fibsem/server/catalog.py
@@ -410,6 +410,32 @@ APP_TOOLS: Tuple[ToolSpec, ...] = (
         },
     ),
     ToolSpec(
+        name="plan_grid_workflow",
+        description="What a grid run would execute — the preflight dialog's content: the (grid, step) sequence with each grid's load first, validated against the grid protocol and the recorded grids. screen_all plans over the known grids and says the run will use whatever the inventory finds. Computes only; reads no hardware.",
+        method="POST",
+        path="/app/workflow/grids/plan",
+        scope="read",
+        router="app",
+        params={
+            "task_names": "grid tasks to run, from the protocol's grid_tasks names",
+            "grid_names": "grids to run them on; omit for every recorded grid",
+            "screen_all": "true = inventory first, then every present grid (no grid_names)",
+        },
+    ),
+    ToolSpec(
+        name="start_grid_workflow",
+        description="Start a grid run — the Grids view's Run button, remotely; with screen_all, its Screen all grids button (inventory, then every present grid). Refused while any workflow, lamella or grid, is running. Call plan_grid_workflow first and show the plan.",
+        method="POST",
+        path="/app/workflow/grids/start",
+        scope="control",
+        router="app",
+        params={
+            "task_names": "grid tasks to run, from the protocol's grid_tasks names",
+            "grid_names": "grids to run them on; omit for every recorded grid",
+            "screen_all": "true = inventory first, then every present grid (no grid_names)",
+        },
+    ),
+    ToolSpec(
         name="set_task_supervision",
         description="Set whether a task asks for supervision, in the live protocol. Takes effect at the workflow's next prompt-or-proceed decision, mid-run — the same behaviour as the GUI's supervised/automated toggle.",
         method="POST",

--- a/tests/server/test_app_router.py
+++ b/tests/server/test_app_router.py
@@ -457,3 +457,63 @@ def test_grid_markers_report_unplaceable_items(client, host, grid_with_overview)
     ).json()
     assert unknown["markers"] == []
     assert unknown["filenames"] == ["overview.tif"]
+
+
+def test_grid_workflow_plan_is_the_preflight_without_hardware(client, host):
+    from fibsem.applications.autolamella.structures import GridRecord
+    from fibsem.applications.autolamella.workflows.tasks.grid.imaging import (
+        BeamOverviewGridTaskConfig,
+    )
+    from fibsem.applications.autolamella.workflows.tasks.grid.manager import (
+        LOAD_ENTRY_NAME,
+    )
+
+    experiment = host.experiment
+    experiment.grid_protocol.add(BeamOverviewGridTaskConfig(task_name="overview_sem"))
+    experiment.grid_protocol.add(BeamOverviewGridTaskConfig(task_name="overview_fib"))
+    experiment.add_grid(GridRecord(name="grid-aspen"))
+    experiment.add_grid(GridRecord(name="grid-birch"))
+
+    body = client.post(
+        "/app/workflow/grids/plan",
+        headers=AUTH,
+        json={
+            "task_names": ["overview_fib", "overview_sem"],
+            "grid_names": ["grid-birch"],
+        },
+    ).json()
+    assert body["valid"] is True
+    assert body["steps"] == [
+        {"grid": "grid-birch", "step": LOAD_ENTRY_NAME},
+        {"grid": "grid-birch", "step": "overview_fib"},
+        {"grid": "grid-birch", "step": "overview_sem"},
+    ]
+
+    every = client.post(
+        "/app/workflow/grids/plan", headers=AUTH, json={"task_names": ["overview_sem"]}
+    ).json()
+    assert every["grid_names"] == ["grid-aspen", "grid-birch"]
+    assert len(every["steps"]) == 4
+
+    screen = client.post(
+        "/app/workflow/grids/plan",
+        headers=AUTH,
+        json={"task_names": ["overview_sem"], "screen_all": True},
+    ).json()
+    assert screen["valid"] is True and screen["screen_all"] is True
+    assert "inventory" in screen["note"]
+
+    bad_task = client.post(
+        "/app/workflow/grids/plan", headers=AUTH, json={"task_names": ["nope"]}
+    ).json()
+    assert bad_task["valid"] is False
+    assert bad_task["task_names"] == ["overview_sem", "overview_fib"]
+    bad_grid = client.post(
+        "/app/workflow/grids/plan",
+        headers=AUTH,
+        json={"task_names": ["overview_sem"], "grid_names": ["grid-oak"]},
+    ).json()
+    assert bad_grid["valid"] is False
+    assert bad_grid["grid_names"] == ["grid-aspen", "grid-birch"]
+    malformed = client.post("/app/workflow/grids/plan", headers=AUTH, json={})
+    assert malformed.status_code == 422

--- a/tests/ui/test_agent_grid_workflow.py
+++ b/tests/ui/test_agent_grid_workflow.py
@@ -1,0 +1,218 @@
+"""The grid run verbs end to end: a remote start request validated and started on
+the GUI thread, sharing the lamella run's worker slot, and the plan that goes
+before it. Same three-thread shape as the lamella start test."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("PyQt5")
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient  # noqa: E402
+from psygnal.containers import EventedDict  # noqa: E402
+
+from fibsem.applications.autolamella.server import AgentContext  # noqa: E402
+from fibsem.applications.autolamella.structures import (  # noqa: E402
+    AutoLamellaTaskProtocol,
+    Experiment,
+    GridRecord,
+)
+from fibsem.applications.autolamella.ui.AutoLamellaUI import AutoLamellaUI  # noqa: E402
+from fibsem.applications.autolamella.workflows.tasks.grid.imaging import (  # noqa: E402
+    BeamOverviewGridTaskConfig,
+)
+from fibsem.applications.autolamella.workflows.tasks.grid.manager import (  # noqa: E402
+    LOAD_ENTRY_NAME,
+)
+from fibsem.server import AuthConfig, build_server  # noqa: E402
+from fibsem.structures import MicroscopeState  # noqa: E402
+
+TOKEN = "test-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+
+@pytest.fixture
+def ui(qapp, monkeypatch, tmp_path):
+    import fibsem.config as fibsem_config
+
+    arctis_config = os.path.join(
+        os.path.dirname(fibsem_config.__file__),
+        "config",
+        "sim-arctis-configuration.yaml",
+    )
+    widget = AutoLamellaUI(parent_ui=None)
+    monkeypatch.setattr(
+        widget.system_widget,
+        "load_configuration",
+        lambda configuration_name=None: arctis_config,
+    )
+    widget.system_widget.connect_to_microscope()
+
+    experiment = Experiment(path=tmp_path, name="grid-start")
+    experiment.task_protocol = AutoLamellaTaskProtocol()
+    experiment.grid_protocol.add(BeamOverviewGridTaskConfig(task_name="overview_sem"))
+    experiment.add_grid(GridRecord(name="grid-aspen"))
+    experiment.add_grid(GridRecord(name="grid-birch"))
+    experiment.add_new_lamella(MicroscopeState(), EventedDict())
+    widget.experiment = experiment
+
+    yield widget
+    widget.experiment = None
+    if widget.microscope is not None:
+        widget.microscope.disconnect()
+    widget.close()
+    widget.deleteLater()
+    qapp.processEvents()
+
+
+def _client(ui, arm_control):
+    app = build_server(
+        ui.microscope,
+        app_context=AgentContext(ui),
+        auth=AuthConfig.generate(arm_control=arm_control, token=TOKEN),
+    )
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _spin_until(qapp, predicate, timeout_s=10.0):
+    deadline = time.monotonic() + timeout_s
+    while not predicate():
+        if time.monotonic() > deadline:
+            raise TimeoutError("condition not reached")
+        qapp.processEvents()
+        time.sleep(0.01)
+
+
+def _post(qapp, client, path, body):
+    """POST from another thread while the GUI thread spins, like production."""
+    posted = {}
+
+    def do_post():
+        posted["response"] = client.post(path, headers=AUTH, json=body)
+
+    threading.Thread(target=do_post, daemon=True).start()
+    _spin_until(qapp, lambda: "response" in posted)
+    return posted["response"]
+
+
+class _AliveThread:
+    @staticmethod
+    def is_alive():
+        return True
+
+
+def test_grid_start_validates_and_starts_on_the_gui_thread(ui, qapp):
+    calls = []
+
+    def fake_start(task_names, grid_names, inventory_first):
+        calls.append((task_names, grid_names, inventory_first))
+        ui._task_worker_thread = _AliveThread()
+
+    ui._start_run_grid_workflow_thread = fake_start
+
+    with _client(ui, arm_control=True) as client:
+        # The protocol read names the grid tasks a run can use.
+        protocol = client.get("/app/protocol", headers=AUTH).json()
+        assert protocol["grid_tasks"] == [
+            {"name": "overview_sem", "type": "BEAM_OVERVIEW_GRID"}
+        ]
+
+        refused = _post(
+            qapp, client, "/app/workflow/grids/start", {"task_names": ["No Such"]}
+        ).json()
+        assert refused["started"] is False
+        assert refused["task_names"] == ["overview_sem"]
+
+        refused = _post(
+            qapp,
+            client,
+            "/app/workflow/grids/start",
+            {"task_names": ["overview_sem"], "grid_names": ["grid-oak"]},
+        ).json()
+        assert refused["started"] is False
+        assert refused["grid_names"] == ["grid-aspen", "grid-birch"]
+
+        refused = _post(
+            qapp,
+            client,
+            "/app/workflow/grids/start",
+            {
+                "task_names": ["overview_sem"],
+                "grid_names": ["grid-aspen"],
+                "screen_all": True,
+            },
+        ).json()
+        assert refused["started"] is False
+        assert "screen_all" in refused["reason"]
+        assert calls == []
+
+        # Omitted grids means every recorded grid; the plan comes back with it.
+        started = _post(
+            qapp, client, "/app/workflow/grids/start", {"task_names": ["overview_sem"]}
+        ).json()
+        assert started["started"] is True
+        assert started["screen_all"] is False
+        assert started["plan"] == [
+            {"grid": "grid-aspen", "step": LOAD_ENTRY_NAME},
+            {"grid": "grid-aspen", "step": "overview_sem"},
+            {"grid": "grid-birch", "step": LOAD_ENTRY_NAME},
+            {"grid": "grid-birch", "step": "overview_sem"},
+        ]
+        assert calls == [(["overview_sem"], ["grid-aspen", "grid-birch"], False)]
+
+        # One worker slot: while it is "running", neither kind of run may start.
+        again = _post(
+            qapp, client, "/app/workflow/grids/start", {"task_names": ["overview_sem"]}
+        ).json()
+        assert again["started"] is False
+        assert "already running" in again["reason"]
+        lamella = _post(
+            qapp, client, "/app/workflow/start", {"task_names": ["overview_sem"]}
+        ).json()
+        assert lamella["started"] is False
+        assert "already running" in lamella["reason"]
+        ui._task_worker_thread = None
+
+        # Screen all grids: inventory first, no grid list, no plan to promise.
+        screened = _post(
+            qapp,
+            client,
+            "/app/workflow/grids/start",
+            {"task_names": ["overview_sem"], "screen_all": True},
+        ).json()
+        assert screened == {"available": True, "started": True, "screen_all": True}
+        assert calls[-1] == (["overview_sem"], None, True)
+        ui._task_worker_thread = None
+
+
+def test_grid_start_requires_control_and_a_valid_body(ui, qapp):
+    with _client(ui, arm_control=False) as client:
+        refused = client.post(
+            "/app/workflow/grids/start", headers=AUTH, json={"task_names": ["x"]}
+        )
+        assert refused.status_code == 403
+        assert refused.json()["detail"]["scope"] == "control"
+        # The plan is a read: it needs no arming.
+        plan = client.post(
+            "/app/workflow/grids/plan",
+            headers=AUTH,
+            json={"task_names": ["overview_sem"]},
+        )
+        assert plan.status_code == 200
+        assert plan.json()["valid"] is True
+    with _client(ui, arm_control=True) as client:
+        for body in (
+            {},
+            {"task_names": []},
+            {"task_names": ["x"], "screen_all": "yes"},
+        ):
+            rejected = client.post("/app/workflow/grids/start", headers=AUTH, json=body)
+            assert rejected.status_code == 422, body
+            assert rejected.json()["detail"]["error_type"] == "missing_field"


### PR DESCRIPTION
Stacked on #767 → #766. FIB-906 rung 1: the agent server drives a screening run the way it drives a lamella run.

**`POST /app/workflow/grids/plan`** (read scope) — the preflight dialog's content: the `(grid, step)` sequence the manager would execute, each grid's load first, validated against the grid protocol and the recorded grids exactly as the start will be (refusals carry the valid task/grid names). `screen_all: true` plans over the known grids and says the run uses whatever the inventory finds. Computes only: exchanges are deliberately not counted, because whether a grid is in the beam is a live stage fact this facade does not read. A POST on the read router because a GET cannot carry the body cleanly; the route says so.

**`POST /app/workflow/grids/start`** (control scope) — the Grids view's Run, or with `screen_all` its Screen all grids (inventory, then every present grid). Marshalled to the GUI thread through the same signal/Future pattern as `start_workflow`, with the same FIB-683 flush-first rule and window chrome (border state, Stop button). Omitted `grid_names` means every recorded grid, as the manager's own default does; `screen_all` with named grids is refused.

**One worker slot.** Lamella and grid runs share `_task_worker_thread`, so `is_workflow_running` refuses either start while the other is live — tested in both directions.

Also: `/app/protocol` grows `grid_tasks` (`name`, registered `type`) so a client can name what a grid run may use. Sidecar: `plan_grid_workflow`, `start_grid_workflow`. Skill: plan-then-start etiquette (an exchange is the most physical thing this server commands). Eight files, three of them tests/docs.

**Tests**: `tests/ui/test_agent_grid_workflow.py` (three-thread shape like the lamella start test — refusals with valid names, omitted-grids default + returned plan, the mutual running guard, screen_all, 403 without control, 422 on malformed bodies; the plan needs no arming); `tests/server/test_app_router.py` plan over HTTP (per-grid order, every-grid default, screen_all note, bad task/grid, malformed).

Not live-run yet against the app — the GUI seam is the same `_start_run_grid_workflow_thread` the Grids view's Run button calls, and the test drives it through a real `AutoLamellaUI` on the Arctis sim config with a stubbed thread start.

Release-Note: Agents with the Control permission can now plan and start grid screening runs (a chosen set of grids, or "screen all grids"), with the same one-run-at-a-time rule as lamella workflows.
