### PR TITLE
[refactor] Read stage.rotation from the instrument, not a configuration file (re-land of #786)

### DIFF
--- a/fibsem/config/microscope-configuration.yaml
+++ b/fibsem/config/microscope-configuration.yaml
@@ -6,7 +6,6 @@ info:
     manufacturer: Demo                                      # the microscope manufactuer                                    [SPECIFIED]        
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]

--- a/fibsem/config/odemis-configuration.yaml
+++ b/fibsem/config/odemis-configuration.yaml
@@ -6,7 +6,6 @@ info:
     manufacturer: Odemis                                      # the microscope manufactuer                                    [SPECIFIED]        
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]

--- a/fibsem/config/sim-arctis-configuration.yaml
+++ b/fibsem/config/sim-arctis-configuration.yaml
@@ -4,7 +4,6 @@ info:
     manufacturer: Demo                                              
 stage:
     enabled:                    true                        
-    rotation:                   false                       
     rotation_reference:         0                           
     shuttle_pre_tilt:           0                        
     manipulator_height_limit:   0.0037                      

--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -24,7 +24,6 @@ fm:
     enabled:                    true                        # this site has a fluorescence microscope                       [USER]
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED]
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]

--- a/fibsem/config/tescan-configuration.yaml
+++ b/fibsem/config/tescan-configuration.yaml
@@ -6,7 +6,6 @@ info:
     manufacturer: Tescan                                      # the microscope manufacturer                                    [SPECIFIED]        
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
     rotation_reference:         180                         # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           0                           # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufacturer]

--- a/fibsem/config/tfs-aquilos2-configuration.yaml
+++ b/fibsem/config/tfs-aquilos2-configuration.yaml
@@ -6,7 +6,6 @@ info:
     manufacturer: Thermo                                    # the microscope manufactuer                                    [SPECIFIED]        
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]

--- a/fibsem/config/tfs-arctis-configuration.yaml
+++ b/fibsem/config/tfs-arctis-configuration.yaml
@@ -6,7 +6,6 @@ info:
     manufacturer: Thermo                                    # the microscope manufactuer                                    [SPECIFIED]        
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   false                       # the stage is able to rotate; false means it has no 180-degree side  [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           0                           # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]

--- a/fibsem/config/tfs-hydra-configuration.yaml
+++ b/fibsem/config/tfs-hydra-configuration.yaml
@@ -6,7 +6,6 @@ info:
     manufacturer: Thermo                                    # the microscope manufactuer                                    [SPECIFIED]        
 stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
-    rotation:                   true                        # the stage is able to rotate; false means it has no 180-degree side  [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
     manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -315,9 +315,34 @@ class FibsemMicroscope(ABC):
 
         return deepcopy(stage_position)
 
+    def _read_stage_capabilities(self) -> None:
+        """Ask the instrument what its stage can do, and record it.
+
+        Only `rotation` today, and it is not a preference: it decides where the FIB
+        orientation is, because `rotation_180` is derived from it (FIB-834). A
+        configuration file used to state it, which meant a compustage could be
+        described as a rotating stage by a typo and nothing would disagree --
+        `sim-arctis-configuration.yaml` was, for as long as nothing read the flag.
+
+        The axes are the honest form of the question: a compustage has no `r` limit
+        because it has no rotation axis. It agrees with `stage_is_compustage` on every
+        backend today, and deliberately does not ask that instead -- "has a rotation
+        axis" is the property the derivation needs, and a future stage that lacks one
+        without being a compustage would answer correctly here for free.
+        """
+        self.system.stage.rotation = "r" in self._get_axis_limits()
+
     def _create_sample_stage(self) -> None:
         """Create the sample stage and holder based on the system settings."""
         from fibsem.microscopes._stage import _create_sample_stage
+
+        # Before the stage object, not after. Every backend wraps this call in a
+        # try/except that logs and carries on, so a failure below leaves the
+        # capability at its field default -- `True`, which on a compustage is the
+        # wrong answer and a silent one. Reading it first means the only way to miss
+        # it is `_get_axis_limits` itself raising, and on a compustage that is a
+        # lookup of a module constant, which cannot.
+        self._read_stage_capabilities()
 
         self._stage = _create_sample_stage(self)
 
