### PR TITLE
[ui] Stack the spinbox steppers on the right; flatten the panel collapse button

### DIFF
--- a/fibsem/ui/napari_style.py
+++ b/fibsem/ui/napari_style.py
@@ -8,6 +8,7 @@ Imported and re-exported by ``fibsem.ui.stylesheets``, so both
 ``from fibsem.ui.stylesheets import NAPARI_STYLE`` and
 ``stylesheets.NAPARI_STYLE`` keep working.
 """
+
 import os as _os
 
 from fibsem.ui.tokens import (

--- a/fibsem/ui/napari_style.py
+++ b/fibsem/ui/napari_style.py
@@ -222,16 +222,18 @@ QSpinBox:disabled, QDoubleSpinBox:disabled {{
     background-color: {DISABLED_BG_COLOR};
 }}
 
+/* Stepper buttons stacked on the right, plus over minus, quiet until hovered.
+   Buttons used to sit either side of the value at 20px each, napari's layout,
+   and left ~54px for the text in a 114px box. Heights are px on purpose: a
+   Qt stylesheet reads "50%" as 50px on a subcontrol, and the box is 28px. */
 QSpinBox::up-button, QDoubleSpinBox::up-button {{
     subcontrol-origin: border;
-    subcontrol-position: center right;
-    background-color: {BORDER_COLOR};
+    subcontrol-position: top right;
+    background-color: transparent;
     border: none;
-    border-left: 1px solid {BORDER_COLOR};
     border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
-    width: 20px;
-    height: 100%;
+    width: 14px;
+    height: 14px;
 }}
 
 QSpinBox::up-button:hover, QDoubleSpinBox::up-button:hover {{
@@ -244,20 +246,18 @@ QSpinBox::up-button:pressed, QDoubleSpinBox::up-button:pressed {{
 
 QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {{
     image: url("__ICONS_DIR__/plus.svg");
-    width: 10px;
-    height: 10px;
+    width: 11px;
+    height: 11px;
 }}
 
 QSpinBox::down-button, QDoubleSpinBox::down-button {{
     subcontrol-origin: border;
-    subcontrol-position: center left;
-    background-color: {BORDER_COLOR};
+    subcontrol-position: bottom right;
+    background-color: transparent;
     border: none;
-    border-right: 1px solid {BORDER_COLOR};
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
-    width: 20px;
-    height: 100%;
+    border-bottom-right-radius: 3px;
+    width: 14px;
+    height: 14px;
 }}
 
 QSpinBox::down-button:hover, QDoubleSpinBox::down-button:hover {{
@@ -270,8 +270,8 @@ QSpinBox::down-button:pressed, QDoubleSpinBox::down-button:pressed {{
 
 QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {{
     image: url("__ICONS_DIR__/minus.svg");
-    width: 10px;
-    height: 10px;
+    width: 11px;
+    height: 11px;
 }}
 
 QSlider::groove:horizontal {{

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -445,54 +445,50 @@ QDateTimeEdit:disabled {{
 
 QDateTimeEdit::up-button {{
     subcontrol-origin: border;
-    subcontrol-position: center right;
-    background-color: {BORDER_COLOR};
+    subcontrol-position: top right;
+    background-color: transparent;
     border: none;
-    border-left: 1px solid {BORDER_COLOR};
     border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
-    width: 20px;
-    height: 100%;
+    width: 14px;
+    height: 14px;
 }}
 
-QDateTimeEdit::up-button:hover {{
+QDateTimeEdit::up-button:hover:hover {{
     background-color: #4a5168;
 }}
 
-QDateTimeEdit::up-button:pressed {{
+QDateTimeEdit::up-button:pressed:pressed {{
     background-color: {ACCENT_COLOR};
 }}
 
 QDateTimeEdit::up-arrow {{
     image: url("__ICONS_DIR__/plus.svg");
-    width: 10px;
-    height: 10px;
+    width: 11px;
+    height: 11px;
 }}
 
 QDateTimeEdit::down-button {{
     subcontrol-origin: border;
-    subcontrol-position: center left;
-    background-color: {BORDER_COLOR};
+    subcontrol-position: bottom right;
+    background-color: transparent;
     border: none;
-    border-right: 1px solid {BORDER_COLOR};
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
-    width: 20px;
-    height: 100%;
+    border-bottom-right-radius: 3px;
+    width: 14px;
+    height: 14px;
 }}
 
-QDateTimeEdit::down-button:hover {{
+QDateTimeEdit::down-button:hover:hover {{
     background-color: #4a5168;
 }}
 
-QDateTimeEdit::down-button:pressed {{
+QDateTimeEdit::down-button:pressed:pressed {{
     background-color: {ACCENT_COLOR};
 }}
 
 QDateTimeEdit::down-arrow {{
     image: url("__ICONS_DIR__/minus.svg");
-    width: 10px;
-    height: 10px;
+    width: 11px;
+    height: 11px;
 }}
 """.replace("__ICONS_DIR__", _ICONS_DIR)
 

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -71,7 +71,7 @@ class QFilePathLineEdit(QWidget):
 
     def text(self) -> str:
         return self.lineEdit.text()
