### PR TITLE
[ui] Stage detail: one advanced switch, enum values as words, no colons

### DIFF
--- a/fibsem/ui/widgets/form_builder.py
+++ b/fibsem/ui/widgets/form_builder.py
@@ -74,6 +74,7 @@ class FormDefaults:
     step: Optional[float] = None
     decimals: Optional[int] = None
 
+
 # A point is an offset from the image centre, so it is signed by definition and
 # must never inherit a floor of zero. The pattern form carried this same pair as
 # a literal default before the row was generalised.
@@ -135,7 +136,7 @@ def effective_scale(metadata: dict) -> Optional[float]:
     """
     base = metadata.get("scale")
     dims = metadata.get("dimensions")
-    return (base ** dims) if (base and dims) else base
+    return (base**dims) if (base and dims) else base
 
 
 def display_suffix(metadata: dict) -> str:
@@ -175,7 +176,9 @@ def _combo(items: Sequence[Any], value: Any, metadata: dict) -> Control:
     )
 
 
-def _point(value: Point, metadata: dict, fallback: Optional[Tuple[float, float]]) -> Control:
+def _point(
+    value: Point, metadata: dict, fallback: Optional[Tuple[float, float]]
+) -> Control:
     """Two spinboxes for a Point-typed field.
 
     Dispatched on the declared `type`, not on the field being called "point", so
@@ -288,7 +291,9 @@ def _scalar_list(value: Any, annotation: Any) -> Control:
     item_type = item_types[0] if item_types else str
     control = QLineEdit()
     control.setPlaceholderText("Enter comma-separated values")
-    control.setText(", ".join(str(v) for v in value) if isinstance(value, list) else str(value))
+    control.setText(
+        ", ".join(str(v) for v in value) if isinstance(value, list) else str(value)
+    )
 
     def read() -> List[Any]:
         text = control.text().strip()