@@ -1155,8 +1180,6 @@ class FibsemMicroscope(ABC):
             self.system.ion.plasma = value
         elif system == "stage":
             self.system.stage.enabled = value
-        elif system == "stage_rotation":
-            self.system.stage.rotation = value
         elif system == "manipulator":
             self.system.manipulator.enabled = value
         elif system == "manipulator_rotation":
@@ -1189,6 +1212,14 @@ class FibsemMicroscope(ABC):
 
         if self.is_available("stage"):
             self.system.stage = system_settings.stage
+            # The line above replaces the whole record, including the capability the
+            # instrument told us about at connect. `system_settings` came from a file,
+            # and files no longer state `rotation` -- so on a compustage this would
+            # silently restore the field default of `True`, move the FIB orientation
+            # half a turn away, and hand the compucentric correction a rotation the
+            # stage cannot make. Re-read rather than preserve: the instrument is the
+            # authority, and it has not changed because someone pressed Apply.
+            self._read_stage_capabilities()
 
         if self.is_available("manipulator"):
             self.system.manipulator = system_settings.manipulator

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2219,11 +2219,19 @@ class StageSystemSettings:
     # Whether the stage has a rotation axis. Load-bearing: it is what `rotation_180`
     # below is derived from, so it describes the geometry and not merely a permission.
     #
-    # There was a `tilt` beside it and there is not any more. Nothing read it, every
-    # shipped file said `true`, and every file always would have: `_get_axis_limits`
-    # returns a `t` axis on every backend, compustage included, because a stage that
-    # cannot tilt is not a stage this project drives. A flag with one reachable value
-    # is not a capability, it is a place for a typo to sit.
+    # **Written by the instrument, not by a file.** No configuration states it any
+    # more: `FibsemMicroscope._read_stage_capabilities` fills it at connect from the
+    # stage's own axes, and again after `apply_configuration` replaces this record.
+    # The default here is what an unconnected `SystemSettings` holds, and it is the
+    # rotating case because that is the commoner stage -- a compustage that never
+    # reached a microscope has no orientations to get wrong.
+    #
+    # There was a `tilt` beside it and there is not any more. Nothing read it, and
+    # every shipped file said `true` because every file always would have:
+    # `_get_axis_limits` returns a `t` axis on every backend, compustage included.
+    # A flag with one reachable value is not a capability, it is a place for a typo
+    # to sit -- which is exactly what `rotation` had become in the simulator's Arctis
+    # configuration before it was read by anything.
     rotation: bool = True
     milling_angle: float = 15
     # Where the stage travels for each instrument to see the sample. Keyed by device

--- a/fibsem/ui/widgets/microscope_config_widget.py
+++ b/fibsem/ui/widgets/microscope_config_widget.py
@@ -250,12 +250,10 @@ class MicroscopeConfigWidget(QWidget):
         g_ion, self._sub_ion = grp(
             "Ion", [("Enabled", "enabled"), ("Plasma", "plasma")]
         )
