### PR TITLE
[server] FM overviews preview in colour and take item markers; unlinked fallback only on one-grid experiments

### DIFF
--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -121,17 +121,21 @@ GRID_OVERVIEW_ROLES = ("overview_sem", "overview_fib", "overview_fm")
 def _rendered_preview(path: str, filename: str, max_width: int) -> Dict[str, Any]:
     """One recorded output file as a downscaled JPEG, or the reason it is not.
 
-    TIFFs (every FibsemImage) read through tifffile; anything else (the PNG
-    thumbnails grid tasks write beside their overviews) through PIL. Stacks
-    and multi-channel images are max-projected to something viewable; this
-    is a preview, not the data.
+    Fluorescence stacks (``.ome.tiff``) composite through the FM canvas's own
+    projection, so each channel keeps its colour; plain TIFFs (every
+    FibsemImage) read through tifffile; anything else (the PNG thumbnails grid
+    tasks write beside their overviews) through PIL. Stacks are max-projected
+    to something viewable; this is a preview, not the data.
     """
     try:
         import numpy as np
 
+        from fibsem.fm.preview import is_fluorescence_image, load_projection
         from fibsem.server.images import preview_jpeg_bytes
 
-        if filename.lower().endswith((".tif", ".tiff")):
+        if is_fluorescence_image(path):
+            data, _ = load_projection(path)
+        elif filename.lower().endswith((".tif", ".tiff")):
             import tifffile
 
             data = np.squeeze(np.asarray(tifffile.imread(path)))
@@ -490,9 +494,16 @@ class AgentContext:
         cannot be placed (no pose, or an image without reprojection metadata)
         are listed under ``unplaced`` with the reason, never dropped silently.
 
-        Which items: the lamellae linked to the grid when any are; otherwise
-        every lamella with a pose, flagged ``linked: false`` — an experiment
-        from before grids were recorded still gets its glance view.
+        Which items: the lamellae linked to the grid when any are. With none
+        linked, an experiment that records a single grid falls back to every
+        posed lamella, flagged ``linked: false`` — an experiment from before
+        grids were recorded still gets its glance view; with several grids
+        that fallback would paint every grid with the same unrelated items, so
+        nothing is placed and the payload says why.
+
+        Fluorescence overviews carry the FM stack's own metadata, not a beam
+        state, so nothing can be reprojected onto them: markers are for SEM
+        and FIB overviews, and an FM file answers with that reason.
         """
         experiment = self._experiment
         if experiment is None:
@@ -508,6 +519,19 @@ class AgentContext:
                 "markers": [],
                 "error": f"No output named {filename!r} for grid {grid_name!r}.",
                 "filenames": self._recorded_grid_basenames(experiment, grid),
+            }
+        from fibsem.fm.preview import is_fluorescence_image
+
+        if is_fluorescence_image(match):
+            return {
+                "available": True,
+                "grid_name": grid_name,
+                "filename": filename,
+                "placeable": False,
+                "reason": "a fluorescence overview carries no beam reprojection "
+                "metadata; markers are placed on SEM and FIB overviews",
+                "markers": [],
+                "unplaced": [],
             }
         try:
             from fibsem.structures import FibsemImage
@@ -541,12 +565,22 @@ class AgentContext:
                 else None,
             },
             "convention": "source-image pixels, origin top-left, +y down",
+            "placeable": True,
             "markers": [],
             "unplaced": [],
         }
         linked = experiment.get_lamellae_for_grid(grid)
-        lamellae = linked if linked else list(experiment.positions)
         payload["linked"] = bool(linked)
+        if linked:
+            lamellae = linked
+        elif len(experiment.grids) <= 1:
+            lamellae = list(experiment.positions)
+        else:
+            lamellae = []
+            payload["reason"] = (
+                "no items are linked to this grid, and with several grids "
+                "recorded the experiment's items are not assumed to be on it"
+            )
         if state is None or state.stage_position is None:
             payload["unplaced"] = [
                 {"item_name": p.name, "reason": "image has no reprojection metadata"}

--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -166,6 +166,70 @@ def _rendered_preview(path: str, filename: str, max_width: int) -> Dict[str, Any
     }
 
 
+def _overview_projector(path: str):
+    """Open a recorded overview and return its scale block plus a projector.
+
+    The projector maps one stage position to a source-pixel Point through the
+    canvas's own reprojection for that kind of image: beam overviews
+    (FibsemImage) through ``reproject_stage_positions_onto_image2``,
+    fluorescence overviews (OME-TIFF) through
+    ``reproject_stage_positions_onto_fm_image``. Both raise, per position, when
+    the image lacks the metadata a projection needs; the caller records the
+    reason against the item rather than guessing. The scale block is what a
+    client needs to place the points on its rendition: source size, pixel size
+    (m), field width (m), the acquisition's stage position.
+    """
+    from fibsem.fm.preview import is_fluorescence_image
+
+    if is_fluorescence_image(path):
+        from fibsem.fm.reprojection import reproject_stage_positions_onto_fm_image
+        from fibsem.fm.structures import FluorescenceImage
+
+        image = FluorescenceImage.load(path)
+        height, width = image.data.shape[-2:]
+        metadata = image.metadata
+        stage = getattr(metadata, "stage_position", None)
+        block = {
+            "width": int(width),
+            "height": int(height),
+            "pixel_size": metadata.pixel_size_x if metadata else None,
+            "hfw": metadata.pixel_size_x * width if metadata else None,
+            "beam_type": "FM",
+            "stage_position": stage.to_dict() if stage is not None else None,
+        }
+
+        def project(position):
+            (point,) = reproject_stage_positions_onto_fm_image(image, [position])
+            return point
+
+        return block, project
+
+    from fibsem.imaging.tiling.reprojection import (
+        reproject_stage_positions_onto_image2,
+    )
+    from fibsem.structures import FibsemImage
+
+    image = FibsemImage.load(path)
+    height, width = image.data.shape[:2]
+    metadata = image.metadata
+    state = getattr(metadata, "microscope_state", None) if metadata else None
+    stage = state.stage_position if state is not None else None
+    block = {
+        "width": int(width),
+        "height": int(height),
+        "pixel_size": metadata.pixel_size.x if metadata else None,
+        "hfw": metadata.image_settings.hfw if metadata else None,
+        "beam_type": metadata.image_settings.beam_type.name if metadata else None,
+        "stage_position": stage.to_dict() if stage is not None else None,
+    }
+
+    def project(position):
+        (point,) = reproject_stage_positions_onto_image2(image, [position])
+        return point
+
+    return block, project
+
+
 class AgentContext:
     """Read-only facade over a running (or resting) AutoLamella session."""
 
@@ -486,13 +550,15 @@ class AgentContext:
     def grid_markers(self, grid_name: str, filename: str) -> Dict[str, Any]:
         """Where the experiment's items fall on one recorded overview.
 
