### PR TITLE
[refactor] What is fitted is asked of the instrument (schema v1, phase 3)

### DIFF
--- a/fibsem/config/tfs-aquilos2-configuration.yaml
+++ b/fibsem/config/tfs-aquilos2-configuration.yaml
@@ -33,12 +33,6 @@ ion:
     dwell_time:                 1.0e-06                     # the default ion dwell time
     detector_mode:              SecondaryElectrons          # the detector mode of the ion beam                             [USER]
     detector_type:              ETD                         # the detector type of the ion beam                             [USER]
-manipulator:
-    enabled:                    true                        # manipulator is enabled                                        [USER]
-gis:
-    enabled:                    true                        # gis is enabled                                                [USER]
-    multichem:                  false                        # multichem is enabled                                          [USER]
-    sputter_coater:             false                       # sputter coater is enabled                                     [USER]                        
 imaging:
     beam_type:                  ELECTRON                    # the default imaging beam type (ELECTRON, or ION)              [USER]
     resolution:                 [1536, 1024]                # the default imaging resolution                        [pixel] [USER]

--- a/fibsem/config/tfs-arctis-configuration.yaml
+++ b/fibsem/config/tfs-arctis-configuration.yaml
@@ -33,12 +33,6 @@ ion:
     dwell_time:                 1.0e-06                     # the default ion dwell time
     detector_mode:              SecondaryElectrons          # the detector mode of the ion beam                             [USER]
     detector_type:              ETD                         # the detector type of the ion beam                             [USER]
-manipulator:
-    enabled:                    false                       # manipulator is enabled                                        [USER]
-gis:
-    enabled:                    false                       # gis is enabled                                                [USER]
-    multichem:                  false                       # multichem is enabled                                          [USER]
-    sputter_coater:             false                       # sputter coater is enabled                                     [USER]                        
 imaging:
     beam_type:                  ELECTRON                    # the default imaging beam type (ELECTRON, or ION)              [USER]
     resolution:                 [1536, 1024]                # the default imaging resolution                        [pixel] [USER]

--- a/fibsem/config/tfs-hydra-configuration.yaml
+++ b/fibsem/config/tfs-hydra-configuration.yaml
@@ -33,12 +33,6 @@ ion:
     dwell_time:                 1.0e-06                     # the default ion dwell time
     detector_mode:              SecondaryElectrons          # the detector mode of the ion beam                             [USER]
     detector_type:              ETD                         # the detector type of the ion beam                             [USER]
-manipulator:
-    enabled:                    true                        # manipulator is enabled                                        [USER]
-gis:
-    enabled:                    true                        # gis is enabled                                                [USER]
-    multichem:                  false                        # multichem is enabled                                          [USER]
-    sputter_coater:             false                       # sputter coater is enabled                                     [USER]                        
 imaging:
     beam_type:                  ELECTRON                    # the default imaging beam type (ELECTRON, or ION)              [USER]
     resolution:                 [1536, 1024]                # the default imaging resolution                        [pixel] [USER]

--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -241,8 +241,62 @@ class FibsemMicroscope(ABC):
         # it is `_get_axis_limits` itself raising, and on a compustage that is a
         # lookup of a module constant, which cannot.
         self._read_stage_capabilities()
+        self._read_hardware_capabilities()
 
         self._stage = _create_sample_stage(self)
