### PR TITLE
[ui] One label column for every form in the Lamella editor

### DIFF
--- a/fibsem/applications/autolamella/ui/autolamella_task_config_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_widget.py
@@ -68,13 +68,16 @@ def resolve_field_types(config: Any) -> Dict[str, Any]:
 @dataclass
 class _Row:
     """One built form row."""
+
     label: QLabel
     control: Control
     field: str
     advanced: bool
 
 
-def build_parameter_rows(config: AutoLamellaTaskConfig, grid: QGridLayout) -> List[_Row]:
+def build_parameter_rows(
+    config: AutoLamellaTaskConfig, grid: QGridLayout
+) -> List[_Row]:
     """Fill *grid* with a control per configurable parameter, and return the rows.
 
     Shared by both containers in this module, which each carried their own copy
@@ -119,11 +122,14 @@ def build_parameter_rows(config: AutoLamellaTaskConfig, grid: QGridLayout) -> Li
 
 class AutoLamellaTaskConfigWidget(QWidget):
     """Widget for configuring AutoLamella task parameters."""
-    
+
     config_changed = pyqtSignal(AutoLamellaTaskConfig)
-    
-    def __init__(self, task_config: Optional[AutoLamellaTaskConfig] = None, 
-                 parent: Optional[QWidget] = None):
+
+    def __init__(
+        self,
+        task_config: Optional[AutoLamellaTaskConfig] = None,
+        parent: Optional[QWidget] = None,
+    ):
         super().__init__(parent)
         self.task_config = task_config
         self._rows: List[_Row] = []
@@ -141,18 +147,20 @@ class AutoLamellaTaskConfigWidget(QWidget):
 
         # Create collapsible section for task parameters
         self.task_params_collapsible = QCollapsible("Task Parameters", self)
-        
+
         # Create content widget for parameters
         self.params_widget = QWidget()
         self.grid_layout = QGridLayout(self.params_widget)
-        
+
         self.task_params_collapsible.addWidget(self.params_widget)
 
         # Create collapsible section for milling parameters
         self.milling_params_collapsible = QCollapsible("Milling Task Parameters", self)
 
         # initialise milling_task_widget
-        microscope, settings = utils.setup_session()  # TODO: pass in from the parent if available...
+        microscope, settings = (
+            utils.setup_session()
+        )  # TODO: pass in from the parent if available...
         self.milling_task_widget = MillingTaskViewerWidget(
             microscope=microscope,
             milling_enabled=False,
@@ -161,11 +169,13 @@ class AutoLamellaTaskConfigWidget(QWidget):
         self.milling_task_widget.setMinimumHeight(600)
         self.milling_params_collapsible.addWidget(self.milling_task_widget)
 
-        self.main_layout.addWidget(self.task_params_collapsible)    # type: ignore
-        self.main_layout.addWidget(self.milling_params_collapsible) # type: ignore
+        self.main_layout.addWidget(self.task_params_collapsible)  # type: ignore
+        self.main_layout.addWidget(self.milling_params_collapsible)  # type: ignore
 
         # Connect milling widget signals
-        self.milling_task_widget.settings_changed.connect(self._on_milling_config_updated)
+        self.milling_task_widget.settings_changed.connect(
+            self._on_milling_config_updated
+        )
 
         self.main_layout.addStretch()
 
@@ -173,7 +183,7 @@ class AutoLamellaTaskConfigWidget(QWidget):
         """Set the task configuration to edit."""
         self.task_config = task_config
         self._update_from_config()
-        
+
     def _update_from_config(self):
         """Update the UI from the current task configuration."""
         if not self.task_config:
@@ -188,8 +198,8 @@ class AutoLamellaTaskConfigWidget(QWidget):
                 # it up would let a focus-out write the displayed text back.
                 if row.control.editable:
                     row.control.connect(
-                    lambda name=row.field: self._on_parameter_changed(name)
-                )
+                        lambda name=row.field: self._on_parameter_changed(name)
+                    )
             self._update_visibility()
             self.task_params_collapsible.show()
         else:
@@ -198,7 +208,9 @@ class AutoLamellaTaskConfigWidget(QWidget):
         # Show/hide milling parameters section
         if self.task_config.milling:
             self._current_milling_key = next(iter(self.task_config.milling))
-            self.milling_task_widget.set_config(self.task_config.milling[self._current_milling_key])
+            self.milling_task_widget.set_config(
+                self.task_config.milling[self._current_milling_key]
+            )
             self.milling_params_collapsible.show()
         else:
             self._current_milling_key = None
@@ -225,8 +237,8 @@ class AutoLamellaTaskConfigWidget(QWidget):
 
     def _on_milling_config_updated(self, milling_config):
         """Handle milling task config updates."""
-        if self.task_config and hasattr(self.task_config, 'milling'):
-            key = getattr(self, '_current_milling_key', None)
+        if self.task_config and hasattr(self.task_config, "milling"):
+            key = getattr(self, "_current_milling_key", None)
             if key and self.task_config.milling is not None:
                 self.task_config.milling[key] = milling_config
 
@@ -246,7 +258,6 @@ class AutoLamellaTaskConfigWidget(QWidget):
             if child and child.widget():
                 child.widget().setParent(None)
 
-    
     def get_task_config(self) -> Optional[AutoLamellaTaskConfig]:
         """Get the current task configuration."""
         return self.task_config
@@ -262,8 +273,11 @@ class AutoLamellaTaskParametersConfigWidget(QWidget):
     config_changed = pyqtSignal(AutoLamellaTaskConfig)
     parameter_changed = pyqtSignal(str, object)  # field name, new value
 
-    def __init__(self, task_config: Optional[AutoLamellaTaskConfig] = None,
-                 parent: Optional[QWidget] = None):
+    def __init__(
+        self,
+        task_config: Optional[AutoLamellaTaskConfig] = None,
+        parent: Optional[QWidget] = None,
+    ):
         super().__init__(parent)
         self.task_config = task_config
         self._rows: List[_Row] = []

--- a/fibsem/applications/autolamella/ui/autolamella_task_config_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_widget.py
@@ -30,7 +30,7 @@ from superqt import QCollapsible
 
 from fibsem import utils
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
-from fibsem.ui.widgets.custom_widgets import TitledPanel
+from fibsem.ui.widgets.custom_widgets import TitledPanel, align_form
 from fibsem.ui.widgets.form_builder import Control, FormDefaults, build_control
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
 
@@ -151,6 +151,7 @@ class AutoLamellaTaskConfigWidget(QWidget):
         # Create content widget for parameters
         self.params_widget = QWidget()
         self.grid_layout = QGridLayout(self.params_widget)
+        align_form(self.grid_layout)
 
         self.task_params_collapsible.addWidget(self.params_widget)
 
@@ -294,6 +295,7 @@ class AutoLamellaTaskParametersConfigWidget(QWidget):
 
         self.params_widget = QWidget()
         self.grid_layout = QGridLayout(self.params_widget)
+        align_form(self.grid_layout)
         self.params_panel = TitledPanel("Task Parameters", content=self.params_widget)
         self.params_panel._btn_collapse.setChecked(True)
 

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -15,6 +15,8 @@ from PyQt5.QtWidgets import (
     QComboBox,
     QDoubleSpinBox,
     QFileDialog,
+    QFormLayout,
+    QGridLayout,
     QHBoxLayout,
     QLabel,
     QLineEdit,
@@ -1037,6 +1039,31 @@ class ElidedLabel(QLabel):
         # draws the elided string, so the stylesheet colour survives.
         if elided != super().text():
             super().setText(elided)
+
+
+# One label column for every settings form in a column of panels, so the controls
+# line up from panel to panel. Wide enough for "Reacquire Alignment Reference".
+FORM_LABEL_WIDTH = 150
+
+
+def align_form(layout) -> None:
+    """Give *layout* the shared label column: labels FORM_LABEL_WIDTH, fields the rest.
+
+    Forms in the editor column used to size their label column each to their own
+    longest label, or split the width in half, so reading down the column no two
+    panels lined their controls up. Works on a QGridLayout (labels in column 0)
+    and a QFormLayout (labels in the label role); call it after the rows exist for
+    a form that is rebuilt.
+    """
+    if isinstance(layout, QGridLayout):
+        layout.setColumnMinimumWidth(0, FORM_LABEL_WIDTH)
+        layout.setColumnStretch(1, 1)
+    elif isinstance(layout, QFormLayout):
+        layout.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+        for row in range(layout.rowCount()):
+            item = layout.itemAt(row, QFormLayout.LabelRole)
+            if item is not None and item.widget() is not None:
+                item.widget().setMinimumWidth(FORM_LABEL_WIDTH)
 
 
 def header_chip(text: str, colour: str) -> QLabel:

--- a/fibsem/ui/widgets/image_settings_widget.py
+++ b/fibsem/ui/widgets/image_settings_widget.py
@@ -52,10 +52,13 @@ WIDGET_CONFIG = {
 class ImageSettingsWidget(QWidget):
     settings_changed = pyqtSignal(ImageSettings)
 
-    def __init__(self, parent: Optional[QWidget] = None,
-                 show_advanced: bool = False,
-                 show_save: bool = False,
-                 always_save: bool = False):
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        show_advanced: bool = False,
+        show_save: bool = False,
+        always_save: bool = False,
+    ):
         """Initialize the ImageSettings widget.
 
         Args:
