### PR TITLE
[refactor] Remove the configuration keys nothing reads (schema v1, phase 2)

### DIFF
--- a/example/example_milling.py
+++ b/example/example_milling.py
@@ -22,11 +22,13 @@ The script will:
 
 """
 
+
 def main():
 
     # connect to microscope
-    microscope, settings = utils.setup_session(manufacturer="Demo", ip_address="localhost")
-
+    microscope, settings = utils.setup_session(
+        manufacturer="Demo", ip_address="localhost"
+    )
 
     # setup milling stage (settings and alignment)
     stage = FibsemMillingStage(
@@ -37,44 +39,44 @@ def main():
             application_file="Si",
             patterning_mode="Serial",
         ),
-        alignment=MillingAlignment(
-            enabled=False
-        )
+        alignment=MillingAlignment(enabled=False),
     )
 
     # rectangle
     rectangle_shape = FibsemRectangleSettings(
-        width = 10.0e-6,
-        height = 10.0e-6,
-        depth = 2.0e-6,
-        rotation = 0.0,
-        centre_x = 0.0,
-        centre_y = 0.0,
+        width=10.0e-6,
+        height=10.0e-6,
+        depth=2.0e-6,
+        rotation=0.0,
+        centre_x=0.0,
+        centre_y=0.0,
     )
 
     # circle
     circle_shape = FibsemCircleSettings(
-        radius = 10.0e-6,
-        depth = 2.0e-6,
-        centre_x = 10e-6,
-        centre_y = 10e-6,
+        radius=10.0e-6,
+        depth=2.0e-6,
+        centre_x=10e-6,
+        centre_y=10e-6,
     )
 
     # line pattern
     line_shape = FibsemLineSettings(
-        start_x = 0.0,
-        start_y = 0.0,
-        end_x = 10.0e-6,
-        end_y = 10.0e-6,
-        depth = 1.0e-6,
+        start_x=0.0,
+        start_y=0.0,
+        end_x=10.0e-6,
+        end_y=10.0e-6,
+        depth=1.0e-6,
     )
 
     logging.info("""\nMilling Pattern Example: """)
-    logging.info(f"The current milling settings are: \n{settings.milling}")
+    logging.info(f"The current milling settings are: \n{stage.milling}")
     logging.info(f"The current rectangle pattern is \n{rectangle_shape}")
     logging.info(f"The current circle pattern ins is \n{circle_shape}")
     logging.info(f"The current line pattern is \n{line_shape}")
-    logging.info("---------------------------------- Milling ----------------------------------\n")
+    logging.info(
+        "---------------------------------- Milling ----------------------------------\n"
+    )
     # setup patterns in a list
     patterns = [rectangle_shape, circle_shape, line_shape]
 
@@ -84,22 +86,22 @@ def main():
     milling.draw_patterns(microscope, patterns)
 
     # run milling
-    milling.run_milling(microscope, stage.milling.milling_current, milling_voltage=stage.milling.milling_voltage)
+    milling.run_milling(
+        microscope,
+        stage.milling.milling_current,
+        milling_voltage=stage.milling.milling_voltage,
+    )
 
     # finish milling
     milling.finish_milling(microscope, microscope.system.ion.beam.beam_current)
 
-
     rect = RectanglePattern(
-        width=10e-6,
-        height=10e-6,
-        depth=2e-6,
-        rotation=0,
-        point=Point(0, 0)
+        width=10e-6, height=10e-6, depth=2e-6, rotation=0, point=Point(0, 0)
     )
     stage.pattern = rect
 
     milling.mill_stages(microscope, stage)
+
 
 if __name__ == "__main__":
     main()

--- a/example/slice_and_view.py
+++ b/example/slice_and_view.py
@@ -9,25 +9,39 @@ import numpy as np
 import fibsem
 from fibsem import acquire, alignment, milling, utils
 from fibsem.alignment import AlignmentSubsystem
-from fibsem.structures import BeamType, FibsemRectangleSettings, ImageSettings
+from fibsem.structures import (
+    BeamType,
+    FibsemMillingSettings,
+    FibsemRectangleSettings,
+    ImageSettings,
+)
 
 
 def main():
 
-    PROTOCOL_PATH = os.path.join(os.path.dirname(__file__), "protocol_slice_and_view.yaml")
-    microscope, settings = utils.setup_session(protocol_path = PROTOCOL_PATH)
+    PROTOCOL_PATH = os.path.join(
+        os.path.dirname(__file__), "protocol_slice_and_view.yaml"
+    )
+    microscope, settings = utils.setup_session(protocol_path=PROTOCOL_PATH)
+
+    # Milling parameters for this run. These used to come from the configuration's
+    # `milling:` block, which no longer exists -- milling belongs to a milling stage,
+    # not to the instrument's configuration.
+    milling_settings = FibsemMillingSettings(
+        milling_current=2.0e-9,
+        milling_voltage=30.0e3,
+        patterning_mode="Serial",
+    )
 
     # setup for milling
-    milling.setup_milling(microscope = microscope,
-        patterning_mode  = "Serial",
-        mill_settings = settings.milling)
-    
+    milling.setup_milling(microscope=microscope, mill_settings=milling_settings)
+
     pattern_settings = FibsemRectangleSettings(
-        width = settings.protocol["milling"]["width"],
-        height = settings.protocol["milling"]["height"],
-        depth = settings.protocol["milling"]["depth"],
-        scan_direction= settings.protocol["milling"]["scan_direction"],
-        cross_section= settings.protocol["milling"]["cross_section"]
+        width=settings.protocol["milling"]["width"],
+        height=settings.protocol["milling"]["height"],
+        depth=settings.protocol["milling"]["depth"],
+        scan_direction=settings.protocol["milling"]["scan_direction"],
+        cross_section=settings.protocol["milling"]["cross_section"],
     )
 
     # angle correction
@@ -43,22 +57,21 @@ def main():
     ref_eb, ref_ib = None, None
 
     for slice_idx in range(int(settings.protocol["steps"])):
-
         # slice
         logging.info("------------------------ SLICE ------------------------")
-        milling_settings = settings.milling  
 
         patterns = milling.draw_pattern(microscope, pattern_settings)
         # estimated_milling_time = milling.estimate_milling_time_in_seconds([patterns])
         # logging.info(f"Estimated milling time: {estimated_milling_time}")
-        milling.run_milling(microscope, milling_current=milling_settings.milling_current)
+        milling.run_milling(
+            microscope, milling_current=milling_settings.milling_current
+        )
         milling.finish_milling(microscope, settings.system.ion.current)
 
         # view
         logging.info("------------------------ VIEW ------------------------")
         settings.image.filename = f"slice_{slice_idx:04d}"
         eb_image = acquire.new_image(microscope, settings.image)
-
 
         # align to the previous slice (stage movement)
         if ref_eb is not None:
@@ -70,7 +83,6 @@ def main():
             )
         ref_eb = eb_image
 
-    
         # update patterns
         pattern_settings.centre_y += settings.protocol["step_size"]
 

--- a/fibsem/config/microscope-configuration.yaml
+++ b/fibsem/config/microscope-configuration.yaml
@@ -9,7 +9,6 @@ stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
-    manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
 electron:                                              
     enabled:                    true                        # the electron beam is enabled                                  [USER]
     column_tilt:                0                           # the column tilt of the electron beam                          [DERIVED - manufactuer]
@@ -36,8 +35,6 @@ ion:
     detector_type:              ETD                         # the detector type of the ion beam                             [USER]
 manipulator:
     enabled:                    true                        # manipulator is enabled                                        [USER]
-    rotation:                   false                       # manipulator is able to rotate                                 [USER]
-    tilt:                       false                       # manipulator is able to tilt                                   [USER]
 gis:
     enabled:                    true                        # gis is enabled                                                [USER]
     multichem:                  true                        # multichem is enabled                                          [USER]
@@ -47,16 +44,8 @@ imaging:
     resolution:                 [1536, 1024]                # the default imaging resolution                        [pixel] [USER]
     hfw:                        150.0e-6                    # the default imaging hfw                               [metres][USER]
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
-    imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               true                        # use autocontrast                                              [USER]
     save:                       false                       # auto save images                                              [USER]
-milling:
-    milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]
-    milling_current:            2.0e-09                     # the default milling current       (Thermo)            [amp]   [USER]   
-    dwell_time:                 1.0e-06                     # the default milling dwell time    (TESCAN)            [second][USER]
-    rate:                       3.4e-09                     # the default milling spuuter rate  (TESCAN)            [um3/s] [USER]
-    spot_size:                  5.4e-08                     # the default milling spot size     (TESCAN)            [metres][USER]
-    preset:                     "30 keV; 20 nA"             # the default milling preset        (TESCAN)                    [USER]
 sim:
     sem: null # "/path/to/sem/image/data"                   # the path to the SEM image data for simulation                 [USER]
     fib: null # "/path/to/fib/image/data"                   # the path to the FIB image data for simulation                 [USER]

--- a/fibsem/config/odemis-configuration.yaml
+++ b/fibsem/config/odemis-configuration.yaml
@@ -9,7 +9,6 @@ stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
-    manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
 electron:                                              
     enabled:                    true                        # the electron beam is enabled                                  [USER]
     column_tilt:                0                           # the column tilt of the electron beam                          [DERIVED - manufactuer]
@@ -36,8 +35,6 @@ ion:
     detector_type:              ETD                         # the detector type of the ion beam                             [USER]
 manipulator:
     enabled:                    false                        # manipulator is enabled                                        [USER]
-    rotation:                   false                       # manipulator is able to rotate                                 [USER]
-    tilt:                       false                       # manipulator is able to tilt                                   [USER]
 gis:
     enabled:                    true                        # gis is enabled                                                [USER]
     multichem:                  true                        # multichem is enabled                                          [USER]
@@ -47,13 +44,5 @@ imaging:
     resolution:                 [1536, 1024]                # the default imaging resolution                        [pixel] [USER]
     hfw:                        150.0e-6                    # the default imaging hfw                               [metres][USER]
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
-    imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               true                        # use autocontrast                                              [USER]
     save:                       false                       # auto save images                                              [USER]
-milling:
-    milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]
-    milling_current:            2.0e-09                     # the default milling current       (Thermo)            [amp]   [USER]   
-    dwell_time:                 1.0e-06                     # the default milling dwell time    (TESCAN)            [second][USER]
-    rate:                       3.4e-09                     # the default milling spuuter rate  (TESCAN)            [um3/s] [USER]
-    spot_size:                  5.4e-08                     # the default milling spot size     (TESCAN)            [metres][USER]
-    preset:                     "30 keV; 20 nA"             # the default milling preset        (TESCAN)                    [USER]

--- a/fibsem/config/sim-arctis-configuration.yaml
+++ b/fibsem/config/sim-arctis-configuration.yaml
@@ -7,7 +7,6 @@ stage:
     enabled:                    true                        
     rotation_reference:         0                           
     shuttle_pre_tilt:           0                        
-    manipulator_height_limit:   0.0037                      
 electron:                                              
     enabled:                    true                        
     column_tilt:                0                           
@@ -37,8 +36,6 @@ fm:
 #   config: /home/patrick/github/fibsem/fibsem/config/fm/fm-configuration-default.yaml
 manipulator:
     enabled:                    false                        
-    rotation:                   false                       
-    tilt:                       false                       
 gis:
     enabled:                    true                        
     multichem:                  false                       
@@ -48,16 +45,8 @@ imaging:
     resolution:                 [1536, 1024]               
     hfw:                        150.0e-6                    
     dwell_time:                 1.0e-06                     
-    imaging_current:            2.0e-11                     
     autocontrast:               false                        
     save:                       false                       
-milling:
-    milling_voltage:            30000                       
-    milling_current:            2.0e-09                        
-    dwell_time:                 1.0e-06                     
-    rate:                       3.4e-09                     
-    spot_size:                  5.4e-08                     
-    preset:                     "30 keV; 20 nA"             
 sim:
     sem: null # "/path/to/sem/image/data"                   
     fib: null # "/path/to/fib/image/data"                   

--- a/fibsem/config/sim-iflm-configuration.yaml
+++ b/fibsem/config/sim-iflm-configuration.yaml
@@ -27,7 +27,6 @@ stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED]
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
-    manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
     device_range:               {x: 20.0e-3}                # the region belonging to each device, from its origin    [metres][SPECIFIED]
     devices:                                                # where the stage travels for each instrument to see the sample
         FIBSEM:
@@ -61,8 +60,6 @@ ion:
     detector_type:              ETD                         # the detector type of the ion beam                             [USER]
 manipulator:
     enabled:                    true                        # manipulator is enabled                                        [USER]
-    rotation:                   false                       # manipulator is able to rotate                                 [USER]
-    tilt:                       false                       # manipulator is able to tilt                                   [USER]
 gis:
     enabled:                    true                        # gis is enabled                                                [USER]
     multichem:                  false                       # multichem is enabled                                          [USER]
@@ -72,16 +69,8 @@ imaging:
     resolution:                 [1536, 1024]                # the default imaging resolution                        [pixel] [USER]
     hfw:                        150.0e-6                    # the default imaging hfw                               [metres][USER]
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
-    imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               false                       # use autocontrast                                              [USER]
     save:                       false                       # auto save images                                              [USER]
-milling:
-    milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]
-    milling_current:            2.0e-09                     # the default milling current       (Thermo)            [amp]   [USER]
-    dwell_time:                 1.0e-06                     # the default milling dwell time    (TESCAN)            [second][USER]
-    rate:                       3.4e-09                     # the default milling spuuter rate  (TESCAN)            [um3/s] [USER]
-    spot_size:                  5.4e-08                     # the default milling spot size     (TESCAN)            [metres][USER]
-    preset:                     "30 keV; 20 nA"             # the default milling preset        (TESCAN)                    [USER]
 sim:
     sem: null # "/path/to/sem/image/data"                   # the path to the SEM image data for simulation                 [USER]
     fib: null # "/path/to/fib/image/data"                   # the path to the FIB image data for simulation                 [USER]

--- a/fibsem/config/tescan-configuration.yaml
+++ b/fibsem/config/tescan-configuration.yaml
@@ -9,7 +9,6 @@ stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation_reference:         180                         # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           0                           # the pre-tilt of the shuttle                                   [SPECIFIED]
-    manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufacturer]
 electron:                                              
     enabled:                    true                        # the electron beam is enabled                                  [USER]
     column_tilt:                0                           # the column tilt of the electron beam                          [DERIVED - manufacturer]
@@ -36,8 +35,6 @@ ion:
     detector_type:              SE                          # the detector type of the ion beam                             [USER]
 manipulator:
     enabled:                    true                        # manipulator is enabled                                        [USER]
-    rotation:                   false                       # manipulator is able to rotate                                 [USER]
-    tilt:                       false                       # manipulator is able to tilt                                   [USER]
 gis:
     enabled:                    true                        # gis is enabled                                                [USER]
     multichem:                  true                        # multichem is enabled                                          [USER]
@@ -47,14 +44,5 @@ imaging:
     resolution:                 [1536, 1024]                # the default imaging resolution                        [pixel] [USER]
     hfw:                        150.0e-6                    # the default imaging hfw                               [metres][USER]
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
-    imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               false                        # use autocontrast                                              [USER]
     save:                       false                       # auto save images                                              [USER]
-milling:
-    milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]
-    milling_current:            2.0e-09                     # the default milling current       (Thermo)            [amp]   [USER]   
-    dwell_time:                 1.0e-06                     # the default milling dwell time    (TESCAN)            [second][USER]
-    rate:                       1.3e-08                     # the cryo ion etching rate         (TESCAN)          [m3/A/s]  [USER]
-    spacing:                    0.005                       # the cryo exposition mesh spacing  (TESCAN)      [dimensionless][USER]
-    spot_size:                  1.0e-06                     # the cryo milling spot size        (TESCAN)            [metres][USER]
-    preset:                     "30 keV; 20 nA"             # the default milling preset        (TESCAN)                    [USER]

--- a/fibsem/config/tfs-aquilos2-configuration.yaml
+++ b/fibsem/config/tfs-aquilos2-configuration.yaml
@@ -9,7 +9,6 @@ stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
-    manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
 electron:                                              
     enabled:                    true                        # the electron beam is enabled                                  [USER]
     column_tilt:                0                           # the column tilt of the electron beam                          [DERIVED - manufactuer]
@@ -36,8 +35,6 @@ ion:
     detector_type:              ETD                         # the detector type of the ion beam                             [USER]
 manipulator:
     enabled:                    true                        # manipulator is enabled                                        [USER]
-    rotation:                   false                       # manipulator is able to rotate                                 [USER]
-    tilt:                       false                       # manipulator is able to tilt                                   [USER]
 gis:
     enabled:                    true                        # gis is enabled                                                [USER]
     multichem:                  false                        # multichem is enabled                                          [USER]
@@ -47,13 +44,5 @@ imaging:
     resolution:                 [1536, 1024]                # the default imaging resolution                        [pixel] [USER]
     hfw:                        150.0e-6                    # the default imaging hfw                               [metres][USER]
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
-    imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               true                        # use autocontrast                                              [USER]
     save:                       false                       # auto save images                                              [USER]
-milling:
-    milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]
-    milling_current:            2.0e-09                     # the default milling current       (Thermo)            [amp]   [USER]   
-    dwell_time:                 1.0e-06                     # the default milling dwell time    (TESCAN)            [second][USER]
-    rate:                       3.4e-09                     # the default milling spuuter rate  (TESCAN)            [um3/s] [USER]
-    spot_size:                  5.4e-08                     # the default milling spot size     (TESCAN)            [metres][USER]
-    preset:                     "30 keV; 20 nA"             # the default milling preset        (TESCAN)                    [USER]

--- a/fibsem/config/tfs-arctis-configuration.yaml
+++ b/fibsem/config/tfs-arctis-configuration.yaml
@@ -9,7 +9,6 @@ stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           0                           # the pre-tilt of the shuttle                                   [SPECIFIED]
-    manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
 electron:                                              
     enabled:                    true                        # the electron beam is enabled                                  [USER]
     column_tilt:                0                           # the column tilt of the electron beam                          [DERIVED - manufactuer]
@@ -36,8 +35,6 @@ ion:
     detector_type:              ETD                         # the detector type of the ion beam                             [USER]
 manipulator:
     enabled:                    false                       # manipulator is enabled                                        [USER]
-    rotation:                   false                       # manipulator is able to rotate                                 [USER]
-    tilt:                       false                       # manipulator is able to tilt                                   [USER]
 gis:
     enabled:                    false                       # gis is enabled                                                [USER]
     multichem:                  false                       # multichem is enabled                                          [USER]
@@ -47,13 +44,5 @@ imaging:
     resolution:                 [1536, 1024]                # the default imaging resolution                        [pixel] [USER]
     hfw:                        150.0e-6                    # the default imaging hfw                               [metres][USER]
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
-    imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               true                        # use autocontrast                                              [USER]
     save:                       false                       # auto save images                                              [USER]
-milling:
-    milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]
-    milling_current:            2.0e-09                     # the default milling current       (Thermo)            [amp]   [USER]   
-    dwell_time:                 1.0e-06                     # the default milling dwell time    (TESCAN)            [second][USER]
-    rate:                       3.4e-09                     # the default milling spuuter rate  (TESCAN)            [um3/s] [USER]
-    spot_size:                  5.4e-08                     # the default milling spot size     (TESCAN)            [metres][USER]
-    preset:                     "30 keV; 20 nA"             # the default milling preset        (TESCAN)                    [USER]

--- a/fibsem/config/tfs-hydra-configuration.yaml
+++ b/fibsem/config/tfs-hydra-configuration.yaml
@@ -9,7 +9,6 @@ stage:
     enabled:                    true                        # the stage is enabled                                          [USER]
     rotation_reference:         0                           # the reference rotation value                                  [SPECIFIED] 
     shuttle_pre_tilt:           35.0                        # the pre-tilt of the shuttle                                   [SPECIFIED]
-    manipulator_height_limit:   0.0037                      # the linked height limit for manipulator (Thermo Only)         [DERIVED - manufactuer]
 electron:                                              
     enabled:                    true                        # the electron beam is enabled                                  [USER]
     column_tilt:                0                           # the column tilt of the electron beam                          [DERIVED - manufactuer]
@@ -36,8 +35,6 @@ ion:
     detector_type:              ETD                         # the detector type of the ion beam                             [USER]
 manipulator:
     enabled:                    true                        # manipulator is enabled                                        [USER]
-    rotation:                   false                       # manipulator is able to rotate                                 [USER]
-    tilt:                       false                       # manipulator is able to tilt                                   [USER]
 gis:
     enabled:                    true                        # gis is enabled                                                [USER]
     multichem:                  false                        # multichem is enabled                                          [USER]
@@ -47,13 +44,5 @@ imaging:
     resolution:                 [1536, 1024]                # the default imaging resolution                        [pixel] [USER]
     hfw:                        150.0e-6                    # the default imaging hfw                               [metres][USER]
     dwell_time:                 1.0e-06                     # the default imaging dwell time                        [second][USER]
-    imaging_current:            2.0e-11                     # the default imaging current                           [amp]   [USER]
     autocontrast:               true                        # use autocontrast                                              [USER]
     save:                       false                       # auto save images                                              [USER]
-milling:
-    milling_voltage:            30000                       # the default milling voltage       (Thermo)            [volt]  [USER]
-    milling_current:            2.0e-09                     # the default milling current       (Thermo)            [amp]   [USER]   
-    dwell_time:                 1.0e-06                     # the default milling dwell time    (TESCAN)            [second][USER]
-    rate:                       3.4e-09                     # the default milling spuuter rate  (TESCAN)            [um3/s] [USER]
-    spot_size:                  5.4e-08                     # the default milling spot size     (TESCAN)            [metres][USER]
-    preset:                     "30 keV; 20 nA"             # the default milling preset        (TESCAN)                    [USER]

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2221,7 +2221,6 @@ DEFAULT_STAGE_DEVICES: Dict[str, StageDeviceSettings] = {
 class StageSystemSettings:
     rotation_reference: float
     shuttle_pre_tilt: float
-    manipulator_height_limit: float
     enabled: bool = True
     # Whether the stage has a rotation axis. Load-bearing: it is what `rotation_180`
     # below is derived from, so it describes the geometry and not merely a permission.
@@ -2279,7 +2278,6 @@ class StageSystemSettings:
         return {
             "rotation_reference": self.rotation_reference,
             "shuttle_pre_tilt": self.shuttle_pre_tilt,
-            "manipulator_height_limit": self.manipulator_height_limit,
             "enabled": self.enabled,
             "rotation": self.rotation,
             "milling_angle": self.milling_angle,
@@ -2301,7 +2299,6 @@ class StageSystemSettings:
         return StageSystemSettings(
             rotation_reference=settings.get("rotation_reference", 0.0),
             shuttle_pre_tilt=settings.get("shuttle_pre_tilt", 0.0),
-            manipulator_height_limit=settings.get("manipulator_height_limit", 0.0037),
             enabled=settings.get("enabled", True),
             rotation=settings.get("rotation", True),
             milling_angle=settings.get("milling_angle", 15.0),
@@ -2338,9 +2335,15 @@ class BeamSystemSettings:
             "enabled": self.enabled,
             "eucentric_height": self.eucentric_height,
             "column_tilt": self.column_tilt,
-            "plasma": self.plasma,
-            "plasma_gas": self.plasma_gas,
         }
+        # Written for the ion column only. One class serves both columns, so the
+        # fields exist on the electron one too, and writing them there put
+        # `electron.plasma` into any configuration saved from the application --
+        # a key no shipped file has ever carried and nothing reads. An electron
+        # column has no plasma source.
+        if self.beam_type is BeamType.ION:
+            ddict["plasma"] = self.plasma
+            ddict["plasma_gas"] = self.plasma_gas
         ddict.update(self.beam.to_dict())
         ddict.update(self.detector.to_dict())
 
@@ -2758,8 +2761,14 @@ class MicroscopeSettings:
     Attributes:
         system (SystemSettings): An instance of the `SystemSettings` class that holds the system settings.
         image (ImageSettings): An instance of the `ImageSettings` class that holds the image settings.
-        milling (FibsemMillingSettings): An instance of the `FibsemMillingSettings` class that holds the fibsem milling settings..
         protocol (dict, optional): A dictionary representing the protocol settings. Defaults to None.
+
+    There is no `milling` here. A `milling:` block existed in the configuration and
+    was read into a `FibsemMillingSettings`, but milling parameters belong to a
+    milling stage -- `FibsemMillingStage.milling`, chosen per pattern from the
+    protocol -- and nothing in the application consulted the configuration-level one.
+    Removed in the schema v1 work; the identically-named `stage.milling` is a
+    different object and is unaffected.
 
     Methods:
         to_dict(): Returns a dictionary representation of the `MicroscopeSettings` object.
@@ -2768,7 +2777,6 @@ class MicroscopeSettings:
 
     system: SystemSettings
     image: ImageSettings
-    milling: FibsemMillingSettings
     protocol: Optional[dict] = None
     fm: Optional["FluorescenceConfiguration"] = None
 
@@ -2776,7 +2784,6 @@ class MicroscopeSettings:
         settings_dict = {
             "imaging": self.image.to_dict(),
             "protocol": self.protocol,
-            "milling": self.milling.to_dict(),
         }
         settings_dict.update(self.system.to_dict())
 
@@ -2806,7 +2813,6 @@ class MicroscopeSettings:
             system=SystemSettings.from_dict(settings),
             image=ImageSettings.from_dict(settings.get("imaging") or {}),
             protocol=protocol,
-            milling=FibsemMillingSettings.from_dict(settings.get("milling") or {}),
             fm=fm_config,
         )
 

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -536,11 +536,13 @@ CONFIGURATION_SCHEMA: Dict[str, Set[str]] = {
         "rotation",
         "rotation_reference",
         "shuttle_pre_tilt",
-        "manipulator_height_limit",
         "milling_angle",
         "devices",
         "device_range",
     },
+    # No `plasma` or `plasma_gas`: an electron column has no plasma source. They are
+    # ion-column keys, and `BeamSystemSettings` carries them on both columns only
+    # because one class serves both.
     "electron": {
         "enabled",
         "column_tilt",
@@ -554,8 +556,6 @@ CONFIGURATION_SCHEMA: Dict[str, Set[str]] = {
         "detector_type",
         "beam_type",
         "working_distance",
-        "plasma",
-        "plasma_gas",
     },
     "ion": {
         "enabled",
@@ -573,17 +573,14 @@ CONFIGURATION_SCHEMA: Dict[str, Set[str]] = {
         "plasma",
         "plasma_gas",
     },
-    "manipulator": {"enabled", "rotation", "tilt"},
+    # `rotation` and `tilt` are the manipulator's own axes. A file could only ever
+    # restate them, and every shipped one said `false`; the instrument knows.
+    "manipulator": {"enabled"},
     "gis": {"enabled", "multichem", "sputter_coater"},
     "imaging": {"beam_type", "resolution", "hfw", "dwell_time", "autocontrast", "save"},
-    "milling": {
-        "milling_voltage",
-        "milling_current",
-        "dwell_time",
-        "rate",
-        "spot_size",
-        "preset",
-    },
+    # No `milling:` block. It was read into a `MicroscopeSettings.milling` that nothing
+    # in the application consulted -- milling parameters belong to a milling stage,
+    # chosen per pattern from the protocol.
     "fm": {"enabled", "config"},
     # Open blocks. `sim:` stays a plain dict the simulator reads with `.get()` rather
     # than a dataclass, and `protocol:` is the application's, so policing either would

--- a/tests/test_configuration_schema.py
+++ b/tests/test_configuration_schema.py
@@ -80,7 +80,6 @@ def test_every_shipped_configuration_declares_its_version(filename: str):
         "manipulator",
         "gis",
         "imaging",
-        "milling",
         "sim",
     ],
 )
@@ -156,12 +155,51 @@ def test_unrecognised_keys_are_reported():
     assert "a_block_from_the_future" in unknown
 
 
-def test_the_dead_key_the_audit_found_is_reported():
-    """`imaging.imaging_current` is still in every shipped file and still read by
-    nothing. Until it is removed, at least say so."""
-    assert "imaging.imaging_current" in utils.unrecognised_configuration_keys(
-        _load("microscope-configuration.yaml")
-    )
+def test_no_shipped_configuration_carries_a_key_this_version_ignores():
+    """The shipped files say only what this version reads.
+
+    They did not: `imaging.imaging_current` was in all eight and read by nothing, and
+    the `milling:` block was six more. Both are gone, and this is what stops another
+    one accumulating -- adding a key to a shipped file without adding it to
+    `CONFIGURATION_SCHEMA` now fails here rather than being quietly dropped at load.
+    """
+    offenders = {
+        filename: utils.unrecognised_configuration_keys(_load(filename))
+        for filename in SHIPPED
+    }
+    assert {k: v for k, v in offenders.items() if v} == {}
+
+
+@pytest.mark.parametrize(
+    "removed",
+    [
+        {"milling": {"milling_current": 2.0e-9, "milling_voltage": 30000}},
+        {"stage": {"manipulator_height_limit": 0.0037}},
+        {"imaging": {"imaging_current": 2.0e-11}},
+        {"manipulator": {"rotation": False, "tilt": False}},
+        {"electron": {"plasma": False, "plasma_gas": "None"}},
+    ],
+)
+def test_a_configuration_written_before_the_keys_were_removed_still_loads(
+    removed: dict,
+):
+    """The promise made when the keys were deleted: an old file keeps working.
+
+    Every site has a configuration on disk carrying these. They are ignored, not
+    honoured and not fatal -- and they are named in the log rather than dropped in
+    silence, so a user who set one can find out it does nothing.
+    """
+    config = copy.deepcopy(_load("microscope-configuration.yaml"))
+    for block, keys in removed.items():
+        config.setdefault(block, {}).update(keys)
+
+    settings = MicroscopeSettings.from_dict(config)
+
+    assert isinstance(settings.system, SystemSettings)
+    reported = utils.unrecognised_configuration_keys(config)
+    for block, keys in removed.items():
+        for key in keys:
+            assert f"{block}.{key}" in reported or block in reported
 
 
 @pytest.mark.parametrize("block", ["sim", "protocol"])

--- a/tests/test_stage_capability_flags.py
+++ b/tests/test_stage_capability_flags.py
@@ -5,9 +5,15 @@ were not. `rotation` distinguishes the two mountings this project drives -- it i
 `rotation_180` is derived from (FIB-834) -- while `tilt` had one reachable value, was
 read by nothing, and existed only as somewhere for a typo to sit.
 
-The tests below pin both halves of that: that nothing lost a capability it was using,
-and that the asymmetry with the *manipulator*, which keeps its own `tilt`, is deliberate
-rather than an edit that missed a line.
+The manipulator's identically-spelled `rotation` and `tilt` have since followed the
+stage's out of the files, for a different reason: they said `false` everywhere, which
+is the default, and the axes an arm has are the instrument's to report. What used to
+be an asymmetry worth asserting is now a shared rule, and the hazard it guarded -- a
+manipulator quietly given an axis it does not have -- moved from the file to the
+default.
+
+The tests below pin that nothing lost a capability it was using, and that nothing
+gains one it never had.
 """
 
 import os
