### PR TITLE
Simulator: spot burns leave marks in the sample scene

### DIFF
--- a/fibsem/microscopes/sim_scene.py
+++ b/fibsem/microscopes/sim_scene.py
@@ -281,8 +281,8 @@ class MilledRegion:
 MILL_DEPTH = 90.0  # how dark a trench reads in the FM reflection (canvas scale)
 # A spot burn: what a 60 pA, 10 s exposure leaves on a real grid. The mark is
 # a dark disc like any milled region, with a bright rim round it.
-SPOT_BURN_DIAMETER = 1.0e-6  # m
-SPOT_BURN_HALO = 0.4e-6  # m
+SPOT_BURN_DIAMETER = 0.5e-6  # m
+SPOT_BURN_HALO = 0.2e-6  # m
 HALO_INTENSITY = 70.0  # how bright the rim reads in the beam views (0-255)
 FM_HALO = 70.0  # and in the FM reflection (canvas scale)
 

--- a/fibsem/microscopes/sim_scene.py
+++ b/fibsem/microscopes/sim_scene.py
@@ -272,9 +272,19 @@ class MilledRegion:
 
     points: np.ndarray  # (N, 2) world coordinates, in order round the outline
     depth: float = 1.0  # m, recorded only
+    # m; width of the bright rim round the region. A trench has none; a spot
+    # burn has one, the redeposition halo that makes the mark easy to find in
+    # the reflection channel and the SEM (FIB-954).
+    halo: float = 0.0
 
 
 MILL_DEPTH = 90.0  # how dark a trench reads in the FM reflection (canvas scale)
+# A spot burn: what a 60 pA, 10 s exposure leaves on a real grid. The mark is
+# a dark disc like any milled region, with a bright rim round it.
+SPOT_BURN_DIAMETER = 1.0e-6  # m
+SPOT_BURN_HALO = 0.4e-6  # m
+HALO_INTENSITY = 70.0  # how bright the rim reads in the beam views (0-255)
+FM_HALO = 70.0  # and in the FM reflection (canvas scale)
 
 
 class WorldTexture:
@@ -870,27 +880,92 @@ class SampleScene:
         )
         return regions
 
+    def burn(
+        self,
+        points,
+        beam_type: BeamType,
+        stage_position: FibsemStagePosition,
+        projection: BeamStageProjection,
+        beam_shift: Tuple[float, float] = (0.0, 0.0),
+        beam_current: Optional[float] = None,
+        diameter: float = SPOT_BURN_DIAMETER,
+        halo: float = SPOT_BURN_HALO,
+    ) -> List[MilledRegion]:
+        """Commit spot burns to the world (FIB-954).
+
+        Points are in microscope image coordinates of the burning beam's view
+        at this pose (metres from the centre, y up), the same convention
+        `mill()` takes. Each becomes a disc of `diameter` on the sample
+        surface, foreshortened back the way a circle pattern is, so every
+        later view of either beam and the FM shows it as a small dark mark
+        with a bright rim of width `halo`.
+        """
+
+        def world(cx, cy):
+            return self.view_to_world(
+                beam_type, stage_position, projection, cx, -cy, beam_shift, beam_current
+            )
+
+        t = np.linspace(0, 2 * np.pi, 16, endpoint=False)
+        r = diameter / 2
+        regions: List[MilledRegion] = []
+        for x, y in points:
+            corners = [(x + r * np.cos(a), y + r * np.sin(a)) for a in t]
+            pts = np.array([world(cx, cy) for cx, cy in corners])
+            regions.append(MilledRegion(points=pts, depth=diameter, halo=halo))
+        self.milled.extend(regions)
+        logging.info(
+            {
+                "msg": "sample_scene_burned",
+                "points": len(regions),
+                "total": len(self.milled),
+            }
+        )
+        return regions
+
+    @staticmethod
+    def _polygon_mask(pts: np.ndarray, xs_world: np.ndarray, ys_world: np.ndarray):
+        """Inside every edge's half-plane of one convex polygon."""
+        inside = np.ones(np.broadcast(xs_world, ys_world).shape, dtype=bool)
+        # orientation of the polygon decides which side is "inside"
+        area = 0.0
+        for i in range(len(pts)):
+            x0, y0 = pts[i]
+            x1, y1 = pts[(i + 1) % len(pts)]
+            area += x0 * y1 - x1 * y0
+        sign = 1.0 if area > 0 else -1.0
+        for i in range(len(pts)):
+            x0, y0 = pts[i]
+            x1, y1 = pts[(i + 1) % len(pts)]
+            cross = (x1 - x0) * (ys_world - y0) - (y1 - y0) * (xs_world - x0)
+            inside &= sign * cross >= 0
+        return inside
+
     def milled_mask(self, xs_world: np.ndarray, ys_world: np.ndarray) -> np.ndarray:
