### PR TITLE
[ui] The milling config widget stops scrolling itself; its hosts do

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -3,6 +3,7 @@ import time
 import warnings
 
 from fibsem import conversions
+from fibsem.ui.widgets.custom_widgets import scrollable
 
 try:
     sys.modules.pop("PySide6.QtCore")
@@ -230,6 +231,7 @@ class AutoLamellaUI(QMainWindow):
         self.fm_control_widget: Optional[FMControlWidget] = None
         self.sample_widget: Optional[FibsemSampleWidget] = None
         self.milling_task_config_widget: Optional[MillingTaskViewerWidget] = None
+        self.milling_tab: Optional[QWidget] = None  # the scroll area around it
         self.det_widget: Optional["FibsemEmbeddedDetectionWidget"] = None
 
         # minimap plot widget — a floating tool window, shown on demand (was a
@@ -702,6 +704,20 @@ class AutoLamellaUI(QMainWindow):
         self.update_microscope_ui()
         self.update_ui()
 
+    def front_tab(self, widget: QWidget) -> None:
+        """Bring forward the tab that holds *widget*.
+
+        The widget may be the tab itself or sit inside a wrapper (the Milling tab is
+        a scroll area around its editor). ``setCurrentWidget`` on a widget that is
+        not a direct tab is a silent no-op, which is how the responder stopped
+        fronting the Milling tab once the wrapper arrived.
+        """
+        candidate = widget
+        while candidate is not None and self.tabWidget.indexOf(candidate) == -1:
+            candidate = candidate.parentWidget()
+        if candidate is not None:
+            self.tabWidget.setCurrentWidget(candidate)
+
     def update_microscope_ui(self):
         """Update the ui based on the current state of the microscope."""
 
@@ -725,7 +741,11 @@ class AutoLamellaUI(QMainWindow):
                 image_widget=self.image_widget,
                 parent=self,
             )
-            self.tabWidget.addTab(self.milling_task_config_widget, "Milling")
+            # The milling widget no longer scrolls itself; its tab does. The tab is
+            # kept by name because indexOf / setCurrentWidget want the tab, not the
+            # widget inside it -- see front_tab.
+            self.milling_tab = scrollable(self.milling_task_config_widget)
+            self.tabWidget.addTab(self.milling_tab, "Milling")
 
             # The hardware view of the grids: the holder, and the magazine when
             # there is one. Slot moves go through the Movement widget, the same
@@ -804,10 +824,9 @@ class AutoLamellaUI(QMainWindow):
                 self.spot_burn_widget.deleteLater()
                 self.spot_burn_widget = None
             if self.milling_task_config_widget is not None:
-                self.tabWidget.removeTab(
-                    self.tabWidget.indexOf(self.milling_task_config_widget)
-                )
-                self.milling_task_config_widget.deleteLater()
+                self.tabWidget.removeTab(self.tabWidget.indexOf(self.milling_tab))
+                self.milling_tab.deleteLater()  # owns the widget
+                self.milling_tab = None
                 self.milling_task_config_widget = None
             if self.movement_widget is not None:
                 self.movement_widget._teardown_connections()

