### PR TITLE
[fix] Draw bitmap, annulus and exclusion milling patterns on the canvas

### DIFF
--- a/fibsem/milling/patterning/plotting.py
+++ b/fibsem/milling/patterning/plotting.py
@@ -446,6 +446,12 @@ def _add_bitmap_mpl(
     ax.imshow(
         rgba,
         extent=(0, 1, 0, 1),
+        # origin="lower", not the default: the rectangle's patch transform maps v=0
+        # to its xy corner, which is the TOP edge on the y-inverted image axes. The
+        # default "upper" puts bitmap row 0 at the extent's `top` (v=1) and so drew
+        # every bitmap upside down. Row 0 is the top-left cell (AutoScript's
+        # convention), and `flip_y` is what mirrors it deliberately.
+        origin="lower",
         transform=edge_rectangle.get_patch_transform()
         + edge_rectangle.get_data_transform(),
         zorder=edge_rectangle.get_zorder(),

--- a/fibsem/milling/patterning/plotting.py
+++ b/fibsem/milling/patterning/plotting.py
@@ -67,7 +67,9 @@ OVERLAP_PROPERTIES = {
 
 
 def _rect_pattern_to_image_pixels(
-    pattern: Union[FibsemRectangleSettings, FibsemBitmapSettings], pixel_size: float, image_shape: Tuple[int, int]
+    pattern: Union[FibsemRectangleSettings, FibsemBitmapSettings],
+    pixel_size: float,
+    image_shape: Tuple[int, int],
 ) -> Tuple[float, float, float, float]:
     """Convert rectangle pattern to image pixel coordinates.
     Args:
@@ -92,6 +94,7 @@ def _rect_pattern_to_image_pixels(
     height = height / pixel_size
 
     return centre.x, centre.y, width, height
+
 
 def _circle_pattern_to_image_pixels(
     pattern: FibsemCircleSettings, pixel_size: float, image_shape: Tuple[int, int]
@@ -121,6 +124,7 @@ def _circle_pattern_to_image_pixels(
     inner_radius_px = max(0, (radius - thickness) / pixel_size) if thickness > 0 else 0
 
     return centre.x, centre.y, radius_px, inner_radius_px, start_angle, end_angle
+
 
 def _line_pattern_to_image_pixels(
     pattern: FibsemLineSettings, pixel_size: float, image_shape: Tuple[int, int]
@@ -152,6 +156,7 @@ def _line_pattern_to_image_pixels(
     )
 
     return start.x, start.y, end.x, end.y
+
 
 def _polygon_pattern_to_image_pixels(
     pattern: FibsemPolygonSettings, pixel_size: float, image_shape: Tuple[int, int]
@@ -237,7 +242,6 @@ def _add_circle_mpl(
 
     if shape.is_exclusion:
         colour = "black"
-
 
     if inner_radius_px > 0:
         # annulus/ring pattern
@@ -434,17 +438,16 @@ def _add_polygon_mpl(
     pixel_size = image.metadata.pixel_size.x
     image_shape = image.data.shape
     pixel_vertices = _polygon_pattern_to_image_pixels(shape, pixel_size, image_shape)
-    
 
     patch = mpatches.Polygon(
-            pixel_vertices,
-            closed=True,
-            linewidth=PROPERTIES["line_width"],
-            edgecolor=colour,
-            facecolor=colour,
-            alpha=PROPERTIES["opacity"],
-            zorder=zorder,
-        )
+        pixel_vertices,
+        closed=True,
+        linewidth=PROPERTIES["line_width"],
+        edgecolor=colour,
+        facecolor=colour,
+        alpha=PROPERTIES["opacity"],
+        zorder=zorder,
+    )
 
     ax.add_patch(patch)
 
@@ -474,15 +477,20 @@ def _add_overlaps_mpl(
     """
     if len(milling_stages) < 2:
         return None
-    
+
     overlap_patches = []
-    
+
     # Create masks for each pattern
     pattern_masks = []
     for stage in milling_stages:
-        stage_mask = create_pattern_mask(stage.pattern, image.data.shape, pixelsize=image.metadata.pixel_size.x, include_exclusions=False)
+        stage_mask = create_pattern_mask(
+            stage.pattern,
+            image.data.shape,
+            pixelsize=image.metadata.pixel_size.x,
+            include_exclusions=False,
+        )
         pattern_masks.append(stage_mask)
-    
+
     # Find overlaps between patterns
     for i in range(len(pattern_masks)):
         for j in range(i + 1, len(pattern_masks)):
@@ -491,10 +499,13 @@ def _add_overlaps_mpl(
                 # Create contour patches for overlap regions
                 try:
                     import skimage.measure
+
                     contours = skimage.measure.find_contours(overlap.astype(float), 0.5)
-                    
+
                     for contour in contours:
-                        if len(contour) > 3:  # Only create patches for significant overlaps
+                        if (
+                            len(contour) > 3
+                        ):  # Only create patches for significant overlaps
                             # Swap x,y coordinates for matplotlib (contour gives row,col)
                             contour_xy = contour[:, [1, 0]]
                             patch = mpatches.Polygon(
@@ -513,7 +524,7 @@ def _add_overlaps_mpl(
                     if len(overlap_coords[0]) > 0:
                         y_min, y_max = overlap_coords[0].min(), overlap_coords[0].max()
                         x_min, x_max = overlap_coords[1].min(), overlap_coords[1].max()
-                        
+
                         patch = mpatches.Rectangle(
                             (x_min, y_min),
                             x_max - x_min,
@@ -617,11 +628,11 @@ def draw_milling_patterns(
             extra_parts.append(stage.milling.preset)
         if show_depth:
             # Get depth from pattern
-            depth_m = getattr(pattern, 'depth', None)
+            depth_m = getattr(pattern, "depth", None)
             if depth_m is not None:
                 depth_um = depth_m * 1e6  # Convert from meters to microns
                 extra_parts.append(f"{depth_um:.1f}μm")
-        
+
         extra = ", ".join(extra_parts)
 
         # Get all shapes from the pattern
@@ -748,13 +759,16 @@ def draw_milling_patterns(
 
     return fig, ax
 
+
 # Plotting utilities for drawing pattern as numpy arrays
+
 
 @dataclass
 class DrawnPattern:
     pattern: np.ndarray
     position: Point
     is_exclusion: bool
+
 
 def _create_annulus_shape(width, height, inner_radius, outer_radius):
     # Create a grid of coordinates
@@ -763,10 +777,17 @@ def _create_annulus_shape(width, height, inner_radius, outer_radius):
     X, Y = np.meshgrid(x, y)
     distance = np.sqrt(X**2 + Y**2)
     # Generate the donut shape
-    donut = np.logical_and(distance <= outer_radius, distance >= inner_radius).astype(int)
+    donut = np.logical_and(distance <= outer_radius, distance >= inner_radius).astype(
+        int
+    )
     return donut
 
-def draw_annulus_shape(pattern_settings: FibsemCircleSettings, image_shape: Tuple[int, int], pixelsize: float) -> DrawnPattern:
+
+def draw_annulus_shape(
+    pattern_settings: FibsemCircleSettings,
+    image_shape: Tuple[int, int],
+    pixelsize: float,
+) -> DrawnPattern:
     """Convert an annulus pattern to a np array. Note: annulus can only be plotted as image
     Args:
         pattern_settings: FibsemCircleSettings: Annulus pattern settings.
@@ -775,7 +796,7 @@ def draw_annulus_shape(pattern_settings: FibsemCircleSettings, image_shape: Tupl
     Returns:
         DrawnPattern: Annulus shape in image.
     """
-    
+
     # image parameters (centre, pixel size)
     icy, icx = get_image_pixel_centre(image_shape)
     pixelsize_x, pixelsize_y = pixelsize, pixelsize
@@ -786,15 +807,15 @@ def draw_annulus_shape(pattern_settings: FibsemCircleSettings, image_shape: Tupl
     center_x = pattern_settings.centre_x
     center_y = pattern_settings.centre_y
 
-    radius_px = radius / pixelsize_x # isotropic
+    radius_px = radius / pixelsize_x  # isotropic
     shape = int(2 * radius_px)
-    inner_radius_ratio = 0 # full circle
+    inner_radius_ratio = 0  # full circle
     if not np.isclose(thickness, 0):
-        inner_radius_ratio = (radius - thickness)/radius
-   
-    annulus_shape = _create_annulus_shape(width=shape, height=shape, 
-                                          inner_radius=inner_radius_ratio, 
-                                          outer_radius=1)
+        inner_radius_ratio = (radius - thickness) / radius
+
+    annulus_shape = _create_annulus_shape(
+        width=shape, height=shape, inner_radius=inner_radius_ratio, outer_radius=1
+    )
 
     # get pattern centre in image coordinates
     pattern_centre_x = int(icx + center_x / pixelsize_x)
@@ -802,9 +823,16 @@ def draw_annulus_shape(pattern_settings: FibsemCircleSettings, image_shape: Tupl
 
     pos = Point(x=pattern_centre_x, y=pattern_centre_y)
 
-    return DrawnPattern(pattern=annulus_shape, position=pos, is_exclusion=pattern_settings.is_exclusion)
+    return DrawnPattern(
+        pattern=annulus_shape, position=pos, is_exclusion=pattern_settings.is_exclusion
+    )
 
-def draw_rectangle_shape(pattern_settings: FibsemRectangleSettings, image_shape: Tuple[int, int], pixelsize: float) -> DrawnPattern:
+
+def draw_rectangle_shape(
+    pattern_settings: FibsemRectangleSettings,
+    image_shape: Tuple[int, int],
+    pixelsize: float,
+) -> DrawnPattern:
     """Convert a rectangle pattern to a np array with rotation support.
     Args:
         pattern_settings: FibsemRectangleSettings: Rectangle pattern settings.
@@ -839,17 +867,19 @@ def draw_rectangle_shape(pattern_settings: FibsemRectangleSettings, image_shape:
     if not np.isclose(rotation, 0):
         # Convert radians to degrees for scipy
         rotation_degrees = np.degrees(rotation)
-        
+
         # Rotate the shape, reshape=True to accommodate the rotated rectangle
         shape = rotate(shape, rotation_degrees, reshape=True, order=1, prefilter=False)
-        
+
         # Convert back to binary (rotation may introduce intermediate values)
         shape = (shape > 0.5).astype(float)
 
     # get pattern centre in image coordinates
     pos = Point(x=cx, y=cy)
 
-    return DrawnPattern(pattern=shape, position=pos, is_exclusion=pattern_settings.is_exclusion)
+    return DrawnPattern(
+        pattern=shape, position=pos, is_exclusion=pattern_settings.is_exclusion
+    )
 
 
 def draw_bitmap_shape(
@@ -933,7 +963,11 @@ def draw_line_shape(
     return DrawnPattern(pattern=shape, position=pos, is_exclusion=False)
 
 
-def draw_polygon_shape(pattern_settings: FibsemPolygonSettings, image_shape: Tuple[int, int], pixelsize: float) -> DrawnPattern:
+def draw_polygon_shape(
+    pattern_settings: FibsemPolygonSettings,
+    image_shape: Tuple[int, int],
+    pixelsize: float,
+) -> DrawnPattern:
     """Convert a polygon pattern to a np array.
     Args:
         pattern_settings: FibsemPolygonSettings: Polygon pattern settings.
@@ -953,42 +987,47 @@ def draw_polygon_shape(pattern_settings: FibsemPolygonSettings, image_shape: Tup
     for vertex in pattern_settings.vertices:
         # position in metres from image centre
         pmx, pmy = vertex[0] / pixelsize_x, vertex[1] / pixelsize_y
-        
+
         # convert to image coordinates
         px = icx + pmx
         py = icy - pmy
-        
+
         vertices_px.append((px, py))
-    
+
     vertices_px = np.array(vertices_px)
-    
+
     # Find bounding box of polygon
     min_x, min_y = np.floor(vertices_px.min(axis=0)).astype(int)
     max_x, max_y = np.ceil(vertices_px.max(axis=0)).astype(int)
-    
+
     # Create shape array with some padding
     padding = 2
     shape_width = max_x - min_x + 2 * padding
     shape_height = max_y - min_y + 2 * padding
-    
+
     # Offset vertices to shape coordinates
     vertices_shape = vertices_px - [min_x - padding, min_y - padding]
-    
+
     # Create the polygon mask
     shape = np.zeros((shape_height, shape_width), dtype=float)
-    
+
     # Use skimage.draw.polygon to fill the polygon
     rr, cc = polygon(vertices_shape[:, 1], vertices_shape[:, 0], shape.shape)
     shape[rr, cc] = 1.0
-    
+
     # Calculate center position
     center_x = (min_x + max_x) // 2
     center_y = (min_y + max_y) // 2
     pos = Point(x=center_x, y=center_y)
 
-    return DrawnPattern(pattern=shape, position=pos, is_exclusion=pattern_settings.is_exclusion)
+    return DrawnPattern(
+        pattern=shape, position=pos, is_exclusion=pattern_settings.is_exclusion
+    )
 
-def draw_pattern_shape(ps: FibsemPatternSettings, image_shape: Tuple[int, int], pixelsize: float) -> DrawnPattern:
+
+def draw_pattern_shape(
+    ps: FibsemPatternSettings, image_shape: Tuple[int, int], pixelsize: float
+) -> DrawnPattern:
     if isinstance(ps, FibsemCircleSettings):
         return draw_annulus_shape(ps, image_shape, pixelsize)
     elif isinstance(ps, FibsemRectangleSettings):
@@ -1002,12 +1041,12 @@ def draw_pattern_shape(ps: FibsemPatternSettings, image_shape: Tuple[int, int], 
     else:
         raise ValueError(f"Unsupported shape type {type(ps)}")
 
-def draw_pattern_in_image(image: np.ndarray, 
-                          drawn_pattern: DrawnPattern) -> np.ndarray:
+
+def draw_pattern_in_image(image: np.ndarray, drawn_pattern: DrawnPattern) -> np.ndarray:
 
     pattern = drawn_pattern.pattern
     pos = drawn_pattern.position
-    
+
     # place the annulus shape in the image
     w = pattern.shape[1] // 2
     h = pattern.shape[0] // 2
@@ -1016,18 +1055,21 @@ def draw_pattern_in_image(image: np.ndarray,
     xmin, xmax = pos.x - w, pos.x + w
     ymin, ymax = pos.y - h, pos.y + h
     zero_image = np.zeros_like(image)
-    zero_image[ymin:ymax, xmin:xmax] = pattern[:2*h, :2*w].astype(bool)
+    zero_image[ymin:ymax, xmin:xmax] = pattern[: 2 * h, : 2 * w].astype(bool)
 
     # if the pattern is an exclusion, set the image to zero
     if drawn_pattern.is_exclusion:
         image[zero_image == 1] = 0
     else:
         # add the annulus shape to the image, clip to 1
-        image = np.clip(image+zero_image, 0, 1)
+        image = np.clip(image + zero_image, 0, 1)
 
     return image
 
-def compose_pattern_image(image: np.ndarray, drawn_patterns: List[DrawnPattern]) -> np.ndarray:
+
+def compose_pattern_image(
+    image: np.ndarray, drawn_patterns: List[DrawnPattern]
+) -> np.ndarray:
     """Create an image with annulus shapes."""
     # create an empty image
     pattern_image = np.zeros_like(image)
@@ -1044,27 +1086,29 @@ def compose_pattern_image(image: np.ndarray, drawn_patterns: List[DrawnPattern])
 
 def simple_example(stages: List[FibsemMillingStage], image: FibsemImage) -> plt.Figure:
     """Simple demonstration of masks and bounding boxes."""
-    
+
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
-    
+
     # Plot 1: Show masks
-    ax1.imshow(image.data, cmap='gray', alpha=0.7)
+    ax1.imshow(image.data, cmap="gray", alpha=0.7)
     ax1.set_title("Pattern Masks")
-    
+
     for i, stage in enumerate(stages):
         # Create mask
-        mask = create_pattern_mask(stage.pattern, image.data.shape, pixelsize=image.metadata.pixel_size.x)
+        mask = create_pattern_mask(
+            stage.pattern, image.data.shape, pixelsize=image.metadata.pixel_size.x
+        )
 
         # Show mask as colored overlay
         masked = np.ma.masked_where(~mask, mask)
-        ax1.imshow(masked, alpha=0.6, cmap='gray', vmin=0, vmax=10)
+        ax1.imshow(masked, alpha=0.6, cmap="gray", vmin=0, vmax=10)
 
         print(f"{stage.name}: {np.sum(mask)} pixels")
-    
+
     # Plot 2: Show bounding boxes
-    ax2.imshow(image.data, cmap='gray')
+    ax2.imshow(image.data, cmap="gray")
     ax2.set_title("Bounding Boxes")
-    
+
     for i, stage in enumerate(stages):
         # Get bounding box
         x_min, y_min, x_max, y_max = get_pattern_bounding_box(stage.pattern, image)
@@ -1072,24 +1116,39 @@ def simple_example(stages: List[FibsemMillingStage], image: FibsemImage) -> plt.
         if (x_min, y_min, x_max, y_max) != (0, 0, 0, 0):
             # Draw bounding box using COLOURS from plotting.py
             bbox = mpatches.Rectangle(
-                (x_min, y_min), x_max - x_min, y_max - y_min,
-                linewidth=2, edgecolor=COLOURS[i % len(COLOURS)], facecolor='none'
+                (x_min, y_min),
+                x_max - x_min,
+                y_max - y_min,
+                linewidth=2,
+                edgecolor=COLOURS[i % len(COLOURS)],
+                facecolor="none",
             )
             ax2.add_patch(bbox)
-            ax2.text(x_min, y_min-5, stage.name, color=COLOURS[i % len(COLOURS)], fontsize=9)
+            ax2.text(
+                x_min,
+                y_min - 5,
+                stage.name,
+                color=COLOURS[i % len(COLOURS)],
+                fontsize=9,
+            )
 
     # Add combined bounding box
     patterns = [stage.pattern for stage in stages]
     x_min, y_min, x_max, y_max = get_patterns_bounding_box(patterns, image)
     if (x_min, y_min, x_max, y_max) != (0, 0, 0, 0):
         combined_bbox = mpatches.Rectangle(
-            (x_min, y_min), x_max - x_min, y_max - y_min,
-            linewidth=3, edgecolor='black', facecolor='none', linestyle='--'
+            (x_min, y_min),
+            x_max - x_min,
+            y_max - y_min,
+            linewidth=3,
+            edgecolor="black",
+            facecolor="none",
+            linestyle="--",
         )
         ax2.add_patch(combined_bbox)
-        ax2.text(x_min, y_max+10, 'Combined', color='black', fontweight='bold')
-    
+        ax2.text(x_min, y_max + 10, "Combined", color="black", fontweight="bold")
+
     plt.tight_layout()
     plt.show()
-    
+
     return fig

--- a/fibsem/milling/patterning/plotting.py
+++ b/fibsem/milling/patterning/plotting.py
@@ -381,10 +381,12 @@ def bitmap_to_rgba(
             blanking_array, output_shape=target_shape, preserve_range=True, order=0
         )
 
+    # No `N`: the list is already 256 long, and passing N alongside it is deprecated
+    # from matplotlib 3.11 and removed in 3.13. The deprecation is raised as an error
+    # under the test suite's warning filters, which is how this surfaced.
     cmap = ListedColormap(
         np.linspace((0, 0, 0, 0), to_rgba(colour, alpha=1), endpoint=True, num=256),
         name=f"{colour}_blend",
-        N=256,
     )
     rgba = cmap(dwell_time_array)
     rgba[blanking_array] = (0, 0, 0, 1)

--- a/fibsem/milling/patterning/plotting.py
+++ b/fibsem/milling/patterning/plotting.py
@@ -244,10 +244,13 @@ def _add_circle_mpl(
         colour = "black"
 
     if inner_radius_px > 0:
-        # annulus/ring pattern
+        # annulus/ring pattern. Annulus takes the OUTER radius and measures `width`
+        # inward from it, so the ring runs radius-thickness .. radius — matching the
+        # mask path (`draw_annulus_shape`). Passing the inner radius as `r` drew the
+        # ring one thickness too small, and too near the centre.
         patch = mpatches.Annulus(
             (px, py),
-            r=inner_radius_px,
+            r=radius_px,
             width=radius_px - inner_radius_px,
             angle=math.degrees(-shape.rotation),
             linewidth=PROPERTIES["line_width"],
@@ -323,6 +326,75 @@ def _add_line_mpl(
         )
 
 
+def bitmap_to_rgba(
+    shape: FibsemBitmapSettings,
+    width_px: float,
+    height_px: float,
+    colour: str,
+    opacity: float = PROPERTIES["opacity"],
+) -> np.ndarray:
+    """Colourise a bitmap pattern's dwell-time array for display.
+
+    Dwell time maps onto a transparent → *colour* ramp; blanked pixels
+    (``bitmap[:, :, 1] == 1``) become opaque black. The array is downsized to the
+    pattern's on-screen size when it is larger, so no cell is subpixel (those are
+    not displayed).
+
+    Args:
+        shape: the bitmap pattern (``shape.bitmap`` may be None → fully transparent).
+        width_px: pattern width in image pixels.
+        height_px: pattern height in image pixels.
+        colour: display colour of the pattern.
+        opacity: alpha applied to the whole array (blanked pixels included).
+    Returns:
+        (H, W, 4) float RGBA array, ready to be drawn over the pattern rectangle.
+    """
+    bitmap = shape.bitmap
+
+    if bitmap is None:
+        bitmap = np.zeros((1, 1, 2), dtype=float)
+
+    if shape.flip_y:
+        bitmap = np.flip(bitmap, axis=0)
+
+    dwell_time_array = bitmap[:, :, 0].astype(np.float64)
+    blanking_array = bitmap[:, :, 1] == 1
+
+    # Ensure no rectangles will be subpixel (these are not displayed)
+    target_shape = list(dwell_time_array.shape)
+    resize_array = False
+    if height_px < dwell_time_array.shape[0]:
+        resize_array = True
+        target_shape[0] = round(height_px)
+    if width_px < dwell_time_array.shape[1]:
+        resize_array = True
+        target_shape[1] = round(width_px)
+
+    if resize_array:
+        dwell_time_array = resize(
+            dwell_time_array,
+            output_shape=target_shape,
+            preserve_range=True,
+            order=1,  # bi-linear interpolation
+        )
+        blanking_array = resize(
+            blanking_array, output_shape=target_shape, preserve_range=True, order=0
+        )
+
+    cmap = ListedColormap(
+        np.linspace((0, 0, 0, 0), to_rgba(colour, alpha=1), endpoint=True, num=256),
+        name=f"{colour}_blend",
+        N=256,
+    )
+    rgba = cmap(dwell_time_array)
+    rgba[blanking_array] = (0, 0, 0, 1)
+
+    # Apply opacity to the array (imshow alpha overrides these values).
+    rgba[:, :, 3] *= opacity
+
+    return rgba
+
+
 def _add_bitmap_mpl(
     shape: FibsemBitmapSettings,
     image: FibsemImage,
@@ -351,48 +423,7 @@ def _add_bitmap_mpl(
         shape, pixel_size, (image_shape[0], image_shape[1])
     )
 
-    bitmap = shape.bitmap
-
-    if bitmap is None:
-        bitmap = np.zeros((1, 1, 2), dtype=float)
-
-    if shape.flip_y:
-        bitmap = np.flip(bitmap, axis=0)
-
-    dwell_time_array = bitmap[:, :, 0].astype(np.float64)
-    blanking_array = bitmap[:, :, 1] == 1
-
-    # Ensure no rectangles will be subpixel (these are not displayed)
-    target_shape = list(dwell_time_array.shape)
-    resize_array = False
-    if height < dwell_time_array.shape[0]:
-        resize_array = True
-        target_shape[0] = round(height)
-    if width < dwell_time_array.shape[1]:
-        resize_array = True
-        target_shape[1] = round(width)
-
-    if resize_array:
-        dwell_time_array = resize(
-            dwell_time_array,
-            output_shape=target_shape,
-            preserve_range=True,
-            order=1,  # bi-linear interpolation
-        )
-        blanking_array = resize(
-            blanking_array, output_shape=target_shape, preserve_range=True, order=0
-        )
-
-    cmap = ListedColormap(
-        np.linspace((0, 0, 0, 0), to_rgba(colour, alpha=1), endpoint=True, num=256),
-        name=f"{colour}_blend",
-        N=256,
-    )
-    rgba = cmap(dwell_time_array)
-    rgba[blanking_array] = (0, 0, 0, 1)
-
-    # Apply opacity to the array (imshow alpha overrides these values).
-    rgba[:, :, 3] *= PROPERTIES["opacity"]
+    rgba = bitmap_to_rgba(shape, width, height, colour)
 
     # Draw the edges
     edge_rectangle = mpatches.Rectangle(

--- a/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
@@ -334,7 +334,9 @@ class MillingPatternOverlay(CanvasOverlay):
 
         The image is an :class:`AxesImage` on the unit square, mapped onto the
         outline through the rectangle's own transform, so rotation and size come
-        out of the patch rather than being applied to the pixel data. It is built
+        out of the patch rather than being applied to the pixel data. Row 0 of the
+        bitmap is drawn at the top of the pattern, matching AutoScript's top-left
+        origin; ``flip_y`` mirrors it. It is built
         directly instead of via ``ax.imshow`` on purpose: ``imshow`` routes through
         ``add_image`` → ``update_datalim``, which would autoscale the axes to the
         image and throw away the user's pan/zoom.
@@ -362,7 +364,10 @@ class MillingPatternOverlay(CanvasOverlay):
         )
         outline.set_transform(self._ax.transData)
 
-        image = AxesImage(self._ax, extent=(0, 1, 0, 1), zorder=zorder)
+        # origin="lower": the patch transform maps v=0 to the rectangle's xy corner,
+        # which is its TOP edge on the y-inverted image axes, so row 0 of the bitmap
+        # has to go at the extent's `bottom` to land at the top of the pattern.
+        image = AxesImage(self._ax, extent=(0, 1, 0, 1), origin="lower", zorder=zorder)
         image.set_data(bitmap_to_rgba(ps, width, height, colour, _FILL_ALPHA))
         image.set_transform(
             outline.get_patch_transform() + outline.get_data_transform()

--- a/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/milling_overlay.py
@@ -15,17 +15,19 @@ nothing until :meth:`set_stages` is called with non-empty stages; :meth:`clear`
 milling.
 
 Deferred (see design doc): direct drag-to-move, FOV rect, alignment area,
-selected-stage highlight, background stages, annulus / bitmap shapes.
+selected-stage highlight, background stages.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional, Sequence
+import math
+from typing import TYPE_CHECKING, List, Optional, Sequence
 
 import matplotlib.lines as mlines
 import matplotlib.patches as mpatches
 from matplotlib.colors import to_rgba
+from matplotlib.image import AxesImage
 
 from fibsem.conversions import microscope_image_to_image_coordinates
 from fibsem.milling.patterning.shapes import (
@@ -35,6 +37,7 @@ from fibsem.milling.patterning.shapes import (
     convert_pattern_to_napari_rect,
 )
 from fibsem.structures import (
+    FibsemBitmapSettings,
     FibsemCircleSettings,
     FibsemImage,
     FibsemLineSettings,
@@ -59,6 +62,7 @@ _FILL_ALPHA = 0.4  # semi-transparent fill; edge stays solid
 _LINEWIDTH = 1.0  # default pattern edge width
 _LINEWIDTH_SELECTED = 2.5  # selected stage edge width
 _BACKGROUND_COLOUR = "black"  # background milling stages
+_EXCLUSION_COLOUR = "black"  # exclusion shapes, whatever their stage's colour
 
 
 class MillingPatternOverlay(CanvasOverlay):
@@ -224,19 +228,28 @@ class MillingPatternOverlay(CanvasOverlay):
         zorder: float,
     ) -> None:
         for pattern_settings in stage.define_patterns():
-            artist = self._shape_to_artist(
+            for artist in self._shape_to_artists(
                 pattern_settings, shape, pixelsize, colour, linewidth, zorder
-            )
-            if artist is not None:
+            ):
                 self._ax.add_artist(artist)
                 self._artists.append(artist)
         self._draw_crosshair(
             stage.pattern.point, shape, pixelsize, colour, zorder + 0.5
         )
 
-    def _shape_to_artist(
+    def _shape_to_artists(
         self, ps, shape, pixelsize: float, colour: str, linewidth: float, zorder: float
-    ):
+    ) -> List:
+        """Artists for one pattern shape (empty when the shape is unsupported).
+
+        Most shapes are a single patch; a bitmap is an outline plus the image
+        drawn inside it, hence the list.
+        """
+        if getattr(ps, "is_exclusion", False):
+            # Exclusion zones are the region the mill must not touch. Black in the
+            # napari path and in the report plot; black here too. Lines have no
+            # is_exclusion, hence the getattr.
+            colour = _EXCLUSION_COLOUR
         # Solid edge + same-colour fill at _FILL_ALPHA. Independent face/edge
         # alphas via RGBA (a patch-level ``alpha`` would dim the edge too).
         patch_kw = dict(
@@ -247,30 +260,115 @@ class MillingPatternOverlay(CanvasOverlay):
         )
         if isinstance(ps, FibsemRectangleSettings):
             verts, _ = convert_pattern_to_napari_rect(ps, shape, pixelsize)
-            return mpatches.Polygon(
-                verts[:, ::-1], closed=True, **patch_kw
-            )  # (y,x)→(x,y)
+            return [
+                mpatches.Polygon(verts[:, ::-1], closed=True, **patch_kw)
+            ]  # (y,x)→(x,y)
+        if isinstance(ps, FibsemBitmapSettings):
+            return self._bitmap_artists(ps, shape, pixelsize, colour, linewidth, zorder)
         if isinstance(ps, FibsemCircleSettings):
-            centre = microscope_image_to_image_coordinates(
-                Point(x=ps.centre_x, y=ps.centre_y), shape, pixelsize
-            )
-            return mpatches.Circle(
-                (centre.x, centre.y), ps.radius / pixelsize, **patch_kw
-            )
+            return self._circle_artists(ps, shape, pixelsize, patch_kw)
         if isinstance(ps, FibsemLineSettings):
             verts, _ = convert_pattern_to_napari_line(ps, shape, pixelsize)
             (y0, x0), (y1, x1) = verts
-            return mlines.Line2D(
-                [x0, x1],
-                [y0, y1],
-                color=colour,
-                linewidth=linewidth,
-                zorder=zorder,
-            )
+            return [
+                mlines.Line2D(
+                    [x0, x1],
+                    [y0, y1],
+                    color=colour,
+                    linewidth=linewidth,
+                    zorder=zorder,
+                )
+            ]
         if isinstance(ps, FibsemPolygonSettings):
             verts, _ = convert_pattern_to_napari_polygon(ps, shape, pixelsize)
-            return mpatches.Polygon(verts[:, ::-1], closed=True, **patch_kw)
-        return None  # bitmap / annulus / unknown — deferred
+            return [mpatches.Polygon(verts[:, ::-1], closed=True, **patch_kw)]
+        return []  # annulus / unknown — deferred
+
+    def _circle_artists(
+        self, ps: FibsemCircleSettings, shape, pixelsize: float, patch_kw
+    ) -> List:
+        """Circle, annulus (``thickness``) or wedge (partial angles), as the shape asks.
+
+        ``thickness`` measures inward from ``radius``, so the ring runs from
+        ``radius - thickness`` to ``radius`` — matplotlib's ``Annulus`` takes that as
+        the *outer* radius plus the width, not the inner radius.
+        """
+        centre = microscope_image_to_image_coordinates(
+            Point(x=ps.centre_x, y=ps.centre_y), shape, pixelsize
+        )
+        radius = ps.radius / pixelsize
+        thickness = min(ps.thickness, ps.radius) / pixelsize if ps.thickness > 0 else 0
+
+        if thickness > 0:
+            return [
+                mpatches.Annulus(
+                    (centre.x, centre.y),
+                    r=radius,
+                    width=thickness,
+                    angle=math.degrees(-ps.rotation),
+                    **patch_kw,
+                )
+            ]
+        if ps.start_angle != 0 or ps.end_angle != 360:
+            return [
+                mpatches.Wedge(
+                    (centre.x, centre.y),
+                    r=radius,
+                    theta1=ps.start_angle,
+                    theta2=ps.end_angle,
+                    **patch_kw,
+                )
+            ]
+        return [mpatches.Circle((centre.x, centre.y), radius, **patch_kw)]
+
+    def _bitmap_artists(
+        self,
+        ps: FibsemBitmapSettings,
+        shape,
+        pixelsize: float,
+        colour: str,
+        linewidth: float,
+        zorder: float,
+    ) -> List:
+        """Outline + colourised bitmap image for one bitmap pattern.
+
+        The image is an :class:`AxesImage` on the unit square, mapped onto the
+        outline through the rectangle's own transform, so rotation and size come
+        out of the patch rather than being applied to the pixel data. It is built
+        directly instead of via ``ax.imshow`` on purpose: ``imshow`` routes through
+        ``add_image`` → ``update_datalim``, which would autoscale the axes to the
+        image and throw away the user's pan/zoom.
+        """
+        # Imported here, not at module import: it pulls in pyplot + skimage, which
+        # the rest of this overlay does not need.
+        from fibsem.milling.patterning.plotting import bitmap_to_rgba
+
+        centre = microscope_image_to_image_coordinates(
+            Point(x=ps.centre_x, y=ps.centre_y), shape, pixelsize
+        )
+        width = ps.width / pixelsize
+        height = ps.height / pixelsize
+
+        outline = mpatches.Rectangle(
+            (centre.x - width / 2, centre.y - height / 2),  # bottom-left corner
+            width=width,
+            height=height,
+            angle=math.degrees(-ps.rotation),
+            rotation_point="center",
+            edgecolor=colour,
+            facecolor="none",
+            linewidth=linewidth,
+            zorder=zorder,
+        )
+        outline.set_transform(self._ax.transData)
+
+        image = AxesImage(self._ax, extent=(0, 1, 0, 1), zorder=zorder)
+        image.set_data(bitmap_to_rgba(ps, width, height, colour, _FILL_ALPHA))
+        image.set_transform(
+            outline.get_patch_transform() + outline.get_data_transform()
+        )
+        image.set_clip_path(self._ax.patch)  # add_artist does not clip, add_image does
+        return [outline, image]
 
     def _draw_crosshair(
         self, point, shape, pixelsize: float, colour: str, zorder: float

--- a/fibsem/ui/widgets/tests/test_milling_overlay.py
+++ b/fibsem/ui/widgets/tests/test_milling_overlay.py
@@ -7,14 +7,18 @@ Shows a few milling stages drawn on a blank FIB canvas — one colour per stage,
 each with a crosshair at its point-of-interest. "Toggle patterns" clears / re-shows
 them to demonstrate that the overlay draws nothing when there is no milling.
 """
+
 import sys
 
+import numpy as np
 from PyQt5.QtWidgets import QApplication, QPushButton, QVBoxLayout, QWidget
 
 from fibsem.milling.base import FibsemMillingStage
 from fibsem.milling.patterning.patterns2 import (
+    BitmapPattern,
     CirclePattern,
     LinePattern,
+    PolygonPattern,
     RectanglePattern,
     TrenchPattern,
 )
@@ -29,14 +33,47 @@ def _stage(name: str, pattern, x_um: float, y_um: float) -> FibsemMillingStage:
     return FibsemMillingStage(name=name, pattern=pattern)
 
 
+def _demo_bitmap() -> np.ndarray:
+    """A dwell-time gradient with a blanked corner, as bitmap points (dwell, blank)."""
+    array = np.zeros((64, 64, 2), dtype=float)
+    array[:, :, 0] = np.linspace(0, 1, 64)[None, :]
+    array[:16, :16, 1] = 1  # blanked -> drawn black
+    return array
+
+
 def build_stages():
     """A spread of pattern types / positions to exercise the overlay."""
     return [
         _stage("Trench", TrenchPattern(), 0, 0),
         _stage("Rect top", RectanglePattern(width=12e-6, height=5e-6), 0, 16),
-        _stage("Rotated", RectanglePattern(width=10e-6, height=3e-6, rotation=25), -22, -2),
+        _stage(
+            "Rotated", RectanglePattern(width=10e-6, height=3e-6, rotation=25), -22, -2
+        ),
+        _stage(
+            "Bitmap",
+            BitmapPattern(width=14e-6, height=10e-6, array=_demo_bitmap(), rotation=10),
+            22,
+            -14,
+        ),
+        _stage("Annulus", CirclePattern(radius=6e-6, thickness=1.5e-6), -20, 14),
+        _stage(
+            "Exclusion",
+            PolygonPattern(
+                vertices=np.array(
+                    [[-6e-6, -3e-6], [6e-6, -3e-6], [6e-6, 3e-6], [-6e-6, 3e-6]]
+                ),
+                is_exclusion=True,
+            ),
+            -22,
+            0,
+        ),
         _stage("Circle", CirclePattern(radius=4e-6), 20, 10),
-        _stage("Line", LinePattern(start_x=-8e-6, end_x=8e-6, start_y=-16e-6, end_y=-16e-6), 0, 0),
+        _stage(
+            "Line",
+            LinePattern(start_x=-8e-6, end_x=8e-6, start_y=-16e-6, end_y=-16e-6),
+            0,
+            0,
+        ),
     ]
 
 
@@ -54,8 +91,8 @@ class MillingOverlayTest(QWidget):
         self.canvas.add_overlay(self.overlay)
 
         stages = build_stages()
-        self.fg = stages[:3]          # foreground (coloured); one is "selected"
-        self.bg = stages[3:]          # background (drawn black)
+        self.fg = stages[:6]  # foreground (coloured); one is "selected"
+        self.bg = stages[6:]  # background (drawn black)
         self.selected = 0
         self._shown = True
         self._render()

--- a/tests/milling/test_pattern_rendering.py
+++ b/tests/milling/test_pattern_rendering.py
@@ -1,0 +1,182 @@
+"""Pattern shapes → matplotlib, in the report-plot path.
+
+``bitmap_to_rgba`` is the one place a bitmap pattern becomes pixels, shared by the
+report plot (``_add_bitmap_mpl``) and the canvas overlay. It had no tests at all,
+which is part of how bitmaps could go missing from the canvas unnoticed.
+
+What is pinned here is the contract the two renderers rely on: dwell time drives a
+transparent → colour ramp, blanked cells are opaque black, an array larger than the
+pattern is downsized (subpixel cells do not render), and an annulus is the ring
+between ``radius - thickness`` and ``radius``.
+"""
+
+import matplotlib
+import numpy as np
+import pytest
+from matplotlib.colors import to_rgba
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.patches import Annulus, Circle, Wedge  # noqa: E402
+
+from fibsem.milling.patterning.plotting import (  # noqa: E402
+    _add_circle_mpl,
+    bitmap_to_rgba,
+)
+from fibsem.structures import (  # noqa: E402
+    BeamType,
+    FibsemBitmapSettings,
+    FibsemCircleSettings,
+    FibsemImage,
+    FibsemImageMetadata,
+    ImageSettings,
+    MicroscopeState,
+    Point,
+)
+
+COLOUR = "yellow"
+OPACITY = 0.5
+
+
+def _bitmap(dwell: np.ndarray, blanked: np.ndarray = None, **kwargs):
+    """A bitmap pattern carrying *dwell* (and optionally *blanked*) directly.
+
+    A float array bypasses the uint8 image → points conversion in
+    ``FibsemBitmapSettings.__post_init__``, so the values arrive unchanged.
+    """
+    array = np.zeros((*dwell.shape, 2), dtype=float)
+    array[:, :, 0] = dwell
+    if blanked is not None:
+        array[:, :, 1] = blanked
+    return FibsemBitmapSettings(
+        width=10e-6,
+        height=10e-6,
+        depth=1e-6,
+        centre_x=0,
+        centre_y=0,
+        array=array,
+        **kwargs,
+    )
+
+
+def test_dwell_time_drives_a_transparent_to_colour_ramp():
+    dwell = np.array([[0.0, 1.0]])
+    rgba = bitmap_to_rgba(_bitmap(dwell), 100, 100, COLOUR, OPACITY)
+
+    assert rgba[0, 0, 3] == pytest.approx(0.0)  # no dwell -> nothing drawn
+    assert rgba[0, 1, 3] == pytest.approx(OPACITY)  # full dwell -> full opacity
+    assert rgba[0, 1, :3] == pytest.approx(to_rgba(COLOUR)[:3], abs=0.01)
+
+
+def test_blanked_cells_are_black():
+    dwell = np.ones((1, 2))
+    blanked = np.array([[0, 1]])
+    rgba = bitmap_to_rgba(_bitmap(dwell, blanked), 100, 100, COLOUR, OPACITY)
+
+    assert rgba[0, 1, :3] == pytest.approx((0.0, 0.0, 0.0))
+    assert rgba[0, 1, 3] == pytest.approx(OPACITY)  # opaque black, not transparent
+    assert rgba[0, 0, :3] != pytest.approx((0.0, 0.0, 0.0))  # the unblanked neighbour
+
+
+def test_a_bitmap_larger_than_the_pattern_is_downsized():
+    # 64x64 cells into a 10x20 px pattern: every cell would be subpixel, and
+    # subpixel cells are not displayed at all.
+    rgba = bitmap_to_rgba(_bitmap(np.ones((64, 64))), 20, 10, COLOUR, OPACITY)
+
+    assert rgba.shape == (10, 20, 4)
+
+
+def test_a_bitmap_smaller_than_the_pattern_is_left_alone():
+    rgba = bitmap_to_rgba(_bitmap(np.ones((4, 4))), 200, 200, COLOUR, OPACITY)
+
+    assert rgba.shape == (4, 4, 4)
+
+
+def test_flip_y_flips_the_rows():
+    dwell = np.array([[0.0], [1.0]])
+    plain = bitmap_to_rgba(_bitmap(dwell), 100, 100, COLOUR, OPACITY)
+    flipped = bitmap_to_rgba(_bitmap(dwell, flip_y=True), 100, 100, COLOUR, OPACITY)
+
+    assert plain[0, 0, 3] == pytest.approx(flipped[1, 0, 3])
+    assert plain[1, 0, 3] == pytest.approx(flipped[0, 0, 3])
+
+
+def test_a_pattern_with_no_bitmap_draws_nothing():
+    """A path-less, array-less bitmap pattern is legal — it must not raise."""
+    shape = FibsemBitmapSettings(
+        width=10e-6, height=10e-6, depth=1e-6, centre_x=0, centre_y=0
+    )
+    rgba = bitmap_to_rgba(shape, 100, 100, COLOUR, OPACITY)
+
+    assert shape.bitmap is None
+    assert rgba[:, :, 3] == pytest.approx(0.0)
+
+
+# ── annulus / wedge geometry ─────────────────────────────────────────────────
+
+RESOLUTION = 512
+PIXEL_SIZE = 1e-8
+
+
+def _image() -> FibsemImage:
+    image = FibsemImage(data=np.zeros((RESOLUTION, RESOLUTION), dtype=np.uint8))
+    image.metadata = FibsemImageMetadata(
+        image_settings=ImageSettings(
+            hfw=RESOLUTION * PIXEL_SIZE,
+            resolution=[RESOLUTION, RESOLUTION],
+            beam_type=BeamType.ION,
+        ),
+        pixel_size=Point(PIXEL_SIZE, PIXEL_SIZE),
+        microscope_state=MicroscopeState(),
+    )
+    return image
+
+
+def _circle(**kwargs) -> FibsemCircleSettings:
+    params = dict(radius=1e-6, depth=1e-6, centre_x=0, centre_y=0)
+    params.update(kwargs)
+    return FibsemCircleSettings(**params)
+
+
+def _patch(shape: FibsemCircleSettings):
+    fig, ax = plt.subplots()
+    try:
+        _add_circle_mpl(shape, _image(), COLOUR, ax=ax)
+        (patch,) = ax.patches
+        return patch
+    finally:
+        plt.close(fig)
+
+
+def test_a_thickness_draws_the_ring_between_radius_and_radius_minus_thickness():
+    """Annulus takes the OUTER radius; passing the inner one drew the wrong ring.
+
+    radius 100 px, thickness 20 px is the ring 80..100 — the same geometry the mask
+    path (``draw_annulus_shape``) builds. Passing r=80 put it at 60..80 instead.
+    """
+    patch = _patch(_circle(radius=100 * PIXEL_SIZE, thickness=20 * PIXEL_SIZE))
+
+    assert isinstance(patch, Annulus)
+    assert patch.get_radii() == pytest.approx((100, 100))  # outer
+    assert patch.get_width() == pytest.approx(20)  # inward from the outer edge
+
+
+def test_no_thickness_is_a_plain_circle():
+    patch = _patch(_circle(thickness=0))
+
+    assert isinstance(patch, Circle)
+    assert patch.get_radius() == pytest.approx(1e-6 / PIXEL_SIZE)
+
+
+def test_partial_angles_draw_a_wedge():
+    patch = _patch(_circle(start_angle=30, end_angle=200))
+
+    assert isinstance(patch, Wedge)
+    assert (patch.theta1, patch.theta2) == (30, 200)
+
+
+def test_an_exclusion_circle_is_black():
+    patch = _patch(_circle(is_exclusion=True))
+
+    assert patch.get_edgecolor()[:3] == pytest.approx((0.0, 0.0, 0.0))

--- a/tests/milling/test_pattern_rendering.py
+++ b/tests/milling/test_pattern_rendering.py
@@ -21,6 +21,7 @@ import matplotlib.pyplot as plt  # noqa: E402
 from matplotlib.patches import Annulus, Circle, Wedge  # noqa: E402
 
 from fibsem.milling.patterning.plotting import (  # noqa: E402
+    _add_bitmap_mpl,
     _add_circle_mpl,
     bitmap_to_rgba,
 )
@@ -180,3 +181,27 @@ def test_an_exclusion_circle_is_black():
     patch = _patch(_circle(is_exclusion=True))
 
     assert patch.get_edgecolor()[:3] == pytest.approx((0.0, 0.0, 0.0))
+
+
+def test_the_report_plot_draws_bitmaps_the_right_way_up():
+    """Row 0 is the top-left cell (AutoScript), so it must land at the pattern's top.
+
+    The image is drawn through the outline rectangle's transform, whose v=0 is the
+    patch's xy corner -- the TOP edge on the y-inverted image axes. imshow's default
+    origin="upper" puts row 0 at the extent's `top` (v=1), i.e. the bottom of the
+    pattern, which is how every bitmap came out upside down.
+    """
+    array = np.zeros((8, 8, 2), dtype=float)
+    array[:4, :, 0] = 1
+    shape = FibsemBitmapSettings(
+        width=1e-6, height=1e-6, depth=1e-6, centre_x=0, centre_y=0, array=array
+    )
+
+    fig, ax = plt.subplots()
+    try:
+        _add_bitmap_mpl(shape, _image(), COLOUR, ax=ax)
+        drawn = ax.images[-1]
+    finally:
+        plt.close(fig)
+
+    assert drawn.origin == "lower"

--- a/tests/ui/test_milling_overlay_shapes.py
+++ b/tests/ui/test_milling_overlay_shapes.py
@@ -1,0 +1,265 @@
+"""Milling pattern shapes on the canvas overlay.
+
+The napari path drew bitmap patterns as their own image layer; when milling moved to
+``FibsemImageCanvas``, ``MillingPatternOverlay`` had no branch for them — every
+``isinstance`` check missed, because ``FibsemBitmapSettings`` is not a
+``FibsemRectangleSettings`` — so a bitmap stage rendered as its crosshair and nothing
+else. These pin the artists back in place, along with the two shape properties the
+overlay used to ignore: a circle's ``thickness`` / angles, and ``is_exclusion``.
+
+``test_drawing_a_bitmap_leaves_the_view_alone`` is the guard on *how* the image is
+drawn: ``ax.imshow`` routes through ``add_image`` → ``update_datalim`` and rescales
+the axes to the pattern, which on a live canvas throws away the operator's pan/zoom.
+The overlay builds the ``AxesImage`` itself to avoid that.
+
+No Qt needed — the overlay talks to a matplotlib axes.
+
+Run directly:
+    python tests/ui/test_milling_overlay_bitmap.py
+"""
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.image import AxesImage  # noqa: E402
+from matplotlib.patches import (  # noqa: E402
+    Annulus,
+    Circle,
+    Polygon,
+    Rectangle,
+    Wedge,
+)
+
+from fibsem.milling.base import FibsemMillingStage  # noqa: E402
+from fibsem.milling.patterning.patterns2 import (  # noqa: E402
+    BitmapPattern,
+    CirclePattern,
+    PolygonPattern,
+    RectanglePattern,
+)
+from fibsem.structures import (  # noqa: E402
+    BeamType,
+    FibsemCircleSettings,
+    FibsemImage,
+    FibsemImageMetadata,
+    ImageSettings,
+    MicroscopeState,
+    Point,
+)
+from fibsem.ui.widgets.canvas.overlays.milling_overlay import (  # noqa: E402
+    MillingPatternOverlay,
+)
+
+RESOLUTION = 512
+HFW = 80e-6
+PIXEL_SIZE = HFW / RESOLUTION
+
+
+class _FakeCanvas:
+    """The overlay only ever asks its canvas to redraw."""
+
+    def __init__(self):
+        self.draws = 0
+
+    def draw_idle(self):
+        self.draws += 1
+
+
+def _image() -> FibsemImage:
+    image = FibsemImage(data=np.zeros((RESOLUTION, RESOLUTION), dtype=np.uint8))
+    image.metadata = FibsemImageMetadata(
+        image_settings=ImageSettings(
+            hfw=HFW, resolution=[RESOLUTION, RESOLUTION], beam_type=BeamType.ION
+        ),
+        pixel_size=Point(PIXEL_SIZE, PIXEL_SIZE),
+        microscope_state=MicroscopeState(),
+    )
+    return image
+
+
+def _bitmap_stage(name: str = "bitmap") -> FibsemMillingStage:
+    array = np.zeros((32, 32, 2), dtype=float)
+    array[:, :, 0] = np.linspace(0, 1, 32)[None, :]  # dwell-time gradient
+    pattern = BitmapPattern(width=10e-6, height=10e-6, depth=1e-6, array=array)
+    pattern.point = Point(0, 0)
+    return FibsemMillingStage(name=name, pattern=pattern)
+
+
+@pytest.fixture
+def axes():
+    """Axes showing an image, with autoscale still on — as a fresh canvas is.
+
+    Autoscale matters: an ``imshow``-drawn overlay only collapses the view while it
+    is on, so an axes with fixed limits would hide the regression.
+    """
+    fig, ax = plt.subplots()
+    ax.imshow(
+        np.zeros((RESOLUTION, RESOLUTION)),
+        extent=(-0.5, RESOLUTION - 0.5, RESOLUTION - 0.5, -0.5),
+    )
+    yield ax
+    plt.close(fig)
+
+
+def _overlay(ax) -> MillingPatternOverlay:
+    overlay = MillingPatternOverlay()
+    overlay.attach(ax, _FakeCanvas())
+    return overlay
+
+
+def test_a_bitmap_stage_draws_its_outline_and_its_bitmap(axes):
+    overlay = _overlay(axes)
+    overlay.set_stages([_bitmap_stage()], _image())
+
+    kinds = [type(a).__name__ for a in overlay._artists]
+    assert kinds.count("AxesImage") == 1, f"bitmap not drawn: {kinds}"
+    assert kinds.count("Rectangle") == 1, f"outline not drawn: {kinds}"
+
+
+def test_the_bitmap_image_sits_inside_the_outline(axes):
+    overlay = _overlay(axes)
+    overlay.set_stages([_bitmap_stage()], _image())
+
+    outline = next(a for a in overlay._artists if isinstance(a, Rectangle))
+    image = next(a for a in overlay._artists if isinstance(a, AxesImage))
+
+    # The pattern is 10 um wide, centred on the image centre.
+    width_px = 10e-6 / PIXEL_SIZE
+    assert outline.get_width() == pytest.approx(width_px)
+    assert outline.get_x() == pytest.approx(RESOLUTION / 2 - width_px / 2, abs=1)
+
+    # The image is drawn on the unit square, through the outline's own transform,
+    # so it lands on the outline whatever the pattern's size and rotation. Its
+    # transform ends in transData, so undo that to compare in image pixels.
+    corners = axes.transData.inverted().transform(
+        image.get_transform().transform([(0, 0), (1, 1)])
+    )
+    assert abs(corners[1][0] - corners[0][0]) == pytest.approx(width_px)
+    assert abs(corners[1][1] - corners[0][1]) == pytest.approx(width_px)
+    assert min(corners[0][0], corners[1][0]) == pytest.approx(outline.get_x())
+
+
+def test_drawing_a_bitmap_leaves_the_view_alone(axes):
+    before = axes.get_xlim(), axes.get_ylim()
+
+    overlay = _overlay(axes)
+    overlay.set_stages([_bitmap_stage()], _image())
+
+    assert (axes.get_xlim(), axes.get_ylim()) == before
+
+
+def test_clearing_removes_the_bitmap_artists(axes):
+    overlay = _overlay(axes)
+    overlay.set_stages([_bitmap_stage()], _image())
+    overlay.clear()
+
+    assert overlay._artists == []
+    assert not axes.images[1:]  # only the background image is left
+
+
+def test_the_other_shapes_still_draw(axes):
+    """The shape → artist branch now returns a list; rectangles must be unaffected."""
+    pattern = RectanglePattern(width=5e-6, height=5e-6, depth=1e-6)
+    pattern.point = Point(0, 0)
+    overlay = _overlay(axes)
+    overlay.set_stages([FibsemMillingStage(name="rect", pattern=pattern)], _image())
+
+    kinds = [type(a).__name__ for a in overlay._artists]
+    assert kinds.count("Polygon") == 1, kinds
+    assert kinds.count("Line2D") == 2  # the crosshair
+
+
+# ── circles: annulus / wedge ─────────────────────────────────────────────────
+
+SHAPE = (RESOLUTION, RESOLUTION)
+
+
+def _circle(**kwargs) -> FibsemCircleSettings:
+    params = dict(radius=5e-6, depth=1e-6, centre_x=0, centre_y=0)
+    params.update(kwargs)
+    return FibsemCircleSettings(**params)
+
+
+def _artist(ps, axes):
+    """The single artist the overlay builds for one shape."""
+    (artist,) = _overlay(axes)._shape_to_artists(
+        ps, SHAPE, PIXEL_SIZE, "yellow", 1.0, 6
+    )
+    return artist
+
+
+def test_a_circle_with_thickness_draws_a_ring_not_a_disc(axes):
+    """An annulus used to render as a filled disc: thickness was ignored."""
+    patch = _artist(_circle(thickness=1e-6), axes)
+
+    assert isinstance(patch, Annulus)
+    # thickness measures inward from the radius: the ring is 4 um .. 5 um.
+    assert patch.get_radii() == pytest.approx((5e-6 / PIXEL_SIZE, 5e-6 / PIXEL_SIZE))
+    assert patch.get_width() == pytest.approx(1e-6 / PIXEL_SIZE)
+
+
+def test_a_thickness_wider_than_the_radius_is_clamped(axes):
+    """``Annulus`` rejects a width past the centre; the pattern must still draw."""
+    patch = _artist(_circle(radius=5e-6, thickness=8e-6), axes)
+
+    assert patch.get_width() == pytest.approx(5e-6 / PIXEL_SIZE)
+
+
+def test_partial_angles_draw_a_wedge(axes):
+    patch = _artist(_circle(start_angle=45, end_angle=135), axes)
+
+    assert isinstance(patch, Wedge)
+    assert (patch.theta1, patch.theta2) == (45, 135)
+
+
+def test_a_plain_circle_is_still_a_circle(axes):
+    assert isinstance(_artist(_circle(), axes), Circle)
+
+
+def test_an_annulus_stage_draws_through_the_stage_path(axes):
+    """End to end, as the canvas drives it: CirclePattern is what carries thickness."""
+    pattern = CirclePattern(radius=5e-6, depth=1e-6, thickness=1e-6)
+    pattern.point = Point(0, 0)
+    overlay = _overlay(axes)
+    overlay.set_stages([FibsemMillingStage(name="annulus", pattern=pattern)], _image())
+
+    kinds = [type(a).__name__ for a in overlay._artists]
+    assert kinds.count("Annulus") == 1, kinds
+
+
+# ── exclusions ───────────────────────────────────────────────────────────────
+
+
+def test_an_exclusion_shape_is_black_whatever_the_stage_colour(axes):
+    """Exclusions are the region the mill must avoid — black, as in napari + the plot."""
+    vertices = np.array([[-5e-6, -5e-6], [5e-6, -5e-6], [5e-6, 5e-6], [-5e-6, 5e-6]])
+    pattern = PolygonPattern(vertices=vertices, depth=1e-6, is_exclusion=True)
+    pattern.point = Point(0, 0)
+    overlay = _overlay(axes)
+    overlay.set_stages([FibsemMillingStage(name="keep out", pattern=pattern)], _image())
+
+    patch = next(a for a in overlay._artists if isinstance(a, Polygon))
+    assert patch.get_edgecolor()[:3] == pytest.approx((0.0, 0.0, 0.0))
+    assert patch.get_facecolor()[:3] == pytest.approx((0.0, 0.0, 0.0))
+
+
+def test_a_normal_shape_keeps_its_stage_colour(axes):
+    """The exclusion branch must not blacken everything else."""
+    vertices = np.array([[-5e-6, -5e-6], [5e-6, -5e-6], [5e-6, 5e-6], [-5e-6, 5e-6]])
+    pattern = PolygonPattern(vertices=vertices, depth=1e-6, is_exclusion=False)
+    pattern.point = Point(0, 0)
+    overlay = _overlay(axes)
+    overlay.set_stages([FibsemMillingStage(name="poly", pattern=pattern)], _image())
+
+    patch = next(a for a in overlay._artists if isinstance(a, Polygon))
+    assert patch.get_edgecolor()[:3] != pytest.approx((0.0, 0.0, 0.0))
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/ui/test_milling_overlay_shapes.py
+++ b/tests/ui/test_milling_overlay_shapes.py
@@ -143,6 +143,49 @@ def test_the_bitmap_image_sits_inside_the_outline(axes):
     assert min(corners[0][0], corners[1][0]) == pytest.approx(outline.get_x())
 
 
+def test_bitmap_row_zero_is_drawn_at_the_top_of_the_pattern(axes):
+    """AutoScript's row 0 is the top-left cell, so that is where it has to appear.
+
+    The image rides the outline rectangle's transform, whose v=0 is the patch's xy
+    corner -- the TOP edge, because the image axes run y-down. imshow's default
+    origin="upper" puts row 0 at the extent's `top` (v=1) and drew every bitmap
+    upside down.
+    """
+    stage = _bitmap_stage()
+    # light the array's top half, leave the bottom half blank
+    stage.pattern.array[:, :, 0] = 0
+    stage.pattern.array[:16, :, 0] = 1
+
+    overlay = _overlay(axes)
+    overlay.set_stages([stage], _image())
+
+    # Render, and look at where the lit half actually came out. The pattern is
+    # axis-aligned, so its halves are two crops of the rendered canvas.
+    outline = next(a for a in overlay._artists if isinstance(a, Rectangle))
+    x0, y0 = outline.get_x(), outline.get_y()
+    w, h = outline.get_width(), outline.get_height()
+    fig = axes.figure
+    fig.canvas.draw()
+    px = np.asarray(fig.canvas.buffer_rgba())[:, :, :3].astype(float)
+
+    def _brightness(y_from: float, y_to: float) -> float:
+        (xa, ya), (xb, yb) = axes.transData.transform(
+            [(x0 + w * 0.2, y_from), (x0 + w * 0.8, y_to)]
+        )
+        # display y is bottom-up, the buffer's rows are top-down
+        rows = slice(int(px.shape[0] - max(ya, yb)), int(px.shape[0] - min(ya, yb)))
+        cols = slice(int(min(xa, xb)), int(max(xa, xb)))
+        return px[rows, cols].mean()
+
+    # inset from the edges, so the outline's own lines are not what is measured
+    top = _brightness(y0 + h * 0.1, y0 + h * 0.4)
+    bottom = _brightness(y0 + h * 0.6, y0 + h * 0.9)
+
+    assert top > bottom, (
+        f"the bitmap is upside down (top={top:.1f} bottom={bottom:.1f})"
+    )
+
+
 def test_drawing_a_bitmap_leaves_the_view_alone(axes):
     before = axes.get_xlim(), axes.get_ylim()
 

--- a/tests/ui/test_milling_overlay_shapes.py
+++ b/tests/ui/test_milling_overlay_shapes.py
@@ -12,15 +12,23 @@ drawn: ``ax.imshow`` routes through ``add_image`` → ``update_datalim`` and res
 the axes to the pattern, which on a live canvas throws away the operator's pan/zoom.
 The overlay builds the ``AxesImage`` itself to avoid that.
 
-No Qt needed — the overlay talks to a matplotlib axes.
+The overlay itself talks to a matplotlib axes and needs no Qt, but importing it walks
+``fibsem.ui.widgets.canvas``, whose package import does — hence the importorskip, which
+the thinner CI builds (no UI extra) rely on.
 
 Run directly:
-    python tests/ui/test_milling_overlay_bitmap.py
+    QT_QPA_PLATFORM=offscreen python tests/ui/test_milling_overlay_shapes.py
 """
 
-import matplotlib
-import numpy as np
-import pytest
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import matplotlib  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
 
 matplotlib.use("Agg")
 


### PR DESCRIPTION
Bitmap milling patterns stopped appearing when milling moved to `FibsemImageCanvas` — a bitmap stage rendered as its crosshair and nothing else. Fixing that turned up two more shape properties the overlay ignored, and two orientation/geometry bugs in the report plot.

## Why bitmaps vanished

`MillingPatternOverlay`'s shape dispatch is a chain of `isinstance` checks, and `FibsemBitmapSettings` is **not** a `FibsemRectangleSettings`, so a bitmap missed every branch and fell through to `return None`. Never a regression in the bitmap code — the branch was listed as deferred when the canvas subsystem landed (#199). The napari path did render them, as their own image layer.

The bitmap colouriser is lifted out of the report plot as `bitmap_to_rgba`, so the canvas and the plot can't drift apart again.

## Also in the same dispatch

- **Annulus / wedge.** A `FibsemCircleSettings` with `thickness` drew as a filled disc; it's now an `Annulus` (and a `Wedge` for partial angles), matching `_add_circle_mpl`.
- **`is_exclusion`.** Ignored entirely; exclusion shapes are now black, as in napari and the report plot. Applied once for all shape types.

## Two bugs fixed in `plotting.py` on the way past

- **`mpatches.Annulus` takes the OUTER radius**, measuring `width` inward. `_add_circle_mpl` passed the *inner* radius as `r`, so a radius-100px, thickness-20px annulus drew the ring at 60–80px instead of 80–100px — wrong size and wrong position. The mask path (`draw_annulus_shape`, `radius - thickness .. radius`) settles which is right. **Report images of annulus patterns change.**
- **Bitmaps were drawn upside down.** AutoScript's row 0 is the top-left cell, but the image rides the outline rectangle's transform, whose `v=0` is the patch's xy corner — the TOP edge, because the image axes run y-down — and `imshow`'s default `origin="upper"` puts row 0 at the extent's `top` (`v=1`), the pattern's bottom. `origin="lower"` in both renderers puts it back. napari had this right, which is why the two paths disagreed. `flip_y` remains what mirrors a bitmap deliberately.

- **A latent matplotlib incompatibility.** `bitmap_to_rgba` passed `N=256` to `ListedColormap` alongside an already-256-long colour list, which matplotlib 3.11 deprecates and 3.13 removes. That code has been live in the report plot all along and no test had ever exercised it, so it surfaced only once these tests existed — as a CI failure on every build job while passing locally on 3.10. Verified against matplotlib 3.11.1 that dropping `N` gives the same 256-entry ramp.

## Implementation note

The overlay builds its `AxesImage` directly rather than calling `ax.imshow`, which routes through `add_image` → `update_datalim` and, while autoscale is on, rescales the axes to the pattern and throws away the operator's pan/zoom. There's a test for that specifically.

## Tests

22 new, in two files (both renamed from `*_bitmap` since they grew past bitmaps):

- `tests/ui/test_milling_overlay_shapes.py` — 13: the bitmap artists exist and sit inside their outline, the view survives being drawn on, annulus radii, thickness clamped past the centre, wedge angles, exclusion colour (and that normal shapes keep theirs), and the orientation. No Qt needed, so these run on CI.
- `tests/milling/test_pattern_rendering.py` — 11: the colour ramp, blanking, downsizing, `flip_y`, a bitmap-less pattern, the annulus geometry, and the report plot's orientation.

Two of these are worth a look as tests rather than as assertions:

- The autoscale guard uses an axes with **autoscale still on** — with fixed limits the `imshow` failure mode is invisible.
- The orientation guard renders a half-lit bitmap and measures which half of the pattern came out bright. My first attempt lit one row and compared the top and bottom fifths; it **passed with the bug still in**, too little signal against the outline's own edge lines. Don't reduce it to asserting the keyword back.

299 passed across `tests/milling`, the canvas/overlay UI tests and the reducer test. The overlay demo harness (`fibsem/ui/widgets/tests/test_milling_overlay.py`) grows a bitmap, an annulus and an exclusion stage, so the three are visible next time someone runs it.

## Notes for review

- The first commit is `ruff format` on `plotting.py` only — CI checks the format of every file a PR touches. I verified the reformat is semantically inert by formatting `main`'s copy and diffing: the only difference is the `bitmap_to_rgba` extraction.
- #784 (circular suspension pattern) leans on the annulus and exclusion branches here — without them its ring draws as a filled disc and its exclusions in the stage colour. It mills correctly either way, so merge order only affects the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
