### PR TITLE
[feature] A widget that renders a MicroscopeState

### DIFF
--- a/fibsem/ui/widgets/microscope_state_widget.py
+++ b/fibsem/ui/widgets/microscope_state_widget.py
@@ -69,6 +69,15 @@ from fibsem.utils import (
 _SAVED_COLOUR = SAVED_POSITION_COLOUR
 _LIVE_COLOUR = CURRENT_POSITION_COLOUR
 
+# Grid columns. Named because three of the four are referred to from two places, and
+# an off-by-one here puts a value in the label column rather than raising.
+_KEY_COLUMN = 0
+_SAVED_COLUMN = 1
+_GAP_COLUMN = 2
+_LIVE_COLUMN = 3
+_KEY_COLUMN_MIN_W = 92  # fits "Working dist." at the default UI font
+_GAP_COLUMN_W = 14
+
 # Rows are compared as *rendered strings*, not as floats. Two records holding
 # 2.0e-11 and 2.0000001e-11 both read "20 pA", and marking that row as a difference
 # would be reporting a change the panel cannot show. Comparing what is drawn asks the
@@ -83,17 +92,35 @@ class MicroscopeStateWidget(QWidget):
     show_refresh:
         Whether to offer a refresh button. A saved pose has nothing to refresh, so the
         embedding list turns it off; a live readout turns it on and owns the signal.
+    show_rotation:
+        Whether the stage has a rotation axis. Pass
+        ``microscope.is_available("stage_rotation")``, which reads the instrument's own
+        axes since FIB-834.
+
+        This is not cosmetic. A compustage has no rotation axis at all -- AutoScript's
+        ``CompustagePosition`` carries ``x``, ``y``, ``z``, ``a`` and nothing else --
+        so ``stage_position_from_autoscript`` writes ``r=0.0`` as a **literal**,
+        because ``FibsemStagePosition`` needs a number and ``get_stage_orientation``
+        raises on ``None``. The record therefore cannot distinguish "the stage is at
+        rotation zero" from "this stage does not rotate", and drawing ``0.0°`` asserts
+        the first. The widget has no microscope to ask, and the host does.
     """
 
     #: Refresh was pressed. Reading the instrument is a device call and this widget
     #: does not make those -- the host decides what one costs.
     refresh_requested = pyqtSignal()
 
-    def __init__(self, show_refresh: bool = False, parent: Optional[QWidget] = None):
+    def __init__(
+        self,
+        show_refresh: bool = False,
+        show_rotation: bool = True,
+        parent: Optional[QWidget] = None,
+    ):
         super().__init__(parent)
         self._state: Optional[MicroscopeState] = None
         self._reference: Optional[MicroscopeState] = None
         self._show_refresh = show_refresh
+        self._show_rotation = show_rotation
         self._setup_ui()
 
     # ------------------------------------------------------------------
@@ -110,10 +137,14 @@ class MicroscopeStateWidget(QWidget):
         header.setSpacing(6)
         self.label_title = QLabel("—")
         self.label_title.setStyleSheet("font-weight: bold;")
-        self.label_mode = QLabel("")
-        self.label_mode.setStyleSheet(f"color: {TEXT_MUTED_COLOR};")
+        # Chips, not a sentence. Which record is on screen is the first thing a
+        # reader needs and the thing they will glance back at, and a chip carrying
+        # the colour its column is drawn in answers it without being read.
+        self.chip_saved = _chip("saved", _SAVED_COLOUR)
+        self.chip_live = _chip("live", _LIVE_COLOUR)
         header.addWidget(self.label_title)
-        header.addWidget(self.label_mode)
+        header.addWidget(self.chip_saved)
+        header.addWidget(self.chip_live)
         header.addStretch()
 
         self.button_refresh = QPushButton("Refresh")
@@ -193,7 +224,14 @@ class MicroscopeStateWidget(QWidget):
     def _refresh(self) -> None:
         state = self._state
         comparing = state is not None and self._reference is not None
-        self.label_mode.setText("saved vs live" if comparing else "")
+        # Both chips when comparing; otherwise the one that describes this record --
+        # a live readout has a refresh button, a saved pose does not.
+        self.chip_saved.setVisible(
+            state is not None and (comparing or not self._show_refresh)
+        )
+        self.chip_live.setVisible(
+            state is not None and (comparing or self._show_refresh)
+        )
 
         if state is None:
             for grid in (self.grid_stage, self.grid_electron, self.grid_ion):
@@ -206,7 +244,8 @@ class MicroscopeStateWidget(QWidget):
 
         reference = self._reference
         self.grid_stage.set_rows(
-            _stage_rows(state), _stage_rows(reference) if comparing else None
+            _stage_rows(state, self._show_rotation),
+            _stage_rows(reference, self._show_rotation) if comparing else None,
         )
         self.grid_electron.set_rows(
             _beam_rows(state.electron_beam, state.electron_detector),
@@ -241,17 +280,28 @@ class MicroscopeStateWidget(QWidget):
 # ---------------------------------------------------------------------------
 
 
-def _stage_rows(state: Optional[MicroscopeState]) -> List[Tuple[str, str]]:
+def _stage_rows(
+    state: Optional[MicroscopeState], show_rotation: bool = True
+) -> List[Tuple[str, str]]:
+    """The stage axes, omitting R on a stage that has none.
+
+    Omitted rather than shown as ``NOT_AVAILABLE``: an em-dash means "the instrument
+    did not report this", and a compustage's missing rotation is not a gap in a
+    reading -- the axis does not exist. A row that will always be empty invites the
+    question of why.
+    """
+    axes = ["X", "Y", "Z"] + (["R"] if show_rotation else []) + ["T"]
     if state is None or state.stage_position is None:
-        return [(k, NOT_AVAILABLE) for k in ("X", "Y", "Z", "R", "T")]
+        return [(axis, NOT_AVAILABLE) for axis in axes]
     position = state.stage_position
-    return [
-        ("X", format_distance(position.x)),
-        ("Y", format_distance(position.y)),
-        ("Z", format_distance(position.z)),
-        ("R", format_angle(position.r)),
-        ("T", format_angle(position.t)),
-    ]
+    values = {
+        "X": format_distance(position.x),
+        "Y": format_distance(position.y),
+        "Z": format_distance(position.z),
+        "R": format_angle(position.r),
+        "T": format_angle(position.t),
+    }
+    return [(axis, values[axis]) for axis in axes]
 
 
 def _beam_rows(
@@ -345,8 +395,17 @@ class _ValueGrid(QWidget):
         self._layout.setContentsMargins(2, 2, 2, 2)
         self._layout.setHorizontalSpacing(10)
         self._layout.setVerticalSpacing(1)
-        self._layout.setColumnStretch(1, 1)
-        self._layout.setColumnStretch(2, 1)
+        # The label column gets a floor. Without one the three-column comparison
+        # squeezed it until "Working dist." and "Scan rotation" were clipped to
+        # "Working dist" and "Scan rotatio" -- which the tests could not see, because
+        # a QLabel reports the text it was given whether or not it has room to draw it.
+        self._layout.setColumnMinimumWidth(_KEY_COLUMN, _KEY_COLUMN_MIN_W)
+        self._layout.setColumnStretch(_SAVED_COLUMN, 1)
+        # A blank column between the two value columns. When every row matches they
+        # are all muted, and without a gap they read as one run of numbers rather than
+        # two things being compared.
+        self._layout.setColumnMinimumWidth(_GAP_COLUMN, _GAP_COLUMN_W)
+        self._layout.setColumnStretch(_LIVE_COLUMN, 1)
 
     def clear(self) -> None:
         while self._layout.count():
@@ -370,9 +429,11 @@ class _ValueGrid(QWidget):
 
         for index, (key, value) in enumerate(rows):
             row = index + offset
-            self._layout.addWidget(_key_label(key), row, 0)
+            self._layout.addWidget(_key_label(key), row, _KEY_COLUMN)
             if not comparing:
-                self._layout.addWidget(_value_label(value, TEXT_COLOR), row, 1)
+                self._layout.addWidget(
+                    _value_label(value, TEXT_COLOR), row, _SAVED_COLUMN
+                )
                 continue
 
             # The reference is the *saved* side and `rows` is the live one, so the
@@ -384,20 +445,31 @@ class _ValueGrid(QWidget):
             self._layout.addWidget(
                 _value_label(was, _SAVED_COLOUR if differs else TEXT_MUTED_COLOR),
                 row,
-                1,
+                _SAVED_COLUMN,
             )
             self._layout.addWidget(
                 _value_label(value, _LIVE_COLOUR if differs else TEXT_MUTED_COLOR),
                 row,
-                2,
+                _LIVE_COLUMN,
             )
 
     def _add_header(self) -> None:
-        for column, text in ((1, "Saved"), (2, "Live")):
+        for column, text in ((_SAVED_COLUMN, "Saved"), (_LIVE_COLUMN, "Live")):
             label = QLabel(text)
             label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
             label.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 9pt;")
             self._layout.addWidget(label, 0, column)
+
+
+def _chip(text: str, colour: str) -> QLabel:
+    """A small pill in the colour its column is drawn in."""
+    label = QLabel(text)
+    label.setStyleSheet(
+        f"color: {colour}; border: 1px solid {colour}; border-radius: 7px;"
+        f"padding: 0px 6px; font-size: 9pt;"
+    )
+    label.setVisible(False)
+    return label
 
 
 def _key_label(text: str) -> QLabel:

--- a/fibsem/ui/widgets/microscope_state_widget.py
+++ b/fibsem/ui/widgets/microscope_state_widget.py
@@ -1,0 +1,416 @@
+"""What the instrument was doing, rendered.
+
+A ``MicroscopeState`` is stage position, both beams, both detectors and a timestamp,
+and it is what every lamella pose is made of (``Lamella.poses`` is literally
+``Dict[str, MicroscopeState]``) and what every image carries in its metadata. Until
+now nothing displayed one. Three partial renderers had grown instead: the HUD ticker
+read a few fields out of image metadata, the lamella pose list showed
+``stage_position.pretty`` and dropped the rest, and the selected-lamella panel reached
+past all of it for the objective position alone. So the beam and detector settings
+recorded at a pose were written to disk and shown to nobody.
+
+**It renders; it does not read.** No microscope reference, no device calls, no polling.
+``set_state`` is given a record and draws it. The refresh button emits a signal and
+stops there, the same contract ``stage_position_widget`` uses, because reading the
+instrument is a device call and the host is the only thing that knows what one costs.
+
+**Two states, one widget.** A saved pose and the live instrument are the same record
+from different sources, so they are the same widget with a different label. Passing a
+reference through ``set_reference`` turns on the comparison, which is the mode with
+something to say: *how far is the instrument from where this lamella was milled*, asked
+before the operator presses Move To.
+
+Display only. ``Move To`` and ``Restore`` belong to the host: the moment this widget
+can drive a stage it needs a threading story, and that is a different widget.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtWidgets import (
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem.structures import BeamSettings, FibsemDetectorSettings, MicroscopeState
+from fibsem.ui.tokens import (
+    CURRENT_POSITION_COLOUR,
+    SAVED_POSITION_COLOUR,
+    TEXT_COLOR,
+    TEXT_MUTED_COLOR,
+    WARN_COLOR,
+)
+from fibsem.ui.widgets.custom_widgets import TitledPanel
+from fibsem.utils import (
+    NOT_AVAILABLE,
+    format_angle,
+    format_current,
+    format_distance,
+    format_resolution_as_str,
+    format_value,
+    format_voltage,
+)
+
+# The two colours the comparison is drawn in, and they are not chosen here.
+# `tokens.py` documents CURRENT_POSITION_COLOUR as "where the stage is now" and
+# SAVED_POSITION_COLOUR as "a marked position", and the FIB/SEM and fluorescence
+# overviews already draw stage markers in them. An operator who has used either
+# canvas has been taught that yellow is live and cyan is saved; inventing a second
+# convention for the same distinction in a panel beside them would be worse than
+# either convention alone.
+_SAVED_COLOUR = SAVED_POSITION_COLOUR
+_LIVE_COLOUR = CURRENT_POSITION_COLOUR
+
+# Rows are compared as *rendered strings*, not as floats. Two records holding
+# 2.0e-11 and 2.0000001e-11 both read "20 pA", and marking that row as a difference
+# would be reporting a change the panel cannot show. Comparing what is drawn asks the
+# same question the reader is asking: do these two columns say different things?
+
+
+class MicroscopeStateWidget(QWidget):
+    """One ``MicroscopeState``, optionally against another.
+
+    Parameters
+    ----------
+    show_refresh:
+        Whether to offer a refresh button. A saved pose has nothing to refresh, so the
+        embedding list turns it off; a live readout turns it on and owns the signal.
+    """
+
+    #: Refresh was pressed. Reading the instrument is a device call and this widget
+    #: does not make those -- the host decides what one costs.
+    refresh_requested = pyqtSignal()
+
+    def __init__(self, show_refresh: bool = False, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self._state: Optional[MicroscopeState] = None
+        self._reference: Optional[MicroscopeState] = None
+        self._show_refresh = show_refresh
+        self._setup_ui()
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    def _setup_ui(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(4)
+
+        header = QHBoxLayout()
+        header.setContentsMargins(0, 0, 0, 0)
+        header.setSpacing(6)
+        self.label_title = QLabel("—")
+        self.label_title.setStyleSheet("font-weight: bold;")
+        self.label_mode = QLabel("")
+        self.label_mode.setStyleSheet(f"color: {TEXT_MUTED_COLOR};")
+        header.addWidget(self.label_title)
+        header.addWidget(self.label_mode)
+        header.addStretch()
+
+        self.button_refresh = QPushButton("Refresh")
+        self.button_refresh.setVisible(self._show_refresh)
+        self.button_refresh.clicked.connect(self.refresh_requested)
+        header.addWidget(self.button_refresh)
+        outer.addLayout(header)
+
+        # Stage is not collapsible. A pose in a list has to say where it is without
+        # being opened, and "where" is the whole of what a pose list is for.
+        self.grid_stage = _ValueGrid()
+        self.panel_stage = TitledPanel(
+            "Stage", content=self.grid_stage, collapsible=False
+        )
+        outer.addWidget(self.panel_stage)
+
+        # The beams collapse, and start collapsed: a pose row that expands to forty
+        # lines is not a row. Their headline values go on the panel title instead, so
+        # a shut section still reports that the FIB is at 30 kV.
+        self.grid_electron = _ValueGrid()
+        self.panel_electron = TitledPanel("Electron", content=self.grid_electron)
+        self.panel_electron.collapse()
+        outer.addWidget(self.panel_electron)
+
+        self.grid_ion = _ValueGrid()
+        self.panel_ion = TitledPanel("Ion", content=self.grid_ion)
+        self.panel_ion.collapse()
+        outer.addWidget(self.panel_ion)
+
+        # There is no fluorescence section. `MicroscopeState` carries only
+        # `objective_position` for it -- no channel, no filter -- and
+        # `get_microscope_state` does not even populate that (AutoLamellaUI patches it
+        # in at the call site afterwards). A section that could never fill is worse
+        # than no section: it reads as an instrument fault rather than a gap in the
+        # record. It arrives when the record can answer for it.
+
+        self.label_delta = QLabel("")
+        self.label_delta.setStyleSheet(f"color: {WARN_COLOR};")
+        self.label_delta.setVisible(False)
+        outer.addWidget(self.label_delta)
+
+        self.label_timestamp = QLabel("")
+        self.label_timestamp.setStyleSheet(
+            f"color: {TEXT_MUTED_COLOR}; font-size: 10pt;"
+        )
+        outer.addWidget(self.label_timestamp)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def set_state(self, state: Optional[MicroscopeState], title: str = "") -> None:
+        """Render ``state``.
+
+        ``title`` is passed in rather than derived. Naming a pose is the host's job --
+        the pose list has the key it was stored under, and classifying a position as
+        an orientation needs a microscope, which this widget does not have.
+        """
+        self._state = state
+        self.label_title.setText(title or "Microscope state")
+        self._refresh()
+
+    def set_reference(self, reference: Optional[MicroscopeState]) -> None:
+        """Compare against ``reference``, or pass ``None`` to stop comparing."""
+        self._reference = reference
+        self._refresh()
+
+    def clear(self) -> None:
+        self._state = None
+        self._reference = None
+        self._refresh()
+
+    # ------------------------------------------------------------------
+    # Rendering
+    # ------------------------------------------------------------------
+
+    def _refresh(self) -> None:
+        state = self._state
+        comparing = state is not None and self._reference is not None
+        self.label_mode.setText("saved vs live" if comparing else "")
+
+        if state is None:
+            for grid in (self.grid_stage, self.grid_electron, self.grid_ion):
+                grid.clear()
+            self.panel_electron.set_title("Electron")
+            self.panel_ion.set_title("Ion")
+            self.label_delta.setVisible(False)
+            self.label_timestamp.setText("")
+            return
+
+        reference = self._reference
+        self.grid_stage.set_rows(
+            _stage_rows(state), _stage_rows(reference) if comparing else None
+        )
+        self.grid_electron.set_rows(
+            _beam_rows(state.electron_beam, state.electron_detector),
+            _beam_rows(reference.electron_beam, reference.electron_detector)
+            if comparing
+            else None,
+        )
+        self.grid_ion.set_rows(
+            _beam_rows(state.ion_beam, state.ion_detector),
+            _beam_rows(reference.ion_beam, reference.ion_detector)
+            if comparing
+            else None,
+        )
+
+        self.panel_electron.set_title(
+            f"Electron   {_beam_headline(state.electron_beam)}"
+        )
+        self.panel_ion.set_title(f"Ion   {_beam_headline(state.ion_beam)}")
+
+        separation = _separation(state, reference) if comparing else None
+        self.label_delta.setVisible(separation is not None)
+        if separation is not None:
+            self.label_delta.setText(
+                f"Stage is {format_distance(separation)} from the saved pose"
+            )
+
+        self.label_timestamp.setText(_timestamp(state.timestamp))
+
+
+# ---------------------------------------------------------------------------
+# Row construction -- pure, so the formatting is testable without a widget
+# ---------------------------------------------------------------------------
+
+
+def _stage_rows(state: Optional[MicroscopeState]) -> List[Tuple[str, str]]:
+    if state is None or state.stage_position is None:
+        return [(k, NOT_AVAILABLE) for k in ("X", "Y", "Z", "R", "T")]
+    position = state.stage_position
+    return [
+        ("X", format_distance(position.x)),
+        ("Y", format_distance(position.y)),
+        ("Z", format_distance(position.z)),
+        ("R", format_angle(position.r)),
+        ("T", format_angle(position.t)),
+    ]
+
+
+def _beam_rows(
+    beam: Optional[BeamSettings], detector: Optional[FibsemDetectorSettings]
+) -> List[Tuple[str, str]]:
+    resolution = beam.resolution if beam else None
+    return [
+        ("Voltage", format_voltage(beam.voltage if beam else None)),
+        ("Current", format_current(beam.beam_current if beam else None)),
+        ("HFW", format_distance(beam.hfw if beam else None)),
+        ("Working dist.", format_distance(beam.working_distance if beam else None)),
+        (
+            "Resolution",
+            format_resolution_as_str(resolution) if resolution else NOT_AVAILABLE,
+        ),
+        (
+            "Dwell",
+            format_value(beam.dwell_time, "s")
+            if beam and beam.dwell_time
+            else NOT_AVAILABLE,
+        ),
+        ("Scan rotation", format_angle(beam.scan_rotation if beam else None)),
+        ("Detector", _detector(detector)),
+    ]
+
+
+def _detector(detector: Optional[FibsemDetectorSettings]) -> str:
+    """``ETD / SE``.
+
+    Abbreviated because the mode names are long -- "SecondaryElectrons" is wider than
+    the value column and would wrap every row it appeared on -- and because type and
+    mode are read together or not at all.
+    """
+    if detector is None:
+        return NOT_AVAILABLE
+    mode = {
+        "SecondaryElectrons": "SE",
+        "BackscatteredElectrons": "BSE",
+        "SecondaryIons": "SI",
+    }.get(detector.mode, detector.mode)
+    return f"{detector.type} / {mode}"
+
+
+def _beam_headline(beam: Optional[BeamSettings]) -> str:
+    """What a collapsed section still says, so shutting one loses less."""
+    if beam is None:
+        return NOT_AVAILABLE
+    return f"{format_voltage(beam.voltage)} · {format_current(beam.beam_current)}"
+
+
+def _separation(state: MicroscopeState, reference: MicroscopeState) -> Optional[float]:
+    """Straight-line distance between two stage positions, in metres.
+
+    One number an operator can act on. It does collapse three axes into one, which is
+    why the rows above it stay -- the scalar says *whether* to look, the rows say
+    where.
+    """
+    here, there = state.stage_position, reference.stage_position
+    if here is None or there is None:
+        return None
+    squares = 0.0
+    for axis in ("x", "y", "z"):
+        a, b = getattr(here, axis), getattr(there, axis)
+        if a is None or b is None:
+            return None
+        squares += (a - b) ** 2
+    return math.sqrt(squares)
+
+
+def _timestamp(value: Optional[float]) -> str:
+    if not value:
+        return ""
+    return datetime.fromtimestamp(value).strftime("%Y-%m-%d %H:%M:%S")
+
+
+# ---------------------------------------------------------------------------
+# The grid
+# ---------------------------------------------------------------------------
+
+
+class _ValueGrid(QWidget):
+    """Label/value rows, or label/saved/live rows when comparing.
+
+    Rebuilt on every update rather than diffed. These are at most eight rows of text
+    and the alternative is a cache that can disagree with the record it draws.
+    """
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self._layout = QGridLayout(self)
+        self._layout.setContentsMargins(2, 2, 2, 2)
+        self._layout.setHorizontalSpacing(10)
+        self._layout.setVerticalSpacing(1)
+        self._layout.setColumnStretch(1, 1)
+        self._layout.setColumnStretch(2, 1)
+
+    def clear(self) -> None:
+        while self._layout.count():
+            item = self._layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.setParent(None)
+
+    def set_rows(
+        self,
+        rows: List[Tuple[str, str]],
+        reference: Optional[List[Tuple[str, str]]] = None,
+    ) -> None:
+        self.clear()
+        comparing = reference is not None
+        if comparing:
+            self._add_header()
+
+        by_key = dict(reference) if comparing else {}
+        offset = 1 if comparing else 0
+
+        for index, (key, value) in enumerate(rows):
+            row = index + offset
+            self._layout.addWidget(_key_label(key), row, 0)
+            if not comparing:
+                self._layout.addWidget(_value_label(value, TEXT_COLOR), row, 1)
+                continue
+
+            # The reference is the *saved* side and `rows` is the live one, so the
+            # saved column is drawn from `by_key`. Compared on the rendered strings:
+            # two records holding 2.0e-11 and 2.0000001e-11 both read "20 pA", and a
+            # row showing the same thing twice is not a difference.
+            was = by_key.get(key, NOT_AVAILABLE)
+            differs = was != value
+            self._layout.addWidget(
+                _value_label(was, _SAVED_COLOUR if differs else TEXT_MUTED_COLOR),
+                row,
+                1,
+            )
+            self._layout.addWidget(
+                _value_label(value, _LIVE_COLOUR if differs else TEXT_MUTED_COLOR),
+                row,
+                2,
+            )
+
+    def _add_header(self) -> None:
+        for column, text in ((1, "Saved"), (2, "Live")):
+            label = QLabel(text)
+            label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+            label.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 9pt;")
+            self._layout.addWidget(label, 0, column)
+
+
+def _key_label(text: str) -> QLabel:
+    label = QLabel(text)
+    label.setStyleSheet(f"color: {TEXT_MUTED_COLOR};")
+    return label
+
+
+def _value_label(text: str, colour: str) -> QLabel:
+    label = QLabel(text)
+    label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+    # Monospaced so the digits line up down the column; a stage position read as a
+    # ragged list of numbers is harder to compare than one that is aligned.
+    label.setStyleSheet(f"color: {colour}; font-family: monospace;")
+    label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+    return label

--- a/tests/ui/test_microscope_state_widget.py
+++ b/tests/ui/test_microscope_state_widget.py
@@ -28,7 +28,11 @@ from fibsem.ui.tokens import (
     SAVED_POSITION_COLOUR,
     TEXT_MUTED_COLOR,
 )
-from fibsem.ui.widgets.microscope_state_widget import MicroscopeStateWidget
+from fibsem.ui.widgets.microscope_state_widget import (
+    _LIVE_COLUMN,
+    _SAVED_COLUMN,
+    MicroscopeStateWidget,
+)
 from fibsem.utils import NOT_AVAILABLE
 
 
@@ -167,7 +171,8 @@ def test_comparing_shows_both_columns(qapp):
 
     rows = _grid_text(widget.grid_stage)
     assert rows["X"] == ["0 nm", "42.00 µm"], "saved column first, then live"
-    assert widget.label_mode.text() == "saved vs live"
+    assert widget.chip_saved.isHidden() is False
+    assert widget.chip_live.isHidden() is False
 
 
 def test_only_the_rows_that_differ_are_coloured(qapp):
@@ -181,12 +186,12 @@ def test_only_the_rows_that_differ_are_coloured(qapp):
     widget.set_state(_state(x=42e-6), title="MILLING")
     widget.set_reference(_state(x=0.0))
 
-    assert SAVED_POSITION_COLOUR in _colour_of(widget.grid_stage, "X", 1)
-    assert CURRENT_POSITION_COLOUR in _colour_of(widget.grid_stage, "X", 2)
+    assert SAVED_POSITION_COLOUR in _colour_of(widget.grid_stage, "X", _SAVED_COLUMN)
+    assert CURRENT_POSITION_COLOUR in _colour_of(widget.grid_stage, "X", _LIVE_COLUMN)
 
     # Y did not move.
-    assert TEXT_MUTED_COLOR in _colour_of(widget.grid_stage, "Y", 1)
-    assert TEXT_MUTED_COLOR in _colour_of(widget.grid_stage, "Y", 2)
+    assert TEXT_MUTED_COLOR in _colour_of(widget.grid_stage, "Y", _SAVED_COLUMN)
+    assert TEXT_MUTED_COLOR in _colour_of(widget.grid_stage, "Y", _LIVE_COLUMN)
 
 
 def test_two_identical_states_colour_nothing(qapp):
@@ -195,7 +200,9 @@ def test_two_identical_states_colour_nothing(qapp):
     widget.set_reference(_state())
 
     for label in ("X", "Y", "Z", "R", "T"):
-        assert TEXT_MUTED_COLOR in _colour_of(widget.grid_stage, label, 1), label
+        assert TEXT_MUTED_COLOR in _colour_of(
+            widget.grid_stage, label, _SAVED_COLUMN
+        ), label
 
 
 def test_values_are_compared_as_rendered_not_as_floats(qapp):
@@ -208,7 +215,7 @@ def test_values_are_compared_as_rendered_not_as_floats(qapp):
     widget.set_reference(_state(ion_current=2.0e-11))
 
     assert _grid_text(widget.grid_ion)["Current"] == ["20 pA", "20 pA"]
-    assert TEXT_MUTED_COLOR in _colour_of(widget.grid_ion, "Current", 1)
+    assert TEXT_MUTED_COLOR in _colour_of(widget.grid_ion, "Current", _SAVED_COLUMN)
 
 
 def test_the_separation_is_reported_in_three_dimensions(qapp):
@@ -231,7 +238,7 @@ def test_dropping_the_reference_stops_comparing(qapp):
 
     assert _grid_text(widget.grid_stage)["X"] == ["42.00 µm"]
     assert widget.label_delta.isHidden() is True
-    assert widget.label_mode.text() == ""
+    assert widget.chip_live.isHidden() is True, "a saved pose is not live"
 
 
 # ---------------------------------------------------------------------------
@@ -287,3 +294,40 @@ def test_there_is_no_fluorescence_section(qapp):
 
     titles = {label.text() for label in widget.findChildren(QLabel) if label.text()}
     assert not any("luoresc" in title for title in titles)
+
+
+# ---------------------------------------------------------------------------
+# A stage with no rotation axis
+# ---------------------------------------------------------------------------
+
+
+def test_a_compustage_shows_no_rotation_row(qapp):
+    """The row is omitted, not dashed.
+
+    A compustage has no rotation axis -- AutoScript's `CompustagePosition` carries
+    x, y, z, a -- so `stage_position_from_autoscript` writes `r=0.0` as a literal,
+    because `FibsemStagePosition` needs a number. The record cannot tell "at rotation
+    zero" from "does not rotate", and `0.0°` asserts the first. An em-dash would be
+    wrong too: it means "not reported", and this axis does not exist.
+    """
+    widget = MicroscopeStateWidget(show_rotation=False)
+    rows = _grid_text(widget.grid_stage)
+    assert rows == {}
+
+    widget.set_state(_state(r=0.0))
+    rows = _grid_text(widget.grid_stage)
+    assert "R" not in rows
+    assert list(rows) == ["X", "Y", "Z", "T"]
+
+
+def test_a_rotating_stage_keeps_its_rotation_row(qapp):
+    widget = MicroscopeStateWidget(show_rotation=True)
+    widget.set_state(_state(r=0.0))
+    assert list(_grid_text(widget.grid_stage)) == ["X", "Y", "Z", "R", "T"]
+
+
+def test_the_rotation_row_is_dropped_from_both_columns_when_comparing(qapp):
+    widget = MicroscopeStateWidget(show_rotation=False)
+    widget.set_state(_state(x=42e-6))
+    widget.set_reference(_state(x=0.0))
+    assert "R" not in _grid_text(widget.grid_stage)

--- a/tests/ui/test_microscope_state_widget.py
+++ b/tests/ui/test_microscope_state_widget.py
@@ -1,0 +1,289 @@
+"""The widget that renders a `MicroscopeState`.
+
+Built from real `MicroscopeState` objects rather than stand-ins: the record is a plain
+dataclass, so there is nothing to fake, and a stub would let a field be renamed under
+the widget without a test noticing.
+
+`qapp` is the shared offscreen QApplication from `tests/conftest.py`; this project has
+no pytest-qt, so there is no `qtbot` and signals are checked by connecting to them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtWidgets import QLabel
+
+from fibsem.structures import (
+    BeamSettings,
+    BeamType,
+    FibsemDetectorSettings,
+    FibsemStagePosition,
+    MicroscopeState,
+)
+from fibsem.ui.tokens import (
+    CURRENT_POSITION_COLOUR,
+    SAVED_POSITION_COLOUR,
+    TEXT_MUTED_COLOR,
+)
+from fibsem.ui.widgets.microscope_state_widget import MicroscopeStateWidget
+from fibsem.utils import NOT_AVAILABLE
+
+
+def _state(x=0.0, y=0.0, z=0.0, r=0.0, t=0.2094, ion_current=2e-11) -> MicroscopeState:
+    """A realistic state: the Demo microscope's MILLING pose, 12 degrees of tilt."""
+    return MicroscopeState(
+        timestamp=1788000000.0,
+        stage_position=FibsemStagePosition(
+            x=x, y=y, z=z, r=r, t=t, coordinate_system="RAW"
+        ),
+        electron_beam=BeamSettings(
+            beam_type=BeamType.ELECTRON,
+            voltage=2000.0,
+            beam_current=1e-10,
+            hfw=150e-6,
+            working_distance=4e-3,
+            resolution=[1536, 1024],
+            dwell_time=1e-6,
+            scan_rotation=0.0,
+        ),
+        ion_beam=BeamSettings(
+            beam_type=BeamType.ION,
+            voltage=30000.0,
+            beam_current=ion_current,
+            hfw=150e-6,
+            working_distance=16.5e-3,
+            resolution=[1536, 1024],
+            dwell_time=1e-6,
+            scan_rotation=0.0,
+        ),
+        electron_detector=FibsemDetectorSettings(type="ETD", mode="SecondaryElectrons"),
+        ion_detector=FibsemDetectorSettings(type="ETD", mode="SecondaryElectrons"),
+    )
+
+
+def _grid_text(grid) -> dict:
+    """{row label: [value, ...]} for a `_ValueGrid`."""
+    layout = grid._layout
+    out = {}
+    for row in range(layout.rowCount()):
+        cells = []
+        for column in range(layout.columnCount()):
+            item = layout.itemAtPosition(row, column)
+            cells.append(item.widget().text() if item is not None else None)
+        if cells[0]:
+            out[cells[0]] = [c for c in cells[1:] if c is not None]
+    return out
+
+
+def _colour_of(grid, label: str, column: int) -> str:
+    layout = grid._layout
+    for row in range(layout.rowCount()):
+        first = layout.itemAtPosition(row, 0)
+        if first is not None and first.widget().text() == label:
+            return layout.itemAtPosition(row, column).widget().styleSheet()
+    raise AssertionError(f"no row {label!r}")
+
+
+# ---------------------------------------------------------------------------
+# Rendering one state
+# ---------------------------------------------------------------------------
+
+
+def test_it_renders_the_stage_position(qapp):
+    widget = MicroscopeStateWidget()
+    widget.set_state(_state(x=42e-6, y=-13e-6), title="MILLING")
+
+    rows = _grid_text(widget.grid_stage)
+    assert rows["X"] == ["42.00 µm"]
+    assert rows["Y"] == ["-13.00 µm"]
+    assert rows["T"] == ["12.0°"]
+    assert widget.label_title.text() == "MILLING"
+
+
+def test_the_beams_are_rendered_too(qapp):
+    """The point of the widget: these were recorded at every pose and shown nowhere."""
+    widget = MicroscopeStateWidget()
+    widget.set_state(_state())
+
+    ion = _grid_text(widget.grid_ion)
+    assert ion["Voltage"] == ["30.00 kV"]
+    assert ion["Current"] == ["20 pA"]
+    assert ion["Resolution"] == ["1536 x 1024"]
+    assert ion["Detector"] == ["ETD / SE"]
+
+
+def test_a_collapsed_beam_still_reports_its_headline(qapp):
+    """So shutting a section loses the detail, not the fact that the FIB is at 30 kV."""
+    widget = MicroscopeStateWidget()
+    widget.set_state(_state())
+
+    assert "30.00 kV" in widget.panel_ion._title_label.text()
+    assert "20 pA" in widget.panel_ion._title_label.text()
+
+
+def test_the_beams_start_collapsed_and_the_stage_does_not_collapse(qapp):
+    """A pose row in a list cannot expand to forty lines, and a pose that will not say
+    where it is has no reason to be in the list."""
+    widget = MicroscopeStateWidget()
+
+    assert widget.panel_stage._collapsible is False
+    assert widget.panel_electron._btn_collapse.isChecked() is False
+    assert widget.panel_ion._btn_collapse.isChecked() is False
+
+
+def test_a_missing_value_renders_as_a_dash(qapp):
+    """`MicroscopeState` is `Optional` throughout, and "not reported" has to stay
+    distinguishable from "reported as zero"."""
+    widget = MicroscopeStateWidget()
+    state = _state()
+    state.ion_beam.beam_current = None
+    widget.set_state(state)
+
+    assert _grid_text(widget.grid_ion)["Current"] == [NOT_AVAILABLE]
+
+
+def test_clearing_empties_every_section(qapp):
+    widget = MicroscopeStateWidget()
+    widget.set_state(_state())
+    widget.clear()
+
+    assert _grid_text(widget.grid_stage) == {}
+    assert widget.label_timestamp.text() == ""
+    assert widget.label_delta.isHidden() is True
+
+
+# ---------------------------------------------------------------------------
+# Comparing two states
+# ---------------------------------------------------------------------------
+
+
+def test_comparing_shows_both_columns(qapp):
+    widget = MicroscopeStateWidget()
+    widget.set_state(_state(x=42e-6), title="MILLING")
+    widget.set_reference(_state(x=0.0))
+
+    rows = _grid_text(widget.grid_stage)
+    assert rows["X"] == ["0 nm", "42.00 µm"], "saved column first, then live"
+    assert widget.label_mode.text() == "saved vs live"
+
+
+def test_only_the_rows_that_differ_are_coloured(qapp):
+    """Colouring every value would hide the two that matter.
+
+    The colours are `tokens.py`'s own: CURRENT_POSITION_COLOUR is documented as "where
+    the stage is now" and SAVED_POSITION_COLOUR as "a marked position", which is what
+    the overview canvases already draw stage markers in.
+    """
+    widget = MicroscopeStateWidget()
+    widget.set_state(_state(x=42e-6), title="MILLING")
+    widget.set_reference(_state(x=0.0))
+
+    assert SAVED_POSITION_COLOUR in _colour_of(widget.grid_stage, "X", 1)
+    assert CURRENT_POSITION_COLOUR in _colour_of(widget.grid_stage, "X", 2)
+
+    # Y did not move.
+    assert TEXT_MUTED_COLOR in _colour_of(widget.grid_stage, "Y", 1)
+    assert TEXT_MUTED_COLOR in _colour_of(widget.grid_stage, "Y", 2)
+
+
+def test_two_identical_states_colour_nothing(qapp):
+    widget = MicroscopeStateWidget()
+    widget.set_state(_state())
+    widget.set_reference(_state())
+
+    for label in ("X", "Y", "Z", "R", "T"):
+        assert TEXT_MUTED_COLOR in _colour_of(widget.grid_stage, label, 1), label
+
+
+def test_values_are_compared_as_rendered_not_as_floats(qapp):
+    """Two records holding 2.0e-11 and 2.0000001e-11 both read "20 pA".
+
+    Marking that row as a difference would report a change the panel cannot show.
+    """
+    widget = MicroscopeStateWidget()
+    widget.set_state(_state(ion_current=2.0000001e-11))
+    widget.set_reference(_state(ion_current=2.0e-11))
+
+    assert _grid_text(widget.grid_ion)["Current"] == ["20 pA", "20 pA"]
+    assert TEXT_MUTED_COLOR in _colour_of(widget.grid_ion, "Current", 1)
+
+
+def test_the_separation_is_reported_in_three_dimensions(qapp):
+    """One number to act on. 3-4-5 in micrometres, so the arithmetic is checkable."""
+    widget = MicroscopeStateWidget()
+    widget.set_state(_state(x=3e-6, y=4e-6, z=0.0))
+    widget.set_reference(_state(x=0.0, y=0.0, z=0.0))
+
+    # `isHidden`, not `isVisible`: a child of a widget that was never shown is never
+    # visible, so `isVisible() is False` would pass here whatever the code did.
+    assert widget.label_delta.isHidden() is False
+    assert "5.00 µm" in widget.label_delta.text()
+
+
+def test_dropping_the_reference_stops_comparing(qapp):
+    widget = MicroscopeStateWidget()
+    widget.set_state(_state(x=42e-6))
+    widget.set_reference(_state(x=0.0))
+    widget.set_reference(None)
+
+    assert _grid_text(widget.grid_stage)["X"] == ["42.00 µm"]
+    assert widget.label_delta.isHidden() is True
+    assert widget.label_mode.text() == ""
+
+
+# ---------------------------------------------------------------------------
+# What it refuses to do
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_emits_and_does_nothing_else(qapp):
+    """The host owns what a refresh costs, because reading the instrument is a device
+    call. Same contract as `stage_position_widget`."""
+    widget = MicroscopeStateWidget(show_refresh=True)
+    widget.set_state(_state())
+
+    fired = []
+    widget.refresh_requested.connect(lambda: fired.append(True))
+    widget.button_refresh.click()
+    assert fired == [True]
+
+    # The record on screen is untouched: the widget did not go and fetch a new one.
+    assert _grid_text(widget.grid_stage)["X"] == ["0 nm"]
+
+
+def test_a_saved_pose_offers_no_refresh(qapp):
+    widget = MicroscopeStateWidget(show_refresh=False)
+    assert widget.button_refresh.isHidden() is True
+
+
+def test_it_holds_no_microscope(qapp):
+    """The architectural constraint, asserted rather than trusted to review.
+
+    A widget that can reach a microscope will eventually be made to poll one on a
+    paint or a selection change, which is the thing this repository keeps off UI
+    event paths.
+    """
+    widget = MicroscopeStateWidget()
+    widget.set_state(_state())
+
+    from fibsem.microscope import FibsemMicroscope
+
+    for name, value in vars(widget).items():
+        assert not isinstance(value, FibsemMicroscope), name
+
+
+def test_there_is_no_fluorescence_section(qapp):
+    """Deliberate, and worth pinning so it is not "fixed" by adding an empty one.
+
+    `MicroscopeState` carries only `objective_position` for the FM -- no channel, no
+    filter -- and `get_microscope_state` does not populate even that; AutoLamellaUI
+    patches it in at the call site. A section that can never fill reads as an
+    instrument fault rather than a gap in the record.
+    """
+    widget = MicroscopeStateWidget()
+
+    titles = {label.text() for label in widget.findChildren(QLabel) if label.text()}
+    assert not any("luoresc" in title for title in titles)


### PR DESCRIPTION
Stacked on #804, which it depends on for the formatters. Review that one first; this diff is only the second commit.

**Mockup:** https://claude.ai/code/artifact/7957d7b9-19cc-4ca8-aea7-76bec01e9a4d

`Lamella.poses` is `Dict[str, MicroscopeState]` and every image carries one in its metadata — and until now nothing displayed one. Three partial renderers had grown instead:

| where | shows | drops |
| --- | --- | --- |
| `hud_ticker` | a few fields from image metadata | stage position, detectors |
| `lamella_pose_list_widget` | `stage_position.pretty`, one line | beams, detectors, timestamp |
| `selected_lamella_widget` | objective position, in its own spin box | everything else |

So the beam and detector settings recorded at every pose were written to disk and shown to nobody.

**Added with no consumers.** The pose list is the first one and is its own change, so a widget swap and the deletion it replaces stay separable.

## The contract

**It renders; it does not read.** No microscope reference — asserted by a test rather than left to review, because a widget that can reach one will eventually be made to poll it on a paint or a selection change. Refresh emits `refresh_requested` and stops, the contract `stage_position_widget` already uses.

**Saved and live are the same widget** — the same record from different sources. `set_reference` turns on the comparison, which is the mode with something to say: *how far is the instrument from where this lamella was milled*, asked before Move To.

## Decisions

- **The diff colours already existed.** `tokens.py` documents `CURRENT_POSITION_COLOUR` as "where the stage is now" and `SAVED_POSITION_COLOUR` as "a marked position", and both overview canvases already draw stage markers in them. An operator who has used either canvas has been taught yellow is live and cyan is saved; a second convention for the same distinction, in a panel beside them, would be worse than either alone.
- **Only differing rows take a colour.** Colouring all of them hides the two that matter.
- **Rows compare as rendered strings, not floats.** Two records holding `2.0e-11` and `2.0000001e-11` both read `20 pA`; marking that as a difference reports a change the panel cannot show.
- **Stage does not collapse; the beams do**, starting collapsed with their headline values on the panel title — a pose row in a list cannot expand to forty lines, but a shut section should still say the FIB is at 30 kV.
- **No fluorescence section**, deliberately, and pinned by a test so it isn't "fixed" by adding an empty one. `MicroscopeState` carries only `objective_position` for the FM — no channel, no filter — and `get_microscope_state` doesn't populate even that (AutoLamellaUI patches it in at the call site). A section that can never fill reads as an instrument fault rather than a gap in the record.
- **Display only.** Move To and Restore belong to the host; the moment this can drive a stage it needs a threading story, and that's a different widget.

## Verification

- 16 widget tests, built from **real `MicroscopeState` objects** — it's a plain dataclass, so there's nothing to fake, and a stub would let a field be renamed underneath without a test noticing.
- **Mutation-checked**: breaking the diff colouring fails exactly `test_only_the_rows_that_differ_are_coloured`; adding an empty FM panel fails exactly `test_there_is_no_fluorescence_section`.
- Driven against a live Demo microscope in all four modes (saved / live / diff / empty) — the values in the mockup are that run's output.
- `tests/ui` + import cycles: **2703 passed**.

## One thing worth copying

The visibility assertions use `isHidden()`, not `isVisible()`. A child of a widget that was never shown is *never* visible, so `assert x.isVisible() is False` passes whatever the code does — two of my assertions were passing for that reason until the delta label failed and exposed it. `isHidden()` reflects the explicit `setVisible` call, which is the thing under test.


---

## Second commit: defects the render showed

Rendering the widget under `NAPARI_STYLE` with live Demo data turned up three things its tests could not see — a `QLabel` reports the text it was *given*, whether or not it has room to draw it.

- **Clipped labels.** The three-column comparison squeezed the label column until `Working dist.` and `Scan rotation` drew as `Working dist` / `Scan rotatio`. The label column now has a minimum width.
- **No separation between the value columns.** With every row matching, both columns are muted and read as one run of numbers. There is now a gap column between them.
- **The chips were missing** — `saved vs live` rendered as a muted sentence where the approved mockup had two pills. Restored, each carrying the colour of the column it names.

## And a rotation row that asserted something false

Raised in review: *what does an Arctis show?* It showed `0.0°`, and that was wrong.

A compustage has no rotation axis. AutoScript's `CompustagePosition` carries `x, y, z, a` and nothing else, so `stage_position_from_autoscript` writes `r=0.0` as a **literal** — `FibsemStagePosition` needs a number and `get_stage_orientation` raises on `None`. The record cannot distinguish *"at rotation zero"* from *"does not rotate"*, and drawing `0.0°` asserts the first.

`show_rotation=False` now **omits the row**. Not `NOT_AVAILABLE` either: an em-dash means "the instrument did not report this", and a missing axis is not a gap in a reading.

The host passes `microscope.is_available("stage_rotation")` — which reads the instrument's own axes since FIB-834 rather than a configuration file. The capability that took three PRs to move out of config is exactly what tells this widget whether to draw the row.

**For the pose list (Phase 2):** a *saved* Arctis pose has no microscope to ask, so a host rendering stored poses will need to carry the capability alongside the record. Worth deciding then, not now.

19 tests, `tests/ui` green (2696).
