### PR TITLE
[ui] Lamella editor: task status as a chip on the row, one warning style

### DIFF
--- a/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_lamella_protocol_editor.py
@@ -48,8 +48,10 @@ from fibsem.structures import (
     Point,
     ReferenceImageParameters,
 )
+from fibsem.ui import stylesheets
 from fibsem.ui.tokens import (
     NEUTRAL_200,
+    SEMANTIC_WARNING_COLOR,
 )
 from fibsem.ui.widgets.canvas.canvas_state import AlignmentSpec, PointsSpec
 from fibsem.ui.widgets.canvas.overlay_controls import (
@@ -90,6 +92,8 @@ _SAVE_DEBOUNCE_MS = 400
 # Reducer overlay ids on the FIB (ION) canvas
 POI_OVERLAY_ID = "poi"
 ALIGNMENT_OVERLAY_ID = "alignment_area"
+
+_WARNING_LABEL_STYLE = f"color: {SEMANTIC_WARNING_COLOR}; font-size: 11px;"
 
 # The view toggles in the FIB canvas's overlay popover, by key.
 OVERLAY_SEM = "sem"
@@ -181,6 +185,29 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         self._active_lamella_name = lamella_name
         self._active_task_name = task_name
         self._apply_editing_lock(self._is_editing_locked())
+        if hasattr(self, "listWidget_selected_task"):
+            self._refresh_task_states()
+
+    def _refresh_task_states(self) -> None:
+        """Chip each task row with what the lamella says about it.
+
+        Completed from the lamella's own record, in progress from what the workflow
+        told this editor it is running. A task with neither shows nothing.
+        """
+        lamella = self._selected_lamella
+        if lamella is None:
+            self.listWidget_selected_task.set_task_states({})
+            return
+        states = {
+            name: ("Completed", stylesheets.GREEN_COLOR)
+            for name in lamella.completed_tasks
+        }
+        if (
+            self._active_lamella_name == lamella.name
+            and self._active_task_name is not None
+        ):
+            states[self._active_task_name] = ("In Progress", stylesheets.ACCENT_COLOR)
+        self.listWidget_selected_task.set_task_states(states)
 
     def _is_editing_locked(self) -> bool:
         if self._active_lamella_name is None:
@@ -318,15 +345,14 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         self.combobox_sem_filenames.currentIndexChanged.connect(self._on_image_selected)
         self.combobox_sem_filenames.setEnabled(self.show_sem_image)
 
+        # One warning style: the theme's warning token, small. Whether a task has
+        # completed is a chip on its row in the list, not a sentence here.
         self.label_lamella_warning = QLabel("")
-        self.label_lamella_warning.setStyleSheet("color: orange;")
+        self.label_lamella_warning.setStyleSheet(_WARNING_LABEL_STYLE)
         self.label_lamella_warning.setWordWrap(True)
         self.label_warning = QLabel("")
-        self.label_warning.setStyleSheet("color: orange;")
+        self.label_warning.setStyleSheet(_WARNING_LABEL_STYLE)
         self.label_warning.setWordWrap(True)
-        self.label_status = QLabel("")
-        self.label_status.setStyleSheet("color: cyan;")
-        self.label_status.setWordWrap(True)
 
         self.grid_layout = QGridLayout()
         self.grid_layout.addLayout(self.button_layout, 0, 0, 1, 2)
@@ -338,8 +364,7 @@ class AutoLamellaProtocolEditorWidget(QWidget):
         self.grid_layout.addWidget(self.combobox_fm_filenames_label, 4, 0, 1, 1)
         self.grid_layout.addWidget(self.combobox_fm_filenames, 4, 1, 1, 1)
         self.grid_layout.addWidget(self.label_lamella_warning, 5, 0, 1, 2)
-        self.grid_layout.addWidget(self.label_status, 6, 0, 1, 2)
-        self.grid_layout.addWidget(self.label_warning, 7, 0, 1, 2)
+        self.grid_layout.addWidget(self.label_warning, 6, 0, 1, 2)
         self.grid_layout.addWidget(self.label_description, 8, 0, 1, 1)
         self.grid_layout.addWidget(self.line_edit_description, 8, 1, 1, 1)
 
@@ -445,6 +470,7 @@ class AutoLamellaProtocolEditorWidget(QWidget):
             list(selected_lamella.task_config.keys())
         )
         self.listWidget_selected_task.set_tasks(task_names)