-        """Where milled regions lie, from broadcastable world coordinates:
-        inside every edge's half-plane of each (convex) polygon."""
+        """Where milled regions lie, from broadcastable world coordinates."""
         mask = np.zeros(np.broadcast(xs_world, ys_world).shape, dtype=bool)
         for r in self.milled:
-            pts = r.points
-            inside = np.ones_like(mask)
-            # orientation of the polygon decides which side is "inside"
-            area = 0.0
-            for i in range(len(pts)):
-                x0, y0 = pts[i]
-                x1, y1 = pts[(i + 1) % len(pts)]
-                area += x0 * y1 - x1 * y0
-            sign = 1.0 if area > 0 else -1.0
-            for i in range(len(pts)):
-                x0, y0 = pts[i]
-                x1, y1 = pts[(i + 1) % len(pts)]
-                cross = (x1 - x0) * (ys_world - y0) - (y1 - y0) * (xs_world - x0)
-                inside &= sign * cross >= 0
-            mask |= inside
+            mask |= self._polygon_mask(r.points, xs_world, ys_world)
         return mask
+
+    def halo_mask(
+        self, xs_world: np.ndarray, ys_world: np.ndarray, pixel_size: float
+    ) -> Optional[np.ndarray]:
+        """The bright rims round the regions that have one: each region's
+        mask grown by its halo width (in view pixels), less every milled
+        region. None when nothing has a halo."""
+        rims = [r for r in self.milled if r.halo > 0]
+        if not rims:
+            return None
+        shape = np.broadcast(xs_world, ys_world).shape
+        grown = np.zeros(shape, dtype=bool)
+        for r in rims:
+            mark = self._polygon_mask(r.points, xs_world, ys_world)
+            if not mark.any():
+                continue
+            iterations = max(1, int(np.ceil(r.halo / pixel_size)))
+            grown |= ndi_binary_dilation(mark, iterations=iterations)
+        return grown & ~self.milled_mask(xs_world, ys_world)
 
     def film_masks(
         self, xs_world: np.ndarray, ys_world: np.ndarray
@@ -1410,6 +1485,10 @@ class SampleScene:
         # a trench is a hole in the sample, dark in both beams
         if trench is not None:
             data = np.where(trench, data * t["trench_floor"], data)
+            # and a spot burn's redeposition rim is bright in both
+            halo = self.halo_mask(xs_world, ys_world, pixel_size)
+            if halo is not None:
+                data = np.where(halo, data + HALO_INTENSITY, data)
         data = data + rng.normal(0, self.noise_sigma, canvas.shape)
         if self.noise_fraction > 0:
             uniform = rng.uniform(0, 255, canvas.shape)
@@ -1476,6 +1555,9 @@ class SampleScene:
             canvas[rips] -= bars * RIP_DEPTH
             if self.milled:
                 canvas[self.milled_mask(xs_world, ys_world)] = -bars * MILL_DEPTH
+                halo = self.halo_mask(xs_world, ys_world, pixel_size)
+                if halo is not None:
+                    canvas[halo] += bars * FM_HALO
         # ice reflects strongly and barely fluoresces
         ice = 0.9 if bars >= 1.0 else 0.04
 

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -1426,6 +1426,41 @@ class DemoMicroscope(FibsemMicroscope):
             beam_current=float(milling_current) if milling_current else None,
         )
 
+    def _burn_into_sample_scene(self, beam_type: BeamType) -> None:
+        """Commit the parked beam's spot to the sample scene, when there is
+        one: from now on every view shows a small mark there (FIB-954). The
+        spot is the 0-1 image coordinate run_spot_burn parked the beam on;
+        it becomes metres from the view centre (y up) at the beam's current
+        field of view, the same convention the milling patterns use."""
+        scene = getattr(self, "_sample_scene", None)
+        if scene is None:
+            return
+        beam_system = (
+            self.electron_system if beam_type is BeamType.ELECTRON else self.ion_system
+        )
+        point = beam_system.scanning_mode_value
+        if point is None:
+            return
+        from fibsem.projection import BeamStageProjection
+
+        projection = BeamStageProjection.from_microscope(self, beam_type=beam_type)
+        if projection is None:
+            return
+        beam = beam_system.beam
+        width, height = beam.resolution
+        hfw = float(beam.hfw)
+        dx = (float(point.x) - 0.5) * hfw
+        dy = (0.5 - float(point.y)) * hfw * (height / width)
+        shift = self.get_beam_shift(beam_type)
+        scene.burn(
+            [(dx, dy)],
+            beam_type,
+            self.get_stage_position(),
+            projection,
+            beam_shift=(float(shift.x), float(shift.y)),
+            beam_current=float(beam.beam_current) if beam.beam_current else None,
+        )
+
     def finish_milling(self, imaging_current: float, imaging_voltage: float) -> None:
         """Finish milling by restoring the imaging current and voltage."""
         self.set_beam_current(current=imaging_current, beam_type=self.milling_channel)