+
+    # ---- fitted subsystems, asked of the instrument ----------------------
+    #
+    # Each probe answers `True`, `False`, or `None` for "this backend cannot say".
+    # `None` is the important one: it leaves the field exactly as the configuration
+    # left it, so a backend with no way to ask, or a probe that raises, can never
+    # take a subsystem away from a site that has one. The failure this guards is not
+    # symmetric -- a GIS that wrongly appears is a menu entry that errors, a GIS that
+    # wrongly disappears is a working instrument that lost a feature on upgrade.
+
+    def _probe_manipulator_installed(self) -> Optional[bool]:
+        """Whether a manipulator is fitted, or None if this backend cannot say."""
+        return None
+
+    def _probe_gis_installed(self) -> Optional[bool]:
+        return None
+
+    def _probe_multichem_installed(self) -> Optional[bool]:
+        return None
+
+    def _probe_sputter_coater_installed(self) -> Optional[bool]:
+        return None
+
+    def _read_hardware_capabilities(self) -> None:
+        """Ask the instrument which subsystems are fitted, and record them.
+
+        The same move as `_read_stage_capabilities`, one record over. These were
+        configuration keys -- `manipulator.enabled`, `gis.enabled`, `gis.multichem`,
+        `gis.sputter_coater` -- which meant a site could describe hardware it does not
+        have, or omit hardware it does, and nothing would disagree. The instrument
+        knows; asking it is both shorter and correct.
+
+        Called at connect and again after `apply_configuration` replaces the records,
+        for the reason the stage capability is: the file does not state these any
+        more, so a replacement would otherwise restore field defaults over what the
+        instrument said.
+        """
+        probes = (
+            (self._probe_manipulator_installed, self.system.manipulator, "enabled"),
+            (self._probe_gis_installed, self.system.gis, "enabled"),
+            (self._probe_multichem_installed, self.system.gis, "multichem"),
+            (self._probe_sputter_coater_installed, self.system.gis, "sputter_coater"),
+        )
+        for probe, record, field_name in probes:
+            try:
+                present = probe()
+            except Exception as e:
+                # A raising probe is ambiguous -- a missing subsystem and a sick
+                # connection look the same -- so it is read as "cannot say".
+                logging.debug(f"Capability probe {probe.__name__} failed: {e}")
+                continue
+            if present is not None:
+                setattr(record, field_name, bool(present))
 
     def _create_grid_loader(self) -> Optional["SampleGridLoader"]:
         """The grid loader for a compustage system, or None when it has no autoloader.
@@ -1134,6 +1188,13 @@ class FibsemMicroscope(ABC):
 
         if self.is_available("gis"):
             self.system.gis = system_settings.gis
+
+        # Both records above were just replaced from a file that no longer states what
+        # is fitted, so re-ask the instrument -- the same reason the stage capability
+        # is re-read. Note this runs after both assignments, not inside either: the
+        # `is_available` guards read the very fields being restored, so probing before
+        # them would decide using the values on their way out.
+        self._read_hardware_capabilities()
 
         # dont update info -> read only
         logging.info("Microscope configuration applied.")

--- a/fibsem/microscopes/autoscript.py
+++ b/fibsem/microscopes/autoscript.py
@@ -1840,6 +1840,32 @@ class ThermoMicroscope(FibsemMicroscope):
             view_tilt=self._beam_view_tilt(beam_type),
         )
 
+    # ---- fitted subsystems, as AutoScript reports them --------------------
+
+    def _probe_manipulator_installed(self) -> Optional[bool]:
+        """`specimen.manipulator.is_installed` -- documented, read-only, a bool."""
+        return bool(self.connection.specimen.manipulator.is_installed)
+
+    def _probe_gis_installed(self) -> Optional[bool]:
+        """A GIS is fitted when the instrument lists at least one port.
+
+        There is no `gas.is_installed`; the ports are the honest form of the question,
+        and they are what `get_available_values("gis_ports")` already reads.
+        """
+        return bool(self.connection.gas.list_all_gis_ports())
+
+    def _probe_multichem_installed(self) -> Optional[bool]:
+        return bool(self.connection.gas.list_all_multichem_ports())
+
+    def _probe_sputter_coater_installed(self) -> Optional[bool]:
+        """The probe `run_sputter_coater` already makes before it will run.
+
+        It raises `NotImplementedError` on an instrument whose `specimen` has no
+        `sputter_coater` attribute at all, so the attribute's presence is the test --
+        the same one, asked at connect instead of at the point of use.
+        """
+        return hasattr(self.connection.specimen, "sputter_coater")
+
     def _get_axis_limits(self) -> Dict[str, RangeLimit]:
         """Get the stage axis limits for x, y, z, t, r."""
         from fibsem.microscopes.simulator import (
@@ -3158,7 +3184,7 @@ class ThermoMicroscope(FibsemMicroscope):
         if key == "gis_ports":
             if self.is_available("gis"):
                 values = self.connection.gas.list_all_gis_ports()
-            elif self.is_available("multichem"):
+            elif self.is_available("gis_multichem"):
                 values = self.connection.gas.list_all_multichem_ports()
             else:
                 values = []

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -1535,7 +1535,7 @@ class DemoMicroscope(FibsemMicroscope):
         # TODO: universalise this for demo, tescan
         """
 