@@ -346,7 +351,9 @@ def build_control(
     kind = type_ if type_ is not None else annotation
 
     if items == "dynamic":
-        resolved = dynamic_items(metadata["microscope_parameter"]) if dynamic_items else None
+        resolved = (
+            dynamic_items(metadata["microscope_parameter"]) if dynamic_items else None
+        )
         return _combo(resolved if resolved else [value], value, metadata)
 
     if items:
@@ -405,7 +412,9 @@ def build_control(
         control.setValue(int(round(value * scale)))
         return Control(
             widget=control,
-            read=lambda: int(round(control.value() / scale)) if scale else control.value(),
+            read=lambda: (
+                int(round(control.value() / scale)) if scale else control.value()
+            ),
             write=lambda new: control.setValue(int(round(new * scale))),
             signals=(control.valueChanged,),
         )
@@ -418,7 +427,9 @@ def build_control(
             minimum,
             maximum,
             metadata.get("step") if metadata.get("step") is not None else defaults.step,
-            metadata.get("decimals") if metadata.get("decimals") is not None else defaults.decimals,
+            metadata.get("decimals")
+            if metadata.get("decimals") is not None
+            else defaults.decimals,
         )
         control.setValue(value * scale)
         return Control(
@@ -441,7 +452,9 @@ def build_control(
     if annotation is None:
         # A milling form, which has no annotation to fall back on: nothing here
         # can render this, and there is no value in showing it disabled.
-        logging.warning("No control for field of type %r (value %r)", type_, type(value))
+        logging.warning(
+            "No control for field of type %r (value %r)", type_, type(value)
+        )
         return None
 
     # Debug, not warning: the form says this itself, visibly and in the right

--- a/fibsem/ui/widgets/form_builder.py
+++ b/fibsem/ui/widgets/form_builder.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import re
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from enum import Enum
@@ -153,9 +154,26 @@ def display_suffix(metadata: dict) -> str:
     return utils._get_display_unit(base, unit) if base else unit
 
 
+def _enum_label(member: Any) -> str:
+    """``CleaningCrossSection`` -> ``Cleaning Cross Section``, ``EACH_ROW`` -> ``Each Row``."""
+    if not isinstance(member, Enum):
+        return str(member)
+    name = member.name
+    if "_" in name or name.isupper():
+        return " ".join(part.capitalize() for part in name.split("_"))
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", name)
+
+
 def _combo(items: Sequence[Any], value: Any, metadata: dict) -> Control:
+    # "CleaningCrossSection" and "EACH_ROW" are names for code; the form shows
+    # words. Here rather than on the Enum branch alone: a field can also reach a
+    # combo through declared `items`, as cross_section does. A declared
+    # format_fn still wins.
+    format_fn = metadata.get("format_fn")
+    if format_fn is None and any(isinstance(item, Enum) for item in items):
+        format_fn = _enum_label
     control = ValueComboBox(
-        list(items), value, metadata.get("unit"), format_fn=metadata.get("format_fn")
+        list(items), value, metadata.get("unit"), format_fn=format_fn
     )
     # ValueComboBox's constructor skips `set_value` for None, which leaves the
     # first item selected. `None` is a real choice for an Optional field -- the

--- a/fibsem/ui/widgets/milling_stages_widget.py
+++ b/fibsem/ui/widgets/milling_stages_widget.py
@@ -14,8 +14,7 @@ from fibsem.milling.base import FibsemMillingStage, MillingStrategy, get_strateg
 from fibsem.milling.patterning import get_pattern
 from fibsem.milling.patterning.patterns2 import BasePattern
 from fibsem.structures import BeamType, FibsemMillingSettings
-from fibsem.ui import stylesheets
-from fibsem.ui.widgets.custom_widgets import IconToolButton, TitledPanel
+from fibsem.ui.widgets.custom_widgets import TitledPanel
 from fibsem.ui.widgets.milling_settings_widget import FibsemMillingSettingsWidget
 from fibsem.ui.widgets.milling_stage_list_widget import MillingStageListWidget
 from fibsem.ui.widgets.pattern_settings_widget import FibsemPatternSettingsWidget
@@ -85,16 +84,8 @@ class FibsemMillingStagesWidget(QWidget):
             microscope=self.microscope,
             settings=FibsemMillingSettings(),
         )
-        self._btn_advanced = IconToolButton(
-            icon="mdi:tune",
-            checked_icon="mdi:tune-variant",
-            checked_color=stylesheets.GRAY_WHITE_COLOR,
-            tooltip="Show advanced settings",
-            checked_tooltip="Hide advanced settings",
-        )
 
         self._milling_panel = TitledPanel("Milling", content=self._milling_widget)
-        self._milling_panel.add_header_widget(self._btn_advanced)
         self._milling_panel._btn_collapse.setChecked(False)
         detail_layout.addWidget(self._milling_panel)
 
@@ -103,16 +94,8 @@ class FibsemMillingStagesWidget(QWidget):
             microscope=self.microscope,
             pattern=get_pattern("Rectangle"),
         )
-        self._btn_advanced_pattern = IconToolButton(
-            icon="mdi:tune",
-            checked_icon="mdi:tune-variant",
-            checked_color=stylesheets.GRAY_WHITE_COLOR,
-            tooltip="Show advanced settings",
-            checked_tooltip="Hide advanced settings",
-        )
 
         self._pattern_panel = TitledPanel("Pattern", content=self._pattern_widget)
-        self._pattern_panel.add_header_widget(self._btn_advanced_pattern)
         self._pattern_panel._btn_collapse.setChecked(False)
         detail_layout.addWidget(self._pattern_panel)
 
@@ -120,16 +103,8 @@ class FibsemMillingStagesWidget(QWidget):
         self._strategy_widget = FibsemStrategySettingsWidget(
             strategy=get_strategy("Standard"),
         )
-        self._btn_advanced_strategy = IconToolButton(
-            icon="mdi:tune",
-            checked_icon="mdi:tune-variant",
-            checked_color=stylesheets.GRAY_WHITE_COLOR,
-            tooltip="Show advanced settings",
-            checked_tooltip="Hide advanced settings",
-        )
 
         self._strategy_panel = TitledPanel("Strategy", content=self._strategy_widget)
-        self._strategy_panel.add_header_widget(self._btn_advanced_strategy)
         self._strategy_panel._btn_collapse.setChecked(False)
         detail_layout.addWidget(self._strategy_panel)
 
@@ -149,11 +124,8 @@ class FibsemMillingStagesWidget(QWidget):
         self._list.stage_changed.connect(self._on_inline_stage_changed)
         self._list.eye_toggled.connect(self.eye_toggled)
         self._milling_widget.settings_changed.connect(self._on_milling_settings_changed)
-        self._btn_advanced.toggled.connect(self._on_advanced_toggled)
         self._pattern_widget.pattern_changed.connect(self._on_pattern_changed)
-        self._btn_advanced_pattern.toggled.connect(self._on_advanced_pattern_toggled)
         self._strategy_widget.strategy_changed.connect(self._on_strategy_changed)
-        self._btn_advanced_strategy.toggled.connect(self._on_advanced_strategy_toggled)
 
     # ------------------------------------------------------------------
     # Private slots
@@ -204,20 +176,11 @@ class FibsemMillingStagesWidget(QWidget):
             self._list.refresh_stage(self._selected_stage)
             self.stages_changed.emit(self._list.get_stages())
 
-    def _on_advanced_toggled(self, checked: bool) -> None:
-        self._milling_widget.set_advanced_visible(checked)
-
-    def _on_advanced_pattern_toggled(self, checked: bool) -> None:
-        self._pattern_widget.set_advanced_visible(checked)
-
     def _on_strategy_changed(self, strategy: MillingStrategy) -> None:
         if self._selected_stage is not None:
             self._selected_stage.strategy = strategy
             self._list.refresh_stage(self._selected_stage)
             self.stages_changed.emit(self._list.get_stages())
-
-    def _on_advanced_strategy_toggled(self, checked: bool) -> None:
-        self._strategy_widget.set_advanced_visible(checked)
 
     def _on_inline_stage_changed(self, stage: FibsemMillingStage) -> None:
         """Handle an inline field edit from the row widget and sync detail panels if selected."""
@@ -277,8 +240,7 @@ class FibsemMillingStagesWidget(QWidget):
         self._milling_widget.set_manufacturer(manufacturer)
 
     def set_advanced_visible(self, show: bool) -> None:
-        self._btn_advanced.blockSignals(True)
-        self._btn_advanced.setChecked(show)
-        self._btn_advanced.blockSignals(False)
-        self._btn_advanced.set_icon_state(show)
+        """Advanced fields in all three detail panels: one switch for one idea."""
         self._milling_widget.set_advanced_visible(show)
+        self._pattern_widget.set_advanced_visible(show)
+        self._strategy_widget.set_advanced_visible(show)

--- a/fibsem/ui/widgets/milling_task_config_widget2.py
+++ b/fibsem/ui/widgets/milling_task_config_widget2.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 from typing import Optional
 
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
     QGridLayout,
     QLabel,
@@ -197,6 +197,19 @@ class MillingTaskConfigWidget2(QWidget):
             "Milling Stages", content=self.milling_stages_widget
         )
         milling_panel.add_header_widget(self._stage_count_chip)
+        # One advanced switch for the stage detail below, where there were three,
+        # one per panel, all meaning the same thing.
+        self._btn_advanced_stages = IconToolButton(
+            icon="mdi:tune",
+            checked_icon="mdi:tune-variant",
+            checked_color=stylesheets.GRAY_WHITE_COLOR,
+            tooltip="Show advanced stage settings",
+            checked_tooltip="Hide advanced stage settings",
+        )
+        self._btn_advanced_stages.toggled.connect(
+            self.milling_stages_widget.set_advanced_visible
+        )
+        milling_panel.add_header_widget(self._btn_advanced_stages)
         milling_panel._btn_collapse.setChecked(True)
         layout.addWidget(milling_panel)
 

--- a/fibsem/ui/widgets/pattern_settings_widget.py
+++ b/fibsem/ui/widgets/pattern_settings_widget.py
@@ -68,7 +68,7 @@ class FibsemPatternSettingsWidget(QWidget):
         type_form = QFormLayout()
         type_form.setContentsMargins(0, 0, 0, 0)
         self._type_combo = ValueComboBox(get_pattern_names(), value=self._pattern.name)
-        type_form.addRow("Pattern:", self._type_combo)
+        type_form.addRow("Pattern", self._type_combo)
         align_form(type_form)
         outer.addLayout(type_form)
 

--- a/fibsem/ui/widgets/strategy_settings_widget.py
+++ b/fibsem/ui/widgets/strategy_settings_widget.py
@@ -16,7 +16,7 @@ from PyQt5.QtWidgets import (
 from fibsem.milling.base import MillingStrategy, get_strategy
 from fibsem.milling.strategy import get_strategy_names
 from fibsem.ui.tokens import (
-    NEUTRAL_700,
+    TEXT_MUTED_COLOR,
 )
 from fibsem.ui.widgets.custom_widgets import ValueComboBox, align_form
 from fibsem.ui.widgets.form_builder import Control, build_control
@@ -71,7 +71,7 @@ class FibsemStrategySettingsWidget(QWidget):
         self._type_combo = ValueComboBox(
             get_strategy_names(), value=self._strategy.name
         )
-        type_form.addRow("Strategy:", self._type_combo)
+        type_form.addRow("Strategy", self._type_combo)
         align_form(type_form)
         outer.addLayout(type_form)
 
@@ -82,7 +82,7 @@ class FibsemStrategySettingsWidget(QWidget):
 
         # Empty-state label (shown when strategy has no config fields)
         self._empty_label = QLabel("No configuration options.")
-        self._empty_label.setStyleSheet(f"color: {NEUTRAL_700}; font-style: italic;")
+        self._empty_label.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 11px;")
         self._empty_label.setVisible(False)
         outer.addWidget(self._empty_label)
 

--- a/tests/ui/test_form_writeback.py
+++ b/tests/ui/test_form_writeback.py
@@ -104,7 +104,9 @@ def test_a_pattern_point_edit_reaches_the_pattern(qapp, microscope, axis):
     emitted = []
     widget.pattern_changed.connect(emitted.append)
 
-    x_control, y_control = _row(widget, "point").control.widget.findChildren(ValueSpinBox)
+    x_control, y_control = _row(widget, "point").control.widget.findChildren(
+        ValueSpinBox
+    )
     {"x": x_control, "y": y_control}[axis].setValue(5.0)
 
     assert emitted, f"editing the {axis} spinbox emitted nothing"
@@ -186,3 +188,20 @@ def test_an_integer_field_survives_the_round_trip_as_an_int(qapp, microscope):
     assert emitted
     value = getattr(emitted[-1], row.field)
     assert type(value) is int and value == 6
+
+
+def test_enum_members_read_as_words():
+    """Enum names are for code; a form shows words. CamelCase splits, UPPER_SNAKE
+    title-cases, and a declared format_fn still wins."""
+    from enum import Enum
+
+    from fibsem.ui.widgets.form_builder import _enum_label
+
+    class Style(Enum):
+        CleaningCrossSection = 1
+        EACH_ROW = 2
+        Plain = 3
+
+    assert _enum_label(Style.CleaningCrossSection) == "Cleaning Cross Section"
+    assert _enum_label(Style.EACH_ROW) == "Each Row"
+    assert _enum_label(Style.Plain) == "Plain"


### PR DESCRIPTION
## Summary

Stacked on #831. A consistency pass over the Milling, Pattern and Strategy panels.

- **One advanced switch.** Each panel carried its own tune icon, three switches for one idea. They are gone; one tune on the Milling Stages header drives the advanced fields of all three. Strategy used to show a tune even with nothing to reveal.
- **Enum values as words.** Generated forms showed enum members by their Python names ("CleaningCrossSection"). A combo built by the form builder now labels enum members as words, "Cleaning Cross Section", "Each Row", whichever path the field took to it: the Enum branch or declared `items`, which is how `cross_section` arrives. A declared `format_fn` still wins. `_enum_label` is covered by a test.
- **No colons** on "Pattern" and "Strategy", which nothing else in the editor had.
- **Empty state** in the muted text token at 11 px, not a raw grey in italics.

The first commit is formatting only for `form_builder.py`, which was not yet formatted.

## Not touched

The Milling panel keeps a band of empty space under its rows when advanced fields are hidden: `QFormLayout` keeps the row spacing of hidden rows. Fixing that is a form-builder change on its own, and the same gap exists in the other generated forms.

## Verification

- 563 tests pass across the form writeback, task-config parameters, pattern, milling settings, config widget, stage list, viewer, select-all, integer settings, FM overview and overview suites.
- Rendered the Lamella editor with a real experiment and checked the three panels by eye.
- Lint and format-check clean, with an isolated unused-import and undefined-name check on every touched file.
