### PR TITLE
[stage] Inventory rows carry one state; get_inventory reads, run_inventory scans

### DIFF
--- a/fibsem/applications/autolamella/server/context.py
+++ b/fibsem/applications/autolamella/server/context.py
@@ -468,7 +468,7 @@ class AgentContext:
         """Every grid the experiment knows, with its latest recorded overviews.
 
         Records only — never the hardware inventory. Which slot a grid sits in
-        and whether it is in the beam are live stage facts, and this facade
+        and whether it is loaded are live stage facts, and this facade
         does not ask the instrument on an observer's behalf.
         """
         experiment = self._experiment
@@ -1184,7 +1184,7 @@ class AgentContext:
         recorded grids exactly as :meth:`start_grid_workflow` will. For
         ``screen_all`` the grids are whatever the inventory finds at run time,
         so the plan names the known grids and says so rather than guessing.
-        Exchanges are deliberately not counted: whether a grid is in the beam
+        Exchanges are deliberately not counted: whether a grid is loaded
         is a live stage fact this facade does not read.
         """
         from fibsem.applications.autolamella.workflows.tasks.grid.manager import (

--- a/fibsem/applications/autolamella/structures.py
+++ b/fibsem/applications/autolamella/structures.py
@@ -1317,7 +1317,7 @@ class GridRecord:
     hardware grid: all of that is resolved live against the stage, so a record
     stays valid when its grid changes slot or leaves the magazine. A record exists
     from the moment a grid is *available* (present in the inventory), so twelve
-    grids can be queued before any has been in the beam.
+    grids can be queued before any has been loaded.
 
     `task_state` and `task_history` are the same types the lamella side uses,
     and the same rule applies: never replace `task_state` wholesale, mutate it.

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -2596,7 +2596,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             return
         self.grids_tab.set_microscope(self.autolamella_ui.microscope)
         self.grid_workflow_widget.set_microscope(self.autolamella_ui.microscope)
-        # An exchange from Microscope -> Sample changes what is in the beam; the
+        # An exchange from Microscope -> Sample changes what is loaded; the
         # Grids tab's chips and the run view's rows follow. The Sample view is
         # rebuilt on every connect, so this is wired here, on every connect.
         sample = getattr(self.autolamella_ui, "sample_widget", None)
@@ -2895,7 +2895,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         """The Grids view's selection onto the end of the running grid queue.
 
         End only: a grid's block is a load and then its tasks, and "run next" would
-        put an exchange in front of the grid that is in the beam, then exchange
+        put an exchange in front of the grid that is loaded, then exchange
         back. The block goes after everything queued, where it costs one exchange.
         """
         from fibsem.applications.autolamella.workflows.tasks.grid.manager import (
@@ -3248,7 +3248,7 @@ class AutoLamellaSingleWindowUI(QMainWindow):
                 card.refresh()
             self.grid_workflow_widget.refresh_grid(grid)
             self.grids_tab.results_widget.refresh()
-            # The run's exchanges change what is in the beam; the Sample view
+            # The run's exchanges change what is loaded; the Sample view
             # draws from the stage and never polls it, so it is told here.
             sample = getattr(self.autolamella_ui, "sample_widget", None)
             if sample is not None:

--- a/fibsem/applications/autolamella/ui/grid_card_widget.py
+++ b/fibsem/applications/autolamella/ui/grid_card_widget.py
@@ -2,7 +2,7 @@
 
 The same card as a lamella's, so the two tabs read alike: a thumbnail, the name
 over a status line, a small icon for the person's verdict, and an actions menu.
-What the hardware says (in the beam, or gone from the magazine) is a chip. The
+What the hardware says (loaded, or gone from the magazine) is a chip. The
 card's object is the ``GridRecord``, not a hardware slot: the inventory entry
 arrives on every refresh and is only drawn.
 """
@@ -38,7 +38,7 @@ from fibsem.applications.autolamella.workflows.tasks.grid.manager import (
     LOAD_ENTRY_NAME as _LOAD_ENTRY_NAME,
 )
 from fibsem.config import CARD_MODES, MODE_COMPACT, MODE_COZY, MODE_STANDARD