-    
+
     def setText(self, text: str) -> None:
         self.lineEdit.setText(text)
 
@@ -100,7 +100,9 @@ class QDirectoryLineEdit(QWidget):
         self.lineEdit.editingFinished.connect(self.editingFinished.emit)
 
     def browse_directory(self):
-        directory = QFileDialog.getExistingDirectory(self, "Select Directory", self.lineEdit.text())
+        directory = QFileDialog.getExistingDirectory(
+            self, "Select Directory", self.lineEdit.text()
+        )
         if directory:
             self.lineEdit.setText(directory)
             self.textChanged.emit(directory)
@@ -111,6 +113,7 @@ class QDirectoryLineEdit(QWidget):
 
     def setText(self, text: str) -> None:
         self.lineEdit.setText(text)
+
 
 class QFileLineEdit(QWidget):
     """Line edit with a browse button that opens a file picker dialog."""
@@ -153,11 +156,13 @@ class QFileLineEdit(QWidget):
         self.lineEdit.setText(text)
 
 
-def _create_combobox_control(value: Union[str, int, float, Enum],
-                             items: list, 
-                             units: Optional[str], 
-                             format_fn: Optional[Callable] = None, 
-                             control: Optional[QComboBox] = None) -> QComboBox:
+def _create_combobox_control(
+    value: Union[str, int, float, Enum],
+    items: list,
+    units: Optional[str],
+    format_fn: Optional[Callable] = None,
+    control: Optional[QComboBox] = None,
+) -> QComboBox:
     """Create a QComboBox control for selecting from a list of items."""
     if control is None:
         control = QComboBox()