+        self._refresh_task_states()
 
         # load fluorescence image
         filenames = sorted(glob.glob(os.path.join(selected_lamella.path, "*.ome.tiff")))
@@ -708,13 +734,6 @@ class AutoLamellaProtocolEditorWidget(QWidget):
 
         # Re-apply lock if this lamella/task is currently being processed
         self._apply_editing_lock(self._is_editing_locked())
-
-        # display label showing task has been completed
-        msg = "Task not yet completed."
-        if selected_stage_name in [t.name for t in selected_lamella.task_history]:
-            msg = f"Task '{selected_stage_name}' has been completed."
-        self.label_status.setText(msg)
-        self.label_status.setVisible(bool(msg))
 
         # special handling for fluorescence acquisition task
         is_fluorescence_task = isinstance(task_config, AcquireFluorescenceImageConfig)

--- a/fibsem/applications/autolamella/ui/tests/test_lamella_protocol_editor_canvas.py
+++ b/fibsem/applications/autolamella/ui/tests/test_lamella_protocol_editor_canvas.py
@@ -521,3 +521,42 @@ def test_view_toggles_are_overlay_controls_on_the_fib_canvas():
     assert not controls._boxes[OVERLAY_EDIT_ALIGNMENT].isEnabled()
     assert _armed(editor.view_controller) is None
     assert ALIGNMENT_OVERLAY_ID not in _overlays(editor.view_controller)
+
+
+def test_task_rows_are_chipped_from_the_lamella_record_and_the_running_task():
+    """Completed comes from the lamella's own task history; In Progress from what the
+    workflow told the editor it is running. Everything else shows nothing."""
+    from fibsem.applications.autolamella.structures import (
+        AutoLamellaTaskState,
+        AutoLamellaTaskStatus,
+    )
+
+    editor, exp = _editor()
+    lamella = exp.positions[0]
+    lamella.task_config = {"Setup": None, "Mill Fiducial": None, "Rough Milling": None}
+    lamella.task_history.append(
+        AutoLamellaTaskState(name="Setup", status=AutoLamellaTaskStatus.Completed)
+    )
+    lamella.task_history.append(
+        AutoLamellaTaskState(name="Mill Fiducial", status=AutoLamellaTaskStatus.Failed)
+    )
+    editor._selected_lamella = lamella
+    editor.listWidget_selected_task.set_tasks(list(lamella.task_config))
+
+    editor.set_active_lamella_name(lamella.name, "Rough Milling")
+
+    chips = {}
+    lst = editor.listWidget_selected_task._list
+    for i in range(lst.count()):
+        row = lst.itemWidget(lst.item(i))
+        if row is not None:
+            chips[lst.item(i).text()] = row.findChild(QWidget, None).text()
+    assert chips == {"Setup": "Completed", "Rough Milling": "In Progress"}
+
+    editor.set_active_lamella_name(None)
+    chips = {
+        lst.item(i).text()
+        for i in range(lst.count())
+        if lst.itemWidget(lst.item(i)) is not None
+    }
+    assert chips == {"Setup"}

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
 from PyQt5.QtCore import QSize, Qt, pyqtSignal
 from PyQt5.QtGui import QColor, QCursor, QFontMetrics, QIcon, QPainter
@@ -818,15 +818,18 @@ class TaskNameListWidget(QWidget):
         header = QWidget()
         header.setStyleSheet(f"background: {CANVAS_BG};")
         header_layout = QHBoxLayout(header)
