### PR TITLE
[fix] Ask the destination, not the current pose, before dropping z from a stage move (FIB-640)

### DIFF
--- a/fibsem/microscope.py
+++ b/fibsem/microscope.py
@@ -376,15 +376,29 @@ class FibsemMicroscope(ABC):
         else:
             self.move_stage_absolute(stage_position)
 
-    def _axis_restrictions_apply(self) -> bool:
+    def _axis_restrictions_apply(
+        self, position: Optional[FibsemStagePosition] = None
+    ) -> bool:
         """Whether the microscope refuses z and rotation, so an absolute move drops them.
 
         Two halves, and they are not the same rule.
 
-        The **orientation** half is a compustage flipped to face its objective. It
-        stays as it was: `get_stage_orientation` can never return "FM" on an offset
-        mount -- the FM is a device there and `orientations["FM"]` is a copy of the FIB
-        entry -- so that half is naturally confined to the mounting it was written for.
+        The **orientation** half asks where the move is *going*, not where the stage is
+        standing. Asking the current pose is what dropped z from the very move that was
+        leaving the fluorescence pose: the stage landed at the requested x/y/t at the old
+        z-height, and the operator pressed Move a second time to finish it. Measured on
+        the Arctis (Aug 2026): with the objective retracted, z and t are both available
+        at t = -180, so a move out of that pose has nothing to lose. A move *into* it is
+        still restricted here -- more conservative than the measurement requires, and
+        free, because the one path that enters the pose sends r and t only.
+
+        `position` is the destination. Without one, or with a partial pose that has no
+        orientation to read (`_safe_rotation_movement` sends a bare tilt), the stage's
+        own pose stands in -- what such a move got before.
+
+        `get_stage_orientation` can never return "FM" on an offset mount -- the FM is a
+        device there and `orientations["FM"]` is a copy of the FIB entry -- so that half
+        is naturally confined to the mounting it was written for.
 
         The **objective** half is gated on `stage_is_compustage` **temporarily**, and
         that gate belongs to FIB-640 to remove. It has only ever run on a compustage,
@@ -402,7 +416,14 @@ class FibsemMicroscope(ABC):
         that preference, and is also where the axis pair gets settled: it measured
         z and t, not z and r.
         """
-        if self.get_stage_orientation() == "FM":
+        destination = (
+            position
+            if position is not None
+            and position.r is not None
+            and position.t is not None
+            else None
+        )
+        if self.get_stage_orientation(destination) == "FM":
             return True
 
         return (

--- a/fibsem/microscopes/autoscript.py
+++ b/fibsem/microscopes/autoscript.py
@@ -1555,7 +1555,7 @@ class ThermoMicroscope(FibsemMicroscope):
             position, compustage=self.stage_is_compustage
         )  # TODO: apply compucentric/raw coordinate offset here?
 
-        if self._axis_restrictions_apply():  # ONLY when restrictions are on
+        if self._axis_restrictions_apply(position):  # ONLY when restrictions are on
             autoscript_position.z = None
             autoscript_position.r = None
 

--- a/tests/fm/test_objective_signal.py
+++ b/tests/fm/test_objective_signal.py
@@ -302,3 +302,11 @@ class TestTheGuardsStillReadTheDevice:
             "move_stage_absolute no longer calls `_axis_restrictions_apply`, so "
             "nothing suppresses z and r while the objective is inserted (FIB-534)"
         )
+        # And it has to hand over the destination. Called bare, the predicate falls
+        # back to the pose the stage is standing in -- which is the bug FIB-640 fixed:
+        # a move out of the fluorescence pose losing its z to the pose it was leaving.
+        assert all(call.args for call in calls), (
+            "move_stage_absolute calls `_axis_restrictions_apply` without the target "
+            "position, so the guard asks where the stage is instead of where it is "
+            "going (FIB-640)"
+        )

--- a/tests/test_axis_restrictions_gate.py
+++ b/tests/test_axis_restrictions_gate.py
@@ -26,6 +26,7 @@ import pytest
 
 import fibsem.config as cfg
 from fibsem import utils
+from fibsem.structures import FibsemStagePosition
 
 IFLM_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-iflm-configuration.yaml")
 ARCTIS_CONFIG = os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
