### PR TITLE
[ui] Milling stages: header over the rows, list sized to them, count as a chip

### DIFF
--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -657,9 +657,17 @@ class TitledPanel(QWidget):
         Capped to the header's height: a stock QPushButton is 30px and would
         otherwise grow the header, so it becomes a compact header button instead.
         """
-        widget.setMaximumHeight(_PANEL_HEADER_HEIGHT)
+        # Cap, never raise: a widget that fixed itself smaller (a 14px chip) keeps
+        # that, and is centred rather than stretched to the header -- which is what
+        # raising its maximum did, and left the chip touching both edges.
+        if widget.minimumHeight() > _PANEL_HEADER_HEIGHT:
+            widget.setMinimumHeight(_PANEL_HEADER_HEIGHT)
+        if widget.maximumHeight() > _PANEL_HEADER_HEIGHT:
+            widget.setMaximumHeight(_PANEL_HEADER_HEIGHT)
         # Insert before the collapse button (always the last item)
-        self._header_layout.insertWidget(self._header_layout.count() - 1, widget)
+        self._header_layout.insertWidget(
+            self._header_layout.count() - 1, widget, 0, Qt.AlignVCenter
+        )
 
     def set_content(self, widget: QWidget) -> None:
         """Replace the body content with widget."""
@@ -1029,6 +1037,26 @@ class ElidedLabel(QLabel):
         # draws the elided string, so the stylesheet colour survives.
         if elided != super().text():
             super().setText(elided)
+
+
+def header_chip(text: str, colour: str) -> QLabel:
+    """A `chip` sized for a panel header: 14px tall, 9px text, tinted like the rest.
+
+    For state a header should show while the panel is collapsed -- "on", "off",
+    "3 stages". `chip()` is built for a card or a row and comes out 20px, which in a
+    24px header reads as a button.
+    """
+    rgb = QColor(colour)
+    tint = f"rgba({rgb.red()}, {rgb.green()}, {rgb.blue()}, 0.15)"
+    label = QLabel(text)
+    label.setAlignment(Qt.AlignCenter)
+    style_with_tooltip(
+        label,
+        f"background-color: {tint}; color: {colour};"
+        " padding: 0px 5px; border-radius: 7px; font-size: 9px;",
+    )
+    label.setFixedHeight(14)
+    return label
 
 
 def chip(text: str, colour: str, font_size: int = 11) -> QLabel:

--- a/fibsem/ui/widgets/milling_stage_list_widget.py
+++ b/fibsem/ui/widgets/milling_stage_list_widget.py
@@ -49,6 +49,7 @@ _DRAG_WIDTH = DRAG_HANDLE_WIDTH
 # Icon buttons, not 32px: two per row was 64px of chrome in a row that has ~500px.
 _BTN_SIZE = QSize(24, 24)
 _ROW_HEIGHT = 40
+_MAX_VISIBLE_ROWS = 8  # beyond this the list scrolls rather than growing
 
 
 def _add_flex_column(layout: QHBoxLayout, widget: QWidget, spec: tuple) -> None:
@@ -383,12 +384,17 @@ class _MillingStageListHeader(QWidget):
         self.setStyleSheet(f"background: {CANVAS_BG};")
 
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(4, 4, 4, 4)
+        # 8px, not the row's 4px: the list insets each row's widget by 4px on both
+        # sides, so this puts the header's cells over the rows' cells exactly, and
+        # gives the flexible columns the same width to share.
+        layout.setContentsMargins(8, 4, 8, 4)
         layout.setSpacing(4)
 
         # Header mirrors the row cell-for-cell so columns stay aligned: a no-text
         # select-all checkbox (matches the row checkbox), then one flexible label
-        # per column using the SAME (min, stretch) spec as the rows.
+        # per column using the SAME (min, stretch) spec as the rows. Each label is
+        # padded on the left by the inset of its column's control text: a combo or
+        # spinbox starts its text 8px in, the name edit 3px.
         self.checkbox_all = QCheckBox()
         self.checkbox_all.setChecked(True)
         self.checkbox_all.setToolTip("Enable/disable all stages")
@@ -406,7 +412,10 @@ class _MillingStageListHeader(QWidget):
             ("Strategy", _COL_STRATEGY),
         ]:
             lbl = QLabel(label_text)
-            lbl.setStyleSheet("font-weight: bold; background: transparent;")
+            text_inset = 3 if label_text == "Stage" else 8
+            lbl.setStyleSheet(
+                f"font-weight: bold; background: transparent; padding-left: {text_inset}px;"
+            )
             _add_flex_column(layout, lbl, spec)
             if label_text == "Pattern":
                 self.lbl_pattern = lbl  # toggled with the pattern column (eye button)
@@ -415,13 +424,9 @@ class _MillingStageListHeader(QWidget):
                     lbl  # retitled "Preset" on backends that mill by preset
                 )
 
-        # trailing spacer matches the row's color+remove+drag vs the header's eye+add,
-        # so the strategy column's right edge lines up with the rows
-        spacer = QWidget()
-        spacer.setFixedWidth(_DRAG_WIDTH)
-        spacer.setStyleSheet("background: transparent;")
-        layout.addWidget(spacer)
-
+        # eye + add sit over the row's colour + remove, and a spacer the width of
+        # the row's drag handle follows them, so the strategy column's right edge
+        # and the buttons both line up with the rows
         self.btn_eye = IconToolButton(
             icon="mdi:eye",
             checked_icon="mdi:eye-off",
@@ -436,6 +441,10 @@ class _MillingStageListHeader(QWidget):
             icon="mdi:plus", tooltip="Add milling stage", size=_BTN_SIZE.width()
         )
         layout.addWidget(self.btn_add)
+        spacer = QWidget()
+        spacer.setFixedWidth(_DRAG_WIDTH)
+        spacer.setStyleSheet("background: transparent;")
+        layout.addWidget(spacer)
 
         self.checkbox_all.stateChanged.connect(
             lambda s: self.select_all_changed.emit(bool(s))
@@ -499,7 +508,8 @@ class MillingStageListWidget(QWidget):
         self._list.setDragDropMode(QAbstractItemView.InternalMove)
         self._list.setDefaultDropAction(Qt.MoveAction)
         self._list.setSpacing(0)
-        self._list.setMinimumHeight(3 * _ROW_HEIGHT)
+        # Sized to its rows (see _update_empty_state): QListWidget's default size
+        # hint is 256px, which left a band of nothing under three stages.
         self._list.setStyleSheet(stylesheets.LIST_WIDGET_STYLESHEET)
         self._list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         # Adjust, not the default Fixed: in Fixed mode a row keeps the geometry it
@@ -655,6 +665,10 @@ class MillingStageListWidget(QWidget):
     def _update_empty_state(self) -> None:
         empty = self._list.count() == 0
         self._empty_label.setVisible(empty)
+        self._list.setVisible(not empty)
+        # Exactly as tall as its rows, up to a screenful; past that it scrolls.
+        rows = min(self._list.count(), _MAX_VISIBLE_ROWS)
+        self._list.setFixedHeight(rows * _ROW_HEIGHT + 2 * self._list.frameWidth())
 
     def _on_add_stage(self) -> None:
         count = self._list.count()

--- a/fibsem/ui/widgets/milling_task_config_widget2.py
+++ b/fibsem/ui/widgets/milling_task_config_widget2.py
@@ -18,7 +18,12 @@ from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.tasks import FibsemMillingTaskConfig
 from fibsem.ui import stylesheets
 from fibsem.ui.icon import fibsem_icon
-from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel, ValueSpinBox
+from fibsem.ui.widgets.custom_widgets import (
+    IconToolButton,
+    TitledPanel,
+    ValueSpinBox,
+    header_chip,
+)
 from fibsem.ui.widgets.milling_alignment_widget import FibsemMillingAlignmentWidget
 from fibsem.ui.widgets.milling_stages_widget import FibsemMillingStagesWidget
 from fibsem.ui.widgets.milling_task_acquisition_settings_widget import (
@@ -180,15 +185,15 @@ class MillingTaskConfigWidget2(QWidget):
         self.milling_stages_widget = FibsemMillingStagesWidget(
             microscope=self.microscope, stages=[]
         )
-        self._btn_stage_count = IconToolButton(
-            icon="mdi:numeric-0-box-outline", size=32
-        )
-        self._btn_stage_count.setEnabled(False)
+        # How many stages are enabled, readable with the panel collapsed. Text
+        # rather than the digit-in-a-box icon it used to be, which looked like a
+        # disabled button and stopped at 9.
+        self._stage_count_chip = header_chip("0 stages", stylesheets.ACCENT_COLOR)
 
         milling_panel = TitledPanel(
             "Milling Stages", content=self.milling_stages_widget
         )
-        milling_panel.add_header_widget(self._btn_stage_count)
+        milling_panel.add_header_widget(self._stage_count_chip)
         milling_panel._btn_collapse.setChecked(True)
         layout.addWidget(milling_panel)
 
@@ -233,15 +238,10 @@ class MillingTaskConfigWidget2(QWidget):
     # ------------------------------------------------------------------
 
     def _update_stage_count_icon(self, n: int) -> None:
-        icon_name = (
-            "mdi:numeric-9-plus-box-outline"
-            if n > 9
-            else f"mdi:numeric-{n}-box-outline"
+        self._stage_count_chip.setText(f"{n} stage{'s' if n != 1 else ''}")
+        self._stage_count_chip.setToolTip(
+            f"{n} enabled milling stage{'s' if n != 1 else ''}"
         )
-        self._btn_stage_count.setIcon(
-            fibsem_icon(icon_name, color=stylesheets.GRAY_ICON_COLOR)
-        )
-        self._btn_stage_count.setToolTip(f"{n} stage{'s' if n != 1 else ''}")
 
     def _emit_settings_changed(self) -> None:
         self.settings_changed.emit(self.get_settings())
@@ -312,7 +312,8 @@ class MillingTaskConfigWidget2(QWidget):
         self.alignment_widget.update_from_settings(settings.alignment)
         self.acquisition_widget.update_from_settings(settings.acquisition)
         self.milling_stages_widget.set_stages(settings.stages)
-        self._update_stage_count_icon(len(settings.stages))
+        # enabled stages, as the change handler counts them; loading used to count all
+        self._update_stage_count_icon(len([s for s in settings.stages if s.enabled]))
         self.blockSignals(False)
         self._on_alignment_checkbox_changed(
             settings.alignment.enabled

--- a/tests/ui/test_titled_panel_header_widgets.py
+++ b/tests/ui/test_titled_panel_header_widgets.py
@@ -1,0 +1,52 @@
+"""What a TitledPanel does with the widgets handed to its header.
+
+The header is a fixed 24px. A widget taller than that is capped to fit; a widget
+that sized itself smaller keeps its size and sits centred. The second half used to
+be wrong: `add_header_widget` raised every widget's maximum to 24px and the layout
+stretched it, so a 14px chip filled the header and touched both edges.
+"""
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtCore import QPoint  # noqa: E402
+from PyQt5.QtWidgets import QApplication, QLabel, QPushButton  # noqa: E402
+
+from fibsem.ui.widgets.custom_widgets import TitledPanel, header_chip  # noqa: E402
+
+
+@pytest.fixture
+def qapp():
+    yield QApplication.instance() or QApplication([])
+
+
+def _panel_with(widget):
+    panel = TitledPanel("Panel", content=QLabel("body"))
+    panel.add_header_widget(widget)
+    panel.resize(300, 100)
+    panel.show()
+    QApplication.processEvents()
+    return panel
+
+
+def test_a_small_header_widget_keeps_its_height_and_is_centred(qapp):
+    chip = header_chip("on", "#50a6ff")
+    panel = _panel_with(chip)
+
+    assert chip.height() == 14
+    top = chip.mapTo(panel._header, QPoint(0, 0)).y()
+    assert top == (panel._header.height() - chip.height()) // 2
+
+
+def test_a_tall_header_widget_is_capped_to_the_header(qapp):
+    """A stock push button wants ~30px under the app stylesheet; the header
+    caps it at 24px. Without the stylesheet it is shorter, so assert the cap and
+    the centring rather than an exact height."""
+    button = QPushButton("Advanced")
+    button.setMinimumHeight(30)  # what the app stylesheet would give it
+    panel = _panel_with(button)
+
+    assert panel._header.height() == 24
+    assert button.height() <= 24
+    assert button.maximumHeight() == 24


### PR DESCRIPTION
## Summary

First of two PRs on the Lamella editor's settings widgets. Three defects in the Milling Stages panel and one in TitledPanel, no design change.

- **Header over the rows.** The header sat 4 px left of every column and its eye/add buttons 18 px right of the rows' colour/remove. The list insets each row widget by 4 px, and the header's drag-handle spacer stood before its buttons instead of after. The header now uses 8 px margins, puts the spacer last, and pads each label by its column's control text inset (8 px for combos and the spinbox, 3 px for the name edit). Measured after: every header cell has the same x as the row cell beneath it.
- **List sized to its rows.** The list took `QListWidget`'s default 256 px size hint, leaving a band of nothing under three stages. It is now exactly its rows' height, up to eight, then scrolls.
- **Count as a chip.** The enabled-stage count was a disabled 32 px icon button showing a digit in a box, capped at 9. It is a 14 px header chip reading "3 stages". Loading a config counted every stage while the change handler counted enabled ones; both count enabled now.
- **TitledPanel stretched small header widgets.** `add_header_widget` raised every widget's maximum height to 24 px and the layout stretched it, so a 14 px chip filled the header and touched both edges. It now only caps a widget taller than the header and centres what it is handed. `header_chip()` is the chip for that slot.

## Verification

- `tests/ui/test_titled_panel_header_widgets.py` (new, on CI): a 14 px chip keeps its height and is centred; a push button is still capped to 24 px.
- 419 tests pass across the stage list, select-all sync, workflow-load warnings, milling viewer and config widget, correlation tab and FM overview suites, all of which build panels with header widgets.
- Rendered the Lamella editor with a real experiment and checked the milling section by eye.
- Lint and format-check clean.
