### PR TITLE
[refactor] Derive stage.rotation_180 instead of configuring it (FIB-834)

### DIFF
--- a/fibsem/config/microscope-configuration.yaml
+++ b/fibsem/config/microscope-configuration.yaml
@@ -6,10 +6,9 @@ info:
     manufacturer: Demo                                      # the microscope manufactuer                                    [SPECIFIED]        
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   true                        # the stage is able to rotate                                   [USER]
+    rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
     tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
-    rotation_180:               180                         # the reference rotation + 180 degrees                          [DERIVED - rotation-reference]
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
 electron:                                              

--- a/fibsem/config/odemis-configuration.yaml
+++ b/fibsem/config/odemis-configuration.yaml
@@ -6,10 +6,9 @@ info:
     manufacturer: Odemis                                      # the microscope manufactuer                                    [SPECIFIED]        
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   true                        # the stage is able to rotate                                   [USER]
+    rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
     tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
-    rotation_180:               180                         # the reference rotation + 180 degrees                          [DERIVED - rotation-reference]
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
 electron:                                              

--- a/fibsem/config/sim-arctis-configuration.yaml
+++ b/fibsem/config/sim-arctis-configuration.yaml
@@ -4,10 +4,9 @@ info:
     manufacturer: Demo                                              
 stage:
     enabled:                    true                        
-    rotation:                   true                        
+    rotation:                   false                       
     tilt:                       true                        
     rotation_reference:         0                           
-    rotation_180:               0                         
     shuttle_pre_tilt:           0                        
     manipulator_height_limit:   0.0037                      
 electron:                                              

--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -24,10 +24,9 @@ fm:
     enabled:                    true                        # this site has a fluorescence microscope                       [USER]
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   true                        # the stage is able to rotate                                   [USER]
+    rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
     tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED]
-    rotation_180:               180                         # the reference rotation + 180 degrees                          [DERIVED - rotation-reference]
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
     device_range:               {x: 20.0e-3}                # the region belonging to each device, from its origin    [metres][SPECIFIED]

--- a/fibsem/config/tescan-configuration.yaml
+++ b/fibsem/config/tescan-configuration.yaml
@@ -6,10 +6,9 @@ info:
     manufacturer: Tescan                                      # the microscope manufacturer                                    [SPECIFIED]        
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   true                        # the stage is able to rotate                                   [USER]
+    rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
     tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         180                         # the reference rotation value                                  [SPECIFIED] 
-    rotation_180:               0                           # the reference rotation + 180 degrees                          [DERIVED - rotation-reference]
     shuttle_pre_tilt:           0                           # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufacturer]
 electron:                                              

--- a/fibsem/config/tfs-aquilos2-configuration.yaml
+++ b/fibsem/config/tfs-aquilos2-configuration.yaml
@@ -6,10 +6,9 @@ info:
     manufacturer: Thermo                                    # the microscope manufactuer                                    [SPECIFIED]        
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   true                        # the stage is able to rotate                                   [USER]
+    rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
     tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
-    rotation_180:               180                         # the reference rotation + 180 degrees                          [DERIVED - rotation-reference]
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
 electron:                                              

--- a/fibsem/config/tfs-arctis-configuration.yaml
+++ b/fibsem/config/tfs-arctis-configuration.yaml
@@ -6,10 +6,9 @@ info:
     manufacturer: Thermo                                    # the microscope manufactuer                                    [SPECIFIED]        
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   false                       # the stage is able to rotate                                   [USER]
+    rotation:                   false                       # the stage is able to rotate; false means it has no 180-degree side  [USER]
     tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
-    rotation_180:               0                           # the reference rotation + 180 degrees                          [DERIVED - rotation-reference]
     shuttle_pre_tilt:           0                           # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
 electron:                                              

--- a/fibsem/config/tfs-hydra-configuration.yaml
+++ b/fibsem/config/tfs-hydra-configuration.yaml
@@ -6,10 +6,9 @@ info:
     manufacturer: Thermo                                    # the microscope manufactuer                                    [SPECIFIED]        
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   true                        # the stage is able to rotate                                   [USER]
+    rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
     tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
-    rotation_180:               180                         # the reference rotation + 180 degrees                          [DERIVED - rotation-reference]
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
 electron:                                              

--- a/fibsem/configuration.py
+++ b/fibsem/configuration.py
@@ -32,7 +32,7 @@ def generate_configuration(user_config: dict) -> dict:
 
     # stage
     config["stage"]["rotation_reference"] = user_config["rotation-reference"]
-    config["stage"]["rotation_180"] = user_config["rotation-reference"] + 180
+    config["stage"].pop("rotation_180", None)  # derived from the reference (FIB-834)
     config["stage"]["shuttle_pre_tilt"] = user_config["shuttle-pre-tilt"]
 
     # electron

--- a/fibsem/guided_setup.py
+++ b/fibsem/guided_setup.py
@@ -396,9 +396,10 @@ class SetupChoices:
 
     ``rotation_reference`` and ``shuttle_pre_tilt`` are Optional because None is a
     real answer here: it means *the wizard did not ask*, so the shipped file's own
