### PR TITLE
[docs] Point install docs at the released [ui] extra, fix Windows quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ There are several ways to install fibsemOS depending on your application and nee
 
 #### PyPI (For Users)
 
+Create a virtual environment (see [Installation Guide](INSTALLATION.md) for
+alternatives to conda), then install with the `[ui]` extra to get the GUI:
+
 ```bash
-pip install fibsem 
+conda create -n fibsem python=3.11 pip
+conda activate fibsem
+pip install "fibsem[ui]"
 ```
 
 #### Github (For Development)
@@ -36,14 +41,14 @@ Install dependencies and package:
 ```bash
 conda create -n fibsem python=3.11 pip
 conda activate fibsem
-pip install -e '.[ui]'
+pip install -e ".[ui]"
 ```
 
 Image labelling (`fibsem_label`) draws in napari, which is not part of `[ui]`; add
 the `[labelling]` extra for it:
 
 ```bash
-pip install -e '.[ui,labelling]'
+pip install -e ".[ui,labelling]"
 ```
 
 To run:
@@ -66,13 +71,13 @@ On internet connected PC (Environment should match python version):
 ```bash
 mkdir pkg
 cd pkg
-pip download fibsem[ui]
+pip download "fibsem[ui]"
 ```
 On Support PC:
 Transfer the pkg directory to the support pc, and then change to the pkg directory
 ```bash
 cd pkg
-pip install --no-index --find-links . fibsem[ui]
+pip install --no-index --find-links . "fibsem[ui]"
 ```
 
 #### Additional Installation Information

--- a/docs/developers/getting-started.md
+++ b/docs/developers/getting-started.md
@@ -44,7 +44,7 @@ tests/                      mirrors the layout; tests/ui needs
 ## First: get it running
 
 ```bash
-pip install -e .[ui,test,dev]
+pip install -e ".[ui,test,dev]"
 fibsem-autolamella-ui
 ```
 


### PR DESCRIPTION
## Summary
- PyPI (For Users) install line was bare `pip install fibsem`, with no `[ui]` extra — following it literally leaves out napari/PyQt5, causing a missing-napari error on first launch. Added an env-creation step and `pip install "fibsem[ui]"`, matching what GETTING_STARTED.md already assumes (`conda activate fibsem`).
- Dev install used single-quoted extras (`pip install -e '.[ui]'`), which cmd.exe/PowerShell pass through literally instead of stripping as a quote — breaking the command on Windows. Switched to double quotes throughout README.md and docs/developers/getting-started.md, matching INSTALLATION.md's existing convention.

Fixes #795

## Test plan
- [x] Confirmed released PyPI 0.5.1 already bundles napari under `[ui]` and caps torch at `<=2.3.0` (via PyPI JSON metadata) — the fix is purely in the docs, not the packaging.
- [ ] Have the reporter on #795 confirm `pip install "fibsem[ui]"` in a fresh env resolves their issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)