### PR TITLE
[refactor] Remove the dead stage.tilt capability flag

### DIFF
--- a/fibsem/config/microscope-configuration.yaml
+++ b/fibsem/config/microscope-configuration.yaml
@@ -7,7 +7,6 @@ info:
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
-    tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]

--- a/fibsem/config/odemis-configuration.yaml
+++ b/fibsem/config/odemis-configuration.yaml
@@ -7,7 +7,6 @@ info:
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
-    tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]

--- a/fibsem/config/sim-arctis-configuration.yaml
+++ b/fibsem/config/sim-arctis-configuration.yaml
@@ -5,7 +5,6 @@ info:
 stage:
     enabled:                    true                        
     rotation:                   false                       
-    tilt:                       true                        
     rotation_reference:         0                           
     shuttle_pre_tilt:           0                        
     manipulator_height_limit:   0.0037                      

--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -25,7 +25,6 @@ fm:
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
-    tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED]
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]

--- a/fibsem/config/tescan-configuration.yaml
+++ b/fibsem/config/tescan-configuration.yaml
@@ -7,7 +7,6 @@ info:
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
-    tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         180                         # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           0                           # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufacturer]

--- a/fibsem/config/tfs-aquilos2-configuration.yaml
+++ b/fibsem/config/tfs-aquilos2-configuration.yaml
@@ -7,7 +7,6 @@ info:
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
-    tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]

--- a/fibsem/config/tfs-arctis-configuration.yaml
+++ b/fibsem/config/tfs-arctis-configuration.yaml
@@ -7,7 +7,6 @@ info:
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation:                   false                       # the stage is able to rotate; false means it has no 180-degree side  [USER]
-    tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           0                           # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]

--- a/fibsem/config/tfs-hydra-configuration.yaml
+++ b/fibsem/config/tfs-hydra-configuration.yaml
@@ -7,7 +7,6 @@ info:
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
-    tilt:                       true                        # the stage is able to tilt                                     [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1130,8 +1130,6 @@ class FibsemMicroscope(ABC):
             return self.system.stage.enabled
         elif system == "stage_rotation":
             return self.system.stage.rotation
-        elif system == "stage_tilt":
-            return self.system.stage.tilt
         elif system == "manipulator":
             return self.system.manipulator.enabled
         elif system == "manipulator_rotation":
@@ -1159,8 +1157,6 @@ class FibsemMicroscope(ABC):
             self.system.stage.enabled = value
         elif system == "stage_rotation":
             self.system.stage.rotation = value
-        elif system == "stage_tilt":
-            self.system.stage.tilt = value
         elif system == "manipulator":
             self.system.manipulator.enabled = value
         elif system == "manipulator_rotation":

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2216,8 +2216,15 @@ class StageSystemSettings:
     shuttle_pre_tilt: float
     manipulator_height_limit: float
     enabled: bool = True
+    # Whether the stage has a rotation axis. Load-bearing: it is what `rotation_180`
+    # below is derived from, so it describes the geometry and not merely a permission.
+    #
+    # There was a `tilt` beside it and there is not any more. Nothing read it, every
+    # shipped file said `true`, and every file always would have: `_get_axis_limits`
+    # returns a `t` axis on every backend, compustage included, because a stage that
+    # cannot tilt is not a stage this project drives. A flag with one reachable value
+    # is not a capability, it is a place for a typo to sit.
     rotation: bool = True
-    tilt: bool = True
     milling_angle: float = 15
     # Where the stage travels for each instrument to see the sample. Keyed by device
     # name -- "FIBSEM" and "FM" today -- and separate from `orientations`, which says
@@ -2260,7 +2267,6 @@ class StageSystemSettings:
             "manipulator_height_limit": self.manipulator_height_limit,
             "enabled": self.enabled,
             "rotation": self.rotation,
