### PR TITLE
[feature] The pose position opens its full state

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -2358,13 +2358,11 @@ class AutoLamellaUI(QMainWindow):
             lamella.update_milling_angle(self.microscope)
             if sync_fluorescence_pose(self.microscope, lamella):
                 self.selected_lamella_widget.refresh_pose(
-                    "FLUORESCENCE", lamella.fluorescence_pose.stage_position.pretty
+                    "FLUORESCENCE", lamella.fluorescence_pose
                 )
 
         self.experiment.save()
-        self.selected_lamella_widget.refresh_pose(
-            pose_name, state.stage_position.pretty
-        )
+        self.selected_lamella_widget.refresh_pose(pose_name, state)
         # The FM overview canvas draws these positions itself rather than reading them
         # back, so a pose that moved here is one it only hears about by being told.
         self.experiment.positions.events.changed.emit()

--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -1487,7 +1487,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             lamella.update_milling_angle(self.microscope)
             if sync_fluorescence_pose(self.microscope, lamella):
                 self.selected_lamella_widget.refresh_pose(
-                    "FLUORESCENCE", lamella.fluorescence_pose.stage_position.pretty
+                    "FLUORESCENCE", lamella.fluorescence_pose
                 )
 
         if self.experiment is not None:
@@ -1496,9 +1496,7 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             # them back, so a pose that moved here is one it only hears about by being
             # told.
             self.experiment.positions.events.changed.emit()