-        use_multichem = self.is_available("multichem")
+        use_multichem = self.is_available("gis_multichem")
         port = gis_settings.port
         gas = gis_settings.gas
         duration = gis_settings.duration

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -578,6 +578,10 @@ CONFIGURATION_SCHEMA: Dict[str, Set[str]] = {
     # `rotation` and `tilt` are the manipulator's own axes. A file could only ever
     # restate them, and every shipped one said `false`; the instrument knows.
     "manipulator": {"enabled"},
+    # Still read, so an existing file naming them loads and they are not reported as
+    # unrecognised -- but the ThermoFisher configurations no longer state them, and on
+    # AutoScript the instrument's answer overwrites whatever a file says. Kept for the
+    # backends that cannot be asked (Tescan, Odemis).
     "gis": {"enabled", "multichem", "sputter_coater"},
     "imaging": {"beam_type", "resolution", "hfw", "dwell_time", "autocontrast", "save"},
     # No `milling:` block. It was read into a `MicroscopeSettings.milling` that nothing

--- a/tests/test_hardware_capability_probes.py
+++ b/tests/test_hardware_capability_probes.py
@@ -1,0 +1,215 @@
+"""Which subsystems are fitted is asked of the instrument, not of a file.
+
+`manipulator.enabled`, `gis.enabled`, `gis.multichem` and `gis.sputter_coater` were
+configuration keys, which meant a site could describe hardware it does not have, or
+omit hardware it does, and nothing would disagree. The same move `rotation` made in
+FIB-834, one record over.
+
+The asymmetry that shapes every test here: a subsystem that wrongly *appears* is a menu
+entry that errors when used, while one that wrongly *disappears* is a working
+instrument that lost a feature on upgrade, silently. So "cannot say" must never mean
+"not fitted".
+"""
+
+from typing import Optional
+
+import pytest
+
+from fibsem import utils
+from fibsem.structures import BeamType
+
+
+@pytest.fixture
+def microscope():
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    yield microscope
+    microscope.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# "cannot say" leaves the configuration alone
+# ---------------------------------------------------------------------------
+
+
+def test_a_backend_that_cannot_probe_keeps_the_configured_answer(microscope):
+    """The default probes all return None, and the Demo backend does not override them.
+
+    This is the case that protects every site whose backend has no way to ask -- Tescan
+    and Odemis today. Reading None as False would disable the GIS on all of them.
+    """
+    microscope.system.gis.enabled = True
+    microscope.system.gis.multichem = True
+    microscope.system.manipulator.enabled = True
+
+    microscope._read_hardware_capabilities()
+
+    assert microscope.system.gis.enabled is True
+    assert microscope.system.gis.multichem is True
+    assert microscope.system.manipulator.enabled is True
+
+
+def test_a_probe_that_raises_is_read_as_cannot_say(microscope, monkeypatch):
+    """A missing subsystem and a sick connection raise the same way.
+
+    Reading an exception as "not fitted" would let one bad call at connect take the
+    GIS away for the whole session.
+    """
+
+    def boom() -> Optional[bool]:
+        raise RuntimeError("connection reset")
+
+    monkeypatch.setattr(microscope, "_probe_gis_installed", boom)
+    microscope.system.gis.enabled = True
+
+    microscope._read_hardware_capabilities()
+
+    assert microscope.system.gis.enabled is True
+
+
+def test_a_probe_that_answers_overrides_the_configuration(microscope, monkeypatch):
+    """The point of the change: the instrument wins over the file."""
+    monkeypatch.setattr(microscope, "_probe_gis_installed", lambda: False)
+    monkeypatch.setattr(microscope, "_probe_manipulator_installed", lambda: True)
+    microscope.system.gis.enabled = True
+    microscope.system.manipulator.enabled = False
+
+    microscope._read_hardware_capabilities()
+
+    assert microscope.system.gis.enabled is False
+    assert microscope.system.manipulator.enabled is True
+
+
+def test_every_probed_field_is_covered(microscope, monkeypatch):
+    for name in (
+        "_probe_manipulator_installed",
+        "_probe_gis_installed",
+        "_probe_multichem_installed",
+        "_probe_sputter_coater_installed",
+    ):
+        monkeypatch.setattr(microscope, name, lambda: True)
+    microscope.system.gis.enabled = False
+    microscope.system.gis.multichem = False
+    microscope.system.gis.sputter_coater = False
+    microscope.system.manipulator.enabled = False
+
+    microscope._read_hardware_capabilities()
+
+    assert microscope.system.gis.enabled
+    assert microscope.system.gis.multichem
+    assert microscope.system.gis.sputter_coater
+    assert microscope.system.manipulator.enabled
+
+
+# ---------------------------------------------------------------------------
+# It survives Apply, which is where the stage capability was lost
+# ---------------------------------------------------------------------------
+
+
+def test_applying_a_configuration_re_reads_the_capabilities(microscope, monkeypatch):
+    """`apply_configuration` replaces `system.gis` and `system.manipulator` wholesale.
+
+    The shipped ThermoFisher files no longer state these, so a replacement restores the
+    field defaults -- `False` -- over what the instrument said at connect. Exactly the
+    trap `rotation` fell into, which is why that call re-reads too.
+    """
+    monkeypatch.setattr(microscope, "_probe_gis_installed", lambda: True)
+    monkeypatch.setattr(microscope, "_probe_manipulator_installed", lambda: True)
+    microscope._read_hardware_capabilities()
+    assert microscope.system.gis.enabled and microscope.system.manipulator.enabled
+
+    from fibsem.structures import SystemSettings
+
+    # a configuration that says nothing about what is fitted, as the tfs files now do
+    incoming = SystemSettings.from_dict({})
+    assert incoming.gis.enabled is False, "fixture no longer exercises the trap"
+    microscope.apply_configuration(incoming)
+
+    assert microscope.system.gis.enabled is True
+    assert microscope.system.manipulator.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# The dispatch key that matched nothing
+# ---------------------------------------------------------------------------
+
+
+def test_the_multichem_capability_is_reachable(microscope):
+    """`is_available` spells it `gis_multichem`.
+
+    Two call sites asked for `"multichem"`, which matches no branch and falls through
+    to `return False` -- so the multichem path was unreachable regardless of hardware.
+    It never showed up because every shipped configuration set `gis.enabled: true`,
+    and the `gis` branch is tested first at both sites.
+    """
+    microscope.system.gis.multichem = True
+    assert microscope.is_available("gis_multichem") is True
+    assert microscope.is_available("multichem") is False
+
+    microscope.system.gis.multichem = False
+    assert microscope.is_available("gis_multichem") is False
+
+
+def test_no_call_site_asks_for_the_key_that_matches_nothing():
+    """A grep, as a test, because the failure is silent and reintroducing it is easy."""
+    import pathlib
+    import re
+
+    root = pathlib.Path(__file__).resolve().parents[1] / "fibsem"
+    offenders = [
+        f"{path.relative_to(root.parent)}:{i}"
+        for path in root.rglob("*.py")
+        for i, line in enumerate(path.read_text().splitlines(), 1)
+        if re.search(r'is_available\(\s*["\']multichem["\']', line)
+    ]
+    assert offenders == []
+
+
+# ---------------------------------------------------------------------------
+# The shipped files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "tfs-aquilos2-configuration.yaml",
+        "tfs-arctis-configuration.yaml",
+        "tfs-hydra-configuration.yaml",
+    ],
+)
+def test_the_autoscript_configurations_no_longer_state_what_is_fitted(filename):
+    import os
+
+    import fibsem.config as cfg
+
+    config = utils.load_yaml(os.path.join(cfg.CONFIG_PATH, filename))
+
+    assert "manipulator" not in config
+    assert "gis" not in config
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["tescan-configuration.yaml", "odemis-configuration.yaml"],
+)
+def test_the_backends_that_cannot_probe_keep_their_keys(filename):
+    """Deliberate, not an oversight.
+
+    `list_all_gis_ports` and `specimen.manipulator.is_installed` are AutoScript APIs.
+    Nothing here can ask a Tescan or an Odemis what is fitted, so removing their keys
+    would disable the GIS on every one of those systems on the strength of a guess.
+    """
+    import os
+
+    import fibsem.config as cfg
+
+    config = utils.load_yaml(os.path.join(cfg.CONFIG_PATH, filename))
+
+    assert config["gis"]["enabled"] is True
+    assert "manipulator" in config
+
+
+def test_a_configuration_that_says_nothing_still_loads_and_images(microscope):
+    """The end state for a ThermoFisher file: no capability keys at all."""
+    image = microscope.acquire_image(beam_type=BeamType.ELECTRON)
+    assert image is not None

