### PR TITLE
[ui] A grid task added on the Protocol tab reaches the Workflow tab's Grids view

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -2827,6 +2827,11 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         self.task_widget.workflow_config_changed.connect(
             self.lamella_workflow_widget.set_workflow_config
         )
+        # And the Grid page → Workflow → Grids: a task added on the Protocol tab
+        # gets its row in the run view without an inventory or a reload.
+        self.task_widget.grid_protocol_changed.connect(
+            self.grid_workflow_widget.refresh
+        )
 
     def _on_lamella_card_selected(self, lamella: Lamella | None):
         """Update task image panel and protocol editor for selected lamella card."""

--- a/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
@@ -191,6 +191,10 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
     """A widget to edit the AutoLamella protocol."""
 
     workflow_config_changed = pyqtSignal(object)  # AutoLamellaWorkflowConfig
+    # The grid protocol changed on this editor's Grid page (a task added,
+    # removed, or edited and saved). Re-emitted here because the Grid page is
+    # built inside this editor, after the window has wired its signals.
+    grid_protocol_changed = pyqtSignal()
 
     def __init__(self, parent: "AutoLamellaUI"):
         super().__init__(parent)
@@ -272,6 +276,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         self.grid_protocol = GridProtocolWidget(parent=self, embedded=True)
         self.grid_protocol.set_experiment(self.experiment)
         self.grid_protocol.set_microscope(self.microscope)
+        self.grid_protocol.protocol_changed.connect(self.grid_protocol_changed)
         self._grid_protocol_visible = getattr(self, "_grid_protocol_visible", False)
 
         # Task parameters (Column 2)

--- a/tests/ui/test_grids_tab.py
+++ b/tests/ui/test_grids_tab.py
@@ -335,3 +335,24 @@ def test_an_experiment_with_no_lamella_tasks_loads(main_ui, tmp_path):
     editor = main_ui.task_widget
     assert not editor.task_parameters_config_widget.isVisibleTo(editor)
     assert not editor.milling_task_editor.isVisibleTo(editor)
+
+
+def test_a_grid_task_added_on_the_protocol_tab_reaches_the_run_view(main_ui, tmp_path):
+    """The Workflow tab's Grids view lists the protocol's grid tasks; a task
+    added on the Protocol tab's Grid page used to appear there only after an
+    inventory or an experiment reload."""
+    ui = main_ui.autolamella_ui
+    ui.system_widget.connect_to_microscope()
+    exp = Experiment(path=tmp_path, name="exp")
+    (tmp_path / "exp").mkdir()
+    exp.task_protocol = AutoLamellaTaskProtocol()
+    ui.experiment = exp
+    main_ui.minimap_widget = _NoMinimap()
+    main_ui._on_experiment_update()
+    run_view = main_ui.grid_workflow_widget
+    assert list(run_view._task_rows) == []
+
+    main_ui.task_widget.grid_protocol.add_task("BEAM_OVERVIEW_GRID", "SEM Overview")
+
+    assert list(run_view._task_rows) == ["SEM Overview"]
+    assert run_view.get_selected_task_names() == ["SEM Overview"]


### PR DESCRIPTION
Found live while setting up an agent-driven screening run: after adding SEM/FM overview tasks on the Protocol tab's Grid page, Workflow → Grids still said "No grid tasks in the protocol" (the server, reading the same protocol, listed both).

`GridProtocolWidget.protocol_changed` fires on every save, but nothing connected it to the run view, whose task list rebuilds only on an inventory or an experiment reload. The editor now re-emits the page's signal as `grid_protocol_changed` (the Grid page is built inside the editor, after the window has wired its signals, so the editor is the stable thing to connect to) and the main window connects it to `grid_workflow_widget.refresh`. Not related to toggling the feature flag mid-session.

Three files; the test builds the real window, connects the sim, adds a task through the Grid page, and asserts the run view's row appears ticked.

Release-Note: Grid tasks added on the Protocol tab now appear in the Workflow tab's Grids view immediately.