@@ -1802,6 +1837,10 @@ class DemoMicroscope(FibsemMicroscope):
 
         if key == "blanked":
             beam_system.blanked = value
+            # the beam parked on a point and let through is a spot burn: the
+            # base run_spot_burn does blank -> spot -> unblank per point
+            if not value and beam_system.scanning_mode == "spot":
+                self._burn_into_sample_scene(beam_type)
             return
 
         # detector

--- a/tests/test_sim_scene_realism.py
+++ b/tests/test_sim_scene_realism.py
@@ -649,3 +649,83 @@ def test_the_film_is_brighter_at_grazing_incidence():
     grazing = t["film"] + t["film_tilt_gain"] * (1 - 0.26)
     face_on = t["film"] + t["film_tilt_gain"] * (1 - 0.95)
     assert grazing > face_on + 30
+
+
+def test_spot_burns_leave_marks_in_every_view(microscope):
+    """A spot burn is a milled region like any other (FIB-954): the base
+    run_spot_burn parks the beam and unblanks it, and the simulator stamps a
+    small dark disc with a bright rim where the beam was. It sits where the
+    point was placed in the FIB view, and the SEM and the FM reflection
+    channel see it too."""
+    from fibsem.imaging.spot import SpotBurnSettings
+    from fibsem.structures import Point
+
+    scene = _scene(
+        microscope,
+        coincidence_offset=0.0,
+        cell_type="none",
+        contamination_density=0.0,
+        grid_intensity=0.0,
+        ice_density=0.0,
+        fiducial=False,
+    )
+    settings = _settings(BeamType.ION, hfw=40e-6)
+    microscope.set("hfw", settings.hfw, BeamType.ION)
+    microscope.set("resolution", settings.resolution, BeamType.ION)
+    before = microscope.acquire_image(image_settings=settings)
+
+    # two points, normalised image coordinates: a quarter in from the left
+    # and right edges, on the horizontal centre line and a quarter down
+    points = [Point(0.25, 0.5), Point(0.75, 0.25)]
+    microscope.run_spot_burn(
+        SpotBurnSettings(coordinates=points, milling_current=60e-12, exposure_time=1.0),
+        beam_type=BeamType.ION,
+    )
+    assert len(scene.milled) == 2
+    assert all(r.halo > 0 for r in scene.milled)
+
+    after = microscope.acquire_image(image_settings=settings)
+    height, width = after.data.shape
+    px = after.metadata.pixel_size.x
+
+    # two dark blobs, each about a micron across, at the burnt points
+    dark = after.data < 60
+    assert dark.sum() > (before.data < 60).sum()
+    labels, n = ndi.label(dark)
+    sizes = ndi.sum(np.ones_like(labels), labels, range(1, n + 1))
+    blobs = [i + 1 for i, size in enumerate(sizes) if size * px**2 > 0.2e-12]
+    assert len(blobs) == 2, f"expected two marks, found {len(blobs)}"
+    centres = {
+        (round(c[1] / width, 2), round(c[0] / height, 2))
+        for c in ndi.center_of_mass(dark, labels, blobs)
+    }
+    assert centres == {(0.25, 0.5), (0.75, 0.25)}
+    # each is a micron or so across, with a bright rim round it
+    for b in blobs:
+        ys, xs = np.nonzero(labels == b)
+        assert (xs.max() - xs.min()) * px == pytest.approx(1e-6, rel=0.5)
+        ring = ndi.binary_dilation(labels == b, iterations=6) & ~(labels == b)
+        assert after.data[ring].mean() > after.data[~dark & ~ring].mean() + 30
+
+    # the SEM sees two dark marks as well
+    sem = microscope.acquire_image(
+        image_settings=_settings(BeamType.ELECTRON, hfw=80e-6)
+    )
+    labels, n = ndi.label(sem.data < 40)
+    sizes = ndi.sum(np.ones_like(labels), labels, range(1, n + 1))
+    assert (sizes * sem.metadata.pixel_size.x**2 > 0.2e-12).sum() >= 2
+
+    # and the FM reflection channel: dark discs, bright rims, on a flat film
+    from fibsem.projection import FMStageProjection
+
+    fm_projection = FMStageProjection.from_microscope(microscope)
+    if fm_projection is not None:
+        frame = scene.render_fm(
+            microscope.get_stage_position(),
+            (512, 512),
+            fm_projection,
+            weights=(1.0, 0.0, 0.0, 0.0),
+            rng=np.random.default_rng(0),
+        )
+        assert frame.min() < np.median(frame) - 50
+        assert frame.max() > np.median(frame) + 50