-        # No "Tilt" here, unlike the manipulator below: every stage this project
-        # drives can tilt, so the checkbox only ever offered a way to be wrong.
-        g_stage, self._sub_stage = grp(
-            "Stage",
-            [("Enabled", "enabled"), ("Rotation", "rotation")],
-        )
+        # Enabled only. "Tilt" went because every stage this project drives can tilt;
+        # "Rotation" went because the instrument answers it at connect, and a file that
+        # disagreed would move the FIB orientation.
+        g_stage, self._sub_stage = grp("Stage", [("Enabled", "enabled")])
         g_manip, self._sub_manip = grp(
             "Manipulator",
             [("Enabled", "enabled"), ("Rotation", "rotation"), ("Tilt", "tilt")],
@@ -496,6 +494,7 @@ class MicroscopeConfigWidget(QWidget):
         # `stage.tilt` that no longer has a checkbox or a field behind it. The
         # manipulator keeps its own `tilt`, which is why this is scoped to the stage.
         c["stage"].pop("tilt", None)
+        c["stage"].pop("rotation", None)
         for key, chk in self._sub_manip.items():
             c.setdefault("manipulator", {})[key] = chk.isChecked()
         for key, chk in self._sub_gis.items():

--- a/tests/test_guided_setup.py
+++ b/tests/test_guided_setup.py
@@ -260,25 +260,44 @@ def test_only_the_simulator_needs_no_vendor_api():
 # ---------------------------------------------------------------------------
 
 
-def test_a_compustage_derives_no_opposite_rotation():
-    """The case a blanket `reference + 180` would get wrong.
+def test_the_wizard_writes_no_stage_capability():
+    """It writes the reference; the instrument says whether there is an opposite.
 
-    A compustage reaches the other side of the grid by tilting, not by turning round,
-    so it has no second rotation -- and ``tfs-arctis`` says so with ``rotation: false``
-    rather than by setting two numbers equal. Both simulated and real Arctis are
-    checked: the simulator is the only place the compustage path runs, so a sim config
-    that disagreed with the instrument would be a hole in every compustage test.
+    A compustage reaches the other side of the grid by tilting rather than turning
+    round, and that used to be stated as ``rotation: false`` in the file the wizard
+    copied. It is now read from the stage's own axes at connect, so the wizard has
+    nothing to write and must not write anything -- a stale ``rotation`` left in a
+    generated file would be a value nothing reads sitting next to a question it looks
+    like it answers.
+
+    Asserted over every model, not only the compustages: the key going missing is the
+    whole change, and a model that still wrote one would be the way it came back.
     """
-    from fibsem.structures import StageSystemSettings
-
-    for key in ("tfs-arctis", "sim-arctis"):
+    for model in wizard.MICROSCOPE_MODELS:
         config = wizard.build_configuration(
-            wizard.SetupChoices(model_key=key, name="Bay 2")
+            wizard.SetupChoices(model_key=model.key, name="Bay 2")
         )
-        stage = StageSystemSettings.from_dict(config["stage"])
-        assert stage.rotation is False, key
-        assert stage.rotation_reference == 0, key
-        assert stage.rotation_180 == 0, key
+        assert "rotation" not in config["stage"], model.key
+        assert "tilt" not in config["stage"], model.key
+
+
+def test_the_compustage_models_are_still_marked_as_such():
+    """The wizard's own record of which models are compustages is untouched.
+
+    It drives ``sim.is_compustage`` for a simulated run -- which is what the simulator
+    reads to report a stage with no rotation axis -- and it is why those two models do
+    not reach the stage question at all.
+    """
+    for key in ("tfs-arctis", "sim-arctis"):
+        assert wizard.get_model(key).is_compustage, key
+        assert wizard.SetupChoices(model_key=key).stage_is_readonly, key
+
+    config = wizard.build_configuration(
+        wizard.SetupChoices(
+            manufacturer_key=wizard.MANUFACTURER_SIMULATOR, model_key="sim-arctis"
+        )
+    )
+    assert config["sim"]["is_compustage"] is True
 
 
 def test_a_supplied_rotation_reference_derives_its_opposite():

--- a/tests/test_stage_capability_flags.py
+++ b/tests/test_stage_capability_flags.py
@@ -12,6 +12,7 @@ rather than an edit that missed a line.
 
 import os
 
+import numpy as np
 import pytest
 
 import fibsem.config as cfg
@@ -20,7 +21,7 @@ from fibsem.microscopes.simulator import (
     STAGE_LIMITS_COMPUSTAGE,
     STAGE_LIMITS_DEFAULT,
 )
-from fibsem.structures import StageSystemSettings
+from fibsem.structures import StageSystemSettings, SystemSettings
 
 # Named rather than globbed. `fibsem/config/*.yaml` is gitignored with an allowlist
 # for the shipped files, so a configuration the developer saved from the wizard sits
@@ -43,21 +44,24 @@ def _stage_block(filename: str) -> dict:
 
 
 @pytest.mark.parametrize("filename", CONFIGS)
-def test_no_shipped_file_states_a_stage_tilt(filename: str):
-    assert "tilt" not in _stage_block(filename)
+@pytest.mark.parametrize("key", ["tilt", "rotation"])
+def test_no_shipped_file_states_a_stage_capability(filename: str, key: str):
+    assert key not in _stage_block(filename)
 
 
 @pytest.mark.parametrize("filename", CONFIGS)
-def test_the_manipulator_keeps_its_own_tilt(filename: str):
+@pytest.mark.parametrize("key", ["tilt", "rotation"])
+def test_the_manipulator_keeps_its_own(filename: str, key: str):
     """The asymmetry is the point, so it is asserted rather than left to be noticed.
 
     A manipulator that cannot tilt is an ordinary manipulator; a stage that cannot tilt
-    is not a stage this project drives. The two keys were spelled the same and meant
-    different things, which is exactly how a scoped edit goes wrong -- a `tilt:` line
-    removed from the wrong block would silently give every manipulator a tilt axis.
+    is not a stage this project drives. The two blocks spell these keys the same and
+    mean different things, which is exactly how a scoped edit goes wrong -- a line
+    removed from the wrong block would silently give every manipulator an axis it does
+    not have, and no other test in the suite would notice.
     """
     config = utils.load_yaml(os.path.join(cfg.CONFIG_PATH, filename))
-    assert "tilt" in config["manipulator"]
+    assert key in config["manipulator"]
 
 
 @pytest.mark.parametrize(
@@ -118,3 +122,92 @@ def test_the_live_microscope_still_answers_for_rotation():
     # asking the old question gets a quiet "no" -- worth knowing, since that is what a
     # stale plugin would see.
     assert microscope.is_available("stage_tilt") is False
+
+
+# ---------------------------------------------------------------------------
+# The capability now comes from the instrument
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("filename", "compustage", "rotates", "opposite"),
+    [
+        ("sim-arctis-configuration.yaml", True, False, 0.0),
+        ("microscope-configuration.yaml", False, True, 180.0),
+        ("tescan-configuration.yaml", False, True, 0.0),
+    ],
+)
+def test_connecting_fills_the_capability_from_the_stage(
+    filename: str, compustage: bool, rotates: bool, opposite: float
+):
+    """No file states `rotation`, so this is the only thing that answers it.
+
+    Both mountings are here rather than only the compustage: a test that just asserted
+    "False for the Arctis" would pass equally well if the capability were never filled
+    and something else happened to be false.
+    """
+    microscope, _ = utils.setup_session(
+        config_path=os.path.join(cfg.CONFIG_PATH, filename), manufacturer="Demo"
+    )
+
+    assert microscope.stage_is_compustage is compustage
+    assert microscope.system.stage.rotation is rotates
+    assert microscope.system.stage.rotation_180 == opposite
+
+
+def test_applying_a_configuration_does_not_overwrite_the_capability():
+    """The regression this change is most likely to grow.
+
+    `apply_configuration` replaces `system.stage` wholesale from a settings object the
+    user chose, and it is reachable from a button in the system setup widget. Since no
+    file states `rotation` any more, the replacement carries the field default of
+    `True` -- so on a compustage, pressing Apply would move the FIB orientation half a
+    turn away and hand the compucentric correction a rotation the stage cannot make.
+
+    The settings applied here are a real load of the same configuration, which is what
+    that button does.
+    """
+    path = os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
+    microscope, _ = utils.setup_session(config_path=path, manufacturer="Demo")
+    assert microscope.system.stage.rotation is False
+
+    applied = SystemSettings.from_dict(utils.load_yaml(path))
+    assert applied.stage.rotation is True, "the file cannot say, so it says the default"
+
+    microscope.apply_configuration(applied)
+
+    assert microscope.system.stage.rotation is False
+    assert microscope.system.stage.rotation_180 == 0.0
+    assert np.isclose(microscope.get_orientation("FIB").r, 0.0)
+
+
+def test_the_thermo_backend_reports_a_compustage_without_a_rotation_axis():
+    """The real Arctis path, which no test on CI can connect to.
+
+    `ThermoMicroscope._get_axis_limits` is where an AutoScript compustage becomes "no
+    `r` axis", and it is what `_read_stage_capabilities` asks. CI has no AutoScript, and
+    the simulator cannot stand in for this branch -- it has its own `_get_axis_limits`.
+    So the branch is asserted from the source, the way FIB-500 pinned its
+    `r=0.0` literal: crude, but it fails if someone deletes the short-circuit, which is
+    the failure that would otherwise reach an instrument.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from fibsem.microscope import ThermoMicroscope
+
+    tree = ast.parse(
+        textwrap.dedent(inspect.getsource(ThermoMicroscope._get_axis_limits))
+    )
+    returns_under_a_compustage_test = [
+        node.body[0].value.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Attribute)
+        and node.test.attr == "stage_is_compustage"
+        and isinstance(node.body[0], ast.Return)
+        and isinstance(node.body[0].value, ast.Name)
+    ]
+    assert returns_under_a_compustage_test == ["STAGE_LIMITS_COMPUSTAGE"]
+    assert "r" not in STAGE_LIMITS_COMPUSTAGE