--- a/tests/test_stage_capability_flags.py
+++ b/tests/test_stage_capability_flags.py
@@ -67,9 +67,14 @@ def test_no_shipped_file_states_a_manipulator_capability(filename: str, key: str
     They said `false` in all eight, which is the dataclass default, so removing them
     changed no instrument's behaviour -- and a manipulator's axes are the
     instrument's to report, not a file's to restate.
+
+    `.get`, because the whole block has since gone from the AutoScript files:
+    `manipulator.enabled` is now probed as well, and a block with nothing left in it
+    was removed rather than left empty. An absent block states no capability, which is
+    what this asks.
     """
     config = utils.load_yaml(os.path.join(cfg.CONFIG_PATH, filename))
-    assert key not in config["manipulator"]
+    assert key not in (config.get("manipulator") or {})
 
 
 @pytest.mark.parametrize("key", ["tilt", "rotation"])


### PR DESCRIPTION
Stacked on #839 → #838 → #837 → #836 → #835. This diff is against #839.

`manipulator.enabled`, `gis.enabled`, `gis.multichem` and `gis.sputter_coater` were
configuration keys, so a site could describe hardware it does not have, or omit hardware
it does, and nothing would disagree. The same move `rotation` made in FIB-834, one record
over: `_read_hardware_capabilities` fills the fields at connect, and again after
`apply_configuration` replaces the records.

The AutoScript probes are the ones the tree already used at the point of use —
`specimen.manipulator.is_installed`, `gas.list_all_gis_ports()`,
`gas.list_all_multichem_ports()`, and the `hasattr(specimen, "sputter_coater")` check
`run_sputter_coater` makes before it will run. Asked once at connect instead.

## "Cannot say" is a third answer, and it is the important one

Each probe returns `True`, `False`, or `None`. **`None` leaves the field exactly as the
configuration left it.**

The failure here is not symmetric. A subsystem that wrongly *appears* is a menu entry
that errors when used; a subsystem that wrongly *disappears* is a working instrument
that lost a feature on upgrade, silently. So a backend with no way to ask, and a probe
that raises — a missing subsystem and a sick connection raise alike — both mean "leave
it alone", never "not fitted".

## Only the ThermoFisher files lose their keys

| file | capability keys |
|---|---|
| `tfs-aquilos2`, `tfs-arctis`, `tfs-hydra` | removed — probed from the instrument |
| `tescan`, `odemis` | **kept** |
| `microscope` (Demo), `sim-arctis`, `sim-iflm` | **kept** |

`list_all_gis_ports` and `specimen.manipulator.is_installed` are AutoScript APIs.
Nothing here can ask a Tescan or an Odemis what is fitted, so removing their keys would
have disabled the GIS on every one of those systems on the strength of a guess. The
readers still accept the keys everywhere, so a file naming them loads and is not
reported as unrecognised; on AutoScript the instrument's answer simply wins.

## A dispatch key that matched nothing

`is_available` spells it `gis_multichem`. Two call sites asked for `"multichem"` —
[`autoscript.py:3161`](fibsem/microscopes/autoscript.py) deciding which port list to
read, and [`simulator.py:1538`](fibsem/microscopes/simulator.py) deciding whether to use
the multichem. That string matches no branch, so both fell through to `return False`:
the multichem path was unreachable regardless of hardware.

It never surfaced because every shipped configuration set `gis.enabled: true` and the
`gis` branch is tested first at both sites. It would have surfaced the moment the GIS
answer started coming from the instrument, which is this PR. Fixed here, with a
grep-as-a-test so it cannot come back quietly.

## Verification

13 tests. Both guards mutation-tested: reading `None` as "not fitted" fails
`test_a_backend_that_cannot_probe_keeps_the_configured_answer`, and dropping the
`apply_configuration` re-read fails `test_applying_a_configuration_re_reads_the_capabilities`.

Full non-UI suite: **1 failed, 4963 passed** — the same pre-existing failure as on
`origin/main`.

## Not verified on hardware

**The gate for this phase was a bench check and it has not happened.** `is_installed` is
documented on the manipulator, and the GIS calls are the ones already in use, but nothing
here has run against a real AutoScript instrument. The `None`-means-leave-alone rule is
what makes that survivable: the worst case for a wrong probe is a subsystem that appears
when it should not, not one that vanishes.

Worth knowing for later: `is_installed` exists on **13** subsystems, including
`SputterCoater`, `ElectronBeam` and `IonBeam` — more than this PR uses.
