### PR TITLE
[ui] Stage detail: fields fill the column, Milling and Pattern open on selection

### DIFF
--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -1059,7 +1059,9 @@ def align_form(layout) -> None:
         layout.setColumnMinimumWidth(0, FORM_LABEL_WIDTH)
         layout.setColumnStretch(1, 1)
     elif isinstance(layout, QFormLayout):
-        layout.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
+        # AllNonFixedFieldsGrow, not ExpandingFieldsGrow: the generated controls
+        # keep Qt's Preferred policy, which the latter leaves at natural width.
+        layout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
         for row in range(layout.rowCount()):
             item = layout.itemAt(row, QFormLayout.LabelRole)
             if item is not None and item.widget() is not None:

--- a/fibsem/ui/widgets/milling_stages_widget.py
+++ b/fibsem/ui/widgets/milling_stages_widget.py
@@ -93,10 +93,10 @@ class FibsemMillingStagesWidget(QWidget):
             checked_tooltip="Hide advanced settings",
         )
 
-        milling_panel = TitledPanel("Milling", content=self._milling_widget)
-        milling_panel.add_header_widget(self._btn_advanced)
-        milling_panel._btn_collapse.setChecked(False)
-        detail_layout.addWidget(milling_panel)
+        self._milling_panel = TitledPanel("Milling", content=self._milling_widget)
+        self._milling_panel.add_header_widget(self._btn_advanced)
+        self._milling_panel._btn_collapse.setChecked(False)
+        detail_layout.addWidget(self._milling_panel)
 
         # Pattern settings
         self._pattern_widget = FibsemPatternSettingsWidget(
@@ -111,10 +111,10 @@ class FibsemMillingStagesWidget(QWidget):
             checked_tooltip="Hide advanced settings",
         )
 
-        pattern_panel = TitledPanel("Pattern", content=self._pattern_widget)
-        pattern_panel.add_header_widget(self._btn_advanced_pattern)
-        pattern_panel._btn_collapse.setChecked(False)
-        detail_layout.addWidget(pattern_panel)
+        self._pattern_panel = TitledPanel("Pattern", content=self._pattern_widget)
+        self._pattern_panel.add_header_widget(self._btn_advanced_pattern)
+        self._pattern_panel._btn_collapse.setChecked(False)
+        detail_layout.addWidget(self._pattern_panel)
 
         # Strategy settings
         self._strategy_widget = FibsemStrategySettingsWidget(
@@ -128,10 +128,10 @@ class FibsemMillingStagesWidget(QWidget):
             checked_tooltip="Hide advanced settings",
         )
 
-        strategy_panel = TitledPanel("Strategy", content=self._strategy_widget)
-        strategy_panel.add_header_widget(self._btn_advanced_strategy)
-        strategy_panel._btn_collapse.setChecked(False)
-        detail_layout.addWidget(strategy_panel)
+        self._strategy_panel = TitledPanel("Strategy", content=self._strategy_widget)
+        self._strategy_panel.add_header_widget(self._btn_advanced_strategy)
+        self._strategy_panel._btn_collapse.setChecked(False)
+        detail_layout.addWidget(self._strategy_panel)
 
         layout.addWidget(self._detail_widget)
         self._detail_widget.setVisible(False)
@@ -164,6 +164,13 @@ class FibsemMillingStagesWidget(QWidget):
         self._milling_widget.set_settings(stage.milling)
         self._pattern_widget.set_pattern(stage.pattern)
         self._strategy_widget.set_strategy(stage.strategy)
+        # Selecting a stage used to reveal three closed headers, so the click
+        # looked like it did nothing. Milling and Pattern open with the first
+        # selection; Strategy stays as the operator left it, since it usually has
+        # nothing to show. After that the panels keep whatever state they were put in.
+        if not self._detail_widget.isVisible():
+            self._milling_panel.expand()
+            self._pattern_panel.expand()
         self._detail_widget.setVisible(True)
 
     def _on_row_selected(self, stage: Optional[FibsemMillingStage]) -> None:


### PR DESCRIPTION
## Summary

Stacked on #830. Two fixes to the Milling, Pattern and Strategy panels under the stage list.

- **Fields fill the column.** The three generated forms laid their controls out at natural width, about 110 px, while every panel above filled the column. `align_form` asked a `QFormLayout` to grow only Expanding fields, and the generated controls keep Qt's Preferred policy. `AllNonFixedFieldsGrow` grows them too, so the fix is one word and applies to all three at once.
- **Milling and Pattern open on selection.** Selecting a stage revealed three closed headers, so the click looked like it did nothing until each was opened. Milling and Pattern now expand with the first selection; Strategy stays as the operator left it, since it usually has nothing to show. After that the panels keep whatever state they were put in.

## Verification

- 83 tests pass across the config widget, milling settings, pattern, stage list, form writeback, integer settings, task-config parameters, select-all sync and milling viewer suites.
- Rendered the Lamella editor with a real experiment: a plain row selection opens Milling and Pattern and leaves Strategy closed; controls span the field column.
- Lint and format-check clean, including an isolated undefined-name check.