--- a/tests/test_stage_rotation_derivation.py
+++ b/tests/test_stage_rotation_derivation.py
@@ -10,9 +10,11 @@ The risk in deriving it is not the arithmetic. It is that three movement paths p
 `rotation_180` in turn, so on a compustage -- where the two were both 0 -- *both*
 comparisons matched and the second always won. Derive it to a half turn and that
 coincidence breaks and the sign flips. The derivation below keeps it at the reference
-for a stage that does not rotate, which is why it does not; `test_the_shipped_files_all
-_derive_what_they_used_to_state` is what holds that, config by config, and
-`tests/test_view_corrected_movement.py` is what holds the movement itself.
+for a stage that does not rotate, which is why it does not.
+`test_the_shipped_rotating_stages_derive_what_they_used_to_state` holds the
+arithmetic config by config, `test_a_connected_compustage_derives_no_opposite_rotation`
+holds the case a file can no longer describe, and
+`tests/test_view_corrected_movement.py` holds the movement itself.
 """
 
 import os
@@ -34,30 +36,37 @@ def _stage(**overrides) -> StageSystemSettings:
     return StageSystemSettings(**fields)
 
 
-# The pairs the eight shipped files stated before FIB-834 removed the key, transcribed
-# from the files as they were. Every row has to survive the derivation, because every
-# row is a stage somebody runs.
+# The values the eight shipped files stated before FIB-834 removed the key,
+# transcribed from the files as they were. Every row has to survive the derivation,
+# because every row is a stage somebody runs.
+#
+# All eight are *rotating* stages as far as a file can tell, and since the capability
+# moved to the instrument that is all a file can tell. The two compustage rows are not
+# here: their answer is no longer in the file, and asserting the field default against
+# them would only be re-testing the default. They are covered by
+# `test_a_connected_compustage_derives_no_opposite_rotation` below, through a
+# microscope, which is the only thing that now knows.
 SHIPPED = {
     "microscope-configuration.yaml": 180.0,
     "odemis-configuration.yaml": 180.0,
-    "sim-arctis-configuration.yaml": 0.0,
     "sim-iflm-configuration.yaml": 180.0,
     "tescan-configuration.yaml": 0.0,
     "tfs-aquilos2-configuration.yaml": 180.0,
-    "tfs-arctis-configuration.yaml": 0.0,
     "tfs-hydra-configuration.yaml": 180.0,
 }
 
+COMPUSTAGE_CONFIGS = (
+    "sim-arctis-configuration.yaml",
+    "tfs-arctis-configuration.yaml",
+)
+ALL_CONFIGS = tuple(SHIPPED) + COMPUSTAGE_CONFIGS
+
 
 @pytest.mark.parametrize("filename", sorted(SHIPPED))
-def test_the_shipped_files_all_derive_what_they_used_to_state(filename: str):
-    """The regression guard for the whole change.
+def test_the_shipped_rotating_stages_derive_what_they_used_to_state(filename: str):
+    """The regression guard for the arithmetic, on the stages a file can describe.
 
-    `sim-arctis` is the row that had to be fixed rather than merely checked: it shipped
-    `rotation: true` where the instrument it stands in for says `false`, so before this
-    it would have derived a half turn for a stage that cannot make one. Nothing caught
-    that, because nothing read the flag -- and the simulator is the only place the
-    compustage path runs at all.
+    Tescan is the row worth having: reference 180, so its opposite is 0 and not 360.
     """
     config = utils.load_yaml(os.path.join(cfg.CONFIG_PATH, filename))
     stage = StageSystemSettings.from_dict(config["stage"])