-        self.selected_lamella_widget.refresh_pose(
-            pose_name, state.stage_position.pretty
-        )
+        self.selected_lamella_widget.refresh_pose(pose_name, state)
 
     def _on_lamella_defect_changed(self, lamella: Optional["Lamella"]):
         """Persist a defect set from this list's row menu.

--- a/fibsem/applications/autolamella/ui/lamella_pose_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_pose_list_widget.py
@@ -199,7 +199,8 @@ def _summary(pose_name: str, state: Optional[MicroscopeState]) -> str:
     if state is None:
         return "No position recorded"
     lines = [f"{pose_name} \u00b7 {format_stage_position(state.stage_position)}"]
-    for label, beam in (("Electron", state.electron_beam), ("Ion", state.ion_beam)):
+    # SEM and FIB, matching the canvases and the popup this tooltip previews.
+    for label, beam in (("SEM", state.electron_beam), ("FIB", state.ion_beam)):
         if beam is None:
             lines.append(f"{label}   {NOT_AVAILABLE}")
             continue

--- a/fibsem/applications/autolamella/ui/lamella_pose_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_pose_list_widget.py
@@ -10,39 +10,92 @@ from PyQt5.QtWidgets import (
     QLabel,
     QListWidget,
     QListWidgetItem,
+    QPushButton,
     QVBoxLayout,
     QWidget,
 )
 
 from fibsem.applications.autolamella.structures import Lamella
+from fibsem.structures import MicroscopeState
 from fibsem.ui import stylesheets
 from fibsem.ui.icon import ICON_MOVE_TO_POSITION, ICON_UPDATE_POSITION
 from fibsem.ui.tokens import (
+    BORDER_COLOR,
     CANVAS_BG,
     NEUTRAL_550,
+    SURFACE_COLOR,
+    TEXT_COLOR,
 )
 from fibsem.ui.widgets.custom_widgets import IconToolButton
+from fibsem.ui.widgets.microscope_state_widget import MicroscopeStateWidget
+from fibsem.utils import (
+    NOT_AVAILABLE,
+    format_current,
+    format_distance,
+    format_stage_position,
+    format_voltage,
+)
 
 _NAME_WIDTH = 110
 _BTN_SIZE = QSize(32, 32)
 _ROW_HEIGHT = 40
 _BTN_SPACER_WIDTH = _BTN_SIZE.width() * 2 + 8  # 2 buttons + 1 gap
 
+_POPUP_WIDTH = 400
+
+# The position control reads as text until it is approached. Flat, transparent and in
+# the same muted colour the label used, so a row at rest looks exactly as it did; the
+# hover state is the whole of the affordance, which is why it has to be visible.
+_POSITION_BUTTON_STYLE = f"""
+QPushButton {{
+    background: transparent;
+    border: none;
+    padding: 0px;
+    text-align: left;
+    color: {NEUTRAL_550};
+}}
+QPushButton:hover {{
+    color: {TEXT_COLOR};
+    text-decoration: underline;
+}}
+QPushButton:disabled {{
+    color: {NEUTRAL_550};
+    text-decoration: none;
+}}
+"""
+
 # Preferred display order; poses not listed keep their insertion order after these.
 _POSE_ORDER = ["MILLING", "FLUORESCENCE"]
 
 
 class LamellaPoseRowWidget(QWidget):
-    """A single pose row: name, pretty position, update and move-to buttons."""
+    """A single pose row: name, position, update and move-to buttons.
+
+    The position is a flat button rather than a label. A pose is a whole
+    ``MicroscopeState`` -- both beams, both detectors, a timestamp -- and the row has
+    space for one line of it, so the rest needs somewhere to go. Making the position
+    itself the control avoids a third icon in a 40-pixel row that already carries two,
+    and puts the affordance on the thing it describes.
+
+    A button rather than a ``QLabel`` with a ``mousePressEvent``: it is focusable and
+    in the tab order, which a label is not, and it brings hover and pressed states
+    with it. Otherwise Details would be the one action in the row unreachable from the
+    keyboard while Move To and Update stayed reachable.
+    """
 
     update_clicked = pyqtSignal(str)  # pose name
     move_to_clicked = pyqtSignal(str)  # pose name
 
     def __init__(
-        self, pose_name: str, pretty: str, parent: Optional[QWidget] = None
+        self,
+        pose_name: str,
+        state: Optional[MicroscopeState],
+        parent: Optional[QWidget] = None,
     ) -> None:
         super().__init__(parent)
         self.pose_name = pose_name
+        self._state = state
+        self._popup: Optional[_PoseDetailPopup] = None
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
 
         layout = QHBoxLayout(self)
@@ -54,11 +107,12 @@ class LamellaPoseRowWidget(QWidget):
         self.name_label.setStyleSheet("background: transparent;")
         layout.addWidget(self.name_label)
 
-        self.position_label = QLabel(pretty)
-        self.position_label.setStyleSheet(
-            f"background: transparent; color: {NEUTRAL_550};"
-        )
-        layout.addWidget(self.position_label, 1)
+        self.position_button = QPushButton()
+        self.position_button.setFlat(True)
+        self.position_button.setCursor(Qt.PointingHandCursor)
+        self.position_button.setStyleSheet(_POSITION_BUTTON_STYLE)
+        self.position_button.clicked.connect(self._show_details)
+        layout.addWidget(self.position_button, 1)
 
         self.btn_move_to = IconToolButton(
             icon=ICON_MOVE_TO_POSITION,
@@ -81,8 +135,80 @@ class LamellaPoseRowWidget(QWidget):
             lambda: self.move_to_clicked.emit(self.pose_name)
         )
 
-    def set_pretty(self, pretty: str) -> None:
-        self.position_label.setText(pretty)
+        self.set_state(state)
+
+    def set_state(self, state: Optional[MicroscopeState]) -> None:
+        """Re-render the row from a pose."""
+        self._state = state
+        position = state.stage_position if state is not None else None
+        self.position_button.setText(
+            format_stage_position(position) if position is not None else "Unknown"
+        )
+        self.position_button.setToolTip(_summary(self.pose_name, state))
+        # Nothing to open when there is no record behind the row.
+        self.position_button.setEnabled(state is not None)
+        if self._popup is not None and self._popup.isVisible():
+            self._popup.set_state(self.pose_name, state)
+
+    def _show_details(self) -> None:
+        if self._state is None:
+            return
+        if self._popup is None:
+            self._popup = _PoseDetailPopup(self)
+        self._popup.set_state(self.pose_name, self._state)
+        self._popup.show_under(self.position_button)
+
+
+class _PoseDetailPopup(QFrame):
+    """The full state, in a popup that closes when you click away.
+
+    ``Qt.Popup`` rather than a dialog: it is non-modal and self-dismissing, so a pose
+    can be read without losing the canvas behind it, and comparing two poses is two
+    clicks rather than four.
+
+    The stylesheet is scoped to the object name. An unscoped ``QFrame { border }``
+    cascades onto every descendant, which draws a box around every value in the table
+    inside.
+    """
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent, Qt.Popup)
+        self.setObjectName("PoseDetailPopup")
+        self.setStyleSheet(
+            f"QFrame#PoseDetailPopup {{ background: {SURFACE_COLOR};"
+            f" border: 1px solid {BORDER_COLOR}; border-radius: 4px; }}"
+        )
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(9, 9, 9, 9)
+        self.state_widget = MicroscopeStateWidget()
+        layout.addWidget(self.state_widget)
+        self.setFixedWidth(_POPUP_WIDTH)
+
+    def set_state(self, pose_name: str, state: Optional[MicroscopeState]) -> None:
+        self.state_widget.set_state(state, title=pose_name)
+
+    def show_under(self, anchor: QWidget) -> None:
+        """Open below the control that summarises the same thing."""
+        self.adjustSize()
+        self.move(anchor.mapToGlobal(anchor.rect().bottomLeft()))
+        self.show()
+
+
+def _summary(pose_name: str, state: Optional[MicroscopeState]) -> str:
+    """The tooltip: enough to answer "is this the pose I want" without a click."""
+    if state is None:
+        return "No position recorded"
+    lines = [f"{pose_name} \u00b7 {format_stage_position(state.stage_position)}"]
+    for label, beam in (("Electron", state.electron_beam), ("Ion", state.ion_beam)):
+        if beam is None:
+            lines.append(f"{label}   {NOT_AVAILABLE}")
+            continue
+        lines.append(
+            f"{label}   {format_voltage(beam.voltage)}"
+            f" \u00b7 {format_current(beam.beam_current)}"
+            f" \u00b7 {format_distance(beam.hfw)}"
+        )
+    return "\n".join(lines)
 
 
 class _LamellaPoseListHeader(QWidget):
@@ -154,18 +280,22 @@ class LamellaPoseListWidget(QWidget):
         if lamella is None or not lamella.poses:
             return
         for pose_name in self._sorted_pose_names(lamella.poses):
-            self._add_row(pose_name, self._pretty(lamella.poses[pose_name]))
+            self._add_row(pose_name, lamella.poses[pose_name])
 
-    def refresh_pose(self, pose_name: str, pretty: str) -> None:
-        """Update the displayed position for an existing pose row, in place.
+    def refresh_pose(self, pose_name: str, state: Optional[MicroscopeState]) -> None:
+        """Update an existing pose row in place, from the record itself.
 
-        Avoids rebuilding the list so row selection/scroll state is preserved.
-        No-op if no row matches *pose_name*.
+        Takes the ``MicroscopeState`` rather than a rendered string: the row now shows
+        more of it than one line, and every caller already had the state in hand and
+        was reaching into it for ``stage_position.pretty`` at the call site.
+
+        Avoids rebuilding the list so row selection/scroll state is preserved. No-op if
+        no row matches *pose_name*.
         """
         for i in range(self._list.count()):
             row = self._list.itemWidget(self._list.item(i))
             if isinstance(row, LamellaPoseRowWidget) and row.pose_name == pose_name:
-                row.set_pretty(pretty)
+                row.set_state(state)
                 return
 
     def clear(self) -> None:
@@ -187,14 +317,10 @@ class LamellaPoseListWidget(QWidget):
 
         return sorted(poses.keys(), key=key)
 
-    @staticmethod
-    def _pretty(pose) -> str:
-        if pose is not None and pose.stage_position is not None:
-            return pose.stage_position.pretty
-        return "Unknown"
-
-    def _add_row(self, pose_name: str, pretty: str) -> LamellaPoseRowWidget:
-        row = LamellaPoseRowWidget(pose_name, pretty)
+    def _add_row(
+        self, pose_name: str, state: Optional[MicroscopeState]
+    ) -> LamellaPoseRowWidget:
+        row = LamellaPoseRowWidget(pose_name, state)
         item = QListWidgetItem()
         item.setSizeHint(QSize(0, _ROW_HEIGHT))
         self._list.addItem(item)

--- a/fibsem/applications/autolamella/ui/selected_lamella_widget.py
+++ b/fibsem/applications/autolamella/ui/selected_lamella_widget.py
@@ -36,12 +36,12 @@ class SelectedLamellaWidget(QWidget):
     are handled by the parent (AutoLamellaUI) via the connected signals.
     """
 
-    objective_position_changed = pyqtSignal(float)     # value in µm
+    objective_position_changed = pyqtSignal(float)  # value in µm
     use_current_objective_requested = pyqtSignal()
     apply_objective_to_all_requested = pyqtSignal()
-    move_objective_requested = pyqtSignal()            # move objective to stored position
-    pose_update_requested = pyqtSignal(str)            # pose name
-    pose_move_to_requested = pyqtSignal(str)           # pose name
+    move_objective_requested = pyqtSignal()  # move objective to stored position
+    pose_update_requested = pyqtSignal(str)  # pose name
+    pose_move_to_requested = pyqtSignal(str)  # pose name
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
@@ -68,9 +68,7 @@ class SelectedLamellaWidget(QWidget):
             "QToolButton::menu-indicator { image: none; }"
         )
         obj_menu = QMenu(self)
-        self._action_move_to_obj_pos = obj_menu.addAction(
-            "Move Objective to Position"
-        )
+        self._action_move_to_obj_pos = obj_menu.addAction("Move Objective to Position")
         obj_menu.addSeparator()
         self._action_use_current_obj_pos = obj_menu.addAction(
             "Use Current Objective Position"
@@ -108,9 +106,7 @@ class SelectedLamellaWidget(QWidget):
         self.spinbox_objective_position.valueChanged.connect(
             self.objective_position_changed
         )
-        self._action_move_to_obj_pos.triggered.connect(
-            self.move_objective_requested
-        )
+        self._action_move_to_obj_pos.triggered.connect(self.move_objective_requested)
         self._action_use_current_obj_pos.triggered.connect(
             self.use_current_objective_requested
         )
@@ -163,7 +159,9 @@ class SelectedLamellaWidget(QWidget):
             if has_fluorescence_pose
             else None
         )
-        self.set_objective_value_um(obj_pos * METRE_TO_MICRON if obj_pos is not None else 0.0)
+        self.set_objective_value_um(
+            obj_pos * METRE_TO_MICRON if obj_pos is not None else 0.0
+        )
         self.label_objective_position.setVisible(has_fluorescence_pose)
         self.spinbox_objective_position.setVisible(has_fluorescence_pose)
         self.btn_objective_actions.setVisible(has_fluorescence_pose)
@@ -182,11 +180,13 @@ class SelectedLamellaWidget(QWidget):
             return
         text = self._lamella.description
         self.description_label.setText(text or "No description")
-        self.description_label.setToolTip(text or "Free-text note (edit in the Lamella editor)")
+        self.description_label.setToolTip(
+            text or "Free-text note (edit in the Lamella editor)"
+        )
 
-    def refresh_pose(self, pose_name: str, pretty: str) -> None:
-        """Update one pose row's position in place, without rebuilding the list."""
-        self.pose_list.refresh_pose(pose_name, pretty)
+    def refresh_pose(self, pose_name: str, state) -> None:
+        """Update one pose row in place, without rebuilding the list."""
+        self.pose_list.refresh_pose(pose_name, state)
 
     def objective_value_um(self) -> float:
         """Current objective spinbox value, in µm."""