-    values stand. That matters more than it sounds -- ``tfs-arctis`` ships
-    ``rotation_reference: 0`` with ``rotation_180: 0``, because a compustage has no
-    180-degree rotation to reach, and re-deriving the pair would silently give it one.
+    values stand -- which for ``tfs-arctis`` includes ``rotation: false``, the flag
+    that says a compustage has no 180-degree rotation to reach (FIB-834). Overwriting
+    the reference on a model the wizard never asked about would leave that flag
+    describing a stage the file no longer describes.
     """
 
     manufacturer_key: str = MANUFACTURERS[0].key
@@ -602,12 +603,13 @@ def build_configuration(choices: SetupChoices) -> dict:
 
     stage = config.setdefault("stage", {})
     if choices.rotation_reference is not None:
-        reference = float(choices.rotation_reference)
-        stage["rotation_reference"] = reference
-        # The derivation the file's own comment documents. Reached only when the user
-        # supplied the reference, i.e. for a model the project does not ship -- a
-        # recognised model keeps its shipped pair, which for a compustage is not this.
-        stage["rotation_180"] = (reference + 180) % 360
+        stage["rotation_reference"] = float(choices.rotation_reference)
+    # Written by no one now: `rotation_180` is derived from the reference and the
+    # `rotation` capability (FIB-834). Popped rather than left alone because the
+    # template this dict was copied from is a shipped file that still carries the key,
+    # and a stale number sitting beside the reference it no longer agrees with is
+    # exactly what someone would go on to edit.
+    stage.pop("rotation_180", None)
     if choices.shuttle_pre_tilt is not None:
         stage["shuttle_pre_tilt"] = float(choices.shuttle_pre_tilt)
 

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -2090,7 +2090,12 @@ class FibsemMicroscope(ABC):
             PRETILT_SIGN = -1.0
 
         if self.stage_is_compustage and self.get_stage_orientation() == "FIB":
-            expected_y *= -1.0  # use this until rotation_180 is deprecated correctly...
+            # Stays after FIB-834 made `rotation_180` derived. A compustage does not
+            # rotate, so it derives to `rotation_reference` -- the same value the
+            # configuration used to state, which is why both comparisons above still
+            # match and this flip is still what separates the two sides. Deriving it to
+            # a half turn instead would have moved the sign here, silently.
+            expected_y *= -1.0
             PRETILT_SIGN = -1.0
 
         corrected_pretilt_angle = PRETILT_SIGN * (

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2213,7 +2213,6 @@ DEFAULT_STAGE_DEVICES: Dict[str, StageDeviceSettings] = {
 @dataclass
 class StageSystemSettings:
     rotation_reference: float
-    rotation_180: float
     shuttle_pre_tilt: float
     manipulator_height_limit: float
     enabled: bool = True
@@ -2234,10 +2233,29 @@ class StageSystemSettings:
         default_factory=lambda: deepcopy(DEFAULT_STAGE_DEVICES)
     )
 
+    @property
+    def rotation_180(self) -> float:
+        """Where the stage sits to face the ion beam, in degrees.
+
+        Derived, not configured. It used to be a field, and every shipped file gave it
+        `(rotation_reference + 180) % 360` -- Tescan included, whose reference of 180
+        is what makes the modulo load-bearing rather than decorative. The two
+        exceptions were the compustages, which set it *equal* to the reference to say
+        "this stage does not turn round". That is a boolean's job, and `rotation` is
+        the boolean -- already on this class, and already `false` on the real Arctis
+        (FIB-834).
+
+        So a value that was never chosen is now computed, and the one case it could not
+        express without a coincidence -- a stage with no rotation axis -- is asked of
+        the field named for it.
+        """
+        if not self.rotation:
+            return self.rotation_reference
+        return (self.rotation_reference + 180) % 360
+
     def to_dict(self):
         return {
             "rotation_reference": self.rotation_reference,
-            "rotation_180": self.rotation_180,
             "shuttle_pre_tilt": self.shuttle_pre_tilt,
             "manipulator_height_limit": self.manipulator_height_limit,
             "enabled": self.enabled,
@@ -2254,9 +2272,13 @@ class StageSystemSettings:
     def from_dict(settings: dict):
         devices = settings.get("devices")
         device_range = settings.get("device_range")
+        # `rotation_180` is deliberately not read. A file written before FIB-834 still
+        # carries the key and still loads -- the value is simply ignored, because it is
+        # now derived from the two fields that decide it. Ignoring beats honouring: a
+        # stored value that disagrees with the derivation is a value someone typed
+        # wrong, and reading it back would preserve the mistake.
         return StageSystemSettings(
             rotation_reference=settings["rotation_reference"],
-            rotation_180=settings["rotation_180"],
             shuttle_pre_tilt=settings["shuttle_pre_tilt"],
             manipulator_height_limit=settings["manipulator_height_limit"],
             enabled=settings.get("enabled", True),

--- a/fibsem/ui/widgets/guided_setup_dialog.py
+++ b/fibsem/ui/widgets/guided_setup_dialog.py
@@ -1082,9 +1082,9 @@ class GuidedSetupDialog(QtWidgets.QDialog):
         self._update_api_note()
         if self.choices.stage_is_readonly:
             # Answers to a question this model no longer asks. Left in place they would
-            # be written anyway -- and for a compustage, whose shipped pair is rotation
-            # reference 0 with rotation_180 0, a value typed for some other model is
-            # exactly the wrong thing to keep.
+            # be written anyway -- and for a compustage, which reaches the other side of
+            # the grid by tilting rather than turning round, a reference typed for some
+            # other model is exactly the wrong thing to keep.
             self.choices.rotation_reference = None
             self.choices.shuttle_pre_tilt = None
             self._stage_read = None
@@ -1657,12 +1657,15 @@ class GuidedSetupDialog(QtWidgets.QDialog):
             # Only shown when the wizard derived it. It is the rotation the other side
             # of the sample is reached at, and someone who typed 250° should see that
             # this became 70° rather than discover it from a stage that turned the
-            # wrong way.
+            # wrong way. Computed here rather than read back from `stage`, which no
+            # longer carries it (FIB-834) -- and only reachable for an editable stage,
+            # i.e. one that rotates, so the modulo is the whole of the derivation.
+            reference = float(stage.get("rotation_reference", 0))
             rows.insert(
                 5,
                 (
                     "Rotated 180°",
-                    f"{float(stage.get('rotation_180', 0)):.2f}° (derived)",
+                    f"{(reference + 180) % 360:.2f}° (derived)",
                 ),
             )
         if self.choices.protocol_path:

--- a/fibsem/ui/widgets/microscope_config_widget.py
+++ b/fibsem/ui/widgets/microscope_config_widget.py
@@ -112,13 +112,10 @@ class MicroscopeConfigWidget(QWidget):
         form = QFormLayout(w)
         self._sb_stage_rot_ref = QSpinBox()
         self._sb_stage_rot_ref.setRange(-360, 360)
-        self._sb_stage_rot_180 = QSpinBox()
-        self._sb_stage_rot_180.setRange(-360, 360)
         self._sb_stage_pretilt = QSpinBox()
         self._sb_stage_pretilt.setRange(0, 90)
         self._dsb_stage_manip_limit = _dsb(0, 100, 4, suffix=" mm")
         form.addRow("Rotation Reference (deg)", self._sb_stage_rot_ref)
-        form.addRow("Rotation 180 (deg)", self._sb_stage_rot_180)
         form.addRow("Shuttle Pre-tilt (deg)", self._sb_stage_pretilt)
         form.addRow("Manipulator Height Limit (mm)", self._dsb_stage_manip_limit)
         return w
@@ -355,7 +352,6 @@ class MicroscopeConfigWidget(QWidget):
 
         stage = c.get("stage", {})
         self._sb_stage_rot_ref.setValue(int(stage.get("rotation_reference", 0)))
-        self._sb_stage_rot_180.setValue(int(stage.get("rotation_180", 180)))
         self._sb_stage_pretilt.setValue(int(stage.get("shuttle_pre_tilt", 0)))
         self._dsb_stage_manip_limit.setValue(
             float(stage.get("manipulator_height_limit", 0)) * constants.SI_TO_MILLI
@@ -446,7 +442,11 @@ class MicroscopeConfigWidget(QWidget):
 
         c.setdefault("stage", {})
         c["stage"]["rotation_reference"] = self._sb_stage_rot_ref.value()
-        c["stage"]["rotation_180"] = self._sb_stage_rot_180.value()
+        # Dropped on save rather than only hidden from the form. `c` is a deepcopy of
+        # the file as loaded, so a pre-FIB-834 configuration edited here would otherwise
+        # be written back still carrying a `rotation_180` no field now feeds -- the
+        # reference edited, the stale number beside it untouched.
+        c["stage"].pop("rotation_180", None)
         c["stage"]["shuttle_pre_tilt"] = self._sb_stage_pretilt.value()
         c["stage"]["manipulator_height_limit"] = (
             self._dsb_stage_manip_limit.value() * constants.MILLI_TO_SI

--- a/tests/test_guided_setup.py
+++ b/tests/test_guided_setup.py
@@ -129,23 +129,37 @@ def test_the_shipped_values_are_offered_as_a_starting_point():
     }
 
 
-def test_the_derived_opposite_matches_what_each_model_ships():
-    """The models that are asked are exactly the ones the derivation suits.
+def test_no_model_writes_a_rotation_180():
+    """The wizard writes the reference; the opposite is derived from it (FIB-834).
 
-    `rotation_180` is derived as `reference + 180`, which reproduces what every asked
-    model ships -- and the one model it would get wrong, the compustage with its 0/0
-    pair, is the one that never reaches the step.
+    Asserted over every model, asked and unasked, because the key leaving the file is
+    the whole change: a `rotation_180` written here would be a number nothing reads,
+    sitting next to the reference it is supposed to track and free to disagree with it.
+
+    Tescan is the case worth having. It ships reference 180, so its opposite is 0 -- and
+    a derivation without the modulo would write 360, which is the same rotation spelled
+    a way that `rotation_angle_is_smaller` handles but a person reading the file does
+    not.
     """
