### PR TITLE
[autoscript] The home slot of the grid on the stage reads Loaded from AutoScript 4.14 (FIB-952)

### DIFF
--- a/fibsem/microscopes/autoscript.py
+++ b/fibsem/microscopes/autoscript.py
@@ -578,9 +578,13 @@ class AutoscriptSampleLoader(SampleGridLoader):
 
     Two things the hardware does that the in-memory model must absorb:
 
-    - A grid that is on the stage makes its magazine slot read ``Empty``. The slot
-      is still that grid's home, so a rescan keeps the grid there while our working
-      slot holds it, and the inventory keeps saying "present, loaded".
+    - The home slot of the grid on the stage. From AutoScript 4.14 it reads
+      ``Loaded`` (release notes 4.14.0, "Autoloader state change"), which says
+      outright that the slot's grid is on the stage, so a fresh connect can put it
+      back in both places. Up to 4.13 it read ``Empty``, and the only way to keep
+      the grid in its home slot was memory: a rescan keeps it there while our
+      working slot holds it. Both paths are kept, so either version reads
+      "present, loaded". States are compared case-blind: they arrive as enum names.
     - ``get_slots(False)`` returns the autoloader's last-known states, which may
       all be ``Unknown`` before any scan; ``get_slots(True)`` runs a physical scan.
       ``get_inventory`` is the first, ``run_inventory`` the second, and the caller
@@ -619,13 +623,14 @@ class AutoscriptSampleLoader(SampleGridLoader):
         loaded = {s.loaded_grid.name for s in self.holder.occupied_slots}
         slots: dict = {}
         unknown: set = set()
+        on_stage: Optional[SampleGrid] = None
         for hw in hw_slots:
             number = int(hw.id)
             name = _slot_name(number - 1)
             previous = self.slots.get(name)
             state = _slot_state(hw)
             grid: Optional[SampleGrid] = None
-            if state == "Occupied":
+            if state in ("Occupied", "Loaded"):
                 described = (getattr(hw, "sample_description", "") or "").strip()
                 grid_name = described or f"Grid-{number:02d}"
                 if previous is not None and previous.loaded_grid is not None:
@@ -633,12 +638,16 @@ class AutoscriptSampleLoader(SampleGridLoader):
                         grid = previous.loaded_grid  # keep identity across scans
                 if grid is None:
                     grid = SampleGrid(name=grid_name)
+                if state == "Loaded":
+                    on_stage = grid  # 4.14: its home slot, and it is on the stage
             elif (
                 previous is not None
                 and previous.loaded_grid is not None
                 and previous.loaded_grid.name in loaded
             ):
-                grid = previous.loaded_grid  # its home; it reads Empty while loaded
+                grid = (
+                    previous.loaded_grid
+                )  # <= 4.13: its home reads Empty while loaded
             elif state == "Unknown":
                 logging.warning(f"Autoloader slot {number} has not been scanned.")
                 unknown.add(name)
@@ -646,9 +655,12 @@ class AutoscriptSampleLoader(SampleGridLoader):
         self.slots = slots
         self.unknown_slots = unknown
 
+        working = self.working_slot
+        if on_stage is not None:
+            # The same object in both places, as a load through us leaves it.
+            working.loaded_grid = on_stage
         # Something may be on the stage that we did not load: reflect the hardware.
         stage = getattr(self._autoloader, "stage", None)
-        working = self.working_slot
         if stage is not None:
             if working.loaded_grid is None and _slot_state(stage) == "Occupied":
                 described = (getattr(stage, "sample_description", "") or "").strip()
@@ -688,7 +700,9 @@ def _slot_state(hw_slot) -> str:
     """``AutoloaderSlot.state`` as a plain string; enum members stringify to it."""
     state = getattr(hw_slot, "state", "Unknown")
     text = str(state)
-    return text.rsplit(".", 1)[-1] if "." in text else text
+    text = text.rsplit(".", 1)[-1] if "." in text else text
+    # Enum names arrive upper-case (``OCCUPIED``); one spelling for the comparisons.
+    return text.capitalize()
 
 
 class AutoscriptSputterCoater:

--- a/tests/test_autoscript_sample_loader.py
+++ b/tests/test_autoscript_sample_loader.py
@@ -40,8 +40,16 @@ class FakeAutoloaderStage:
 class FakeAutoloader:
     """Twelve slots; loading moves a grid onto ``stage`` and empties its slot."""
 
-    def __init__(self, occupied: Optional[dict] = None, scanned: bool = True) -> None:
+    def __init__(
+        self,
+        occupied: Optional[dict] = None,
+        scanned: bool = True,
+        reports_loaded: bool = False,
+    ) -> None:
+        """``reports_loaded`` is AutoScript 4.14: the home slot of the grid on the
+        stage reads ``Loaded``; before that it read ``Empty``."""
         self.is_installed = True