@@ -201,7 +204,9 @@ class ImageSettingsWidget(QWidget):
         # Path
         self.path_label = QLabel("Path")
         self.path_edit = QDirectoryLineEdit()
-        self.path_edit.button_browse.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
+        self.path_edit.button_browse.setStyleSheet(
+            stylesheets.TOOLBUTTON_ICON_STYLESHEET
+        )
         layout.addWidget(self.path_label, 9, 0)
         layout.addWidget(self.path_edit, 9, 1)
 
@@ -212,9 +217,12 @@ class ImageSettingsWidget(QWidget):
         layout.addWidget(self.filename_edit, 10, 1)
 
         self._save_widgets: list[QWidget] = [
-            self.save_image_label, self.save_image_check,
-            self.path_label, self.path_edit,
-            self.filename_label, self.filename_edit,
+            self.save_image_label,
+            self.save_image_check,
+            self.path_label,
+            self.path_edit,
+            self.filename_label,
+            self.filename_edit,
         ]
 
     def _connect_signals(self):
@@ -273,7 +281,12 @@ class ImageSettingsWidget(QWidget):
         """Enable/disable path and filename controls based on save_image checkbox."""
         enabled = self.save_image_check.isChecked()
         tooltip = "" if enabled else "Enable 'Save Image' to set path/filename"