-            "tilt": self.tilt,
             "milling_angle": self.milling_angle,
             "device_range": device_axes_to_dict(self.device_range),
             "devices": {
@@ -2283,7 +2289,6 @@ class StageSystemSettings:
             manipulator_height_limit=settings["manipulator_height_limit"],
             enabled=settings.get("enabled", True),
             rotation=settings.get("rotation", True),
-            tilt=settings.get("tilt", True),
             milling_angle=settings.get("milling_angle", 15.0),
             device_range=(
                 device_axes_from_dict(device_range, "device range")

--- a/fibsem/ui/widgets/microscope_config_widget.py
+++ b/fibsem/ui/widgets/microscope_config_widget.py
@@ -250,9 +250,11 @@ class MicroscopeConfigWidget(QWidget):
         g_ion, self._sub_ion = grp(
             "Ion", [("Enabled", "enabled"), ("Plasma", "plasma")]
         )
+        # No "Tilt" here, unlike the manipulator below: every stage this project
+        # drives can tilt, so the checkbox only ever offered a way to be wrong.
         g_stage, self._sub_stage = grp(
             "Stage",
-            [("Enabled", "enabled"), ("Rotation", "rotation"), ("Tilt", "tilt")],
+            [("Enabled", "enabled"), ("Rotation", "rotation")],
         )
         g_manip, self._sub_manip = grp(
             "Manipulator",
@@ -489,6 +491,11 @@ class MicroscopeConfigWidget(QWidget):
             c.setdefault("ion", {})[key] = chk.isChecked()
         for key, chk in self._sub_stage.items():
             c.setdefault("stage", {})[key] = chk.isChecked()
+        # Same reason as `rotation_180` above: `c` is a deepcopy of the file as loaded,
+        # so an older configuration edited here would be written back still carrying a
+        # `stage.tilt` that no longer has a checkbox or a field behind it. The
+        # manipulator keeps its own `tilt`, which is why this is scoped to the stage.
+        c["stage"].pop("tilt", None)
         for key, chk in self._sub_manip.items():
             c.setdefault("manipulator", {})[key] = chk.isChecked()
         for key, chk in self._sub_gis.items():

--- a/tests/test_stage_capability_flags.py
+++ b/tests/test_stage_capability_flags.py
@@ -1,0 +1,120 @@
+"""`stage.tilt` is gone, and `stage.rotation` is not.
+
+Two booleans sat side by side in the stage configuration and looked like a pair. They
+were not. `rotation` distinguishes the two mountings this project drives -- it is what
+`rotation_180` is derived from (FIB-834) -- while `tilt` had one reachable value, was
+read by nothing, and existed only as somewhere for a typo to sit.
+
+The tests below pin both halves of that: that nothing lost a capability it was using,
+and that the asymmetry with the *manipulator*, which keeps its own `tilt`, is deliberate
+rather than an edit that missed a line.
+"""
+
+import os
+
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.microscopes.simulator import (
+    STAGE_LIMITS_COMPUSTAGE,
+    STAGE_LIMITS_DEFAULT,
+)
+from fibsem.structures import StageSystemSettings
+
+# Named rather than globbed. `fibsem/config/*.yaml` is gitignored with an allowlist
+# for the shipped files, so a configuration the developer saved from the wizard sits
+# in this same folder -- and a glob would sweep it in, failing on one machine and not
+# another for a reason that looks nothing like the cause.
+CONFIGS = (
+    "microscope-configuration.yaml",
+    "odemis-configuration.yaml",
+    "sim-arctis-configuration.yaml",
+    "sim-iflm-configuration.yaml",
+    "tescan-configuration.yaml",
+    "tfs-aquilos2-configuration.yaml",
+    "tfs-arctis-configuration.yaml",
+    "tfs-hydra-configuration.yaml",
+)
+
+
+def _stage_block(filename: str) -> dict:
+    return utils.load_yaml(os.path.join(cfg.CONFIG_PATH, filename))["stage"]
+
+
+@pytest.mark.parametrize("filename", CONFIGS)
+def test_no_shipped_file_states_a_stage_tilt(filename: str):
+    assert "tilt" not in _stage_block(filename)
+
+
+@pytest.mark.parametrize("filename", CONFIGS)
+def test_the_manipulator_keeps_its_own_tilt(filename: str):
+    """The asymmetry is the point, so it is asserted rather than left to be noticed.
+
+    A manipulator that cannot tilt is an ordinary manipulator; a stage that cannot tilt
+    is not a stage this project drives. The two keys were spelled the same and meant
+    different things, which is exactly how a scoped edit goes wrong -- a `tilt:` line
+    removed from the wrong block would silently give every manipulator a tilt axis.
+    """
+    config = utils.load_yaml(os.path.join(cfg.CONFIG_PATH, filename))
+    assert "tilt" in config["manipulator"]
+
+
+@pytest.mark.parametrize(
+    ("label", "limits"),
+    [("default", STAGE_LIMITS_DEFAULT), ("compustage", STAGE_LIMITS_COMPUSTAGE)],
+)
+def test_every_stage_has_a_tilt_axis(label: str, limits: dict):
+    """Why the flag had one reachable value.
+
+    A compustage is the stage that differs, and it differs by dropping `r` -- it reaches
+    the other side of the grid by tilting, so it needs `t` more than an ordinary stage
+    does, not less. Nothing here can answer "no" to tilt, which is what made a
+    configurable `tilt` a way to describe a machine that does not exist.
+    """
+    assert "t" in limits, label
+
+
+def test_only_the_compustage_drops_the_rotation_axis():
+    """The counterpart, and the reason `rotation` stays.
+
+    This is a real difference between two real mountings, and it is the input to the
+    `rotation_180` derivation, so a stage misdescribed here reaches the orientation
+    table and the compucentric correction.
+    """
+    assert "r" in STAGE_LIMITS_DEFAULT
+    assert "r" not in STAGE_LIMITS_COMPUSTAGE
+
+
+def test_a_stored_stage_tilt_is_ignored_rather_than_rejected():
+    """A configuration written before the removal still loads.
+
+    Dropped rather than honoured, for the same reason as `rotation_180`: there is no
+    field left to put it in, and refusing the file instead would make a dead flag able
+    to stop an instrument from starting.
+    """
+    stage = StageSystemSettings.from_dict(
+        {
+            "rotation_reference": 0.0,
+            "shuttle_pre_tilt": 35.0,
+            "manipulator_height_limit": 0.0037,
+            "tilt": False,
+        }
+    )
+    assert not hasattr(stage, "tilt")
+    assert "tilt" not in stage.to_dict()
+    assert stage.rotation_180 == 180.0
+
+
+def test_the_live_microscope_still_answers_for_rotation():
+    """`is_available` lost `stage_tilt` and kept `stage_rotation`."""
+    microscope, _ = utils.setup_session(
+        config_path=os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml"),
+        manufacturer="Demo",
+    )
+    assert microscope.is_available("stage_rotation") is False
+    assert microscope.is_available("stage") is True
+    # Unknown subsystems fall through to False rather than raising, so a caller left
+    # asking the old question gets a quiet "no" -- worth knowing, since that is what a
+    # stale plugin would see.
+    assert microscope.is_available("stage_tilt") is False


### PR DESCRIPTION
#782 has merged; this is now rebased onto `main` as a single commit.

`stage.tilt` was configured per system and read by nothing. `is_available("stage_tilt")` has **no call sites** anywhere in the repository, and the only other access was the accessor pair it sat behind.

It also had one reachable value. `_get_axis_limits` returns a `t` axis on every backend — the base default, the Thermo query, and `STAGE_LIMITS_COMPUSTAGE` alike — because a stage that cannot tilt is not a stage this project drives. The compustage is the mounting that differs, and it differs by dropping **`r`**: it reaches the other side of the grid by tilting, so it needs the tilt axis more than an ordinary stage does, not less.

A flag that can only say "true" is not a capability. It is a place for a typo to sit — and `sim-arctis-configuration.yaml` is the standing proof, since it carried a wrong `rotation: true` for however long precisely because nothing read it (fixed in #782).

**`stage.rotation` stays**, and is not the same kind of thing: it distinguishes two real mountings and is what `rotation_180` is derived from, so it describes the geometry rather than granting a permission.

## What changed

- The `tilt` field on `StageSystemSettings`, and its `to_dict`/`from_dict` entries.
- Both `is_available` / `set_available` branches in `microscope.py`.
- The "Tilt" checkbox on the config editor's Stage group (the manipulator keeps its own).
- The `stage.tilt` key in all 8 shipped configurations.

`from_dict` already read the key with a default, so a configuration written before this still loads and its value is ignored. The editor drops the key on save rather than writing back a flag with nothing behind it.

## The manipulator keeps its own `tilt`

That one is a genuine option — every shipped file sets it `false`. So the YAML edit is scoped to the `stage:` block, and a test asserts the asymmetry across all 8 files rather than leaving it to be noticed. A `tilt:` line removed from the wrong block would silently give every manipulator a tilt axis, and nothing else in the suite would have caught it.

## One behaviour change for review

`is_available("stage_tilt")` returned `True`; it now falls through to the method's unknown-subsystem `False`. Nothing in the repository asks, but an out-of-tree plugin that did would flip from true to false rather than raise.

Left as a clean removal rather than a deprecation shim, on the grounds that the question has never had a caller. Happy to add a shim that returns `True` with a `DeprecationWarning` if the plugin contract makes that the better call.

## Verification

- **Full non-UI suite: 4779 passed, 22 skipped, 1 xfailed.** The xfail is the pre-existing FIB-868 correlator alias.
- New `tests/test_stage_capability_flags.py` (21 tests) pins: no shipped file states `stage.tilt`; every shipped file still states `manipulator.tilt`; every stage limit set has a `t` axis and only the compustage lacks `r`; a stored `tilt` loads and is ignored; and `is_available` lost `stage_tilt` while keeping `stage_rotation`.
- Config editor smoke-tested against a legacy file carrying `stage.tilt: false` — dropped on save, `manipulator.tilt` preserved, config still loads and derives `rotation_180 = 180`.
- `tests/ui/test_guided_setup_dialog.py` and `test_configuration_import.py`: 73 passed.

## Note

My first draft of the test globbed `fibsem/config/*-configuration.yaml`. That folder is gitignored with an allowlist for the shipped files, so a configuration saved from the setup wizard lives there too and would have been swept into the parametrisation — a test that fails on one machine and not another, for a reason that looks nothing like the cause. It now names the 8 shipped files explicitly.

