### PR TITLE
[ui] Lamella editor: the view toggles move onto the FIB canvas

### DIFF
--- a/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
@@ -276,8 +276,10 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         )
         self.overlay_controls.toggled.connect(self._on_overlay_toggled)
         fib_canvas = self.view_controller.get_canvas(BeamType.ION)
+        # The eye, as on the overview canvases' overlay control; layers is the FM
+        # channel control's icon.
         self.btn_overlays = fib_canvas.add_toolbar_button(
-            "mdi:layers", "Overlays", self._toggle_overlays_popover, checkable=True
+            "mdi:eye-outline", "Overlays", self._toggle_overlays_popover, checkable=True
         )
         fib_canvas._reposition_overlay_buttons()
         self.overlay_popover = CanvasPopover(self.overlay_controls, parent=fib_canvas)

--- a/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
@@ -52,6 +52,10 @@ from fibsem.ui.tokens import (
     NEUTRAL_200,
 )
 from fibsem.ui.widgets.canvas.canvas_state import AlignmentSpec, PointsSpec
+from fibsem.ui.widgets.canvas.overlay_controls import (
+    CanvasOverlayControls,
+    CanvasPopover,
+)
 from fibsem.ui.widgets.canvas.quad_view import (
     LamellaEditorView,
     MicroscopeViewController,
@@ -86,6 +90,12 @@ _SAVE_DEBOUNCE_MS = 400
 # Reducer overlay ids on the FIB (ION) canvas
 POI_OVERLAY_ID = "poi"
 ALIGNMENT_OVERLAY_ID = "alignment_area"
+
+# The view toggles in the FIB canvas's overlay popover, by key.
+OVERLAY_SEM = "sem"
+OVERLAY_RELATED = "related"
+OVERLAY_ALIGNMENT = "alignment"
+OVERLAY_EDIT_ALIGNMENT = "edit_alignment"
 
 
 class AutoLamellaProtocolEditorWidget(QWidget):
@@ -240,52 +250,37 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         )
         self.pushButton_open_correlation.clicked.connect(self._open_correlation_dialog)
 