@@ -65,7 +74,42 @@ def test_the_shipped_files_all_derive_what_they_used_to_state(filename: str):
     assert stage.rotation_180 == SHIPPED[filename]
 
 
-@pytest.mark.parametrize("filename", sorted(SHIPPED))
+def test_a_connected_compustage_derives_no_opposite_rotation():
+    """The compustage half, which only a microscope can answer.
+
+    This is what the two removed rows became. `sim-arctis` is the configuration that
+    stands in for an Arctis, and it declares `sim.is_compustage`, so the simulator
+    reports a stage with no `r` axis and the capability is read from that rather than
+    from anything in the file.
+
+    `tfs-arctis` is deliberately not exercised here. It is a *ThermoFisher* file, and
+    its compustage is reported by AutoScript at connect; run against the simulator it
+    would describe an ordinary stage, which is correct -- the simulator it was pointed
+    at does not have a compustage. That is the change working, not a gap in it.
+    """
+    microscope, _ = utils.setup_session(
+        config_path=os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml"),
+        manufacturer="Demo",
+    )
+
+    assert microscope.stage_is_compustage
+    assert microscope.system.stage.rotation is False
+    assert microscope.system.stage.rotation_180 == 0.0
+
+
+def test_a_connected_rotating_stage_sits_half_a_turn_away():
+    """The counterpart, so the test above is not passing for a trivial reason."""
+    microscope, _ = utils.setup_session(
+        config_path=os.path.join(cfg.CONFIG_PATH, "microscope-configuration.yaml"),
+        manufacturer="Demo",
+    )
+
+    assert not microscope.stage_is_compustage
+    assert microscope.system.stage.rotation is True
+    assert microscope.system.stage.rotation_180 == 180.0
+
+
+@pytest.mark.parametrize("filename", sorted(ALL_CONFIGS))
 def test_no_shipped_file_still_states_it(filename: str):
     config = utils.load_yaml(os.path.join(cfg.CONFIG_PATH, filename))
     assert "rotation_180" not in config["stage"]