@@ -21,7 +27,11 @@ from fibsem.microscopes.simulator import (
     STAGE_LIMITS_COMPUSTAGE,
     STAGE_LIMITS_DEFAULT,
 )
-from fibsem.structures import StageSystemSettings, SystemSettings
+from fibsem.structures import (
+    ManipulatorSystemSettings,
+    StageSystemSettings,
+    SystemSettings,
+)
 
 # Named rather than globbed. `fibsem/config/*.yaml` is gitignored with an allowlist
 # for the shipped files, so a configuration the developer saved from the wizard sits
@@ -51,17 +61,28 @@ def test_no_shipped_file_states_a_stage_capability(filename: str, key: str):
 
 @pytest.mark.parametrize("filename", CONFIGS)
 @pytest.mark.parametrize("key", ["tilt", "rotation"])
-def test_the_manipulator_keeps_its_own(filename: str, key: str):
-    """The asymmetry is the point, so it is asserted rather than left to be noticed.
+def test_no_shipped_file_states_a_manipulator_capability(filename: str, key: str):
+    """The manipulator's keys have now followed the stage's out of the files.
 
-    A manipulator that cannot tilt is an ordinary manipulator; a stage that cannot tilt
-    is not a stage this project drives. The two blocks spell these keys the same and
-    mean different things, which is exactly how a scoped edit goes wrong -- a line
-    removed from the wrong block would silently give every manipulator an axis it does
-    not have, and no other test in the suite would notice.
+    They said `false` in all eight, which is the dataclass default, so removing them
+    changed no instrument's behaviour -- and a manipulator's axes are the
+    instrument's to report, not a file's to restate.
     """
     config = utils.load_yaml(os.path.join(cfg.CONFIG_PATH, filename))
-    assert key in config["manipulator"]
+    assert key not in config["manipulator"]
+
+
+@pytest.mark.parametrize("key", ["tilt", "rotation"])
+def test_a_manipulator_does_not_gain_an_axis_by_default(key: str):
+    """What the removed keys were holding down.
+
+    The two blocks spell these keys the same and mean different things, which is how a
+    scoped edit goes wrong: a manipulator quietly given an axis it does not have.
+    While the files said `false` that was safe by restatement; now it is safe by
+    default, and this is the test that says so. `False` is the only correct default --
+    an axis assumed present is a move the hardware will refuse.
+    """
+    assert getattr(ManipulatorSystemSettings.from_dict({}), key) is False
 
 
 @pytest.mark.parametrize(
@@ -101,7 +122,6 @@ def test_a_stored_stage_tilt_is_ignored_rather_than_rejected():
         {
             "rotation_reference": 0.0,
             "shuttle_pre_tilt": 35.0,
-            "manipulator_height_limit": 0.0037,
             "tilt": False,
         }
     )

--- a/tests/test_stage_rotation_derivation.py
+++ b/tests/test_stage_rotation_derivation.py
@@ -30,7 +30,6 @@ def _stage(**overrides) -> StageSystemSettings:
     fields = dict(
         rotation_reference=0.0,
         shuttle_pre_tilt=35.0,
-        manipulator_height_limit=0.0037,
     )
     fields.update(overrides)
     return StageSystemSettings(**fields)
@@ -152,7 +151,6 @@ def test_a_stored_value_is_ignored_rather_than_honoured():
             "rotation_reference": 0.0,
             "rotation_180": 99.0,
             "shuttle_pre_tilt": 35.0,
-            "manipulator_height_limit": 0.0037,
         }
     )
     assert stage.rotation_180 == 180.0


### PR DESCRIPTION
Stacked on #835 — review that first; this diff is against it.

What phase 1 was for. Every key here was verified dead by hand before it went, and an
old file carrying all of them still loads: the readers default, and the keys are named
in one log line rather than dropped in silence.

## Out of all eight shipped configurations

| removed | why it is dead |
|---|---|
| the `milling:` block (6 keys) | read into a `MicroscopeSettings.milling` nothing consulted |
| `imaging.imaging_current` | `ImageSettings` has no such field |
| `stage.manipulator_height_limit` | stored, serialised, never read |
| `manipulator.rotation`, `.tilt` | `false` in every file, which is the default |

**The `milling:` collision is worth a note.** An earlier audit counted 19 reads of
`milling_current` and concluded the block was load-bearing. Those were
`stage.milling.milling_current` — `FibsemMillingStage.milling`, chosen per pattern from
the protocol, a different object that spells its attribute the same way. The
configuration-level one had no readers in `fibsem/` at all. `stage.milling` is
untouched here.

## And one that was never in a file, but was being written into one

`BeamSystemSettings` serves both columns, so `to_dict` put `electron.plasma` and
`electron.plasma_gas` into any configuration saved from the application. An electron
column has no plasma source. They are written for the ion column only now.

`ion.plasma` is untouched and live — `tfs-arctis` sets it with a Xenon gas, and
`is_available("ion_plasma")` reads it. Only the electron side goes.

## The test that had to be rewritten rather than deleted

`test_the_manipulator_keeps_its_own` asserted the manipulator kept the two keys the
stage lost in FIB-834, and said why:

> a line removed from the wrong block would silently give every manipulator an axis it
> does not have, and no other test in the suite would notice

This PR removes those lines from the right block, on purpose, so that assertion
inverts. The hazard it names does not go away though — it moves from the file to the
default, and that is where it is asserted now:
`ManipulatorSystemSettings.from_dict({})` answers `False` to both. `False` is the only
correct default, because an axis assumed present is a move the hardware will refuse.

## Verified, not assumed

The eight files were edited by script and then checked at the **parsed** level against
`git show HEAD:` — every key that differs is one of the intended ones, no value
changed, nothing else moved. Reading the line diff would not have caught a mis-scoped
edit that took `rotation` out of `stage:` instead of `manipulator:`, which is the exact
mistake the test above was written about.

New coverage: no shipped configuration carries a key this version ignores (so another
one cannot accumulate), and a configuration written before the removal still loads with
every removed key reported.

Full non-UI suite: **1 failed, 4927 passed, 22 skipped, 1 xfailed**. The failure is
`test_editor_passes_a_real_reference_image`, which fails identically on stock
`origin/main` and passes on CI.

## Two things reviewers should know

**`fibsem/validation.py:244` still reads `settings.milling`.** Left alone deliberately:
nothing imports that module and #824 deletes it, so editing it here would only make a
conflict. **If #824 is closed rather than merged, that line needs a follow-up.**

**The two `example/` files carry reformat noise.** They had to change — they referenced
the removed field — and `example/` is not in ruff's exclude list while CI
format-checks every changed `.py`, so touching them at all requires formatting the
whole file. The substantive change in each is one or two lines.

## Not in this PR

Writing `stage.devices` and `device_range` into the shipped configurations — the same
phase in the spec, opposite direction. They appear in exactly one file today
(`sim-iflm`), so every other instrument's mounting geometry rides on a dataclass
default nobody can see. It needs no code and is better reviewed on its own.
