### PR TITLE
[fix] Say why AutoScript is unavailable, and where a copy was found

### DIFF
--- a/fibsem/microscopes/autoscript.py
+++ b/fibsem/microscopes/autoscript.py
@@ -9,6 +9,7 @@ import them from here.
 from __future__ import annotations
 
 import copy
+import glob
 import logging
 import os
 import sys
@@ -18,7 +19,7 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from packaging.version import InvalidVersion
+from packaging.version import InvalidVersion, Version
 from packaging.version import parse as parse_version
 from skimage import transform
 
@@ -67,6 +68,35 @@ if TYPE_CHECKING:
 
 THERMO_API_AVAILABLE = False
 MINIMUM_AUTOSCRIPT_VERSION_4_7 = parse_version("4.7")
+# Set when the guarded import below fails, so the connection error can say why.
+THERMO_API_IMPORT_ERROR: Optional[str] = None
+# Declared so importers can rely on the name; only meaningful once
+# THERMO_API_AVAILABLE is True.
+AUTOSCRIPT_VERSION: Optional[Version] = None
+
+# Legacy install locations, kept on sys.path for older machines. Current installs
+# copy the AutoScript packages into the active environment's site-packages (see
+# INSTALLATION.md), so these rarely match any more.
+_LEGACY_AUTOSCRIPT_SYS_PATHS = [
+    r"C:\Program Files\Thermo Scientific AutoScript",
+    r"C:\Program Files\Enthought\Python\envs\AutoScript\Lib\site-packages",
+    r"C:\Program Files\Python36\envs\AutoScript",
+    r"C:\Program Files\Python36\envs\AutoScript\Lib\site-packages",
+]
+
+# Where a copy of AutoScript might be sitting when the import fails. Searched only
+# to build the diagnostic message; never added to sys.path.
+_AUTOSCRIPT_SEARCH_GLOBS = [
+    r"C:\ProgramData\miniforge3\envs\*\Lib\site-packages",
+    r"C:\ProgramData\miniconda3\envs\*\Lib\site-packages",
+    r"C:\ProgramData\anaconda3\envs\*\Lib\site-packages",
+    os.path.expanduser(r"~\miniforge3\envs\*\Lib\site-packages"),
+    os.path.expanduser(r"~\miniconda3\envs\*\Lib\site-packages"),
+    os.path.expanduser(r"~\anaconda3\envs\*\Lib\site-packages"),
+    os.path.expanduser(r"~\.conda\envs\*\Lib\site-packages"),
+    r"C:\Program Files\Python*\envs\AutoScript\Lib\site-packages",
+    *_LEGACY_AUTOSCRIPT_SYS_PATHS,
+]
 
 
 class AutoScriptException(Exception):
@@ -74,12 +104,8 @@ class AutoScriptException(Exception):
 
 
 try:
-    sys.path.append(r"C:\Program Files\Thermo Scientific AutoScript")
-    sys.path.append(
-        r"C:\Program Files\Enthought\Python\envs\AutoScript\Lib\site-packages"
-    )
-    sys.path.append(r"C:\Program Files\Python36\envs\AutoScript")
-    sys.path.append(r"C:\Program Files\Python36\envs\AutoScript\Lib\site-packages")
+    for _legacy_path in _LEGACY_AUTOSCRIPT_SYS_PATHS:
+        sys.path.append(_legacy_path)
     import autoscript_sdb_microscope_client
     from autoscript_sdb_microscope_client import SdbMicroscopeClient
 
@@ -91,7 +117,7 @@ try:
 
     # special case for Monash development environment
     if os.environ.get("COMPUTERNAME", "hostname") == "MU00190108":
-        print("Overwriting autoscript version to 4.7, for Monash dev install")
+        logging.info("Overwriting autoscript version to 4.7, for Monash dev install")
         AUTOSCRIPT_VERSION = MINIMUM_AUTOSCRIPT_VERSION_4_7
 
     if AUTOSCRIPT_VERSION < MINIMUM_AUTOSCRIPT_VERSION_4_7:
@@ -132,17 +158,96 @@ try:
 
     THERMO_API_AVAILABLE = True
 except AutoScriptException as e:
+    THERMO_API_IMPORT_ERROR = str(e)
     logging.warning("Failed to load AutoScript (ThermoFisher): %s", str(e))
-    pass
 except ImportError as e:
+    THERMO_API_IMPORT_ERROR = str(e)
     logging.debug("AutoScript (ThermoFisher) not found: %s", str(e))
-    pass
-except Exception:
+except Exception as e:
+    THERMO_API_IMPORT_ERROR = str(e)
     logging.error(
         "Failed to load AutoScript (ThermoFisher) due to unexpected error",
         exc_info=True,
     )
