### PR TITLE
[ui] Generated forms fold their hidden rows away; drop the napari layer-controls test

### DIFF
--- a/fibsem/applications/autolamella/ui/tests/test_lamella_protocol_editor_canvas.py
+++ b/fibsem/applications/autolamella/ui/tests/test_lamella_protocol_editor_canvas.py
@@ -422,29 +422,7 @@ def test_eye_toggle_routes_through_the_reducer_when_wired():
     assert w._patterns_visible is True
 
 
-# --- the shell: the landmine that breaks the *other* tabs ----------------------
-
-
-def test_layer_controls_menu_survives_a_migrated_tab():
-    """The whole reason tabs can migrate one at a time.
-
-    The handler used to build a dict literal dereferencing all three viewer attributes,
-    so a tab that stopped creating its viewer raised AttributeError for *every* menu
-    entry — and an exception escaping a Qt slot aborts the process under PyQt5
-    (FIB-329). Calling it on an object with no viewer attributes at all is the harshest
-    version of that: it must be a no-op, not a crash.
-    """
-    from fibsem.applications.autolamella.ui.AutoLamellaMainUI import (
-        AutoLamellaSingleWindowUI,
-    )
-
-    class _NoViewers:
-        pass
-
-    handler = AutoLamellaSingleWindowUI._on_toggle_viewer_layer_controls
-    for key in ("microscope", "overview", "lamella", "nonsense"):
-        handler(_NoViewers(), True, key)  # must not raise
-        handler(_NoViewers(), False, key)
+# --- the shell -----------------------------------------------------------------
 
 
 def test_protocol_tab_embeds_the_canvas_not_a_napari_window():

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -1046,6 +1046,41 @@ class ElidedLabel(QLabel):
 FORM_LABEL_WIDTH = 150
 
 
