### PR TITLE
[ui] Reference Images: one panel, one row per image, a warning only when it matters

### DIFF
--- a/fibsem/ui/widgets/reference_image_parameters_widget.py
+++ b/fibsem/ui/widgets/reference_image_parameters_widget.py
@@ -4,6 +4,7 @@ from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
     QCheckBox,
     QGridLayout,
+    QHBoxLayout,
     QLabel,
     QVBoxLayout,
     QWidget,
@@ -12,6 +13,7 @@ from PyQt5.QtWidgets import (
 from fibsem.constants import MICRO_TO_SI, SI_TO_MICRO
 from fibsem.structures import ReferenceImageParameters
 from fibsem.ui import stylesheets
+from fibsem.ui.tokens import SEMANTIC_WARNING_COLOR
 from fibsem.ui.widgets.custom_widgets import (
     IconToolButton,
     TitledPanel,
@@ -82,23 +84,24 @@ class ReferenceImageParametersWidget(QWidget):
         align_form(acq_layout)
 
         # Beam Type Options
-        self.acquire_sem_check = QCheckBox("Acquire SEM")
+        self.acquire_sem_check = QCheckBox("SEM")  # under a "Beams" row label
         self.acquire_sem_check.setChecked(True)
         self.acquire_sem_check.setToolTip(WIDGET_CONFIG["acquire_sem"]["tooltip"])
 
-        self.acquire_fib_check = QCheckBox("Acquire FIB")
+        self.acquire_fib_check = QCheckBox("FIB")
         self.acquire_fib_check.setChecked(True)
         self.acquire_fib_check.setToolTip(WIDGET_CONFIG["acquire_fib"]["tooltip"])
 
         # Image 1 Options
-        self.acquire_image1_label = QLabel("Acquire Image 1")
-        self.acquire_image1_label.setToolTip(WIDGET_CONFIG["acquire_image1"]["tooltip"])
+        # One row per image: its switch and its field of view together. The row's
+        # label is both the old "Acquire Image 1" and "Field of View 1" labels.
         self.acquire_image1_check = QCheckBox()
         self.acquire_image1_check.setChecked(True)
         self.acquire_image1_check.setToolTip(WIDGET_CONFIG["acquire_image1"]["tooltip"])
 
-        self.fov1_label = QLabel("Field of View 1")
+        self.fov1_label = QLabel("Image 1")
         self.fov1_label.setToolTip(WIDGET_CONFIG["field_of_view1"]["tooltip"])
+        self.acquire_image1_label = self.fov1_label
         fov1_config = WIDGET_CONFIG["field_of_view1"]
         self.fov1_spinbox = ValueSpinBox(
             suffix=fov1_config["suffix"],
@@ -111,14 +114,13 @@ class ReferenceImageParametersWidget(QWidget):
         self.fov1_spinbox.setValue(fov1_config["default"])
 
         # Image 2 Options
-        self.acquire_image2_label = QLabel("Acquire Image 2")
-        self.acquire_image2_label.setToolTip(WIDGET_CONFIG["acquire_image2"]["tooltip"])
         self.acquire_image2_check = QCheckBox()
         self.acquire_image2_check.setChecked(True)
         self.acquire_image2_check.setToolTip(WIDGET_CONFIG["acquire_image2"]["tooltip"])
 
-        self.fov2_label = QLabel("Field of View 2")
+        self.fov2_label = QLabel("Image 2")
         self.fov2_label.setToolTip(WIDGET_CONFIG["field_of_view2"]["tooltip"])
+        self.acquire_image2_label = self.fov2_label
         fov2_config = WIDGET_CONFIG["field_of_view2"]
         self.fov2_spinbox = ValueSpinBox(
             suffix=fov2_config["suffix"],
@@ -130,32 +132,44 @@ class ReferenceImageParametersWidget(QWidget):
         )
         self.fov2_spinbox.setValue(fov2_config["default"])
 
-        # Info/Warning label for acquisition information
-        self.info_label = QLabel()
-        self.info_label.setStyleSheet(stylesheets.LABEL_INSTRUCTIONS_STYLE)
+        # Said only when it matters: no beam or no image selected means the task
+        # acquires nothing. The sentence that restated the settings above is gone.
+        self.info_label = QLabel("No reference images will be acquired.")
+        self.info_label.setStyleSheet(
+            f"color: {SEMANTIC_WARNING_COLOR}; font-size: 11px;"
+        )
         self.info_label.setWordWrap(True)
         self.info_label.setVisible(False)
 
-        # Layout arrangement
-        acq_layout.addWidget(self.acquire_sem_check, 0, 0)
-        acq_layout.addWidget(self.acquire_fib_check, 0, 1)
-        acq_layout.addWidget(self.acquire_image1_label, 1, 0)
-        acq_layout.addWidget(self.acquire_image1_check, 1, 1)
-        acq_layout.addWidget(self.fov1_label, 2, 0)
-        acq_layout.addWidget(self.fov1_spinbox, 2, 1)
-        acq_layout.addWidget(self.acquire_image2_label, 3, 0)
-        acq_layout.addWidget(self.acquire_image2_check, 3, 1)
-        acq_layout.addWidget(self.fov2_label, 4, 0)
-        acq_layout.addWidget(self.fov2_spinbox, 4, 1)
-        acq_layout.addWidget(self.info_label, 5, 0, 1, 2)
-
-        acq_panel = TitledPanel("Acquisition", content=acq_content)
-        acq_panel._btn_collapse.setChecked(True)
-
-        # ── Imaging Settings panel ───────────────────────────────────
+        # The imaging settings continue the same form rather than sitting in a
+        # panel of their own: they describe these images, and a second header
+        # was a lot of weight for three rows.
         self.imaging_widget = ImageSettingsWidget(show_advanced=False, parent=self)
         self.imaging_widget.show_field_of_view(False)
         self.imaging_widget.set_show_advanced_button(False)
+
+        beams = QHBoxLayout()
+        beams.setSpacing(12)
+        beams.addWidget(self.acquire_sem_check)
+        beams.addWidget(self.acquire_fib_check)
+        beams.addStretch()
+        image1 = QHBoxLayout()
+        image1.setSpacing(8)
+        image1.addWidget(self.acquire_image1_check)
+        image1.addWidget(self.fov1_spinbox, 1)
+        image2 = QHBoxLayout()
+        image2.setSpacing(8)
+        image2.addWidget(self.acquire_image2_check)
+        image2.addWidget(self.fov2_spinbox, 1)
+
+        acq_layout.addWidget(QLabel("Beams"), 0, 0)
+        acq_layout.addLayout(beams, 0, 1)
+        acq_layout.addWidget(self.fov1_label, 1, 0)
+        acq_layout.addLayout(image1, 1, 1)
+        acq_layout.addWidget(self.fov2_label, 2, 0)
+        acq_layout.addLayout(image2, 2, 1)
+        acq_layout.addWidget(self.imaging_widget, 3, 0, 1, 2)
+        acq_layout.addWidget(self.info_label, 4, 0, 1, 2)
 
         self._btn_advanced_imaging = IconToolButton(
             icon="mdi:tune",
@@ -165,14 +179,11 @@ class ReferenceImageParametersWidget(QWidget):
             checked_tooltip="Hide advanced settings",
         )
 
-        self.imaging_settings_panel = TitledPanel(
-            "Imaging Settings", content=self.imaging_widget
-        )
-        self.imaging_settings_panel.add_header_widget(self._btn_advanced_imaging)
-        self.imaging_settings_panel._btn_collapse.setChecked(True)
+        self.panel = TitledPanel("Reference Images", content=acq_content)
+        self.panel.add_header_widget(self._btn_advanced_imaging)
+        self.panel._btn_collapse.setChecked(True)
 
-        main_layout.addWidget(acq_panel)
-        main_layout.addWidget(self.imaging_settings_panel)
+        main_layout.addWidget(self.panel)
         main_layout.addStretch()
 
     def _connect_signals(self):
@@ -216,52 +227,15 @@ class ReferenceImageParametersWidget(QWidget):
         self._emit_settings_changed()
 
     def _update_information_text(self):
-        """Update info/warning label based on acquisition settings."""
-        # Check acquisition settings
-        acquire_sem = self.acquire_sem_check.isChecked()
-        acquire_fib = self.acquire_fib_check.isChecked()
-        acquire_image1 = self.acquire_image1_check.isChecked()
-        acquire_image2 = self.acquire_image2_check.isChecked()
-
-        # Check if no beam types are selected
-        no_beams = not acquire_sem and not acquire_fib
-
-        # Check if no images are selected
-        no_images = not acquire_image1 and not acquire_image2
-
-        # Determine if any images will be acquired
-        will_acquire = not (no_beams or no_images)
-
-        # Enable/disable imaging settings based on whether images will be acquired
-        self.imaging_settings_panel.setEnabled(will_acquire)
-
-        # Build message
-        if not will_acquire:
-            # Warning case - no images will be acquired
-            message = "No reference images will be acquired"
-            self.info_label.setVisible(True)
-        else:
-            # Valid acquisition - show what will be acquired
-            # Build beam types string
-            beam_types = []
-            if acquire_sem:
-                beam_types.append("SEM")
-            if acquire_fib:
-                beam_types.append("FIB")
-            beam_str = " and ".join(beam_types)
-
-            # Build FOV string
-            fovs = []
-            if acquire_image1:
-                fovs.append(f"{self.fov1_spinbox.value():.0f}μm")
-            if acquire_image2:
-                fovs.append(f"{self.fov2_spinbox.value():.0f}μm")
-            fov_str = " and ".join(fovs)
-
-            # Construct message
-            message = f"Acquire {beam_str} reference images at {fov_str} after task completion"
-        self.info_label.setText(message)
-        self.info_label.setVisible(True)
+        """Warn when the settings mean nothing gets acquired; grey the imaging rows."""
+        beams = self.acquire_sem_check.isChecked() or self.acquire_fib_check.isChecked()
+        images = (
+            self.acquire_image1_check.isChecked()
+            or self.acquire_image2_check.isChecked()
+        )
+        will_acquire = beams and images
+        self.imaging_widget.setEnabled(will_acquire)
+        self.info_label.setVisible(not will_acquire)
 
     def show_field_of_view(self, field: int, show: bool):
         """Show or hide a specific field of view control.


### PR DESCRIPTION
## Summary

Stacked on #828. Third of the settings-widget PRs.

The reference-image settings were two panels ("Acquisition" and "Imaging Settings") and six rows for two facts: which beams, and two images at two fields of view. Now:

- **One panel, "Reference Images".** The imaging rows (resolution, dwell time, the advanced ones behind the tune) continue the same form under the image rows. They describe these images, and a second header was a lot of weight for three rows. The advanced tune sits on the one header.
- **One row per image.** "Image 1" is its switch and its field of view side by side; same for "Image 2". The beams share a "Beams" row as SEM and FIB.
- **A warning only when it matters.** The italic sentence that restated the settings above it is gone. The one thing it said that the form did not, that nothing would be acquired, survives as a warning in the theme's warning colour, shown only when no beam or no image is selected. The imaging rows grey out in that state, as before.

Attribute names are kept for callers; `acquire_image1_label` is the same object as the row's label, so `show_field_of_view` and the enable logic are unchanged.

## Verification

- Reference-image widget and form-writeback suites pass, plus the task-config and editor canvas suites (the known pre-existing failure aside).
- Rendered the Lamella editor with a real experiment and checked the panel by eye, including the shared label column from #828.
- Lint and format-check clean.