@@ -165,7 +170,7 @@ def _create_combobox_control(value: Union[str, int, float, Enum],
         if isinstance(item, (float, int)):
             item_str = format_value(val=item, unit=units, precision=1)
         elif isinstance(item, Enum):
-            item_str = item.name # TODO: migrate to QEnumComboBox
+            item_str = item.name  # TODO: migrate to QEnumComboBox
         elif format_fn is not None:
             item_str = format_fn(item)
         else:
@@ -186,7 +191,9 @@ def _create_combobox_control(value: Union[str, int, float, Enum],
         if len(items) == 0:
             logging.warning(f"No items available for combobox with value {value}")
         else:
-            logging.debug(f"Warning: No matching item or nearest found for {items} with value {value}. Using first item.")
+            logging.debug(
+                f"Warning: No matching item or nearest found for {items} with value {value}. Using first item."
+            )
             idx = 0
 
     if idx >= 0:
@@ -327,7 +334,10 @@ class ValueSpinBox(QDoubleSpinBox):
         super().__init__(parent)
         if suffix:
             self.setSuffix(f" {suffix}")
-        self.setRange(minimum if minimum is not None else 0.0, maximum if maximum is not None else 1e6)
+        self.setRange(
+            minimum if minimum is not None else 0.0,
+            maximum if maximum is not None else 1e6,
+        )
         self.setSingleStep(step if step is not None else 0.01)
         self.setDecimals(decimals if decimals is not None else 3)
         if tooltip:
@@ -341,6 +351,7 @@ class ValueSpinBox(QDoubleSpinBox):
 @dataclass
 class ContextMenuAction:
     """Represents a single action in a context menu."""
+
     label: str
     callback: Optional[Callable] = None
     icon: Optional[QIcon] = None
@@ -353,6 +364,7 @@ class ContextMenuAction:
 @dataclass
 class ContextMenuConfig:
     """Configuration for a context menu."""
+
     actions: list[ContextMenuAction] = field(default_factory=list)
 
     def add_action(
@@ -366,15 +378,17 @@ class ContextMenuConfig:
         data: Optional[Any] = None,
     ) -> "ContextMenuConfig":
         """Add an action to the menu configuration. Returns self for chaining."""
-        self.actions.append(ContextMenuAction(
-            label=label,
-            callback=callback,
-            icon=icon,
-            tooltip=tooltip,
-            enabled=enabled,
-            separator_after=separator_after,
-            data=data,
-        ))
+        self.actions.append(
+            ContextMenuAction(
+                label=label,
+                callback=callback,
+                icon=icon,
+                tooltip=tooltip,
+                enabled=enabled,
+                separator_after=separator_after,
+                data=data,
+            )
+        )
         return self
 
     def add_separator(self) -> "ContextMenuConfig":
@@ -476,7 +490,9 @@ class ContextMenu(QMenu):
             if menu_action.callback is not None:
                 menu_action.callback()
         except Exception:
-            logging.exception("Context menu action '%s' raised an exception.", menu_action.label)
+            logging.exception(
+                "Context menu action '%s' raised an exception.", menu_action.label
+            )
             try:
                 from fibsem.ui import notification_service
 
@@ -514,6 +530,7 @@ def show_context_menu(
     selected = menu.show_at_cursor()
     return selected.label if selected else None
 
+
 class TitledPanel(QWidget):
     """A styled panel with a dark header row (title label + optional widgets) and a collapsible content area.
 
@@ -525,8 +542,13 @@ class TitledPanel(QWidget):
         fixed = TitledPanel("Setup", content=setup_widget, collapsible=False)
     """
 
-    def __init__(self, title: str, content: Optional[QWidget] = None,
-                 collapsible: bool = True, parent=None) -> None:
+    def __init__(
+        self,
+        title: str,
+        content: Optional[QWidget] = None,
+        collapsible: bool = True,
+        parent=None,
+    ) -> None:
         super().__init__(parent)
         self._collapsible = collapsible
         self.setObjectName("TitledPanel")
@@ -540,7 +562,9 @@ class TitledPanel(QWidget):
 
         # Header
         self._header = QWidget()
-        self._header.setStyleSheet(f"background: {CANVAS_BG}; border-radius: 3px 3px 0 0;")
+        self._header.setStyleSheet(
+            f"background: {CANVAS_BG}; border-radius: 3px 3px 0 0;"
+        )
         self._header_layout = QHBoxLayout(self._header)
         self._header_layout.setContentsMargins(8, 3, 4, 3)
         self._header_layout.setSpacing(4)
@@ -615,8 +639,15 @@ class _SpinnerLabel(QLabel):
     it ``autostart`` and drive visibility via :meth:`start`/:meth:`stop`.
     """
 
-    def __init__(self, icon_name="mdi:loading", color="#4fc3f7", size=24,
-                 step_deg=20, interval_ms=40, parent=None):
+    def __init__(
+        self,
+        icon_name="mdi:loading",
+        color="#4fc3f7",
+        size=24,
+        step_deg=20,
+        interval_ms=40,
+        parent=None,
+    ):
         super().__init__(parent)
         self._spin = qta.Spin(self, interval=interval_ms, step=step_deg)
         self._icon = fibsem_icon(icon_name, color=color, animation=self._spin)
@@ -645,7 +676,7 @@ class _SpinnerLabel(QLabel):
     def stop(self):
         self._active = False
         self._spin.stop()
-        self.update()        # repaint blank
+        self.update()  # repaint blank
 
     def clear(self):
         # blanking the spinner implies stopping its animation
@@ -699,11 +730,17 @@ class IconToolButton(QToolButton):
         self._icon = icon
         self._color = color
         self._checked_icon = checked_icon if checked_icon is not None else icon
-        self._checked_color = checked_color if checked_color is not None else stylesheets.GRAY_WHITE_COLOR
+        self._checked_color = (
+            checked_color if checked_color is not None else stylesheets.GRAY_WHITE_COLOR
+        )
         self._tooltip = tooltip
-        self._checked_tooltip = checked_tooltip if checked_tooltip is not None else tooltip
+        self._checked_tooltip = (
+            checked_tooltip if checked_tooltip is not None else tooltip
+        )
 
-        self._has_state = checkable or checked_icon is not None or checked_color is not None
+        self._has_state = (
+            checkable or checked_icon is not None or checked_color is not None
+        )
 
         self.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
         if size is not None:
@@ -765,7 +802,9 @@ class TaskNameListWidget(QWidget):
         header_layout.addWidget(lbl)
         header_layout.addStretch()
         self.btn_add = IconToolButton("mdi:plus", tooltip="Add task", size=24)
-        self.btn_remove = IconToolButton("mdi:trash-can-outline", tooltip="Remove task", size=24)
+        self.btn_remove = IconToolButton(
+            "mdi:trash-can-outline", tooltip="Remove task", size=24
+        )
         header_layout.addWidget(self.btn_add)
         header_layout.addWidget(self.btn_remove)
         outer.addWidget(header)
@@ -819,8 +858,6 @@ class TaskNameListWidget(QWidget):
             self.select(preferred)
         elif self._list.count() > 0:
             self._list.setCurrentRow(0)
-
-
 
 
 # ---------------------------------------------------------------------------

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, List, Optional, Union
 
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import QSize, Qt, pyqtSignal
 from PyQt5.QtGui import QColor, QCursor, QFontMetrics, QIcon, QPainter
 from PyQt5.QtWidgets import (
     QAbstractItemView,
@@ -31,6 +31,7 @@ from fibsem.ui import stylesheets as stylesheets
 from fibsem.ui.icon import fibsem_icon, qta
 from fibsem.ui.tokens import (
     CANVAS_BG,
+    TEXT_MUTED_COLOR,
 )
 from fibsem.ui.utils import install_wheel_blocker
 from fibsem.utils import format_value
@@ -566,18 +567,26 @@ class TitledPanel(QWidget):
             f"background: {CANVAS_BG}; border-radius: 3px 3px 0 0;"
         )
         self._header_layout = QHBoxLayout(self._header)
-        self._header_layout.setContentsMargins(8, 3, 4, 3)
+        self._header_layout.setContentsMargins(8, 1, 3, 1)
         self._header_layout.setSpacing(4)
         self._title_label = QLabel(title)
         self._title_label.setStyleSheet("font-weight: bold; background: transparent;")
         self._header_layout.addWidget(self._title_label)
         self._header_layout.addStretch()
 
-        # Collapse toggle — always the last item in the header; checked=expanded
+        # Collapse toggle — always the last item in the header; checked=expanded.
+        # Its own stylesheet rather than the shared toolbutton one: that draws a
+        # bordered, filled box for the checked state, and here checked means
+        # expanded, so every open panel wore a permanent pressed button. The chevron
+        # already says which state this is. No hover box either -- the whole header
+        # is chrome, and a lit rectangle in it draws the eye for nothing.
         self._btn_collapse = QToolButton()
         self._btn_collapse.setCheckable(True)
         self._btn_collapse.setChecked(True)
-        self._btn_collapse.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
+        self._btn_collapse.setStyleSheet(
+            "QToolButton { border: none; padding: 0px 3px; background: transparent; }"
+        )
+        self._btn_collapse.setIconSize(QSize(14, 14))
         self._btn_collapse.toggled.connect(self._on_collapse_toggled)
         self._header_layout.addWidget(self._btn_collapse)
 
@@ -611,7 +620,7 @@ class TitledPanel(QWidget):
             expanded = True
         self._body.setVisible(expanded)
         icon = "mdi:chevron-up" if expanded else "mdi:chevron-down"
-        self._btn_collapse.setIcon(fibsem_icon(icon, color=stylesheets.GRAY_ICON_COLOR))
+        self._btn_collapse.setIcon(fibsem_icon(icon, color=TEXT_MUTED_COLOR))
         self._btn_collapse.setToolTip("Collapse" if expanded else "Expand")
 
     def set_title(self, title: str) -> None:


### PR DESCRIPTION
## Summary

Two theme changes, both rendered against real widgets on a Demo microscope before merging.

**Spinbox steppers.** `QSpinBox`/`QDoubleSpinBox` had a 20 px minus on the left and a 20 px plus on the right, napari's layout, leaving ~54 px for the value in a 114 px box, so "30.00 kV" clipped. They now stack on the right in one 14 px column, plus over minus, transparent until hovered. The value gets ~86 px. `QDateTimeEdit` follows so date fields keep the same shape.

**Panel collapse button.** `TitledPanel`'s collapse toggle used the shared toolbutton stylesheet, whose checked state draws a bordered, filled box. Checked means expanded, so every open panel wore a permanently pressed button. It now has its own flat stylesheet with a muted 14 px chevron, and the header's vertical padding drops from 3 to 1 px: 22 px headers instead of 31. Panels with header buttons keep the button's height.

## A Qt trap, now documented in the stylesheet

Qt stylesheets do not accept percentage heights on subcontrols. The old rules said `height: 100%`, which Qt read as 100 px; it only looked right because the two buttons sat at opposite ends. A first attempt with `50%` put minus above plus, because both buttons overflowed and the down button painted over the top half. The new rules use 14 px each for the 28 px box, with a comment saying why.

The first commit is formatting only: CI format-checks every touched file and two were not yet formatted.

## Verification

- 177 UI tests pass offscreen: stylesheet render, preferences dialog, correlation tab, preflight and queue dialogs, and the panel tests.
- Lint and format-check clean on every changed file.
- Before/after renders of the beam, detector, milling and imaging settings widgets checked by eye; plus is on top everywhere.
