### PR TITLE
[refactor] MicroscopeStateWidget: SEM/FIB naming, headline placement, rotation row

### DIFF
--- a/fibsem/ui/widgets/microscope_state_widget.py
+++ b/fibsem/ui/widgets/microscope_state_widget.py
@@ -143,16 +143,27 @@ class MicroscopeStateWidget(QWidget):
         )
         outer.addWidget(self.panel_stage)
 
-        # The beams collapse, and start collapsed: a pose row that expands to forty
-        # lines is not a row. Their headline values go on the panel title instead, so
-        # a shut section still reports that the FIB is at 30 kV.
+        # SEM and FIB, not Electron and Ion. The enum members are ELECTRON and ION,
+        # but every surface an operator reads says SEM and FIB -- the quad-view panel
+        # titles, the coincidence tabs, the stage orientations. A readout beside those
+        # canvases should name the beams the way the canvases do.
+        #
+        # Collapsed to start. Opening both takes the popup from 277 to 635 pixels
+        # tall, which is a lot of panel to drop over a row that may already be near
+        # the bottom of one -- and the headline on each title carries the values most
+        # glances are after, so a shut section still reports that the FIB is at
+        # 30 kV. Expanding is one click when the rest is actually wanted.
         self.grid_electron = _ValueGrid()
-        self.panel_electron = TitledPanel("Electron", content=self.grid_electron)
+        self.panel_electron = TitledPanel("SEM", content=self.grid_electron)
+        self.headline_electron = _headline_label()
+        self.panel_electron.add_header_widget(self.headline_electron)
         self.panel_electron.collapse()
         outer.addWidget(self.panel_electron)
 
         self.grid_ion = _ValueGrid()
-        self.panel_ion = TitledPanel("Ion", content=self.grid_ion)
+        self.panel_ion = TitledPanel("FIB", content=self.grid_ion)
+        self.headline_ion = _headline_label()
+        self.panel_ion.add_header_widget(self.headline_ion)
         self.panel_ion.collapse()
         outer.addWidget(self.panel_ion)
 
@@ -218,8 +229,8 @@ class MicroscopeStateWidget(QWidget):
         if state is None:
             for grid in (self.grid_stage, self.grid_electron, self.grid_ion):
                 grid.clear()
-            self.panel_electron.set_title("Electron")
-            self.panel_ion.set_title("Ion")
+            self.headline_electron.setText("")
+            self.headline_ion.setText("")
             self.label_delta.setVisible(False)
             self.label_timestamp.setText("")
             return
@@ -241,10 +252,8 @@ class MicroscopeStateWidget(QWidget):
             else None,
         )
 
-        self.panel_electron.set_title(
-            f"Electron   {_beam_headline(state.electron_beam)}"
-        )
-        self.panel_ion.set_title(f"Ion   {_beam_headline(state.ion_beam)}")
+        self.headline_electron.setText(_beam_headline(state.electron_beam))
+        self.headline_ion.setText(_beam_headline(state.ion_beam))
 
         separation = _separation(state, reference) if comparing else None
         self.label_delta.setVisible(separation is not None)
@@ -438,6 +447,25 @@ class _ValueGrid(QWidget):
             label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
             label.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 9pt;")
             self._layout.addWidget(label, 0, column)
+
+
+def _headline_label() -> QLabel:
+    """The collapsed summary, right-aligned in the panel header.
+
+    Right rather than appended to the title, so it sits on the same edge as the values
+    it summarises: expand the section and `2.00 kV` in the header is directly above
+    `2.00 kV` in the rows. Appended, it started at a different x for each section --
+    the name lengths differ -- and inherited the title's bold, which made data look
+    like a heading.
+
+    `add_header_widget` inserts before the collapse button, which is the placement
+    `TitledPanel` is built for.
+    """
+    label = QLabel("")
+    # Explicitly normal: the header's own rule bolds the title, and without this the
+    # values arrive bold too.
+    label.setStyleSheet("background: transparent; font-weight: normal;")
+    return label
 
 
 def _chip(text: str, colour: str) -> QLabel:

