### PR TITLE
Fluorescence Image Viewer on the View menu; Acquire Image takes every channel

### DIFF
--- a/docs/developers/render_user_guide.py
+++ b/docs/developers/render_user_guide.py
@@ -1362,27 +1362,32 @@ def render_fluorescence(h: Harness) -> None:
     h.pump(400)
     h.shot("channels", target=fmc.channelPanel, crop=True)
 
-    # Acquire Image takes the selected channel only; Acquire Z-Stack takes
-    # every channel at every plane, so a two-plane stack (the smallest it
-    # accepts) is the way to one image with all four channels in it
+    # Acquire Image takes every channel in the list on one plane (FIB-943),
+    # so one press gives the four-channel image the viewer composes
     import glob
 
     from fibsem.fm.structures import FluorescenceImage
     from fibsem.ui.fm.widgets.fm_image_viewer_widget import FMImageViewerWidget
 
     quad.set_selected("fm")
-    zp = fmc.zParametersWidget
-    zp.doubleSpinBox_zstep.setValue(2.0)
-    zp.doubleSpinBox_zmin.setValue(-1.0)
-    zp.doubleSpinBox_zmax.setValue(1.0)
-    h.pump(200)
-    fmc.pushButton_acquire_zstack.click()
+    fmc.pushButton_acquire_single_image.click()
     h.wait_fm(fmc)
     # the Microscope tab's FM view shows the frame just taken, one channel
     h.shot("fm-view-live", target=fm_panel)
 
