### PR TITLE
Developer documentation in a neutral register

### DIFF
--- a/SCRIPTING.md
+++ b/SCRIPTING.md
@@ -174,11 +174,7 @@ To clear a mark again, use `lamella.defect.clear()`.
 
 Everything above assumes you loaded the experiment yourself. AutoLamella can instead run a script against the experiment it already has open, from **Tools → Scripts → Manage scripts…**.
 
-> **Off by default.** Turn it on in **File → Preferences… → Features → Enable User Scripts**. It takes effect immediately — no restart — and persists in `user-preferences.yaml`.
->
-> A script gets the application's own access to the microscope and none of its guard rails, so the menu is not offered to anyone who has not asked for it. Switching it on warns you once; switching it off hides the menu again. Hiding the menu hides the whole feature, since that is the only route to the dialog and the dialog is the only thing that runs a script.
->
-> None of this affects the headless recipes above: loading an experiment yourself in a notebook or a plain `python` script needs no flag.
+> A script gets the application's own access to the microscope and none of its guard rails. The menu is available to everyone (the feature flag was retired in September 2026); run only scripts you have read.
 
 Everything happens in that dialog. The menu itself only opens it and the scripts folder — it deliberately does not run anything, because a menu item has no way to show you a script that is still going, and no way to stop it.
 

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -1,36 +1,36 @@
 # Developer documentation
 
