### PR TITLE
[refactor] The sample holder moves into the microscope configuration (schema v1, phase 4)

### DIFF
--- a/fibsem/config/default-sample-holder.yaml
+++ b/fibsem/config/default-sample-holder.yaml
@@ -1,26 +1,16 @@
-# Sample Holder Configuration
-#
-# Slot positions are written by the calibration wizard ("Calibrate slot positions"
-# in the Sample Holder panel on the Microscope tab), which records the orientation
-# and stage geometry they were captured against. A position without that record,
-# or captured against a different pre-tilt / reference rotation, is not trusted
-# and reads as "not calibrated". Do not type positions in by hand.
-
-name: "Pre-Tilted 35deg Shuttle"
-description: "Standard 35 degree pre-tilt shuttle with 2 grid slots"
+name: Pre-Tilted 35deg Shuttle
 capacity: 2
-
 slots:
   Slot-01:
-    name: "Slot-01"
+    name: Slot-01
     index: 0
     position: null
     loaded_grid: null
     calibration: null
-
   Slot-02:
-    name: "Slot-02"
+    name: Slot-02
     index: 1
     position: null
     loaded_grid: null
     calibration: null
+description: Standard 35 degree pre-tilt shuttle with 2 grid slots

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -1109,6 +1109,7 @@ class FibsemMicroscope(ABC):
             self.set_beam_system_settings(system_settings.ion)
 
         if self.is_available("stage"):
+            previous_stage = self.system.stage
             self.system.stage = system_settings.stage
             # The line above replaces the whole record, including the capability the
             # instrument told us about at connect. `system_settings` came from a file,
@@ -1118,6 +1119,15 @@ class FibsemMicroscope(ABC):
             # stage cannot make. Re-read rather than preserve: the instrument is the
             # authority, and it has not changed because someone pressed Apply.
             self._read_stage_capabilities()
+            # The same replacement empties the holder map, for the same reason: a
+            # configuration written before the holder moved into it has no `holders:`.
+            # But which holder is in the shuttle is a physical fact, and pressing Apply
+            # did not change it -- so it is carried across, and the running `Stage`
+            # keeps agreeing with the configuration it came from. A file that *does*
+            # name holders wins, because then the user is choosing one.
+            if not self.system.stage.holders:
+                self.system.stage.holders = previous_stage.holders
+                self.system.stage.active_holder = previous_stage.active_holder
 
         if self.is_available("manipulator"):
             self.system.manipulator = system_settings.manipulator

--- a/fibsem/microscopes/_stage.py
+++ b/fibsem/microscopes/_stage.py
@@ -561,6 +561,53 @@ def uncalibrated_message(slot_name: str) -> str:
     )
 
 
+def _resolve_configured_holder(stage_settings) -> SampleHolder:
+    """The holder on the stage: from the configuration, or imported into it.
+
+    Three cases, in order.
+
+    **The configuration names one.** `stage.holders` with an `active_holder` that
+    picks one out of it. This is where a system ends up once its configuration has
+    been saved, and the only case that involves no files.
+
+    **It does not, and the site has a `sample-holder.yaml`.** The holder moved into the
+    microscope configuration, but every calibrated site has its slot positions in the
+    old file and those are not reproducible -- someone stood at the microscope and
+    captured them. So the file is imported as an entry and selected, and the site keeps
+    its calibration without being shown a list it did not ask for.
+
+    Read-only: nothing is written back here. The imported holder is on
+    `stage.holders`, so the next save of the configuration carries it, but a session
+    that saves nothing leaves both files exactly as it found them. Re-importing every
+    session costs nothing and is safer than rewriting a user's configuration on their
+    behalf at connect time.
+
+    **Neither.** The shipped default, as before.
+    """
+    active = stage_settings.active_holder
+    configured = stage_settings.holders.get(active) if active else None
+    if configured is not None:
+        return configured
+
+    path = Path(SAMPLE_HOLDER_CONFIGURATION_PATH)
+    migrating = path.exists()
+    if not migrating:
+        logging.info(f"Sample holder config not found at {path}, using default.")
+        path = Path(DEFAULT_SAMPLE_HOLDER_CONFIGURATION_PATH)
+
+    holder = SampleHolder.load(path)
+    if migrating:
+        logging.info(
+            f"Imported sample holder '{holder.name}' from {path} into the microscope "
+            "configuration. Save the configuration to keep it there."
+        )
+    # Selected either way, so a session that saves its configuration records which
+    # holder it was actually using rather than an empty selection.
+    stage_settings.holders[holder.name] = holder
+    stage_settings.active_holder = holder.name
+    return holder
+
+
 def _create_sample_stage(microscope: "FibsemMicroscope") -> "Stage":
     if microscope.stage_is_compustage:
         # The working slot is the compustage origin by construction: the loader puts