-        Computed here, in source-image pixels, through the same reprojection
-        the overview canvas uses — so no client ever re-derives stage geometry
-        (the compucentric offset and canvas-origin traps live in one place).
-        ``image`` carries the scale contract: source size, pixel size, field
-        width, the stage position the overview was taken from. Items that
-        cannot be placed (no pose, or an image without reprojection metadata)
-        are listed under ``unplaced`` with the reason, never dropped silently.
+        Computed here, in source-image pixels, through the same reprojections
+        the overview canvases use — the beam one for SEM/FIB overviews, the FM
+        one for fluorescence overviews — so no client ever re-derives stage
+        geometry (the compucentric offset and canvas-origin traps live in one
+        place). ``image`` carries the scale contract: source size, pixel size,
+        field width, the stage position the overview was taken from. Items
+        that cannot be placed (no pose, or an image without the metadata its
+        projection needs) are listed under ``unplaced`` with the reason, never
+        dropped silently.
 
         Which items: the lamellae linked to the grid when any are. With none
         linked, an experiment that records a single grid falls back to every
@@ -500,10 +566,6 @@ class AgentContext:
         grids were recorded still gets its glance view; with several grids
         that fallback would paint every grid with the same unrelated items, so
         nothing is placed and the payload says why.
-
-        Fluorescence overviews carry the FM stack's own metadata, not a beam
-        state, so nothing can be reprojected onto them: markers are for SEM
-        and FIB overviews, and an FM file answers with that reason.
         """
         experiment = self._experiment
         if experiment is None:
@@ -520,23 +582,8 @@ class AgentContext:
                 "error": f"No output named {filename!r} for grid {grid_name!r}.",
                 "filenames": self._recorded_grid_basenames(experiment, grid),
             }
-        from fibsem.fm.preview import is_fluorescence_image
-
-        if is_fluorescence_image(match):
-            return {
-                "available": True,
-                "grid_name": grid_name,
-                "filename": filename,
-                "placeable": False,
-                "reason": "a fluorescence overview carries no beam reprojection "
-                "metadata; markers are placed on SEM and FIB overviews",
-                "markers": [],
-                "unplaced": [],
-            }
         try:
-            from fibsem.structures import FibsemImage
-
-            image = FibsemImage.load(match)
+            image_block, project = _overview_projector(match)
         except Exception as exc:  # noqa: BLE001 - a broken file is a data fact
             return {
                 "available": True,
@@ -545,27 +592,12 @@ class AgentContext:
                 "markers": [],
                 "error": f"Could not read {filename!r}: {exc}",
             }
-        metadata = image.metadata
-        state = getattr(metadata, "microscope_state", None) if metadata else None
-        height, width = image.data.shape[:2]
         payload: Dict[str, Any] = {
             "available": True,
             "grid_name": grid_name,
             "filename": filename,
-            "image": {
-                "width": int(width),
-                "height": int(height),
-                "pixel_size": metadata.pixel_size.x if metadata else None,
-                "hfw": metadata.image_settings.hfw if metadata else None,
-                "beam_type": metadata.image_settings.beam_type.name
-                if metadata
-                else None,
-                "stage_position": state.stage_position.to_dict()
-                if state is not None and state.stage_position is not None
-                else None,
-            },
+            "image": image_block,
             "convention": "source-image pixels, origin top-left, +y down",
-            "placeable": True,
             "markers": [],
             "unplaced": [],
         }
@@ -581,17 +613,7 @@ class AgentContext:
                 "no items are linked to this grid, and with several grids "
                 "recorded the experiment's items are not assumed to be on it"
             )
-        if state is None or state.stage_position is None:
-            payload["unplaced"] = [
-                {"item_name": p.name, "reason": "image has no reprojection metadata"}
-                for p in lamellae
-            ]
-            return payload
-
-        from fibsem.imaging.tiling.reprojection import (
-            reproject_stage_positions_onto_image2,
-        )
-
+        width, height = image_block["width"], image_block["height"]
         workflow = experiment.task_protocol.workflow_config
         for lamella in lamellae:
             pose = lamella.milling_pose
@@ -602,7 +624,7 @@ class AgentContext:
                 )
                 continue
             try:
-                (point,) = reproject_stage_positions_onto_image2(image, [position])
+                point = project(position)
             except Exception as exc:  # noqa: BLE001 - one bad pose must not hide the rest
                 payload["unplaced"].append(
                     {"item_name": lamella.name, "reason": str(exc)}

--- a/tests/server/test_app_router.py
+++ b/tests/server/test_app_router.py
@@ -517,3 +517,110 @@ def test_grid_workflow_plan_is_the_preflight_without_hardware(client, host):
     assert bad_grid["grid_names"] == ["grid-aspen", "grid-birch"]
     malformed = client.post("/app/workflow/grids/plan", headers=AUTH, json={})
     assert malformed.status_code == 422
+
+
+def test_fm_overview_previews_in_colour_and_markers_decline(
+    client, host, grid_with_overview
+):
+    """A fluorescence overview is an OME-TIFF stack: the preview composites it
+    channel-by-colour (a grey max-projection loses the channels), and markers
+    say why nothing can be reprojected onto it instead of a loader error."""
+    import numpy as np
+    from PIL import Image
+
+    from fibsem.applications.autolamella.structures import (
+        AutoLamellaTaskState,
+        AutoLamellaTaskStatus,
+    )
+    from fibsem.fm.structures import (
+        FluorescenceChannelMetadata,
+        FluorescenceImage,
+        FluorescenceImageMetadata,
+    )
+
+    experiment = host.experiment
+    grid = grid_with_overview
+    outdir = experiment.grid_path(grid) / "overview_fm"
+    outdir.mkdir(parents=True)
+    # Two channels, red and green, in separate corners: the composite must
+    # carry both hues, which a single-plane grey projection cannot.
+    data = np.zeros((2, 3, 64, 64), dtype=np.uint16)
+    data[0, :, :32, :32] = 4000
+    data[1, :, 32:, 32:] = 4000
+    channels = [
+        FluorescenceChannelMetadata(
+            name=f"Channel-{i:02d}",
+            excitation_wavelength=488.0,
+            power=0.5,
+            exposure_time=0.1,
+            gain=1.0,
+            offset=0.0,
+            color=colour,
+        )
+        for i, colour in enumerate(("red", "green"))
+    ]
+    metadata = FluorescenceImageMetadata(
+        acquisition_date="2026-01-01T00:00:00",
+        pixel_size_x=1e-7,
+        pixel_size_y=1e-7,
+        resolution=(64, 64),
+        channels=channels,
+        z_positions=[-1e-6, 0.0, 1e-6],
+    )
+    FluorescenceImage(data=data, metadata=metadata).save(
+        str(outdir / "overview.ome.tiff")
+    )
+    grid.task_history.append(
+        AutoLamellaTaskState(
+            name="overview_fm",
+            status=AutoLamellaTaskStatus.Completed,
+            outputs={"overview_fm": ["overview_fm/overview.ome.tiff"]},
+        )
+    )
+
+    served = client.get("/app/grids/grid-aspen/outputs/overview.ome.tiff", headers=AUTH)
+    assert served.status_code == 200
+    import io
+
+    rgb = np.asarray(Image.open(io.BytesIO(served.content)).convert("RGB")).astype(int)
+    top_left, bottom_right = rgb[8, 8], rgb[56, 56]
+    assert top_left[0] > 150 and top_left[1] < 80  # red corner
+    assert bottom_right[1] > 150 and bottom_right[0] < 80  # green corner
+
+    markers = client.get(
+        "/app/grids/grid-aspen/outputs/overview.ome.tiff/markers", headers=AUTH
+    ).json()
+    assert markers["placeable"] is False
+    assert markers["markers"] == [] and "error" not in markers
+    assert "fluorescence" in markers["reason"]
+
+    listed = client.get("/app/grids", headers=AUTH).json()["items"][0]["overviews"]
+    assert listed == {
+        "overview_sem": "overview.tif",
+        "overview_fm": "overview.ome.tiff",
+    }
+
+
+def test_unlinked_items_fall_back_only_on_a_single_grid_experiment(
+    client, host, grid_with_overview
+):
+    from fibsem.applications.autolamella.structures import GridRecord
+
+    experiment = host.experiment
+    for lamella in experiment.positions:
+        lamella.grid_id = None
+    # One grid recorded: every posed item is shown, flagged as unlinked.
+    body = client.get(
+        "/app/grids/grid-aspen/outputs/overview.tif/markers", headers=AUTH
+    ).json()
+    assert body["linked"] is False and body["placeable"] is True
+    assert len(body["markers"]) == 2
+
+    # A second grid: the same items would paint both grids, so neither gets them.
+    experiment.add_grid(GridRecord(name="grid-birch"))
+    body = client.get(
+        "/app/grids/grid-aspen/outputs/overview.tif/markers", headers=AUTH
+    ).json()
+    assert body["linked"] is False
+    assert body["markers"] == [] and body["unplaced"] == []
+    assert "several grids" in body["reason"]

--- a/tests/server/test_app_router.py
+++ b/tests/server/test_app_router.py
@@ -519,12 +519,13 @@ def test_grid_workflow_plan_is_the_preflight_without_hardware(client, host):
     assert malformed.status_code == 422
 
 
-def test_fm_overview_previews_in_colour_and_markers_decline(
+def test_fm_overview_previews_in_colour_and_places_markers(
     client, host, grid_with_overview
 ):
     """A fluorescence overview is an OME-TIFF stack: the preview composites it
     channel-by-colour (a grey max-projection loses the channels), and markers
