### PR TITLE
[refactor] One home for rendering a value as text, and one micro sign

### DIFF
--- a/fibsem/ui/widgets/angle_measure.py
+++ b/fibsem/ui/widgets/angle_measure.py
@@ -15,15 +15,15 @@ from PyQt5 import QtWidgets
 from PyQt5.QtCore import QPoint, QRect, Qt
 from PyQt5.QtGui import QColor, QFont, QPainter, QPainterPath, QPen
 
-from fibsem.ui.widgets.drag_distance import _fmt_distance, _MeasureOverlayBase
+from fibsem.ui.widgets.drag_distance import _MeasureOverlayBase
 
-_COLOR_ARM1  = QColor(80, 200, 255, 220)   # blue
-_COLOR_ARM2  = QColor(120, 255, 120, 220)  # green
-_COLOR_ARC   = QColor(255, 220, 50, 200)   # yellow
+_COLOR_ARM1 = QColor(80, 200, 255, 220)  # blue
+_COLOR_ARM2 = QColor(120, 255, 120, 220)  # green
+_COLOR_ARC = QColor(255, 220, 50, 200)  # yellow
 _COLOR_LABEL = QColor(255, 220, 50, 230)
-_TEXT_BG     = QColor(20, 20, 20, 180)
+_TEXT_BG = QColor(20, 20, 20, 180)
 _DOT_R = 5
-_ARC_R = 40   # arc radius in screen pixels
+_ARC_R = 40  # arc radius in screen pixels
 
 
 class AngleMeasureOverlay(_MeasureOverlayBase):
@@ -40,12 +40,17 @@ class AngleMeasureOverlay(_MeasureOverlayBase):
         on_measure: Optional[Callable[[float], None]] = None,
         parent: Optional[QtWidgets.QWidget] = None,
     ):
-        super().__init__(pixel_size=pixel_size, scale=scale, unit=unit,
-                         on_measure=on_measure, parent=parent)
-        self._phase = 0          # 0=idle, 1=drawing arm1, 2=drawing arm2
+        super().__init__(
+            pixel_size=pixel_size,
+            scale=scale,
+            unit=unit,
+            on_measure=on_measure,
+            parent=parent,
+        )
+        self._phase = 0  # 0=idle, 1=drawing arm1, 2=drawing arm2
         self._vertex: Optional[QPoint] = None
-        self._arm1:   Optional[QPoint] = None
-        self._arm2:   Optional[QPoint] = None
+        self._arm1: Optional[QPoint] = None
+        self._arm2: Optional[QPoint] = None
 
     # ------------------------------------------------------------------
     # Public API — override start() for two-phase gesture
@@ -53,6 +58,7 @@ class AngleMeasureOverlay(_MeasureOverlayBase):
 
     def start(self, global_pos: QPoint, source_widget: QtWidgets.QWidget) -> None:
         from PyQt5.QtCore import QRect
+
         geo = source_widget.rect()
         top_left = source_widget.mapToGlobal(geo.topLeft())
         self.setGeometry(QRect(top_left, geo.size()))
@@ -143,11 +149,13 @@ class AngleMeasureOverlay(_MeasureOverlayBase):
 
         # --- Phase hint ---
         if self._phase == 1:
-            self._draw_label(painter, "Set first arm →", vx, vy,
-                             _COLOR_ARM1, offset_y=-22)
+            self._draw_label(
+                painter, "Set first arm →", vx, vy, _COLOR_ARM1, offset_y=-22
+            )
         elif self._phase == 2 and self._arm2 is None:
-            self._draw_label(painter, "Set second arm →", vx, vy,
-                             _COLOR_ARM2, offset_y=-22)
+            self._draw_label(
+                painter, "Set second arm →", vx, vy, _COLOR_ARM2, offset_y=-22
+            )
 
         # --- Arc + angle ---
         if self._arm1 and self._arm2:
@@ -168,8 +176,7 @@ class AngleMeasureOverlay(_MeasureOverlayBase):
     def _dot(self, painter: QPainter, pt: QPoint, color: QColor) -> None:
         painter.setBrush(color)
         painter.setPen(Qt.NoPen)
-        painter.drawEllipse(pt.x() - _DOT_R, pt.y() - _DOT_R,
-                            _DOT_R * 2, _DOT_R * 2)
+        painter.drawEllipse(pt.x() - _DOT_R, pt.y() - _DOT_R, _DOT_R * 2, _DOT_R * 2)
 
     def _draw_arc(self, painter: QPainter, vx: int, vy: int, angle: float) -> None:
         start_angle = self._angle_of(self._arm1) * 180 / math.pi
@@ -177,18 +184,15 @@ class AngleMeasureOverlay(_MeasureOverlayBase):
 
         painter.setBrush(QColor(255, 220, 50, 40))
         painter.setPen(QPen(_COLOR_ARC, 1.5))
-        arc_rect = QRect(int(vx - _ARC_R), int(vy - _ARC_R),
-                         _ARC_R * 2, _ARC_R * 2)
+        arc_rect = QRect(int(vx - _ARC_R), int(vy - _ARC_R), _ARC_R * 2, _ARC_R * 2)
         # Qt angles: CCW positive, 1/16 degree units
-        painter.drawPie(arc_rect,
-                        int(start_angle * 16),
-                        int(span * 16))
+        painter.drawPie(arc_rect, int(start_angle * 16), int(span * 16))
 
     def _angle_of(self, pt: Optional[QPoint]) -> float:
         if pt is None:
             return 0.0
         dx = pt.x() - self._vertex.x()
-        dy = -(pt.y() - self._vertex.y())   # flip Y for screen coords
+        dy = -(pt.y() - self._vertex.y())  # flip Y for screen coords
         return math.atan2(dy, dx)
 
     def _signed_angle(self) -> float:
@@ -197,8 +201,10 @@ class AngleMeasureOverlay(_MeasureOverlayBase):
         a2 = self._angle_of(self._arm2)
         diff = a2 - a1
         # Normalise to (-π, π]
-        while diff > math.pi:  diff -= 2 * math.pi
-        while diff <= -math.pi: diff += 2 * math.pi
+        while diff > math.pi:
+            diff -= 2 * math.pi
+        while diff <= -math.pi:
+            diff += 2 * math.pi
         return diff
 
     def _midpoint_angle(self) -> float:

--- a/fibsem/ui/widgets/canvas/overlays/ruler_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/ruler_overlay.py
@@ -10,6 +10,7 @@ from fibsem.ui.tokens import (
     WHITE_ICON_COLOR,
 )
 from fibsem.ui.widgets.canvas.overlays.base import CanvasOverlay
+from fibsem.utils import format_distance
 
 if TYPE_CHECKING:
     from fibsem.ui.widgets.canvas.canvas_base import ContentRect