-    # the standalone viewer is where a multi-channel image is composed: load
-    # the file the acquisition wrote
+    # View > Fluorescence Image Viewer: where a multi-channel image is composed
+    view = next(a.menu() for a in h.window.menuBar().actions() if a.text() == "View")
+    view.popup(h.window.mapToGlobal(QPoint(0, 0)))
+    h.pump(300)
+    h.shot(
+        "view-menu",
+        target=view,
+        callout_rects=[view.actionGeometry(h.window.action_open_fm_image_viewer)],
+    )
+    view.close()
+    h.pump(200)
+
+    # the standalone viewer: load the file the acquisition wrote
     def newest(pattern):
         files = sorted(
             glob.glob(os.path.join(h._tmp.name, pattern)), key=os.path.getmtime
@@ -1393,7 +1398,7 @@ def render_fluorescence(h: Harness) -> None:
     viewer.resize(1180, 700)
     viewer.show()
     h.pump(300)
-    viewer.add_image(FluorescenceImage.load(newest("z-stack-*.ome.tiff")))
+    viewer.add_image(FluorescenceImage.load(newest("image-*.ome.tiff")))
     h.pump(800)
     vcanvas = viewer.canvas
     h.shot(
@@ -1433,6 +1438,7 @@ def render_fluorescence(h: Harness) -> None:
     h.pump(300)
 
     # a z-stack: the parameters, then the slice controls under the view
+    zp = fmc.zParametersWidget
     zp.doubleSpinBox_zmin.setValue(-10.0)
     zp.doubleSpinBox_zmax.setValue(10.0)
     zp.doubleSpinBox_zstep.setValue(2.0)

--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -605,6 +605,14 @@ class AutoLamellaSingleWindowUI(QMainWindow):
             )
             fullscreen_menu.addAction(act)
 
+        # The standalone viewer, where a multi-channel image is composed: the
+        # Microscope tab's fluorescence view shows one frame (FIB-942). Needs no
+        # experiment; it is a file viewer.
+        view_menu.addSeparator()
+        self.action_open_fm_image_viewer = QAction("Fluorescence Image Viewer...", self)
+        self.action_open_fm_image_viewer.triggered.connect(self._open_fm_image_viewer)
+        view_menu.addAction(self.action_open_fm_image_viewer)
+
         # keep the checkable / enabled state honest each time the menu opens
         view_menu.aboutToShow.connect(self._sync_view_menu)
 
@@ -798,12 +806,6 @@ class AutoLamellaSingleWindowUI(QMainWindow):
 
         self._dev_menu = dev_menu
         self._dev_menu.menuAction().setVisible(self.dev_mode)
-
-        action_open_fm_image_viewer = QAction("Open Fluorescence Image Viewer", self)
-        action_open_fm_image_viewer.triggered.connect(self._open_fm_image_viewer)
-        dev_menu.addAction(action_open_fm_image_viewer)
-
-        dev_menu.addSeparator()
 
         action_load_fm_configuration = QAction("Load Fluorescence Configuration", self)
         action_load_fm_configuration.triggered.connect(self._import_fm_configuration)

--- a/fibsem/applications/autolamella/ui/AutoLamellaUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaUI.py
@@ -968,20 +968,26 @@ class AutoLamellaUI(QMainWindow):
 
     #### FLUORESCENCE IMAGE VIEWER
 
+    def _fm_image_viewer_start_directory(self) -> str:
+        """Where the viewer's Load dialog opens: the open experiment, else the folder
+        of the most recent one, else the log directory. The viewer reads files, so it
+        needs no experiment (FIB-942); this only picks a sensible first folder."""
+        if self.experiment is not None and self.experiment.path:
+            return str(self.experiment.path)
+        recent = fibsem_cfg.load_user_preferences().experiment.recent_experiments
+        for path in recent:
+            parent = os.path.dirname(path)
+            if os.path.isdir(parent):
+                return parent
+        return fibsem_cfg.LOG_PATH
+
     def _open_fm_image_viewer(self):
         """Open the FM Image Viewer as a standalone window."""
-        if self.experiment is None:
-            notification_service.show_toast(
-                "Please load an experiment first... [No Experiment Loaded]", "warning"
-            )
-            return
-
-        experiment_path = str(self.experiment.path) if self.experiment.path else None
         # Parented to None so it gets its own taskbar entry and native minimise, like the
         # coincidence viewer. That means nothing else owns it, so the reference here is
         # what keeps it alive — drop it and Python collects the window mid-session.
         self._fm_image_viewer_window = FMImageViewerWidget(
-            start_directory=experiment_path
+            start_directory=self._fm_image_viewer_start_directory()
         )
         self._fm_image_viewer_window.resize(1180, 700)
         self._fm_image_viewer_window.show()

--- a/fibsem/ui/widgets/fluorescence_control_widget.py
+++ b/fibsem/ui/widgets/fluorescence_control_widget.py
@@ -863,10 +863,13 @@ class FMControlWidget(QWidget):
 
         settings = self._get_current_settings()
 
+        # Both buttons take every channel in the list; the z-stack one adds the
+        # planes. Acquire Image used to take the selected channel only, so the
+        # only way to one image with all its channels in it was a two-plane
+        # stack (FIB-943). The selected channel is for the live view.
+        channel_settings = settings["channel_settings"]
         z_parameters = None
-        channel_settings = settings["selected_channel_settings"]
         if self.sender() is self.pushButton_acquire_zstack:
-            channel_settings = settings["channel_settings"]
             z_parameters = settings["z_parameters"]
 
         # Generate filename for saving

--- a/tests/ui/test_fm_acquire_image_channels.py
+++ b/tests/ui/test_fm_acquire_image_channels.py
@@ -1,0 +1,95 @@
+"""Acquire Image takes every channel in the list, one plane (FIB-943).
+
+It used to take the selected channel only, so the one way to a single image with
+all its channels in it was a two-plane z-stack. The selected channel is what the
+live view streams; the list is what an acquisition takes, image or stack alike.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication  # noqa: E402
+
+from fibsem.fm.structures import ChannelSettings  # noqa: E402
+from fibsem.ui.widgets import fluorescence_control_widget as module  # noqa: E402
+from fibsem.ui.widgets.fluorescence_control_widget import (  # noqa: E402
+    FMControlWidget,
+    _DemoHost,
+)
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture()
+def widget(qapp):
+    from fibsem.ui.fm.overview_app import build_microscope
+
+    host = _DemoHost()
+    w = FMControlWidget(microscope=build_microscope(), parent=host)
+    w.fm.objective.insert()
+    w.channelSettingsWidget.channel_settings = [
+        ChannelSettings(name="one", excitation_wavelength=365.0),
+        ChannelSettings(name="two", excitation_wavelength=450.0),
+        ChannelSettings(name="three", excitation_wavelength=550.0),
+    ]
+    yield w
+    w.close()
+    w.deleteLater()
+    qapp.processEvents()
+
+
+@pytest.fixture()
+def started(monkeypatch, widget):
+    """Capture what the acquisition worker would be started with, without running it."""
+    calls = []
+
+    class _Worker:
+        def __init__(self, fn, *args):
+            calls.append(args)
+
+        def start(self):
+            widget.fm.set_acquiring(False)
+
+    monkeypatch.setattr(module, "FunctionWorker", _Worker)
+    monkeypatch.setattr(
+        widget, "_generate_acquisition_filename", lambda name: f"/tmp/{name}.ome.tiff"
+    )
+    return calls
+
+
+def test_acquire_image_takes_every_channel_on_one_plane(widget, started):
+    widget.pushButton_acquire_single_image.click()
+    assert len(started) == 1
+    channels, zparams, filename = started[0]
+    assert [c.name for c in channels] == ["one", "two", "three"]
+    assert zparams is None
+    assert filename.endswith("image.ome.tiff")
+
+
+def test_acquire_z_stack_takes_the_same_channels_with_planes(widget, started):
+    widget.pushButton_acquire_zstack.click()
+    channels, zparams, filename = started[0]
+    assert [c.name for c in channels] == ["one", "two", "three"]
+    assert zparams is not None
+    assert filename.endswith("z-stack.ome.tiff")
+
+
+def test_the_live_view_still_streams_the_selected_channel(widget, monkeypatch):
+    streamed = []
+    monkeypatch.setattr(
+        widget.fm,
+        "start_acquisition",
+        lambda channel_settings: streamed.append(channel_settings),
+    )
+    channels = widget.channelSettingsWidget.channel_settings
+    widget.channelSettingsWidget._list._set_selected(channels[1])
+    widget.toggle_acquisition()
+    assert [c.name for c in streamed] == ["two"]

--- a/tests/ui/test_fm_image_viewer_menu.py
+++ b/tests/ui/test_fm_image_viewer_menu.py
@@ -1,0 +1,71 @@
+"""The Fluorescence Image Viewer opens from the View menu, with or without an
+experiment (FIB-942).
+
+It used to sit on the Development menu, hidden unless dev mode was on, and refused to
+open without an experiment loaded, so the user guide could not say where it was. It
+is a file viewer: the experiment only chooses which folder Load opens in.
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt5.QtWidgets import QApplication
+
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture(scope="module")
+def main_ui(qapp):
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as module
+
+    window = module.AutoLamellaSingleWindowUI()
+    yield window
+    # closeEvent ends in app.quit(); on the shared test QApplication that latches an
+    # interrupt every later QEventLoop.exec_() returns from. Stub it for the close.
+    original_quit = qapp.quit
+    qapp.quit = lambda: None
+    try:
+        window.close()
+    finally:
+        qapp.quit = original_quit
+
+
+def _menu_titles(window, title):
+    menu = next(a.menu() for a in window.menuBar().actions() if a.text() == title)
+    return [a.text() for a in menu.actions() if a.text()]
+
+
+def test_the_viewer_is_on_the_view_menu(main_ui):
+    assert "Fluorescence Image Viewer..." in _menu_titles(main_ui, "View")
+
+
+def test_and_no_longer_on_the_development_menu(main_ui):
+    assert not any("Image Viewer" in t for t in _menu_titles(main_ui, "Development"))
+
+
+def test_it_opens_without_an_experiment(main_ui, qapp, monkeypatch):
+    ui = main_ui.autolamella_ui
+    assert ui.experiment is None
+    toasts = []
+    from fibsem.applications.autolamella.ui import AutoLamellaUI as module
+
+    monkeypatch.setattr(
+        module.notification_service, "show_toast", lambda *a, **k: toasts.append(a)
+    )
+    main_ui.action_open_fm_image_viewer.trigger()
+    qapp.processEvents()
+    window = ui._fm_image_viewer_window
+    try:
+        assert window is not None and window.isVisible()
+        assert toasts == []
+        assert os.path.isdir(window.start_directory)
+    finally:
+        window.close()


### PR DESCRIPTION
Closes FIB-942 and FIB-943, both found writing the Fluorescence page of the user guide.

**FIB-942** The Fluorescence Image Viewer was only on the Development menu (hidden unless dev mode is on) and refused to open without an experiment, so the guide could not say where to find it. It is a file viewer, so it moves to **View → Fluorescence Image Viewer...** and opens regardless; the experiment only chooses the folder Load starts in (open experiment → most recent experiment's folder → log directory).

**FIB-943** Acquire Image took the selected channel only, so the only route to one image with all its channels was a two-plane z-stack. Both acquire buttons now take every channel in the list, the z-stack one adding the planes. The selected channel is what the live view streams, unchanged.

Tests: `tests/ui/test_fm_image_viewer_menu.py` (on View, not on Development, opens with no experiment and a real start directory) and `tests/ui/test_fm_acquire_image_channels.py` (image = all channels/no planes, z-stack = all channels/planes, live = selected). The harness's fluorescence page photographs the View menu and composes the four-channel image from Acquire Image; site PR to follow with the re-rendered page.