-        header_layout.setContentsMargins(8, 3, 4, 3)
+        # The same header as TitledPanel, at the same fixed height, so the list
+        # sits level with the panels under it.
+        header.setFixedHeight(_PANEL_HEADER_HEIGHT)
+        header_layout.setContentsMargins(8, 0, 3, 0)
         header_layout.setSpacing(4)
         lbl = QLabel("Task Name")
         lbl.setStyleSheet("font-weight: bold; background: transparent;")
         header_layout.addWidget(lbl)
         header_layout.addStretch()
-        self.btn_add = IconToolButton("mdi:plus", tooltip="Add task", size=24)
+        self.btn_add = IconToolButton("mdi:plus", tooltip="Add task", size=22)
         self.btn_remove = IconToolButton(
-            "mdi:trash-can-outline", tooltip="Remove task", size=24
+            "mdi:trash-can-outline", tooltip="Remove task", size=22
         )
         header_layout.addWidget(self.btn_add)
         header_layout.addWidget(self.btn_remove)
@@ -838,12 +841,47 @@ class TaskNameListWidget(QWidget):
         self._list.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         outer.addWidget(self._list)
 
+        # Per-task status chips, by task name; reapplied when the list repopulates.
+        self._states: Dict[str, Tuple[str, str]] = {}
+
         # Wire signals
         self._list.itemSelectionChanged.connect(
             lambda: self.task_selected.emit(self.selected_task)
         )
         self.btn_add.clicked.connect(self.add_clicked)
         self.btn_remove.clicked.connect(self.remove_clicked)
+
+    def set_task_states(self, states: Mapping[str, Tuple[str, str]]) -> None:
+        """Show a status chip at the right of each named row: ``{name: (text, colour)}``.
+
+        Rows not in *states* show nothing, which is what "not started" looks like.
+        The chip rides in an item widget that is transparent to the mouse and paints
+        no background, so the row's text, selection and click behaviour are the
+        list's own.
+        """
+        self._states = dict(states)
+        for i in range(self._list.count()):
+            item = self._list.item(i)
+            # Replacing an item widget only schedules the old one for deletion, and
+            # it keeps painting until then -- so a chip changing from Completed to
+            # In Progress drew both on top of each other. Take it down now.
+            previous = self._list.itemWidget(item)
+            if previous is not None:
+                self._list.removeItemWidget(item)
+                previous.hide()
+                previous.deleteLater()
+            state = self._states.get(item.text())
+            if state is None:
+                continue
+            text, colour = state
+            row = QWidget()
+            row.setAttribute(Qt.WA_TransparentForMouseEvents)
+            row.setStyleSheet("background: transparent;")
+            layout = QHBoxLayout(row)
+            layout.setContentsMargins(0, 0, 8, 0)
+            layout.addStretch()
+            layout.addWidget(chip(text, colour, font_size=10))
+            self._list.setItemWidget(item, row)
 
     def set_buttons_visible(self, add: bool, remove: bool) -> None:
         """Show or hide the add and remove header buttons independently."""
@@ -869,6 +907,8 @@ class TaskNameListWidget(QWidget):
             self._list.addItem(name)
         self._restore_selection(names, current)
         self._list.blockSignals(False)
+        if self._states:
+            self.set_task_states(self._states)
 
     def select(self, name: str) -> None:
         """Select the item with the given name (exact match)."""