-        for w in [self.path_label, self.path_edit, self.filename_label, self.filename_edit]:
+        for w in [
+            self.path_label,
+            self.path_edit,
+            self.filename_label,
+            self.filename_edit,
+        ]:
             w.setEnabled(enabled)
             w.setToolTip(tooltip)
 
@@ -282,7 +295,12 @@ class ImageSettingsWidget(QWidget):
         if self._always_save:
             self.save_image_label.setVisible(False)
             self.save_image_check.setVisible(False)
-            for w in [self.path_label, self.path_edit, self.filename_label, self.filename_edit]:
+            for w in [
+                self.path_label,
+                self.path_edit,
+                self.filename_label,
+                self.filename_edit,
+            ]:
                 w.setVisible(True)
                 w.setEnabled(True)
         else:
@@ -329,7 +347,9 @@ class ImageSettingsWidget(QWidget):
         """
         return self._show_advanced
 
-    def set_available_resolutions(self, resolutions: list, default: str | None = None) -> None:
+    def set_available_resolutions(
+        self, resolutions: list, default: str | None = None
+    ) -> None:
         """Replace the resolution combo items with a custom list.
 
         Args:
@@ -396,14 +416,18 @@ class ImageSettingsWidget(QWidget):
 
         # Update only the fields controlled by this widget
         self._settings.resolution = tuple(resolution) if resolution else (1536, 1024)
-        self._settings.dwell_time = self.dwell_time_spinbox.value() * MICRO_TO_SI  # Convert μs to s
+        self._settings.dwell_time = (
+            self.dwell_time_spinbox.value() * MICRO_TO_SI
+        )  # Convert μs to s
         self._settings.hfw = self.hfw_spinbox.value() * MICRO_TO_SI  # Convert μm to m
         self._settings.autocontrast = self.autocontrast_check.isChecked()
         self._settings.line_integration = line_integration
         self._settings.scan_interlacing = scan_interlacing
         self._settings.frame_integration = frame_integration
         self._settings.drift_correction = self.drift_correction_check.isChecked()
