### PR TITLE
[ui] Milling sections: state as a header chip, switches as form rows

### DIFF
--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -1073,17 +1073,23 @@ def header_chip(text: str, colour: str) -> QLabel:
     "3 stages". `chip()` is built for a card or a row and comes out 20px, which in a
     24px header reads as a button.
     """
-    rgb = QColor(colour)
-    tint = f"rgba({rgb.red()}, {rgb.green()}, {rgb.blue()}, 0.15)"
     label = QLabel(text)
     label.setAlignment(Qt.AlignCenter)
+    label.setFixedHeight(14)
+    set_header_chip(label, text, colour)
+    return label
+
+
+def set_header_chip(label: QLabel, text: str, colour: str) -> None:
+    """Re-word and re-tint a `header_chip`: "on" in the accent, "off" muted."""
+    rgb = QColor(colour)
+    tint = f"rgba({rgb.red()}, {rgb.green()}, {rgb.blue()}, 0.15)"
+    label.setText(text)
     style_with_tooltip(
         label,
         f"background-color: {tint}; color: {colour};"
         " padding: 0px 5px; border-radius: 7px; font-size: 9px;",
     )
-    label.setFixedHeight(14)
-    return label
 
 
 def chip(text: str, colour: str, font_size: int = 11) -> QLabel:

--- a/fibsem/ui/widgets/milling_alignment_widget.py
+++ b/fibsem/ui/widgets/milling_alignment_widget.py
@@ -1,4 +1,4 @@
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QCheckBox, QGridLayout, QLabel, QSpinBox, QWidget
 
 from fibsem.structures import MillingAlignment
@@ -68,32 +68,42 @@ class FibsemMillingAlignmentWidget(QWidget):
 
         # Enabled checkbox
         enabled_config = WIDGET_CONFIG["enabled"]
-        self.enabled_checkbox = QCheckBox(enabled_config["label"])
+        # Each switch is a form row -- label, then a bare checkbox in the field
+        # column -- the shape every other boolean in the editor has.
+        self.enabled_checkbox = QCheckBox()
         self.enabled_checkbox.setChecked(enabled_config["default"])
         self.enabled_checkbox.setToolTip(enabled_config["tooltip"])
-        layout.addWidget(self.enabled_checkbox, 0, 0, 1, 2)
+        enabled_label = QLabel(enabled_config["label"])
+        enabled_label.setToolTip(enabled_config["tooltip"])
+        layout.addWidget(enabled_label, 0, 0)
+        layout.addWidget(self.enabled_checkbox, 0, 1, alignment=Qt.AlignLeft)
 
-        # use autocontrast and use autofocus on the same row
         use_contrast_config = WIDGET_CONFIG["use_contrast"]
-        self.autocontrast_checkbox = QCheckBox(use_contrast_config["label"])
+        self.autocontrast_checkbox = QCheckBox()
         self.autocontrast_checkbox.setChecked(use_contrast_config["default"])
         self.autocontrast_checkbox.setToolTip(use_contrast_config["tooltip"])
-        layout.addWidget(self.autocontrast_checkbox, 1, 0, 1, 1)
+        contrast_label = QLabel(use_contrast_config["label"])
+        contrast_label.setToolTip(use_contrast_config["tooltip"])
+        layout.addWidget(contrast_label, 1, 0)
+        layout.addWidget(self.autocontrast_checkbox, 1, 1, alignment=Qt.AlignLeft)
 
         use_autofocus_config = WIDGET_CONFIG["use_autofocus"]
-        self.autofocus_checkbox = QCheckBox(use_autofocus_config["label"])
+        self.autofocus_checkbox = QCheckBox()
         self.autofocus_checkbox.setChecked(use_autofocus_config["default"])
         self.autofocus_checkbox.setToolTip(use_autofocus_config["tooltip"])
-        layout.addWidget(self.autofocus_checkbox, 1, 1, 1, 1)
+        focus_label = QLabel(use_autofocus_config["label"])
+        focus_label.setToolTip(use_autofocus_config["tooltip"])
+        layout.addWidget(focus_label, 2, 0)
+        layout.addWidget(self.autofocus_checkbox, 2, 1, alignment=Qt.AlignLeft)
 
         # Alignment steps
         self.steps_label = QLabel("Alignment Steps")
-        layout.addWidget(self.steps_label, 2, 0)
+        layout.addWidget(self.steps_label, 3, 0)
         self.steps_spinbox = IntegerValueSpinBox()
         steps_config = WIDGET_CONFIG["steps"]
         self.steps_spinbox.setRange(*steps_config["range"])
         self.steps_spinbox.setValue(steps_config["default"])
-        layout.addWidget(self.steps_spinbox, 2, 1)
+        layout.addWidget(self.steps_spinbox, 3, 1)
 
         # Image settings widget
         self.image_settings_widget = ImageSettingsWidget(show_advanced=False)
@@ -101,7 +111,7 @@ class FibsemMillingAlignmentWidget(QWidget):
         self.image_settings_widget.show_field_of_view(False)
         self.image_settings_widget.set_show_autocontrast(False)
         self.image_settings_widget.drift_correction_check.setVisible(False)
-        layout.addWidget(self.image_settings_widget, 3, 0, 1, 2)
+        layout.addWidget(self.image_settings_widget, 4, 0, 1, 2)
 
     def _connect_signals(self):
         """Connect widget signals to their respective handlers.

