### PR TITLE
[refactor] A configuration loads whether or not it says everything (schema v1)

### DIFF
--- a/fibsem/config/microscope-configuration.yaml
+++ b/fibsem/config/microscope-configuration.yaml
@@ -1,5 +1,6 @@
 # Please don't edit or delet this file, it is the default configuration for the microscope
 # configuration 
+version: 1                                                  # configuration schema version
 info:
     name: openfibsem-microscope-configuration               # a descriptive name for your configuration                     [SPECIFIED]
     ip_address: 192.168.0.1                                 # the ip address of the microscope PC                           [SPECIFIED]

--- a/fibsem/config/odemis-configuration.yaml
+++ b/fibsem/config/odemis-configuration.yaml
@@ -1,5 +1,6 @@
 # Please don't edit or delet this file, it is the default configuration for the microscope
 # configuration 
+version: 1                                                  # configuration schema version
 info:
     name: odemis-microscope-configuration               # a descriptive name for your configuration                     [SPECIFIED]
     ip_address: 192.168.0.1                                 # the ip address of the microscope PC                           [SPECIFIED]

--- a/fibsem/config/sim-arctis-configuration.yaml
+++ b/fibsem/config/sim-arctis-configuration.yaml
@@ -1,3 +1,4 @@
+version: 1                                                  # configuration schema version
 info:
     name: sim-tfs-arctis-configuration               
     ip_address: 192.168.0.1                                 

--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -16,6 +16,7 @@
 # 35 degree pre-tilted shuttle and a half turn to reach the ion beam, which is what
 # puts the FM orientation at (r=180, t=17) -- identical to the FIB one, and the reason
 # an offset system cannot tell the two apart. See FIB-830.
+version: 1                                                  # configuration schema version
 info:
     name: sim-iflm-configuration                            # a descriptive name for your configuration                     [SPECIFIED]
     ip_address: 192.168.0.1                                 # the ip address of the microscope PC                           [SPECIFIED]

--- a/fibsem/config/tescan-configuration.yaml
+++ b/fibsem/config/tescan-configuration.yaml
@@ -1,5 +1,6 @@
 # Please don't edit or delete this file, it is the default configuration for the microscope
 # configuration 
+version: 1                                                  # configuration schema version
 info:
     name: tescan-microscope-configuration               # a descriptive name for your configuration                     [SPECIFIED]
     ip_address: localhost                                 # the ip address of the microscope PC                           [SPECIFIED]

--- a/fibsem/config/tfs-aquilos2-configuration.yaml
+++ b/fibsem/config/tfs-aquilos2-configuration.yaml
@@ -1,5 +1,6 @@
 # Please don't edit or delet this file, it is the default configuration for the microscope
 # configuration 
+version: 1                                                  # configuration schema version
 info:
     name: tfs-aquilos2-configuration                        # a descriptive name for your configuration                     [SPECIFIED]
     ip_address: 192.168.0.1                                 # the ip address of the microscope PC                           [SPECIFIED]

--- a/fibsem/config/tfs-arctis-configuration.yaml
+++ b/fibsem/config/tfs-arctis-configuration.yaml
@@ -1,5 +1,6 @@
 # Please don't edit or delet this file, it is the default configuration for the microscope
 # configuration 
+version: 1                                                  # configuration schema version
 info:
     name: tfs-arctis-configuration                          # a descriptive name for your configuration                     [SPECIFIED]
     ip_address: localhost                                 # the ip address of the microscope PC                           [SPECIFIED]

--- a/fibsem/config/tfs-hydra-configuration.yaml
+++ b/fibsem/config/tfs-hydra-configuration.yaml
@@ -1,5 +1,6 @@
 # Please don't edit or delet this file, it is the default configuration for the microscope
 # configuration 