-        self._settings.save = True if self._always_save else self.save_image_check.isChecked()
+        self._settings.save = (
+            True if self._always_save else self.save_image_check.isChecked()
+        )
         self._settings.path = self.path_edit.text() or None
         self._settings.filename = self.filename_edit.text()
 

--- a/fibsem/ui/widgets/image_settings_widget.py
+++ b/fibsem/ui/widgets/image_settings_widget.py
@@ -24,7 +24,11 @@ from fibsem.ui.tokens import (
     NEUTRAL_400,
 )
 from fibsem.ui.utils import install_wheel_blocker
-from fibsem.ui.widgets.custom_widgets import IconToolButton, QDirectoryLineEdit
+from fibsem.ui.widgets.custom_widgets import (
+    IconToolButton,
+    QDirectoryLineEdit,
+    align_form,
+)
 
 # GUI Configuration Constants
 WIDGET_CONFIG = {
@@ -111,6 +115,7 @@ class ImageSettingsWidget(QWidget):
         grid_widget = QWidget()
         layout = QGridLayout(grid_widget)
         layout.setContentsMargins(0, 0, 0, 0)
+        align_form(layout)
         outer_layout.addWidget(grid_widget)
 
         # Resolution

--- a/fibsem/ui/widgets/milling_alignment_widget.py
+++ b/fibsem/ui/widgets/milling_alignment_widget.py
@@ -9,12 +9,21 @@ from fibsem.ui.widgets.image_settings_widget import ImageSettingsWidget
 
 # GUI Configuration Constants
 WIDGET_CONFIG = {
-    "enabled": {"default": True, "label": "Enable Initial Alignment",
-                "tooltip": "Align between imaging and milling current before starting milling"},
-    "use_contrast": {"default": True, "label": "Use Auto Contrast",
-                     "tooltip": "Autocontrast before acquiring alignment image"},
-    "use_autofocus": {"default": False, "label": "Use Auto Focus",
-                      "tooltip": "Autofocus before acquiring alignment image"},
+    "enabled": {
+        "default": True,
+        "label": "Enable Initial Alignment",
+        "tooltip": "Align between imaging and milling current before starting milling",
+    },
+    "use_contrast": {
+        "default": True,
+        "label": "Use Auto Contrast",
+        "tooltip": "Autocontrast before acquiring alignment image",
+    },
+    "use_autofocus": {
+        "default": False,
+        "label": "Use Auto Focus",
+        "tooltip": "Autofocus before acquiring alignment image",
+    },
     "steps": {"range": (1, 9), "default": 3},
 }
 
@@ -127,7 +136,7 @@ class FibsemMillingAlignmentWidget(QWidget):
 
     def _emit_settings_changed(self):
         """Emit the settings_changed signal with current settings.
-        
+
         Called whenever any control value changes to notify listeners
         of the updated MillingAlignment settings.
         """
@@ -187,7 +196,7 @@ class FibsemMillingAlignmentWidget(QWidget):
 
     def set_show_advanced(self, show_advanced: bool):
         """Set the visibility of advanced settings.
-        
+
         Args:
             show_advanced: True to show advanced settings, False to hide them
         """
@@ -196,14 +205,14 @@ class FibsemMillingAlignmentWidget(QWidget):
 
     def toggle_advanced(self):
         """Toggle the visibility of advanced settings.
-        
+
         Switches between showing and hiding the advanced controls.
         """
         self.set_show_advanced(not self._show_advanced)
 
     def get_show_advanced(self) -> bool:
         """Get the current advanced settings visibility state.
-        
+
         Returns:
             True if advanced settings are currently visible, False otherwise
         """

--- a/fibsem/ui/widgets/milling_alignment_widget.py
+++ b/fibsem/ui/widgets/milling_alignment_widget.py
@@ -4,6 +4,7 @@ from PyQt5.QtWidgets import QCheckBox, QGridLayout, QLabel, QSpinBox, QWidget
 from fibsem.structures import MillingAlignment
 from fibsem.ui.widgets.custom_widgets import (
     IntegerValueSpinBox,
+    align_form,
 )
 from fibsem.ui.widgets.image_settings_widget import ImageSettingsWidget
 
@@ -61,7 +62,9 @@ class FibsemMillingAlignmentWidget(QWidget):
         and alignment imaging settings widget.
         """
         layout = QGridLayout()
+        layout.setContentsMargins(4, 4, 4, 4)  # as the other forms in the column
         self.setLayout(layout)
+        align_form(layout)
 
         # Enabled checkbox
         enabled_config = WIDGET_CONFIG["enabled"]

--- a/fibsem/ui/widgets/milling_settings_widget.py
+++ b/fibsem/ui/widgets/milling_settings_widget.py
@@ -19,17 +19,18 @@ from fibsem.ui.widgets.form_builder import Control, build_control
 class _Row:
     """One built form row. `mfr` is this form's own twist: a field declared for
     one manufacturer is hidden on the others."""
+
     label: QLabel
     control: Control
     field: str
     advanced: bool
     mfr: Optional[str]
 
+
 _META = FibsemMillingSettings().field_metadata
 
 # Fields hidden from UI — derived from metadata (hidden=True), not hardcoded
 _HIDDEN_FIELDS = {name for name, m in _META.items() if m.get("hidden", False)}
-
 
 
 class FibsemMillingSettingsWidget(QWidget):

--- a/fibsem/ui/widgets/milling_settings_widget.py
+++ b/fibsem/ui/widgets/milling_settings_widget.py
@@ -12,6 +12,7 @@ from PyQt5.QtWidgets import (
 
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, FibsemMillingSettings
+from fibsem.ui.widgets.custom_widgets import align_form
 from fibsem.ui.widgets.form_builder import Control, build_control
 
 
@@ -88,6 +89,8 @@ class FibsemMillingSettingsWidget(QWidget):
                     mfr=m.get("manufacturer"),
                 )
             )
+
+        align_form(layout)
 
     def _dynamic_items(self, parameter: str):
         """Resolve an `items: "dynamic"` field against the microscope."""

--- a/fibsem/ui/widgets/milling_task_config_widget2.py
+++ b/fibsem/ui/widgets/milling_task_config_widget2.py
@@ -22,6 +22,7 @@ from fibsem.ui.widgets.custom_widgets import (
     IconToolButton,
     TitledPanel,
     ValueSpinBox,
+    align_form,
     header_chip,
 )
 from fibsem.ui.widgets.milling_alignment_widget import FibsemMillingAlignmentWidget
@@ -87,12 +88,16 @@ class MillingTaskConfigWidget2(QWidget):
         # scrolling wraps this widget -- see `scrollable`.
         content_widget = QWidget()
         layout = QVBoxLayout(content_widget)
+        # No margin of its own: the panels below sit flush with the other panels in
+        # the column that hosts this widget, rather than inset by Qt's default 11px.
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
         main_layout.addWidget(content_widget)
 
         # ── Core panel ──────────────────────────────────────────────
         core_content = QWidget()
         core_grid = QGridLayout(core_content)
-        core_grid.setContentsMargins(0, 0, 0, 0)
+        core_grid.setContentsMargins(4, 4, 4, 4)  # as the other forms in the column
 
         self.name_edit = QLineEdit()
         self.name_edit.setText(_WIDGET_CONFIG["name"]["default"])
@@ -117,7 +122,7 @@ class MillingTaskConfigWidget2(QWidget):
         core_grid.addWidget(QLabel("Field of View"), 1, 0)
         core_grid.addWidget(self.field_of_view_spinbox, 1, 1)
         core_grid.addWidget(self.label_instructions, 2, 0, 1, 2)
-        core_grid.setColumnStretch(1, 1)
+        align_form(core_grid)
 
         self.core_panel = TitledPanel("Milling Parameters", content=core_content)
         self.core_panel._btn_collapse.setChecked(True)

--- a/fibsem/ui/widgets/pattern_settings_widget.py
+++ b/fibsem/ui/widgets/pattern_settings_widget.py
@@ -24,6 +24,7 @@ from fibsem.ui.widgets.form_builder import Control, build_control
 @dataclass
 class _Row:
     """One built form row: the label, the control, and whether it is advanced."""
+
     label: QLabel
     control: Control
     field: str

--- a/fibsem/ui/widgets/pattern_settings_widget.py
+++ b/fibsem/ui/widgets/pattern_settings_widget.py
@@ -17,7 +17,7 @@ from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.patterning import get_pattern, get_pattern_names
 from fibsem.milling.patterning.patterns2 import BasePattern
 from fibsem.structures import BeamType
-from fibsem.ui.widgets.custom_widgets import ValueComboBox
+from fibsem.ui.widgets.custom_widgets import ValueComboBox, align_form
 from fibsem.ui.widgets.form_builder import Control, build_control
 
 
@@ -69,6 +69,7 @@ class FibsemPatternSettingsWidget(QWidget):
         type_form.setContentsMargins(0, 0, 0, 0)
         self._type_combo = ValueComboBox(get_pattern_names(), value=self._pattern.name)
         type_form.addRow("Pattern:", self._type_combo)
+        align_form(type_form)
         outer.addLayout(type_form)
 
         # Field form — rebuilt on type change
@@ -122,6 +123,7 @@ class FibsemPatternSettingsWidget(QWidget):
                 )
             )
 
+        align_form(self._fields_form)
         self._update_visibility()
 
     def _dynamic_items(self, parameter: str):

--- a/fibsem/ui/widgets/reference_image_parameters_widget.py
+++ b/fibsem/ui/widgets/reference_image_parameters_widget.py
@@ -159,7 +159,9 @@ class ReferenceImageParametersWidget(QWidget):
             checked_tooltip="Hide advanced settings",
         )
 
-        self.imaging_settings_panel = TitledPanel("Imaging Settings", content=self.imaging_widget)
+        self.imaging_settings_panel = TitledPanel(
+            "Imaging Settings", content=self.imaging_widget
+        )
         self.imaging_settings_panel.add_header_widget(self._btn_advanced_imaging)
         self.imaging_settings_panel._btn_collapse.setChecked(True)
 
@@ -175,7 +177,9 @@ class ReferenceImageParametersWidget(QWidget):
         self.acquire_fib_check.toggled.connect(self._on_acquisition_toggled)
         self.acquire_image1_check.toggled.connect(self._on_image1_toggled)
         self.acquire_image2_check.toggled.connect(self._on_image2_toggled)
-        self._btn_advanced_imaging.toggled.connect(self.imaging_widget.set_show_advanced)
+        self._btn_advanced_imaging.toggled.connect(
+            self.imaging_widget.set_show_advanced
+        )
 
         self.imaging_widget.settings_changed.connect(self._emit_settings_changed)
 
@@ -286,8 +290,12 @@ class ReferenceImageParametersWidget(QWidget):
 
         # Update settings
         self._settings.imaging = self.imaging_widget.get_settings()
-        self._settings.field_of_view1 = self.fov1_spinbox.value() * MICRO_TO_SI  # Convert μm to m
-        self._settings.field_of_view2 = self.fov2_spinbox.value() * MICRO_TO_SI  # Convert μm to m
+        self._settings.field_of_view1 = (
+            self.fov1_spinbox.value() * MICRO_TO_SI
+        )  # Convert μm to m
+        self._settings.field_of_view2 = (
+            self.fov2_spinbox.value() * MICRO_TO_SI
+        )  # Convert μm to m
         self._settings.acquire_sem = self.acquire_sem_check.isChecked()
         self._settings.acquire_fib = self.acquire_fib_check.isChecked()
         self._settings.acquire_image1 = self.acquire_image1_check.isChecked()
@@ -313,8 +321,12 @@ class ReferenceImageParametersWidget(QWidget):
         self.acquire_image2_check.blockSignals(True)
 
         # Set field of view values
-        self.fov1_spinbox.setValue(self._settings.field_of_view1 * SI_TO_MICRO)  # Convert m to μm
-        self.fov2_spinbox.setValue(self._settings.field_of_view2 * SI_TO_MICRO)  # Convert m to μm
+        self.fov1_spinbox.setValue(
+            self._settings.field_of_view1 * SI_TO_MICRO
+        )  # Convert m to μm
+        self.fov2_spinbox.setValue(
+            self._settings.field_of_view2 * SI_TO_MICRO
+        )  # Convert m to μm
 
         # Set acquisition options
         self.acquire_sem_check.setChecked(self._settings.acquire_sem)

--- a/fibsem/ui/widgets/reference_image_parameters_widget.py
+++ b/fibsem/ui/widgets/reference_image_parameters_widget.py
@@ -12,7 +12,12 @@ from PyQt5.QtWidgets import (
 from fibsem.constants import MICRO_TO_SI, SI_TO_MICRO
 from fibsem.structures import ReferenceImageParameters
 from fibsem.ui import stylesheets
-from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel, ValueSpinBox
+from fibsem.ui.widgets.custom_widgets import (
+    IconToolButton,
+    TitledPanel,
+    ValueSpinBox,
+    align_form,
+)
 from fibsem.ui.widgets.image_settings_widget import ImageSettingsWidget
 
 # GUI Configuration Constants
@@ -74,6 +79,7 @@ class ReferenceImageParametersWidget(QWidget):
         acq_content = QWidget()
         acq_layout = QGridLayout(acq_content)
         acq_layout.setContentsMargins(4, 4, 4, 4)
+        align_form(acq_layout)
 
         # Beam Type Options
         self.acquire_sem_check = QCheckBox("Acquire SEM")

--- a/fibsem/ui/widgets/strategy_settings_widget.py
+++ b/fibsem/ui/widgets/strategy_settings_widget.py
@@ -25,6 +25,7 @@ from fibsem.ui.widgets.form_builder import Control, build_control
 @dataclass
 class _Row:
     """One built form row: the label, the control, and whether it is advanced."""
+
     label: QLabel
     control: Control
     field: str
@@ -98,7 +99,7 @@ class FibsemStrategySettingsWidget(QWidget):
         locked = strategy.name not in names
         self._type_combo.blockSignals(True)
         self._type_combo.clear()
-        for name in ([strategy.name] if locked else names):
+        for name in [strategy.name] if locked else names:
             self._type_combo.addItem(name, name)
         self._type_combo.set_value(strategy.name)
         self._type_combo.blockSignals(False)

--- a/fibsem/ui/widgets/strategy_settings_widget.py
+++ b/fibsem/ui/widgets/strategy_settings_widget.py
@@ -18,7 +18,7 @@ from fibsem.milling.strategy import get_strategy_names
 from fibsem.ui.tokens import (
     NEUTRAL_700,
 )
-from fibsem.ui.widgets.custom_widgets import ValueComboBox
+from fibsem.ui.widgets.custom_widgets import ValueComboBox, align_form
 from fibsem.ui.widgets.form_builder import Control, build_control
 
 
@@ -72,6 +72,7 @@ class FibsemStrategySettingsWidget(QWidget):
             get_strategy_names(), value=self._strategy.name
         )
         type_form.addRow("Strategy:", self._type_combo)
+        align_form(type_form)
         outer.addLayout(type_form)
 
         # Config field form — rebuilt on type change
@@ -143,6 +144,7 @@ class FibsemStrategySettingsWidget(QWidget):
                 )
             )
 
+        align_form(self._config_form)
         self._empty_label.setVisible(len(self._rows) == 0)
         self._update_visibility()
 


### PR DESCRIPTION
## Summary

Stacked on #827. Second of the settings-widget PRs.

Each settings form in the Lamella editor's column sized its label column its own way: the task parameters to their longest label, the reference-image and imaging forms to half the width, the milling forms to Qt's default. Reading down the column, no two panels lined their controls up, and a "Resolution" label sat beside a half-width combo.

## What changed

- `align_form(layout)` in `custom_widgets`: gives a `QGridLayout` (labels in column 0) or a `QFormLayout` (labels in the label role) the shared column, `FORM_LABEL_WIDTH` = 150 px for labels and the rest for fields. For a form that is rebuilt it is called after the rows exist.
- Every form in the column calls it: task parameters (both containers), reference images, imaging settings, milling parameters, alignment, milling settings, pattern and strategy.
- Two grids kept Qt's default 11 px margins where the rest use 4 px, and the milling config widget inset its whole panel stack by 11 px. Both are 4 px and 0 px now, so the milling panels sit flush with the panels above them.

The first commit is formatting only: seven of the touched files were not yet formatted and CI checks every touched file.

## Verification

- 381 tests pass across every suite that builds these forms (milling settings, config widget, pattern, reference images, spot burn, form writeback, overview, settings widgets, task config parameters, viewer-less widgets, stage list, header widgets); the one failure is the pre-existing `test_layer_controls_menu_survives_a_migrated_tab`.
- Rendered the Lamella editor with a real experiment, every panel expanded and advanced shown; controls start at the same x in every panel.
- Lint and format-check clean.