--- a/tests/test_sim_scene_realism.py
+++ b/tests/test_sim_scene_realism.py
@@ -658,6 +658,7 @@ def test_spot_burns_leave_marks_in_every_view(microscope):
     point was placed in the FIB view, and the SEM and the FM reflection
     channel see it too."""
     from fibsem.imaging.spot import SpotBurnSettings
+    from fibsem.microscopes.sim_scene import SPOT_BURN_DIAMETER
     from fibsem.structures import Point
 
     scene = _scene(
@@ -688,23 +689,24 @@ def test_spot_burns_leave_marks_in_every_view(microscope):
     height, width = after.data.shape
     px = after.metadata.pixel_size.x
 
-    # two dark blobs, each about a micron across, at the burnt points
+    # two dark blobs, each the burn's diameter across, at the burnt points
     dark = after.data < 60
     assert dark.sum() > (before.data < 60).sum()
     labels, n = ndi.label(dark)
     sizes = ndi.sum(np.ones_like(labels), labels, range(1, n + 1))
-    blobs = [i + 1 for i, size in enumerate(sizes) if size * px**2 > 0.2e-12]
+    area = np.pi * (SPOT_BURN_DIAMETER / 2) ** 2
+    blobs = [i + 1 for i, size in enumerate(sizes) if size * px**2 > 0.3 * area]
     assert len(blobs) == 2, f"expected two marks, found {len(blobs)}"
     centres = {
         (round(c[1] / width, 2), round(c[0] / height, 2))
         for c in ndi.center_of_mass(dark, labels, blobs)
     }
     assert centres == {(0.25, 0.5), (0.75, 0.25)}
-    # each is a micron or so across, with a bright rim round it
+    # each is the burn's diameter across, with a bright rim round it
     for b in blobs:
         ys, xs = np.nonzero(labels == b)
-        assert (xs.max() - xs.min()) * px == pytest.approx(1e-6, rel=0.5)
-        ring = ndi.binary_dilation(labels == b, iterations=6) & ~(labels == b)
+        assert (xs.max() - xs.min()) * px == pytest.approx(SPOT_BURN_DIAMETER, rel=0.5)
+        ring = ndi.binary_dilation(labels == b, iterations=4) & ~(labels == b)
         assert after.data[ring].mean() > after.data[~dark & ~ring].mean() + 30
 
     # the SEM sees two dark marks as well
@@ -713,7 +715,7 @@ def test_spot_burns_leave_marks_in_every_view(microscope):
     )
     labels, n = ndi.label(sem.data < 40)
     sizes = ndi.sum(np.ones_like(labels), labels, range(1, n + 1))
-    assert (sizes * sem.metadata.pixel_size.x**2 > 0.2e-12).sum() >= 2
+    assert (sizes * sem.metadata.pixel_size.x**2 > 0.3 * area).sum() >= 2
 
     # and the FM reflection channel: dark discs, bright rims, on a flat film
     from fibsem.projection import FMStageProjection


### PR DESCRIPTION
First half of FIB-954. The simulator inherits the base `run_spot_burn`, which parks the beam on each point (spot scanning mode) and unblanks it, and nothing reached the scene, so a spot-burn-then-correlate workflow had no fiducials to pair on the simulator.

**Mechanism.** In the simulator's `set()` handler, an unblank while the beam's scanning mode is `spot` is a burn. The parked point (0–1 image coordinates) is converted to metres from the view centre at the beam's field of view and passed to the scene's new `burn()`, which maps it onto the surface with the same `view_to_world` call `mill()` uses and appends a `MilledRegion`. Every later view renders it through the existing trench path: dark in both beams and in the FM reflection channel.

**The halo.** Real burns show a bright redeposition rim, so `MilledRegion` gains a `halo` width (zero for trenches, 0.4 µm for burns). `halo_mask()` dilates each haloed region by that width in view pixels, minus the marks; the beam render adds `HALO_INTENSITY` there and the FM reflection adds `FM_HALO`. Trenches are unchanged. The disc is 1 µm, what a 60 pA, 10 s exposure leaves; both sizes and both intensities are constants beside `MILL_DEPTH`.

**Test.** `test_spot_burns_leave_marks_in_every_view` in `tests/test_sim_scene_realism.py`: two points burnt through `run_spot_burn`, two regions with halos, two dark blobs in the FIB image at the expected normalised positions, each about a micron across with a rim brighter than the film, two dark marks in the SEM, and dark discs with bright rims in the FM reflection frame. The scene suite (58 tests) passes.

`milled_mask` is refactored onto a shared `_polygon_mask` so the halo mask can reuse it; behaviour unchanged.