--- a/tests/ui/test_guided_setup_dialog.py
+++ b/tests/ui/test_guided_setup_dialog.py
@@ -158,11 +158,13 @@ def test_the_compustage_is_shown_the_step_but_cannot_edit_it(dialog):
 
 
 def test_the_compustage_writes_its_shipped_values_untouched(dialog):
-    """Read-only means the wizard did not ask, so the shipped values stand -- including
-    ``rotation: false``, which is what stops the derivation handing a compustage a
-    half turn it cannot make (FIB-834)."""
-    from fibsem.structures import StageSystemSettings
+    """Read-only means the wizard did not ask, so the shipped values stand.
 
+    Which is now a shorter list than it was: the compustage no longer says so in the
+    file at all. ``rotation`` moved to the instrument, so what the wizard must get
+    right here is the reference it did not ask about, and that it writes no capability
+    of its own for the stage to disagree with later.
+    """
     dialog._select_model("tfs-arctis")
     dialog._show_step(STEP_STAGE)
     dialog._read_current_step()
@@ -171,9 +173,11 @@ def test_the_compustage_writes_its_shipped_values_untouched(dialog):
 
     config = wizard.build_configuration(dialog.choices)
     assert config["stage"]["rotation_reference"] == 0
-    stage = StageSystemSettings.from_dict(config["stage"])
-    assert stage.rotation is False
-    assert stage.rotation_180 == 0
+    assert config["stage"]["shuttle_pre_tilt"] == 0
+    assert "rotation" not in config["stage"]
+    # The wizard's own record of the mounting, which is what a simulated run reads to
+    # report a stage with no rotation axis.
+    assert wizard.get_model("tfs-arctis").is_compustage
 
 
 def test_the_stage_step_is_prefilled_from_the_chosen_model(dialog):