-        self.pushButton_toggle_sem_image = IconToolButton(
-            icon="mdi:eye-off",
-            checked_icon="mdi:eye",
-            tooltip="Show SEM reference image.",
-            checked_tooltip="Hide SEM reference image.",
-            checkable=True,
-            checked=self.show_sem_image,
+        # View toggles live on the FIB canvas, not in the editor header: they change
+        # what is drawn over the image, so they sit with the canvas tools, in the same
+        # popover the overview canvases use. Listing "Edit alignment area" under
+        # "Alignment area" also makes the dependency between them visible, where a
+        # greyed pencil six buttons along did not.
+        self.overlay_controls = CanvasOverlayControls(
+            [
+                (OVERLAY_SEM, "SEM image", self.show_sem_image),
+                (
+                    OVERLAY_RELATED,
+                    "Related milling tasks",
+                    self.show_related_milling_tasks,
+                ),
+                (OVERLAY_ALIGNMENT, "Alignment area", self.show_alignment_area),
+                (
+                    OVERLAY_EDIT_ALIGNMENT,
+                    "Edit alignment area",
+                    self.alignment_area_editable,
+                ),
+            ]
         )
-        self.pushButton_toggle_sem_image.toggled.connect(self._on_toggle_sem_image)
-
-        self.pushButton_toggle_related_tasks = IconToolButton(
-            icon="mdi:layers-off",
-            checked_icon="mdi:layers",
-            tooltip="Show related milling tasks.",
-            checked_tooltip="Hide related milling tasks.",
-            checkable=True,
-            checked=self.show_related_milling_tasks,
+        self.overlay_controls.set_enabled(
+            OVERLAY_EDIT_ALIGNMENT, self.show_alignment_area
         )
-        self.pushButton_toggle_related_tasks.toggled.connect(
-            self._on_toggle_related_tasks
+        self.overlay_controls.toggled.connect(self._on_overlay_toggled)
+        fib_canvas = self.view_controller.get_canvas(BeamType.ION)
+        self.btn_overlays = fib_canvas.add_toolbar_button(
+            "mdi:layers", "Overlays", self._toggle_overlays_popover, checkable=True
         )
-
-        self.pushButton_toggle_alignment_area = IconToolButton(
-            icon="mdi:crop-free",
-            checked_icon="mdi:crop-free",
-            tooltip="Show alignment area.",
-            checked_tooltip="Hide alignment area.",
-            checkable=True,
-            checked=self.show_alignment_area,
-        )
-        self.pushButton_toggle_alignment_area.toggled.connect(
-            self._on_toggle_alignment_area
-        )
-
-        self.pushButton_edit_alignment_area = IconToolButton(
-            icon="mdi:pencil-off",
-            checked_icon="mdi:pencil",
-            tooltip="Enable alignment area editing.",
-            checked_tooltip="Disable alignment area editing.",
-            checkable=True,
-            checked=self.alignment_area_editable,
-        )
-        self.pushButton_edit_alignment_area.setEnabled(self.show_alignment_area)
-        self.pushButton_edit_alignment_area.toggled.connect(
-            self._on_toggle_alignment_area_editable
-        )
+        fib_canvas._reposition_overlay_buttons()
+        self.overlay_popover = CanvasPopover(self.overlay_controls, parent=fib_canvas)
 
         self.label_lamella_name = QLabel("")
         self.label_lamella_name.setStyleSheet(
@@ -304,10 +299,6 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         self.button_layout.addStretch()
         self.button_layout.addWidget(self.pushButton_refresh_positions)
         self.button_layout.addWidget(self.pushButton_apply_to_other)
-        self.button_layout.addWidget(self.pushButton_toggle_sem_image)
-        self.button_layout.addWidget(self.pushButton_toggle_related_tasks)
-        self.button_layout.addWidget(self.pushButton_toggle_alignment_area)
-        self.button_layout.addWidget(self.pushButton_edit_alignment_area)
         self.button_layout.addWidget(self.pushButton_open_correlation)
         self.listWidget_selected_task = TaskNameListWidget()
         self.listWidget_selected_task.set_buttons_visible(add=False, remove=False)
@@ -546,7 +537,7 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         self.combobox_sem_filenames.setEnabled(
             self.show_sem_image and len(sem_filenames) > 0
         )
-        self.pushButton_toggle_sem_image.setEnabled(len(sem_filenames) > 0)
+        self.overlay_controls.set_enabled(OVERLAY_SEM, len(sem_filenames) > 0)
 
         # warnings and widget enablement
         lamella_warnings = []
@@ -566,6 +557,20 @@ class AutoLamellaProtocolEditorWidget(QWidget):
 
         self._on_image_selected(0)
         self._draw_point_of_interest(selected_lamella.poi)
+
+    def _toggle_overlays_popover(self) -> None:
+        """Show or hide the overlays popover, anchored under its button."""
+        self.overlay_popover.set_open(self.btn_overlays.isChecked(), self.btn_overlays)
+
+    def _on_overlay_toggled(self, key: str, checked: bool) -> None:
+        handler = {
+            OVERLAY_SEM: self._on_toggle_sem_image,
+            OVERLAY_RELATED: self._on_toggle_related_tasks,
+            OVERLAY_ALIGNMENT: self._on_toggle_alignment_area,
+            OVERLAY_EDIT_ALIGNMENT: self._on_toggle_alignment_area_editable,
+        }.get(key)
+        if handler is not None:
+            handler(checked)
 
     def _on_toggle_sem_image(self, checked: bool):
         """Toggle displaying the sem image and enablement of sem controls."""
@@ -913,11 +918,10 @@ class AutoLamellaProtocolEditorWidget(QWidget):
     def _on_toggle_alignment_area(self, checked: bool):
         self.show_alignment_area = checked
         if not checked:
+            # Unchecking the edit switch runs its handler, which disarms the overlay.
             self.alignment_area_editable = False
-            self.pushButton_edit_alignment_area.blockSignals(True)
-            self.pushButton_edit_alignment_area.setChecked(False)
-            self.pushButton_edit_alignment_area.blockSignals(False)
-        self.pushButton_edit_alignment_area.setEnabled(checked)
+            self.overlay_controls.set_visible(OVERLAY_EDIT_ALIGNMENT, False)
+        self.overlay_controls.set_enabled(OVERLAY_EDIT_ALIGNMENT, checked)
         self._draw_alignment_area()
         if not checked:
             self.view_controller.arm_overlay(BeamType.ION, None)

--- a/fibsem/applications/autolamella/ui/tests/test_lamella_protocol_editor_canvas.py
+++ b/fibsem/applications/autolamella/ui/tests/test_lamella_protocol_editor_canvas.py
@@ -14,6 +14,7 @@ must survive one tab having migrated.
 Run directly (no display needed):
     QT_QPA_PLATFORM=offscreen python fibsem/ui/widgets/tests/test_lamella_protocol_editor_canvas.py
 """
+
 from __future__ import annotations
 
 import os
@@ -130,7 +131,9 @@ def test_editor_is_napari_free():
 
 def test_fib_image_reaches_the_ion_canvas():
     editor, _ = _editor()
-    image = FibsemImage.generate_blank_image(resolution=_RESOLUTION, hfw=_HFW, random=True)
+    image = FibsemImage.generate_blank_image(
+        resolution=_RESOLUTION, hfw=_HFW, random=True
+    )
     editor.image = image
     editor.view_controller.set_image(BeamType.ION, image)
     canvas = editor.view_controller.get_canvas(BeamType.ION)
@@ -197,7 +200,9 @@ def test_alignment_area_draws_removes_and_folds_edits_back():
     assert lamella.alignment_area.top == 0.2
 
     # an edit signalled for a different overlay on the same canvas must be ignored
-    editor._on_controller_overlay_edited(BeamType.ION, "milling", FibsemRectangle(0.9, 0.9, 0.05, 0.05))
+    editor._on_controller_overlay_edited(
+        BeamType.ION, "milling", FibsemRectangle(0.9, 0.9, 0.05, 0.05)
+    )
     assert lamella.alignment_area.left == 0.1
 
     editor._on_toggle_alignment_area_editable(False)
@@ -468,3 +473,51 @@ def _main() -> int:
 
 if __name__ == "__main__":
     sys.exit(_main())
+
+
+# --- the view toggles live on the canvas ----------------------------------------
+
+
+def test_view_toggles_are_overlay_controls_on_the_fib_canvas():
+    """SEM image, related tasks, alignment area and its edit switch moved out of the
+    editor header into the FIB canvas's overlay popover, the same control the
+    overview canvases use. The editor's own flags follow the switches."""
+    from fibsem.applications.autolamella.ui.autolamella_lamella_protocol_editor import (
+        OVERLAY_ALIGNMENT,
+        OVERLAY_EDIT_ALIGNMENT,
+        OVERLAY_RELATED,
+        OVERLAY_SEM,
+    )
+
+    editor, exp = _editor()
+    editor.image = FibsemImage.generate_blank_image(resolution=_RESOLUTION, hfw=_HFW)
+    editor._selected_lamella = exp.positions[0]
+    controls = editor.overlay_controls
+    assert set(controls.keys()) == {
+        OVERLAY_SEM,
+        OVERLAY_RELATED,
+        OVERLAY_ALIGNMENT,
+        OVERLAY_EDIT_ALIGNMENT,
+    }
+    assert editor.btn_overlays.parentWidget() is editor.view_controller.get_canvas(
+        BeamType.ION
+    )
+    assert not hasattr(editor, "pushButton_toggle_sem_image")
+
+    controls.set_visible(OVERLAY_SEM, True)
+    assert editor.show_sem_image is True
+    controls.set_visible(OVERLAY_RELATED, False)
+    assert editor.show_related_milling_tasks is False
+
+    # editing depends on showing: turning the area off unchecks and greys the edit
+    # switch, and disarms the overlay
+    controls.set_visible(OVERLAY_EDIT_ALIGNMENT, True)
+    assert editor.alignment_area_editable is True
+    assert _armed(editor.view_controller) == ALIGNMENT_OVERLAY_ID
+    controls.set_visible(OVERLAY_ALIGNMENT, False)
+    assert editor.show_alignment_area is False
+    assert editor.alignment_area_editable is False
+    assert controls.is_visible(OVERLAY_EDIT_ALIGNMENT) is False
+    assert not controls._boxes[OVERLAY_EDIT_ALIGNMENT].isEnabled()
+    assert _armed(editor.view_controller) is None
+    assert ALIGNMENT_OVERLAY_ID not in _overlays(editor.view_controller)


### PR DESCRIPTION
## Summary

Stacked on #809. Second of the Lamella editor tidy-up.

The editor header had seven icon buttons mixing three kinds of action: canvas view toggles, a data action that writes to other lamellae, and opening a dialog. The four view toggles (SEM image, related milling tasks, alignment area, edit alignment area) now live on the FIB canvas as one layers button that opens the overlay popover the overview canvases already use, with the four as checkboxes. The header keeps reload, apply-to-other-lamellae and correlation.

Listing "Edit alignment area" under "Alignment area" makes their dependency visible: turning the area off unchecks and greys the edit switch, as the old greyed pencil did, but in the same list.

## What changed

- `autolamella_lamella_protocol_editor.py`: the four `IconToolButton`s are replaced by a `CanvasOverlayControls` in a `CanvasPopover` parented to the FIB canvas, opened by a `add_toolbar_button` layers button. One `_on_overlay_toggled` dispatcher routes each key to the existing handler; the editor's flags and handlers are unchanged, so the tests that drive them directly still pass.
- A test asserting the four keys exist, that the button is parented to the FIB canvas, that the flags follow the switches, and that turning the area off unchecks, greys and disarms the edit switch.

## Verification

- 33 of 34 pass in the editor canvas suite; the one failure is the pre-existing `test_layer_controls_menu_survives_a_migrated_tab`, unrelated and not on CI. Spot-burn widget suite passes.
- Rendered offscreen with a real experiment and the popover open, checked by eye.
- Lint and format-check clean.
