### PR TITLE
[deps] napari moves out of [ui] into a new [labelling] extra (FIB-407)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -53,11 +53,10 @@ jobs:
         python -m pip install --upgrade pip
         # UI deps (the [ui] extra) are intentionally not installed *here*. Not
         # because the tests that need them do not matter -- the `ui-tests` job
-        # below runs every one of them -- but because installing napari adds 100
-        # packages and 116 MB to a job that runs eight times, and registers three
-        # pytest plugins (napari, napari-plugin-engine, npe2) into the session,
-        # one of them an autouse fixture that would run around all 2000-odd tests
-        # here to serve none of them.
+        # below runs every one of them -- but because Qt is dead weight on a job
+        # that runs eight times. (napari used to be the bigger reason: 100
+        # packages, 116 MB and three pytest plugins. It is in [labelling] now and
+        # no CI job installs it.)
         python -m pip install ".[test]"
     - name: Install the plugin entry point fixture
       # A packaged plugin is the only way into two of the three extension

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,9 @@ Two reasons, both of which have produced confidently wrong reports:
 - **napari cannot be constructed under `QT_QPA_PLATFORM=offscreen`** — its GL canvas
   aborts the process with no traceback. Any test of a napari path is therefore against a
   stub, and proves nothing about the real widget.
-- **CI installs `.[test]`, not `.[ui]`.** The Qt tests `importorskip` there. A UI test you
-  watched pass locally may not have run in CI at all.
+- **CI's build matrix installs `.[test]`, not `.[ui]`.** The Qt tests `importorskip` there
+  and run only in the `ui-tests` job; nothing installs `[labelling]`, so napari paths never
+  run on CI. A UI test you watched pass locally may not have run in CI at all.
 
 For anything about wiring, say plainly that you have not run the application, or run it.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,9 +123,10 @@ minutes; run it before pushing rather than after every edit.
 QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_something.py -q
 ```
 
-**CI is thinner than a development environment.** It installs `.[test]`, not `.[ui]`, so
-the napari and PyQt5 tests `importorskip` and are skipped there. A UI test passing locally
-is not evidence CI ran it.
+**CI is thinner than a development environment.** The build matrix installs `.[test]`, not
+`.[ui]`, so the PyQt5 tests `importorskip` and are skipped there; only the `ui-tests` job
+runs them. No job installs `[labelling]`, so nothing that needs napari runs on CI at all. A
+UI test passing locally is not evidence CI ran it.
 
 **Prefer real objects to stand-ins.** A fake encodes the author's assumption about the
 collaborator, so the test can only confirm that assumption and never contradict it. Before

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ conda activate fibsem
 pip install -e '.[ui]'
 ```
 