--- a/fibsem/ui/widgets/milling_task_acquisition_settings_widget.py
+++ b/fibsem/ui/widgets/milling_task_acquisition_settings_widget.py
@@ -56,7 +56,7 @@ class FibsemMillingTaskAcquisitionSettingsWidget(QWidget):
 
         # Image settings widget
         self.image_settings_widget = ImageSettingsWidget(show_advanced=show_advanced)
-        self.image_settings_widget.show_field_of_view(False) # uses milling task fov
+        self.image_settings_widget.show_field_of_view(False)  # uses milling task fov
 
         hbox = QHBoxLayout()
         hbox.addWidget(self.acquire_sem_checkbox)

--- a/fibsem/ui/widgets/milling_task_acquisition_settings_widget.py
+++ b/fibsem/ui/widgets/milling_task_acquisition_settings_widget.py
@@ -1,7 +1,8 @@
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QCheckBox, QHBoxLayout, QVBoxLayout, QWidget
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtWidgets import QCheckBox, QGridLayout, QLabel, QWidget
 
 from fibsem.milling.tasks import MillingTaskAcquisitionSettings
+from fibsem.ui.widgets.custom_widgets import align_form
 from fibsem.ui.widgets.image_settings_widget import ImageSettingsWidget
 
 
@@ -35,18 +36,21 @@ class FibsemMillingTaskAcquisitionSettingsWidget(QWidget):
         Args:
             show_advanced: Whether to show advanced settings in the image settings widget
         """
-        layout = QVBoxLayout()
+        layout = QGridLayout()
+        layout.setContentsMargins(4, 4, 4, 4)
+        align_form(layout)
         self.setLayout(layout)
 
-        # Enabled checkbox
-        self.acquire_sem_checkbox = QCheckBox("Acquire SEM Image")
+        # One row per beam -- label, then a bare checkbox -- the shape every other
+        # boolean in the editor has.
+        self.acquire_sem_checkbox = QCheckBox()
         self.acquire_sem_checkbox.setChecked(True)
         self.acquire_sem_checkbox.setToolTip(
             self._settings.__dataclass_fields__["acquire_sem"].metadata.get(
                 "tooltip", ""
             )
         )
-        self.acquire_fib_checkbox = QCheckBox("Acquire FIB Image")
+        self.acquire_fib_checkbox = QCheckBox()
         self.acquire_fib_checkbox.setChecked(True)
         self.acquire_fib_checkbox.setToolTip(
             self._settings.__dataclass_fields__["acquire_fib"].metadata.get(
@@ -58,11 +62,11 @@ class FibsemMillingTaskAcquisitionSettingsWidget(QWidget):
         self.image_settings_widget = ImageSettingsWidget(show_advanced=show_advanced)
         self.image_settings_widget.show_field_of_view(False)  # uses milling task fov
 
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.acquire_sem_checkbox)
-        hbox.addWidget(self.acquire_fib_checkbox)
-        layout.addLayout(hbox)
-        layout.addWidget(self.image_settings_widget)
+        layout.addWidget(QLabel("SEM Image"), 0, 0)
+        layout.addWidget(self.acquire_sem_checkbox, 0, 1, alignment=Qt.AlignLeft)
+        layout.addWidget(QLabel("FIB Image"), 1, 0)
+        layout.addWidget(self.acquire_fib_checkbox, 1, 1, alignment=Qt.AlignLeft)
+        layout.addWidget(self.image_settings_widget, 2, 0, 1, 2)
 
     def _connect_signals(self):
         """Connect widget signals to their respective handlers."""

--- a/fibsem/ui/widgets/milling_task_config_widget2.py
+++ b/fibsem/ui/widgets/milling_task_config_widget2.py
@@ -8,7 +8,6 @@ from PyQt5.QtWidgets import (
     QGridLayout,
     QLabel,
     QLineEdit,
-    QScrollArea,
     QVBoxLayout,
     QWidget,
 )
@@ -17,13 +16,13 @@ from fibsem import constants
 from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.tasks import FibsemMillingTaskConfig
 from fibsem.ui import stylesheets
-from fibsem.ui.icon import fibsem_icon
 from fibsem.ui.widgets.custom_widgets import (
     IconToolButton,
     TitledPanel,
     ValueSpinBox,
     align_form,
     header_chip,
+    set_header_chip,
 )
 from fibsem.ui.widgets.milling_alignment_widget import FibsemMillingAlignmentWidget
 from fibsem.ui.widgets.milling_stages_widget import FibsemMillingStagesWidget
@@ -44,6 +43,14 @@ _WIDGET_CONFIG = {
 }
 
 _INSTRUCTIONS_TEXT = "Instructions: Right Click to Move Current Pattern"
+
+
+def _set_state_chip(chip, on: bool) -> None:
+    set_header_chip(
+        chip,
+        "on" if on else "off",
+        stylesheets.ACCENT_COLOR if on else stylesheets.TEXT_MUTED_COLOR,
+    )
 
 
 class MillingTaskConfigWidget2(QWidget):
@@ -134,14 +141,10 @@ class MillingTaskConfigWidget2(QWidget):
         )
         self.alignment_widget.image_settings_widget.set_show_advanced_button(False)
 
-        self._btn_enable_alignment = IconToolButton(
-            icon="mdi:checkbox-blank-outline",
-            checked_icon="mdi:checkbox-marked-outline",
-            checked_color=stylesheets.GRAY_WHITE_COLOR,
-            tooltip="Enable alignment",
-            checked_tooltip="Disable alignment",
-            checked=True,
-        )
+        # Whether alignment runs, readable with the panel collapsed. A chip that
+        # mirrors the body's switch rather than a second switch in the header:
+        # two controls for one setting was one too many.
+        self._alignment_state_chip = header_chip("on", stylesheets.ACCENT_COLOR)
         self._btn_advanced_alignment = IconToolButton(
             icon="mdi:tune",
             checked_icon="mdi:tune-variant",
@@ -151,7 +154,7 @@ class MillingTaskConfigWidget2(QWidget):
         )
 
         self.alignment_panel = TitledPanel("Alignment", content=self.alignment_widget)
-        self.alignment_panel.add_header_widget(self._btn_enable_alignment)
+        self.alignment_panel.add_header_widget(self._alignment_state_chip)
         self.alignment_panel.add_header_widget(self._btn_advanced_alignment)
         self.alignment_panel._btn_collapse.setChecked(False)
         layout.addWidget(self.alignment_panel)
@@ -162,14 +165,9 @@ class MillingTaskConfigWidget2(QWidget):
         )
         self.acquisition_widget.image_settings_widget.set_show_advanced_button(False)
 
-        self._btn_enable_acquisition = IconToolButton(
-            icon="mdi:checkbox-blank-outline",
-            checked_icon="mdi:checkbox-marked-outline",
-            checked_color=stylesheets.GRAY_WHITE_COLOR,
-            tooltip="Enable acquisition",
-            checked_tooltip="Disable acquisition",
-            checked=True,
-        )
+        # "on" when either beam acquires; the old header switch set both beams
+        # at once, which nothing on it said.
+        self._acquisition_state_chip = header_chip("on", stylesheets.ACCENT_COLOR)
         self._btn_advanced_acquisition = IconToolButton(
             icon="mdi:tune",
             checked_icon="mdi:tune-variant",
@@ -181,7 +179,7 @@ class MillingTaskConfigWidget2(QWidget):
         self.acquisition_panel = TitledPanel(
             "Acquisition", content=self.acquisition_widget
         )
-        self.acquisition_panel.add_header_widget(self._btn_enable_acquisition)
+        self.acquisition_panel.add_header_widget(self._acquisition_state_chip)
         self.acquisition_panel.add_header_widget(self._btn_advanced_acquisition)
         self.acquisition_panel._btn_collapse.setChecked(False)
         layout.addWidget(self.acquisition_panel)
@@ -218,12 +216,8 @@ class MillingTaskConfigWidget2(QWidget):
                 len([s for s in stages if s.enabled])
             )
         )
-        self._btn_enable_alignment.toggled.connect(self._on_enable_alignment_toggled)
         self._btn_advanced_alignment.toggled.connect(
             self._on_advanced_alignment_toggled
-        )
-        self._btn_enable_acquisition.toggled.connect(
-            self._on_enable_acquisition_toggled
         )
         self._btn_advanced_acquisition.toggled.connect(
             self._on_advanced_acquisition_toggled
@@ -251,41 +245,18 @@ class MillingTaskConfigWidget2(QWidget):
     def _emit_settings_changed(self) -> None:
         self.settings_changed.emit(self.get_settings())
 
-    def _on_enable_alignment_toggled(self, checked: bool) -> None:
-        self.alignment_widget.enabled_checkbox.blockSignals(True)
-        self.alignment_widget.enabled_checkbox.setChecked(checked)
-        self.alignment_widget.enabled_checkbox.blockSignals(False)
-        self.alignment_widget._update_controls_enabled()
-        self._emit_settings_changed()
-
     def _on_alignment_checkbox_changed(self, checked: bool) -> None:
-        self._btn_enable_alignment.blockSignals(True)
-        self._btn_enable_alignment.setChecked(checked)
-        self._btn_enable_alignment.blockSignals(False)
-        self._btn_enable_alignment.set_icon_state(checked)
+        _set_state_chip(self._alignment_state_chip, checked)
 
     def _on_advanced_alignment_toggled(self, checked: bool) -> None:
         self.alignment_widget.set_show_advanced(checked)
 
-    def _on_enable_acquisition_toggled(self, checked: bool) -> None:
-        aw = self.acquisition_widget
-        aw.acquire_sem_checkbox.blockSignals(True)
-        aw.acquire_fib_checkbox.blockSignals(True)
-        aw.acquire_sem_checkbox.setChecked(checked)
-        aw.acquire_fib_checkbox.setChecked(checked)
-        aw.acquire_sem_checkbox.blockSignals(False)
-        aw.acquire_fib_checkbox.blockSignals(False)
-        aw._update_image_settings_enabled()
-
     def _on_acquisition_checkbox_changed(self) -> None:
         aw = self.acquisition_widget
-        any_enabled = (
-            aw.acquire_sem_checkbox.isChecked() or aw.acquire_fib_checkbox.isChecked()
+        _set_state_chip(
+            self._acquisition_state_chip,
+            aw.acquire_sem_checkbox.isChecked() or aw.acquire_fib_checkbox.isChecked(),
         )
-        self._btn_enable_acquisition.blockSignals(True)
-        self._btn_enable_acquisition.setChecked(any_enabled)
-        self._btn_enable_acquisition.blockSignals(False)
-        self._btn_enable_acquisition.set_icon_state(any_enabled)
 
     def _on_advanced_acquisition_toggled(self, checked: bool) -> None:
         self.acquisition_widget.set_show_advanced(checked)
@@ -317,6 +288,10 @@ class MillingTaskConfigWidget2(QWidget):
         self.alignment_widget.update_from_settings(settings.alignment)
         self.acquisition_widget.update_from_settings(settings.acquisition)
         self.milling_stages_widget.set_stages(settings.stages)
+        self._on_alignment_checkbox_changed(
+            self.alignment_widget.enabled_checkbox.isChecked()
+        )
+        self._on_acquisition_checkbox_changed()
         # enabled stages, as the change handler counts them; loading used to count all
         self._update_stage_count_icon(len([s for s in settings.stages if s.enabled]))
         self.blockSignals(False)


### PR DESCRIPTION
## Summary

Stacked on #829. Last of the settings-widget PRs.

The Alignment and Acquisition panels each had an enable icon in the header and the same switch again in the body. For Acquisition the header icon set both beams at once, which nothing on it said.

## What changed

- **Header chips instead of header switches.** Each panel's header shows a 14 px chip, "on" in the accent tint or "off" muted, that mirrors the body: alignment's own switch, and either beam for acquisition. It is readable with the panel collapsed, which is what the icon was for, and it is not a second control for the same setting. The chips follow a loaded config as well as live edits.
- **Switches as form rows.** Alignment's three booleans were text checkboxes in a two-by-two block; Acquisition's two shared one row. All five are now a label in the shared column with a bare checkbox beside it, the shape every other boolean in the editor has.
- `set_header_chip(label, text, colour)` in `custom_widgets` re-words and re-tints a `header_chip`.

The first commit is formatting only for the acquisition widget, which was not yet formatted.

## Verification

- 56 tests pass across the milling config widget, viewer, form writeback, viewer-less widgets, header widgets and editor canvas suites; the one failure is the pre-existing `test_layer_controls_menu_survives_a_migrated_tab`.
- Rendered the Lamella editor with a real experiment, both panels expanded, and checked the chips flip with the switches.
- Lint and format-check clean.