@@ -21,20 +22,6 @@ _RULER_PICK_PX = 10  # screen-space hit radius for ruler endpoints / line body
 
 def _clampf(v: float, lo: float, hi: float) -> float:
     return lo if v < lo else hi if v > hi else v
-
-
-def _format_distance(metres: float) -> str:
-    """Auto-scale a distance in metres to a short SI string."""
-    a = abs(metres)
-    if a == 0:
-        return "0 nm"
-    if a < 1e-6:
-        return f"{metres * 1e9:.1f} nm"
-    if a < 1e-3:
-        return f"{metres * 1e6:.2f} µm"
-    if a < 1.0:
-        return f"{metres * 1e3:.3f} mm"
-    return f"{metres:.4f} m"
 
 
 class RulerOverlay(CanvasOverlay):
@@ -63,8 +50,8 @@ class RulerOverlay(CanvasOverlay):
         self._visible: bool = False
 
         # artists
-        self._line = None   # Line2D segment
-        self._dots = None   # Line2D endpoint markers
+        self._line = None  # Line2D segment
+        self._dots = None  # Line2D endpoint markers
         self._label = None  # Annotation (distance)
 
         # drag state: None | "p1" | "p2" | "line"
@@ -167,27 +154,48 @@ class RulerOverlay(CanvasOverlay):
             return
         xs, ys = self._xs_ys()
         (self._line,) = self._ax.plot(
-            xs, ys, color=self._color, linewidth=1.6,
-            solid_capstyle="round", zorder=8,
+            xs,
+            ys,
+            color=self._color,
+            linewidth=1.6,
+            solid_capstyle="round",
+            zorder=8,
         )
         (self._dots,) = self._ax.plot(
-            xs, ys, linestyle="none", marker="o", markersize=6,
-            markerfacecolor=self._color, markeredgecolor="white",
-            markeredgewidth=0.8, zorder=9,
+            xs,
+            ys,
+            linestyle="none",
+            marker="o",
+            markersize=6,
+            markerfacecolor=self._color,
+            markeredgecolor="white",
+            markeredgewidth=0.8,
+            zorder=9,
         )
         mx, my = (xs[0] + xs[1]) / 2.0, (ys[0] + ys[1]) / 2.0
         self._label = self._ax.annotate(
-            self._text(), xy=(mx, my), xytext=(0, 9),
-            textcoords="offset points", ha="center", va="bottom",
-            fontsize=8, color=WHITE_ICON_COLOR, zorder=10,
-            bbox=dict(boxstyle="round,pad=0.3", facecolor=_BG,
-                      edgecolor=self._color, alpha=0.8, linewidth=0.8),
+            self._text(),
+            xy=(mx, my),
+            xytext=(0, 9),
+            textcoords="offset points",
+            ha="center",
+            va="bottom",
+            fontsize=8,
+            color=WHITE_ICON_COLOR,
+            zorder=10,
+            bbox=dict(
+                boxstyle="round,pad=0.3",
+                facecolor=_BG,
+                edgecolor=self._color,
+                alpha=0.8,
+                linewidth=0.8,
+            ),
         )
 
     def _text(self) -> str:
         d = math.hypot(self._p2[0] - self._p1[0], self._p2[1] - self._p1[1])
         if self._pixel_size:
-            return _format_distance(d * self._pixel_size)
+            return format_distance(d * self._pixel_size)
         return f"{d:.0f} px"
 
     def _update_artists(self) -> None:
@@ -254,9 +262,15 @@ class RulerOverlay(CanvasOverlay):
             return
         left, top, right, bottom = rect.x0, rect.y0, rect.x1, rect.y1
         if self._drag == "p1":
-            self._p1 = [_clampf(p1[0] + dx, left, right), _clampf(p1[1] + dy, top, bottom)]
+            self._p1 = [
+                _clampf(p1[0] + dx, left, right),
+                _clampf(p1[1] + dy, top, bottom),
+            ]
         elif self._drag == "p2":
-            self._p2 = [_clampf(p2[0] + dx, left, right), _clampf(p2[1] + dy, top, bottom)]
+            self._p2 = [
+                _clampf(p2[0] + dx, left, right),
+                _clampf(p2[1] + dy, top, bottom),
+            ]
         else:  # move the whole line, clamped so both endpoints stay in bounds
             minx, maxx = min(p1[0], p2[0]), max(p1[0], p2[0])
             miny, maxy = min(p1[1], p2[1]), max(p1[1], p2[1])

--- a/fibsem/ui/widgets/coincidence_milling_confirmation_dialog.py
+++ b/fibsem/ui/widgets/coincidence_milling_confirmation_dialog.py
@@ -34,6 +34,7 @@ from fibsem.ui.widgets.preflight import (
     format_duration,
     meta_label,
 )
+from fibsem.utils import format_current
 
 # The dimensions that determine the milled volume, in the order they read. Driven off
 # the pattern's own to_dict() rather than isinstance checks, so a new pattern type
@@ -48,14 +49,6 @@ _DIMENSION_KEYS: List[Tuple[str, str]] = [
     ("height", "tall"),
     ("depth", "deep"),
 ]
-
-
-def _format_current(amps: float) -> str:
-    """`1.0 nA` / `60 pA` — milling currents span three orders of magnitude, and
-    everything-in-pA turns the common nA case into a four-digit number."""
-    if amps >= 1e-9:
-        return f"{amps * constants.SI_TO_NANO:.1f} nA"
-    return f"{amps * constants.SI_TO_PICO:.0f} pA"
 
 
 def _pattern_summary(stage: FibsemMillingStage) -> str:
@@ -126,12 +119,15 @@ class CoincidenceMillingConfirmationDialog(QDialog):
         if not currents:
             return None
         if len(currents) == 1:
-            return _format_current(currents[0])
-        return f"{_format_current(currents[0])} – {_format_current(currents[-1])}"
+            return format_current(currents[0])
+        return f"{format_current(currents[0])} – {format_current(currents[-1])}"
 
     def _meta_line(self) -> str:
         stages = self.task_config.enabled_stages
-        bits = [self.lamella_name, f"{len(stages)} stage{'s' if len(stages) != 1 else ''}"]
+        bits = [
+            self.lamella_name,
+            f"{len(stages)} stage{'s' if len(stages) != 1 else ''}",
+        ]
         fov = getattr(self.task_config, "field_of_view", None)
         if fov:
             bits.append(f"{fov * constants.SI_TO_MICRO:.0f} µm field of view")
