### PR TITLE
[ui] Milling stage rows fit their panel instead of running off the right edge

### DIFF
--- a/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
@@ -408,10 +408,11 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         splitter.addWidget(col1_scroll)
         splitter.addWidget(col2_scroll)
         splitter.addWidget(col3_scroll)
-        # The middle column at the width the canvas Overview tab's settings column
-        # has there: the grid task's settings are that column, and the lamella
-        # parameters had been squeezed into 350 px with their labels cut short.
-        splitter.setSizes([280, 620, 530])
+        # The middle column wide enough that the grid task's settings (the canvas
+        # Overview tab's settings column) and the lamella parameters keep their
+        # labels; the third wide enough that a milling stage row shows every cell
+        # at its readable minimum without running off the edge.
+        splitter.setSizes([280, 580, 580])
 
         self._main_layout.addWidget(splitter)
 

--- a/fibsem/ui/widgets/milling_stage_list_widget.py
+++ b/fibsem/ui/widgets/milling_stage_list_widget.py
@@ -12,6 +12,7 @@ from PyQt5.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QListView,
     QListWidget,
     QListWidgetItem,
     QSizePolicy,
@@ -36,14 +37,17 @@ from fibsem.ui.widgets.custom_widgets import IconToolButton, ValueComboBox, Valu
 # Columns are flexible: each is (minimum_width, stretch). The header and every row
 # consume the SAME spec so their column boundaries stay aligned as the panel resizes,
 # while the whole row can shrink well below the old ~660px fixed-width floor.
-_COL_NAME = (90, 3)
-_COL_PATTERN = (70, 2)
-_COL_DEPTH = (70, 2)
-_COL_CURRENT = (60, 2)
-_COL_STRATEGY = (70, 2)
+# Minimums are what the cell's text needs: "200.0 pA" or "Standard" plus the combo's
+# arrow, "2.0 µm" plus the stacked stepper. Below these a cell clips mid-word.
+_COL_NAME = (80, 3)
+_COL_PATTERN = (84, 2)
+_COL_DEPTH = (84, 2)
+_COL_CURRENT = (106, 2)
+_COL_STRATEGY = (108, 2)
 _CHECKBOX_WIDTH = 24
 _DRAG_WIDTH = DRAG_HANDLE_WIDTH
-_BTN_SIZE = QSize(32, 32)
+# Icon buttons, not 32px: two per row was 64px of chrome in a row that has ~500px.
+_BTN_SIZE = QSize(24, 24)
 _ROW_HEIGHT = 40
 
 
@@ -136,7 +140,7 @@ class MillingStageRowWidget(QWidget):
         self._show_preset = show_preset
 
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(6, 3, 6, 3)
+        layout.setContentsMargins(4, 3, 4, 3)
         layout.setSpacing(4)
 
         self.checkbox = QCheckBox()
@@ -287,6 +291,8 @@ class MillingStageRowWidget(QWidget):
     def refresh(self) -> None:
         self._block_controls(True)
         self.name_edit.setText(self.stage.name)
+        # show the start of a long name, not its scrolled end
+        self.name_edit.setCursorPosition(0)
         self.name_edit.setToolTip(self.stage.summary)
         self.pattern_combo.set_value(self.stage.pattern.name)
         depth = getattr(self.stage.pattern, "depth", None)
@@ -377,7 +383,7 @@ class _MillingStageListHeader(QWidget):
         self.setStyleSheet(f"background: {CANVAS_BG};")
 
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(6, 4, 6, 4)
+        layout.setContentsMargins(4, 4, 4, 4)
         layout.setSpacing(4)
 
         # Header mirrors the row cell-for-cell so columns stay aligned: a no-text
@@ -496,6 +502,11 @@ class MillingStageListWidget(QWidget):
         self._list.setMinimumHeight(3 * _ROW_HEIGHT)
         self._list.setStyleSheet(stylesheets.LIST_WIDGET_STYLESHEET)
         self._list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        # Adjust, not the default Fixed: in Fixed mode a row keeps the geometry it
+        # was given when inserted, which comes from its ~680px size hint, so in any
+        # panel narrower than that the row ran off the right edge and the Strategy
+        # column read as "St". Adjust relays the rows out to the viewport on resize.
+        self._list.setResizeMode(QListView.Adjust)
         self._list.setFocusPolicy(Qt.NoFocus)
         layout.addWidget(self._list)
 


### PR DESCRIPTION
## Summary

On the Protocol tab the milling stage table clipped its Strategy column to "St" at the default column width. Two causes, both fixed.

**The rows never relaid out.** `QListView`'s default `Fixed` resize mode gives an index widget its geometry once, at insertion, from the widget's size hint (~680 px), and never updates it when the viewport resizes. In any panel narrower than that the row simply ran off the right edge. The list now uses `Adjust` mode, which relays rows to the viewport on resize.

**The cells were cramped once they fit.** The declared column minimums (60 to 70 px) were below what a combo needs for "200.0 pA" or "Standard" plus its arrow and padding, so cells clipped mid-word. Minimums are now what the longest value needs (measured), the two per-row buttons are 24 px instead of 32, row margins are 4 px, and a long stage name shows its start rather than its scrolled end. A row's minimum is 500 px.

The Protocol tab's splitter gives its third column 580 px instead of 530, taken from the middle column, whose form never needed 620.

## Verification

- Measured offscreen: at a 547 px viewport the row is 539 px; row minimum 496 to 500 px.
- Rendered the Protocol tab at 1440×860 and the Lamella tab's editor at 536 px with a real experiment; every cell reads in full on both, including the drag handle.
- 44 tests pass across the stage list, select-all sync, workflow-load warnings, milling task viewer and spot-burn suites.
- Lint and format-check clean.