--- a/tests/ui/test_task_name_list_widget.py
+++ b/tests/ui/test_task_name_list_widget.py
@@ -1,0 +1,69 @@
+"""Status chips on the task list's rows.
+
+The Lamella tab used to say "Task 'X' has been completed." in a cyan sentence under
+the image pickers. Completion is a property of a row, so it is drawn on the row: a
+chip at the right, in the colour the rest of the window uses for that state, and
+nothing at all for a task that has not started.
+"""
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtCore import Qt  # noqa: E402
+from PyQt5.QtWidgets import QApplication, QLabel  # noqa: E402
+
+from fibsem.ui.widgets.custom_widgets import TaskNameListWidget  # noqa: E402
+
+
+@pytest.fixture
+def qapp():
+    yield QApplication.instance() or QApplication([])
+
+
+def _chips(widget: TaskNameListWidget):
+    """Row index -> chip text, for rows that carry one."""
+    out = {}
+    for i in range(widget._list.count()):
+        row = widget._list.itemWidget(widget._list.item(i))
+        if row is not None:
+            out[i] = row.findChild(QLabel).text()
+    return out
+
+
+def test_only_named_rows_get_a_chip(qapp):
+    widget = TaskNameListWidget()
+    widget.set_tasks(["Setup", "Mill Fiducial", "Rough Milling", "Polishing"])
+
+    widget.set_task_states(
+        {"Setup": ("Completed", "#4caf50"), "Rough Milling": ("In Progress", "#50a6ff")}
+    )
+
+    assert _chips(widget) == {0: "Completed", 2: "In Progress"}
+
+
+def test_chips_survive_a_repopulate_and_clear_when_asked(qapp):
+    widget = TaskNameListWidget()
+    widget.set_tasks(["Setup", "Polishing"])
+    widget.set_task_states({"Setup": ("Completed", "#4caf50")})
+
+    widget.set_tasks(["Setup", "Polishing", "Extra"])
+    assert _chips(widget) == {0: "Completed"}
+
+    widget.set_task_states({})
+    assert _chips(widget) == {}
+
+
+def test_the_chip_does_not_change_the_row_text_or_selection(qapp):
+    """The chip rides in an item widget; the row's text and click handling stay the
+    list's own, so `selected_task` and every existing caller keep working."""
+    widget = TaskNameListWidget()
+    widget.set_tasks(["Setup", "Polishing"])
+    widget.set_task_states({"Polishing": ("Completed", "#4caf50")})
+
+    widget.select("Polishing")
+
+    assert widget.selected_task == "Polishing"
+    assert widget._list.item(1).text() == "Polishing"
+    row = widget._list.itemWidget(widget._list.item(1))
+    assert row.testAttribute(Qt.WA_TransparentForMouseEvents)


### PR DESCRIPTION
## Summary

Stacked on #810. Third of the Lamella editor tidy-up.

The cyan "Task 'X' has been completed." sentence under the image pickers is gone. Each task row carries its own state as a chip at the right: **Completed** from the lamella's task history, **In Progress** for the task the workflow reported it is running, and nothing for a task that has not started. The chip is the existing `chip()` pill, so the list matches the cards and the timeline.

## What changed

- `TaskNameListWidget.set_task_states({name: (text, colour)})`: chips ride in an item widget that is transparent to the mouse and paints no background, so the row's text, selection and every existing caller are untouched. States are reapplied on `set_tasks`. A replaced item widget is only scheduled for deletion by Qt and keeps painting until then, which drew two chips on top of each other; the old one is now removed explicitly.
- The list header takes `TitledPanel`'s padding (1 px, 22 px buttons) so it no longer sits heavier than the panels below it. The Protocol tab's list follows.
- The editor computes states in `_refresh_task_states`, called on lamella change and whenever the window reports the active task.
- The two remaining warning labels use the theme's warning token at 11 px instead of raw `orange`.

## Verification

- New `tests/ui/test_task_name_list_widget.py` (3 tests, on CI) covers which rows get a chip, survival across repopulate, clearing, and that text and selection are unchanged.
- A new editor test asserts chips follow the lamella record and the active task, and that a Failed history entry shows nothing.
- Editor canvas suite: 35 of 36; the one failure is the pre-existing `test_layer_controls_menu_survives_a_migrated_tab`.
- Rendered with a real experiment and an active task, checked by eye.
- Lint and format-check clean.

## Open choice

Failed and Cancelled history entries show nothing, as agreed (Completed and In Progress only). If a red "Failed" chip would help during a run, it is one line in `_refresh_task_states`.