@@ -150,7 +146,7 @@ class CoincidenceMillingConfirmationDialog(QDialog):
         return [
             (
                 stage.name,
-                f"{_format_current(stage.milling.milling_current)}"
+                f"{format_current(stage.milling.milling_current)}"
                 f" · {_pattern_summary(stage)}"
                 f" · {format_duration(stage.estimated_time)}",
             )
@@ -177,17 +173,21 @@ class CoincidenceMillingConfirmationDialog(QDialog):
                 # mill will halt itself when it will not.
                 trigger += "  → monitoring only; you stop the mill"
             detail.append(("Drop trigger", trigger))
-            detail.append((
-                "Monitoring",
-                f"starts after {format_duration(config.warmup_duration)} warmup"
-                f" · times out at {format_duration(config.timeout)}",
-            ))
-            detail.append((
-                "Mode",
-                "supervised — you stop the mill manually"
-                if config.supervised
-                else "automated — stops itself on the drop trigger",
-            ))
+            detail.append(
+                (
+                    "Monitoring",
+                    f"starts after {format_duration(config.warmup_duration)} warmup"
+                    f" · times out at {format_duration(config.timeout)}",
+                )
+            )
+            detail.append(
+                (
+                    "Mode",
+                    "supervised — you stop the mill manually"
+                    if config.supervised
+                    else "automated — stops itself on the drop trigger",
+                )
+            )
             saved = (
                 f"saved (every {config.save_rate_limit} frames)"
                 if config.save_fm_images
@@ -197,7 +197,9 @@ class CoincidenceMillingConfirmationDialog(QDialog):
                 saved += " · FIB image acquired"
             detail.append(("FM images", saved))
 
-        detail.append(("Estimated time", format_duration(self.task_config.estimated_time)))
+        detail.append(
+            ("Estimated time", format_duration(self.task_config.estimated_time))
+        )
         return detail
 
     # ── layout ───────────────────────────────────────────────────────────

--- a/fibsem/ui/widgets/drag_distance.py
+++ b/fibsem/ui/widgets/drag_distance.py
@@ -32,12 +32,14 @@ from PyQt5 import QtWidgets
 from PyQt5.QtCore import QPoint, QRect, Qt
 from PyQt5.QtGui import QColor, QFont, QPainter, QPainterPath, QPen
 
+from fibsem.utils import format_distance
+
 # ---------------------------------------------------------------------------
 # Shared colours
 # ---------------------------------------------------------------------------
-_LINE_COLOR = QColor(255, 220, 50, 230)      # yellow  – diagonal / main
-_LINE_COLOR_H = QColor(80, 200, 255, 230)    # blue    – horizontal
-_LINE_COLOR_V = QColor(120, 255, 120, 230)   # green   – vertical
+_LINE_COLOR = QColor(255, 220, 50, 230)  # yellow  – diagonal / main
+_LINE_COLOR_H = QColor(80, 200, 255, 230)  # blue    – horizontal
+_LINE_COLOR_V = QColor(120, 255, 120, 230)  # green   – vertical
 _RECT_FILL = QColor(255, 220, 50, 30)
 _TEXT_BG = QColor(20, 20, 20, 180)
 _ENDPOINT_RADIUS = 5
@@ -57,19 +59,6 @@ class ConstraintMode(Enum):
 # ---------------------------------------------------------------------------
 # SI formatting helpers
 # ---------------------------------------------------------------------------
-
-def _fmt_distance(metres: float) -> str:
-    """Auto-scale a distance in metres to a human-readable SI string."""
-    abs_m = abs(metres)
-    if abs_m == 0:
-        return "0 nm"
-    if abs_m < 1e-6:
-        return f"{metres * 1e9:.1f} nm"
-    if abs_m < 1e-3:
-        return f"{metres * 1e6:.2f} µm"
-    if abs_m < 1.0:
-        return f"{metres * 1e3:.3f} mm"
-    return f"{metres:.4f} m"
 
 
 def _fmt_area(m2: float) -> str:
@@ -104,7 +93,7 @@ class _MeasureOverlayBase(QtWidgets.QWidget):
         parent: Optional[QtWidgets.QWidget] = None,
     ):
         super().__init__(parent)
-        self._pixel_size = pixel_size   # metres per pixel; None = use scale/unit
+        self._pixel_size = pixel_size  # metres per pixel; None = use scale/unit
         self._scale = scale
         self._unit = unit
         self._on_measure = on_measure
@@ -119,14 +108,14 @@ class _MeasureOverlayBase(QtWidgets.QWidget):
     def _fmt(self, pixels: float) -> str:
         """Format a pixel distance using pixel_size (SI) or scale/unit."""
         if self._pixel_size is not None:
-            return _fmt_distance(pixels * self._pixel_size)
+            return format_distance(pixels * self._pixel_size)
         return f"{pixels * self._scale:.1f} {self._unit}"
 
     def _fmt_area(self, pixels_sq: float) -> str:
         """Format a pixel area using pixel_size (SI) or scale/unit."""
         if self._pixel_size is not None:
-            return _fmt_area(pixels_sq * self._pixel_size ** 2)
-        return f"{pixels_sq * self._scale ** 2:.1f} {self._unit}²"
+            return _fmt_area(pixels_sq * self._pixel_size**2)
+        return f"{pixels_sq * self._scale**2:.1f} {self._unit}²"
 
     # ------------------------------------------------------------------
     # Public API
@@ -204,6 +193,7 @@ class _MeasureOverlayBase(QtWidgets.QWidget):
 # Ruler
 # ---------------------------------------------------------------------------
 
+
 class DragDistanceOverlay(_MeasureOverlayBase):
     """Drag-to-measure line overlay.
 
@@ -225,8 +215,13 @@ class DragDistanceOverlay(_MeasureOverlayBase):
         on_measure: Optional[Callable[[float], None]] = None,
         parent: Optional[QtWidgets.QWidget] = None,
     ):
-        super().__init__(pixel_size=pixel_size, scale=scale, unit=unit,
-                         on_measure=on_measure, parent=parent)
+        super().__init__(
+            pixel_size=pixel_size,
+            scale=scale,
+            unit=unit,
+            on_measure=on_measure,
+            parent=parent,
+        )
         self._default_constraint = constraint
         self._constraint = constraint
 
@@ -285,11 +280,23 @@ class DragDistanceOverlay(_MeasureOverlayBase):
             cr = 3
             painter.drawEllipse(x2 - cr, y1 - cr, cr * 2, cr * 2)
             # Component labels
-            self._draw_label(painter, self._fmt(abs(dx)),
-                             (x1 + x2) / 2, y1, _LINE_COLOR_H, offset_y=-18)
+            self._draw_label(
+                painter,
+                self._fmt(abs(dx)),
+                (x1 + x2) / 2,
+                y1,
+                _LINE_COLOR_H,
+                offset_y=-18,
+            )
             side = 18 if x2 >= x1 else -18
-            self._draw_label(painter, self._fmt(abs(dy)),
-                             x2, (y1 + y2) / 2, _LINE_COLOR_V, offset_x=side)
+            self._draw_label(
+                painter,
+                self._fmt(abs(dy)),
+                x2,
+                (y1 + y2) / 2,
+                _LINE_COLOR_V,
+                offset_x=side,
+            )
             line_color = _LINE_COLOR
 
         elif self._constraint == ConstraintMode.HORIZONTAL:
@@ -361,6 +368,7 @@ class DragDistanceOverlay(_MeasureOverlayBase):
 # Rectangle
 # ---------------------------------------------------------------------------
 
+
 class RectMeasureOverlay(_MeasureOverlayBase):
     """Drag-to-measure rectangle overlay.
 
@@ -379,8 +387,13 @@ class RectMeasureOverlay(_MeasureOverlayBase):
         on_measure: Optional[Callable[[float, float, float], None]] = None,
         parent: Optional[QtWidgets.QWidget] = None,
     ):