@@ -586,11 +633,7 @@ def _create_sample_stage(microscope: "FibsemMicroscope") -> "Stage":
         # from its config, a real system wraps its autoloader.
         loader: Optional[SampleGridLoader] = microscope._create_grid_loader()
     else:
-        path = Path(SAMPLE_HOLDER_CONFIGURATION_PATH)
-        if not path.exists():
-            logging.info(f"Sample holder config not found at {path}, using default.")
-            path = Path(DEFAULT_SAMPLE_HOLDER_CONFIGURATION_PATH)
-        holder = SampleHolder.load(path)
+        holder = _resolve_configured_holder(microscope.system.stage)
         # Trust only positions the wizard captured against this stage geometry. The
         # old stamping of SEM r/t onto whatever x/y/z the file held is gone: a
         # calibrated position carries its own r/t, and an uncalibrated one has none.

--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2254,6 +2254,16 @@ class StageSystemSettings:
     devices: Dict[str, StageDeviceSettings] = field(
         default_factory=lambda: deepcopy(DEFAULT_STAGE_DEVICES)
     )
+    # The holders this system has, and which one is on the stage. A keyed map with a
+    # selection rather than a single holder, because a site that swaps a flat shuttle
+    # for a pre-tilted one should select the other entry rather than re-enter its
+    # geometry -- and, once pre-tilt moves onto the holder, re-calibrate for it.
+    #
+    # Empty by default. `_create_sample_stage` fills it, importing a `sample-holder.yaml`
+    # if the site has one; nothing here reads that file, so a `SystemSettings` built
+    # from a dict stays a pure function of that dict.
+    holders: Dict[str, "SampleHolder"] = field(default_factory=dict)
+    active_holder: str = ""
 
     @property
     def rotation_180(self) -> float:
@@ -2286,6 +2296,14 @@ class StageSystemSettings:
             "devices": {
                 name: device.to_dict() for name, device in self.devices.items()
             },
+            # `include_grids=False`: which grid is in which slot is session state and
+            # has its own file. Writing it here would make the configuration go stale
+            # every time someone swapped a grid.
+            "holders": {
+                name: holder.to_dict(include_grids=False)
+                for name, holder in self.holders.items()
+            },
+            "active_holder": self.active_holder,
         }
 
     @staticmethod
@@ -2316,6 +2334,11 @@ class StageSystemSettings:
                 if devices
                 else deepcopy(DEFAULT_STAGE_DEVICES)
             ),
+            holders={
+                name: SampleHolder.from_dict(holder)
+                for name, holder in (settings.get("holders") or {}).items()
+            },
+            active_holder=settings.get("active_holder", ""),
         )
 
 

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -539,6 +539,8 @@ CONFIGURATION_SCHEMA: Dict[str, Set[str]] = {
         "milling_angle",
         "devices",
         "device_range",
+        "holders",
+        "active_holder",
     },
     # No `plasma` or `plasma_gas`: an electron column has no plasma source. They are
     # ion-column keys, and `BeamSystemSettings` carries them on both columns only