+version: 1                                                  # configuration schema version
 info:
     name: tfs-hydra-configuration                           # a descriptive name for your configuration                     [SPECIFIED]
     ip_address: 192.168.0.1                                 # the ip address of the microscope PC                           [SPECIFIED]

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -1311,13 +1311,13 @@ class BeamSettings:
         current = state_dict.get("beam_current", state_dict.get("current", None))
 
         beam_settings = BeamSettings(
-            beam_type=BeamType[state_dict["beam_type"].upper()],
+            beam_type=BeamType[state_dict.get("beam_type", "ELECTRON").upper()],
             working_distance=wd,
             beam_current=current,
-            voltage=state_dict["voltage"],
-            hfw=state_dict["hfw"],
-            resolution=state_dict["resolution"],
-            dwell_time=state_dict["dwell_time"],
+            voltage=state_dict.get("voltage"),
+            hfw=state_dict.get("hfw"),
+            resolution=state_dict.get("resolution"),
+            dwell_time=state_dict.get("dwell_time"),
             stigmation=stigmation,
             shift=shift,
             scan_rotation=state_dict.get("scan_rotation", 0.0),
@@ -2292,9 +2292,9 @@ class StageSystemSettings:
         # stored value that disagrees with the derivation is a value someone typed
         # wrong, and reading it back would preserve the mistake.
         return StageSystemSettings(
-            rotation_reference=settings["rotation_reference"],
-            shuttle_pre_tilt=settings["shuttle_pre_tilt"],
-            manipulator_height_limit=settings["manipulator_height_limit"],
+            rotation_reference=settings.get("rotation_reference", 0.0),
+            shuttle_pre_tilt=settings.get("shuttle_pre_tilt", 0.0),
+            manipulator_height_limit=settings.get("manipulator_height_limit", 0.0037),
             enabled=settings.get("enabled", True),
             rotation=settings.get("rotation", True),
             milling_angle=settings.get("milling_angle", 15.0),
@@ -2349,12 +2349,12 @@ class BeamSystemSettings:
     @staticmethod
     def from_dict(settings: dict) -> "BeamSystemSettings":
         return BeamSystemSettings(
-            beam_type=BeamType[settings["beam_type"]],
-            enabled=settings["enabled"],
+            beam_type=BeamType[settings.get("beam_type", "ELECTRON")],
+            enabled=settings.get("enabled", True),
             beam=BeamSettings.from_dict(settings),
             detector=FibsemDetectorSettings.from_dict(settings),
-            eucentric_height=settings["eucentric_height"],
-            column_tilt=settings["column_tilt"],
+            eucentric_height=settings.get("eucentric_height", 0.0),
+            column_tilt=settings.get("column_tilt", 0.0),
             plasma=settings.get("plasma", False),
             plasma_gas=settings.get("plasma_gas", None),
         )
@@ -2376,9 +2376,9 @@ class ManipulatorSystemSettings:
     @staticmethod
     def from_dict(settings: dict):
         return ManipulatorSystemSettings(
-            enabled=settings["enabled"],
-            rotation=settings["rotation"],
-            tilt=settings["tilt"],
+            enabled=settings.get("enabled", True),
+            rotation=settings.get("rotation", False),
+            tilt=settings.get("tilt", False),
         )
 
 
@@ -2399,9 +2399,9 @@ class GISSystemSettings:
     @staticmethod
     def from_dict(settings: dict):
         return GISSystemSettings(
-            enabled=settings["enabled"],
-            multichem=settings["multichem"],
-            sputter_coater=settings["sputter_coater"],
+            enabled=settings.get("enabled", False),
+            multichem=settings.get("multichem", False),
+            sputter_coater=settings.get("sputter_coater", False),
         )
 
 
@@ -2538,17 +2538,25 @@ class SystemSettings:
     @staticmethod
     def from_dict(settings: dict):
 
-        # TODO: remove this once the settings are updated
-        settings["electron"]["beam_type"] = BeamType.ELECTRON.name
-        settings["ion"]["beam_type"] = BeamType.ION.name
+        # A missing *section* defaults like a missing field. A configuration that
+        # drops a block it does not need -- no GIS, no manipulator -- is a
+        # configuration, not a corrupt file, and this is what lets a key be removed
+        # from the shipped files without every existing one raising `KeyError` at
+        # load.
+        electron = dict(settings.get("electron") or {})
+        ion = dict(settings.get("ion") or {})
+        electron["beam_type"] = BeamType.ELECTRON.name
+        ion["beam_type"] = BeamType.ION.name
 
         return SystemSettings(
-            stage=StageSystemSettings.from_dict(settings["stage"]),
-            electron=BeamSystemSettings.from_dict(settings["electron"]),
-            ion=BeamSystemSettings.from_dict(settings["ion"]),
-            manipulator=ManipulatorSystemSettings.from_dict(settings["manipulator"]),
-            gis=GISSystemSettings.from_dict(settings["gis"]),
-            info=SystemInfo.from_dict(settings["info"]),
+            stage=StageSystemSettings.from_dict(settings.get("stage") or {}),
+            electron=BeamSystemSettings.from_dict(electron),
+            ion=BeamSystemSettings.from_dict(ion),
+            manipulator=ManipulatorSystemSettings.from_dict(
+                settings.get("manipulator") or {}
+            ),
+            gis=GISSystemSettings.from_dict(settings.get("gis") or {}),
+            info=SystemInfo.from_dict(settings.get("info") or {}),
             sim=settings.get("sim", {}),
             # The same `fm:` block `MicroscopeSettings.from_dict` reads `config` from.
             # Two readers, one key each: this is the hardware fact, that is a path to
@@ -2776,9 +2784,9 @@ class MicroscopeSettings:
 
         return MicroscopeSettings(
             system=SystemSettings.from_dict(settings),
-            image=ImageSettings.from_dict(settings["imaging"]),
+            image=ImageSettings.from_dict(settings.get("imaging") or {}),
             protocol=protocol,
-            milling=FibsemMillingSettings.from_dict(settings["milling"]),
+            milling=FibsemMillingSettings.from_dict(settings.get("milling") or {}),
             fm=fm_config,
         )
 

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2183,6 +2183,13 @@ class StageDeviceSettings:
 # per-device windows are how it happened.
 DEFAULT_DEVICE_RANGE = FibsemStagePosition(x=20.0e-3)
 
+# The ion column's angle from the electron column, in degrees. A property of the
+# instrument rather than a preference, and the same on every dual-beam this supports,
+# which is why a file that omits it can still be read correctly. Declared once because
+# it is read in two places -- the config reader and the geometry recorded on an image
+# -- and they must not be able to disagree about it.
+DEFAULT_FIB_COLUMN_TILT: float = 52.0
+
 # **The default is the objective under the grid**: the FM shares the beams' origin, and
 # is told apart by the pose the sample is held in. A site whose objective is offset --
 # piescope, METEOR, iFLM, all in the TFS SDB chamber -- declares the traverse instead,
@@ -2348,13 +2355,25 @@ class BeamSystemSettings:
 
     @staticmethod
     def from_dict(settings: dict) -> "BeamSystemSettings":
+        beam_type = BeamType[settings.get("beam_type", "ELECTRON")]
+
+        # The default depends on which column this is, so it cannot be a single
+        # number: an absent electron column tilt is 0, an absent ion column tilt is
+        # not. Taken from `FibsemHardwareGeometry`, which already declares both --
+        # the alternative is two independent defaults for one physical constant,
+        # which is how a config missing its `ion:` block came to load with a 52
+        # degree column recorded as 0.
+        default_column_tilt = (
+            DEFAULT_FIB_COLUMN_TILT if beam_type is BeamType.ION else 0.0
+        )
+
         return BeamSystemSettings(
-            beam_type=BeamType[settings.get("beam_type", "ELECTRON")],
+            beam_type=beam_type,
             enabled=settings.get("enabled", True),
             beam=BeamSettings.from_dict(settings),
             detector=FibsemDetectorSettings.from_dict(settings),
             eucentric_height=settings.get("eucentric_height", 0.0),
-            column_tilt=settings.get("column_tilt", 0.0),
+            column_tilt=settings.get("column_tilt", default_column_tilt),
             plasma=settings.get("plasma", False),
             plasma_gas=settings.get("plasma_gas", None),
         )
@@ -2671,7 +2690,8 @@ class FibsemHardwareGeometry:
     """
 
     column_tilt: float = 0.0  # electron column
-    fib_column_tilt: float = 52.0  # ion column; fixes the compustage FIB pose
+    # ion column; fixes the compustage FIB pose
+    fib_column_tilt: float = DEFAULT_FIB_COLUMN_TILT
     shuttle_pre_tilt: float = 0.0
     rotation_reference: float = 0.0
     rotation_180: float = 180.0
@@ -2718,7 +2738,7 @@ class FibsemHardwareGeometry:
         # point of the record is that such a file still loads.
         return cls(
             column_tilt=ddict.get("column_tilt", 0.0),
-            fib_column_tilt=ddict.get("fib_column_tilt", 52.0),
+            fib_column_tilt=ddict.get("fib_column_tilt", DEFAULT_FIB_COLUMN_TILT),
             shuttle_pre_tilt=ddict.get("shuttle_pre_tilt", 0.0),
             rotation_reference=ddict.get("rotation_reference", 0.0),
             rotation_180=ddict.get("rotation_180", 180.0),
@@ -3172,10 +3192,12 @@ class FibsemImageMetadata:
         """Recover the geometry from a pre-v6 `system` blob.
 
         Read with `.get()` chains rather than by building a `SystemSettings` first.
-        That constructor is bracket-indexed throughout -- a blob missing any of
-        `stage`, `electron`, `ion`, `manipulator`, `gis` or `info` raises KeyError --
-        and inheriting that here would break exactly the old files this exists to
-        load. See `tests/test_metadata_fixtures.py`.
+        That constructor used to be bracket-indexed and raise on a blob missing any
+        block, which would have broken exactly the old files this exists to load; it
+        now defaults instead, so the two routes agree and the choice is no longer
+        load-bearing. The agreement is not free, though -- it holds because both
+        declare the FIB column tilt from one constant -- and
+        `tests/test_metadata_fixtures.py` pins it.
 
         Compustage is recovered the way the reprojection used to detect it, by model
         name, falling back to the simulator flag. That match is wrong -- a capability

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -7,7 +7,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
 
 import yaml
 from PIL import Image
@@ -501,6 +501,8 @@ def load_microscope_configuration(
     # load config
     config = load_yaml(os.path.join(config_path))
 
+    report_unrecognised_configuration_keys(config, source=str(config_path))
+
     # load protocol
     protocol = load_protocol(protocol_path)
 
@@ -508,6 +510,118 @@ def load_microscope_configuration(
     settings = MicroscopeSettings.from_dict(config, protocol=protocol)
 
     return settings
+
+
+# Every block and key this version reads. A configuration may hold others -- one
+# written before a key was removed, or hand-edited with a guess -- and those are
+# ignored, which is the contract that lets old files keep working.
+#
+# But ignored *silently* is how `imaging.imaging_current` came to be a setting a user
+# could type, save, reload and never see again: `ImageSettings` has no such field, so
+# it was dropped on load and nothing said so. One line at load is the difference
+# between "my setting vanished" and "my setting is not supported".
+CONFIGURATION_SCHEMA: Dict[str, Set[str]] = {
+    "version": set(),
+    "info": {
+        "name",
+        "ip_address",
+        "manufacturer",
+        "model",
+        "serial_number",
+        "hardware_version",
+        "software_version",
+    },
+    "stage": {
+        "enabled",
+        "rotation",
+        "rotation_reference",
+        "shuttle_pre_tilt",
+        "manipulator_height_limit",
+        "milling_angle",
+        "devices",
+        "device_range",
+    },
+    "electron": {
+        "enabled",
+        "column_tilt",
+        "eucentric_height",
+        "voltage",
+        "current",
+        "resolution",
+        "hfw",
+        "dwell_time",
+        "detector_mode",
+        "detector_type",
+        "beam_type",
+        "working_distance",
+        "plasma",
+        "plasma_gas",
+    },
+    "ion": {
+        "enabled",
+        "column_tilt",
+        "eucentric_height",
+        "voltage",
+        "current",
+        "resolution",
+        "hfw",
+        "dwell_time",
+        "detector_mode",
+        "detector_type",
+        "beam_type",
+        "working_distance",
+        "plasma",
+        "plasma_gas",
+    },
+    "manipulator": {"enabled", "rotation", "tilt"},
+    "gis": {"enabled", "multichem", "sputter_coater"},
+    "imaging": {"beam_type", "resolution", "hfw", "dwell_time", "autocontrast", "save"},
+    "milling": {
+        "milling_voltage",
+        "milling_current",
+        "dwell_time",
+        "rate",
+        "spot_size",
+        "preset",
+    },
+    "fm": {"enabled", "config"},
+    # Open blocks. `sim:` stays a plain dict the simulator reads with `.get()` rather
+    # than a dataclass, and `protocol:` is the application's, so policing either would
+    # invent warnings every time a backend gains a key.
+    "sim": set(),
+    "protocol": set(),
+}
+
+
+def unrecognised_configuration_keys(config: dict) -> List[str]:
+    """Dotted paths in *config* that this version does not read.
+
+    A block with an empty set in the schema is accepted wholesale -- `sim:` and
+    `protocol:` carry backend- and application-specific keys that this function has no
+    business policing.
+    """
+    unknown: List[str] = []
+    for block, value in (config or {}).items():
+        known = CONFIGURATION_SCHEMA.get(block)
+        if known is None:
+            unknown.append(block)
+            continue
+        if not known or not isinstance(value, dict):
+            continue
+        unknown.extend(f"{block}.{key}" for key in value if key not in known)
+    return sorted(unknown)
+
+
+def report_unrecognised_configuration_keys(config: dict, source: str = "") -> List[str]:
+    """Log the keys this version ignores, once, and return them."""
+    unknown = unrecognised_configuration_keys(config)
+    if unknown:
+        where = f" in {source}" if source else ""
+        logging.info(
+            f"Configuration{where} contains {len(unknown)} key(s) this version does "
+            f"not use, and which will not be saved back: {', '.join(unknown)}"
+        )
+    return unknown
 
 
 def load_protocol(protocol_path: Path = None) -> dict:

--- a/tests/test_configuration_schema.py
+++ b/tests/test_configuration_schema.py
@@ -17,7 +17,11 @@ import pytest
 
 import fibsem.config as cfg
 from fibsem import utils
-from fibsem.structures import MicroscopeSettings, SystemSettings
+from fibsem.structures import (
+    DEFAULT_FIB_COLUMN_TILT,
+    MicroscopeSettings,
+    SystemSettings,
+)
 
 # Named rather than globbed: `fibsem/config/*.yaml` is gitignored with an allowlist,
 # so a configuration saved from the wizard sits in the same folder and a glob would
@@ -111,7 +115,11 @@ def test_a_missing_field_defaults_rather_than_raising():
 
     settings = MicroscopeSettings.from_dict(config)
     assert settings.system.stage.rotation_reference == 0.0
-    assert settings.system.ion.column_tilt == 0.0
+    # Not 0: the ion column's default is the angle between the columns, because a
+    # dual-beam whose FIB sits at 0 degrees is not a conservative fallback but a
+    # different instrument. See `DEFAULT_FIB_COLUMN_TILT`.
+    assert settings.system.ion.column_tilt == DEFAULT_FIB_COLUMN_TILT
+    assert settings.system.electron.column_tilt == 0.0
 
 
 def test_reading_does_not_mutate_the_dict_it_was_given():

--- a/tests/test_configuration_schema.py
+++ b/tests/test_configuration_schema.py
@@ -1,0 +1,187 @@
+"""A configuration loads whether or not it says everything.
+
+Two directions, and the readers only handled one of them. A file carrying *extra* keys
+has always loaded -- `from_dict` reads what it names and ignores the rest. A file
+*missing* a key raised `KeyError`, which is why removing `rotation_180` in FIB-834
+needed its reader changed first, and why the six dead `milling:` keys and
+`imaging.imaging_current` could not simply be deleted.
+
+Both directions now work, which is what lets the rest of the schema change happen as
+one refactor rather than a sequence of them.
+"""
+
+import copy
+import os
+
+import pytest
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.structures import MicroscopeSettings, SystemSettings
+
+# Named rather than globbed: `fibsem/config/*.yaml` is gitignored with an allowlist,
+# so a configuration saved from the wizard sits in the same folder and a glob would
+# sweep it in -- failing on one machine and not another.
+SHIPPED = (
+    "microscope-configuration.yaml",
+    "odemis-configuration.yaml",
+    "sim-arctis-configuration.yaml",
+    "sim-iflm-configuration.yaml",
+    "tescan-configuration.yaml",
+    "tfs-aquilos2-configuration.yaml",
+    "tfs-arctis-configuration.yaml",
+    "tfs-hydra-configuration.yaml",
+)
+
+
+def _load(filename: str) -> dict:
+    return utils.load_yaml(os.path.join(cfg.CONFIG_PATH, filename))
+
+
+# ---------------------------------------------------------------------------
+# Nothing that used to load stopped loading
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("filename", SHIPPED)
+def test_every_shipped_configuration_still_loads(filename: str):
+    settings = MicroscopeSettings.from_dict(_load(filename))
+    assert settings.system.info.manufacturer
+    assert settings.system.electron.beam.voltage is not None
+
+
+@pytest.mark.parametrize("filename", SHIPPED)
+def test_every_shipped_configuration_declares_its_version(filename: str):
+    """A format change cannot migrate a file that does not say what format it is.
+
+    Cheap now; impossible to add retrospectively, because a file without the field is
+    indistinguishable from one written before the field existed.
+    """
+    assert _load(filename)["version"] == 1
+
+
+# ---------------------------------------------------------------------------
+# A configuration may leave things out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        "version",
+        "info",
+        "stage",
+        "electron",
+        "ion",
+        "manipulator",
+        "gis",
+        "imaging",
+        "milling",
+        "sim",
+    ],
+)
+def test_any_block_may_be_absent(block: str):
+    """A configuration that drops a section it does not need is a configuration, not a
+    corrupt file. This is the change that unblocks removing keys from the shipped
+    files without every existing one raising at load."""
+    config = copy.deepcopy(_load("microscope-configuration.yaml"))
+    config.pop(block)
+
+    settings = MicroscopeSettings.from_dict(config)
+    assert isinstance(settings.system, SystemSettings)
+
+
+def test_an_empty_configuration_loads():
+    """The limit case, and the one that catches a reader missed in a nested class.
+
+    `BeamSettings.from_dict` was the one this found: it is reached through
+    `BeamSystemSettings`, so converting the classes named in the audit was not enough
+    and a per-field grep did not show it.
+    """
+    settings = MicroscopeSettings.from_dict({})
+
+    assert settings.system.stage.shuttle_pre_tilt == 0.0
+    assert settings.system.electron.beam.voltage is None
+
+
+def test_a_missing_field_defaults_rather_than_raising():
+    config = copy.deepcopy(_load("microscope-configuration.yaml"))
+    del config["stage"]["rotation_reference"]
+    del config["ion"]["column_tilt"]
+
+    settings = MicroscopeSettings.from_dict(config)
+    assert settings.system.stage.rotation_reference == 0.0
+    assert settings.system.ion.column_tilt == 0.0
+
+
+def test_reading_does_not_mutate_the_dict_it_was_given():
+    """`from_dict` used to stamp `beam_type` into the caller's `electron` block.
+
+    Harmless while one caller loaded one file, and not harmless once the editor holds
+    a configuration dict and saves it back -- the stamped key would be written to
+    disk.
+    """
+    config = _load("microscope-configuration.yaml")
+    before = copy.deepcopy(config)
+
+    SystemSettings.from_dict(config)
+
+    assert config == before
+
+
+# ---------------------------------------------------------------------------
+# Extra keys are ignored, and said out loud
+# ---------------------------------------------------------------------------
+
+
+def test_unrecognised_keys_are_reported():
+    """Ignoring silently is how `imaging.imaging_current` became a setting a user
+    could type, save, reload, and never see again -- `ImageSettings` has no such
+    field, so it was dropped on load and nothing said so."""
+    config = copy.deepcopy(_load("microscope-configuration.yaml"))
+    config["stage"]["nonsense"] = 1
+    config["a_block_from_the_future"] = {"x": 1}
+
+    unknown = utils.unrecognised_configuration_keys(config)
+
+    assert "stage.nonsense" in unknown
+    assert "a_block_from_the_future" in unknown
+
+
+def test_the_dead_key_the_audit_found_is_reported():
+    """`imaging.imaging_current` is still in every shipped file and still read by
+    nothing. Until it is removed, at least say so."""
+    assert "imaging.imaging_current" in utils.unrecognised_configuration_keys(
+        _load("microscope-configuration.yaml")
+    )
+
+
+@pytest.mark.parametrize("block", ["sim", "protocol"])
+def test_open_blocks_are_not_policed(block: str):
+    """`sim:` and `protocol:` carry backend- and application-specific keys that this
+    schema has no business knowing about."""
+    unknown = utils.unrecognised_configuration_keys({block: {"anything": 1}})
+    assert unknown == []
+
+
+def test_a_configuration_that_says_nothing_extra_reports_nothing():
+    config = {
+        "version": 1,
+        "info": {"name": "x", "ip_address": "y", "manufacturer": "Demo"},
+        "stage": {"rotation_reference": 0.0},
+    }
+    assert utils.unrecognised_configuration_keys(config) == []
+
+
+def test_reporting_is_logged_at_load(caplog):
+    """One line, at load, naming what was ignored."""
+    import logging
+
+    config = copy.deepcopy(_load("microscope-configuration.yaml"))
+    config["stage"]["nonsense"] = 1
+
+    with caplog.at_level(logging.INFO):
+        utils.report_unrecognised_configuration_keys(config, source="test.yaml")
+
+    assert "stage.nonsense" in caplog.text
+    assert "test.yaml" in caplog.text

--- a/tests/test_metadata_fixtures.py
+++ b/tests/test_metadata_fixtures.py
@@ -9,6 +9,7 @@ This is the guard for FIB-481, which replaces the embedded `SystemSettings` with
 compact geometry record. Every value asserted here is one the reprojection path reads.
 """
 
+import copy
 import json
 import os
 from typing import Any, Dict
@@ -85,7 +86,9 @@ def test_reprojection_geometry_is_readable(name: str) -> None:
 
 
 @pytest.mark.parametrize("name,model,compustage,via", FIXTURES)
-def test_compustage_detection(name: str, model: str, compustage: bool, via: str) -> None:
+def test_compustage_detection(
+    name: str, model: str, compustage: bool, via: str
+) -> None:
     """The migration guard: v6 records compustage, v5-and-earlier had it inferred.
 
     The answer must not change. `via` records which arm of the old expression fired --
@@ -168,23 +171,57 @@ def test_compustage_angles_are_recovered_as_zero_not_absent() -> None:
     ) == (35.0, 110, 290)
 
 
-@pytest.mark.parametrize("missing", ["stage", "electron", "ion", "manipulator", "gis", "info"])
-def test_system_settings_from_dict_is_not_a_safe_migration_path(missing: str) -> None:
-    """`SystemSettings.from_dict` is bracket-indexed throughout, so it raises rather
-    than degrading when a key is absent.
+@pytest.mark.parametrize(
+    "missing", ["stage", "electron", "ion", "manipulator", "gis", "info"]
+)
+def test_a_partial_legacy_blob_recovers_the_same_geometry_either_way(
+    missing: str,
+) -> None:
+    """The two ways of reading an old `system` blob must not disagree.
 
-    Recorded as a test because it constrains how the geometry record is derived: read
-    the raw dict with `.get()` chains instead of constructing a full `SystemSettings`
-    first, or the migration inherits this on exactly the old files it exists to
-    protect. See FIB-481.
+    This test used to assert the opposite. `SystemSettings.from_dict` was
+    bracket-indexed, so a blob missing any block raised `KeyError`, and that was the
+    stated reason `_geometry_from_legacy_system` reads the raw dict with `.get()`
+    chains instead: a migration written through the constructor would have broken
+    loudly on exactly the old files it exists to load. See FIB-481.
+
+    The readers now default rather than raise -- FIB-834 needed that before any key
+    could be removed from a shipped file -- which took the loud failure away and left
+    a quiet one. It was real: a blob with no `ion:` block recovered a FIB column tilt
+    of 52 degrees through the geometry record and 0 through `SystemSettings`, because
+    the two declared the constant separately. Zero is not a plausible reading for a
+    dual-beam, and nothing would have said so.
+
+    So the constraint is now that the defaults agree, which is a property of the code
+    rather than of one call site, and this pins it in the direction that matters: both
+    routes, every block, same answer.
     """
     from fibsem.structures import SystemSettings
 
-    full = load("thermo_arctis_compustage_v3.json")["system"]
+    full = load("thermo_aquilos_v3.json")["system"]
     partial = {k: v for k, v in full.items() if k != missing}
 
-    with pytest.raises(KeyError):
-        SystemSettings.from_dict(partial)
+    geometry = FibsemImageMetadata._geometry_from_legacy_system(partial)
+    system = SystemSettings.from_dict(copy.deepcopy(partial))
+
+    assert geometry.shuttle_pre_tilt == system.stage.shuttle_pre_tilt
+    assert geometry.rotation_reference == system.stage.rotation_reference
+    assert geometry.rotation_180 == system.stage.rotation_180
+    assert geometry.column_tilt == system.electron.column_tilt
+    assert geometry.fib_column_tilt == system.ion.column_tilt
+
+
+def test_an_absent_ion_block_does_not_flatten_the_fib_column() -> None:
+    """The specific value the agreement test exists to protect.
+
+    52 degrees, not 0 -- the angle between the columns is what every SEM-to-FIB
+    reprojection turns on, so a default of 0 is not a conservative fallback, it is a
+    wrong instrument.
+    """
+    from fibsem.structures import DEFAULT_FIB_COLUMN_TILT, SystemSettings
+
+    assert SystemSettings.from_dict({}).ion.column_tilt == DEFAULT_FIB_COLUMN_TILT
+    assert SystemSettings.from_dict({}).electron.column_tilt == 0.0
 
 
 def test_an_acquired_image_snapshots_the_instrument_rather_than_aliasing_it() -> None:


### PR DESCRIPTION
Phase 1 of the configuration schema work. It changes no configuration file's meaning
and removes no key — it makes the **readers** tolerant, which is what every later
phase needs and what `rotation_180` needed one-off in FIB-834.

## Two directions, and only one worked

A file carrying *extra* keys has always loaded: `from_dict` reads what it names and
ignores the rest. A file *missing* a key raised `KeyError` — which is why the six dead
`milling:` keys, `imaging.imaging_current` and `stage.manipulator_height_limit` could
not simply be deleted from the shipped files. Every configuration already in the field
would have stopped loading.

Both directions work now, which is what lets the rest of the schema change happen as
one refactor rather than a sequence of them.

- **21 required subscripts become `.get()`** with the field's own default, across
  `StageSystemSettings`, `BeamSystemSettings`, `ManipulatorSystemSettings`,
  `GISSystemSettings`, `SystemSettings` and `MicroscopeSettings`. Every block may now
  be absent, and an empty dictionary loads.
- **`version: 1`** in all eight shipped configurations. Cheap now and impossible to
  add retrospectively: a file without the field is indistinguishable from one written
  before the field existed, so a later format change would have to guess.
- **Unrecognised keys are logged once at load** rather than dropped in silence. Not
  theoretical — `imaging.imaging_current` is in every shipped file, `ImageSettings`
  has no such field, and it has been silently discarded on load for as long as it has
  existed. One line turns "my setting vanished" into "my setting is not supported".
  `sim:` and `protocol:` are deliberately not policed; they carry backend- and
  application-specific keys this schema has no business knowing about.

## Three things the tests found that the audit had not

**A nested reader.** `BeamSettings.from_dict` — reached *through* `BeamSystemSettings`
— also required `voltage`, `hfw`, `resolution` and `dwell_time`. The AST scan that
produced the count of 21 only looked at the classes named in the audit, and a
field-name grep cannot see a class that is handed the whole dict.
`test_an_empty_configuration_loads` is what surfaced it.

**A mutating reader.** `SystemSettings.from_dict` stamped `beam_type` into the
caller's `electron` and `ion` blocks. Harmless while one caller loaded one file; not
harmless once an editor holds a configuration dict and writes it back, because the
stamped key would reach disk. It copies now, pinned by
`test_reading_does_not_mutate_the_dict_it_was_given`.

**A wrong default this change would have hidden** — the second commit, and the one
worth reviewing closely.

## Optional keys turn a loud failure into a quiet one

That is the point of the first commit, but it means a wrong default is no longer
detectable, and there was one. A configuration or a pre-v6 image blob with no `ion:`
block loaded with an ion column tilt of **0 degrees**, because `BeamSystemSettings`
defaulted the field to 0 while `FibsemHardwareGeometry` declared the same physical
constant as 52.

52 degrees is the angle between the columns. Every SEM-to-FIB reprojection turns on
it, so 0 is not a conservative fallback — it is a different instrument, loaded without
complaint. The two declarations could disagree because there were two of them; there
is now one, `DEFAULT_FIB_COLUMN_TILT`, and `BeamSystemSettings.from_dict` picks its
default by beam type rather than using a single number for both columns.

### The test that had to change

`test_system_settings_from_dict_is_not_a_safe_migration_path` asserted the `KeyError`
this refactor removes, so it could not survive as written. Its subject was worth
keeping: it recorded *why* `_geometry_from_legacy_system` reads the raw dict with
`.get()` chains instead of building a `SystemSettings` first — doing the latter would
have inherited the raising on exactly the old files the migration exists to load
(FIB-481).

That reason has genuinely expired rather than been silenced. What replaces it asserts
the property that now matters, and that the shared constant is what makes true: both
read routes recover the same geometry from a blob missing any block.

## Verification

Full non-UI suite: **1 failed, 4921 passed, 22 skipped, 1 xfailed**. The single
failure is `tests/correlation/test_correlation_setup_regressions.py::test_editor_passes_a_real_reference_image`,
which fails identically on stock `origin/main` — checked in a detached worktree, not
inferred.

The new guard was mutation-tested rather than assumed: restoring the flat `0.0`
default fails three tests, and letting the two declarations drift apart fails the
agreement test on the `ion` case alone.

## Not in this PR

Removing keys is phase 2. Two corrections to that plan, found while auditing here:

- The `milling:` block is **not** fully dead — `settings.milling` still has live
  readers in `example/example_milling.py` and `example/slice_and_view.py` (a third is
  in `validation.py`, which #824 deletes). Those examples need updating first.
- `manipulator.rotation` / `.tilt` are live via `is_available("manipulator_rotation")`.
  This PR means phase 2 can drop them from the shipped YAML while the dataclass keeps
  the fields at their defaults; removing the *fields* is phase 3, gated on the
  hardware read.