-        super().__init__(pixel_size=pixel_size, scale=scale, unit=unit,
-                         on_measure=on_measure, parent=parent)
+        super().__init__(
+            pixel_size=pixel_size,
+            scale=scale,
+            unit=unit,
+            on_measure=on_measure,
+            parent=parent,
+        )
         self._square = False
 
     def _on_start(self) -> None:
@@ -446,26 +459,40 @@ class RectMeasureOverlay(_MeasureOverlayBase):
 
         # Width label — centred above the top edge
         top_y = min(y1, y2)
-        self._draw_label(painter, self._fmt(abs(dx)),
-                         (x1 + x2) / 2, top_y, _LINE_COLOR_H, offset_y=-18)
+        self._draw_label(
+            painter,
+            self._fmt(abs(dx)),
+            (x1 + x2) / 2,
+            top_y,
+            _LINE_COLOR_H,
+            offset_y=-18,
+        )
 
         # Height label — centred to the right of the right edge
         right_x = max(x1, x2)
-        self._draw_label(painter, self._fmt(abs(dy)),
-                         right_x, (y1 + y2) / 2, _LINE_COLOR_V, offset_x=18)
+        self._draw_label(
+            painter,
+            self._fmt(abs(dy)),
+            right_x,
+            (y1 + y2) / 2,
+            _LINE_COLOR_V,
+            offset_x=18,
+        )
 
         # Area label — centred inside the rectangle (if large enough)
         area_label = self._fmt_area(abs(dx) * abs(dy))
         if self._square:
             area_label += "  [■]"
         if abs(dx) > 80 and abs(dy) > 30:
-            self._draw_label(painter, area_label,
-                             (x1 + x2) / 2, (y1 + y2) / 2, _LINE_COLOR)
+            self._draw_label(
+                painter, area_label, (x1 + x2) / 2, (y1 + y2) / 2, _LINE_COLOR
+            )
         else:
             # Fallback: place outside, below the bottom edge
             bottom_y = max(y1, y2)
-            self._draw_label(painter, area_label,
-                             (x1 + x2) / 2, bottom_y, _LINE_COLOR, offset_y=18)
+            self._draw_label(
+                painter, area_label, (x1 + x2) / 2, bottom_y, _LINE_COLOR, offset_y=18
+            )
 
         painter.end()
 
@@ -482,7 +509,9 @@ class RectMeasureOverlay(_MeasureOverlayBase):
         if self._on_measure:
             self._on_measure(w, h, area)
         else:
-            print(f"Rectangle: {self._fmt(abs(dx))} × {self._fmt(abs(dy))}  area={self._fmt_area(abs(dx) * abs(dy))}")
+            print(
+                f"Rectangle: {self._fmt(abs(dx))} × {self._fmt(abs(dy))}  area={self._fmt_area(abs(dx) * abs(dy))}"
+            )
 
     def _apply_square(self, pos: QPoint) -> QPoint:
         if not self._square or not self._start:
@@ -499,6 +528,7 @@ class RectMeasureOverlay(_MeasureOverlayBase):
 # ---------------------------------------------------------------------------
 # Mixins
 # ---------------------------------------------------------------------------
+
 
 class DragDistanceMixin:
     """Adds left-click drag-to-measure (ruler) to any QWidget."""