-    pass
+
+
+def find_autoscript_install_candidates() -> List[str]:
+    """site-packages directories holding an AutoScript client package.
+
+    A best-effort search of the common conda and venv roots, used only to explain
+    a failed import. It does not change what gets imported.
+    """
+    candidates: List[str] = []
+    for pattern in _AUTOSCRIPT_SEARCH_GLOBS:
+        for site_packages_dir in glob.glob(pattern):
+            marker = os.path.join(site_packages_dir, "autoscript_sdb_microscope_client")
+            if os.path.isdir(marker) and site_packages_dir not in candidates:
+                candidates.append(site_packages_dir)
+    return candidates
+
+
+def _is_active_environment(site_packages_dir: str) -> bool:
+    """Whether `site_packages_dir` is on this interpreter's sys.path.
+
+    Separates a broken copy in the environment that is running from a complete
+    copy in some other environment that was never activated.
+    """
+    target = os.path.normcase(os.path.abspath(site_packages_dir))
+    return any(os.path.normcase(os.path.abspath(p)) == target for p in sys.path if p)
+
+
+def _format_candidate_list(paths: List[str], limit: int = 5) -> str:
+    shown = paths[:limit]
+    text = "; ".join(shown)
+    remaining = len(paths) - len(shown)
+    if remaining > 0:
+        text += f"; and {remaining} more"
+    return text
+
+
+def autoscript_unavailable_message() -> str:
+    """Why AutoScript could not be used, with the most likely fix.
+
+    Three different situations used to share one "not installed" message: never
+    installed, too old, or a partial copy. The import error is quoted when there
+    is one, and any copies found on disk are sorted by whether they sit in the
+    environment that is running.
+    """
+    parts = ["Autoscript (ThermoFisher) is not available."]
+
+    if THERMO_API_IMPORT_ERROR:
+        parts.append(f"Reason: {THERMO_API_IMPORT_ERROR}.")
+
+    candidates = find_autoscript_install_candidates()
+    active_env_candidates = [c for c in candidates if _is_active_environment(c)]
+    other_env_candidates = [c for c in candidates if c not in active_env_candidates]
+
+    if active_env_candidates:
+        parts.append(
+            "Found AutoScript packages in the currently active environment ("
+            + _format_candidate_list(active_env_candidates)
+            + ") but they did not import successfully -- check that ALL required "
+            "packages were copied (autoscript_core, autoscript_sdb_microscope_client, "
+            "autoscript_sdb_microscope_client_tests, autoscript_toolkit, "
+            "thermoscientific_logging) and that their versions match."
+        )
+    if other_env_candidates:
+        parts.append(
+            "Found AutoScript packages in a different environment than the one "
+            "currently running: "
+            + _format_candidate_list(other_env_candidates)
+            + ". Make sure you activated the environment AutoScript was copied "
+            "into, or copy the AutoScript packages into this environment's "
+            "site-packages instead."
+        )
+    if not candidates:
+        parts.append(
+            f"No AutoScript installation was found in {len(_AUTOSCRIPT_SEARCH_GLOBS)} "
+            "common locations."
+        )
+
+    parts.append("Please see INSTALLATION.md for installation instructions.")
+    return " ".join(parts)
 
 
 def stage_position_to_autoscript(
@@ -788,9 +893,7 @@ class ThermoMicroscope(FibsemMicroscope):
 
     def __init__(self, system_settings: SystemSettings):
         if not THERMO_API_AVAILABLE:
-            raise Exception(
-                "Autoscript (ThermoFisher) not installed. Please see the user guide for installation instructions."
-            )
+            raise Exception(autoscript_unavailable_message())
 
         # create microscope client
         self.connection = SdbMicroscopeClient()

--- a/tests/test_autoscript_unavailable_message.py
+++ b/tests/test_autoscript_unavailable_message.py
@@ -1,0 +1,125 @@
+"""The connection error when AutoScript cannot be imported.
+
+One "not installed" string used to cover three different situations: never
+installed, too old, or a partial copy in the wrong environment. The message now
+quotes the import error and sorts any copies found on disk by whether they sit in
+the environment that is running. CI never has AutoScript, so `ThermoMicroscope`
+refuses to construct here and the message is what a user would actually see.
+"""
+
+import os
+import sys
+
+import pytest
+
+from fibsem.microscopes import autoscript
+
+
+def _fake_site_packages(root, name):
+    site = root / name / "Lib" / "site-packages"
+    (site / "autoscript_sdb_microscope_client").mkdir(parents=True)
+    return str(site)
+
+
+@pytest.fixture
+def searched(tmp_path, monkeypatch):
+    """Point the candidate search at a scratch tree and forget any real error."""
+    monkeypatch.setattr(
+        autoscript,
+        "_AUTOSCRIPT_SEARCH_GLOBS",
+        [str(tmp_path / "*" / "Lib" / "site-packages")],
+    )
+    monkeypatch.setattr(autoscript, "THERMO_API_IMPORT_ERROR", None)
+    return tmp_path
+
+
+def test_nothing_found_says_so(searched):
+    message = autoscript.autoscript_unavailable_message()
+
+    assert message.startswith("Autoscript (ThermoFisher) is not available.")
+    assert "No AutoScript installation was found in 1 common locations" in message
+    assert "INSTALLATION.md" in message
+
+
+def test_the_import_error_is_quoted(searched, monkeypatch):
+    monkeypatch.setattr(
+        autoscript, "THERMO_API_IMPORT_ERROR", "No module named 'autoscript_core'"
+    )
+
+    assert "Reason: No module named 'autoscript_core'." in (
+        autoscript.autoscript_unavailable_message()
+    )
+
+
+def test_a_copy_in_the_running_environment_is_called_partial(searched, monkeypatch):
+    site = _fake_site_packages(searched, "running")
+    monkeypatch.syspath_prepend(site)
+
+    message = autoscript.autoscript_unavailable_message()
+
+    assert "in the currently active environment" in message
+    assert site in message
+    assert "autoscript_core" in message
+    assert "different environment" not in message
+
+
+def test_a_copy_elsewhere_points_at_activation(searched):
+    site = _fake_site_packages(searched, "other-env")
+    assert site not in sys.path
+
+    message = autoscript.autoscript_unavailable_message()
+
+    assert "in a different environment than the one currently running" in message
+    assert site in message
+    assert "currently active environment" not in message
+
+
+def test_both_kinds_are_reported_separately(searched, monkeypatch):
+    active = _fake_site_packages(searched, "running")
+    other = _fake_site_packages(searched, "other-env")
+    monkeypatch.syspath_prepend(active)
+
+    message = autoscript.autoscript_unavailable_message()
+
+    assert "currently active environment (" + active + ")" in message
+    assert "currently running: " + other + "." in message
+
+
+def test_long_candidate_lists_are_capped(searched):
+    sites = [_fake_site_packages(searched, f"env{i}") for i in range(7)]
+
+    message = autoscript.autoscript_unavailable_message()
+
+    assert "; and 2 more" in message
+    assert sum(site in message for site in sites) == 5
+
+
+def test_the_search_never_touches_sys_path(searched):
+    _fake_site_packages(searched, "other-env")
+    before = list(sys.path)
+
+    autoscript.find_autoscript_install_candidates()
+    autoscript.autoscript_unavailable_message()
+
+    assert sys.path == before
+
+
+@pytest.mark.skipif(autoscript.THERMO_API_AVAILABLE, reason="AutoScript is installed")
+def test_constructing_the_backend_raises_the_diagnostic(searched):
+    from fibsem import utils
+
+    settings = utils.load_microscope_configuration()
+
+    with pytest.raises(
+        Exception, match="Autoscript \\(ThermoFisher\\) is not available"
+    ):
+        autoscript.ThermoMicroscope(settings.system)
+
+
+def test_active_environment_check_normalises_the_path(tmp_path, monkeypatch):
+    site = tmp_path / "env" / "Lib" / "site-packages"
+    site.mkdir(parents=True)
+    monkeypatch.syspath_prepend(str(site))
+
+    assert autoscript._is_active_environment(os.path.join(str(site), ".", ""))
+    assert not autoscript._is_active_environment(str(tmp_path / "elsewhere"))


### PR DESCRIPTION
## Summary

Stacked on #799. A user on a support PC got `Autoscript (ThermoFisher) not installed` on a machine where AutoLamella had run before. That one string covered three different situations: never installed, too old, or a partial copy that failed to import, with the real exception going to a debug log line nobody reads.

## What changed

All in `fibsem/microscopes/autoscript.py`:

- The import guard records the exception text in `THERMO_API_IMPORT_ERROR`.
- `ThermoMicroscope.__init__` raises `autoscript_unavailable_message()`, which quotes that error and lists any `autoscript_sdb_microscope_client` package found under the common conda and venv roots. Copies are split by whether their site-packages is on `sys.path` (a broken copy in the running environment, so check every package was copied) or not (the wrong environment was activated). Lists are capped at 5 with a count of the rest.
- The search is diagnostic only. It never adds anything to `sys.path`; the four legacy paths are still appended as before, now from one list.
- The Monash version override logs instead of printing.

## Verification

- `tests/test_autoscript_unavailable_message.py` covers: nothing found, the error is quoted, active-environment copy, other-environment copy, both at once, the cap, `sys.path` untouched, and that constructing the backend on a machine without AutoScript raises the diagnostic.
- 119 tests pass across the new file and its neighbours, offscreen.
- The happy path is unchanged: diffing the guard's try block against main shows the same four sys.path appends in the same order, the Monash override logging instead of printing, and CompustagePosition in the structures import (already imported by this file's own guard before). Everything else runs only after the guard has failed.