-    say why nothing can be reprojected onto it instead of a loader error."""
+    go through the FM canvas's own reprojection, which reads the stage
+    position and hardware geometry the mosaic recorded."""
     import numpy as np
     from PIL import Image
 
@@ -537,9 +538,11 @@ def test_fm_overview_previews_in_colour_and_markers_decline(
         FluorescenceImage,
         FluorescenceImageMetadata,
     )
+    from fibsem.structures import FibsemHardwareGeometry, FibsemStagePosition
 
     experiment = host.experiment
     grid = grid_with_overview
+    centre = FibsemStagePosition(x=1e-3, y=-2e-3, z=0.0, r=0.0, t=0.0)
     outdir = experiment.grid_path(grid) / "overview_fm"
     outdir.mkdir(parents=True)
     # Two channels, red and green, in separate corners: the composite must
@@ -566,7 +569,20 @@ def test_fm_overview_previews_in_colour_and_markers_decline(
         resolution=(64, 64),
         channels=channels,
         z_positions=[-1e-6, 0.0, 1e-6],
+        stage_position=centre,
+        geometry=FibsemHardwareGeometry(
+            column_tilt=0,
+            fib_column_tilt=52,
+            shuttle_pre_tilt=0,
+            rotation_reference=0,
+            rotation_180=0,
+            is_compustage=True,
+            camera_tilt=180.0,
+        ),
     )