--- a/fibsem/ui/widgets/hud_ticker.py
+++ b/fibsem/ui/widgets/hud_ticker.py
@@ -10,9 +10,9 @@ Usage::
 
 The ticker resizes itself to always match the parent's width.
 """
+
 from __future__ import annotations
 
-import math
 from typing import Optional
 
 from PyQt5 import QtWidgets
@@ -20,39 +20,15 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QColor, QFont, QPainter, QPainterPath
 
 from fibsem.structures import FibsemImage
-from fibsem.ui.widgets.drag_distance import _fmt_distance
+from fibsem.utils import format_angle, format_distance
 
 _BG = QColor(10, 10, 12, 190)
 _TEXT = QColor(210, 210, 210, 230)
 _DIVIDER = QColor(80, 80, 90, 180)
-_LABEL = QColor(120, 170, 255, 200)   # blue-ish key labels
+_LABEL = QColor(120, 170, 255, 200)  # blue-ish key labels
 _HEIGHT = 26
 _PADDING = 12
 _DIVIDER_W = 1
-
-
-def _deg(radians: Optional[float]) -> str:
-    if radians is None:
-        return "—"
-    return f"{math.degrees(radians):.1f}°"
-
-def _um(metres: Optional[float]) -> str:
-    if metres is None:
-        return "—"
-    return _fmt_distance(metres)
-
-def _kv(volts: Optional[float]) -> str:
-    if volts is None:
-        return "—"
-    return f"{volts / 1e3:.2f} kV"
-
-def _na(amps: Optional[float]) -> str:
-    if amps is None:
-        return "—"
-    abs_a = abs(amps)
-    if abs_a < 1e-9:
-        return f"{amps * 1e12:.0f} pA"
-    return f"{amps * 1e9:.2f} nA"
 
 
 class HUDTicker(QtWidgets.QWidget):
@@ -84,10 +60,10 @@ class HUDTicker(QtWidgets.QWidget):
         if state and state.stage_position:
             sp = state.stage_position
             self._segments += [
-                ("X", _um(sp.x)),
-                ("Y", _um(sp.y)),
-                ("Z", _um(sp.z)),
-                ("T", _deg(sp.t)),
+                ("X", format_distance(sp.x)),
+                ("Y", format_distance(sp.y)),
+                ("Z", format_distance(sp.z)),
+                ("T", format_angle(sp.t)),
             ]
         else:
             self._segments += [("X", "—"), ("Y", "—"), ("Z", "—"), ("T", "—")]
@@ -97,14 +73,15 @@ class HUDTicker(QtWidgets.QWidget):
         # --- Acquisition ---
         s = meta.image_settings
         self._segments += [
-            ("HFW",  _um(s.hfw) if s else "—"),
-            ("px",   _fmt_distance(meta.pixel_size.x) + "/px"),
-            ("res",  f"{s.resolution[0]}×{s.resolution[1]}" if s else "—"),
+            ("HFW", format_distance(s.hfw) if s else "—"),
+            ("px", format_distance(meta.pixel_size.x) + "/px"),
+            ("res", f"{s.resolution[0]}×{s.resolution[1]}" if s else "—"),
         ]
 
         # Timestamp
         if state and state.timestamp:
             import datetime
+
             ts = datetime.datetime.fromtimestamp(state.timestamp).strftime("%H:%M:%S")
             self._segments.append(None)
             self._segments.append(("t", ts))

--- a/fibsem/ui/widgets/profile_line.py
+++ b/fibsem/ui/widgets/profile_line.py
@@ -26,17 +26,18 @@ from fibsem.ui.tokens import (
     NEUTRAL_900,
     PANEL_COLOR,
 )
-from fibsem.ui.widgets.drag_distance import _fmt_distance, _MeasureOverlayBase
+from fibsem.ui.widgets.drag_distance import _MeasureOverlayBase
 
 try:
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
     from matplotlib.figure import Figure
+
     _MPL = True
 except ImportError:
     _MPL = False
 
-_LINE_COLOR = QColor(255, 140, 0, 230)   # orange
-_TEXT_BG    = QColor(20, 20, 20, 180)
+_LINE_COLOR = QColor(255, 140, 0, 230)  # orange
+_TEXT_BG = QColor(20, 20, 20, 180)
 _DOT_R = 5
 
 
@@ -54,7 +55,7 @@ class _ProfilePlotWidget(QtWidgets.QWidget):
 
         if _MPL:
             self._fig = Figure(figsize=(4, 1.8), facecolor=NEUTRAL_900)
-            self._ax  = self._fig.add_subplot(111)
+            self._ax = self._fig.add_subplot(111)
             self._canvas = FigureCanvasQTAgg(self._fig)
             layout.addWidget(self._canvas)
             self._style_axes()
@@ -172,15 +173,19 @@ class ProfileLineOverlay(_MeasureOverlayBase):
         painter.setBrush(_LINE_COLOR)
         painter.setPen(Qt.NoPen)
         for px, py in [(x1, y1), (x2, y2)]:
-            painter.drawEllipse(px - _DOT_R, py - _DOT_R,
-                                _DOT_R * 2, _DOT_R * 2)
+            painter.drawEllipse(px - _DOT_R, py - _DOT_R, _DOT_R * 2, _DOT_R * 2)
 
         # Distance label
         dx, dy = x2 - x1, y2 - y1
         length = math.hypot(dx, dy) or 1
-        self._draw_label(painter, self._fmt(length),
-                         (x1 + x2) / 2, (y1 + y2) / 2,
-                         _LINE_COLOR, offset_y=-18)
+        self._draw_label(
+            painter,
+            self._fmt(length),
+            (x1 + x2) / 2,
+            (y1 + y2) / 2,
+            _LINE_COLOR,
+            offset_y=-18,
+        )
 
         painter.end()
 
@@ -216,11 +221,14 @@ class ProfileLineOverlay(_MeasureOverlayBase):
             distances = np.linspace(0, real_length, num_samples)
             # Pick best SI unit
             if real_length < 1e-6:
-                distances *= 1e9;  unit = "nm"
+                distances *= 1e9
+                unit = "nm"
             elif real_length < 1e-3:
-                distances *= 1e6;  unit = "µm"
+                distances *= 1e6
+                unit = "µm"
             else:
-                distances *= 1e3;  unit = "mm"
+                distances *= 1e3
+                unit = "mm"
         else:
             distances = np.linspace(0, pixel_length, num_samples)
             unit = "px"

--- a/fibsem/ui/widgets/tests/test_ruler_overlay.py
+++ b/fibsem/ui/widgets/tests/test_ruler_overlay.py
@@ -7,6 +7,7 @@ Or via pytest. Covers SI formatting, the toolbar toggle (seed + activate +
 restore), endpoint/line drag with bounds clamping, screen-space hit testing,
 and that the overlay stays fully inert (no artists, no input) while hidden.
 """
+
 from __future__ import annotations
 
 import os
@@ -18,10 +19,8 @@ import numpy as np
 from PyQt5.QtWidgets import QApplication
 
 from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
-from fibsem.ui.widgets.canvas.overlays.ruler_overlay import (
-    RulerOverlay,
-    _format_distance,
-)
+from fibsem.ui.widgets.canvas.overlays.ruler_overlay import RulerOverlay
+from fibsem.utils import format_distance
 
 _W, _H = 1536, 1024
 _PX = 10e-9  # 10 nm / px
@@ -51,10 +50,12 @@ def _ruler_on(c: FibsemImageCanvas) -> RulerOverlay:
 
 
 def test_si_formatting():
-    assert _format_distance(5e-9) == "5.0 nm"
-    assert _format_distance(2.5e-6) == "2.50 µm"
-    assert _format_distance(3e-3) == "3.000 mm"
-    assert _format_distance(0) == "0 nm"
+    # The overlay no longer owns this; it is `utils.format_distance`, which these
+    # values pinned before the move and still pin after it.
+    assert format_distance(5e-9) == "5.0 nm"
+    assert format_distance(2.5e-6) == "2.50 µm"
+    assert format_distance(3e-3) == "3.000 mm"
+    assert format_distance(0) == "0 nm"
 
 
 def test_toggle_on_seeds_and_activates():
@@ -68,7 +69,7 @@ def test_toggle_on_seeds_and_activates():
     seed_len = abs(r._p2[0] - r._p1[0])
     assert abs(seed_len - 0.25 * _W) < 1e-6
     assert abs(r.measurement() - seed_len * _PX) < 1e-18
-    assert r._label.get_text() == _format_distance(seed_len * _PX)
+    assert r._label.get_text() == format_distance(seed_len * _PX)
 
 
 def test_drag_endpoint_updates_distance():
@@ -80,7 +81,7 @@ def test_drag_endpoint_updates_distance():
     r._drag_start_pts = (list(r._p1), list(r._p2))
     r._blit_bg = None  # force the draw_idle path (skip blit)
     r._on_motion(_ev(xdata=r._p2[0] + 200, ydata=r._p2[1] + 100))
-    expected = ((seed_len + 200) ** 2 + 100 ** 2) ** 0.5
+    expected = ((seed_len + 200) ** 2 + 100**2) ** 0.5
     assert abs(r.measurement() - expected * _PX) < 1e-15
     r._on_release(_ev(button=1))
     assert c._overlay_consuming_event is False

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -14,7 +14,7 @@ from PIL import Image
 
 from fibsem import config as cfg
 from fibsem import manufacturers