-    from fibsem import utils
+    for model in wizard.MICROSCOPE_MODELS:
+        config = wizard.build_configuration(wizard.SetupChoices(model_key=model.key))
+        assert "rotation_180" not in config["stage"], model.key
 
-    for key in ("tfs-hydra", "tfs-aquilos2", "tescan"):
-        model = wizard.get_model(key)
-        shipped = utils.load_yaml(model.path)["stage"]
-        reference = float(shipped["rotation_reference"])
-        config = wizard.build_configuration(
-            wizard.SetupChoices(model_key=key, rotation_reference=reference)
-        )
-        assert config["stage"]["rotation_180"] == float(shipped["rotation_180"]), key
+
+def test_the_derived_opposite_matches_what_each_model_needs():
+    """The derivation, read back through the settings that consume it.
+
+    The asked models all rotate, so each lands a half turn from its own reference --
+    Tescan at 0, from a reference of 180.
+    """
+    from fibsem.structures import StageSystemSettings
+
+    expected = {"tfs-hydra": 180.0, "tfs-aquilos2": 180.0, "tescan": 0.0}
+    for key, opposite in expected.items():
+        config = wizard.build_configuration(wizard.SetupChoices(model_key=key))
+        stage = StageSystemSettings.from_dict(config["stage"])
+        assert stage.rotation is True, key
+        assert stage.rotation_180 == opposite, key
 
 
 def test_the_simulator_does_not_skip_the_stage_step():
