### PR TITLE
[fix] Setup Lamella Position records its pose, POI and references again without coincidence alignment

### DIFF
--- a/fibsem/applications/autolamella/workflows/tasks/select_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_position.py
@@ -120,6 +120,49 @@ class SelectMillingPositionTask(AutoLamellaTask):
                 field_of_view=self.config.reference_imaging.field_of_view1,
             )
 
+        # confirm with user to move to milling position
+        if self.validate:
+            ask_user(
+                parent_ui=self.parent_ui,
+                msg=f"Double click the image to move to the milling position for {self.lamella.name}. "
+                f"Press Continue when done.",
+                pos="Continue",
+            )
+
+        # select point of interest
+        if self.config.select_poi:
+            poi = select_poi_ui(
+                parent_ui=self.parent_ui,
+                # the FIB image the reference acquisition above displayed — the
+                # marker's coordinates only mean something against it
+                image=self._last_fib_image,
+                msg=f"Move the marker to the point of interest for {self.lamella.name}. Press Continue when done.",
+                validate=self.validate,
+                initial_poi=self.lamella.poi,
+            )
+            if poi is not None:
+                self.lamella.poi = poi
+                synced = self.lamella.sync_tasks_to_poi()
+                if synced:
+                    logging.info(f"Synced tasks to POI: {synced}")
+
+        # validate alignment area
+        self._validate_alignment_area()
+
+        # acquire alignment reference image
+        self._acquire_alignment_reference_image(
+            image_settings=self.image_settings,
+            reduced_area=self.lamella.alignment_area,
+            field_of_view=self.config.reference_imaging.field_of_view1,
+        )
+
+        # reference images
+        self._acquire_set_of_reference_images(self.image_settings)
+
+        # store milling pose and angle
+        self.lamella.milling_pose = self.microscope.get_microscope_state()
+        self.lamella.update_milling_angle(self.microscope)
+
     def _align_coincident_for_milling(
         self, milling_angle: float, is_close: bool
     ) -> None:
@@ -204,46 +247,3 @@ class SelectMillingPositionTask(AutoLamellaTask):
                 "at the target tilt",
                 tilt.reason,
             )
-
-        # confirm with user to move to milling position
-        if self.validate:
-            ask_user(
-                parent_ui=self.parent_ui,
-                msg=f"Double click the image to move to the milling position for {self.lamella.name}. "
-                f"Press Continue when done.",
-                pos="Continue",
-            )
-
-        # select point of interest
-        if self.config.select_poi:
-            poi = select_poi_ui(
-                parent_ui=self.parent_ui,
-                # the FIB image the reference acquisition above displayed — the
-                # marker's coordinates only mean something against it
-                image=self._last_fib_image,
-                msg=f"Move the marker to the point of interest for {self.lamella.name}. Press Continue when done.",
-                validate=self.validate,
-                initial_poi=self.lamella.poi,
-            )
-            if poi is not None:
-                self.lamella.poi = poi
-                synced = self.lamella.sync_tasks_to_poi()
-                if synced:
-                    logging.info(f"Synced tasks to POI: {synced}")
-
-        # validate alignment area
-        self._validate_alignment_area()
-
-        # acquire alignment reference image
-        self._acquire_alignment_reference_image(
-            image_settings=self.image_settings,
-            reduced_area=self.lamella.alignment_area,
-            field_of_view=self.config.reference_imaging.field_of_view1,
-        )
-
-        # reference images
-        self._acquire_set_of_reference_images(self.image_settings)
-
-        # store milling pose and angle
-        self.lamella.milling_pose = self.microscope.get_microscope_state()
-        self.lamella.update_milling_angle(self.microscope)

--- a/tests/autolamella/test_select_position_records_pose.py
+++ b/tests/autolamella/test_select_position_records_pose.py
@@ -1,0 +1,59 @@
+"""SelectMillingPositionTask records the milling pose and the alignment
+reference whether or not coincidence alignment is on.
+
+Regression: the task's tail -- the position confirmation, the point of
+interest, the alignment area, the reference images and the milling pose --
+had ended up inside the coincidence helper, which only runs with
+``auto_milling_alignment`` on and returns early when the stage is already at
+the milling angle. With the default configuration the task moved, imaged,
+and recorded nothing.
+"""
+
+import os
+
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.applications.autolamella.structures import Lamella
+from fibsem.applications.autolamella.workflows.tasks.base import (
+    ALIGNMENT_REFERENCE_IMAGE_FILENAME,
+)
+from fibsem.applications.autolamella.workflows.tasks.select_position import (
+    SelectMillingPositionTask,
+    SelectMillingPositionTaskConfig,
+)
+
+CONFIG = os.path.join(cfg.CONFIG_PATH, "microscope-configuration.yaml")
+
+
+@pytest.fixture
+def microscope():
+    microscope, _ = utils.setup_session(manufacturer="Demo", config_path=CONFIG)
+    yield microscope
+    microscope.disconnect()
+
+
+@pytest.mark.parametrize("auto_milling_alignment", [False, True])
+def test_the_task_records_pose_and_reference_either_way(
+    microscope, tmp_path, auto_milling_alignment
+):
+    lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+    lamella.path.mkdir(parents=True, exist_ok=True)
+    lamella.milling_pose = microscope.get_microscope_state()
+    assert lamella.milling_angle is None
+    config = SelectMillingPositionTaskConfig(
+        auto_milling_alignment=auto_milling_alignment,
+        use_autofocus=False,
+        select_poi=True,
+    )
+    task = SelectMillingPositionTask(
+        microscope=microscope, config=config, lamella=lamella
+    )
+
+    task._run()
+
+    assert lamella.milling_angle is not None, "milling pose and angle were stored"
+    assert os.path.exists(
+        os.path.join(lamella.path, ALIGNMENT_REFERENCE_IMAGE_FILENAME)
+    ), "the alignment reference was acquired"


### PR DESCRIPTION
## What broke

e126e568 (2 Sept) inserted `_align_coincident_for_milling` into the middle of `SelectMillingPositionTask._run`, and the tail of `_run` went with it. On `main` the position confirmation, the point-of-interest question, the alignment-area validation, the reference images and the milling-pose store all sit at the **end of the coincidence helper**:

- the helper only runs with `auto_milling_alignment` on, which is off by default;
- it returns early at `if is_close: return` when the stage is already at the milling angle.

So with the default configuration Setup moves to the pose, images, tilts, and records nothing — no POI, no alignment reference, no `milling_pose`. Before that commit `_run` ran those steps unconditionally (`_run` was lines 61–177; they are its last 40).

## Fix

A pure dedent: the 42 lines move back to the end of `_run`, unchanged. The helper keeps only the alignment and the tilt. Diff is 43 insertions / 43 deletions, all whitespace-equivalent.

## Test

`tests/autolamella/test_select_position_records_pose.py`: with `auto_milling_alignment` off and on, on the Demo, the task ends with `milling_angle` set and `ref_alignment_ib.tif` on disk. Off failed before the change. The two existing coincidence tests still pass.

Independent of the propose-and-review stack (#788–#794), which should rebase onto this once merged so its Setup step no longer needs the alignment path to reach the POI.

Release-Note: Setup Lamella Position again asks for the milling position and point of interest and records the milling pose without Auto Coincidence Alignment turned on.