+Image labelling (`fibsem_label`) draws in napari, which is not part of `[ui]`; add
+the `[labelling]` extra for it:
+
+```bash
+pip install -e '.[ui,labelling]'
+```
+
 To run:
 ```bash
 fibsem-autolamella-ui

--- a/fibsem/ui/FibsemLabellingUI.py
+++ b/fibsem/ui/FibsemLabellingUI.py
@@ -4,7 +4,13 @@ import os
 import sys
 from typing import Optional
 
-import napari
+try:
+    import napari
+except ImportError as _e:  # pragma: no cover - exercised only on a napari-less install
+    raise ImportError(
+        "Image labelling draws in napari, which is no longer part of the [ui] extra. "
+        "Install it with: pip install 'fibsem[labelling]'"
+    ) from _e
 import napari.utils.notifications
 import numpy as np
 import yaml
@@ -126,7 +132,7 @@ SAM_MASK_LAYER_PROPERTIES = {
 CONFIGURATION = {
     "IMAGES": {
         "FILE_EXT": ".tif",
-        "SUPPORTED_FILE_EXT": [".tif", ".png", ".jpg", ".jpeg"]
+        "SUPPORTED_FILE_EXT": [".tif", ".png", ".jpg", ".jpeg"],
     },
     "LABELS": {
         "COLOR_MAP": CLASS_COLORS,
@@ -148,8 +154,9 @@ CONFIGURATION = {
     "TOOLTIPS": {
         "AUTOSAVE": "Automatically save the image when moving to the next image",
         "SAVE_RGB": "Save the RGB mask when saving the image. This is in additional to the class mask, and is only for visualisation purposes.",
-    }
+    },
 }
+
 
 # ref (other sam labelling tools):
 # https://github.com/JoOkuma/napari-segment-anything (Apache License 2.0)
@@ -167,12 +174,12 @@ class FibsemLabellingUI(QtWidgets.QDialog):
 
         self.img_layer: NapariImageLayer = None
         self.mask_layer: NapariLabelsLayer = None
-        
+
         # sam
         self.sam_mask_layer: NapariLabelsLayer = None
-        self.sam_pts_layer: NapariPointsLayer = None   
-        self.logits: np.ndarray = None          # sam logits
-        self.image: np.ndarray = None           # sam image
+        self.sam_pts_layer: NapariPointsLayer = None
+        self.logits: np.ndarray = None  # sam logits
+        self.image: np.ndarray = None  # sam image
 
         # widget
         self.model_widget = FibsemSegmentationModelWidget()
@@ -180,10 +187,16 @@ class FibsemLabellingUI(QtWidgets.QDialog):
         self.setup_connections()
 
         if _DEBUG:
-            self.lineEdit_data_path.setText("/home/patrick/github/data/autolamella-paper/model-development/train/serial-liftout/train")
-            self.lineEdit_labels_path.setText("/home/patrick/github/fibsem/fibsem/log/labels2")
-            self.model_widget.lineEdit_checkpoint.setText("autolamella-serial-liftout-20240107.pt")
-    
+            self.lineEdit_data_path.setText(
+                "/home/patrick/github/data/autolamella-paper/model-development/train/serial-liftout/train"
+            )
+            self.lineEdit_labels_path.setText(
+                "/home/patrick/github/fibsem/fibsem/log/labels2"
+            )
+            self.model_widget.lineEdit_checkpoint.setText(
+                "autolamella-serial-liftout-20240107.pt"
+            )
+
     def _setup_ui(self):
         """Hand-built replacement for the former Qt Designer form.
 
@@ -300,7 +313,9 @@ class FibsemLabellingUI(QtWidgets.QDialog):
         self.model_widget.checkpoint_seg_button.clicked.connect(self.select_filepath)
         self.pushButton_data_config.clicked.connect(self.select_filepath)
         self.lineEdit_data_config.setText(CLASS_CONFIG_PATH)
-        self.comboBox_data_file_ext.addItems(CONFIGURATION["IMAGES"]["SUPPORTED_FILE_EXT"])
+        self.comboBox_data_file_ext.addItems(
+            CONFIGURATION["IMAGES"]["SUPPORTED_FILE_EXT"]
+        )
 
         self.tabWidget.addTab(self.model_widget, "Model")
 
@@ -324,9 +339,15 @@ class FibsemLabellingUI(QtWidgets.QDialog):
 
         # style
         self.pushButton_load_data.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
-        self.model_widget.pushButton_load_model.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
-        self.pushButton_model_confirm.setStyleSheet(stylesheets.CONFIRM_BUTTON_STYLESHEET)
-        self.pushButton_model_clear.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.model_widget.pushButton_load_model.setStyleSheet(
+            stylesheets.PRIMARY_BUTTON_STYLESHEET
+        )
+        self.pushButton_model_confirm.setStyleSheet(
+            stylesheets.CONFIRM_BUTTON_STYLESHEET
+        )
+        self.pushButton_model_clear.setStyleSheet(
+            stylesheets.SECONDARY_BUTTON_STYLESHEET
+        )
 
         # tooltips
         self.checkBox_autosave.setToolTip(CONFIGURATION["TOOLTIPS"]["AUTOSAVE"])
@@ -351,12 +372,16 @@ class FibsemLabellingUI(QtWidgets.QDialog):
             if path is not None and path != "":
                 self.model_widget.lineEdit_checkpoint.setText(path)
         elif self.sender() == self.pushButton_data_config:
-            path = open_existing_file_dialog(msg="Select Configuration File", path=CLASS_CONFIG_PATH, _filter="*.yaml")
+            path = open_existing_file_dialog(
+                msg="Select Configuration File",
+                path=CLASS_CONFIG_PATH,
+                _filter="*.yaml",
+            )
             if path is not None and path != "":
                 self.lineEdit_data_config.setText(path)
 
                 with open(path) as f:
-                    CLASS_CONFIG = yaml.load(f, Loader=yaml.FullLoader) 
+                    CLASS_CONFIG = yaml.load(f, Loader=yaml.FullLoader)
 
                 CONFIGURATION["LABELS"]["COLOR_MAP"] = CLASS_CONFIG["CLASS_COLORS"]
                 CONFIGURATION["LABELS"]["LABEL_MAP"] = CLASS_CONFIG["CLASS_LABELS"]
@@ -366,15 +391,17 @@ class FibsemLabellingUI(QtWidgets.QDialog):
         # read raw data
         data_path = self.lineEdit_data_path.text()
         labels_path = self.lineEdit_labels_path.text()
-        
+
         # create required directories
         os.makedirs(labels_path, exist_ok=True)
-        
-        # check if save and raw are the same 
+
+        # check if save and raw are the same
         if data_path == labels_path:
-            napari.utils.notifications.show_error("Save and Raw directories cannot be the same")
+            napari.utils.notifications.show_error(
+                "Save and Raw directories cannot be the same"
+            )
             return
-            
+
         # get filenames
         CONFIGURATION["IMAGES"]["FILE_EXT"] = self.comboBox_data_file_ext.currentText()
         file_ext = CONFIGURATION["IMAGES"]["FILE_EXT"]
@@ -400,7 +427,9 @@ class FibsemLabellingUI(QtWidgets.QDialog):
 
         # load filenames as single layer
         image_layer_config = CONFIGURATION["LAYERS"]["IMAGE"]
-        self.img_layer = self.viewer.open(filenames, name=image_layer_config["name"], stack=True)[0]
+        self.img_layer = self.viewer.open(
+            filenames, name=image_layer_config["name"], stack=True
+        )[0]
         self.img_layer.opacity = image_layer_config["opacity"]
         self.img_layer.blending = image_layer_config["blending"]
 
@@ -420,18 +449,21 @@ class FibsemLabellingUI(QtWidgets.QDialog):
         self.update_instructions()
 
         # TODO: fix this event, it just doesn't work?
-        # self.mask_layer.events.data.connect(self.save_image) 
+        # self.mask_layer.events.data.connect(self.save_image)
 
     def update_ui_elements(self):
         # update ui elements on data loaded
         n_labels = len(CONFIGURATION["LABELS"]["LABEL_MAP"])
-        ldict = CONFIGURATION['LABELS']['LABEL_MAP']
-        cdict = CONFIGURATION['LABELS']['COLOR_MAP']
-        label_map = [f"{i:02d} - {ldict.get(i, 'Unspecified')} ({cdict.get(i, 'Unspecified')})" for i in range(n_labels)]
+        ldict = CONFIGURATION["LABELS"]["LABEL_MAP"]
+        cdict = CONFIGURATION["LABELS"]["COLOR_MAP"]
+        label_map = [
+            f"{i:02d} - {ldict.get(i, 'Unspecified')} ({cdict.get(i, 'Unspecified')})"
+            for i in range(n_labels)
+        ]
         self.comboBox_model_class_index.clear()
         self.comboBox_model_class_index.addItems(label_map)
 
-    def previous_image(self , event: Optional[Event] = None) -> None:
+    def previous_image(self, event: Optional[Event] = None) -> None:
         idx = int(self.viewer.dims.point[0])
         idx -= 1
         idx = np.clip(idx, 0, len(self.filenames) - 1)
@@ -455,14 +487,13 @@ class FibsemLabellingUI(QtWidgets.QDialog):
         # only resave the labels...
         label = np.asarray(self.mask_layer.data).astype(np.uint8)
 
-        im = Image.fromarray(label) # TODO: replace with tifffile?
+        im = Image.fromarray(label)  # TODO: replace with tifffile?
         im.save(os.path.join(self.labels_path, f"{bname}{file_ext}"))
-        
+
         logging.info(f"Saving mask to {os.path.basename(fname)}")
 
         # optionally save an rgb mask (for easy visualisation)
         if CONFIGURATION["SAVE"]["SAVE_RGB"] and self.checkBox_save_rgb.isChecked():
-            
             colormap = CONFIGURATION["LABELS"]["COLOR_MAP"]
             colormap_rgb = convert_color_names_to_rgb(colormap)
 
@@ -475,30 +506,29 @@ class FibsemLabellingUI(QtWidgets.QDialog):
 
             logging.info(f"Saving RGB mask to {os.path.join(RGB_PATH, f'{bname}.png')}")
 
-    
     def update_viewer_to_image(self, idx: int):
         self.viewer.dims.set_point(0, idx)
 
     def update_image(self):
         """Update the current image when the index is changed.
         Attempt to autosave the previous image"""
-        
+
         idx = int(self.viewer.dims.point[0])
         logging.info(f"UPDATING IMAGE: LAST IDX: {self.last_idx}, CURRENT IDX {idx}")
-        
+
         # save previous image
         if self.last_idx != idx:
             if self.checkBox_autosave.isChecked():
                 self.save_image()
-            self.last_idx = idx # update last index
-        
+            self.last_idx = idx  # update last index
+
         # update mask layer
         self.mask_layer.data = self.get_label_image()
 
         # set active layers
         if self.model is not None:
             if self.model_type == "SegmentAnythingModel":
-                self.model.is_image_set = False # TODO: implement this, so we don't have to recompute the image embedding each time
+                self.model.is_image_set = False  # TODO: implement this, so we don't have to recompute the image embedding each time
                 self.logits = None
                 self.image = None
         self.set_active_layers()
@@ -516,18 +546,17 @@ class FibsemLabellingUI(QtWidgets.QDialog):
     def update_instructions(self):
         """Update instructions based on the current state of the UI"""
         # display instructions
-        msg=""
+        msg = ""
 
         if not self.is_data_loaded:
             msg = INSTRUCTIONS["START"]
-        else: 
+        else:
             msg = INSTRUCTIONS["READY"]
 
-            if self.model is None: 
+            if self.model is None:
                 msg += INSTRUCTIONS["MODEL_NOT_LOADED"]
 
             elif self.model is not None:
-
                 if self.model_type == "SegmentAnythingModel":
                     msg += INSTRUCTIONS["SAM_MODEL_LOADED"]
                 else:
@@ -540,14 +569,14 @@ class FibsemLabellingUI(QtWidgets.QDialog):
         Multi-step process:
             1. Check if a label image exists for the current image. If so, load it.
             2. If no label image exists, check if a model is loaded. If so, use the model to generate a label image.
-            3. Otherwise, return a blank image.        
+            3. Otherwise, return a blank image.
         Returns:
             np.ndarray: label image
         """
 
         idx = int(self.viewer.dims.point[0])
         fname = self.filenames[idx]
-        image = np.asarray(self.img_layer.data[idx]) # req for lazy load
+        image = np.asarray(self.img_layer.data[idx])  # req for lazy load
 
         logging.info(f"IDX: {idx}, Loading image from {os.path.basename(fname)}")
 
@@ -590,13 +619,15 @@ class FibsemLabellingUI(QtWidgets.QDialog):
     def load_model(self):
         """Load the model and update the UI based on the selected model"""
         self.model = self.model_widget.model
-        self.model_type =  self.model_widget.model_type
-        self.label_model_info.setText(f"Model: {os.path.basename(self.model.checkpoint)}")
+        self.model_type = self.model_widget.model_type
+        self.label_model_info.setText(
+            f"Model: {os.path.basename(self.model.checkpoint)}"
+        )
 
         # specific layers for SAM model
         if self.model_type == "SegmentAnythingModel":
             self.add_sam_pts_layer()
-            
+
             self.pushButton_model_confirm.clicked.connect(self.accept_sam_mask)
             self.pushButton_model_clear.clicked.connect(self.clear_sam_data)
             self.pushButton_model_confirm.setVisible(True)
@@ -624,10 +655,10 @@ class FibsemLabellingUI(QtWidgets.QDialog):
         self.sam_pts_layer.mode = "add"
 
     def _mouse_button_modifier(self, layer: NapariPointsLayer, event: Event) -> None:
-        """Use the mouse button modifier to set the point prompt 
+        """Use the mouse button modifier to set the point prompt
         type (left click = positive, right click = negative)"""
         self.sam_pts_layer.selected_data = []
-         # prompt schema: 1: pos, 0: neg, -1: background
+        # prompt schema: 1: pos, 0: neg, -1: background
         if event.button == 1:
             self.sam_pts_layer.current_face_color = "blue"
             self.sam_pts_layer.current_properties = {"prompt": 1}
@@ -648,15 +679,17 @@ class FibsemLabellingUI(QtWidgets.QDialog):
         # prepare image for sam model (requires rgb)
         if self.image is None:
             idx = int(self.viewer.dims.point[0])
-            image = np.asarray(self.img_layer.data[idx]) # req for lazy load
+            image = np.asarray(self.img_layer.data[idx])  # req for lazy load
             self.image = Image.fromarray(image).convert("RGB")
 
         # TODO: dont' recompute image embedding each time
-        mask, score, self.logits = self.model.predict(image=self.image, 
-                                                points=points, 
-                                                labels=points_labels, 
-                                                input_masks=self.logits,
-                                                multimask_output=False)
+        mask, score, self.logits = self.model.predict(
+            image=self.image,
+            points=points,
+            labels=points_labels,
+            input_masks=self.logits,
+            multimask_output=False,
+        )
 
         # add layer for mask
         try:
@@ -667,7 +700,7 @@ class FibsemLabellingUI(QtWidgets.QDialog):
                 data=mask,
                 name=sam_mask_config["name"],
                 opacity=sam_mask_config["opacity"],
-                blending= sam_mask_config["blending"],
+                blending=sam_mask_config["blending"],
                 colormap=sam_mask_config["colormap"],
             )
 
@@ -732,7 +765,7 @@ class FibsemLabellingUI(QtWidgets.QDialog):
         if self.mask_layer is not None:
             self.mask_layer.selected_label = cidx
 
-    def clear_sam_data(self, event = None) -> None:
+    def clear_sam_data(self, event=None) -> None:
         """Clear SAM points and mask data layers"""
         # clear points
         # TODO: find the proper way to do this, not doing this way causes issues with face colour
@@ -751,6 +784,7 @@ class FibsemLabellingUI(QtWidgets.QDialog):
             pass
         event.accept()
 
+
 def main():
     viewer = napari.Viewer(ndisplay=2)
     fibsem_labelling_ui = FibsemLabellingUI(viewer=viewer)
@@ -759,7 +793,6 @@ def main():
         area="right",
         add_vertical_stretch=True,
         name=f"OpenFIBSEM v{get_version_string()} - Image Labelling",
-
     )
     napari.run()
 

--- a/fibsem/ui/FibsemSegmentationModelWidget.py
+++ b/fibsem/ui/FibsemSegmentationModelWidget.py
@@ -1,5 +1,10 @@
-
-import napari
+try:
+    import napari
+except ImportError as _e:  # pragma: no cover - exercised only on a napari-less install
+    raise ImportError(
+        "Image labelling draws in napari, which is no longer part of the [ui] extra. "
+        "Install it with: pip install 'fibsem[labelling]'"
+    ) from _e
 import napari.utils.notifications
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import pyqtSignal
@@ -25,6 +30,7 @@ AVAILABLE_MODELS = ["SegmentationModel"]
 if SEGMENT_ANYTHING_AVAIABLE:
     AVAILABLE_MODELS.append("SegmentAnythingModel")
 RECOMMENDED_SAM_CHECKPOINTS = ["facebook/sam-vit-base", "Zigeng/SlimSAM-uniform-50"]
+
 
 class FibsemSegmentationModelWidget(QtWidgets.QDialog):
     continue_signal = pyqtSignal(DetectedFeatures)
@@ -94,7 +100,6 @@ class FibsemSegmentationModelWidget(QtWidgets.QDialog):
             self.lineEdit_checkpoint.setToolTip("Please use a pretrained model.")
             self.checkpoint_seg_button.setEnabled(True)
         elif model_type == "SegmentAnythingModel":
-
             self.lineEdit_checkpoint.setText(RECOMMENDED_SAM_CHECKPOINTS[0])
             self.lineEdit_checkpoint.setToolTip(f"""Any supported transformer SAM model from HuggingFace can be used. 
                                                 \nRecommended: 
@@ -110,17 +115,20 @@ class FibsemSegmentationModelWidget(QtWidgets.QDialog):
 
         self.pushButton_load_model.setEnabled(False)
         self.pushButton_load_model.setText("Loading...")
-        self.pushButton_load_model.setStyleSheet(stylesheets.USER_ATTENTION_BUTTON_STYLESHEET)
-        self.pushButton_load_model.setToolTip("Downloading model... check terminal for progress...")
+        self.pushButton_load_model.setStyleSheet(
+            stylesheets.USER_ATTENTION_BUTTON_STYLESHEET
+        )
+        self.pushButton_load_model.setToolTip(
+            "Downloading model... check terminal for progress..."
+        )
 
         worker = self.load_model_worker(model_type=model_type, checkpoint=checkpoint)
         worker.finished.connect(self.load_model_finished)
         worker.start()
 
-
     @thread_worker
     def load_model_worker(self, model_type: str, checkpoint: str):
-        
+
         if model_type == "SegmentationModel":
             self.model = load_model(checkpoint=checkpoint)
 
@@ -143,16 +151,16 @@ class FibsemSegmentationModelWidget(QtWidgets.QDialog):
             print(f"Loaded: {self.model}, {self.model.device}, {self.model.checkpoint}")
             self.model_loaded.emit()
 
+
 def main():
 
-    viewer  = napari.Viewer()
+    viewer = napari.Viewer()
     widget = FibsemSegmentationModelWidget()
-    viewer.window.add_dock_widget(widget, 
-                                  area="right", 
-                                  name="Fibsem Segmentation Model")
+    viewer.window.add_dock_widget(
+        widget, area="right", name="Fibsem Segmentation Model"
+    )
 
     napari.run()
-    
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,14 +57,25 @@ ml = [
     "kaleido==0.2.0",
     "transformers>=4.36.2",
 ]
+# The application UI. napari is NOT here any more: since #778 the main window
+# imports none of it, and it costs ~100 packages and 116 MB. It lives in
+# [labelling] below, for the two widgets that still draw with it.
 ui = [
-    "napari>=0.4.17; python_version < '3.9'",         # Python 3.8 support stops after 0.4.19
-    "napari>=0.5.1,<=0.5.6; python_version >= '3.9'", # NumPy 2 well supported from 0.5.1
     "pyqt5>=5.15.9",
     "pyqt5-qt5 == 5.15.2 ; platform_system == 'Windows'",
     "qtawesome>=1.4.0", # bundled Material Design Icons font (offline icon rendering); >=1.4.0 guards Spin.start/stop before first paint
 ]
 odemis = ["pylibtiff", "shapely"]
+
+# Image labelling and model-assisted segmentation (`fibsem_label`,
+# FibsemLabellingUI, FibsemSegmentationModelWidget) -- the one part of the tree
+# that still draws in napari (FIB-407). Pulls in [ui] for Qt and [ml] for the
+# models, since the labelling UI imports torch at module level.
+labelling = [
+    "fibsem[ui,ml]",
+    "napari>=0.4.17; python_version < '3.9'",         # Python 3.8 support stops after 0.4.19
+    "napari>=0.5.1,<=0.5.6; python_version >= '3.9'", # NumPy 2 well supported from 0.5.1
+]
 
 reporting = [
     "reportlab<3.6.13; python_version < '3.9'",
@@ -129,7 +140,7 @@ addopts = "-ra --strict-markers --strict-config"
 markers = [
     "slow: tests dominated by simulated-hardware timing (deselect with -m 'not slow')",
     "hardware_sim: drives the Demo microscope simulator end-to-end",
-    "ui: requires the [ui] extra (napari/pyqt5); auto-skipped when absent",
+    "ui: requires the [ui] extra (pyqt5); auto-skipped when absent",
     "integration: exercises multiple components together",
 ]
 # Treat warnings as errors so new deprecations fail fast. Add targeted `ignore`

--- a/tests/correlation/test_fit_settings_survive_image_change.py
+++ b/tests/correlation/test_fit_settings_survive_image_change.py
@@ -9,6 +9,7 @@ Not cosmetic: the config is read back when the dialog is accepted and written to
 `protocol.correlation` for every lamella, so a reset before close discarded the
 user's fit settings into the saved experiment.
 """
+
 import os
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -17,7 +18,7 @@ import numpy as np
 import pytest
 
 pytest.importorskip("PyQt5")
-pytest.importorskip("napari")
+pytest.importorskip("PyQt5")
 
 from fibsem.correlation.config import CorrelationConfig, FitSettings
 from fibsem.fm.structures import (
@@ -40,9 +41,14 @@ def _fm_image(channel_names, nz: int = 5) -> FluorescenceImage:
         resolution=(_SIZE, _SIZE),
         channels=[
             FluorescenceChannelMetadata(
-                name=name, color="#00ff00", excitation_wavelength=488,
-                emission_wavelength=509, power=1.0, exposure_time=0.1,
-                gain=1.0, offset=0.0,
+                name=name,
+                color="#00ff00",
+                excitation_wavelength=488,
+                emission_wavelength=509,
+                power=1.0,
+                exposure_time=0.1,
+                gain=1.0,
+                offset=0.0,
             )
             for name in channel_names
         ],
@@ -86,8 +92,12 @@ def test_a_new_volume_with_the_same_channels_changes_nothing(widget):
     """
     widget.set_fm_image(_fm_image(["GFP", "mCherry"]))
     _set_all_five(
-        widget, fib="Gaussian", fid_method="Hole", poi_method="None",
-        fid_ch="mCherry", poi_ch="GFP",
+        widget,
+        fib="Gaussian",
+        fid_method="Hole",
+        poi_method="None",
+        fid_ch="mCherry",
+        poi_ch="GFP",
     )
     before = _read_all_five(widget)
 
@@ -102,8 +112,12 @@ def test_the_method_combos_are_never_touched_by_an_image_change(widget):
     channels must leave them alone."""
     widget.set_fm_image(_fm_image(["GFP", "mCherry"]))
     _set_all_five(
-        widget, fib="Gaussian", fid_method="Hole", poi_method="None",
-        fid_ch="GFP", poi_ch="mCherry",
+        widget,
+        fib="Gaussian",
+        fid_method="Hole",
+        poi_method="None",
+        fid_ch="GFP",
+        poi_ch="mCherry",
     )
 
     widget.set_fm_image(_fm_image(["DAPI", "Cy5", "TxRed"]))
@@ -164,8 +178,12 @@ def test_what_is_read_back_for_the_protocol_reflects_the_user(widget):
     back on accept is persisted to protocol.correlation for every lamella."""
     widget.set_fm_image(_fm_image(["GFP", "mCherry"]))
     _set_all_five(
-        widget, fib="Gaussian", fid_method="Hole", poi_method="None",
-        fid_ch="mCherry", poi_ch="GFP",
+        widget,
+        fib="Gaussian",
+        fid_method="Hole",
+        poi_method="None",
+        fid_ch="mCherry",
+        poi_ch="GFP",
     )
 
     widget.set_fm_image(_fm_image(["GFP", "mCherry"]))

--- a/tests/ui/test_border_stylesheet.py
+++ b/tests/ui/test_border_stylesheet.py
@@ -5,12 +5,13 @@ lives in tests/test_border_stylesheet_single_source.py, which imports nothing an
 still runs on CI. This module needs the real ``fibsem.ui`` package, and importing any
 part of it pulls in Qt through ``fibsem/ui/__init__.py``, so it skips without PyQt5.
 """
+
 import re
 
 import pytest
 
 pytest.importorskip("PyQt5")
-pytest.importorskip("napari")
+pytest.importorskip("PyQt5")
 
 from fibsem.ui.stylesheets import (  # noqa: E402
     BORDER_STATE_COLOURS,
@@ -20,7 +21,7 @@ from fibsem.ui.stylesheets import (  # noqa: E402
 
 RULE = re.compile(
     r'QFrame#(?P<name>\w+)\[borderState="(?P<state>\w+)"\]\s*'
-    r'\{\s*border:\s*(?P<px>\d+)px solid (?P<colour>#[0-9A-Fa-f]{6});\s*\}'
+    r"\{\s*border:\s*(?P<px>\d+)px solid (?P<colour>#[0-9A-Fa-f]{6});\s*\}"
 )
 
 # Every widget that owns a border frame. Adding one here is the cheap way to keep

--- a/tests/ui/test_coincidence_viewer_layering.py
+++ b/tests/ui/test_coincidence_viewer_layering.py
@@ -22,7 +22,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 import pytest
 
 pytest.importorskip("PyQt5")
-pytest.importorskip("napari")
+pytest.importorskip("PyQt5")
 
 from PyQt5.QtWidgets import QApplication
 

--- a/tests/ui/test_configuration_import.py
+++ b/tests/ui/test_configuration_import.py
@@ -15,7 +15,7 @@ import shutil
 import pytest
 
 pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
-pytest.importorskip("napari")
+pytest.importorskip("PyQt5")
 
 import fibsem.config as cfg
 from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
@@ -72,8 +72,12 @@ def setup_widget(qapp, tmp_path, monkeypatch):
 
 def _import_file(widget, monkeypatch, path: str, set_as_default: bool = False):
     """Drive import_configuration_from_file with the dialogs answered for us."""
-    monkeypatch.setattr(widget_module, "open_existing_file_dialog", lambda **kwargs: path)
-    monkeypatch.setattr(widget_module, "message_box_ui", lambda **kwargs: set_as_default)
+    monkeypatch.setattr(
+        widget_module, "open_existing_file_dialog", lambda **kwargs: path
+    )
+    monkeypatch.setattr(
+        widget_module, "message_box_ui", lambda **kwargs: set_as_default
+    )
     widget.import_configuration_from_file()
 
 
@@ -82,7 +86,9 @@ def _items(widget) -> list:
     return [combo.itemText(i) for i in range(combo.count())]
 
 
-def test_imported_configuration_is_selectable(setup_widget, monkeypatch, configuration_file):
+def test_imported_configuration_is_selectable(
+    setup_widget, monkeypatch, configuration_file
+):
     """The reported crash: import a configuration, then select it."""
     widget = setup_widget
     path = configuration_file("meteor.yaml")
@@ -100,7 +106,9 @@ def test_imported_configuration_is_selectable(setup_widget, monkeypatch, configu
     assert not [t for t in widget.toasts if t[0] == "error"]
 
 
-def test_every_offered_name_resolves_to_a_path(setup_widget, monkeypatch, configuration_file):
+def test_every_offered_name_resolves_to_a_path(
+    setup_widget, monkeypatch, configuration_file
+):
     """The invariant the combo box depends on -- no entry may be unregistered."""
     widget = setup_widget
 
@@ -112,7 +120,9 @@ def test_every_offered_name_resolves_to_a_path(setup_widget, monkeypatch, config
         assert cfg.USER_CONFIGURATIONS.get(name, {}).get("path") is not None
 
 
-def test_reimporting_the_same_file_adds_no_duplicate(setup_widget, monkeypatch, configuration_file):
+def test_reimporting_the_same_file_adds_no_duplicate(
+    setup_widget, monkeypatch, configuration_file
+):
     widget = setup_widget
     path = configuration_file("meteor.yaml")
 
@@ -155,7 +165,9 @@ def test_declining_the_default_prompt_still_leaves_it_selectable(
     """Answering No to "make this the default?" must not strand the entry."""
     widget = setup_widget
 
-    _import_file(widget, monkeypatch, configuration_file("meteor.yaml"), set_as_default=False)
+    _import_file(
+        widget, monkeypatch, configuration_file("meteor.yaml"), set_as_default=False
+    )
 
     assert cfg.USER_CONFIGURATIONS_YAML["default"] == "default-configuration"
     assert cfg.USER_CONFIGURATIONS.get("meteor", {}).get("path") is not None

--- a/tests/ui/test_guided_setup_dialog.py
+++ b/tests/ui/test_guided_setup_dialog.py
@@ -808,7 +808,7 @@ def test_a_save_that_fails_leaves_the_dialog_open(dialog, monkeypatch):
 @pytest.fixture
 def connection_tab(qapp, isolated_state, monkeypatch):
     """The connection tab on a fresh install, since that is what most of these test."""
-    pytest.importorskip("napari")
+    pytest.importorskip("PyQt5")
     from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
 
     monkeypatch.setattr(
@@ -832,7 +832,7 @@ def test_writing_preferences_does_not_suppress_the_offer(
     that file -- for any preference -- also ended the first run, and the callout could
     not be reached at all.
     """
-    pytest.importorskip("napari")
+    pytest.importorskip("PyQt5")
     from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
 
     monkeypatch.setattr(
@@ -852,7 +852,7 @@ def test_writing_preferences_does_not_suppress_the_offer(
 
 def test_a_dismissed_offer_stays_dismissed(qapp, isolated_state, monkeypatch):
     """Dismissal is its own answer, not a side effect of anything else."""
-    pytest.importorskip("napari")
+    pytest.importorskip("PyQt5")
     from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
 
     monkeypatch.setattr(
@@ -889,7 +889,7 @@ def test_the_offer_is_absent_once_a_configuration_is_registered(
     monkeypatch.setattr(
         "fibsem.ui.notification_service.show_toast", lambda *a, **k: None
     )
-    pytest.importorskip("napari")
+    pytest.importorskip("PyQt5")
     from fibsem.ui.FibsemSystemSetupWidget import FibsemSystemSetupWidget
 
     cfg.register_configuration(

--- a/tests/ui/test_no_qt_warnings_on_workflow_load.py
+++ b/tests/ui/test_no_qt_warnings_on_workflow_load.py
@@ -31,6 +31,7 @@ check that used to be each caller's problem. So the second property is now
 pinned on what each row ends up drawing, plus a guard that no module goes back
 to naming the asset itself.
 """
+
 from contextlib import contextmanager
 from pathlib import Path
 from typing import List, Tuple
@@ -38,7 +39,7 @@ from typing import List, Tuple
 import pytest
 
 pytest.importorskip("PyQt5")
-pytest.importorskip("napari")
+pytest.importorskip("PyQt5")
 
 from PyQt5.QtCore import (  # noqa: E402
     Qt,

--- a/tests/ui/test_task_output_discovery.py
+++ b/tests/ui/test_task_output_discovery.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 pytest.importorskip("PyQt5")
-pytest.importorskip("napari")
+pytest.importorskip("PyQt5")
 
 from fibsem.applications.autolamella.structures import Lamella
 from fibsem.applications.autolamella.task_outputs import final_reference_images

--- a/tests/ui/test_task_row_layout.py
+++ b/tests/ui/test_task_row_layout.py
@@ -11,7 +11,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 import pytest
 
 pytest.importorskip("PyQt5")
-pytest.importorskip("napari")
+pytest.importorskip("PyQt5")
 
 from PyQt5.QtWidgets import QApplication, QGridLayout
 
@@ -96,7 +96,9 @@ def _render(tmp_path, resolution):
         pixel_size=Point(1e-7, 1e-7),
         microscope_state=MicroscopeState(),
     )
-    image = FibsemImage(data=np.zeros((height, width), dtype=np.uint8), metadata=metadata)
+    image = FibsemImage(
+        data=np.zeros((height, width), dtype=np.uint8), metadata=metadata
+    )
     path = image.save(str(tmp_path / f"ref_{width}x{height}.tif"))
 
     arr, _ = _load_and_resize(path)
@@ -104,7 +106,9 @@ def _render(tmp_path, resolution):
     return w, h
 
 
-@pytest.mark.parametrize("resolution", [(1536, 1024), (1024, 1024), (2048, 2048), (512, 1024)])
+@pytest.mark.parametrize(
+    "resolution", [(1536, 1024), (1024, 1024), (2048, 2048), (512, 1024)]
+)
 def test_every_tile_fits_the_placeholder_box(app, tmp_path, resolution):
     """A tile must never exceed the placeholder it replaces.
 


### PR DESCRIPTION
Stacked on #778. With that merged the main application imports no napari, so `[ui]` no longer needs the ~100 packages and 116 MB it brought along.

- **`[ui]`** is now PyQt5 + qtawesome only.
- **`[labelling]`** (new) is napari plus `fibsem[ui,ml]` — for `fibsem_label` / `FibsemLabellingUI` and `FibsemSegmentationModelWidget`, the two widgets that still draw with it. It pulls in `[ml]` because the labelling UI imports torch at module level (measured here: the import fails without `[ml]` today, before this change). Self-referencing extras resolve (`pip install --dry-run '.[labelling]'` passes).
- Both napari widgets raise an `ImportError` with `pip install 'fibsem[labelling]'` in it instead of a bare `ModuleNotFoundError`.
- **Nine UI test files** used `pytest.importorskip("napari")` as a proxy for "the `[ui]` extra is installed" and use no napari. Left alone they would have *silently skipped* in the `ui-tests` job once napari left the extra; they now guard on `PyQt5`. (118 tests across those files pass locally.)
- README, CONTRIBUTING, AGENTS.md, the `ui` pytest marker text and the CI workflow comment say where napari lives now. No CI job installs `[labelling]`, so napari paths never run on CI — stated in the docs rather than left implicit.

Includes `ruff format` churn in the touched files, from format-on-touch.