@@ -246,28 +260,37 @@ def test_only_the_simulator_needs_no_vendor_api():
 # ---------------------------------------------------------------------------
 
 
-def test_a_recognised_model_keeps_its_shipped_stage_values():
-    """The compustage case, which a derivation would get wrong.
+def test_a_compustage_derives_no_opposite_rotation():
+    """The case a blanket `reference + 180` would get wrong.
 
-    ``tfs-arctis`` ships rotation reference 0 with ``rotation_180`` also 0, because a
-    compustage reaches the other side by tilting rather than rotating. Deriving the
-    pair would hand it a 180-degree rotation it does not have.
+    A compustage reaches the other side of the grid by tilting, not by turning round,
+    so it has no second rotation -- and ``tfs-arctis`` says so with ``rotation: false``
+    rather than by setting two numbers equal. Both simulated and real Arctis are
+    checked: the simulator is the only place the compustage path runs, so a sim config
+    that disagreed with the instrument would be a hole in every compustage test.
     """
-    config = wizard.build_configuration(
-        wizard.SetupChoices(model_key="tfs-arctis", name="Bay 2")
-    )
-    assert config["stage"]["rotation_reference"] == 0
-    assert config["stage"]["rotation_180"] == 0
+    from fibsem.structures import StageSystemSettings
+
+    for key in ("tfs-arctis", "sim-arctis"):
+        config = wizard.build_configuration(
+            wizard.SetupChoices(model_key=key, name="Bay 2")
+        )
+        stage = StageSystemSettings.from_dict(config["stage"])
+        assert stage.rotation is False, key
+        assert stage.rotation_reference == 0, key
+        assert stage.rotation_180 == 0, key
 
 
 def test_a_supplied_rotation_reference_derives_its_opposite():
+    from fibsem.structures import StageSystemSettings
+
     config = wizard.build_configuration(
         wizard.SetupChoices(
             model_key="tfs-other", rotation_reference=250.0, name="Bench"
         )
     )
     assert config["stage"]["rotation_reference"] == 250.0
-    assert config["stage"]["rotation_180"] == 70.0
+    assert StageSystemSettings.from_dict(config["stage"]).rotation_180 == 70.0
 
 
 def test_the_name_becomes_the_configurations_name():

--- a/tests/test_microscope.py
+++ b/tests/test_microscope.py
@@ -21,14 +21,17 @@ def test_microscope():
     assert microscope.get_beam_current(BeamType.ION) == beam_current
 
 
-@pytest.mark.parametrize("tilt_deg,expected", [
-    (0,    "SEM"),      # exact SEM position
-    (-23,  "MILLING"),  # standard milling tilt (below SEM)
-    (-10,  "MILLING"),  # arbitrary tilt between SEM and -45°
-    (15,   "MILLING"),  # above SEM tilt
-    (-128, "FIB"),      # compustage FIB position
-    (-50,  "NONE"),     # below -45° floor
-])
+@pytest.mark.parametrize(
+    "tilt_deg,expected",
+    [
+        (0, "SEM"),  # exact SEM position
+        (-23, "MILLING"),  # standard milling tilt (below SEM)
+        (-10, "MILLING"),  # arbitrary tilt between SEM and -45°
+        (15, "MILLING"),  # above SEM tilt
+        (-128, "FIB"),  # compustage FIB position
+        (-50, "NONE"),  # below -45° floor
+    ],
+)
 def test_get_stage_orientation_compustage(tilt_deg, expected):
     """Test get_stage_orientation for compustage (pretilt=0)."""
     microscope, _ = utils.setup_session(manufacturer="Demo")
@@ -40,20 +43,24 @@ def test_get_stage_orientation_compustage(tilt_deg, expected):
     assert microscope.get_stage_orientation(pos) == expected
 
 
-@pytest.mark.parametrize("rotation_deg,tilt_deg,expected", [
-    (0,   35,  "SEM"),      # exact SEM position
-    (0,   12,  "MILLING"),  # standard milling tilt (below SEM)
-    (0,   20,  "MILLING"),  # arbitrary tilt between MILLING and SEM
-    (0,   42,  "MILLING"),  # above SEM tilt
-    (180, 17,  "FIB"),      # FIB position (rotation_180=180, col_tilt-pretilt=17)
-    (0,   -50, "NONE"),     # below -45° floor
-])
+@pytest.mark.parametrize(
+    "rotation_deg,tilt_deg,expected",
+    [
+        (0, 35, "SEM"),  # exact SEM position
+        (0, 12, "MILLING"),  # standard milling tilt (below SEM)
+        (0, 20, "MILLING"),  # arbitrary tilt between MILLING and SEM
+        (0, 42, "MILLING"),  # above SEM tilt
+        (180, 17, "FIB"),  # FIB position (rotation_180=180, col_tilt-pretilt=17)
+        (0, -50, "NONE"),  # below -45° floor
+    ],
+)
 def test_get_stage_orientation_non_compustage(rotation_deg, tilt_deg, expected):
     """Test get_stage_orientation for non-compustage (pretilt=35°)."""
     microscope, _ = utils.setup_session(manufacturer="Demo")
     microscope.stage_is_compustage = False
     microscope.system.stage.shuttle_pre_tilt = 35
-    microscope.system.stage.rotation_180 = 180
+    microscope.system.stage.rotation_reference = 0
+    microscope.system.stage.rotation = True  # so FIB derives to 180 (FIB-834)
     microscope._update_orientations()
 
     pos = FibsemStagePosition(r=np.radians(rotation_deg), t=np.radians(tilt_deg))
@@ -161,6 +168,7 @@ def test_the_replacement_move_matches_the_deprecated_one():
 # get_target_position: MILLING <-> FM conversions (FIB-234)
 # ---------------------------------------------------------------------------
 
+
 def test_get_target_position_milling_to_fm_compustage():
     """MILLING -> FM is now supported on compustage systems."""
     microscope, _ = utils.setup_session(manufacturer="Demo")
@@ -205,10 +213,10 @@ def test_get_target_position_milling_to_fm_non_compustage_raises():
     microscope.system.stage.shuttle_pre_tilt = 35
     microscope._update_orientations()
 
-    milling_pos = FibsemStagePosition(
-        r=np.radians(0), t=np.radians(12)
-    )
-    with pytest.raises(ValueError, match="Cannot move to FM position on non-compustage"):
+    milling_pos = FibsemStagePosition(r=np.radians(0), t=np.radians(12))
+    with pytest.raises(
+        ValueError, match="Cannot move to FM position on non-compustage"
+    ):
         microscope.get_target_position(milling_pos, target_orientation="FM")
 
 

--- a/tests/test_orientation_transform_parity.py
+++ b/tests/test_orientation_transform_parity.py
@@ -114,14 +114,15 @@ OFFSET_BEHAVIOUR = {
 def _microscope(compustage: bool):
     """A Demo microscope with realistic stage geometry for the given mounting.
 