+        self.reports_loaded = reports_loaded
         self.stage = FakeAutoloaderStage()
         self._slots: List[FakeAutoloaderSlot] = [
             FakeAutoloaderSlot(i, "Empty" if scanned else "Unknown")
@@ -73,7 +81,8 @@ class FakeAutoloader:
         slot = self._slots[grid_id - 1]
         self.stage.sample_description = slot.sample_description
         self.stage.state = "Occupied"
-        slot.state = "Empty"  # what the hardware reports for a grid on the stage
+        # The home slot of a grid on the stage: Loaded from 4.14, Empty before.
+        slot.state = "Loaded" if self.reports_loaded else "Empty"
         self._loaded_from = grid_id
 
     def unload(self) -> None:
@@ -180,6 +189,45 @@ class TestInventory:
         assert rows["Slot-05"].state is GridSlotState.UNKNOWN
         assert not rows["Slot-05"].present
 
+    def test_a_loaded_slot_puts_its_grid_on_the_stage_on_a_fresh_connect(self):
+        """AutoScript 4.14 (FIB-952): the home slot of the grid on the stage reads
+        LOADED. On a fresh connect, with no memory of any exchange, that grid is
+        present in its slot, loaded, and in our working slot, named from the slot
+        description. States are matched case-blind, as the enum names arrive."""
+        from fibsem.microscopes._stage import GridSlotState
+
+        hw = FakeAutoloader(
+            occupied={2: "grid-elm", 4: "grid-birch"}, reports_loaded=True
+        )
+        hw.load(4)  # loaded from the vendor UI before we connected
+        hw._slots[1].state = "OCCUPIED"
+        hw._slots[3].state = "LOADED"
+        hw.stage.state = "OCCUPIED"
+        microscope, loader = _microscope_with(hw)
+        loader.get_inventory()
+        rows = {r.name: r for r in microscope._stage.grid_inventory() if r.present}
+        assert set(rows) == {"grid-elm", "grid-birch"}
+        assert rows["grid-birch"].state is GridSlotState.LOADED
+        assert rows["grid-elm"].state is GridSlotState.OCCUPIED
+        assert [g.name for g in microscope._stage.loaded_grids] == ["grid-birch"]
+        assert loader.working_slot.loaded_grid is loader.slots["Slot-04"].loaded_grid
+        # Already the loaded grid: no exchange.
+        before = len(hw.calls)
+        microscope._stage.ensure_loaded("grid-birch")
+        assert hw.calls[before:] == []
+
+    def test_the_4_13_home_slot_reads_empty_and_memory_still_keeps_the_grid(self):
+        """Before 4.14 the home slot reads Empty while its grid is out; a rescan
+        keeps the grid there only because we remember loading it."""
+        hw = FakeAutoloader(occupied={4: "grid-birch"})
+        microscope, loader = _microscope_with(hw)
+        loader.get_inventory()
+        microscope._stage.ensure_loaded("grid-birch")
+        assert hw._slots[3].state == "Empty"
+        loader.get_inventory()
+        assert loader.slots["Slot-04"].loaded_grid is not None
+        assert [g.name for g in microscope._stage.loaded_grids] == ["grid-birch"]
+
     def test_inventory_rows_come_from_the_magazine(self):
         hw = FakeAutoloader(occupied={1: "a", 2: "b"})
         microscope, loader = _microscope_with(hw)
@@ -204,6 +252,26 @@ class TestExchange:
         assert microscope._stage.loaded_grids[0].name == "grid-cedar"
         # the magazine slot stays the grid's home, whatever the hardware reads
         assert loader.slots["Slot-03"].loaded_grid.name == "grid-cedar"
+
+    def test_an_exchange_on_4_14_reads_loaded_then_occupied_again(self):
+        from fibsem.microscopes._stage import GridSlotState
+
+        hw = FakeAutoloader(occupied={1: "a", 2: "b"}, reports_loaded=True)
+        microscope, loader = _microscope_with(hw)
+        loader.get_inventory()
+        stage = microscope._stage
+        stage.ensure_loaded("a")
+        loader.get_inventory()
+        rows = {r.name: r.state for r in stage.grid_inventory() if r.present}
+        assert rows == {"a": GridSlotState.LOADED, "b": GridSlotState.OCCUPIED}
+        stage.ensure_loaded("b")  # unload a, load b
+        loader.get_inventory()
+        rows = {r.name: r.state for r in stage.grid_inventory() if r.present}
+        assert rows == {"a": GridSlotState.OCCUPIED, "b": GridSlotState.LOADED}
+        stage.unload()
+        loader.get_inventory()
+        rows = {r.name: r.state for r in stage.grid_inventory() if r.present}
+        assert rows == {"a": GridSlotState.OCCUPIED, "b": GridSlotState.OCCUPIED}
 
     def test_the_home_slot_survives_a_rescan_while_loaded(self):
         hw = FakeAutoloader(occupied={3: "grid-cedar", 4: "grid-elm"})


### PR DESCRIPTION
AutoScript 4.14.0 (release notes p.7, "Autoloader state change") makes the magazine slot whose grid is on the stage report **Loaded** instead of **Empty**. Up to 4.13 the only way to keep that grid in its home slot was memory of the exchange, so after a restart with a grid already on the stage the slot read as empty and the grid could only appear as "Grid-on-stage" from `autoloader.stage`.

- A `Loaded` slot gives its grid, named from the slot description or `Grid-NN`, and puts the same object in the working slot, so a fresh connect reads present and LOADED on 4.14.
- The memory path stays for 4.13, where the home slot reads Empty.
- States are compared case-blind, since they arrive as enum names (`OCCUPIED`).
- The class docstring describes both versions.

**Tests** (`tests/test_autoscript_sample_loader.py`): the fake gains a 4.14 mode. A Loaded slot on a fresh connect is present, loaded and in the working slot with no exchange when asked for; the 4.13 path still keeps the grid through memory; an exchange on 4.14 reads Loaded then Occupied again through load, swap and unload. 78 across the loader, inventory and Sample view suites.

Verification on an Arctis running 4.14 is FIB-953 items 8 and 9.