--- a/fibsem/ui/widgets/microscope_state_widget.py
+++ b/fibsem/ui/widgets/microscope_state_widget.py
@@ -92,35 +92,17 @@ class MicroscopeStateWidget(QWidget):
     show_refresh:
         Whether to offer a refresh button. A saved pose has nothing to refresh, so the
         embedding list turns it off; a live readout turns it on and owns the signal.
-    show_rotation:
-        Whether the stage has a rotation axis. Pass
-        ``microscope.is_available("stage_rotation")``, which reads the instrument's own
-        axes since FIB-834.
-
-        This is not cosmetic. A compustage has no rotation axis at all -- AutoScript's
-        ``CompustagePosition`` carries ``x``, ``y``, ``z``, ``a`` and nothing else --
-        so ``stage_position_from_autoscript`` writes ``r=0.0`` as a **literal**,
-        because ``FibsemStagePosition`` needs a number and ``get_stage_orientation``
-        raises on ``None``. The record therefore cannot distinguish "the stage is at
-        rotation zero" from "this stage does not rotate", and drawing ``0.0°`` asserts
-        the first. The widget has no microscope to ask, and the host does.
     """
 
     #: Refresh was pressed. Reading the instrument is a device call and this widget
     #: does not make those -- the host decides what one costs.
     refresh_requested = pyqtSignal()
 
-    def __init__(
-        self,
-        show_refresh: bool = False,
-        show_rotation: bool = True,
-        parent: Optional[QWidget] = None,
-    ):
+    def __init__(self, show_refresh: bool = False, parent: Optional[QWidget] = None):
         super().__init__(parent)
         self._state: Optional[MicroscopeState] = None
         self._reference: Optional[MicroscopeState] = None
         self._show_refresh = show_refresh
-        self._show_rotation = show_rotation
         self._setup_ui()
 
     # ------------------------------------------------------------------
@@ -244,8 +226,7 @@ class MicroscopeStateWidget(QWidget):
 
         reference = self._reference
         self.grid_stage.set_rows(
-            _stage_rows(state, self._show_rotation),
-            _stage_rows(reference, self._show_rotation) if comparing else None,
+            _stage_rows(state), _stage_rows(reference) if comparing else None
         )
         self.grid_electron.set_rows(
             _beam_rows(state.electron_beam, state.electron_detector),
@@ -280,28 +261,26 @@ class MicroscopeStateWidget(QWidget):
 # ---------------------------------------------------------------------------
 
 
-def _stage_rows(
-    state: Optional[MicroscopeState], show_rotation: bool = True
-) -> List[Tuple[str, str]]:
-    """The stage axes, omitting R on a stage that has none.
+def _stage_rows(state: Optional[MicroscopeState]) -> List[Tuple[str, str]]:
+    """The five stage axes, R included on every stage.
 
-    Omitted rather than shown as ``NOT_AVAILABLE``: an em-dash means "the instrument
-    did not report this", and a compustage's missing rotation is not a gap in a
-    reading -- the axis does not exist. A row that will always be empty invites the
-    question of why.
+    A compustage has no rotation axis -- AutoScript's ``CompustagePosition`` carries
+    x, y, z, a, so ``stage_position_from_autoscript`` writes ``r=0.0`` as a literal --
+    and the row therefore reads 0.0 degrees there rather than saying the axis is
+    absent. Kept that way deliberately (Patrick, 2026-09-08): the alternative was a
+    flag the host had to set correctly from a capability the record does not carry,
+    which is a lot of machinery to avoid one honest zero.
     """
-    axes = ["X", "Y", "Z"] + (["R"] if show_rotation else []) + ["T"]
     if state is None or state.stage_position is None:
-        return [(axis, NOT_AVAILABLE) for axis in axes]
+        return [(axis, NOT_AVAILABLE) for axis in ("X", "Y", "Z", "R", "T")]
     position = state.stage_position