@@ -102,3 +103,51 @@ def test_the_predicate_reads_the_microscope_rather_than_being_told(config_path: 
 
     assert before is False
     assert after is microscope.stage_is_compustage
+
+
+def _at_fm_pose(microscope, z: float = 5.0e-3) -> None:
+    fm = microscope.get_orientation("FM")
+    microscope.move_stage_absolute(
+        FibsemStagePosition(x=0.0, y=0.0, z=z, r=fm.r, t=fm.t, coordinate_system="RAW")
+    )
+    microscope.fm.objective.retract()
+    assert microscope.get_stage_orientation() == "FM"
+
+
+def _pose(microscope, orientation: str, z: float) -> FibsemStagePosition:
+    o = microscope.get_orientation(orientation)
+    return FibsemStagePosition(
+        x=100e-6, y=50e-6, z=z, r=o.r, t=o.t, coordinate_system="RAW"
+    )
+
+
+def test_leaving_the_fluorescence_pose_with_the_objective_out_is_not_restricted():
+    """The reported bug (FIB-640). Measured: z and t are both available at t = -180
+    once the objective is retracted, so the move out carries its z and lands on the
+    first press. Asking the stage's current pose here is what dropped it."""
+    microscope = _microscope(ARCTIS_CONFIG)
+    _at_fm_pose(microscope, z=5.0e-3)
+
+    target = _pose(microscope, "MILLING", z=12.0e-3)
+    assert microscope._axis_restrictions_apply(target) is False
+
+
+def test_moving_into_the_fluorescence_pose_is_still_restricted():
+    """More conservative than the measurement requires, and free: the one path that
+    enters the pose sends r and t only."""
+    microscope = _microscope(ARCTIS_CONFIG)
+    microscope.fm.objective.retract()
+    microscope.move_to_orientation("SEM")
+
+    target = _pose(microscope, "FM", z=12.0e-3)
+    assert microscope._axis_restrictions_apply(target) is True
+
+
+def test_a_partial_pose_falls_back_to_where_the_stage_is():
+    """`_safe_rotation_movement` sends a bare tilt with no rotation: nothing to read a
+    destination from, so the stage's own pose stands in -- what such a move got before."""
+    microscope = _microscope(ARCTIS_CONFIG)
+    _at_fm_pose(microscope)
+
+    tilt_only = FibsemStagePosition(t=0.0, coordinate_system="RAW")
+    assert microscope._axis_restrictions_apply(tilt_only) is True


### PR DESCRIPTION
## The bug

With the stage in the fluorescence orientation, clicking a lamella's milling pose lands at the right x/y/tilt but the **old z-height**. The operator presses it a second time to finish the move.

`ThermoMicroscope.move_stage_absolute` drops z and rotation when it expects the microscope to refuse them, and the orientation half of that guard asked where the stage was *standing*. So a move out of the fluorescence pose lost its z to the pose it was leaving. The second press works because by then the stage reads as `MILLING`.

## What was measured

On the Arctis, at t = -180 with the objective **retracted**, z and t are both available. The pose restricts nothing; it is the inserted objective that does. A move out of the pose therefore has nothing to lose.

## The change

`_axis_restrictions_apply` takes the target position and asks *its* orientation ([fibsem/microscope.py](fibsem/microscope.py)). The one call site passes it ([fibsem/microscopes/autoscript.py](fibsem/microscopes/autoscript.py)).

- A move **into** the fluorescence pose is still restricted. More conservative than the measurement requires, and free: the one path that enters the pose (`move_to_microscope_compustage`) sends r and t only.
- A partial pose with no orientation to read (`_safe_rotation_movement` sends a bare tilt) falls back to the stage's own pose — what such a move got before.

## Deliberately untouched

Both owned by FIB-640, which stays open for them:

- The dropped axes remain **z and r**. The measurement says z and **t**; `r` does not exist on a compustage. With the objective inserted, a reorienting move still sends the tilt and the microscope refuses it — same as today.
- The temporary compustage gate on the objective half from #643 stays.

## Tests

- Three added to `tests/test_axis_restrictions_gate.py`: the reported case (leaving FM, objective out → not restricted), moving into FM (still restricted), partial pose (falls back).
- The FIB-534 AST pin in `tests/fm/test_objective_signal.py` now also asserts the call passes the position. Called bare, the default falls back to the current pose and silently restores the bug.
- None of #643's six tests flip.

393 pass across `test_axis_restrictions_gate`, `test_objective_signal`, `test_movement`, `test_view_corrected_movement`. Ruff clean.

## Not verified

The fix is not executable in CI — AutoScript is not installed, so the predicate is tested rather than the move. The behaviour it relies on (z available in the FM pose with the objective out) was measured on hardware; the fix itself has not been run there.