-from fibsem.microscopes._stage import GridInventoryEntry
+from fibsem.microscopes._stage import GridInventoryEntry, GridSlotState
 from fibsem.ui import stylesheets
 from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.tokens import (
@@ -378,8 +378,8 @@ class GridCardWidget(QWidget):
         return self._entry is not None and self._entry.present
 
     @property
-    def in_beam(self) -> bool:
-        return self._entry is not None and self._entry.in_beam
+    def loaded(self) -> bool:
+        return self._entry is not None and self._entry.loaded
 
     def set_controls_enabled(self, enabled: bool) -> None:
         """The host's lockout while a workflow owns the loader."""
@@ -409,9 +409,11 @@ class GridCardWidget(QWidget):
             old.deleteLater()
         self._chip_widgets = []
         chips: List[Tuple[str, str]] = []
-        if not present:
+        if self._entry is not None and self._entry.state is GridSlotState.UNKNOWN:
+            chips.append(("not scanned", NEUTRAL_700))
+        elif not present:
             chips.append(("not present", NEUTRAL_700))
-        elif self.in_beam:
+        elif self.loaded:
             chips.append(("Loaded", OK_COLOR))
         for label, chip_colour in chips:
             widget = chip(label, chip_colour)
@@ -443,9 +445,9 @@ class GridCardWidget(QWidget):
         # Load brings a grid into the beam; only with a loader, and only for a grid
         # that is present and not already there. Unload for the one that is.
         can = self._controls_enabled
-        self._action_load.setVisible(self._has_loader and not self.in_beam)
+        self._action_load.setVisible(self._has_loader and not self.loaded)
         self._action_load.setEnabled(present and can)
-        self._action_unload.setVisible(self._has_loader and self.in_beam)
+        self._action_unload.setVisible(self._has_loader and self.loaded)
         self._action_unload.setEnabled(can)
         self._action_rename.setEnabled(can)
 

--- a/fibsem/applications/autolamella/ui/grid_workflow_widget.py
+++ b/fibsem/applications/autolamella/ui/grid_workflow_widget.py
@@ -3,7 +3,7 @@
 The run view for grids, beside the lamella one and sharing its chrome: the Run
 and Stop buttons, the timeline on the right, the confirmation before a start.
 Grid rows come from the experiment's records with the hardware's word on each
-(slot, in beam) drawn as chips; only a present grid can be ticked. Task rows
+(slot, loaded) drawn as chips; only a present grid can be ticked. Task rows
 come from the grid protocol in its order, and the order can be changed here.
 Settings live on Grids → Protocol.
 
@@ -43,7 +43,7 @@ from fibsem.applications.autolamella.workflows.tasks.grid.manager import (
     LOAD_ENTRY_NAME,
     plan_grid_run,
 )
-from fibsem.microscopes._stage import GridInventoryEntry
+from fibsem.microscopes._stage import GridInventoryEntry, GridSlotState
 from fibsem.ui import stylesheets
 from fibsem.ui.icon import (
     DRAG_HANDLE_HEIGHT,
@@ -142,8 +142,8 @@ class _GridRow(QWidget):
         return self._entry is not None and self._entry.present
 
     @property
-    def in_beam(self) -> bool:
-        return self._entry is not None and self._entry.in_beam
+    def loaded(self) -> bool:
+        return self._entry is not None and self._entry.loaded
 
     def set_inventory(self, entry: Optional[GridInventoryEntry]) -> None:
         self._entry = entry
@@ -167,9 +167,11 @@ class _GridRow(QWidget):
         self._chip_widgets = []
         entry = self._entry
         chips: List[Tuple[str, str]] = []
-        if entry is None or not entry.present:
+        if entry is not None and entry.state is GridSlotState.UNKNOWN:
+            chips.append(("not scanned", NEUTRAL_700))
+        elif entry is None or not entry.present:
             chips.append(("not present", NEUTRAL_700))
-        elif entry.in_beam:
+        elif entry.loaded:
             chips.append(("Loaded", OK_COLOR))
         for label, chip_colour in chips:
             widget = chip(label, chip_colour)
@@ -549,7 +551,7 @@ class GridWorkflowWidget(QWidget):
                 row.checkbox.setChecked(checked)
 
     def exchanges_for(self, grids: List[GridRecord]) -> int:
-        """How many of these grids are not in the beam now: the exchanges a run
+        """How many of these grids are not loaded now: the exchanges a run
         would make on a loader, zero on a fixed holder."""
         stage = self.stage
         if stage is None or stage.loader is None:
@@ -557,7 +559,7 @@ class GridWorkflowWidget(QWidget):
         count = 0
         for g in grids:
             row = self._grid_rows.get(g.name)
-            if row is not None and not row.in_beam:
+            if row is not None and not row.loaded:
                 count += 1
         return count
 
@@ -681,7 +683,7 @@ class GridRunPreflightDialog(QDialog):
             metric(
                 "Exchanges",
                 "one per grid" if screen_all else str(exchanges),
-                "" if exchanges or screen_all else "all in the beam",
+                "" if exchanges or screen_all else "all loaded",
             )
         )
         layout.addLayout(metrics)

--- a/fibsem/applications/autolamella/ui/grids_tab_widget.py
+++ b/fibsem/applications/autolamella/ui/grids_tab_widget.py
@@ -3,7 +3,7 @@
 Mirrors the Lamella tab: cards on the left, the selected grid's results on the
 right; the grid protocol is edited on the Protocol tab beside the lamella one. The tab's object is what grids are *available to this experiment*, not
 what the hardware holds; empty magazine slots never appear here (that is
-Microscope → Sample). Slot, present and in-beam are read from the stage's
+Microscope → Sample). Slot, present and loaded are read from the stage's
 inventory on every refresh and drawn as chips.
 
 Run inventory, Load and Unload are conveniences over the same ``Stage``
@@ -87,8 +87,8 @@ class GridsTabWidget(QWidget):
             fibsem_icon(ICON_INVENTORY, color=stylesheets.GRAY_ICON_COLOR)
         )
         self.btn_inventory.setToolTip(
-            "Run inventory: refresh what the hardware holds and add a record for "
-            "every grid it finds"
+            "Refresh: read what the hardware knows it holds and add a record for "
+            "every grid it finds. A magazine scan is on Microscope → Sample"
         )
         self.btn_inventory.clicked.connect(self._on_run_inventory)
 
@@ -280,20 +280,15 @@ class GridsTabWidget(QWidget):
         stage = self.stage
         if stage is None or self._experiment is None:
             return
-        if stage.loader is not None and not self._confirm(
-            "Run inventory",
-            "Scan the magazine? The autoloader checks every slot for a grid and "
-            "reads the names on the slot descriptions; it takes a moment and the "
-            "magazine must not be opened while it runs.",
-        ):
-            return
         experiment = self._experiment
 
         def job() -> None:
-            stage.run_inventory()
+            # A read: nothing moves, so nothing to ask. The physical scan lives
+            # on the Sample view, where the hardware is.
+            stage.get_inventory()
             experiment.sync_grids_from_inventory(stage)
 
-        self._start(job, "Running inventory…", "Inventory complete.")
+        self._start(job, "Reading inventory…", "Inventory read.")
 
     def _on_load(self, grid: GridRecord) -> None:
         stage = self.stage
@@ -303,7 +298,7 @@ class GridsTabWidget(QWidget):
         def job() -> None:
             stage.ensure_loaded(grid.name)
 
-        self._start(job, f"Loading {grid.name}…", f"{grid.name} is in the beam.")
+        self._start(job, f"Loading {grid.name}…", f"{grid.name} is loaded.")
 
     def _on_unload(self, grid: GridRecord) -> None:
         stage = self.stage

--- a/fibsem/applications/autolamella/workflows/tasks/grid/manager.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid/manager.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 # the exchanges fall and the timeline shows how each one went, and the history
 # entry the exchange leaves on the grid. Not a task in the protocol: loading is
 # the manager's job. It is in the queue so it can be *seen*, not so it can be
-# switched off -- a task whose grid is not in the beam loads it anyway, so
+# switched off -- a task whose grid is not loaded loads it anyway, so
 # removing or reordering a load item changes what is shown, never what runs.
 # Readable where it shows: the queue, the timeline, the summary, the history.
 LOAD_ENTRY_NAME = "Load grid"
@@ -255,7 +255,7 @@ class GridTaskManager(BaseTaskManager):
             status=status,
             error_message=None if loaded else self._not_loaded[grid.name],
             msg=(
-                f"Grid {grid.name} is in the beam."
+                f"Grid {grid.name} is loaded."
                 if loaded
                 else f"Grid {grid.name} could not be loaded."
             ),
@@ -273,13 +273,13 @@ class GridTaskManager(BaseTaskManager):
         if grid.name in self._not_loaded:
             return False
         stage = self.microscope._stage
-        in_beam = stage.holder.find_slot_by_grid_name(grid.name) is not None
+        loaded = stage.holder.find_slot_by_grid_name(grid.name) is not None
         entry = AutoLamellaTaskState(
             name=LOAD_ENTRY_NAME,
             task_type=LOAD_TASK_TYPE,
             status=AutoLamellaTaskStatus.InProgress,
         )
-        if not in_beam:
+        if not loaded:
             logging.info(f"Loading grid {grid.name}.")
             self._say(status_bar=f"Loading grid {grid.name}...")
         try:
@@ -296,7 +296,7 @@ class GridTaskManager(BaseTaskManager):
                 "Its remaining tasks in this run are skipped."
             )
             return False
-        if not in_beam:
+        if not loaded:
             entry.status = AutoLamellaTaskStatus.Completed
             entry.status_message = f"Loaded into {slot.name}."
             entry.end_timestamp = datetime.timestamp(datetime.now())

--- a/fibsem/applications/autolamella/workflows/tasks/grid/screening.py
+++ b/fibsem/applications/autolamella/workflows/tasks/grid/screening.py
@@ -3,7 +3,7 @@
 The Arctis user's real ask is "inventory all my grids and acquire the overviews".
 Nothing here is new; it is the order in which the pieces that exist get called,
 written once so the button, a script and the agent server run the same thing.
-On a fixed holder every present grid is already in the beam, so the same call
+On a fixed holder every present grid is already loaded, so the same call
 is a run with zero exchanges.
 """
 
@@ -31,7 +31,10 @@ def present_grids(
     """Refresh the inventory, record every present grid, and return their names
     in slot order. The selection "Screen all grids" runs over."""
     stage = microscope._stage
-    inventory = stage.run_inventory()
+    # A read, not a scan: the operator will have inventoried the magazine (in
+    # xT or from the Sample view), and a physical scan in front of every
+    # screening run is the wait this call exists to avoid.
+    inventory = stage.get_inventory()
     added = experiment.sync_grids_from_inventory(stage)
     if added:
         logging.info(f"Inventory added {len(added)} grid(s): {[g.name for g in added]}")

--- a/fibsem/microscopes/_stage.py
+++ b/fibsem/microscopes/_stage.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Tuple, Union
 
@@ -225,7 +226,7 @@ class SampleHolder:
 
     @property
     def occupied_slots(self) -> List["GridSlot"]:
-        """The working slots that hold a grid: what is in the beam right now."""
+        """The working slots that hold a grid: what is loaded right now."""
         return [
             s
             for s in sorted(self.slots.values(), key=lambda s: s.index)
@@ -378,23 +379,46 @@ class GridExchangeError(RuntimeError):
     """A grid could not be moved into, or out of, the holder's working slot."""
 
 
+class GridSlotState(str, Enum):
+    """Where a grid is, as one word: the state of an inventory slot.
+
+    ``UNKNOWN`` -- no inventory has answered for this slot yet; ``EMPTY`` -- the
+    slot holds no grid; ``OCCUPIED`` -- a grid is in the slot and not on the
+    microscope; ``LOADED`` -- the grid is in the microscope's sample holder. On a
+    fixed holder a named slot is LOADED outright: its grid is already in the
+    holder, and reaching it is only a stage move.
+    """
+
+    UNKNOWN = "unknown"
+    EMPTY = "empty"
+    OCCUPIED = "occupied"
+    LOADED = "loaded"
+
+
 @dataclass
 class GridInventoryEntry:
     """One row of ``Stage.grid_inventory()``: a slot, and what it holds.
 
     ``source`` says which hardware answered -- ``"magazine"`` on a system with a
-    loader, ``"holder"`` otherwise. ``present`` is whether the slot holds a grid;
-    ``in_beam`` whether that grid is in a holder working slot right now. The two
-    are kept apart on purpose: *available* is what a run can select from, *in beam*
-    is what it can act on without an exchange.
+    loader, ``"holder"`` otherwise. ``state`` is the one stored fact; ``present``
+    (the grid is available to the system) and ``loaded`` (it is in the holder
+    right now) are read off it. Kept apart on purpose: *present* is what a run
+    can select from, *loaded* is what it can act on without an exchange.
     """
 
     slot_name: str
     index: int
     source: str
     name: Optional[str]
-    present: bool
-    in_beam: bool
+    state: GridSlotState
+
+    @property
+    def present(self) -> bool:
+        return self.state in (GridSlotState.OCCUPIED, GridSlotState.LOADED)
+
+    @property
+    def loaded(self) -> bool:
+        return self.state is GridSlotState.LOADED
 
 
 class SampleGridLoader:
@@ -404,9 +428,9 @@ class SampleGridLoader:
     is distinct from the holder's working slot(s). ``load_grid`` moves a grid from a
     magazine slot into the working slot and ``unload_grid`` retracts it.
 
-    A magazine slot keeps its grid while that grid is in the beam: the slot is the
+    A magazine slot keeps its grid while that grid is loaded: the slot is the
     grid's home, and the working slot references the *same* ``SampleGrid``. So
-    "present" is read from the magazine and "in beam" from the holder, and neither
+    "present" is read from the magazine and "loaded" from the holder, and neither
     is cached anywhere else.
 
     Subclasses talk to hardware through ``_do_load`` / ``_do_unload`` /
@@ -418,6 +442,11 @@ class SampleGridLoader:
         self.parent = parent
         self.capacity = capacity
         self.slots: dict[str, GridSlot] = {}
+        # Until the hardware has answered, every slot is UNKNOWN; after a scan the
+        # slots it still could not read stay so. An in-memory magazine is known
+        # from the start.
+        self.scanned = False
+        self.unknown_slots: set = set()
         self._ensure_slots()
 
     def _ensure_slots(self) -> None:
@@ -474,9 +503,18 @@ class SampleGridLoader:
         slot.loaded_grid = grid
         self._write_slot_description(slot)
 
+    def get_inventory(self) -> List[GridSlot]:
+        """Read what the autoloader already knows about its magazine: instant,
+        nothing moves. Its answer is only as fresh as its own last scan."""
+        self._read_magazine()
+        self.scanned = True
+        return self.loaded_magazine_slots
+
     def run_inventory(self) -> List[GridSlot]:
-        """Ask the hardware which magazine slots hold a grid, then report them."""
+        """Have the autoloader scan the magazine, slot by slot: slow, and the
+        magazine must stay shut while it runs. Then report what it found."""
         self._scan_magazine()
+        self.scanned = True
         return self.loaded_magazine_slots
 
     # -- exchange ----------------------------------------------------------
@@ -520,8 +558,12 @@ class SampleGridLoader:
     def _do_unload(self, working_slot: GridSlot) -> None:
         """Physically retract the grid in the working slot."""
 
+    def _read_magazine(self) -> None:
+        """Refresh ``self.slots`` from what the hardware already knows. Nothing to
+        read in memory: the slots are the state."""
+
     def _scan_magazine(self) -> None:
-        """Refresh ``self.slots`` from the hardware. Nothing to scan in memory."""
+        """Refresh ``self.slots`` from a physical scan. Nothing to scan in memory."""
 
     def _write_slot_description(self, slot: GridSlot) -> None:
         """Persist a slot's grid name where the hardware keeps it."""
@@ -569,6 +611,7 @@ class DemoSampleLoader(SampleGridLoader):
                 )
             name = names.get(number, names.get(str(number))) or f"Grid-{number:02d}"
             slot.loaded_grid = SampleGrid(name=str(name))
+        self.scanned = True  # an in-memory magazine is known from the start
 
     def _do_load(self, slot: GridSlot) -> None:
         self._exchange()
@@ -653,34 +696,43 @@ class Stage:
         return slot.loaded_grid if slot is not None else None
 
     def grid_inventory(self) -> List[GridInventoryEntry]:
-        """Which grids exist this session, and which are in the beam. Derived, not stored.
+        """Which grids exist this session, and which are loaded. Derived, not stored.
 
-        With a loader the rows are the magazine slots and "in beam" means the grid is
+        With a loader the rows are the magazine slots and "loaded" means the grid is
         in a holder working slot. Without one the rows are the holder slots, and every
-        present grid is in the beam, because reaching it is only a stage move. Callers
+        present grid is loaded, because reaching it is only a stage move. Callers
         never need to know which case they got.
         """
-        if self.loader is not None:
-            in_beam = {s.loaded_grid.name for s in self.holder.occupied_slots}
-            slots = sorted(self.loader.slots.values(), key=lambda s: s.index)
+        loader = self.loader
+        if loader is not None:
+            loaded = {s.loaded_grid.name for s in self.holder.occupied_slots}
+            slots = sorted(loader.slots.values(), key=lambda s: s.index)
             source = "magazine"
         else:
-            in_beam = None
+            loaded = None
             slots = sorted(self.holder.slots.values(), key=lambda s: s.index)
             source = "holder"
 
         entries: List[GridInventoryEntry] = []
         for slot in slots:
             grid = slot.loaded_grid
-            present = grid is not None
+            if loader is not None and (
+                not loader.scanned or slot.name in loader.unknown_slots
+            ):
+                state = GridSlotState.UNKNOWN
+            elif grid is None:
+                state = GridSlotState.EMPTY
+            elif loaded is None or grid.name in loaded:
+                state = GridSlotState.LOADED
+            else:
+                state = GridSlotState.OCCUPIED
             entries.append(
                 GridInventoryEntry(
                     slot_name=slot.name,
                     index=slot.index,
                     source=source,
                     name=grid.name if grid is not None else None,
-                    present=present,
-                    in_beam=present and (in_beam is None or grid.name in in_beam),  # type: ignore[union-attr]
+                    state=state,
                 )
             )
         return entries
@@ -747,7 +799,7 @@ class Stage:
 
     @property
     def loaded_grids(self) -> List[SampleGrid]:
-        """The grids in the beam right now, read from the holder every time."""
+        """The grids loaded right now, read from the holder every time."""
         return [s.loaded_grid for s in self.holder.occupied_slots]  # type: ignore[misc]
 
     def ensure_loaded(self, grid_name: str) -> GridSlot:
@@ -792,11 +844,23 @@ class Stage:
 
     # -- naming and refreshing the inventory, on either shape --------------
 
-    def run_inventory(self) -> List[GridInventoryEntry]:
-        """Refresh what the hardware knows and return the inventory.
+    def get_inventory(self) -> List[GridInventoryEntry]:
+        """Read what the hardware knows and return the inventory: instant.
 
-        A magazine scan with a loader. On a fixed holder there is nothing to scan:
-        occupancy is what the operator declared, so this is a plain refresh.
+        With a loader, the autoloader's own record of its magazine, as fresh as
+        its last scan (xT's inventory counts). On a fixed holder occupancy is what
+        the operator declared, so this is a plain refresh.
+        """
+        if self.loader is not None:
+            self.loader.get_inventory()
+        return self.grid_inventory()
+
+    def run_inventory(self) -> List[GridInventoryEntry]:
+        """Scan the magazine and return the inventory: the slow one.
+
+        With a loader the autoloader checks every slot physically, which takes a
+        while and needs the magazine shut. On a fixed holder there is nothing to
+        scan, so it is the same refresh as ``get_inventory``.
         """
         if self.loader is not None:
             self.loader.run_inventory()

--- a/fibsem/microscopes/autoscript.py
+++ b/fibsem/microscopes/autoscript.py
@@ -383,15 +383,17 @@ class AutoscriptSampleLoader(SampleGridLoader):
 
     - A grid that is on the stage makes its magazine slot read ``Empty``. The slot
       is still that grid's home, so a rescan keeps the grid there while our working
-      slot holds it, and the inventory keeps saying "present, in beam".
-    - ``get_slots(False)`` returns last-known states, which may all be ``Unknown``
-      before any scan. Then, and only then, ``get_slots(True)`` runs a physical scan.
+      slot holds it, and the inventory keeps saying "present, loaded".
+    - ``get_slots(False)`` returns the autoloader's last-known states, which may
+      all be ``Unknown`` before any scan; ``get_slots(True)`` runs a physical scan.
+      ``get_inventory`` is the first, ``run_inventory`` the second, and the caller
+      chooses: a read is instant, a scan is not.
 
     Confirmed from operator code: the ``get_slots(bool)`` shape, the state strings,
     ``load(id)`` / ``unload()``, and ``autoloader.stage`` reporting what is on the
     microscope. Not verified on hardware: whether ``sample_description`` is writable
     (a refusal is logged, not raised). The magazine is not queried on construction;
-    call ``run_inventory()``.
+    call ``get_inventory()`` or ``run_inventory()``.
     """
 
     @property
@@ -407,15 +409,19 @@ class AutoscriptSampleLoader(SampleGridLoader):
 
     # -- inventory -----------------------------------------------------------
 
+    def _read_magazine(self) -> None:
+        self._apply_hardware_slots(list(self._autoloader.get_slots(False)))
+
     def _scan_magazine(self) -> None:
-        hw_slots = list(self._autoloader.get_slots(False))
-        if hw_slots and all(_slot_state(s) == "Unknown" for s in hw_slots):
-            hw_slots = list(self._autoloader.get_slots(True))
+        self._apply_hardware_slots(list(self._autoloader.get_slots(True)))
+
+    def _apply_hardware_slots(self, hw_slots: list) -> None:
         if hw_slots:
             self.capacity = len(hw_slots)
 
-        in_beam = {s.loaded_grid.name for s in self.holder.occupied_slots}
+        loaded = {s.loaded_grid.name for s in self.holder.occupied_slots}
         slots: dict = {}
+        unknown: set = set()
         for hw in hw_slots:
             number = int(hw.id)
             name = _slot_name(number - 1)
@@ -433,15 +439,15 @@ class AutoscriptSampleLoader(SampleGridLoader):
             elif (
                 previous is not None
                 and previous.loaded_grid is not None
-                and previous.loaded_grid.name in in_beam
+                and previous.loaded_grid.name in loaded
             ):
-                grid = (
-                    previous.loaded_grid
-                )  # its home; it reads Empty while in the beam
+                grid = previous.loaded_grid  # its home; it reads Empty while loaded
             elif state == "Unknown":
                 logging.warning(f"Autoloader slot {number} has not been scanned.")
+                unknown.add(name)
             slots[name] = GridSlot(name=name, index=number - 1, loaded_grid=grid)
         self.slots = slots
+        self.unknown_slots = unknown
 
         # Something may be on the stage that we did not load: reflect the hardware.
         stage = getattr(self._autoloader, "stage", None)

--- a/fibsem/ui/widgets/sample_loader_widget.py
+++ b/fibsem/ui/widgets/sample_loader_widget.py
@@ -54,6 +54,7 @@ _ICON_BTN = 26
 ICON_LOAD = "mdi:login"
 ICON_UNLOAD = "mdi:logout"
 ICON_INVENTORY = "mdi:refresh"
+ICON_SCAN = "mdi:magnify-scan"
 _ICON_BTN_STYLE = """
 QToolButton {
     background: transparent;
@@ -70,26 +71,31 @@ QToolButton:disabled { background: transparent; }
 # scanned since the magazine was opened) reads as empty until an inventory says
 # otherwise: the loader model does not carry the hardware's Unknown state.
 _STATE_COLOUR = {
-    "in_beam": OK_COLOR,
+    "unknown": NEUTRAL_700,
+    "loaded": OK_COLOR,
     "occupied": TEXT_COLOR,
     "empty": NEUTRAL_700,
 }
 _STATE_TEXT = {
-    "in_beam": "loaded",
+    "unknown": "unknown",
+    "loaded": "loaded",
     "occupied": "occupied",
     "empty": "empty",
 }
 _STATE_TIP = {
-    "in_beam": "This grid is in the holder's working slot right now",
+    "unknown": "Not read yet: run an inventory to find out what is in this slot",
+    "loaded": "This grid is in the holder's working slot right now",
     "occupied": "A grid is in this magazine slot; Load brings it into the beam",
     "empty": "Nothing in this magazine slot (or not scanned since the magazine was opened)",
 }
 
 
-def slot_state(slot: GridSlot, in_beam: bool) -> str:
+def slot_state(slot: GridSlot, loaded: bool) -> str:
+    """The row state for a slot the stage has answered for. UNKNOWN rows are
+    handed their state directly, from the inventory."""
     if slot.loaded_grid is None:
         return "empty"
-    return "in_beam" if in_beam else "occupied"
+    return "loaded" if loaded else "occupied"
 
 
 class _MagazineRow(QWidget):
@@ -100,10 +106,10 @@ class _MagazineRow(QWidget):
     unload_clicked = pyqtSignal(object)  # GridSlot
     grid_named = pyqtSignal(object, str)  # GridSlot, new name
 
-    def __init__(self, slot: GridSlot, in_beam: bool, parent=None) -> None:
+    def __init__(self, slot: GridSlot, state: str, parent=None) -> None:
         super().__init__(parent)
         self.slot = slot
-        self.state = "empty"
+        self.state = state
         self.setAttribute(Qt.WA_TranslucentBackground)
         self.setFixedHeight(_ROW_HEIGHT)
 
@@ -143,11 +149,11 @@ class _MagazineRow(QWidget):
         self.btn_action.clicked.connect(self._on_action)
         layout.addWidget(self.btn_action)
 
-        self.refresh(in_beam)
+        self.refresh(state)
 
-    def refresh(self, in_beam: bool, controls_enabled: bool = True) -> None:
+    def refresh(self, state: str, controls_enabled: bool = True) -> None:
         slot = self.slot
-        self.state = slot_state(slot, in_beam)
+        self.state = state
         grid = slot.loaded_grid
         name = grid.name if grid is not None else ""
         if self.name_edit.text() != name:
@@ -158,14 +164,14 @@ class _MagazineRow(QWidget):
         self.name_edit.setToolTip(
             "The grid in this slot; written to the autoloader's slot description"
             if grid is not None
-            else _STATE_TIP["empty"]
+            else _STATE_TIP[self.state if self.state == "unknown" else "empty"]
         )
         style_with_tooltip(
             self.dot,
             f"background: {_STATE_COLOUR[self.state]}; border-radius: 5px;",
         )
         self.dot.setToolTip(_STATE_TIP[self.state])
-        colour = TEXT_STRONG_COLOR if self.state == "in_beam" else TEXT_MUTED_COLOR
+        colour = TEXT_STRONG_COLOR if self.state == "loaded" else TEXT_MUTED_COLOR
         style_with_tooltip(
             self.state_label,
             f"color: {colour}; font-size: 11px; background: transparent;",
@@ -173,7 +179,7 @@ class _MagazineRow(QWidget):
         self.state_label.setText(_STATE_TEXT[self.state])
         self.state_label.setToolTip(_STATE_TIP[self.state])
 
-        if self.state == "in_beam":
+        if self.state == "loaded":
             self.btn_action.setIcon(
                 fibsem_icon(ICON_UNLOAD, color=stylesheets.GRAY_ICON_COLOR)
             )
@@ -200,7 +206,7 @@ class _MagazineRow(QWidget):
         self.btn_action.setEnabled(self.state != "empty" and controls_enabled)
 
     def _on_action(self) -> None:
-        if self.state == "in_beam":
+        if self.state == "loaded":
             self.unload_clicked.emit(self.slot)
         elif self.state == "occupied":
             self.load_clicked.emit(self.slot)
@@ -237,6 +243,7 @@ class SampleLoaderWidget(QWidget):
         self._busy = False
         self._controls_enabled = True
         self._scanned_at: Optional[datetime] = None
+        self._read_at: Optional[datetime] = None
         self._worker = None
         self._setup_ui()
         self.refresh()
@@ -263,10 +270,21 @@ class SampleLoaderWidget(QWidget):
             fibsem_icon(ICON_INVENTORY, color=stylesheets.GRAY_ICON_COLOR)
         )
         self.btn_inventory.setToolTip(
-            "Run inventory: ask the autoloader which magazine slots hold a grid, "
-            "and read their names"
+            "Refresh: read what the autoloader knows about its magazine. Instant; "
+            "as fresh as its last scan"
         )
-        self.btn_inventory.clicked.connect(self._on_run_inventory)
+        self.btn_inventory.clicked.connect(self._on_get_inventory)
+        # The scan is the slow one, and moves the magazine: it asks first.
+        self.btn_scan = QToolButton()
+        self.btn_scan.setFixedSize(_ICON_BTN, _ICON_BTN)
+        self.btn_scan.setIconSize(QSize(18, 18))
+        self.btn_scan.setStyleSheet(_ICON_BTN_STYLE)
+        self.btn_scan.setIcon(fibsem_icon(ICON_SCAN, color=stylesheets.GRAY_ICON_COLOR))
+        self.btn_scan.setToolTip(
+            "Scan magazine: the autoloader checks every slot for a grid. Takes a "
+            "while; the magazine must stay shut"
+        )
+        self.btn_scan.clicked.connect(self._on_run_inventory)
 
         self.facts_label = QLabel()
         self.facts_label.setWordWrap(True)
@@ -294,6 +312,7 @@ class SampleLoaderWidget(QWidget):
 
         self._panel = TitledPanel("Loader", content=inner, collapsible=True)
         self._panel.add_header_widget(self.btn_inventory)
+        self._panel.add_header_widget(self.btn_scan)
         layout.addWidget(self._panel)
 
     # -- model -----------------------------------------------------------------
@@ -307,12 +326,6 @@ class SampleLoaderWidget(QWidget):
     def busy(self) -> bool:
         return self._busy
 
-    def _in_beam_names(self) -> set:
-        loader = self.loader
-        if loader is None:
-            return set()
-        return {s.loaded_grid.name for s in loader.holder.occupied_slots}  # type: ignore[union-attr]
-
     def refresh(self) -> None:
         loader = self.loader
         self._list.clear()
@@ -322,12 +335,16 @@ class SampleLoaderWidget(QWidget):
             self.facts_label.setText("No autoloader on this system.")
             return
 
-        in_beam = self._in_beam_names()
+        states = {
+            e.slot_name: e.state.value for e in self._microscope._stage.grid_inventory()
+        }
         slots = sorted(loader.slots.values(), key=lambda s: s.index)
         occupied = sum(1 for s in slots if s.loaded_grid is not None)
         scanned = (
             f"scanned {self._scanned_at.strftime('%H:%M')}"
             if self._scanned_at is not None
+            else f"read {self._read_at.strftime('%H:%M')}, not scanned this session"
+            if self._read_at is not None
             else "not scanned this session"
         )
         plural = "" if occupied == 1 else "s"
@@ -337,11 +354,8 @@ class SampleLoaderWidget(QWidget):
 
         controls = self._controls_enabled and not self._busy
         for slot in slots:
-            row = _MagazineRow(
-                slot,
-                in_beam=bool(slot.loaded_grid) and slot.loaded_grid.name in in_beam,
-            )
-            row.refresh(row.state == "in_beam", controls_enabled=controls)
+            row = _MagazineRow(slot, states.get(slot.name, "unknown"))
+            row.refresh(row.state, controls_enabled=controls)
             row.load_clicked.connect(self._on_load)
             row.unload_clicked.connect(self._on_unload)
             row.grid_named.connect(self._on_grid_named)
@@ -368,8 +382,9 @@ class SampleLoaderWidget(QWidget):
     def _apply_controls(self) -> None:
         active = self._controls_enabled and not self._busy and self.loader is not None
         self.btn_inventory.setEnabled(active)
+        self.btn_scan.setEnabled(active)
         for row in self._rows:
-            row.refresh(row.state == "in_beam", controls_enabled=active)
+            row.refresh(row.state, controls_enabled=active)
 
     # -- edits -----------------------------------------------------------------
 
@@ -388,14 +403,24 @@ class SampleLoaderWidget(QWidget):
 
     # -- hardware, off the GUI thread --------------------------------------------
 
+    def _on_get_inventory(self) -> None:
+        if self.loader is None:
+            return
+
+        def job() -> None:
+            self._microscope._stage.get_inventory()
+            self._read_at = datetime.now()
+
+        self._start(job, "Reading the magazine…", "Inventory read.")
+
     def _on_run_inventory(self) -> None:
         loader = self.loader
         if loader is None:
             return
         if not self._confirm(
-            "Run inventory",
+            "Scan magazine",
             "Scan the magazine? The autoloader checks every slot for a grid and "
-            "reads the names on the slot descriptions; it takes a moment and the "
+            "reads the names on the slot descriptions; it takes a while and the "
             "magazine must not be opened while it runs.",
         ):
             return
@@ -404,7 +429,7 @@ class SampleLoaderWidget(QWidget):
             self._microscope._stage.run_inventory()
             self._scanned_at = datetime.now()
 
-        self._start(job, "Scanning the magazine…", "Inventory complete.")
+        self._start(job, "Scanning the magazine…", "Scan complete.")
 
     def _on_load(self, slot: GridSlot) -> None:
         loader = self.loader
@@ -415,7 +440,7 @@ class SampleLoaderWidget(QWidget):
         def job() -> None:
             loader.load_grid(slot.name)
 
-        self._start(job, f"Loading {name}…", f"{name} is in the beam.")
+        self._start(job, f"Loading {name}…", f"{name} is loaded.")
 
     def _on_unload(self, slot: GridSlot) -> None:
         loader = self.loader

--- a/tests/autolamella/test_grid_task_manager.py
+++ b/tests/autolamella/test_grid_task_manager.py
@@ -190,7 +190,7 @@ class TestOrderAndLoading:
             assert entry.status is Status.Completed
             assert "Slot-01" in entry.status_message
             assert entry.end_timestamp is not None
-        # the last grid is left in the beam; nothing unloads at the end of a run
+        # the last grid is left loaded; nothing unloads at the end of a run
         assert microscope._stage.loaded_grids[0].name == "Grid-02"
 
     def test_a_grid_already_in_the_beam_is_not_loaded_again(

--- a/tests/test_autoscript_sample_loader.py
+++ b/tests/test_autoscript_sample_loader.py
@@ -125,17 +125,24 @@ class TestInventory:
         }
         assert loader.slots["Slot-02"].loaded_grid is None
 
-    def test_uses_last_known_states_unless_all_unknown(self):
-        hw = FakeAutoloader(occupied={2: "g"})
-        _, loader = _microscope_with(hw)
-        loader.run_inventory()
-        assert hw.calls == [("get_slots", False)]
+    def test_get_inventory_reads_what_the_autoloader_knows(self):
+        """A read is `get_slots(False)` and nothing else: instant, and only as
+        fresh as the autoloader's own last scan -- unscanned slots stay UNKNOWN."""
+        from fibsem.microscopes._stage import GridSlotState
 
-    def test_forces_a_scan_when_nothing_is_known(self):
+        hw = FakeAutoloader(occupied={2: "g"}, scanned=False)
+        microscope, loader = _microscope_with(hw)
+        assert loader.get_inventory() == []
+        assert hw.calls == [("get_slots", False)]
+        rows = microscope._stage.grid_inventory()
+        assert {r.state for r in rows} == {GridSlotState.UNKNOWN}
+
+    def test_run_inventory_scans_the_magazine(self):
+        """A scan is `get_slots(True)`: the slow one, the caller's explicit choice."""
         hw = FakeAutoloader(occupied={2: "g"}, scanned=False)
         _, loader = _microscope_with(hw)
         slots = loader.run_inventory()
-        assert hw.calls == [("get_slots", False), ("get_slots", True)]
+        assert hw.calls == [("get_slots", True)]
         assert [s.name for s in slots] == ["Slot-02"]
 
     def test_capacity_follows_the_hardware(self):
@@ -152,6 +159,26 @@ class TestInventory:
         microscope, loader = _microscope_with(hw)
         loader.run_inventory()
         assert [g.name for g in microscope._stage.loaded_grids] == ["grid-birch"]
+
+    def test_slots_are_unknown_until_the_hardware_has_answered(self):
+        """Before any inventory every magazine slot is UNKNOWN, and nothing is
+        present: the UI says "run an inventory" rather than "empty". After a
+        scan, a slot the autoloader still could not read stays UNKNOWN."""
+        from fibsem.microscopes._stage import GridSlotState
+
+        hw = FakeAutoloader(occupied={1: "a", 2: "b"})
+        microscope, loader = _microscope_with(hw)
+        rows = microscope._stage.grid_inventory()
+        assert {r.state for r in rows} == {GridSlotState.UNKNOWN}
+        assert not any(r.present for r in rows)
+
+        hw._slots[4].state = "Unknown"  # one slot the autoloader has not read
+        loader.get_inventory()  # a read keeps it that way; a scan would resolve it
+        rows = {r.slot_name: r for r in microscope._stage.grid_inventory()}
+        assert rows["Slot-01"].state is GridSlotState.OCCUPIED
+        assert rows["Slot-03"].state is GridSlotState.EMPTY
+        assert rows["Slot-05"].state is GridSlotState.UNKNOWN
+        assert not rows["Slot-05"].present
 
     def test_inventory_rows_come_from_the_magazine(self):
         hw = FakeAutoloader(occupied={1: "a", 2: "b"})
@@ -185,7 +212,7 @@ class TestExchange:
         microscope._stage.ensure_loaded("grid-cedar")
         loader.run_inventory()  # hardware now reads slot 3 as Empty
         assert loader.slots["Slot-03"].loaded_grid.name == "grid-cedar"
-        assert microscope._stage.grid_inventory()[2].in_beam is True
+        assert microscope._stage.grid_inventory()[2].loaded is True
 
     def test_exchange_unloads_then_loads(self):
         hw = FakeAutoloader(occupied={1: "a", 2: "b"})

--- a/tests/test_grid_inventory.py
+++ b/tests/test_grid_inventory.py
@@ -1,7 +1,7 @@
 """The loader magazine, the Demo autoloader, and ``Stage.grid_inventory()``.
 
 Two hardware shapes, one query. On a compustage the inventory is the loader's
-magazine and "in beam" is whichever grid sits in the holder's working slot; on a
+magazine and "loaded" is whichever grid sits in the holder's working slot; on a
 fixed holder the inventory is the holder itself and every present grid is in the
 beam. Nothing here is cached: every answer is re-derived from the slots.
 """
@@ -144,7 +144,7 @@ class TestExchange:
         grid = loader.load_grid("Slot-02")
         working = microscope._stage.holder.slots["Slot-01"]
         assert working.loaded_grid is grid
-        # the magazine slot is the grid's home; it keeps the grid while it is in the beam
+        # the magazine slot is the grid's home; it keeps the grid while it is loaded
         assert loader.slots["Slot-02"].loaded_grid is grid
 
     def test_load_another_grid_exchanges(self):
@@ -193,7 +193,7 @@ class TestExchange:
         with pytest.raises(GridExchangeError):
             loader.load_grid("Slot-02")
         working = microscope._stage.holder.slots["Slot-01"]
-        # the unload half of the exchange failed, so Grid-01 is still in the beam
+        # the unload half of the exchange failed, so Grid-01 is still loaded
         assert working.loaded_grid.name == "Grid-01"
         assert loader.fail_next_exchange is False
 
@@ -217,9 +217,9 @@ class TestInventoryWithLoader:
         loader = _with_magazine(microscope)
         loader.load_grid("Slot-02")
         one, two, three = (_entry(microscope, f"Slot-0{i}") for i in (1, 2, 3))
-        assert (one.present, one.in_beam) == (True, False)
-        assert (two.present, two.in_beam) == (True, True)
-        assert (three.present, three.in_beam, three.name) == (False, False, None)
+        assert (one.present, one.loaded) == (True, False)
+        assert (two.present, two.loaded) == (True, True)
+        assert (three.present, three.loaded, three.name) == (False, False, None)
 
     def test_in_beam_follows_the_holder_not_a_cache(self):
         microscope = _compustage_demo()
@@ -229,8 +229,8 @@ class TestInventoryWithLoader:
         microscope._stage.holder.slots["Slot-01"].loaded_grid = loader.slots[
             "Slot-05"
         ].loaded_grid
-        assert _entry(microscope, "Slot-02").in_beam is False
-        assert _entry(microscope, "Slot-05").in_beam is True
+        assert _entry(microscope, "Slot-02").loaded is False
+        assert _entry(microscope, "Slot-05").loaded is True
 
 
 class TestInventoryOnFixedHolder:
@@ -242,9 +242,9 @@ class TestInventoryOnFixedHolder:
         assert len(rows) == len(holder.slots)
         assert {r.source for r in rows} == {"holder"}
         first = _entry(microscope, "Slot-01")
-        assert (first.name, first.present, first.in_beam) == ("grid-aspen", True, True)
+        assert (first.name, first.present, first.loaded) == ("grid-aspen", True, True)
         second = _entry(microscope, "Slot-02")
-        assert (second.name, second.present, second.in_beam) == (None, False, False)
+        assert (second.name, second.present, second.loaded) == (None, False, False)
 
 
 # ---------------------------------------------------------------------------
@@ -441,6 +441,16 @@ class TestRunInventory:
         assert scanned == [True]
         assert [r.name for r in rows if r.present] == ["Grid-01", "Grid-02", "Grid-05"]
 
+    def test_get_inventory_reads_without_a_scan(self):
+        microscope = _compustage_demo()
+        loader = _with_magazine(microscope)
+        calls = []
+        loader._read_magazine = lambda: calls.append("read")  # type: ignore[assignment]
+        loader._scan_magazine = lambda: calls.append("scan")  # type: ignore[assignment]
+        rows = microscope._stage.get_inventory()
+        assert calls == ["read"]
+        assert [r.name for r in rows if r.present] == ["Grid-01", "Grid-02", "Grid-05"]
+
     def test_on_fixed_holder_is_a_refresh(self):
         microscope = _fixed_demo()
         microscope._stage.holder.slots["Slot-01"].loaded_grid = SampleGrid(name="g")
@@ -469,3 +479,49 @@ def test_current_grid_is_none_before_the_first_position_read():
     stage.move_to_slot("Slot-01")
     assert stage.current_grid is not None
     assert stage.current_grid.name == "Grid-01"
+
+
+# ---------------------------------------------------------------------------
+# The slot state: where the grid is, as one word
+# ---------------------------------------------------------------------------
+
+
+class TestSlotState:
+    def test_a_magazine_reads_occupied_loaded_and_empty(self):
+        from fibsem.microscopes._stage import GridSlotState
+
+        microscope = _compustage_demo()
+        _with_magazine(microscope, occupied=(1, 2))
+        stage = microscope._stage
+        stage.ensure_loaded("Grid-02")
+        rows = {e.slot_name: e for e in stage.grid_inventory()}
+        assert rows["Slot-01"].state is GridSlotState.OCCUPIED
+        assert rows["Slot-02"].state is GridSlotState.LOADED
+        assert rows["Slot-03"].state is GridSlotState.EMPTY
+        # present and loaded are read off the state
+        assert rows["Slot-01"].present and not rows["Slot-01"].loaded
+        assert rows["Slot-02"].present and rows["Slot-02"].loaded
+        assert not rows["Slot-03"].present
+
+    def test_a_fixed_holder_slot_with_a_grid_is_loaded_outright(self):
+        """Its grid is already in the holder: reaching it is a stage move."""
+        from fibsem.microscopes._stage import GridSlotState
+
+        microscope = _fixed_demo()
+        stage = microscope._stage
+        stage.assign_grid("Slot-01", SampleGrid(name="grid-ash"), persist=False)
+        rows = {e.slot_name: e for e in stage.grid_inventory()}
+        assert rows["Slot-01"].state is GridSlotState.LOADED
+        assert rows["Slot-02"].state is GridSlotState.EMPTY
+        assert GridSlotState.UNKNOWN not in {e.state for e in rows.values()}
+
+    def test_the_demo_magazine_is_known_from_the_start(self):
+        """An in-memory magazine has nothing to scan, so its slots are never
+        UNKNOWN; the tests and the simulator rely on reading it before any
+        inventory has run."""
+        from fibsem.microscopes._stage import GridSlotState
+
+        microscope = _compustage_demo()
+        _with_magazine(microscope, occupied=(1,))
+        states = {e.state for e in microscope._stage.grid_inventory()}
+        assert states == {GridSlotState.OCCUPIED, GridSlotState.EMPTY}

--- a/tests/ui/test_grid_workflow_widget.py
+++ b/tests/ui/test_grid_workflow_widget.py
@@ -134,6 +134,18 @@ class TestSelection:
         assert [c.text() for c in row._chip_widgets] == ["Loaded"]
         assert row.sizeHint().width() <= 380
 
+    def test_an_unscanned_magazine_says_so_on_every_row(self, view, arctis):
+        """Before an inventory the rows are UNKNOWN: the chip says the magazine
+        has not been read, not that the grids are missing, and none can be run."""
+        arctis._stage.loader.scanned = False
+        view.refresh()
+        rows = [view._grid_rows[n] for n in ("Grid-01", "Grid-02", "Grid-03")]
+        assert all([c.text() for c in r._chip_widgets] == ["not scanned"] for r in rows)
+        assert not any(r.checkbox.isEnabled() for r in rows)
+        arctis._stage.loader.scanned = True
+        view.refresh()
+        assert all(r.checkbox.isEnabled() for r in rows)
+
     def test_the_fm_task_is_greyed_without_a_fluorescence_microscope(
         self, qapp, experiment
     ):
@@ -332,7 +344,7 @@ def test_a_grid_run_from_the_window_on_a_fixed_holder(main_ui, tmp_path, monkeyp
     QTest.qWait(200)  # let the finished signal land
 
     grid = exp.get_grid_by_name("grid-aspen")
-    # a fixed holder: the grid was in the beam already, so no load entry
+    # a fixed holder: the grid was loaded already, so no load entry
     assert [t.name for t in grid.task_history] == ["overview_sem"]
     assert grid.task_history[-1].status is AutoLamellaTaskStatus.Completed
     assert len(grid_outputs(exp, grid, "overview_sem")) == 1

--- a/tests/ui/test_grids_tab.py
+++ b/tests/ui/test_grids_tab.py
@@ -108,12 +108,12 @@ class TestCards:
         ]
         assert tab.summary_label.text() == "3 in this experiment · 3 present"
         card = tab.cards.cards[0]
-        assert [c.text() for c in card._chip_widgets] == []  # present, not in beam
+        assert [c.text() for c in card._chip_widgets] == []  # present, not loaded
         assert "slot 01" in card._status_label.toolTip()
         assert card.is_present and card.status_text == "Not run"
         assert card._action_load.isVisible() and card._action_load.isEnabled()
         assert not card._action_unload.isVisible()
-        assert tab.status_label.text() == "Inventory complete."
+        assert tab.status_label.text() == "Inventory read."
         # saved as it went
         assert (
             len(Experiment.load(Path(experiment.path) / "experiment.yaml").grids) == 3
@@ -134,7 +134,7 @@ class TestCards:
         assert arctis._stage.loaded_grids[0].name == "Grid-02"
         assert [c.text() for c in card._chip_widgets] == ["Loaded"]
         assert card._action_unload.isVisible() and not card._action_load.isVisible()
-        assert tab.status_label.text() == "Grid-02 is in the beam."
+        assert tab.status_label.text() == "Grid-02 is loaded."
         card._action_unload.trigger()
         assert arctis._stage.loaded_grids == []
         assert [c.text() for c in card._chip_widgets] == []

--- a/tests/ui/test_sample_loader_widget.py
+++ b/tests/ui/test_sample_loader_widget.py
@@ -50,11 +50,11 @@ def test_load_brings_the_grid_into_the_beam(widget, arctis):
     widget.loader_changed.connect(lambda: changed.append(True))
     widget._row_widget(1).btn_action.click()
     assert arctis._stage.loaded_grids[0].name == "Grid-02"
-    assert states(widget)[:3] == ["occupied", "in_beam", "occupied"]
+    assert states(widget)[:3] == ["occupied", "loaded", "occupied"]
     # the loaded row's action turns into Unload; the others still offer Load
     assert "Return Grid-02" in widget._row_widget(1).btn_action.toolTip()
     assert "into the beam" in widget._row_widget(0).btn_action.toolTip()
-    assert widget.status_label.text() == "Grid-02 is in the beam."
+    assert widget.status_label.text() == "Grid-02 is loaded."
     assert changed == [True]
     assert not widget.busy
 
@@ -67,19 +67,25 @@ def test_unload_returns_it(widget, arctis):
     assert "returned to the magazine" in widget.status_label.text()
 
 
-def test_run_inventory_asks_first_then_stamps_the_scan(widget, monkeypatch):
+def test_refresh_reads_without_asking_and_the_scan_asks_first(widget, monkeypatch):
+    """Two buttons: the refresh reads what the autoloader knows (instant, nothing
+    moves, no question); the scan is the slow physical inventory and asks."""
     asked = []
-    widget._synchronous = False  # so the confirmation is consulted...
+    widget._synchronous = False  # so a confirmation, if any, is consulted...
     monkeypatch.setattr(
         widget, "_confirm", lambda title, text: asked.append(title) or False
     )
-    widget.btn_inventory.click()
-    assert asked == ["Run inventory"] and "not scanned" in widget.facts_label.text()
+    widget.btn_scan.click()
+    assert asked == ["Scan magazine"] and "not scanned" in widget.facts_label.text()
     monkeypatch.undo()
     widget._synchronous = True  # ...and answered yes without a dialog
     widget.btn_inventory.click()
+    assert widget.status_label.text() == "Inventory read."
+    assert "read " in widget.facts_label.text()
+    assert "not scanned this session" in widget.facts_label.text()
+    widget.btn_scan.click()
     assert "scanned " in widget.facts_label.text()
-    assert widget.status_label.text() == "Inventory complete."
+    assert widget.status_label.text() == "Scan complete."
 
 
 def test_a_refused_exchange_is_reported_and_the_controls_come_back(widget, arctis):


### PR DESCRIPTION
From the tester's questions on the loader interface. Three commits.

- **`in_beam` → `loaded`.** A grid is loaded when it is in the microscope's sample holder; "in beam" named the same thing from the other side and read as a third state. Field, properties, prose and status lines.
- **One state per inventory slot**, `GridSlotState`: `UNKNOWN` (no inventory has answered), `EMPTY`, `OCCUPIED` (in the magazine), `LOADED` (on the microscope). `present` and `loaded` are read off it. A fixed-holder slot with a grid is LOADED outright. UNKNOWN is real: an AutoScript magazine reads UNKNOWN everywhere until the hardware has answered, and a slot the scan could not read stays so; the Demo magazine is known from the start. Sample view rows say "unknown", cards and run-view rows carry a "not scanned" chip and cannot be ticked.
- **`get_inventory()` reads, `run_inventory()` scans.** The old call hid the decision (read, scan only if everything was unknown). Get is `get_slots(False)`: instant, nothing moves. Run is `get_slots(True)`: the slow physical scan. Screen all grids and the Grids tab refresh read and no longer ask; the Sample view gets a second header icon for the scan, behind the confirmation, and its facts line says "read HH:MM" or "scanned HH:MM".

The bench doc is updated to match: its snippets print the state, 2.2 is the read, 2.3 the scan followed by the question of whether a read follows a manual magazine change.

**Tests**: 162 across the grid suites, with new ones for the state on both hardware shapes, read-versus-scan on the AutoScript fake, unknown rows on the run view, and the two Sample view buttons. 17 files, over the usual count because a field rename reaches every reader.