-For people, and coding agents, changing or extending fibsemOS. The user guide
-for operating the application is at [fibsemos.org/docs](https://www.fibsemos.org/docs).
+Documentation for changing or extending fibsemOS. The user guide for
+operating the application is at [fibsemos.org/docs](https://www.fibsemos.org/docs).
 
-| Page | Read it when |
+| Page | Contents |
 | -- | -- |
-| [Getting started as a developer](getting-started.md) | You are new here: the lay of the land, how to run it, and which path fits your goal. |
-| [Contributing](../../CONTRIBUTING.md) | Before your first pull request: PR size, the Python floor, formatting, tests, network rules. |
-| [Extending fibsemOS](extending.md) | You want to add a pattern, strategy or task, drive the microscope from a script, or support an instrument. |
-| [Scripting experiments](../../SCRIPTING.md) | You want to read or change an experiment's data from Python, in a notebook or from the app. |
-| [The simulator](../simulator.md) | What the Demo microscope images, every scene key, and how the figures are generated. |
-| [The screenshot harness](screenshot-harness.md) | You changed the interface and the user guide's screenshots need re-rendering, or you are adding a page to the guide. |
-| [AGENTS.md](../../AGENTS.md) | You are a coding agent. Everything in Contributing applies; this adds what is specific to agents. |
+| [Getting started as a developer](getting-started.md) | Repository layout, running the application against the simulator, running tests, and which extension point applies to a given goal. |
+| [Contributing](../../CONTRIBUTING.md) | Pull request size, the Python version floor, formatting, tests, and network rules. |
+| [Extending fibsemOS](extending.md) | Scripts, plugins (patterns, strategies, tasks), workflow tasks, and microscope backends. |
+| [Scripting experiments](../../SCRIPTING.md) | Reading and modifying experiment data from Python, in a notebook or from the application. |
+| [The simulator](../simulator.md) | What the Demo microscope images, the scene configuration keys, and how the figures are generated. |
+| [The screenshot harness](screenshot-harness.md) | How the user guide's screenshots are rendered from the application, and how to add a page. |
+| [AGENTS.md](../../AGENTS.md) | Conventions for coding agents. Contributing applies in full; this file adds what is specific to agents. |
 
-Developers and agents read the same pages. There is no separate agent
-documentation beyond `AGENTS.md` and the skills under `.claude/skills/`,
-which are entry points into these pages rather than rewrites of them.
+Developers and coding agents use the same pages. `AGENTS.md` and the skills
+under `.claude/skills/` are entry points into them, not separate
+documentation.
 
-## Keeping these true
+## Generated content
 
-Two of these pages are partly generated, and the rest are checked by tests
-where a claim can be executed:
+Two of these pages are partly generated, and the code examples in a third
+are executed by the test suite:
 
-- `simulator.md`'s figures and key table are written by
+- The figures and the key table in `simulator.md` are written by
   [`render_simulator_examples.py`](render_simulator_examples.py) from the
-  scene's own defaults. Re-run it after changing the simulator.
+  scene's defaults. Re-run it after changing the simulator.
 - The user guide's screenshots are written by
   [`render_user_guide.py`](render_user_guide.py) from the running
-  application; a page state that names a widget that no longer exists fails
-  the run rather than leaving a stale image.
-- `SCRIPTING.md`'s example scripts run in the test suite against a real
+  application. A page state that names a widget that no longer exists fails
+  the run.
+- The example scripts in `SCRIPTING.md` run in the test suite against a real
   experiment and the simulator.
 
-If you change something one of these pages describes, change the page in
+A change to something one of these pages describes should update the page in
 the same pull request.

--- a/docs/developers/extending.md
+++ b/docs/developers/extending.md
@@ -1,25 +1,26 @@
 # Extending fibsemOS
 
-The extension points we recommend and keep stable, in order of how much
-they ask of you: a script, a plugin, a workflow task, a microscope backend.
-Each section says what the seam is, where the reference implementation is,
-and the mistakes that have cost people time. Other routes exist in the code;
-if you need one, open an issue first.
+fibsemOS has four supported extension points, listed here in increasing
+order of integration: a script, a plugin, a workflow task, and a microscope
+backend. Each section describes the interface, the reference implementation,
+and the constraints that are not obvious from the code. Other approaches are
+possible; open an issue before relying on internals that are not listed
+here.
 
 ## Choosing a route
 
-| You want to | Use | Where it runs |
+| Goal | Mechanism | Where it runs |
 | -- | -- | -- |
-| Read or change experiment data, offline | A plain Python script with `Experiment.load()` | Anywhere, no app |
-| Drive the microscope for an acquisition sweep or a one-off procedure | A plain script with `utils.setup_session()` | Anywhere, no app |
-| Run something against the experiment the app has open | A user script in the scripts folder, run from **Tools → Scripts** | Inside the app |
-| Add a milling pattern, a milling strategy or a workflow task that others can install | A plugin package with entry points | Inside the app, discovered at start |
-| Add a step to the AutoLamella workflow with supervision and history | A workflow task (as a plugin, or in the tree) | Inside the workflow queue |
-| Support an instrument fibsemOS does not drive yet | A `FibsemMicroscope` implementation | The library, under everything else |
+| Read or modify experiment data, offline | A Python script using `Experiment.load()` | Anywhere; no application |
+| Drive the microscope for an acquisition sweep or a one-off procedure | A Python script using `utils.setup_session()` | Anywhere; no application |
+| Run a procedure against the experiment the application has open | A user script in the scripts folder, run from **Tools → Scripts** | Inside the application |
+| Add a milling pattern, a milling strategy or a workflow task that others can install | A plugin package with entry points | Inside the application, discovered at start |
+| Add a step to the AutoLamella workflow with supervision and history | A workflow task (as a plugin, or in the repository) | Inside the workflow queue |
+| Support an instrument fibsemOS does not drive yet | A `FibsemMicroscope` implementation | The library; everything else is built on it |
 
 ## Scripts
 
-### Against the library, with no app
+### Against the library
 
 ```python
 from fibsem import utils, acquire
@@ -29,28 +30,28 @@ microscope, settings = utils.setup_session(manufacturer="Demo")
 image = acquire.acquire_image(microscope, ImageSettings(hfw=80e-6, beam_type=BeamType.ION))
 ```
 
-`setup_session()` connects using a configuration file (the shipped Demo one
-by default) and returns the microscope and its settings. The `fibsem.acquire`,
-`fibsem.imaging` and `fibsem.milling` modules do the rest, and every
-`FibsemMicroscope` method is available directly. Use
-`acquire.acquire_image(microscope, settings)` rather than the microscope's
-own `acquire_image`: the method is the raw grab and ignores `save=True`; the
-module function applies autocontrast and gamma and writes the file.
+`setup_session()` connects using a configuration file (the shipped Demo
+configuration by default) and returns the microscope and its settings. The
+`fibsem.acquire`, `fibsem.imaging` and `fibsem.milling` modules provide the
+higher-level operations, and every `FibsemMicroscope` method is available
+directly. Use `acquire.acquire_image(microscope, settings)` rather than the
+microscope's own `acquire_image`: the method returns the raw frame and
+ignores `save=True`; the module function applies autocontrast and gamma and
+writes the file.
 
-To read or change an experiment's data, `Experiment.load()` gives you the
-lamellae, their history and the ready-made dataframes.
-[SCRIPTING.md](../../SCRIPTING.md) is the guide, with examples that the test
-suite executes against real data.
+`Experiment.load()` gives access to an experiment's lamellae, their history
+and the summary dataframes. [SCRIPTING.md](../../SCRIPTING.md) covers this
+in full, with examples that the test suite executes against real data.
 
-### Inside the app
+### Inside the application
 
-AutoLamella runs a `.py` file from the scripts folder against the experiment
-it has open, from **Tools → Scripts → Manage scripts…** (off by default;
-enable it under **File → Preferences… → Features**). The contract is one
-module-level function:
+AutoLamella can run a `.py` file from the scripts folder against the open
+experiment, from **Tools → Scripts → Manage scripts…**. The feature is off
+by default; enable it under **File → Preferences… → Features**. A script
+is one module-level function:
 
 ```python
-"""Export the experiment summary to CSV."""   # first line becomes the tooltip
+"""Export the experiment summary to CSV."""   # the first line becomes the tooltip
 
 def run(ctx):
     out = ctx.path / "summary.csv"
@@ -58,150 +59,153 @@ def run(ctx):
     return out
 ```
 
-`ctx` is a `ScriptContext` (`fibsem/applications/autolamella/scripting.py`):
-the experiment, its path, a logger, and, if the script declares
-`uses_microscope = True`, the microscope. Declare `writes = True` to have the
-experiment saved afterwards. Return the result rather than printing it: a
-string becomes a toast, a DataFrame opens in a table, a path opens its
-folder. Use `ctx` rather than reaching into the UI object; the GUI's
-internals move, and its `experiment` attribute is rebound on load, so a
-cached reference goes stale silently.
+`ctx` is a `ScriptContext` (`fibsem/applications/autolamella/scripting.py`)
+carrying the experiment, its path, a logger and, if the script declares
+`uses_microscope = True`, the microscope. Declaring `writes = True` saves
+the experiment afterwards. Return values are displayed: a string as a
+notification, a DataFrame as a table, a path by opening its folder. Use
+`ctx` rather than the UI object; the UI's internals change between
+versions, and its `experiment` attribute is replaced on load, so a cached
+reference becomes stale without error.
 
-Microscope scripts run on a background thread, must not mutate
-`ctx.experiment`, and must call `ctx.raise_if_cancelled()` between steps or
-Stop cannot stop them. Nothing validates what they do to the hardware. The
-[Running scripts from the GUI](../../SCRIPTING.md#running-scripts-from-the-gui)
-and [Microscope scripts](../../SCRIPTING.md#microscope-scripts) sections have
-the full contract; three working examples are in `examples/scripts/`.
+Microscope scripts run on a background thread, must not modify
+`ctx.experiment`, and must call `ctx.raise_if_cancelled()` between steps for
+Stop to take effect. Nothing validates what a script does to the hardware.
+The [Running scripts from the GUI](../../SCRIPTING.md#running-scripts-from-the-gui)
+and [Microscope scripts](../../SCRIPTING.md#microscope-scripts) sections give
+the full contract; `examples/scripts/` contains three working examples.
 
 ## Plugins
 
 fibsemOS loads three entry-point groups at start: `fibsem.patterns`,
-`fibsem.strategies` and `fibsem.tasks`. A plugin is an ordinary Python
-package that declares one or more of them in its `pyproject.toml` and is
-installed into the same environment as fibsemOS. No registration calls, no
-files in the fibsem tree; the app finds it on the next start.
+`fibsem.strategies` and `fibsem.tasks`. A plugin is a Python package that
+declares one or more of these in its `pyproject.toml` and is installed into
+the same environment as fibsemOS. No registration calls or files in the
+fibsem tree are needed; the application discovers it on the next start.
 
-**Start from the example.** The
-[fibsem-plugin-example](https://github.com/fibsem-os/fibsem-plugin-example)
-repository is a template covering all three groups, with tests that check
-the contract, a CI workflow that installs against fibsemOS `main` so you
-learn about breaking changes before a collaborator does, and a README that
-walks through renaming it. Read its "When nothing shows up" section before
-you need it.
+The [fibsem-plugin-example](https://github.com/fibsem-os/fibsem-plugin-example)
+repository is a template covering all three groups. It includes tests that
+check the contract, a CI workflow that installs against fibsemOS `main` so
+breaking changes are detected early, and a README describing how to rename
+it. Its "When nothing shows up" section covers the diagnostic steps.
 
-What each group contributes:
+Each group contributes one kind of object:
 
 - **A pattern** (`fibsem.patterns`): a subclass of `BasePattern` from
   `fibsem.milling.patterning.patterns2` whose `define()` returns the shapes
-  to mill. Appears in the pattern list of every milling stage.
-- **A strategy** (`fibsem.strategies`): how a pattern is milled, such as in
-  N passes. Appears in the strategy list of every stage.
-- **A task** (`fibsem.tasks`): an `AutoLamellaTask` with its config class,
-  as described in the next section. Appears in the Add Task dialog.
+  to mill. It appears in the pattern list of every milling stage.
+- **A strategy** (`fibsem.strategies`): how a pattern is milled, for example
+  in N passes. It appears in the strategy list of every stage.
+- **A task** (`fibsem.tasks`): an `AutoLamellaTask` with its configuration
+  class, as described in the next section. It appears in the Add Task
+  dialog.
 
-Three facts about loading that the example's tests enforce, because getting
-them wrong is silent:
+Three constraints on loading. Each produces no error when violated, so the
+example's tests check them:
 
 1. **Pattern modules are imported while `fibsem.milling.base` is only
-   partly initialised.** Import `BasePattern` from `patterns2`, never from
-   the `fibsem.milling.patterning` package, and import nothing that reaches
-   back into `fibsem.milling.base`, which includes everything under
-   `fibsem.applications`. A pattern and a task in the same file is enough to
-   break the pattern. Strategies and tasks have no such restriction.
-2. **A plugin that fails to import is simply absent.** The app starts, the
-   class is not in the list, and the reason is in the log and in the
-   Plugins panel (**Tools → Plugins…**, or `fibsem-cli plugins`), which
-   lists every declared entry point with what became of it, including ones
-   shadowed by a built-in of the same name. `fibsem/plugins/loader.py` is
-   the loader and documents the records it keeps.
-3. **Editing `pyproject.toml` does nothing until you reinstall.** Entry
-   points live in the installed metadata, so `pip install -e .` again after
-   changing them. Editing Python files needs no reinstall.
+   partly initialised.** Import `BasePattern` from `patterns2`, not from the
+   `fibsem.milling.patterning` package, and import nothing that depends on
+   `fibsem.milling.base`, which includes everything under
+   `fibsem.applications`. A pattern and a task defined in the same module
+   breaks the pattern. Strategies and tasks have no such restriction.
+2. **A plugin that fails to import is absent.** The application starts
+   without it and the class does not appear in the list. The reason is
+   recorded in the log and in the Plugins panel (**Tools → Plugins…**, or
+   `fibsem-cli plugins`), which lists every declared entry point and its
+   outcome, including entry points shadowed by a built-in of the same name.
+   `fibsem/plugins/loader.py` is the loader and documents the records it
+   keeps.
+3. **Changes to `pyproject.toml` take effect only after reinstalling.**
+   Entry points are read from the installed metadata, so run
+   `pip install -e .` again after editing them. Changes to Python files need
+   no reinstall.
 
-One trap in the forms: distances are stored in metres and scaled for
-display, and a distance field without `scale` metadata renders as
-`0.000 m`. Spread `DEFAULT_DISTANCE_METADATA` from `fibsem.milling.properties`
-into distance fields, as the built-in patterns do; the example's tests check
-this too.
+Distances in configuration forms are stored in metres and scaled for
+display. A distance field without `scale` metadata renders as `0.000 m`.
+Spread `DEFAULT_DISTANCE_METADATA` from `fibsem.milling.properties` into
+distance fields, as the built-in patterns do; the example's tests check this
+as well.
 
 ## Workflow tasks
 
-A task is one step done to one lamella. Subclass `AutoLamellaTask`
+A task is one step applied to one lamella. Subclass `AutoLamellaTask`
 (`fibsem/applications/autolamella/workflows/tasks/base.py`) with a matching
 `AutoLamellaTaskConfig`, and register both with `register_task()` in the
-tree or with the `fibsem.tasks` entry point from a plugin. Read one existing
-task module end to end first; `fiducial.py` is a good mid-complexity
-example.
+repository or through the `fibsem.tasks` entry point from a plugin.
+`fiducial.py` is a representative task module of moderate complexity.
 
 Four contracts:
 
-- **Override `_run()`, not `run()`.** `run()` is the lifecycle wrapper:
-  `pre_task()`, the hooks, `_run()`, `post_task()`. Overriding it loses the
-  task's state, its history entry and every hook, with no error.
+- **Override `_run()`, not `run()`.** `run()` is the lifecycle wrapper: it
+  calls `pre_task()`, the hooks, `_run()` and `post_task()`. Overriding
+  `run()` loses the task's state, its history entry and every hook, without
+  an error.
 - **Questions go through `ask()`** (`workflows/interaction.py`). Build a
   `Request` carrying everything needed to answer it and block on the
-  responder. Never reach into widgets from the workflow thread. This seam is
-  what lets the GUI, the operator and a remote agent all answer the same
-  question, and what makes supervised and unsupervised runs the same code.
-- **Record what you produce** on the task's history entry
-  (`task_state.outputs`, role → files), and write images under
-  `lamella.path`. That is what the Review panel and the reports read;
-  unrecorded files are invisible, and files elsewhere are lost when the
-  experiment is copied off the microscope.
-- **Cancellation is cooperative.** Stop sets an event. A task that never
-  calls `self._check_for_abort()`, or a strategy that never checks
+  responder. Do not access widgets from the workflow thread. This interface
+  is what allows the GUI, the operator and a remote agent to answer the same
+  question, and it is why supervised and unsupervised runs share one code
+  path.
+- **Record outputs** on the task's history entry (`task_state.outputs`,
+  mapping role to files), and write images under `lamella.path`. The Review
+  panel and the reports read from there; unrecorded files are not shown,
+  and files written elsewhere are lost when the experiment is copied off
+  the microscope.
+- **Cancellation is cooperative.** Stop sets an event. A task that does not
+  call `self._check_for_abort()`, or a strategy that does not check
   `stop_event`, cannot be stopped.
 
-`task_type` is written into protocol files, so it is permanent: renaming it
-orphans every protocol that names it. Config classes are serialised into the
-protocol as well, so keep them to plain types that round-trip through YAML.
+`task_type` is written into protocol files and is therefore permanent:
+renaming it orphans every protocol that names it. Configuration classes are
+serialised into the protocol as well, so they should contain only plain
+types that round-trip through YAML.
 
 ## Supporting a microscope
 
-The seam is `FibsemMicroscope` (`fibsem/microscope.py`), an abstract class
-covering acquisition, movement, milling and state. Once a backend implements
-it and is registered, everything above, workflows, UI and server, works
+The interface is `FibsemMicroscope` (`fibsem/microscope.py`), an abstract
+class covering acquisition, movement, milling and state. Once a backend
+implements it and is registered, the workflows, UI and server work
 unchanged.
 
-- **Template**: `DemoMicroscope` in `fibsem/microscopes/simulator.py` is the
-  reference implementation, complete and hardware-free.
-  `fibsem/microscopes/tescan.py` shows a vendor SDK behind the same
-  interface. `microscopes/zeiss.py` is an empty placeholder awaiting a
-  SerialFIB migration; if Zeiss is your goal, fill it in rather than starting
+- **Reference implementations.** `DemoMicroscope` in
+  `fibsem/microscopes/simulator.py` is the complete, hardware-free
+  reference. `fibsem/microscopes/tescan.py` shows a vendor SDK behind the
+  same interface. `microscopes/zeiss.py` is an empty placeholder awaiting a
+  SerialFIB migration; a Zeiss backend should be built there rather than in
   a new file.
-- **Register it.** Implementing the class is not enough: the manufacturer
-  dispatch is hardcoded in a few places, and missing one gives
-  `NotImplementedError` at connect, not at import. `fibsem/manufacturers.py`
-  (the constant and alias), `setup_session()` in `fibsem/utils.py` (the
-  branch that constructs your class), `fibsem/configuration.py` (the
-  accepted manufacturers), and `fibsem/guided_setup.py` (`MANUFACTURERS`, and a
-  `MicroscopeModel` per instrument, which is what the first-run wizard
-  offers).
+- **Registration.** Implementing the class is not sufficient. The
+  manufacturer dispatch is hard-coded in four places, and a missing entry
+  raises `NotImplementedError` at connection time, not at import:
+  `fibsem/manufacturers.py` (the constant and alias), `setup_session()` in
+  `fibsem/utils.py` (the branch that constructs the class),
+  `fibsem/configuration.py` (the accepted manufacturers), and
+  `fibsem/guided_setup.py` (`MANUFACTURERS`, and a `MicroscopeModel` per
+  instrument, which is what the first-run wizard offers).
 - **Configuration.** Instruments are described by a YAML file in
   `fibsem/config/`; `fibsem-generate-config` scaffolds one. For a
   manufacturer it does not know, scaffold a Demo configuration and edit it.
-- **Verify.** Connect with `utils.setup_session()` and run the tests that
-  exercise the Demo through the same interface (`tests/test_acquire.py`,
+- **Verification.** Connect with `utils.setup_session()` and run the tests
+  that exercise the Demo through the same interface (`tests/test_acquire.py`,
   `tests/test_movement.py`, `tests/test_microscope.py`), then connect through
-  the app. You do not need all of the abstract methods working to start: get
-  acquisition and stage movement right and let the rest raise until their
-  subsystem's turn.
+  the application. Not every abstract method needs to work at first:
+  acquisition and stage movement are the prerequisites for the rest, and
+  unimplemented methods can raise until their subsystem is addressed.
 
-### A fluorescence microscope
+### Fluorescence microscopes
 
 Subclass `FluorescenceMicroscope` (`fibsem/fm/microscope.py`), which covers
-the objective, the filter set, the camera and acquisition; the
+the objective, the filter set, the camera and acquisition.
 `SimulatedFluorescenceMicroscope` in `fibsem/microscopes/simulator.py` is
 the hardware-free reference, and the Thermo Fisher and Odemis backends in
-`fibsem/fm/` are the two real ones. This interface is still in active
-development: expect it to change, and open an issue before building on it
-so the change can go the right way.
+`fibsem/fm/` are the two hardware implementations. This interface is under
+active development and is expected to change; open an issue before building
+on it.
 
-## Your own segmentation model
+## Segmentation models
 
-`fibsem/segmentation/` is the home: `SegmentationModelHuggingFace` loads
-checkpoints from the Hub, and the local-checkpoint paths sit beside it. A
-general model library (sidecar metadata, local and Hub resolution) is
-planned but not built; for now match the loading shape the existing models
-use, and expect this area to firm up.
+Models live under `fibsem/segmentation/`. `SegmentationModelHuggingFace`
+loads checkpoints from the Hugging Face Hub, and the local-checkpoint paths
+are beside it. A general model library (sidecar metadata, local and Hub
+resolution) is planned but not implemented. For now, match the loading
+interface of the existing models; this area is expected to change.

--- a/docs/developers/extending.md
+++ b/docs/developers/extending.md
@@ -46,9 +46,8 @@ in full, with examples that the test suite executes against real data.
 ### Inside the application
 
 AutoLamella can run a `.py` file from the scripts folder against the open
-experiment, from **Tools → Scripts → Manage scripts…**. The feature is off
-by default; enable it under **File → Preferences… → Features**. A script
-is one module-level function:
+experiment, from **Tools → Scripts → Manage scripts…**. A script is one
+module-level function:
 
 ```python
 """Export the experiment summary to CSV."""   # the first line becomes the tooltip

--- a/docs/developers/getting-started.md
+++ b/docs/developers/getting-started.md
@@ -1,31 +1,30 @@
 # Getting started as a developer
 
-This is a router, not a manual: find your goal below and follow its path.
-The rules of the road live in [CONTRIBUTING.md](../../CONTRIBUTING.md) (PR
-size, py3.8 floor, format-on-touch, tests) and [AGENTS.md](../../AGENTS.md);
-read those once before your first change. The paved roads themselves, the
-extension points we recommend and keep stable, are on
-[Extending fibsemOS](extending.md); this page says which one fits your goal.
-Other routes exist in the code; if you need one, open an issue first.
+This page covers the repository layout, how to run the application and the
+tests, and which extension point applies to a given goal. Contribution rules
+(pull request size, the Python 3.8 floor, formatting, tests) are in
+[CONTRIBUTING.md](../../CONTRIBUTING.md) and [AGENTS.md](../../AGENTS.md).
+The supported extension points are described on
+[Extending fibsemOS](extending.md). Other approaches are possible; open an
+issue before relying on internals that are not listed there.
 
-## The lay of the land
+## Repository layout
 
 ```
-fibsem/                     the instrument library (no app logic)
-  microscope.py             FibsemMicroscope — the ABC every microscope
-                            implements (plus, historically, the TFS
-                            implementation itself — ThermoMicroscope lives
-                            in this file, not in microscopes/)
-  microscopes/              tescan, odemis, simulator (DemoMicroscope — the
-                            reference); autoscript.py is TFS helper
-                            subsystems, not the microscope class
-  structures.py             the shared vocabulary: FibsemImage, Point,
-                            FibsemRectangle, stage positions, settings
-  milling/, imaging/        beam operations built on the ABC
-  segmentation/             segmentation models (see "your own model")
-  ui/                       shared Qt widgets, tokens.py palette, canvases
+fibsem/                     the instrument library (no application logic)
+  microscope.py             FibsemMicroscope, the abstract class every backend
+                            implements; also holds ThermoMicroscope, the
+                            Thermo Fisher implementation
+  microscopes/              tescan, odemis, simulator (DemoMicroscope, the
+                            reference implementation); autoscript.py holds
+                            Thermo Fisher helper subsystems, not the class
+  structures.py             shared types: FibsemImage, Point, FibsemRectangle,
+                            stage positions, settings
+  milling/, imaging/        beam operations built on the abstract class
+  segmentation/             segmentation models
+  ui/                       shared Qt widgets, the palette (tokens.py), canvases
   server/                   the agent/bench HTTP server (build_server)
-  mcp/                      the fibsem-mcp sidecar (MCP → HTTP)
+  mcp/                      the fibsem-mcp sidecar (MCP to HTTP)
   plugins/                  entry-point loading: fibsem.patterns,
                             fibsem.strategies, fibsem.tasks
 
@@ -35,77 +34,70 @@ fibsem/applications/autolamella/
                             registration, one module per task
   workflows/interaction.py  how tasks ask questions (ask(), Request types)
   ui/                       the application windows
-  server/                   AgentContext — what remote agents see
-  scripting.py              ScriptContext — what user scripts see
+  server/                   AgentContext, the view remote agents get
+  scripting.py              ScriptContext, the view user scripts get
 
-tests/                      mirrors the layout; tests/ui needs
+tests/                      mirrors the layout; tests/ui requires
                             QT_QPA_PLATFORM=offscreen
 ```
 
-## First: get it running
+## Running the application
 
 ```bash
 pip install -e ".[ui,test,dev]"
 fibsem-autolamella-ui
 ```
 
-In the app, connect with the **Demo** (simulator) configuration — no
-hardware needed; every workflow runs against it. That launch-and-click
-loop is the ground truth here: green tests are weaker evidence than usual
-(see AGENTS.md), so run the app for anything about wiring.
+Connect with the **Demo** configuration. No hardware is needed; every
+workflow runs against the simulator, which images a synthetic cryo-grid
+with cells, film, defects and a holder of grids, so navigation, alignment
+and milling can be exercised end to end. See [the simulator](../simulator.md).
 
-The simulator can image a synthetic cryo-grid, with cells, film, rips and a
-holder full of grids, so navigation, alignment and milling can be exercised for
-real; see [the simulator page](../simulator.md).
+Running the application is the primary check for any change to wiring or
+user interface. CI does not run the Qt test suite, and a passing test run
+is not sufficient evidence that a widget works; see AGENTS.md.
 
-Run tests per affected file, never the whole suite by default:
+## Running tests
+
+Run the test files for the code you changed rather than the whole suite:
 
 ```bash
 QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_something.py -q
 ```
 
-## "I want to support my microscope"
+## Which extension point
 
-The seam is `FibsemMicroscope`, the reference implementation is the Demo,
-and implementing the class is only half of it: the manufacturer has to be
-registered in four places or connecting fails at runtime. All of it, with
-the tests to run, is under [Supporting a microscope](extending.md#supporting-a-microscope).
+**Supporting a microscope.** Implement `FibsemMicroscope`, using the Demo
+implementation as the reference, and register the manufacturer in the four
+places listed under [Supporting a microscope](extending.md#supporting-a-microscope).
+Implementing the class without registering it fails at connection time.
 
-## "I want to automate something"
+**Automating a procedure.** Three options, in increasing order of
+integration: a plain script against the library with no application; a user
+script that the application runs against the open experiment, receiving a
+`ScriptContext`; or a workflow task, when the procedure should run in the
+queue with supervision and history. The [choosing a route](extending.md#choosing-a-route)
+table compares them, and [SCRIPTING.md](../../SCRIPTING.md) covers scripts in
+full.
 
-Three tiers, from least to most involved: a plain script against the
-library with no app; a user script that the app runs against the experiment
-it has open, receiving a `ScriptContext`; or a workflow task, when the
-automation should live in the queue with supervision and history. The
-[choosing a route](extending.md#choosing-a-route) table says which, and
-[SCRIPTING.md](../../SCRIPTING.md) covers scripts in full.
-
-## "I want to add or extend a workflow task"
-
-Subclass `AutoLamellaTask` with a matching config, override `_run()`, ask
-questions through `ask()`, record what you produce. The contracts, the
-mistakes that lose state silently, and shipping a task as a plugin are under
+**Adding or extending a workflow task.** Subclass `AutoLamellaTask` with a
+matching configuration class, override `_run()`, ask questions through
+`ask()`, and record outputs on the task's history entry. The contracts, the
+failure modes, and shipping a task as a plugin are under
 [Workflow tasks](extending.md#workflow-tasks) and [Plugins](extending.md#plugins).
 
-## "I want to use my own segmentation model"
+**Using a segmentation model.** Models live under `fibsem/segmentation/`;
+see [Segmentation models](extending.md#segmentation-models).
 
-`fibsem/segmentation/` is the home; the caveats are under
-[Your own segmentation model](extending.md#your-own-segmentation-model).
+**Building against the agent server.** The agent server is internal for
+now. `docs/agent-server.md` describes it; the tool catalogue in
+`fibsem/server/catalog.py` is the contract, and the supervision skill under
+`.claude/skills/` is a reference client.
 
-## "I want to build against the agent server"
-
-The agent server is internal for now. `docs/agent-server.md` in this
-repository describes it; the tool catalog in `fibsem/server/catalog.py` is
-the contract, and the supervision skill under `.claude/skills/` shows what a
-well-behaved client looks like.
-
-## "I want to work on the UI"
-
-Use the role-named palette tokens (`fibsem/ui/tokens.py`) and prebuilt
-stylesheets — never pasted hex. Two rules with history behind them: UI
-event handlers never read the microscope (push updates or cached state
-only — an observer must not make the app poll hardware), and anything
-cross-thread goes through signals or the responder seam, never direct
-widget access. Check layout with an offscreen screenshot
-(`widget.grab().save(...)`) before calling a widget done, and remember CI
-does not run the Qt tests — launch the app.
+**Working on the user interface.** Use the palette tokens in
+`fibsem/ui/tokens.py` and the shared stylesheets rather than literal
+colours. Two rules: UI event handlers do not read from the microscope
+(updates are pushed, or come from cached state), and cross-thread
+communication goes through signals or the responder seam, never through
+direct widget access. Check layout with an offscreen screenshot
+(`widget.grab().save(...)`) and by running the application.

--- a/docs/developers/screenshot-harness.md
+++ b/docs/developers/screenshot-harness.md
@@ -1,17 +1,17 @@
 # The user guide's screenshot harness
 
 Every screenshot in the user guide on fibsemos.org is rendered by
-[`render_user_guide.py`](render_user_guide.py) from the real AutoLamella
-window, driven against the Demo microscope with the sample scene on. Nothing
-is captured by hand. The point is that the guide can be re-shot after any
-change to the interface instead of rotting, and that a control the guide
-names must still exist for the render to succeed.
+[`render_user_guide.py`](render_user_guide.py) from the AutoLamella window,
+running against the Demo microscope with the sample scene enabled. None are
+captured by hand. This allows the guide to be re-rendered after any change
+to the interface, and it means a control the guide names must still exist
+for the render to succeed.
 
 ## Running it
 
 From the repository root, with the docs site checked out beside this
-repository (the script also looks a few directories up, so a git worktree
-works):
+repository (the script also searches a few directories up, so a git
+worktree works):
 
 ```bash
 python docs/developers/render_user_guide.py            # every page
@@ -20,33 +20,34 @@ python docs/developers/render_user_guide.py --list     # the page names
 python docs/developers/render_user_guide.py --site ../fibsem-os.github.io
 ```
 
-It runs on Qt's offscreen platform, so it needs no display; set
+It runs on Qt's offscreen platform and needs no display; set
 `QT_QPA_PLATFORM` to override. A full run takes twenty to thirty minutes,
-most of it the two supervised workflow runs on the Workflows page; a single
-page is usually under two minutes.
+most of it the two supervised workflow runs on the Workflows page. A single
+page usually takes under two minutes.
 
-Images land in the site checkout under `public/doc/img/<page>/<name>.png`,
-at 1x, with `public/doc/img/manifest.json` listing what each page
-produced. After a run, rebuild the site and commit the images together with
-the page that uses them.
+Images are written to the site checkout under
+`public/doc/img/<page>/<name>.png`, at 1x, and `public/doc/img/manifest.json`
+lists what each page produced. After a run, rebuild the site and commit the
+images together with the page that uses them.
 
-## What it isolates
+## Isolation
 
-The harness never touches the machine it runs on:
+The harness does not modify the machine it runs on:
 
 - The configuration registry, preferences, saved positions and the sample
   holder files are redirected to a temporary directory. The stage module
-  imports the holder paths by name, so those are rebound in that module too,
-  or a calibration would land in the real file.
-- The working directory is moved to the temporary directory, because
-  acquisitions made with no experiment open save into it.
+  imports the holder paths by name, so those are rebound in that module as
+  well; otherwise a calibration would be written to the real file.
+- The working directory is changed to the temporary directory, because
+  acquisitions made with no experiment open are saved there.
 - The shipped `sim-arctis` and `sim-iflm` configurations are registered in
-  memory under those names; the worked example's experiment is created in
-  the temporary directory and adopted the way Create Experiment does it.
+  memory under those names. The worked example's experiment is created in
+  the temporary directory the same way Create Experiment does it.
 - Everything a screenshot could show of the machine is replaced by the
-  worked example: `C:\fibsemOS\config`, `D:\fibsemOS\experiments`,
-  the experiment `yeast-grid-a`, a configuration named `Arctis Bay 2`. A
-  path to this checkout or the home directory in an image is a bug.
+  worked example: `C:\fibsemOS\config`, `D:\fibsemOS\experiments`, the
+  experiment `yeast-grid-a`, and a configuration named `Arctis Bay 2`. A
+  path to the checkout or the home directory appearing in an image is a
+  bug.
 
 ## Adding a page
 
@@ -65,104 +66,102 @@ def render_milling(h: Harness) -> None:
 ```
 
 `Harness` owns one application and one main window for the whole run and
-carries the state between pages, so a page may find a previous page's
-connection or experiment already in place. The helpers are written to be
-idempotent for that reason: `connect()` keeps a connection to the same
-configuration and would otherwise toggle the button and disconnect,
-`ensure_experiment()` and `ensure_lamellae()` create only what is missing.
+carries state between pages, so a page may find a previous page's connection
+or experiment already in place. The helpers are idempotent for that reason:
+`connect()` keeps an existing connection to the same configuration rather
+than toggling the button and disconnecting; `ensure_experiment()` and
+`ensure_lamellae()` create only what is missing.
 
-The helpers a page uses:
-
-| Helper | What it does |
+| Helper | Purpose |
 | -- | -- |
 | `connect(name)` | Connect through the Connection tab to `sim-arctis` or `sim-iflm`. |
 | `first_run(on)` | Show or hide the first-run offer on the Connection tab. |
 | `show_tab(i)`, `show_main_tab("Protocol")` | Select a main-window tab. |
-| `ensure_experiment()`, `ensure_lamellae(n)` | The worked example's experiment and lamellae. |
-| `cell_positions(n)` | Stage positions of `n` cells on plain film, from the scene's own feature list and support masks. Every marked position comes from here, so none sits on a grid bar. |
+| `ensure_experiment()`, `ensure_lamellae(n)` | Create the worked example's experiment and lamellae if absent. |
+| `cell_positions(n)` | Stage positions of `n` cells on plain film, from the scene's feature list and support masks. Every marked position comes from here, so none sits on a grid bar. |
 | `wait_acquisition(iw)`, `wait_move(ctrl, iw)`, `wait_fm(fmc)` | Pump the event loop until the worker behind an acquisition, a stage move or a fluorescence acquisition has finished. |
-| `pump(ms)` | Run the event loop for a while: paints, timers, queued signals. |
-| `shot(name, ...)` | Grab and annotate; below. |
+| `pump(ms)` | Run the event loop for a period: paints, timers, queued signals. |
+| `shot(name, ...)` | Capture and annotate; see below. |
 
-### Photographing
+### Capturing
 
-`shot()` grabs the main window by default, or the widget passed as
-`target`, and writes `<page>/<name>.png`. Its options:
+`shot()` captures the main window by default, or the widget passed as
+`target`, and writes `<page>/<name>.png`. Options:
 
 - `callouts`: widgets to mark, numbered in order. A bare widget gets a
-  numbered badge at its corner; `Box(widget)` gets a light box round it as
-  well. The rule is badges for controls and boxes for regions (a panel, a
-  tab bar, the quad view), because a box round a single button only repeats
-  its edge. A callout that is not visible raises: the guide must not
-  describe a control the reader cannot see.
+  numbered badge at its corner; `Box(widget)` adds a light box around it.
+  The convention is badges for controls and boxes for regions (a panel, a
+  tab bar, the quad view), since a box around a single button only repeats
+  its edge. A callout that is not visible raises an error, so the guide
+  cannot describe a control the reader cannot see.
 - `callout_rects`: rectangles in the target's coordinates, for things that
   are not widgets, such as a menu item from `menu.actionGeometry(action)`.
-- `clicks`: `(rect, "Alt + Double click")` pairs. Drawn as a box, a
-  crosshair at the click itself, and a pill naming the gesture.
-  `image_point_rect(canvas, panel, x, y)` gives the rect for an image
+- `clicks`: `(rect, "Alt + Double click")` pairs, drawn as a box, a
+  crosshair at the click point, and a label naming the gesture.
+  `image_point_rect(canvas, panel, x, y)` gives the rectangle for an image
   pixel.
 - `crop=True`: trim a panel to the area its visible children occupy, with
-  a margin for the badges; `height=` caps a list that stretches to fill its
+  a margin for the badges. `height=` caps a list that stretches to fill its
   tab.
 
-Menus are their own top-level windows, so a menu is grabbed by popping it
-up and passing it as the target. Dialogs are shown with `show()`, never
-`exec_()`, so the harness keeps the event loop.
+A menu is its own top-level window, so it is captured by popping it up and
+passing it as the target. Dialogs are shown with `show()`, not `exec_()`,
+so the harness keeps control of the event loop.
 
-## Getting to a state
+## Reaching a state
 
 The harness drives the same handlers the buttons do, in preference to
-reaching into state, so a screenshot shows what a user's click produces.
-Some things in the application stand in the way of that, and the pages have
-had to work round them. Knowing these saves an afternoon:
+setting state directly, so a screenshot shows what a user's action produces.
+Several parts of the application require workarounds:
 
 - **Modal dialogs block the harness.** A `dialog.exec_()` inside a handler
-  runs its own event loop and the harness never regains control. Confirm
-  steps are answered by replacing the function that shows them
+  runs its own event loop and the harness does not regain control.
+  Confirmation steps are answered by replacing the function that shows them
   (`ow._confirm = lambda *_: True` on the overview widget,
-  `confirm_run_workflow_dialog` in the main-window module), and the
-  workflow's completion summary is suppressed and then shown by hand with
-  `show()` for its own screenshot.
-- **Supervised prompts live on the Experiment tab** under the Microscope
-  tab. Poll `ui.WAITING_FOR_USER_INTERACTION`, switch there, photograph,
-  then answer with `pushButton_yes` or `pushButton_no`. A milling prompt
-  comes back after the run (Yes is Run Milling again, No is Continue), so
-  the Workflows page answers Yes once per task name and Continue after.
-- **Lists rebuild after a run.** The Workflow tab's lamella and task
-  checkboxes are cleared when a run finishes; re-tick both before the next
-  run, and check `ui.is_workflow_running` right after pressing Run or a run
-  that silently did not start looks like one that finished instantly.
-- **Acquire Image on the Fluorescence tab takes the selected channel
-  only**, and the Microscope tab's fluorescence view shows one frame. A
-  multi-channel composite is a two-plane z-stack opened in the standalone
-  Fluorescence Image Viewer, whose canvas has the channel controls. A
-  loaded stack opens in max projection; turn it off to see the slice
-  controls. The fluorescence toolbar exists only on the selected view.
-- **The ion beam's overview tiles step further across the stage than
-  their width**, and a 3 × 3 at 400 µm runs past the simulated stage
-  limits. FIB overviews are taken at 250 µm, and at the MILLING orientation
-  as a single row.
+  `confirm_run_workflow_dialog` in the main-window module). The workflow's
+  completion summary is suppressed and then shown with `show()` for its own
+  screenshot.
+- **Supervised prompts appear on the Experiment tab** under the Microscope
+  tab. Poll `ui.WAITING_FOR_USER_INTERACTION`, switch there, capture, then
+  answer with `pushButton_yes` or `pushButton_no`. A milling prompt is
+  repeated after the run (Yes runs milling again, No continues), so the
+  Workflows page answers Yes once per task name and Continue afterwards.
+- **Lists are rebuilt after a run.** The Workflow tab's lamella and task
+  checkboxes are cleared when a run finishes. Re-tick both before the next
+  run, and check `ui.is_workflow_running` immediately after pressing Run;
+  otherwise a run that did not start is indistinguishable from one that
+  finished instantly.
+- **Acquire Image on the Fluorescence tab takes every channel in the list**,
+  and the Microscope tab's fluorescence view shows one frame. A
+  multi-channel composite is composed in the standalone Fluorescence Image
+  Viewer (View menu), whose canvas has the channel controls. A loaded stack
+  opens in maximum projection; turn it off to reach the slice controls. The
+  fluorescence toolbar exists only on the selected view.
+- **The ion beam's overview tiles step further across the stage than their
+  width**, and a 3 × 3 at 400 µm exceeds the simulated stage limits. FIB
+  overviews are taken at 250 µm, and at the MILLING orientation as a single
+  row.
 - **The development environment's example plugin** appears in the task and
-  pattern lists. It is removed from a combo before the combo is
-  photographed; it is not part of the product.
-- **Panels inside a scroll area** are grabbed from the scroll area's content
-  widget, which lays out at full height, not from the tab, which shows only
-  the visible part.
+  pattern lists. It is removed from a combo box before the combo box is
+  captured; it is not part of the product.
+- **Panels inside a scroll area** are captured from the scroll area's
+  content widget, which lays out at full height, rather than from the tab,
+  which shows only the visible part.
 
 ## Determinism
 
 Runs are deterministic apart from one pixel column at the seam between the
-quad view and the control panel in full-window shots, a layout-rounding
-artefact at the vispy canvas edge. Every panel and dialog shot is
-byte-identical across runs. The scene seed, window size (1600 × 1000, no
-screen to clamp it) and stage positions are fixed; the run is offscreen so
-fonts and metrics do not depend on the machine.
+quad view and the control panel in full-window captures, a layout-rounding
+artefact at the vispy canvas edge. Every panel and dialog capture is
+byte-identical across runs. The scene seed, window size (1600 × 1000, with
+no screen to clamp it) and stage positions are fixed, and the run is
+offscreen, so fonts and metrics do not depend on the machine.
 
 ## When a render fails
 
 The most common failure is a callout naming a widget that has been renamed
-or removed: the run raises with the callout's index and type. That is the
-mechanism working. Fix the page function, or the guide's prose if the
-control really has gone, and re-render that page. The second most common is
-a wait helper timing out because a modal dialog appeared; find it and
-replace the function that shows it, as above.
+or removed: the run raises an error giving the callout's index and type.
+This is the intended behaviour. Fix the page function, or the guide's prose
+if the control has been removed, and re-render that page. The second most
+common failure is a wait helper timing out because a modal dialog appeared;
+find the dialog and replace the function that shows it, as described above.


### PR DESCRIPTION
The four developer pages under `docs/developers/` (index, getting started, extending, screenshot harness) are rewritten in a plain, neutral register before they are published on the site (fibsem-os.github.io #10 copies them at build time). The first draft used metaphors and conversational asides ("a router, not a manual", "paved roads", "the mistakes that have cost people time"); these are gone. The facts, examples and cross-references are unchanged, apart from the segmentation section's heading, now "Segmentation models", and its anchor.

`docs/simulator.md`, `CONTRIBUTING.md` and `SCRIPTING.md`, which also publish, are not touched here.