@@ -647,11 +651,9 @@ def test_stage_answers_do_not_survive_a_change_of_model(dialog):
 
     For a compustage, which reaches the other side of the grid by tilting rather than
     turning round, a reference typed for some other model is exactly the wrong thing to
-    keep -- it would be carried into a file whose ``rotation: false`` describes a
-    different stage.
+    keep: the instrument will report no rotation axis, and the stale reference would
+    still be sitting in the file describing where the stage rotates to.
     """
-    from fibsem.structures import StageSystemSettings
-
     dialog._select_model("tfs-other")
     dialog._show_step(STEP_STAGE)
     dialog._rotation_spin.setValue(250.0)
@@ -665,7 +667,7 @@ def test_stage_answers_do_not_survive_a_change_of_model(dialog):
 
     config = wizard.build_configuration(dialog.choices)
     assert config["stage"]["rotation_reference"] == 0
-    assert StageSystemSettings.from_dict(config["stage"]).rotation_180 == 0
+    assert "rotation" not in config["stage"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Re-lands #786, whose code never reached `main`.

**Byte-identical cherry-pick** of `b5427cf2` — verified by diffing the two patches, not by eye. Original authorship preserved. No review comments were left on #786, so nothing is being silently dropped.

## Why it went missing

#786's base was `claude/remove-dead-stage-tilt-flag` (#783's branch). #783 was squash-merged to `main` **first**, so when #786 then merged into that branch, the resulting commit had nowhere further to go. GitHub marks #786 *Merged* — correctly, its commits are in its base — but `main` never received them:

```
main has _read_stage_capabilities:      0
main still configures stage.rotation:   2 occurrences in sim-arctis
```

The lesson, recorded in the commit message: retarget a stacked PR to `main` as soon as the one below it lands.

## What it does (unchanged from #786)

`stage.rotation` decides where the FIB orientation is — `rotation_180` derives from it (FIB-834) — so it describes the hardware, and a file was the wrong place for it. `sim-arctis-configuration.yaml` is the proof: it claimed `true` for a compustage for as long as nothing read the flag.

`_read_stage_capabilities()` now sets it from the stage's own axes at connect, read via `_get_axis_limits` rather than `_stage.axes` — the latter can be absent, since every backend wraps `_create_sample_stage` in a `try/except` that logs and carries on.

The trap it guards: `apply_configuration` replaces `system.stage` wholesale from a user-chosen settings object, reachable from a button in `FibsemSystemSetupWidget`. With no file stating `rotation`, that would restore the field default of `True` — moving the FIB orientation half a turn on a compustage. It re-reads afterwards. Both guards are mutation-checked.

**Behaviour change:** a configuration can no longer make a non-compustage backend act like one. `tfs-arctis-configuration.yaml` run against the *simulator* now reports an ordinary rotating stage; `sim-arctis-configuration.yaml`, which declares `sim.is_compustage`, is the file for that job.

Full rationale is in the commit message and on #786.

## Re-verified on this base

Not assumed from #786's run — `main` has moved (#783, #785, #796) since:

- Lint and format clean on the changed files.
- Affected suites: **606 passed** (capability flags, rotation derivation, guided setup, orientation parity, microscope, the 144-combination `test_view_corrected_movement` sweep, guided-setup dialog).
- Live check on the simulator: `sim-arctis` → `compustage=True, rotation=False, rotation_180=0`; `microscope-configuration` → `compustage=False, rotation=True, rotation_180=180`.

## Ordering with #797

This touches `fibsem/ui/widgets/microscope_config_widget.py` (11 lines); #797 deletes that file. **Merge this one first** and #797 rebases cleanly. If #797 goes first instead, drop this PR's hunk in that file — nothing else here depends on it.

## Still outstanding, as on #786

- **Worth a look on a real Arctis before shipping.** CI has no AutoScript, so the Thermo compustage branch cannot be exercised; it is pinned from source with an AST assertion.
- `OdemisThermoMicroscope` hardcodes `stage_is_compustage = False` and inherits the base axis limits, so it always answers "rotates". No regression, but a METEOR on an Arctis would be described wrongly. Deliberately left alone.
