### PR TITLE
[ui] Spinbox steppers: bigger, muted glyphs, pulled in from the box edges

### DIFF
--- a/fibsem/ui/icons/stepper-minus.svg
+++ b/fibsem/ui/icons/stepper-minus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+  <line x1="2" y1="5" x2="8" y2="5" stroke="#868e93" stroke-width="1.5"/>
+</svg>

--- a/fibsem/ui/icons/stepper-plus.svg
+++ b/fibsem/ui/icons/stepper-plus.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+  <line x1="2" y1="5" x2="8" y2="5" stroke="#868e93" stroke-width="1.5"/>
+  <line x1="5" y1="2" x2="5" y2="8" stroke="#868e93" stroke-width="1.5"/>
+</svg>

--- a/fibsem/ui/napari_style.py
+++ b/fibsem/ui/napari_style.py
@@ -225,15 +225,21 @@ QSpinBox:disabled, QDoubleSpinBox:disabled {{
 /* Stepper buttons stacked on the right, plus over minus, quiet until hovered.
    Buttons used to sit either side of the value at 20px each, napari's layout,
    and left ~54px for the text in a 114px box. Heights are px on purpose: a
-   Qt stylesheet reads "50%" as 50px on a subcontrol, and the box is 28px. */
+   Qt stylesheet reads "50%" as 50px on a subcontrol, and the box is 28px.
+   Each button is inset 2px from the box edge so the glyphs sit toward the
+   middle rather than in the corners. The stepper SVGs draw a 1.5px stroke in
+   the muted text colour on a 10px canvas; at 14px that is ~8px of ink, a step
+   below the value beside it, like the combo arrows. plus.svg / minus.svg stay
+   for anything else that uses them. */
 QSpinBox::up-button, QDoubleSpinBox::up-button {{
     subcontrol-origin: border;
     subcontrol-position: top right;
     background-color: transparent;
     border: none;
     border-top-right-radius: 3px;
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 12px;
+    margin-top: 2px;
 }}
 
 QSpinBox::up-button:hover, QDoubleSpinBox::up-button:hover {{
@@ -245,9 +251,9 @@ QSpinBox::up-button:pressed, QDoubleSpinBox::up-button:pressed {{
 }}
 
 QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {{
-    image: url("__ICONS_DIR__/plus.svg");
-    width: 11px;
-    height: 11px;
+    image: url("__ICONS_DIR__/stepper-plus.svg");
+    width: 14px;
+    height: 14px;
 }}
 
 QSpinBox::down-button, QDoubleSpinBox::down-button {{
@@ -256,8 +262,9 @@ QSpinBox::down-button, QDoubleSpinBox::down-button {{
     background-color: transparent;
     border: none;
     border-bottom-right-radius: 3px;
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 12px;
+    margin-bottom: 2px;
 }}
 
 QSpinBox::down-button:hover, QDoubleSpinBox::down-button:hover {{
@@ -269,9 +276,9 @@ QSpinBox::down-button:pressed, QDoubleSpinBox::down-button:pressed {{
 }}
 
 QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {{
-    image: url("__ICONS_DIR__/minus.svg");
-    width: 11px;
-    height: 11px;
+    image: url("__ICONS_DIR__/stepper-minus.svg");
+    width: 14px;
+    height: 14px;
 }}
 
 QSlider::groove:horizontal {{

--- a/fibsem/ui/stylesheets.py
+++ b/fibsem/ui/stylesheets.py
@@ -471,8 +471,9 @@ QDateTimeEdit::up-button {{
     background-color: transparent;
     border: none;
     border-top-right-radius: 3px;
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 12px;
+    margin-top: 2px;
 }}
 
 QDateTimeEdit::up-button:hover:hover {{
@@ -484,9 +485,9 @@ QDateTimeEdit::up-button:pressed:pressed {{
 }}
 
 QDateTimeEdit::up-arrow {{
-    image: url("__ICONS_DIR__/plus.svg");
-    width: 11px;
-    height: 11px;
+    image: url("__ICONS_DIR__/stepper-plus.svg");
+    width: 14px;
+    height: 14px;
 }}
 
 QDateTimeEdit::down-button {{
@@ -495,8 +496,9 @@ QDateTimeEdit::down-button {{
     background-color: transparent;
     border: none;
     border-bottom-right-radius: 3px;
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 12px;
+    margin-bottom: 2px;
 }}
 
 QDateTimeEdit::down-button:hover:hover {{
@@ -508,9 +510,9 @@ QDateTimeEdit::down-button:pressed:pressed {{
 }}
 
 QDateTimeEdit::down-arrow {{
-    image: url("__ICONS_DIR__/minus.svg");
-    width: 11px;
-    height: 11px;
+    image: url("__ICONS_DIR__/stepper-minus.svg");
+    width: 14px;
+    height: 14px;
 }}
 """.replace("__ICONS_DIR__", _ICONS_DIR)
 


### PR DESCRIPTION
## Summary

Follow-up to #806. The stacked +/− steppers read as squished, and at 4x the reason was plain: the `plus.svg`/`minus.svg` canvases are 10 px with the stroke spanning only the middle 6 px, so the 11 px rule drew about 6.5 px of ink, and each 14 px button filled its half of the 28 px box, so the symbols sat hard against the top and bottom borders.

## What changed

- Each button is 12 px tall, inset 2 px from the box edge, 16 px wide, and draws a 14 px glyph: about 8 px of ink, pulled toward the middle with a visible gap between the two.
- New `stepper-plus.svg` / `stepper-minus.svg` draw the 1.5 px stroke in the muted text colour (`#868e93`) instead of the full text colour, so the stepper sits a step below the value beside it, the same weight as the combo arrows. The original SVGs stay for anything else that uses them.
- `QDateTimeEdit` in `stylesheets.py` follows.
- Text width loses 2 px per box.

Chosen from six colour and stroke weights rendered side by side at 1x and 4x.

## Verification

- Beam, detector, milling and imaging settings widgets rendered on a Demo microscope, plus a 4x zoom of one box.
- Stylesheet render and preferences dialog tests pass. Lint and format-check clean.