-    The stage settings are set explicitly rather than loaded from a configuration file,
-    for two reasons. `setup_session` resolves a *user* configuration path, so a test
-    reading one would depend on whichever system the developer last connected to. And
-    the bare `manufacturer="Demo"` defaults are actively misleading here: they leave
-    `rotation_180 = 0`, which puts FIB at (r=0, t=17) and MILLING at (r=0, t=12) -- five
-    degrees apart with the same rotation, so a position built at the FIB orientation
-    classifies as MILLING and **FIB becomes unreachable as a source orientation**. The
-    values below match the shipped configurations.
+    The stage settings are set explicitly rather than loaded from a configuration file:
+    `setup_session` resolves a *user* configuration path, so a test reading one would
+    depend on whichever system the developer last connected to. The values below match
+    the shipped configurations.
+
+    `stage.rotation` is what separates the two mountings. It is the capability the FIB
+    rotation is derived from (FIB-834), so setting it is setting the geometry -- there
+    is no second number to keep in step, and no way to write the pair that the stage
+    could not physically be.
     """
     microscope, _ = utils.setup_session(manufacturer="Demo")
     microscope.stage_is_compustage = compustage
@@ -131,12 +132,12 @@ def _microscope(compustage: bool):
     if compustage:
         # Arctis: no wedge and no rotation; every orientation is reached by tilting.
         stage.shuttle_pre_tilt = 0
-        stage.rotation_180 = 0
+        stage.rotation = False
     else:
         # Pre-tilted shuttle: 35 degree wedge, and the ion beam is reached by turning
         # half way round.
         stage.shuttle_pre_tilt = 35
-        stage.rotation_180 = 180
+        stage.rotation = True
 
     microscope._update_orientations()
     return microscope
@@ -355,8 +356,13 @@ def test_the_correction_applies_to_half_turns_however_they_are_written(
     microscope = _microscope(compustage=False)
     stage = microscope.system.stage
     stage.rotation_reference = reference_deg
-    stage.rotation_180 = fib_deg
     microscope._update_orientations()
+    # The FIB rotation is written straight onto the orientation table rather than
+    # configured, because since FIB-834 there is no configuration that produces these
+    # pairs -- the derivation only ever yields a half turn. That is the point: what is
+    # under test is `get_target_position` reading an orientation table, and the table is
+    # the seam a future orientation at some other angle would arrive through.
+    microscope.orientations["FIB"].r = np.radians(fib_deg)
 
     position = _position_at(microscope, "SEM")
     result = microscope.get_target_position(

--- a/tests/test_stage_rotation_derivation.py
+++ b/tests/test_stage_rotation_derivation.py
@@ -1,0 +1,130 @@
+"""`stage.rotation_180` is derived, not configured (FIB-834).
+
+It was a field in every shipped configuration, and in every one of them it held
+`(rotation_reference + 180) % 360` -- except on the two compustages, which set it
+*equal* to the reference to mean "this stage does not turn round". A value doing a
+boolean's job, next to the boolean, which already said so.
+
+The risk in deriving it is not the arithmetic. It is that three movement paths pick
+`PRETILT_SIGN` by comparing the live stage rotation against `rotation_reference` and
+`rotation_180` in turn, so on a compustage -- where the two were both 0 -- *both*
+comparisons matched and the second always won. Derive it to a half turn and that
+coincidence breaks and the sign flips. The derivation below keeps it at the reference
+for a stage that does not rotate, which is why it does not; `test_the_shipped_files_all
+_derive_what_they_used_to_state` is what holds that, config by config, and
+`tests/test_view_corrected_movement.py` is what holds the movement itself.
+"""
+
+import os
+
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.structures import StageSystemSettings
+
+
+def _stage(**overrides) -> StageSystemSettings:
+    fields = dict(
+        rotation_reference=0.0,
+        shuttle_pre_tilt=35.0,
+        manipulator_height_limit=0.0037,
+    )
+    fields.update(overrides)
+    return StageSystemSettings(**fields)
+
+
+# The pairs the eight shipped files stated before FIB-834 removed the key, transcribed
+# from the files as they were. Every row has to survive the derivation, because every
+# row is a stage somebody runs.
+SHIPPED = {
+    "microscope-configuration.yaml": 180.0,
+    "odemis-configuration.yaml": 180.0,
+    "sim-arctis-configuration.yaml": 0.0,
+    "sim-iflm-configuration.yaml": 180.0,
+    "tescan-configuration.yaml": 0.0,
+    "tfs-aquilos2-configuration.yaml": 180.0,
+    "tfs-arctis-configuration.yaml": 0.0,
+    "tfs-hydra-configuration.yaml": 180.0,
+}
+
+
+@pytest.mark.parametrize("filename", sorted(SHIPPED))
+def test_the_shipped_files_all_derive_what_they_used_to_state(filename: str):
+    """The regression guard for the whole change.
+
+    `sim-arctis` is the row that had to be fixed rather than merely checked: it shipped
+    `rotation: true` where the instrument it stands in for says `false`, so before this
+    it would have derived a half turn for a stage that cannot make one. Nothing caught
+    that, because nothing read the flag -- and the simulator is the only place the
+    compustage path runs at all.
+    """
+    config = utils.load_yaml(os.path.join(cfg.CONFIG_PATH, filename))
+    stage = StageSystemSettings.from_dict(config["stage"])
+
+    assert stage.rotation_180 == SHIPPED[filename]
+
+
+@pytest.mark.parametrize("filename", sorted(SHIPPED))
+def test_no_shipped_file_still_states_it(filename: str):
+    config = utils.load_yaml(os.path.join(cfg.CONFIG_PATH, filename))
+    assert "rotation_180" not in config["stage"]
+
+
+def test_a_rotating_stage_sits_half_a_turn_from_its_reference():
+    assert _stage(rotation_reference=0.0).rotation_180 == 180.0
+
+
+def test_the_half_turn_wraps():
+    """Tescan's reference is 180, so its opposite is 0 and not 360.
+
+    The modulo is the difference between a file that reads `0` and one that reads `360`.
+    Both compare equal through `rotation_angle_is_smaller`, so nothing would have broken
+    -- it would just have been written in a spelling no other configuration uses, for a
+    reader to wonder about. `fibsem/configuration.py` omitted the modulo for years.
+    """
+    assert _stage(rotation_reference=180.0).rotation_180 == 0.0
+
+
+def test_a_stage_that_does_not_rotate_has_no_opposite():
+    """The compustage. It reaches the other side of the grid by tilting.
+
+    Returning the reference rather than raising or returning None keeps every consumer
+    branch-free: the movement paths compare a live rotation against both values, and
+    two equal targets is exactly the "there is only one side" they already handled.
+    """
+    assert _stage(rotation_reference=0.0, rotation=False).rotation_180 == 0.0
+
+
+def test_a_stored_value_is_ignored_rather_than_honoured():
+    """A configuration written before FIB-834 still loads, and its number is dropped.
+
+    Honouring it would preserve the one thing removing the field was meant to stop --
+    a stated opposite that disagrees with the reference beside it. This file says the
+    stage sits at 0 and turns round to 99; it turns round to 180.
+    """
+    stage = StageSystemSettings.from_dict(
+        {
+            "rotation_reference": 0.0,
+            "rotation_180": 99.0,
+            "shuttle_pre_tilt": 35.0,
+            "manipulator_height_limit": 0.0037,
+        }
+    )
+    assert stage.rotation_180 == 180.0
+
+
+def test_it_is_not_written_back_out():
+    """`to_dict` feeds both the saved file and the RPC client's `SystemSettings`.
+
+    The client rebuilds from this dict, so what matters is that the two inputs to the
+    derivation cross the wire -- not the derived value itself, which would only give the
+    two ends a way to disagree.
+    """
+    stage = _stage(rotation_reference=180.0)
+    payload = stage.to_dict()
+
+    assert "rotation_180" not in payload
+    assert payload["rotation_reference"] == 180.0
+    assert payload["rotation"] is True
+    assert StageSystemSettings.from_dict(payload).rotation_180 == 0.0

--- a/tests/ui/test_guided_setup_dialog.py
+++ b/tests/ui/test_guided_setup_dialog.py
@@ -158,8 +158,11 @@ def test_the_compustage_is_shown_the_step_but_cannot_edit_it(dialog):
 
 
 def test_the_compustage_writes_its_shipped_values_untouched(dialog):
-    """Read-only means the wizard did not ask, so the shipped pair stands -- including
-    the 0/0 rotation a derivation would get wrong."""
+    """Read-only means the wizard did not ask, so the shipped values stand -- including
+    ``rotation: false``, which is what stops the derivation handing a compustage a
+    half turn it cannot make (FIB-834)."""
+    from fibsem.structures import StageSystemSettings
+
     dialog._select_model("tfs-arctis")
     dialog._show_step(STEP_STAGE)
     dialog._read_current_step()
@@ -168,7 +171,9 @@ def test_the_compustage_writes_its_shipped_values_untouched(dialog):
 
     config = wizard.build_configuration(dialog.choices)
     assert config["stage"]["rotation_reference"] == 0
-    assert config["stage"]["rotation_180"] == 0
+    stage = StageSystemSettings.from_dict(config["stage"])
+    assert stage.rotation is False
+    assert stage.rotation_180 == 0
 
 
 def test_the_stage_step_is_prefilled_from_the_chosen_model(dialog):
@@ -640,9 +645,13 @@ def test_the_diagram_paints_at_the_extremes(qapp, pre_tilt, stage_tilt):
 def test_stage_answers_do_not_survive_a_change_of_model(dialog):
     """Left in place they would be written over the shipped values.
 