+    # The linked items sit at the beam overview's centre (the stage origin);
+    # put one at this mosaic's centre instead so it lands mid-image.
+    experiment.positions[0].milling_pose.stage_position = centre
     FluorescenceImage(data=data, metadata=metadata).save(
         str(outdir / "overview.ome.tiff")
     )
@@ -590,9 +606,16 @@ def test_fm_overview_previews_in_colour_and_markers_decline(
     markers = client.get(
         "/app/grids/grid-aspen/outputs/overview.ome.tiff/markers", headers=AUTH
     ).json()
-    assert markers["placeable"] is False
-    assert markers["markers"] == [] and "error" not in markers
-    assert "fluorescence" in markers["reason"]
+    assert markers["image"]["beam_type"] == "FM"
+    assert markers["image"]["width"] == 64 and markers["image"]["pixel_size"] == 1e-7
+    assert markers["unplaced"] == []
+    by_name = {m["item_name"]: m for m in markers["markers"]}
+    at_centre = by_name[experiment.positions[0].name]
+    assert at_centre["x"] == pytest.approx(32.0) and at_centre["y"] == pytest.approx(
+        32.0
+    )
+    assert at_centre["inside"] is True
+    assert by_name[experiment.positions[1].name]["inside"] is False
 
     listed = client.get("/app/grids", headers=AUTH).json()["items"][0]["overviews"]
     assert listed == {
@@ -613,7 +636,7 @@ def test_unlinked_items_fall_back_only_on_a_single_grid_experiment(
     body = client.get(
         "/app/grids/grid-aspen/outputs/overview.tif/markers", headers=AUTH
     ).json()
-    assert body["linked"] is False and body["placeable"] is True
+    assert body["linked"] is False
     assert len(body["markers"]) == 2
 
     # A second grid: the same items would paint both grids, so neither gets them.


### PR DESCRIPTION
Stacked on #768. Three findings from the first agent-driven screening run on the sim (Grid-01 + Grid-03, SEM + FM overviews), fixed in the layer they belong to:

- **FM previews were grey.** The fluorescence overview is an OME-TIFF stack and `_rendered_preview` max-projected it through tifffile like any TIFF, discarding the channels. It now composites through `fibsem.fm.preview.load_projection` — the FM canvas's own projection — so each channel keeps its colour. Applies to item-card fluorescence images too. Verified on the run's real 7×7 mosaic: ~27 % of pixels red-dominant (the red fluorescence channel over the grey reflected one) where the old path gave none.
- **FM markers returned a loader error** ("Invalid Data format for Fibsem Image") because the endpoint tried `FibsemImage.load` on the stack. The mosaic records the stage position and hardware geometry it was captured under, and `fibsem.fm.reprojection.reproject_stage_positions_onto_fm_image` projects onto it — the way the Overview tab already draws positions on FM overviews. A small projector factory now picks the canvas's own reprojection per image kind (beam or FM) and hands back the scale block (`beam_type: "FM"`, pixel size, field width, stage position) beside it; the per-item loop is shared. An FM image from before the geometry was recorded refuses per item with the reprojection's own reason, as a beam image without a stage position does. Verified on the run's real mosaic: the acquisition position lands at the image centre.
- **The `linked: false` fallback** (every posed lamella when none is linked to the grid) is right for a one-grid experiment and noise on a multi-grid one — the live run painted "3 off image" on every panel. It now applies only when the experiment records a single grid; otherwise nothing is placed and the payload says why.

The dashboard needs no change for any of this: it draws whatever markers the server sends, so FM panels now get them too.

Test-fixture trap worth knowing: a `FluorescenceImage` saved without `z_positions` reloads with C and Z swapped (the loader disambiguates the axis order from the metadata), which looks like a broken composite. Real mosaics carry them.

Two files.

Release-Note: Fluorescence overviews and images preview in their channel colours in the dashboard and agent API, and lamella markers are now placed on fluorescence overviews as well as SEM/FIB ones.