--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -94,6 +94,7 @@ from fibsem.ui.widgets.coincidence_milling_confirmation_dialog import (
 from fibsem.ui.widgets.custom_widgets import (
     IntegerValueSpinBox,
     TitledPanel,
+    scrollable,
 )
 
 if TYPE_CHECKING:
@@ -836,7 +837,8 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
         self.milling_viewer_widget.settings_changed.connect(
             lambda *_: self._autosave_milling_config()
         )
-        return self.milling_viewer_widget
+        # the milling widget no longer scrolls itself; the tab does
+        return scrollable(self.milling_viewer_widget)
 
     def _build_fm_tab(self) -> QWidget:
         if self.microscope is None or self.microscope.fm is None:

--- a/fibsem/applications/autolamella/ui/qt_responder.py
+++ b/fibsem/applications/autolamella/ui/qt_responder.py
@@ -411,7 +411,7 @@ class QtResponder(QObject):
         widget = self._milling_widget()
         widget.update_from_settings(request.config)
         widget.setEnabled(True)
-        self._ui.tabWidget.setCurrentWidget(widget)
+        self._ui.front_tab(widget)
 
     def _clear_milling_config(self, request: ClearMillingConfig) -> None:
         """Clear the milling editor. Moved from handle_workflow_update."""
@@ -569,7 +569,7 @@ class QtResponder(QObject):
         widget = self._milling_widget()
         widget.update_from_settings(request.config)
         widget.setEnabled(True)
-        self._ui.tabWidget.setCurrentWidget(widget)
+        self._ui.front_tab(widget)
         # The workflow runs the mill; the editor's own Run button stands down
         # (moved from handle_workflow_update's milling_enabled branch).
         widget.milling_widget.pushButton_run_milling.setVisible(False)

--- a/fibsem/ui/FibsemUI.py
+++ b/fibsem/ui/FibsemUI.py
@@ -44,6 +44,7 @@ from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.stylesheets import NAPARI_STYLE
 from fibsem.ui.tokens import GRAY_ICON_COLOR
 from fibsem.ui.widgets.canvas.quad_view import MicroscopeViewController
+from fibsem.ui.widgets.custom_widgets import scrollable
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 from fibsem.ui.widgets.overview_widget import FibsemOverviewWidget
 from fibsem.versioning import get_version_string
@@ -241,7 +242,8 @@ class FibsemUI(QMainWindow):
             # add widgets to tabs
             self._add_control_tab(self.image_widget, "Image")
             self._add_control_tab(self.movement_widget, "Movement")
-            self._add_control_tab(self.milling_widget, "Milling")
+            # the milling widget no longer scrolls itself; the tab does
+            self._add_control_tab(scrollable(self.milling_widget), "Milling")
             self._add_control_tab(self.sample_widget, "Sample")
 
             if self.microscope.system.manipulator.enabled:

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -20,6 +20,7 @@ from PyQt5.QtWidgets import (
     QLineEdit,
     QListWidget,
     QMenu,
+    QScrollArea,
     QSizePolicy,
     QSpinBox,
     QToolButton,
@@ -530,6 +531,20 @@ def show_context_menu(
     menu = ContextMenu(config, parent=parent)
     selected = menu.show_at_cursor()
     return selected.label if selected else None
+
+
+def scrollable(widget: QWidget) -> QScrollArea:
+    """*widget* inside a vertical-only QScrollArea that resizes it to the viewport.
+
+    For a tab or column whose content can outgrow the window. Widgets should not
+    scroll themselves: a scroll area inside another only adds a second bar, and the
+    host is the one that knows whether there is room.
+    """
+    scroll = QScrollArea()
+    scroll.setWidgetResizable(True)
+    scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+    scroll.setWidget(widget)
+    return scroll
 
 
 # Panel headers share one height: tall enough for a 24px icon button.

--- a/fibsem/ui/widgets/milling_task_config_widget2.py
+++ b/fibsem/ui/widgets/milling_task_config_widget2.py
@@ -169,7 +169,9 @@ class MillingTaskConfigWidget2(QWidget):
             checked_tooltip="Hide advanced settings",
         )
 
-        self.acquisition_panel = TitledPanel("Acquisition", content=self.acquisition_widget)
+        self.acquisition_panel = TitledPanel(
+            "Acquisition", content=self.acquisition_widget
+        )
         self.acquisition_panel.add_header_widget(self._btn_enable_acquisition)
         self.acquisition_panel.add_header_widget(self._btn_advanced_acquisition)
         self.acquisition_panel._btn_collapse.setChecked(False)
@@ -179,10 +181,14 @@ class MillingTaskConfigWidget2(QWidget):
         self.milling_stages_widget = FibsemMillingStagesWidget(
             microscope=self.microscope, stages=[]
         )
-        self._btn_stage_count = IconToolButton(icon="mdi:numeric-0-box-outline", size=32)
+        self._btn_stage_count = IconToolButton(
+            icon="mdi:numeric-0-box-outline", size=32
+        )
         self._btn_stage_count.setEnabled(False)
 
-        milling_panel = TitledPanel("Milling Stages", content=self.milling_stages_widget)
+        milling_panel = TitledPanel(
+            "Milling Stages", content=self.milling_stages_widget
+        )
         milling_panel.add_header_widget(self._btn_stage_count)
         milling_panel._btn_collapse.setChecked(True)
         layout.addWidget(milling_panel)
@@ -199,23 +205,43 @@ class MillingTaskConfigWidget2(QWidget):
         self.milling_stages_widget.stages_changed.connect(self._emit_settings_changed)
         self.milling_stages_widget.eye_toggled.connect(self.eye_toggled)
         self.milling_stages_widget.stages_changed.connect(
-            lambda stages: self._update_stage_count_icon(len([s for s in stages if s.enabled]))
+            lambda stages: self._update_stage_count_icon(
+                len([s for s in stages if s.enabled])
+            )
         )
         self._btn_enable_alignment.toggled.connect(self._on_enable_alignment_toggled)
-        self._btn_advanced_alignment.toggled.connect(self._on_advanced_alignment_toggled)
-        self._btn_enable_acquisition.toggled.connect(self._on_enable_acquisition_toggled)
-        self._btn_advanced_acquisition.toggled.connect(self._on_advanced_acquisition_toggled)
-        self.alignment_widget.enabled_checkbox.toggled.connect(self._on_alignment_checkbox_changed)
-        self.acquisition_widget.acquire_sem_checkbox.toggled.connect(self._on_acquisition_checkbox_changed)
-        self.acquisition_widget.acquire_fib_checkbox.toggled.connect(self._on_acquisition_checkbox_changed)
+        self._btn_advanced_alignment.toggled.connect(
+            self._on_advanced_alignment_toggled
+        )
+        self._btn_enable_acquisition.toggled.connect(
+            self._on_enable_acquisition_toggled
+        )
+        self._btn_advanced_acquisition.toggled.connect(
+            self._on_advanced_acquisition_toggled
+        )
+        self.alignment_widget.enabled_checkbox.toggled.connect(
+            self._on_alignment_checkbox_changed
+        )
+        self.acquisition_widget.acquire_sem_checkbox.toggled.connect(
+            self._on_acquisition_checkbox_changed
+        )
+        self.acquisition_widget.acquire_fib_checkbox.toggled.connect(
+            self._on_acquisition_checkbox_changed
+        )
 
     # ------------------------------------------------------------------
     # Private slots
     # ------------------------------------------------------------------
 
     def _update_stage_count_icon(self, n: int) -> None:
-        icon_name = "mdi:numeric-9-plus-box-outline" if n > 9 else f"mdi:numeric-{n}-box-outline"
-        self._btn_stage_count.setIcon(fibsem_icon(icon_name, color=stylesheets.GRAY_ICON_COLOR))
+        icon_name = (
+            "mdi:numeric-9-plus-box-outline"
+            if n > 9
+            else f"mdi:numeric-{n}-box-outline"
+        )
+        self._btn_stage_count.setIcon(
+            fibsem_icon(icon_name, color=stylesheets.GRAY_ICON_COLOR)
+        )
         self._btn_stage_count.setToolTip(f"{n} stage{'s' if n != 1 else ''}")
 
     def _emit_settings_changed(self) -> None:
@@ -249,7 +275,9 @@ class MillingTaskConfigWidget2(QWidget):
 
     def _on_acquisition_checkbox_changed(self) -> None:
         aw = self.acquisition_widget
-        any_enabled = aw.acquire_sem_checkbox.isChecked() or aw.acquire_fib_checkbox.isChecked()
+        any_enabled = (
+            aw.acquire_sem_checkbox.isChecked() or aw.acquire_fib_checkbox.isChecked()
+        )
         self._btn_enable_acquisition.blockSignals(True)
         self._btn_enable_acquisition.setChecked(any_enabled)
         self._btn_enable_acquisition.blockSignals(False)
@@ -287,7 +315,9 @@ class MillingTaskConfigWidget2(QWidget):
         self.milling_stages_widget.set_stages(settings.stages)
         self._update_stage_count_icon(len(settings.stages))
         self.blockSignals(False)
-        self._on_alignment_checkbox_changed(settings.alignment.enabled)  # sync button state to loaded values
+        self._on_alignment_checkbox_changed(
+            settings.alignment.enabled
+        )  # sync button state to loaded values
         self._on_acquisition_checkbox_changed()  # sync button state to loaded values
 
     def set_config(self, config: FibsemMillingTaskConfig) -> None:
@@ -295,4 +325,3 @@ class MillingTaskConfigWidget2(QWidget):
 
     def clear(self) -> None:
         self.update_from_settings(FibsemMillingTaskConfig())
-

--- a/fibsem/ui/widgets/milling_task_config_widget2.py
+++ b/fibsem/ui/widgets/milling_task_config_widget2.py
@@ -76,14 +76,13 @@ class MillingTaskConfigWidget2(QWidget):
         main_layout = QVBoxLayout(self)
         main_layout.setContentsMargins(0, 0, 0, 0)
 
+        # No scroll area of its own: every host that shows this widget already
+        # scrolls the column it sits in, and one nested inside it only ever added a
+        # second bar (the Lamella tab showed three, stacked). A host that wants
+        # scrolling wraps this widget -- see `scrollable`.
         content_widget = QWidget()
         layout = QVBoxLayout(content_widget)
-
-        scroll_area = QScrollArea()
-        scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
-        scroll_area.setWidget(content_widget)
-        main_layout.addWidget(scroll_area)
+        main_layout.addWidget(content_widget)
 
         # ── Core panel ──────────────────────────────────────────────
         core_content = QWidget()

--- a/tests/ui/test_qt_responder.py
+++ b/tests/ui/test_qt_responder.py
@@ -233,7 +233,8 @@ def test_a_milling_config_lands_in_the_editor_and_fronts_its_tab(ui, qapp):
 
     assert "error" not in outcome
     assert ui.milling_task_config_widget.get_config().name == "from-the-workflow"
-    assert ui.tabWidget.currentWidget() is ui.milling_task_config_widget
+    # the editor is what the operator sees, whichever tab wraps it
+    assert ui.milling_task_config_widget.isVisibleTo(ui.tabWidget)
 
 
 def test_clearing_the_milling_config_resets_the_editor(ui, qapp):


### PR DESCRIPTION
## Summary

Follows #809, one level down. `MillingTaskConfigWidget2` wrapped its own content in a `QScrollArea`. Every host that shows it already scrolls the column it sits in, so the inner one only added a second bar: the Lamella tab's milling section had its own bordered, scrolling box inside the editor's scrolling column. The widget now lays its content out directly.

Three hosts placed the milling widget bare with no scroll of their own, and would have clipped on a short window: the AutoLamella **Milling** tab, `FibsemUI`'s Milling tab, and the coincidence viewer's Milling tab. Each now wraps it with `scrollable`, a small helper added to `custom_widgets` for a tab or column whose content can outgrow the window.

The first commit is formatting only: `milling_task_config_widget2.py` was not yet formatted and CI checks every touched file.

## Two things the wrapper broke, fixed in the same commit

- The workflow responder fronted the Milling tab with `tabWidget.setCurrentWidget(<milling widget>)`. With a scroll area as the tab that is a silent no-op, and CI caught it. `AutoLamellaUI.front_tab(widget)` now walks up to the tab that holds a widget, and the responder uses it.
- Disconnect removed the Milling tab by `indexOf(<milling widget>)`, which would have returned -1 and leaked the tab. The UI keeps `milling_tab` and removes and deletes that.

## One behaviour note

On the AutoLamella Milling tab the whole viewer now scrolls as one, including the Run Milling button at its foot. Before, that button stayed pinned below the config's inner scroll. With a stage list of ordinary length it makes no difference; on a very short window the button scrolls with the content instead of staying in view.

## Verification

- Offscreen: the AutoLamella Milling tab is a `QScrollArea` and the milling widget contains none; the Lamella tab's editor renders its milling section flat in the column.
- 150 tests pass across every `tests/ui` file that builds `AutoLamellaUI`, including the responder test that caught the fronting no-op; plus the config widget, viewer, editor canvas and coincidence suites, with only the pre-existing `test_layer_controls_menu_survives_a_migrated_tab` failing.
- Lint and format-check clean.