--- a/tests/test_holder_in_configuration.py
+++ b/tests/test_holder_in_configuration.py
@@ -1,0 +1,314 @@
+"""The sample holder lives in the microscope configuration.
+
+It used to live in `sample-holder.yaml`, a second file beside the configuration with
+its own loader and no version. `stage.holders` is a keyed map with an
+`active_holder`, so a site that swaps a flat shuttle for a pre-tilted one selects the
+other entry instead of re-entering its geometry.
+
+The migration is what these tests are mostly about. A calibrated holder's slot
+positions were captured by somebody standing at the microscope; they cannot be
+regenerated, and losing them is worse than any failure mode this refactor was meant to
+fix.
+"""
+
+import os
+
+import pytest
+import yaml
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.microscopes import _stage as stage_module
+from fibsem.microscopes._stage import _resolve_configured_holder
+from fibsem.structures import (
+    FibsemStagePosition,
+    GridSlot,
+    SampleHolder,
+    SlotCalibration,
+    StageSystemSettings,
+    SystemSettings,
+)
+
+
+def _calibrated_holder(name: str = "Pre-Tilted 35deg Shuttle") -> SampleHolder:
+    """A holder as a calibrated site has it: a real position and the record proving it."""
+    return SampleHolder(
+        name=name,
+        capacity=2,
+        slots={
+            "Slot-01": GridSlot(
+                name="Slot-01",
+                index=0,
+                position=FibsemStagePosition(
+                    name="Slot-01", x=1.5e-3, y=-2.5e-3, z=4.0e-3, r=0.5, t=0.61
+                ),
+                calibration=SlotCalibration(
+                    orientation="SEM",
+                    pre_tilt=35.0,
+                    rotation_reference=110.0,
+                    captured_at="2026-01-01T00:00:00",
+                    fibsem_version="v0.5.2",
+                ),
+            ),
+            "Slot-02": GridSlot(name="Slot-02", index=1),
+        },
+    )
+
+
+def _stage_settings(**overrides) -> StageSystemSettings:
+    fields = dict(rotation_reference=110.0, shuttle_pre_tilt=35.0)
+    fields.update(overrides)
+    return StageSystemSettings(**fields)
+
+
+# ---------------------------------------------------------------------------
+# It survives the configuration round trip
+# ---------------------------------------------------------------------------
+
+
+def test_a_holder_survives_the_configuration_round_trip():
+    """Including the calibration record, which is the part that cannot be recreated."""
+    holder = _calibrated_holder()
+    stage = _stage_settings(holders={holder.name: holder}, active_holder=holder.name)
+
+    restored = StageSystemSettings.from_dict(stage.to_dict())
+
+    slot = restored.holders[holder.name].slots["Slot-01"]
+    assert restored.active_holder == holder.name
+    assert slot.position.x == pytest.approx(1.5e-3)
+    assert slot.position.t == pytest.approx(0.61)
+    assert slot.calibration.pre_tilt == 35.0
+    assert slot.calibration.rotation_reference == 110.0
+    assert slot.is_calibrated
+
+
+def test_the_grids_in_the_slots_are_not_written_into_the_configuration():
+    """Occupancy is session state and has its own file.
+
+    Writing it here would make the configuration go stale every time someone swapped a
+    grid, and make a saved configuration claim a grid is loaded that was taken out
+    weeks ago.
+    """
+    from fibsem.structures import SampleGrid
+
+    holder = _calibrated_holder()
+    holder.slots["Slot-01"].loaded_grid = SampleGrid(name="grid-A")
+    stage = _stage_settings(holders={holder.name: holder}, active_holder=holder.name)
+
+    written = stage.to_dict()["holders"][holder.name]["slots"]["Slot-01"]
+
+    assert written["loaded_grid"] is None
+    assert written["position"] is not None  # the calibration still goes
+
+
+def test_a_configuration_with_no_holders_loads():
+    """Every configuration in the field is one of these."""
+    stage = StageSystemSettings.from_dict({})
+    assert stage.holders == {}
+    assert stage.active_holder == ""
+
+
+def test_the_holder_reaches_system_settings():
+    holder = _calibrated_holder()
+    system = SystemSettings.from_dict(
+        {
+            "stage": {
+                "holders": {holder.name: holder.to_dict()},
+                "active_holder": holder.name,
+            }
+        }
+    )
+    assert system.stage.holders[holder.name].slots["Slot-01"].is_calibrated
+
+
+# ---------------------------------------------------------------------------
+# Resolving which holder is on the stage
+# ---------------------------------------------------------------------------
+
+
+def test_a_configured_holder_is_used_and_no_file_is_read(monkeypatch, tmp_path):
+    """The end state: the configuration answers, and `sample-holder.yaml` is irrelevant.
+
+    The path is pointed at a file that does not exist, so a resolution that still
+    reached for it would raise rather than quietly pass.
+    """
+    monkeypatch.setattr(
+        stage_module, "SAMPLE_HOLDER_CONFIGURATION_PATH", str(tmp_path / "absent.yaml")
+    )
+    holder = _calibrated_holder()
+    stage = _stage_settings(holders={holder.name: holder}, active_holder=holder.name)
+
+    resolved = _resolve_configured_holder(stage)
+
+    assert resolved is holder
+
+
+def test_an_existing_holder_file_is_imported_with_its_calibration(
+    monkeypatch, tmp_path
+):
+    """The migration, and the only test here that really matters.
+
+    A site upgrading has a calibrated `sample-holder.yaml` and no `holders:` block.
+    Its slot positions must arrive intact, and be selected, without anyone being asked
+    to choose from a list.
+    """
+    path = tmp_path / "sample-holder.yaml"
+    path.write_text(yaml.dump(_calibrated_holder().to_dict(include_grids=False)))
+    monkeypatch.setattr(stage_module, "SAMPLE_HOLDER_CONFIGURATION_PATH", str(path))
+
+    stage = _stage_settings()
+    resolved = _resolve_configured_holder(stage)
+
+    slot = resolved.slots["Slot-01"]
+    assert slot.position.x == pytest.approx(1.5e-3)
+    assert slot.calibration.pre_tilt == 35.0
+    assert slot.is_calibrated, "the calibration record did not survive the import"
+
+    # imported into the configuration, and selected
+    assert stage.active_holder == "Pre-Tilted 35deg Shuttle"
+    assert stage.holders[stage.active_holder] is resolved
+
+
+def test_the_migration_does_not_rewrite_either_file(monkeypatch, tmp_path):
+    """Nothing is written back at connect time.
+
+    The imported holder is on `stage.holders`, so saving the configuration keeps it --
+    but a session that saves nothing must leave the user's files exactly as it found
+    them. Rewriting a configuration on someone's behalf while they are connecting is
+    how a good migration becomes a support ticket.
+    """
+    path = tmp_path / "sample-holder.yaml"
+    original = yaml.dump(_calibrated_holder().to_dict(include_grids=False))
+    path.write_text(original)
+    monkeypatch.setattr(stage_module, "SAMPLE_HOLDER_CONFIGURATION_PATH", str(path))
+
+    _resolve_configured_holder(_stage_settings())
+
+    assert path.read_text() == original
+
+
+def test_the_shipped_default_is_used_when_there_is_neither(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        stage_module, "SAMPLE_HOLDER_CONFIGURATION_PATH", str(tmp_path / "absent.yaml")
+    )
+    stage = _stage_settings()
+
+    resolved = _resolve_configured_holder(stage)
+
+    assert resolved.capacity == 2
+    assert stage.active_holder == resolved.name
+
+
+def test_resolving_twice_is_stable(monkeypatch, tmp_path):
+    """The migration runs every session until the configuration is saved, so it has to
+    be idempotent -- not accumulate an entry per connect."""
+    path = tmp_path / "sample-holder.yaml"
+    path.write_text(yaml.dump(_calibrated_holder().to_dict(include_grids=False)))
+    monkeypatch.setattr(stage_module, "SAMPLE_HOLDER_CONFIGURATION_PATH", str(path))
+
+    stage = _stage_settings()
+    first = _resolve_configured_holder(stage)
+    second = _resolve_configured_holder(stage)
+
+    assert len(stage.holders) == 1
+    assert second is first, "the second resolution re-imported instead of reusing"
+
+
+def test_a_second_holder_can_sit_alongside_the_active_one():
+    """The reason this is a map and not a field: a site with two shuttles keeps both
+    calibrated and selects between them."""
+    pre_tilted = _calibrated_holder("Pre-Tilted 35deg Shuttle")
+    flat = _calibrated_holder("Flat Shuttle")
+    stage = _stage_settings(
+        holders={pre_tilted.name: pre_tilted, flat.name: flat},
+        active_holder=flat.name,
+    )
+
+    assert _resolve_configured_holder(stage) is flat
+    restored = StageSystemSettings.from_dict(stage.to_dict())
+    assert set(restored.holders) == {"Pre-Tilted 35deg Shuttle", "Flat Shuttle"}
+    assert restored.active_holder == "Flat Shuttle"
+
+
+def test_an_active_holder_naming_nothing_falls_back_rather_than_raising(
+    monkeypatch, tmp_path
+):
+    """A hand-edited configuration can name a holder that is not in the map.
+
+    A KeyError here would stop the microscope from connecting over a typo, so it
+    resolves the way a configuration with no selection does.
+    """
+    monkeypatch.setattr(
+        stage_module, "SAMPLE_HOLDER_CONFIGURATION_PATH", str(tmp_path / "absent.yaml")
+    )
+    holder = _calibrated_holder()
+    stage = _stage_settings(holders={holder.name: holder}, active_holder="not-a-holder")
+
+    resolved = _resolve_configured_holder(stage)
+
+    assert resolved is not None
+    assert stage.active_holder == resolved.name
+
+
+def test_the_schema_knows_about_the_new_keys():
+    from fibsem import utils
+
+    assert (
+        utils.unrecognised_configuration_keys(
+            {"stage": {"holders": {}, "active_holder": "x"}}
+        )
+        == []
+    )
+
+
+def test_the_default_holder_file_still_ships():
+    """The migration's third case reads it, so its absence would be a silent break."""
+    assert os.path.exists(cfg.DEFAULT_SAMPLE_HOLDER_CONFIGURATION_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Pressing Apply does not forget which holder is in the shuttle
+# ---------------------------------------------------------------------------
+
+
+def test_applying_a_configuration_keeps_the_holder_selection():
+    """`apply_configuration` replaces `system.stage` wholesale.
+
+    The same trap `rotation` fell into, one field over: a configuration written before
+    the holder moved into it has no `holders:`, so Apply would empty the map and clear
+    the selection while the running `Stage` carried on using a holder the configuration
+    no longer knew about. Which holder is in the shuttle is a physical fact and
+    pressing Apply did not change it.
+    """
+    path = os.path.join(cfg.CONFIG_PATH, "microscope-configuration.yaml")
+    microscope, _ = utils.setup_session(config_path=path, manufacturer="Demo")
+
+    holder = _calibrated_holder()
+    microscope.system.stage.holders = {holder.name: holder}
+    microscope.system.stage.active_holder = holder.name
+
+    # a real load of the same file, which is what the Apply button does
+    from_file = SystemSettings.from_dict(utils.load_yaml(path))
+    assert not from_file.stage.holders, "fixture no longer exercises the trap"
+    microscope.apply_configuration(from_file)
+
+    assert microscope.system.stage.active_holder == holder.name
+    assert microscope.system.stage.holders[holder.name] is holder
+
+
+def test_a_configuration_that_names_holders_wins_over_the_live_one():
+    """The other half: a file that does name holders is a user choosing one."""
+    path = os.path.join(cfg.CONFIG_PATH, "microscope-configuration.yaml")
+    microscope, _ = utils.setup_session(config_path=path, manufacturer="Demo")
+
+    microscope.system.stage.holders = {"old": _calibrated_holder("old")}
+    microscope.system.stage.active_holder = "old"
+
+    chosen = _calibrated_holder("Flat Shuttle")
+    incoming = SystemSettings.from_dict(utils.load_yaml(path))
+    incoming.stage.holders = {chosen.name: chosen}
+    incoming.stage.active_holder = chosen.name
+    microscope.apply_configuration(incoming)
+
+    assert microscope.system.stage.active_holder == "Flat Shuttle"
+    assert set(microscope.system.stage.holders) == {"Flat Shuttle"}


### PR DESCRIPTION
Stacked on #837 → #836 → #835. This diff is against #837.

`stage.holders`, a keyed map, with `active_holder` naming the one on the stage.

The holder was a second file beside the configuration — `sample-holder.yaml`, its own
loader, no version — describing hardware the configuration already describes. A map
rather than a single holder, because a site that swaps a flat shuttle for a pre-tilted
one should select the other entry rather than re-enter its geometry (and, once pre-tilt
moves onto the holder, recalibrate for it).

`loaded_grid` does not come along. Which grid is in which slot changes every session and
keeps its own occupancy file; writing it here would make a saved configuration claim a
grid is loaded that was taken out weeks ago. `to_dict` passes `include_grids=False`.

## The migration is the part worth reviewing

A calibrated holder's slot positions were captured by somebody standing at the
microscope. **They cannot be regenerated, and losing them is worse than anything this
refactor was meant to fix.**

`_resolve_configured_holder` has three cases:

1. the configuration names a holder → use it, touch no files
2. it does not, and `sample-holder.yaml` exists → import it as an entry and select it
3. neither → the shipped default, as before

A calibrated site upgrades with its calibration intact and is never shown a list.

**Nothing is written back.** The imported holder is on `stage.holders`, so the next save
of the configuration carries it — but a session that saves nothing leaves both files
exactly as it found them. Re-importing every session is idempotent and costs nothing;
rewriting a user's configuration on their behalf at connect time is how a good migration
becomes a support ticket.

`StageSystemSettings.from_dict` stays a pure function of its argument and reads no
files. The migration lives at the one place that already touched them.

## A trap found on the way: `apply_configuration`

It replaces `system.stage` wholesale — which is exactly how `rotation` earned its
comment there. The holder is the same trap one field over: a configuration written
before this change has no `holders:`, so pressing Apply would empty the map and clear
the selection, while the running `Stage` carried on using a holder the configuration no
longer knew about.

Which holder is in the shuttle is a physical fact and Apply did not change it, so it is
carried across. A file that *does* name holders wins, because then the user is choosing
one.

## Verification

15 tests. The four failure modes that cost something were **mutation-tested** rather
than assumed:

| mutation | caught by |
|---|---|
| migration silently ignores the site's file | `test_an_existing_holder_file_is_imported_with_its_calibration` |
| imported but not selected | `test_resolving_twice_is_stable` + 2 others |
| migration rewrites the user's file | `test_the_migration_does_not_rewrite_either_file` |
| Apply carry-over removed | `test_applying_a_configuration_keeps_the_holder_selection` |

Full non-UI suite: **1 failed, 4942 passed** — the same pre-existing failure as on
`origin/main`.

## Not in this PR

Pre-tilt moving onto the holder. Note for that one: `SampleHolder.pre_tilt` **already
exists**, as a property reading back from `self._parent.system.stage.shuttle_pre_tilt`.
Giving the holder a stored `pre_tilt` while `StageSystemSettings.shuttle_pre_tilt`
becomes a property over the active holder points the two at each other — the existing
property has to go in the same commit as the new field, or it recurses.

No UI yet for choosing between holders. The map and the selection are readable and
saveable; the picker belongs with the configuration editor.