+class FormGrid(QGridLayout):
+    """A two-column form that folds its hidden rows away.
+
+    QFormLayout keeps the vertical spacing of a row whose widgets are hidden, so
+    a form with its advanced rows hidden ended in a band of nothing the height
+    of those rows' gaps. QGridLayout drops an empty row's spacing along with the
+    row. This speaks the three QFormLayout calls the generated forms use --
+    addRow, rowCount, removeRow -- over a grid, so those forms fold correctly
+    without changing how they are built. `align_form` treats it as the grid it is.
+    """
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._rows: List[Tuple[QWidget, QWidget]] = []
+
+    def addRow(self, label, field: QWidget) -> None:  # noqa: N802 - Qt naming
+        if isinstance(label, str):
+            label = QLabel(label)
+        row = len(self._rows)
+        self.addWidget(label, row, 0)
+        self.addWidget(field, row, 1)
+        self._rows.append((label, field))
+
+    def rowCount(self) -> int:  # noqa: N802 - Qt naming
+        # QGridLayout.rowCount never shrinks; the forms ask how many rows are live.
+        return len(self._rows)
+
+    def removeRow(self, row: int) -> None:  # noqa: N802 - Qt naming
+        label, field = self._rows.pop(row)
+        for widget in (label, field):
+            self.removeWidget(widget)
+            widget.setParent(None)
+            widget.deleteLater()
+
+
 def align_form(layout) -> None:
     """Give *layout* the shared label column: labels FORM_LABEL_WIDTH, fields the rest.
 

--- a/fibsem/ui/widgets/milling_settings_widget.py
+++ b/fibsem/ui/widgets/milling_settings_widget.py
@@ -5,14 +5,13 @@ from typing import Dict, List, Optional
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
-    QFormLayout,
     QLabel,
     QWidget,
 )
 
 from fibsem.microscope import FibsemMicroscope
 from fibsem.structures import BeamType, FibsemMillingSettings
-from fibsem.ui.widgets.custom_widgets import align_form
+from fibsem.ui.widgets.custom_widgets import FormGrid, align_form
 from fibsem.ui.widgets.form_builder import Control, build_control
 
 
@@ -59,7 +58,7 @@ class FibsemMillingSettingsWidget(QWidget):
     # ------------------------------------------------------------------
 
     def _setup_ui(self) -> None:
-        layout = QFormLayout(self)
+        layout = FormGrid(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
         for field_name, m in _META.items():

--- a/fibsem/ui/widgets/pattern_settings_widget.py
+++ b/fibsem/ui/widgets/pattern_settings_widget.py
@@ -7,7 +7,6 @@ from typing import List, Optional
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
-    QFormLayout,
     QLabel,
     QVBoxLayout,
     QWidget,
@@ -17,7 +16,7 @@ from fibsem.microscope import FibsemMicroscope
 from fibsem.milling.patterning import get_pattern, get_pattern_names
 from fibsem.milling.patterning.patterns2 import BasePattern
 from fibsem.structures import BeamType
-from fibsem.ui.widgets.custom_widgets import ValueComboBox, align_form
+from fibsem.ui.widgets.custom_widgets import FormGrid, ValueComboBox, align_form
 from fibsem.ui.widgets.form_builder import Control, build_control
 
 
@@ -65,7 +64,7 @@ class FibsemPatternSettingsWidget(QWidget):
         outer.setSpacing(4)
 
         # Pattern type selector — fixed row, not rebuilt
-        type_form = QFormLayout()
+        type_form = FormGrid()
         type_form.setContentsMargins(0, 0, 0, 0)
         self._type_combo = ValueComboBox(get_pattern_names(), value=self._pattern.name)
         type_form.addRow("Pattern", self._type_combo)
@@ -73,7 +72,7 @@ class FibsemPatternSettingsWidget(QWidget):
         outer.addLayout(type_form)
 
         # Field form — rebuilt on type change
-        self._fields_form = QFormLayout()
+        self._fields_form = FormGrid()
         self._fields_form.setContentsMargins(0, 0, 0, 0)
         outer.addLayout(self._fields_form)
 

--- a/fibsem/ui/widgets/strategy_settings_widget.py
+++ b/fibsem/ui/widgets/strategy_settings_widget.py
@@ -7,7 +7,6 @@ from typing import Any, List, Optional
 
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import (
-    QFormLayout,
     QLabel,
     QVBoxLayout,
     QWidget,
@@ -18,7 +17,7 @@ from fibsem.milling.strategy import get_strategy_names
 from fibsem.ui.tokens import (
     TEXT_MUTED_COLOR,
 )
-from fibsem.ui.widgets.custom_widgets import ValueComboBox, align_form
+from fibsem.ui.widgets.custom_widgets import FormGrid, ValueComboBox, align_form
 from fibsem.ui.widgets.form_builder import Control, build_control
 
 
@@ -66,7 +65,7 @@ class FibsemStrategySettingsWidget(QWidget):
         outer.setSpacing(4)
 
         # Strategy type selector — fixed, not rebuilt
-        type_form = QFormLayout()
+        type_form = FormGrid()
         type_form.setContentsMargins(0, 0, 0, 0)
         self._type_combo = ValueComboBox(
             get_strategy_names(), value=self._strategy.name
@@ -76,7 +75,7 @@ class FibsemStrategySettingsWidget(QWidget):
         outer.addLayout(type_form)
 
         # Config field form — rebuilt on type change
-        self._config_form = QFormLayout()
+        self._config_form = FormGrid()
         self._config_form.setContentsMargins(0, 0, 0, 0)
         outer.addLayout(self._config_form)
 

--- a/tests/ui/test_form_writeback.py
+++ b/tests/ui/test_form_writeback.py
@@ -205,3 +205,44 @@ def test_enum_members_read_as_words():
     assert _enum_label(Style.CleaningCrossSection) == "Cleaning Cross Section"
     assert _enum_label(Style.EACH_ROW) == "Each Row"
     assert _enum_label(Style.Plain) == "Plain"
+
+
+def test_a_form_grid_folds_its_hidden_rows_away(qapp):
+    """QFormLayout keeps the spacing of a hidden row, so a form with its advanced
+    rows hidden ended in a band of nothing. FormGrid drops the row and its gap."""
+    from PyQt5.QtWidgets import QLabel, QLineEdit, QWidget
+
+    from fibsem.ui.widgets.custom_widgets import FormGrid
+
+    def build(hidden_rows: int) -> int:
+        host = QWidget()
+        grid = FormGrid(host)
+        grid.setContentsMargins(0, 0, 0, 0)
+        for i in range(3 + hidden_rows):
+            label, field = QLabel(f"Row {i}"), QLineEdit()
+            grid.addRow(label, field)
+            if i >= 3:
+                label.setVisible(False)
+                field.setVisible(False)
+        host.show()
+        qapp.processEvents()
+        assert grid.rowCount() == 3 + hidden_rows
+        return host.sizeHint().height()
+
+    assert build(hidden_rows=3) == build(hidden_rows=0)
+
+
+def test_a_form_grid_can_be_emptied_and_refilled(qapp):
+    from PyQt5.QtWidgets import QLineEdit, QWidget
+
+    from fibsem.ui.widgets.custom_widgets import FormGrid
+
+    host = QWidget()
+    grid = FormGrid(host)
+    grid.addRow("One", QLineEdit())
+    grid.addRow("Two", QLineEdit())
+    while grid.rowCount():
+        grid.removeRow(0)
+    assert grid.rowCount() == 0
+    grid.addRow("Three", QLineEdit())
+    assert grid.rowCount() == 1


### PR DESCRIPTION
## Summary

Stacked on #832. Two loose ends from the settings-widget pass.

**The empty band under the generated forms.** `QFormLayout` keeps the vertical spacing of a row whose widgets are hidden, so the Milling, Pattern and Strategy forms ended in a band of nothing the height of their hidden rows' gaps: advanced rows, and rows filtered out for the manufacturer. Measured: a 6-row form with 3 hidden is 114 px in a `QFormLayout` and 96 px in a `QGridLayout`. `FormGrid` is a `QGridLayout` that speaks the three `QFormLayout` calls those forms use, `addRow`, `rowCount` and `removeRow`, so the forms fold correctly without changing how they are built. `align_form` already treats it as the grid it is. The milling form with advanced hidden now measures exactly its one visible row.

**The stale test.** `test_layer_controls_menu_survives_a_migrated_tab` asserted that the main window's napari layer-controls menu handler tolerated a tab with no viewer. That handler, and the per-tab napari viewers it guarded, are gone from the window; the test has failed on every run since and only lives in a harness CI does not run. Removed. The neighbouring test that pins the Protocol tab to the canvas stays.

## Verification

- Two new tests in `tests/ui/test_form_writeback.py`: a `FormGrid` with hidden rows is exactly as tall as one without them, and it can be emptied and refilled the way the pattern and strategy forms do on a type change.
- 90 tests pass across milling settings, pattern, config widget, form writeback, integer settings, task-config parameters, the editor canvas suite (now fully green) and the milling viewer.
- Rendered the Lamella editor with a real experiment: the Milling panel ends under its last visible row.
- Lint and format-check clean, with the isolated unused-import and undefined-name check.