-    values = {
-        "X": format_distance(position.x),
-        "Y": format_distance(position.y),
-        "Z": format_distance(position.z),
-        "R": format_angle(position.r),
-        "T": format_angle(position.t),
-    }
-    return [(axis, values[axis]) for axis in axes]
+    return [
+        ("X", format_distance(position.x)),
+        ("Y", format_distance(position.y)),
+        ("Z", format_distance(position.z)),
+        ("R", format_angle(position.r)),
+        ("T", format_angle(position.t)),
+    ]
 
 
 def _beam_rows(

--- a/tests/ui/test_microscope_state_widget.py
+++ b/tests/ui/test_microscope_state_widget.py
@@ -120,22 +120,55 @@ def test_the_beams_are_rendered_too(qapp):
 
 
 def test_a_collapsed_beam_still_reports_its_headline(qapp):
-    """So shutting a section loses the detail, not the fact that the FIB is at 30 kV."""
+    """So shutting a section loses the detail, not the fact that the FIB is at 30 kV.
+
+    The headline is its own right-aligned label in the panel header rather than part
+    of the title, so it lands on the same edge as the values it summarises.
+    """
     widget = MicroscopeStateWidget()
     widget.set_state(_state())
 
-    assert "30.00 kV" in widget.panel_ion._title_label.text()
-    assert "20 pA" in widget.panel_ion._title_label.text()
+    assert widget.panel_ion._btn_collapse.isChecked() is False
+    assert "30.00 kV" in widget.headline_ion.text()
+    assert "20 pA" in widget.headline_ion.text()
+    # The title stays the section's name; the numbers are not part of it.
+    assert widget.panel_ion._title_label.text() == "FIB"
+    assert "font-weight: normal" in widget.headline_ion.styleSheet()
+
+
+def test_the_beams_are_named_the_way_the_canvases_name_them(qapp):
+    """SEM and FIB, not Electron and Ion.
+
+    The enum members are ELECTRON and ION, but every surface an operator reads says
+    SEM and FIB -- the quad-view panel titles, the coincidence tabs, the stage
+    orientations. A readout beside those canvases should agree with them.
+    """
+    widget = MicroscopeStateWidget()
+    assert widget.panel_electron._title_label.text() == "SEM"
+    assert widget.panel_ion._title_label.text() == "FIB"
+
+    widget.set_state(_state())
+    assert widget.panel_electron._title_label.text() == "SEM"
+    assert widget.panel_ion._title_label.text() == "FIB"
+
+    titles = {label.text() for label in widget.findChildren(QLabel) if label.text()}
+    assert not any(t.startswith(("Electron", "Ion")) for t in titles)
 
 
 def test_the_beams_start_collapsed_and_the_stage_does_not_collapse(qapp):
-    """A pose row in a list cannot expand to forty lines, and a pose that will not say
-    where it is has no reason to be in the list."""
+    """Collapsed keeps the popup short: opening both takes it from 277 to 635 pixels,
+    dropped over a row that may already be near the bottom of a panel. The headline on
+    each title carries what most glances are after.
+
+    The stage never collapses: a pose that will not say where it is has no reason to
+    be on screen.
+    """
     widget = MicroscopeStateWidget()
 
     assert widget.panel_stage._collapsible is False
     assert widget.panel_electron._btn_collapse.isChecked() is False
     assert widget.panel_ion._btn_collapse.isChecked() is False
+    assert widget.panel_electron._collapsible is True
 
 
 def test_a_missing_value_renders_as_a_dash(qapp):
@@ -155,6 +188,7 @@ def test_clearing_empties_every_section(qapp):
     widget.clear()
 
     assert _grid_text(widget.grid_stage) == {}
+    assert widget.headline_ion.text() == "", "a cleared panel reports no values"
     assert widget.label_timestamp.text() == ""
     assert widget.label_delta.isHidden() is True
 

--- a/tests/ui/test_microscope_state_widget.py
+++ b/tests/ui/test_microscope_state_widget.py
@@ -301,33 +301,18 @@ def test_there_is_no_fluorescence_section(qapp):
 # ---------------------------------------------------------------------------
 
 
-def test_a_compustage_shows_no_rotation_row(qapp):
-    """The row is omitted, not dashed.
+def test_a_compustage_still_shows_a_rotation_row(qapp):
+    """It reads 0.0 degrees, and that is the intended answer.
 
     A compustage has no rotation axis -- AutoScript's `CompustagePosition` carries
-    x, y, z, a -- so `stage_position_from_autoscript` writes `r=0.0` as a literal,
-    because `FibsemStagePosition` needs a number. The record cannot tell "at rotation
-    zero" from "does not rotate", and `0.0°` asserts the first. An em-dash would be
-    wrong too: it means "not reported", and this axis does not exist.
+    x, y, z, a -- so `stage_position_from_autoscript` writes `r=0.0` as a literal and
+    the record cannot say "this stage does not rotate". Hiding the row would need the
+    host to pass a capability the record does not carry, and a saved pose has no
+    microscope to ask. One honest zero is the cheaper answer.
     """
-    widget = MicroscopeStateWidget(show_rotation=False)
-    rows = _grid_text(widget.grid_stage)
-    assert rows == {}
-
+    widget = MicroscopeStateWidget()
     widget.set_state(_state(r=0.0))
+
     rows = _grid_text(widget.grid_stage)
-    assert "R" not in rows
-    assert list(rows) == ["X", "Y", "Z", "T"]
-
-
-def test_a_rotating_stage_keeps_its_rotation_row(qapp):
-    widget = MicroscopeStateWidget(show_rotation=True)
-    widget.set_state(_state(r=0.0))
-    assert list(_grid_text(widget.grid_stage)) == ["X", "Y", "Z", "R", "T"]
-
-
-def test_the_rotation_row_is_dropped_from_both_columns_when_comparing(qapp):
-    widget = MicroscopeStateWidget(show_rotation=False)
-    widget.set_state(_state(x=42e-6))
-    widget.set_reference(_state(x=0.0))
-    assert "R" not in _grid_text(widget.grid_stage)
+    assert list(rows) == ["X", "Y", "Z", "R", "T"]
+    assert rows["R"] == ["0.0°"]


### PR DESCRIPTION
Two commits that were made on #805's branch **after that PR had already merged**, so they never reached `main`. Both were decisions taken in review; re-landed here unchanged, as a clean cherry-pick onto current `main`.

## Why they were stranded

#805 merged at 14:01 with head `694bbca3`. I went on pushing to that branch until 14:52 — the rotation-row fix, then the SEM/FIB rename. GitHub happily accepts pushes to a merged PR's branch and still runs CI on them, so the poll I had watching it reported "11/11 passing" for an hour on a PR that was already closed. My error, and the second time this session that a MERGED state hid work that never landed (see #786 → #798).

## What's in them

**Show the rotation row on every stage** (`857e5627`). Reverses a `show_rotation` flag added earlier the same day. A compustage has no rotation axis — AutoScript's `CompustagePosition` carries `x, y, z, a`, so `stage_position_from_autoscript` writes `r=0.0` as a literal — and hiding the row cost a constructor flag the host had to set from a capability *the record does not carry*. That works for a live readout, which has a microscope to ask; it does not work for a saved pose, which is what the widget exists for. One honest zero is cheaper (Patrick, 2026-09-08). The reasoning stays in `_stage_rows` and is pinned by a test.

**SEM and FIB, headline on the right** (`44f29c53`). The enum members are ELECTRON and ION, but every surface an operator reads says SEM and FIB — quad-view panel titles, coincidence tabs, stage orientations. A readout beside those canvases should agree with them. `beam_settings_widget` is the one holdout still saying "Electron Beam Settings"; left alone rather than swept in.

The collapsed summary also moves out of the title into a right-aligned header label, so it sits on the same edge as the values it summarises — expand SEM and `2.00 kV` in the header is directly above `2.00 kV` in the rows. Appended to the title it started at a different x per section (the names differ in length) and inherited the title's bold, making data look like a heading.

Sections stay collapsed. Opening both was tried and reverted: it takes the popup from 277 to 635 pixels tall, dropped over a row that may already be near the bottom of a panel.

## Verification

- Cherry-picked cleanly onto current `main` (which has since taken #806, #809 and the docs work).
- `tests/ui/test_microscope_state_widget.py`: 18 passed. Lint and format clean.

## Note for reviewers

Both edits were nearly lost the same way, twice: `ruff` wraps a long `set_title(...)` across three lines, and a string replacement written against the unwrapped form matches nothing and reports nothing. The tests caught it both times, because they assert titles and headlines *after* a state is set rather than only at construction.