--- a/fibsem/applications/autolamella/ui/tests/test-selected-lamella.py
+++ b/fibsem/applications/autolamella/ui/tests/test-selected-lamella.py
@@ -1,4 +1,5 @@
 """Test script for SelectedLamellaWidget (objective + pose list)."""
+
 import sys
 from pathlib import Path
 
@@ -18,18 +19,23 @@ from fibsem.applications.autolamella.ui.selected_lamella_widget import (
 from fibsem.structures import FibsemStagePosition, MicroscopeState
 
 
-def _pose(x: float, y: float, z: float, r: float = 0.0, t: float = 0.0,
-          objective: float = None) -> MicroscopeState:
-    state = MicroscopeState(
-        stage_position=FibsemStagePosition(x=x, y=y, z=z, r=r, t=t)
-    )
+def _pose(
+    x: float,
+    y: float,
+    z: float,
+    r: float = 0.0,
+    t: float = 0.0,
+    objective: float = None,
+) -> MicroscopeState:
+    state = MicroscopeState(stage_position=FibsemStagePosition(x=x, y=y, z=z, r=r, t=t))
     if objective is not None:
         state.objective_position = objective
     return state
 
 
-def _make_lamella(number: int, petname: str, with_objective: bool,
-                  with_fluorescence: bool) -> Lamella:
+def _make_lamella(
+    number: int, petname: str, with_objective: bool, with_fluorescence: bool
+) -> Lamella:
     lamella = Lamella(path=Path(f"/tmp/test/{petname}"), number=number, petname=petname)
     lamella.milling_pose = _pose(1e-3 * number, 2e-3, 3e-3, r=0.1, t=0.2)
     if with_fluorescence:
@@ -120,7 +126,7 @@ class TestWindow(QWidget):
             return
         new_state = _pose(9e-3, 8e-3, 7e-3)
         self._current.poses[name] = new_state
-        self.widget.refresh_pose(name, new_state.stage_position.pretty)
+        self.widget.refresh_pose(name, new_state)
         self._log(f"pose_update_requested: {name} (refreshed in place)")
 
     def _log(self, msg: str) -> None:

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -18,6 +18,7 @@ from fibsem.constants import DATETIME_LOG, MICRON_SYMBOL, MU_SYMBOL, TIME_FILE
 from fibsem.structures import (
     BeamType,
     FibsemImage,
+    FibsemStagePosition,
     MicroscopeSettings,
 )
 
@@ -247,6 +248,30 @@ def format_current(amps: Optional[float]) -> str:
     if abs(amps) >= 1e-9:
         return format_value(amps, "A", precision=1, scale=1e9)
     return format_value(amps, "A", precision=0, scale=1e12)
+
+
+def format_stage_position(position: Optional["FibsemStagePosition"]) -> str:
+    """A stage position on one line, in the units each axis deserves.
+
+    Deliberately *not* `FibsemStagePosition.pretty`, which is fixed millimetres to two
+    decimals and stays that way. That is the right choice where `pretty` is used --
+    five `logging.info` calls and an error message -- because a log column in one unit
+    can be read down, and one that alternates micrometres and millimetres cannot. It
+    is the wrong choice on screen: at the milling pose `pretty` renders every
+    translation axis as "0.00mm", where the operator's move was 42 micrometres.
+
+    So both exist, and the difference between them is the medium rather than an
+    oversight.
+    """
+    if position is None:
+        return NOT_AVAILABLE
+    return (
+        f"X:{format_distance(position.x)}, "
+        f"Y:{format_distance(position.y)}, "
+        f"Z:{format_distance(position.z)}, "
+        f"R:{format_angle(position.r)}, "
+        f"T:{format_angle(position.t)}"
+    )
 
 
 def format_voltage(volts: Optional[float]) -> str:

--- a/tests/ui/test_lamella_pose_row.py
+++ b/tests/ui/test_lamella_pose_row.py
@@ -108,8 +108,10 @@ def test_the_tooltip_carries_the_beams(qapp):
     tooltip = row.position_button.toolTip()
 
     assert "MILLING" in tooltip
-    assert "2.00 kV" in tooltip and "100 pA" in tooltip  # electron
-    assert "30.00 kV" in tooltip and "20 pA" in tooltip  # ion
+    # SEM and FIB, matching the canvases and the popup this previews.
+    assert "SEM" in tooltip and "2.00 kV" in tooltip and "100 pA" in tooltip
+    assert "FIB" in tooltip and "30.00 kV" in tooltip and "20 pA" in tooltip
+    assert "Electron" not in tooltip and "Ion" not in tooltip
 
 
 def test_the_tooltip_survives_a_beam_that_was_never_configured(qapp):
@@ -117,7 +119,7 @@ def test_the_tooltip_survives_a_beam_that_was_never_configured(qapp):
     state.ion_beam = None
     row = LamellaPoseRowWidget("MILLING", state)
 
-    assert "Ion" in row.position_button.toolTip()
+    assert "FIB" in row.position_button.toolTip()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ui/test_lamella_pose_row.py
+++ b/tests/ui/test_lamella_pose_row.py
@@ -1,0 +1,225 @@
+"""The pose row, and the details affordance on its position.
+
+A pose is a whole `MicroscopeState`; the row has space for one line of it. These cover
+the three places the rest of it now goes -- the tooltip, the popup, and the formatters
+the line itself is built from.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")  # CI installs .[test] only; the UI extra is deliberate
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QLabel, QPushButton
+
+from fibsem.applications.autolamella.structures import Lamella
+from fibsem.applications.autolamella.ui.lamella_pose_list_widget import (
+    LamellaPoseListWidget,
+    LamellaPoseRowWidget,
+)
+from fibsem.structures import (
+    BeamSettings,
+    BeamType,
+    FibsemStagePosition,
+    MicroscopeState,
+)
+
+
+def _state(x=0.0, y=0.0, ion_current=2e-11) -> MicroscopeState:
+    return MicroscopeState(
+        timestamp=1788000000.0,
+        stage_position=FibsemStagePosition(
+            x=x, y=y, z=0.0, r=0.0, t=np.radians(12), coordinate_system="RAW"
+        ),
+        electron_beam=BeamSettings(
+            beam_type=BeamType.ELECTRON, voltage=2000.0, beam_current=1e-10, hfw=150e-6
+        ),
+        ion_beam=BeamSettings(
+            beam_type=BeamType.ION,
+            voltage=30000.0,
+            beam_current=ion_current,
+            hfw=150e-6,
+        ),
+    )
+
+
+def _lamella() -> Lamella:
+    lamella = Lamella(path=Path("/tmp/pose-row-test"), number=1, petname="01-test")
+    lamella.milling_pose = _state()
+    lamella.fluorescence_pose = _state(x=42e-6, y=-13e-6)
+    return lamella
+
+
+# ---------------------------------------------------------------------------
+# The position is a control
+# ---------------------------------------------------------------------------
+
+
+def test_the_position_is_a_button_not_a_label(qapp):
+    """A `QLabel` with a `mousePressEvent` would not be focusable or in the tab order,
+    which would make Details the one action in the row unreachable from the keyboard
+    while Move To and Update stayed reachable."""
+    row = LamellaPoseRowWidget("MILLING", _state())
+
+    assert isinstance(row.position_button, QPushButton)
+    assert row.position_button.focusPolicy() != Qt.NoFocus
+    assert row.position_button.cursor().shape() == Qt.PointingHandCursor
+
+
+def test_the_row_looks_unchanged_until_hovered(qapp):
+    """The affordance is the hover state; at rest the row must read as it always did.
+
+    Asserted on the stylesheet because that is where the decision lives -- resting
+    colour muted and no underline, both only appearing under `:hover`.
+    """
+    row = LamellaPoseRowWidget("MILLING", _state())
+    style = row.position_button.styleSheet()
+
+    resting, hover = style.split("QPushButton:hover")
+    assert "text-decoration: underline" not in resting
+    assert "text-decoration: underline" in hover
+    assert "border: none" in resting
+
+
+def test_the_position_uses_the_scaled_formatters(qapp):
+    """Not `stage_position.pretty`, which is fixed millimetres and would round this
+    13 micrometre offset to "-0.01mm"."""
+    row = LamellaPoseRowWidget("FLUORESCENCE", _state(x=42e-6, y=-13e-6))
+
+    text = row.position_button.text()
+    assert "42.00 µm" in text
+    assert "-13.00 µm" in text
+
+
+# ---------------------------------------------------------------------------
+# The tooltip -- a glance, no click
+# ---------------------------------------------------------------------------
+
+
+def test_the_tooltip_carries_the_beams(qapp):
+    """The point of the affordance: these are recorded at every pose and the row has
+    no space for them."""
+    row = LamellaPoseRowWidget("MILLING", _state())
+    tooltip = row.position_button.toolTip()
+
+    assert "MILLING" in tooltip
+    assert "2.00 kV" in tooltip and "100 pA" in tooltip  # electron
+    assert "30.00 kV" in tooltip and "20 pA" in tooltip  # ion
+
+
+def test_the_tooltip_survives_a_beam_that_was_never_configured(qapp):
+    state = _state()
+    state.ion_beam = None
+    row = LamellaPoseRowWidget("MILLING", state)
+
+    assert "Ion" in row.position_button.toolTip()
+
+
+# ---------------------------------------------------------------------------
+# The popup
+# ---------------------------------------------------------------------------
+
+
+def test_clicking_the_position_opens_the_full_state(qapp):
+    row = LamellaPoseRowWidget("MILLING", _state())
+    row.position_button.click()
+
+    assert row._popup is not None
+    assert row._popup.state_widget.label_title.text() == "MILLING"
+
+
+def test_the_popup_dismisses_itself(qapp):
+    """`Qt.Popup`, not a dialog. It closes on a click outside and does not block, so a
+    pose can be read without losing the canvas and two poses are two clicks."""
+    row = LamellaPoseRowWidget("MILLING", _state())
+    row.position_button.click()
+
+    assert bool(row._popup.windowFlags() & Qt.Popup)
+    assert row._popup.isModal() is False
+
+
+def test_the_popup_frame_style_is_scoped_to_itself(qapp):
+    """An unscoped `QFrame { border }` cascades onto every descendant, drawing a box
+    around every value in the table inside. Found by rendering it."""
+    row = LamellaPoseRowWidget("MILLING", _state())
+    row.position_button.click()
+
+    assert "QFrame#PoseDetailPopup" in row._popup.styleSheet()
+
+
+def test_an_open_popup_follows_the_row(qapp):
+    """A pose updated while its detail is open should not go on showing the old one."""
+    row = LamellaPoseRowWidget("MILLING", _state())
+    row.position_button.click()
+    row.set_state(_state(x=42e-6))
+
+    values = row._popup.state_widget.grid_stage._layout
+    texts = [
+        values.itemAt(i).widget().text()
+        for i in range(values.count())
+        if values.itemAt(i).widget() is not None
+    ]
+    assert "42.00 µm" in texts
+
+
+# ---------------------------------------------------------------------------
+# A pose with nothing behind it
+# ---------------------------------------------------------------------------
+
+
+def test_a_row_with_no_record_offers_nothing_to_open(qapp):
+    row = LamellaPoseRowWidget("LANDING", None)
+
+    assert row.position_button.text() == "Unknown"
+    assert row.position_button.isEnabled() is False
+
+
+def test_the_name_stays_a_plain_label(qapp):
+    """Only the position became a control; the name has nothing to expand."""
+    row = LamellaPoseRowWidget("MILLING", _state())
+    assert isinstance(row.name_label, QLabel)
+
+
+# ---------------------------------------------------------------------------
+# The list carries records, not rendered strings
+# ---------------------------------------------------------------------------
+
+
+def test_the_list_builds_rows_from_the_poses(qapp):
+    widget = LamellaPoseListWidget()
+    widget.set_lamella(_lamella())
+
+    rows = [
+        widget._list.itemWidget(widget._list.item(i))
+        for i in range(widget._list.count())
+    ]
+    assert [row.pose_name for row in rows] == ["MILLING", "FLUORESCENCE"]
+    assert "42.00 µm" in rows[1].position_button.text()
+
+
+def test_refresh_pose_takes_the_record(qapp):
+    """It used to take a pre-rendered string, and every caller reached into the state
+    for `stage_position.pretty` to produce one. The row needs more of the record than
+    that now, so the record is what it is given."""
+    widget = LamellaPoseListWidget()
+    widget.set_lamella(_lamella())
+
+    widget.refresh_pose("MILLING", _state(x=99e-6))
+
+    row = widget._list.itemWidget(widget._list.item(0))
+    assert "99.00 µm" in row.position_button.text()
+    assert "MILLING" in row.position_button.toolTip()
+
+
+def test_refreshing_an_unknown_pose_is_a_no_op(qapp):
+    widget = LamellaPoseListWidget()
+    widget.set_lamella(_lamella())
+    widget.refresh_pose("NOT_A_POSE", _state(x=99e-6))
+
+    row = widget._list.itemWidget(widget._list.item(0))
+    assert "99.00 µm" not in row.position_button.text()


### PR DESCRIPTION
Stacked on #805 (which is stacked on #804). This diff is only the fourth commit.

The first consumer of `MicroscopeStateWidget`. A pose is a whole `MicroscopeState` and the row has space for one line of it, so the rest needed somewhere to go — **hover for a summary, click for the record.**

## Why the position and not a third icon

The row is 40px and already carries Move To and Update. A third icon crowds it, and the position is the thing the detail is *about*.

**A button, not a `QLabel` with a `mousePressEvent`:**

- focusable and in the tab order — otherwise Details is the one action in the row unreachable from the keyboard while its two neighbours stay reachable
- hover and pressed states for free
- *less* code than the label subclassing done elsewhere in the app (`channel_list_widget`, `coordinate_list_widget`)

At rest it is styled to read exactly as the label did. The hover state — brightens, underlines, pointer cursor — is the whole of the affordance, which is why it has to be visible.

`Qt.Popup` rather than a dialog: non-modal and self-dismissing, so a pose can be read without losing the canvas behind it, and comparing two poses is two clicks rather than four.

## The line itself now scales

`format_stage_position` renders each axis in the unit it deserves. On a real pose from the DEV-TEST experiment this is not cosmetic:

```
pretty       X:0.21mm,     Y:0.01mm,   Z:-0.08mm
formatted    X:213.10 µm,  Y:9.03 µm,  Z:-75.18 µm
```

A 9 µm offset reads as `0.01mm`, and a 29 µm one as `0.03mm`.

**`pretty` is deliberately left alone.** Its other callers are five `logging.info` lines and an error message, and fixed units are right there — a log column in one unit can be read down, one that alternates µm and mm cannot. Both exist now, and the difference between them is the medium rather than an oversight.

## `refresh_pose` takes the record

It took a pre-rendered string, and **all four callers** reached into the state for `stage_position.pretty` to produce one. The row needs more of the record than a line, so the record is what it's given — which made every call site shorter, not longer.

## Verification

- 14 new tests, plus `tests/ui` and the formatting suites: **2754 passed**.
- Rendered against the **DEV-TEST experiment's poses read from disk**, not only constructed ones — the numbers in the table above are that render's.
- The app starts and quickloads that experiment with no traceback.

One test worth noting: `test_the_popup_frame_style_is_scoped_to_itself`. An unscoped `QFrame { border }` cascades onto every descendant and draws a box around every value in the table inside. I hit that while building the mockup, so it is pinned rather than left to be rediscovered.