-from fibsem.constants import DATETIME_LOG, TIME_FILE
+from fibsem.constants import DATETIME_LOG, MICRON_SYMBOL, MU_SYMBOL, TIME_FILE
 from fibsem.structures import (
     BeamType,
     FibsemImage,
@@ -99,10 +99,17 @@ def format_time_remaining(seconds: float, pad: bool = False) -> str:
     return f"{secs}s"
 
 
+# `MU_SYMBOL` rather than a literal, and specifically U+00B5 MICRO SIGN rather than
+# U+03BC GREEK SMALL LETTER MU. The two are indistinguishable on screen and unequal to
+# every string comparison, and this table used to disagree with `constants.MICRON_SYMBOL`
+# -- which every spin-box suffix and scalebar already uses. `imaging/drawing.py` records
+# the reason the house character is the micro sign: the default font on Windows has no
+# glyph for the Greek letter, so the Greek one renders as a box on the platform most
+# instruments are driven from.
 SI_PREFIXES = {
     -12: "p",
     -9: "n",
-    -6: "μ",
+    -6: MU_SYMBOL,
     -3: "m",
     0: "",
     3: "k",
@@ -110,6 +117,11 @@ SI_PREFIXES = {
     9: "G",
     12: "T",
 }
+
+# What every formatter here renders for a value the instrument did not report. An
+# em-dash rather than "None" or "0": the distinction between "not measured" and
+# "measured as zero" is one an operator has to be able to make at a glance.
+NOT_AVAILABLE = "—"
 
 _MIN_SI_EXP = min(SI_PREFIXES)
 _MAX_SI_EXP = max(SI_PREFIXES)
@@ -174,11 +186,77 @@ def format_value(
     Returns:
         str: The formatted value with the appropriate SI prefix.
     """
+    if val is None:
+        return NOT_AVAILABLE
     scale = scale if scale is not None else _get_scale_from_value(val)
     prefix, multiplier = _get_prefix_from_scale(scale)
     scaled_val = val * scale * multiplier
     unit = unit or ""
     return f"{scaled_val:.{precision}f} {prefix}{unit}"
+
+
+# ---------------------------------------------------------------------------
+# Named formatting policies
+#
+# `format_value` is the primitive: one precision, whichever SI prefix the magnitude
+# lands on. These are the conventions that were being written out by hand instead,
+# each in more than one place, because they vary precision *per band* -- which is a
+# real readability rule and not something a single `precision` argument can express.
+# Milling currents are the clearest case: three orders of magnitude, and rendering
+# everything in pA turns the common nA reading into a four-digit number.
+# ---------------------------------------------------------------------------
+
+
+def format_angle(radians: Optional[float], precision: int = 1) -> str:
+    """An angle in radians, as degrees.
+
+    Not a `format_value` call: SI prefixes are the wrong vocabulary for an angle, and
+    nobody wants to read a stage tilt in milliradians.
+    """
+    if radians is None:
+        return NOT_AVAILABLE
+    return f"{math.degrees(radians):.{precision}f}°"
+
+
+def format_distance(metres: Optional[float]) -> str:
+    """A distance, with more decimals the larger the unit.
+
+    A stage move is interesting to the nanometre and a stage position to the micron,
+    so the precision follows the prefix rather than being fixed. Zero is rendered in
+    nanometres: `format_value` would land it on bare metres, and "0.00 m" beside a
+    column of micron readings reads as a different quantity.
+    """
+    if metres is None:
+        return NOT_AVAILABLE
+    magnitude = abs(metres)
+    if magnitude == 0:
+        return "0 nm"
+    if magnitude < 1e-6:
+        return f"{metres * 1e9:.1f} nm"
+    if magnitude < 1e-3:
+        return f"{metres * 1e6:.2f} {MICRON_SYMBOL}"
+    if magnitude < 1.0:
+        return f"{metres * 1e3:.3f} mm"
+    return f"{metres:.4f} m"
+
+
+def format_current(amps: Optional[float]) -> str:
+    """A beam current: `1.0 nA`, `60 pA`."""
+    if amps is None:
+        return NOT_AVAILABLE
+    if abs(amps) >= 1e-9:
+        return format_value(amps, "A", precision=1, scale=1e9)
+    return format_value(amps, "A", precision=0, scale=1e12)
+
+
+def format_voltage(volts: Optional[float]) -> str:
+    """A beam voltage, pinned to kV.
+
+    Pinned rather than auto-scaled so a column of voltages stays comparable: a 500 V
+    landing energy beside a 30 kV one should read `0.50 kV`, not switch units halfway
+    down the list.
+    """
+    return format_value(volts, "V", precision=2, scale=1e-3)
 
 
 def make_logging_directory(path: Optional[Path] = None, name="run"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
 
+from fibsem import constants
 from fibsem.utils import (
     _get_display_unit,
     _get_prefix_from_scale,
@@ -31,7 +32,11 @@ def test_get_prefix_from_scale_small_values():
     assert multiplier == pytest.approx(1.0)
 
     prefix, multiplier = _get_prefix_from_scale(1e6)
-    assert prefix == "μ"
+    # Against the constant, not a literal: this used to pin U+03BC GREEK SMALL LETTER
+    # MU while every suffix and scalebar in the app used U+00B5 MICRO SIGN, and the two
+    # are indistinguishable on screen. A literal here can be the wrong character and
+    # still look right. See tests/test_value_formatting.py.
+    assert prefix == constants.MU_SYMBOL
     assert multiplier == pytest.approx(1.0)
 
     prefix, multiplier = _get_prefix_from_scale(1e9)
@@ -55,7 +60,9 @@ def test_format_value_auto_scale_and_override():
     assert format_value(5000, unit="m", precision=1, scale=0.001) == "5.0 km"
 
     # tiny values between micro and pico
-    assert format_value(2.5e-6, unit="m", precision=1) == "2.5 μm"
+    assert (
+        format_value(2.5e-6, unit="m", precision=1) == f"2.5 {constants.MICRON_SYMBOL}"
+    )
     assert format_value(7e-10, unit="m", precision=1) == "700.0 pm"
     assert format_value(3e-12, unit="m", precision=2) == "3.00 pm"
     assert format_value(0.2e-9, unit="A", precision=0) == "200 pA"

--- a/tests/test_value_formatting.py
+++ b/tests/test_value_formatting.py
@@ -1,0 +1,181 @@
+"""One home for rendering a value as text.
+
+`utils.format_value` already existed and was used in ~38 places, but four widgets and
+the CLI had each written their own anyway, because it could not express three things
+they needed: a value the instrument did not report, a zero that stays in the units of
+its neighbours, and a precision that varies with the SI band. The named helpers here
+are those three conventions, and the tests below are mostly *equivalence* tests -- the
+originals are transcribed and the replacements asserted to agree, because a formatting
+consolidation is only worth doing if nothing on screen moves.
+"""
+
+import math
+
+import pytest
+
+from fibsem import constants
+from fibsem.utils import (
+    NOT_AVAILABLE,
+    SI_PREFIXES,
+    format_angle,
+    format_current,
+    format_distance,
+    format_value,
+    format_voltage,
+)
+
+# ---------------------------------------------------------------------------
+# The micro sign
+# ---------------------------------------------------------------------------
+
+
+def test_the_si_table_uses_the_house_micro_sign():
+    """U+00B5 MICRO SIGN, not U+03BC GREEK SMALL LETTER MU.
+
+    They are indistinguishable on screen and unequal to every string comparison, and
+    this table used to hold the Greek letter while `constants.MICRON_SYMBOL` -- which
+    every spin-box suffix and scalebar uses -- held the micro sign. `imaging/drawing.py`
+    records why the micro sign is the house character: the default Windows font has no
+    glyph for the Greek one, so it renders as a box on the platform most instruments
+    are driven from.
+
+    Asserted by codepoint rather than by `==` on a literal, because a literal in this
+    file could be the wrong character and the test would still pass.
+    """
+    assert ord(SI_PREFIXES[-6]) == 0x00B5
+    assert SI_PREFIXES[-6] == constants.MU_SYMBOL
+
+
+def test_format_value_agrees_with_the_micron_symbol_used_everywhere_else():
+    assert format_value(150e-6, "m").endswith(constants.MICRON_SYMBOL)
+
+
+# ---------------------------------------------------------------------------
+# Missing values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fn", [format_value, format_angle, format_distance, format_current, format_voltage]
+)
+def test_every_formatter_renders_a_missing_value(fn):
+    """The reason four widgets wrote their own: `format_value(None)` raised.
+
+    `MicroscopeState` is full of `Optional` fields -- a beam that was never configured
+    reports `None` for its current -- so a formatter that raises on None cannot be used
+    to render one, which is how each of these came to exist separately.
+    """
+    assert fn(None) == NOT_AVAILABLE
+
+
+def test_a_missing_value_is_distinguishable_from_zero():
+    """The distinction an operator has to be able to make at a glance: the instrument
+    did not report this, versus it reported zero."""
+    assert format_current(None) != format_current(0.0)
+    assert format_distance(None) != format_distance(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Equivalence with what each site used to do
+# ---------------------------------------------------------------------------
+
+
+def _original_distance(metres: float) -> str:
+    """Transcribed from `drag_distance._fmt_distance`, which
+    `canvas/overlays/ruler_overlay._format_distance` duplicated line for line."""
+    magnitude = abs(metres)
+    if magnitude == 0:
+        return "0 nm"
+    if magnitude < 1e-6:
+        return f"{metres * 1e9:.1f} nm"
+    if magnitude < 1e-3:
+        return f"{metres * 1e6:.2f} µm"
+    if magnitude < 1.0:
+        return f"{metres * 1e3:.3f} mm"
+    return f"{metres:.4f} m"
+
+
+def _original_current(amps: float) -> str:
+    """Transcribed from `coincidence_milling_confirmation_dialog._format_current`."""
+    if amps >= 1e-9:
+        return f"{amps * constants.SI_TO_NANO:.1f} nA"
+    return f"{amps * constants.SI_TO_PICO:.0f} pA"
+
+
+def _original_voltage(volts: float) -> str:
+    """Transcribed from `hud_ticker._kv`."""
+    return f"{volts / 1e3:.2f} kV"
+
+
+def _original_angle(radians: float) -> str:
+    """Transcribed from `hud_ticker._deg`."""
+    return f"{math.degrees(radians):.1f}°"
+
+
+DISTANCES = [0.0, 1e-12, 1e-9, 5e-9, 999e-9, 1e-6, 150e-6, 1e-3, 7e-3, 0.5, 1.0, 12.3]
+CURRENTS = [1e-13, 50e-12, 2e-11, 1e-9, 2e-9, 30e-9, 1e-6]
+VOLTAGES = [0.0, 500.0, 2000.0, 8000.0, 30000.0]
+ANGLES = [0.0, math.pi, -math.pi / 4, 0.6108652381980153]
+
+
+@pytest.mark.parametrize("metres", DISTANCES)
+def test_format_distance_matches_the_two_copies_it_replaced(metres):
+    assert format_distance(metres) == _original_distance(metres)
+
+
+@pytest.mark.parametrize("amps", CURRENTS)
+def test_format_current_matches_the_dialog_it_replaced(amps):
+    assert format_current(amps) == _original_current(amps)
+
+
+@pytest.mark.parametrize("volts", VOLTAGES)
+def test_format_voltage_matches_the_hud_it_replaced(volts):
+    assert format_voltage(volts) == _original_voltage(volts)
+
+
+@pytest.mark.parametrize("radians", ANGLES)
+def test_format_angle_matches_the_hud_it_replaced(radians):
+    assert format_angle(radians) == _original_angle(radians)
+
+
+# ---------------------------------------------------------------------------
+# The band conventions, stated rather than inferred
+# ---------------------------------------------------------------------------
+
+
+def test_distance_precision_follows_the_prefix():
+    """A stage move is interesting to the nanometre, a stage position to the micron."""
+    assert format_distance(5e-9) == "5.0 nm"
+    assert format_distance(2.5e-6) == f"2.50 {constants.MICRON_SYMBOL}"
+    assert format_distance(3e-3) == "3.000 mm"
+    assert format_distance(1.5) == "1.5000 m"
+
+
+def test_zero_distance_stays_in_nanometres():
+    """`format_value` lands zero on bare metres -- `_get_scale_from_value` returns 1.0
+    for it -- and "0.00 m" in a column of micron readings reads as another quantity."""
+    assert format_distance(0.0) == "0 nm"
+    assert format_value(0.0, "m") == "0.00 m"
+
+
+def test_current_does_not_run_past_nanoamps():
+    """Milling currents span three orders of magnitude and the operator thinks in
+    pA/nA; switching to µA at the top of the range breaks the comparison."""
+    assert format_current(60e-12) == "60 pA"
+    assert format_current(1e-9) == "1.0 nA"
+    assert format_current(1e-6) == "1000.0 nA"
+
+
+def test_voltage_is_pinned_to_kilovolts():
+    """So a 500 V landing energy and a 30 kV beam stay comparable down a column.
+    `format_value` would auto-scale the first to volts."""
+    assert format_voltage(500) == "0.50 kV"
+    assert format_voltage(30000) == "30.00 kV"
+    assert format_value(500, "V") == "500.00 V"
+
+
+def test_angle_is_degrees_not_an_si_prefix():
+    """Nobody reads a stage tilt in milliradians, which is what `format_value` would
+    give a small angle."""
+    assert format_angle(math.radians(35)) == "35.0°"
+    assert format_angle(0.0) == "0.0°"

--- a/tests/ui/test_form_builder.py
+++ b/tests/ui/test_form_builder.py
@@ -54,7 +54,9 @@ def test_a_point_field_is_dispatched_on_its_type_not_its_name(qapp):
     pattern with an equivalent field could not get the two-spinbox row no matter
     what it declared. Nothing here is named "point".
     """
-    control = build_control(meta(type=Point, scale=1e6, unit="m"), Point(x=1e-6, y=-2e-6))
+    control = build_control(
+        meta(type=Point, scale=1e6, unit="m"), Point(x=1e-6, y=-2e-6)
+    )
 
     spinboxes = control.widget.findChildren(ValueSpinBox)
     assert len(spinboxes) == 2
@@ -85,7 +87,7 @@ def test_a_scaled_field_with_no_unit_gets_no_suffix():
     "" for the same input, and it was the one that was right.
     """
     assert display_suffix(meta(scale=1e6)) == ""
-    assert display_suffix(meta(scale=1e6, unit="m")) == "μm"
+    assert display_suffix(meta(scale=1e6, unit="m")) == "µm"
     assert display_suffix(meta(unit="m")) == "m"
 
 
@@ -97,7 +99,7 @@ def test_dimensions_raise_the_scale_but_not_the_suffix():
     area = meta(scale=1e6, dimensions=2, unit="m²")
 
     assert effective_scale(area) == 1e12
-    assert display_suffix(area) == "μm²"
+    assert display_suffix(area) == "µm²"
 
 
 # --- one branch per control type, each round-tripping -------------------------
@@ -156,7 +158,9 @@ def test_the_fallback_range_fills_in_undeclared_bounds(qapp):
     passes the bounds it already had, so a form's ranges do not change just
     because the builder is now shared.
     """
-    control = build_control(meta(type=float), 0.0, defaults=FormDefaults(float_range=(-1e10, 1e10)))
+    control = build_control(
+        meta(type=float), 0.0, defaults=FormDefaults(float_range=(-1e10, 1e10))
+    )
 
     assert (control.widget.minimum(), control.widget.maximum()) == (-1e10, 1e10)
 
@@ -187,7 +191,8 @@ def test_dynamic_items_are_resolved_through_the_caller(qapp):
 def test_dynamic_items_fall_back_to_the_current_value(qapp):
     """No resolver, or nothing cached: the field still shows what it holds."""
     control = build_control(
-        meta(items="dynamic", microscope_parameter="scan_direction", type=str), "TopToBottom"
+        meta(items="dynamic", microscope_parameter="scan_direction", type=str),
+        "TopToBottom",
     )
 
     assert control.read() == "TopToBottom"


### PR DESCRIPTION
Groundwork for the `MicroscopeStateWidget`, which needs all of these and shouldn't be the excuse for writing a fifth copy.

`utils.format_value` already existed with ~38 callers, yet four widgets and the CLI had each written their own. Worth asking why before deleting them — it couldn't express three things they needed:

- **A value the instrument didn't report.** `format_value(None)` raised `TypeError`, and `MicroscopeState` is full of `Optional` fields — a beam that was never configured reports `None` for its current. Now returns `—`, so "not measured" stays distinguishable from "measured as zero".
- **A zero that stays in its neighbours' units.** `_get_scale_from_value` returns 1.0 for zero, so `format_value(0.0, "m")` is `0.00 m` — which in a column of micron readings reads as a different quantity.
- **Precision that varies with the SI band.** A real readability rule, not something one `precision` argument expresses: a stage move is interesting to the nanometre, a stage position to the micron, and every milling current in pA turns the common nA case into a four-digit number.

So `format_angle`, `format_distance`, `format_current`, `format_voltage` join `format_value` as named policies.

## Proven equivalent before anything was repointed

Originals transcribed, then compared across ~4000 randomised values apiece:

| helper | replaces | mismatches |
| --- | --- | --- |
| `format_distance` | `drag_distance._fmt_distance` **and** `ruler_overlay._format_distance` (duplicates, line for line) | 0 / 4012 |
| `format_voltage` | `hud_ticker._kv` | 0 / 4005 |
| `format_angle` | `hud_ticker._deg` | 0 / 4003 |
| `format_current` | `coincidence_milling_confirmation_dialog._format_current` | 0 / 4007 |

**One genuine conflict:** the two current formatters already disagreed — the dialog renders nA to one decimal, `hud_ticker` to two. Took the dialog's, being the one whose docstring gives a reason. The HUD never actually rendered a current (see below), so nothing on screen moves.

## The micro sign

`SI_PREFIXES` held **U+03BC GREEK SMALL LETTER MU** while `constants.MICRON_SYMBOL` — every spin-box suffix and scalebar in the app — holds **U+00B5 MICRO SIGN**. Indistinguishable on screen, unequal to every string comparison.

57 files use the micro sign against 10 with the Greek letter, and `imaging/drawing.py` records why the micro sign is the house character:

> `# default font on windows doesnt support greek characters`

So the Greek one renders as a box on the platform most instruments are driven from. `format_value` now uses `MU_SYMBOL`.

Three tests pinned the old character, and one is the argument in miniature — `test_dimensions_raise_the_scale_but_not_the_suffix` has a docstring saying it *"still reads `µm²`"* with the micro sign, directly above an assertion written with the Greek one. The two `test_utils.py` assertions now reference `constants.MU_SYMBOL` rather than a literal, since a literal here can be the wrong character and still look right.

## Fell out along the way

- `hud_ticker._kv` and `_na` were **dead code** — the ticker renders no voltage or current.
- `_fmt_distance` was an **unused import** in both `angle_measure` and `profile_line`.

Dropped rather than repointed.

## Deliberately not in scope

`cli.py` renders ASCII units (`um`, `us`, `uA`) and the word `"None"`. That's right for a terminal and wrong to unify with the widgets, so it keeps its own.

Four pre-existing unused imports remain in touched files (`QPainterPath`, `QPoint`, `QRect`, `BeamType`) — F401 isn't in this project's ruleset and they predate this change.

## Verification

- **Full non-UI suite** and `tests/ui` both green on this base. The two `test_utils.py` and two `test_form_builder.py` failures the micro-sign change surfaced are fixed as described, not suppressed.
- New `tests/test_value_formatting.py` (41 tests): the equivalence cases above, the missing-value and zero conventions, the band rules stated rather than inferred, and the micro sign asserted **by codepoint** — `ord(SI_PREFIXES[-6]) == 0x00B5` — because a literal in the test file could be the wrong character and pass.
- `fibsem/ui/widgets/tests/test_ruler_overlay.py` updated for the moved function. Note it lives outside `testpaths = ["tests"]`, so **CI does not run it**; verified locally.

## Diff size

Six of the touched widget files were **already unformatted on `main`**, so CI's `ruff format --check` over changed files forces a reflow. That inflates the diff well beyond the edits described here — the substantive changes are `fibsem/utils.py` plus the deletions listed above.