-    For a compustage, whose shipped pair is rotation reference 0 with ``rotation_180``
-    also 0, a number typed for some other model is exactly the wrong thing to keep.
+    For a compustage, which reaches the other side of the grid by tilting rather than
+    turning round, a reference typed for some other model is exactly the wrong thing to
+    keep -- it would be carried into a file whose ``rotation: false`` describes a
+    different stage.
     """
+    from fibsem.structures import StageSystemSettings
+
     dialog._select_model("tfs-other")
     dialog._show_step(STEP_STAGE)
     dialog._rotation_spin.setValue(250.0)
@@ -656,7 +665,7 @@ def test_stage_answers_do_not_survive_a_change_of_model(dialog):
 
     config = wizard.build_configuration(dialog.choices)
     assert config["stage"]["rotation_reference"] == 0
-    assert config["stage"]["rotation_180"] == 0
+    assert StageSystemSettings.from_dict(config["stage"]).rotation_180 == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes FIB-834.

`stage.rotation_180` was configured per system, but it was never a number anyone chose. Every shipped file gave it `(rotation_reference + 180) % 360` — Tescan included, whose reference of 180 is what makes the modulo load-bearing rather than decorative. The two exceptions were the compustages, which set it *equal* to the reference to mean "this stage does not turn round".

That is a boolean's job, and `stage.rotation` is the boolean — already on the class, and already `false` on the real Arctis.

| config | `rotation` | `rotation_reference` | stated `rotation_180` | now derives |
| --- | --- | --- | --- | --- |
| microscope-configuration | true | 0 | 180 | 180 |
| odemis | true | 0 | 180 | 180 |
| tfs-aquilos2 | true | 0 | 180 | 180 |
| tfs-hydra | true | 0 | 180 | 180 |
| sim-iflm | true | 0 | 180 | 180 |
| tescan | true | 180 | 0 | 0 |
| tfs-arctis | **false** | 0 | 0 | 0 |
| sim-arctis | **false** (was `true`) | 0 | 0 | 0 |

## What changed

- **`StageSystemSettings.rotation_180` is a property** — the reference for a stage that cannot rotate, `(reference + 180) % 360` otherwise. Every read site is untouched.
- **`from_dict` no longer requires the key**, and ignores it when present. A configuration written before this still loads; a stored value that disagrees with the derivation is *dropped* rather than honoured, since that disagreement is the thing this exists to stop. **This mattered:** the old reader used `settings["rotation_180"]`, a hard subscript, so simply deleting the key from a user's file would have raised `KeyError` at load.
- **`to_dict` stops emitting it.** The two inputs cross the RPC wire instead of the derived value, which could only give the two ends a way to disagree.
- **The key is gone** from all 8 shipped configs, `configuration.py`, `guided_setup.build_configuration`, and the config editor (spinbox deleted; a stale key in a loaded file is dropped on save rather than written back).
- **`sim-arctis-configuration.yaml` now says `rotation: false`.** It claimed `true` where the instrument it stands in for says `false`. Nothing read the flag, so nothing caught it — and the simulator is the only place the compustage path runs at all. The derivation now depends on it.

**Kept:** the stored field on `FibsemHardwareGeometry`. It is stamped onto every image and read back to reproject saved mosaics under the geometry they were acquired with. Derive on the live system; keep recording what was true at acquisition.

## Verification

The derivation reproduces the previously stated value for **every shipped config**, pinned file-by-file in a new `tests/test_stage_rotation_derivation.py`.

The exposure is `PRETILT_SIGN`, chosen by comparing the live rotation against `rotation_reference` and `rotation_180` in turn. On a compustage the two were both `0`, so *both* comparisons matched and the ion branch always won — derive it to a half turn and that coincidence breaks. It doesn't here, because the derivation returns the reference for a non-rotating stage.

Measured rather than argued. Swept the Arctis across `rotation_180` ∈ {0, 90, 180, 270, 359}, comparing 24 outputs each — orientation table, orientation classification, `_y_corrected_stage_movement` and its inverse over 5 tilts × 2 beams:

```
r180=  90.0: 0 observable differ, 5 internal-sign differ
r180= 180.0: 0 observable differ, 5 internal-sign differ
r180= 270.0: 0 observable differ, 5 internal-sign differ
r180= 359.0: 0 observable differ, 0 internal-sign differ
```

The value is inert on a compustage: it reaches `PRETILT_SIGN`, but that multiplies `shuttle_pre_tilt + column_tilt`, which is `0 + 0` on an Arctis. Note this is a coincidence of that geometry, not a structural guarantee — the same sweep with a hypothetical 35° pre-tilt changes 5 of 5 saved-image outputs. Which is the argument for deriving the field rather than trusting people to type it.

Also run:

- `tests/test_view_corrected_movement.py` — the 144-combination forward+inverse parity sweep FIB-834 names as the real gate — plus Tescan movement, projection-height and beam-stage-projection: **738 passed**.
- **Full non-UI suite: 4747 passed, 33 skipped, 1 xfailed.** Skips are the uninstalled plugin fixture; the xfail is the pre-existing FIB-868 correlator alias.
- `tests/ui/test_guided_setup_dialog.py` and the surrounding UI tests.
- Live on the simulator across all three mountings: orientation tables and SEM/FIB/MILLING round-trips identical to before, compustage FIB still `r=0, t=-128`. Config-editor widget smoke-tested directly, including a legacy file that still carries the key.

## Notes for review

- **19 files, over the usual ~5.** Eight are the shipped configs, one deleted line each; four more are their readers and writers. The field cannot be removed from some configurations and not others.
- **`tests/test_microscope.py` picked up a `ruff format` reflow.** It was already unformatted on `main`, but CI's `ruff format --check` runs on *changed* files, so touching it forced the fix. That's ~40 lines of mechanical churn unrelated to the change.
- **`tests/test_orientation_transform_parity.py`** has one test that needs a FIB rotation the derivation cannot produce (a quarter turn, pinning that the compucentric correction is *not* applied to it). It now writes that straight onto `microscope.orientations["FIB"].r` — the seam a future orientation at some other angle would arrive through — rather than configuring it.
- Follow-on, not in scope: `stage.rotation`/`stage.tilt` are otherwise dead — `is_available("stage_rotation")` has no call sites — and the capability is derivable live from `microscope._stage.limits` (`STAGE_LIMITS_COMPUSTAGE` has no `r` axis). Moving it to hardware truth would make `rotation` a runtime field rather than a configured one, with no further change to this derivation.
