### PR TITLE
[ui] Lamella editor: one scroll area, no forced milling height, flat icon toggles

### DIFF
--- a/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
@@ -200,7 +200,6 @@ class AutoLamellaProtocolEditorWidget(QWidget):
             milling_enabled=False,
             parent=self,
         )
-        self.milling_task_editor.setMinimumHeight(550)
         # drive patterns/reposition on the FIB canvas (not napari)
         self.milling_task_editor.set_controller(self.view_controller)
         self.milling_task_editor.set_alignment_area_visible(False)
@@ -351,28 +350,16 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         self.grid_layout.addWidget(self.label_description, 8, 0, 1, 1)
         self.grid_layout.addWidget(self.line_edit_description, 8, 1, 1, 1)
 
-        # main layout
+        # main layout. No scroll area here: the window wraps this editor in one
+        # already, and a second one nested inside it only ever added a second bar.
         self.main_layout = QVBoxLayout(self)
-        self.scroll_content_layout = QVBoxLayout()
-
-        self.scroll_area = QScrollArea()
-        self.scroll_area.setWidgetResizable(True)  # required to resize
-        self.scroll_area.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)  # type: ignore
-        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)  # type: ignore
-        self.scroll_content_layout.addLayout(self.grid_layout)
-        self.scroll_content_layout.addWidget(self.task_parameters_config_widget)
-        self.scroll_content_layout.addWidget(self.spot_burn_coordinates_widget)
-        self.scroll_content_layout.addWidget(self.ref_image_params_widget)  # type: ignore
-        self.scroll_content_layout.addWidget(self.milling_task_editor)  # type: ignore
-        self.scroll_content_layout.addWidget(
-            self.fluorescence_acquisition_task_config_widget
-        )  # type: ignore
-        self.scroll_content_layout.addStretch()
-
-        self.scroll_content_widget = QWidget()
-        self.scroll_content_widget.setLayout(self.scroll_content_layout)
-        self.scroll_area.setWidget(self.scroll_content_widget)  # type: ignore
-        self.main_layout.addWidget(self.scroll_area)  # type: ignore
+        self.main_layout.addLayout(self.grid_layout)
+        self.main_layout.addWidget(self.task_parameters_config_widget)
+        self.main_layout.addWidget(self.spot_burn_coordinates_widget)
+        self.main_layout.addWidget(self.ref_image_params_widget)  # type: ignore
+        self.main_layout.addWidget(self.milling_task_editor)  # type: ignore
+        self.main_layout.addWidget(self.fluorescence_acquisition_task_config_widget)  # type: ignore
+        self.main_layout.addStretch()
 
     def _initialise_widgets(self):
         """Initialise the widgets based on the current experiment protocol."""

--- a/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
@@ -291,7 +291,6 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
             milling_enabled=False,
             parent=self,
         )
-        self.milling_task_editor.setMinimumHeight(550)
 
         self.fluorescence_acquisition_task_config_widget = (
             AutoLamellaFluorescenceAcquisitionTaskConfigWidget(

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -388,6 +388,28 @@ def border_stylesheet(object_name: str) -> str:
 
 
 # TODO: no token -- #6a6a6a, #8a8a8a
+# For `IconToolButton`, whose checked state already swaps the icon: no border in any
+# state, a faint fill on hover, and an accent tint when checked. The bordered, filled
+# checked box of TOOLBUTTON_ICON_STYLESHEET below made every toggled-on button in a
+# panel header look pressed, which is the loudest thing in a row of quiet chrome.
+ICON_TOOLBUTTON_STYLESHEET = """
+    QToolButton {
+        border: none;
+        border-radius: 4px;
+        padding: 2px 4px;
+        background-color: transparent;
+    }
+    QToolButton:hover {
+        background-color: rgba(255, 255, 255, 25);
+    }
+    QToolButton:checked {
+        background-color: rgba(80, 166, 255, 45);
+    }
+    QToolButton:checked:hover {
+        background-color: rgba(80, 166, 255, 70);
+    }
+"""
+
 TOOLBUTTON_ICON_STYLESHEET = f"""
     QToolButton {{
         border: 1px solid transparent;

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -751,7 +751,7 @@ class IconToolButton(QToolButton):
             checkable or checked_icon is not None or checked_color is not None
         )
 
-        self.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
+        self.setStyleSheet(stylesheets.ICON_TOOLBUTTON_STYLESHEET)
         if size is not None:
             self.setFixedSize(size, size)
 


### PR DESCRIPTION
## Summary

First of a short stack tidying the Lamella tab's protocol editor. Two fixes, no design change.

- **One scroll area.** The editor built its own `QScrollArea` while `AutoLamellaMainUI` already wraps it in one. On a short window that showed two bars. The editor's own is gone; its content goes straight into the main layout.
- **No forced milling height.** `MillingTaskViewerWidget` had a 550 px minimum in both the Lamella and Protocol tabs, so any milling task forced a scrollbar even with short content. Removed in both.
- **Flat icon toggles.** `IconToolButton` used the shared toolbutton stylesheet, whose checked state draws a bordered, filled box, so every toggled-on button in a panel header looked pressed. It now has its own `ICON_TOOLBUTTON_STYLESHEET`: no border, a faint fill on hover, an accent tint when checked. The icon-colour swap it already did was too subtle to carry state alone. The 13 raw `QToolButton`s on the old stylesheet are untouched.

## Verification

- 159 of 160 tests pass across the lamella editor canvas suite, the spot-burn widget suite, the stylesheet render test and the correlation tab. The one failure is pre-existing on main: `test_layer_controls_menu_survives_a_migrated_tab` looks for a method the main window no longer has, and lives under `fibsem/.../tests`, which CI does not run.
- Both editors rendered offscreen with a real experiment before and after and checked by eye.
- Lint and format-check clean.
