### PR TITLE
Correlation page: spot burns land on the reference, show through cells, and the setup task syncs the fluorescence pose

### DIFF
--- a/docs/developers/render_user_guide.py
+++ b/docs/developers/render_user_guide.py
@@ -2062,6 +2062,13 @@ def render_correlation(h: Harness) -> None:
             protocol.task_config[config.task_name] = config
             for lamella in experiment.positions:
                 lamella.task_config[config.task_name] = copy.deepcopy(config)
+        # the setup task moves the site; the stack should be taken where it
+        # ends up, so the fluorescence pose follows (off by default)
+        setup_name = protocol.workflow_config.tasks[0].name
+        for holder in [protocol.task_config] + [
+            lamella.task_config for lamella in experiment.positions
+        ]:
+            holder[setup_name].sync_fluorescence_pose = True
         # after the setup task, before the milling: burn, then image
         tasks = protocol.workflow_config.tasks
         setup, fiducial = tasks[0].name, tasks[1].name
@@ -2221,14 +2228,14 @@ def render_correlation(h: Harness) -> None:
     h.pump(800)
     led.listWidget_selected_task.select(SPOT)
     h.pump(600)
-    # the reference taken after the burn at the field the points were placed
-    # in: the final set is numbered largest field first, so the burn's field
-    # (field of view 1, the smaller) is the last of them
+    # the reference taken after the fiducial was milled, at the smaller of its
+    # fields, so the FIB image carries the marks and the fiducial the stack
+    # shows too (the final set is numbered largest field first)
     fib_combo = led.combobox_fib_filenames
     finals = [
         i
         for i in range(fib_combo.count())
-        if "Spot Burn" in str(fib_combo.itemData(i))
+        if "Mill Fiducial" in str(fib_combo.itemData(i))
         and "final" in str(fib_combo.itemData(i))
     ]
     if finals:
@@ -2405,6 +2412,8 @@ def render_correlation(h: Harness) -> None:
 
         fib_list = widget._coords_tab.fib_list
         marks = fib_marks(led.image)
+        if len(marks) < len(fib_list.coordinates):
+            raise RuntimeError(f"found {len(marks)} burn marks in the FIB reference")
         if os.environ.get("FIBSEM_GUIDE_DEBUG"):
             import logging as _logging
 
@@ -2418,18 +2427,14 @@ def render_correlation(h: Harness) -> None:
                     "fib_file": led.combobox_fib_filenames.currentData(),
                 }
             )
-        refined = []
-        for c in fib_list.coordinates:
-            d, (mx, my) = min(
-                (np.hypot(x - c.point.x, y - c.point.y), (x, y)) for x, y in marks
+        # the seeds are normalised to the burn's own image, so on this one they
+        # are at another scale: pair them to the marks by the fit, not by distance
+        refined = [
+            Coordinate(PointXYZ(float(mx), float(my), 0.0), PointType.FIB)
+            for mx, my in pair(
+                [(c.point.x, c.point.y) for c in fib_list.coordinates], marks
             )
-            if d * float(led.image.metadata.pixel_size.x) > 5e-6:
-                raise RuntimeError(
-                    f"no burn mark near FIB point {c.point.x, c.point.y}"
-                )
-            refined.append(
-                Coordinate(PointXYZ(float(mx), float(my), 0.0), PointType.FIB)
-            )
+        ]
         fib_list.coordinates = refined
         widget._refresh_canvas(widget._point_specs[PointType.FIB].adapter)
         widget._coords_tab.update_headers()

--- a/docs/developers/render_user_guide.py
+++ b/docs/developers/render_user_guide.py
@@ -2106,6 +2106,25 @@ def render_correlation(h: Harness) -> None:
         numbered=True,
     )
 
+    # -- a burn by hand: the Spot Burn tab outside a workflow -----------------
+    from fibsem.imaging.spot import SpotBurnSettings
+
+    h.show_main_tab("Microscope")
+    sbw = h.ui.spot_burn_widget
+    h.ui.set_spot_burn_widget_active(True)
+    h.ui.tabWidget.setCurrentWidget(sbw)
+    sbw.set_workflow_mode(False)
+    sbw.set_settings(SpotBurnSettings(coordinates=points))
+    h.pump(600)
+    fib_panel = h.window.view_controller.widget._all_panels[2]
+    h.shot(
+        "spot-burn-by-hand",
+        callouts=[Box(fib_panel), Box(sbw.coord_editor), sbw.pushButton_run_spot_burn],
+        numbered=True,
+    )
+    sbw.clear_points_layer()
+    h.pump(300)
+
     # -- the run: setup, burn (supervised), fluorescence stack ---------------
     ww = h.window.lamella_workflow_widget
     ww.lamella_list.set_all_selected(False)

--- a/docs/developers/render_user_guide.py
+++ b/docs/developers/render_user_guide.py
@@ -1991,10 +1991,385 @@ def render_workflows(h: Harness) -> None:
     h.pump(300)
 
 
+@page("correlation")
+def render_correlation(h: Harness) -> None:
+    """Spot burn fiducials and the correlation workflow (Arctis): the two
+    tasks in the protocol, the supervised burn, the fluorescence stack, and
+    the correlation dialog from the Lamella tab through to the accepted POI."""
+    import copy
+    import itertools
+
+    import numpy as np
+    from scipy import ndimage as ndi
+
+    from fibsem.applications.autolamella.structures import AutoLamellaTaskDescription
+    from fibsem.applications.autolamella.ui import AutoLamellaMainUI as main_module
+    from fibsem.applications.autolamella.workflows.tasks.acquire_fluorescence import (
+        AcquireFluorescenceImageConfig,
+    )
+    from fibsem.applications.autolamella.workflows.tasks.spot_burn import (
+        SpotBurnFiducialTaskConfig,
+    )
+    from fibsem.correlation.structures import PointType
+    from fibsem.fm.structures import ChannelSettings, ZParameters
+    from fibsem.structures import Point
+    from fibsem.ui.correlation.widgets import correlation_tab_widget as ctw
+
+    h.first_run(False)
+    h.show_tab(0)
+    h.connect("sim-arctis")
+    lamellae = h.ensure_lamellae(3)
+    experiment = h.ui.experiment
+    protocol = experiment.task_protocol
+
+    # -- the two tasks in the protocol -------------------------------------
+    SPOT, FMTASK = "Spot Burn Fiducial", "Acquire Fluorescence Image"
+    fm = h.ui.microscope.fm
+    lines = sorted(fm.filter_set.available_excitation_wavelengths)
+
+    def nearest(target):
+        return min(lines, key=lambda v: abs(v - target))
+
+    channels = [
+        ChannelSettings(
+            name="Reflection",
+            excitation_wavelength=nearest(550),
+            emission_wavelength=None,
+        ),
+        ChannelSettings(
+            name="GFP",
+            excitation_wavelength=nearest(488),
+            emission_wavelength="Fluorescence",
+        ),
+    ]
+    # an asymmetric layout, so the pairs are unambiguous when the FM view is
+    # rotated or mirrored against the FIB view
+    points = [Point(0.3, 0.35), Point(0.7, 0.3), Point(0.65, 0.7), Point(0.35, 0.62)]
+    if SPOT not in protocol.task_config:
+        burn = SpotBurnFiducialTaskConfig(task_name=SPOT, coordinates=points)
+        burn.reference_imaging.field_of_view1 = 50e-6
+        burn.reference_imaging.field_of_view2 = 100e-6
+        acquire = AcquireFluorescenceImageConfig(
+            task_name=FMTASK,
+            channel_settings=channels,
+            zparams=ZParameters(zmin=-2e-6, zmax=2e-6, zstep=1e-6),
+        )
+        for focus_pass in acquire.autofocus_settings.passes:
+            focus_pass.enabled = False  # the sim's autofocus is a no-op; skip the sweep
+        for config in (burn, acquire):
+            protocol.task_config[config.task_name] = config
+            for lamella in experiment.positions:
+                lamella.task_config[config.task_name] = copy.deepcopy(config)
+        # after the setup task, before the milling: burn, then image
+        tasks = protocol.workflow_config.tasks
+        setup = tasks[0].name
+        tasks.insert(
+            1,
+            AutoLamellaTaskDescription(
+                name=SPOT, supervise=True, required=False, requires=[setup]
+            ),
+        )
+        tasks.insert(
+            2,
+            AutoLamellaTaskDescription(
+                name=FMTASK, supervise=False, required=False, requires=[SPOT]
+            ),
+        )
+        experiment.save()
+        editor = h.window.task_widget
+        editor._initialise_widgets()
+        editor.workflow_config_changed.emit(protocol.workflow_config)
+        h.pump(500)
+
+    # the Protocol tab with each task's settings
+    h.show_main_tab("Protocol")
+    editor = h.window.task_widget
+    editor.task_list_widget.select(SPOT)
+    h.pump(600)
+    h.shot(
+        "protocol-spot-burn",
+        callouts=[
+            Box(editor.task_list_widget),
+            Box(editor.task_parameters_config_widget),
+            editor.pushButton_edit_spot_burn,
+        ],
+        numbered=True,
+    )
+    editor.task_list_widget.select(FMTASK)
+    h.pump(600)
+    h.shot(
+        "protocol-acquire-fm",
+        callouts=[
+            Box(editor.task_list_widget),
+            Box(editor.fluorescence_acquisition_task_config_widget),
+        ],
+        numbered=True,
+    )
+
+    # -- the run: setup, burn (supervised), fluorescence stack ---------------
+    ww = h.window.lamella_workflow_widget
+    ww.lamella_list.set_all_selected(False)
+    ww.lamella_list._row(0).checkbox.setChecked(True)
+    ww.workflow.set_all_selected(False)
+    for i in range(3):
+        ww.workflow._row(i).checkbox.setChecked(True)
+    h.pump(300)
+    h.show_main_tab("Workflow")
+    h.shot(
+        "workflow-selection",
+        callouts=[Box(ww.workflow), h.window.run_workflow_btn],
+        numbered=True,
+    )
+    main_module.confirm_run_workflow_dialog = lambda *_args, **_kwargs: True
+    h.ui._show_workflow_summary = lambda: None
+    h.window.run_workflow_btn.click()
+    h.pump(1500)
+    if not h.ui.is_workflow_running:
+        raise RuntimeError("workflow did not start")
+    burn_shot_taken = False
+    burn_ran = False
+    waited = 0
+    while (h.ui.is_workflow_running or waited < 2000) and waited < 1200000:
+        h.pump(250)
+        waited += 250
+        if not h.ui.WAITING_FOR_USER_INTERACTION:
+            continue
+        h.pump(1200)
+        question = h.ui.ui_responder.pending_question
+        if callable(question):
+            question = question()
+        kind = type(question).__name__ if question is not None else "Confirm"
+        if kind == "RunSpotBurn":
+            if not burn_shot_taken:
+                # the question, on the Experiment tab, and the points on the FIB
+                # view with the Spot Burn tab open
+                burn_shot_taken = True
+                h.show_main_tab("Microscope")
+                h.ui.tabWidget.setCurrentWidget(h.ui.tab)
+                h.pump(500)
+                h.shot(
+                    "prompt-spot-burn",
+                    callouts=[
+                        Box(h.ui.label_instructions),
+                        h.ui.pushButton_yes,
+                        h.ui.pushButton_no,
+                    ],
+                    numbered=True,
+                )
+                h.ui.tabWidget.setCurrentWidget(h.ui.spot_burn_widget)
+                h.pump(500)
+                sbw = h.ui.spot_burn_widget
+                fib_panel = h.window.view_controller.widget._all_panels[2]
+                h.shot(
+                    "spot-burn-tab",
+                    callouts=[
+                        Box(fib_panel),
+                        Box(sbw.coord_editor),
+                        sbw.comboBox_beam_current,
+                        sbw.doubleSpinBox_exposure_time,
+                    ],
+                    numbered=True,
+                )
+            if not burn_ran:
+                burn_ran = True
+                h.ui.pushButton_yes.click()  # Run Spot Burn; re-asks when done
+            else:
+                h.ui.pushButton_no.click()  # Continue
+        else:
+            h.ui.pushButton_yes.click()
+        h.pump(800)
+    if h.ui.is_workflow_running:
+        raise RuntimeError("workflow did not finish")
+    h.pump(1500)
+
+    # -- the Lamella tab: the marks in the FIB reference, the FM stack -------
+    h.show_main_tab("Lamella")
+    led = h.window.lamella_widget
+    led.select_lamella(lamellae[0].name)
+    h.pump(800)
+    led.listWidget_selected_task.select(SPOT)
+    h.pump(600)
+    # the reference taken after the burn, so the marks are in it
+    fib_combo = led.combobox_fib_filenames
+    for i in range(fib_combo.count()):
+        data = str(fib_combo.itemData(i))
+        if "Spot Burn" in data and "final" in data:
+            fib_combo.setCurrentIndex(i)
+            break
+    h.pump(800)
+    h.shot(
+        "lamella-after-burn",
+        callouts=[
+            Box(led.view_controller.widget),
+            fib_combo,
+            led.pushButton_open_correlation,
+        ],
+        numbered=True,
+    )
+    # the FM image selector shows for a fluorescence task
+    led.listWidget_selected_task.select(FMTASK)
+    h.pump(800)
+    h.shot(
+        "lamella-fm-stack",
+        callouts=[Box(led.view_controller.widget), led.combobox_fm_filenames],
+        numbered=True,
+    )
+    led.listWidget_selected_task.select(SPOT)
+    h.pump(600)
+
+    # -- the correlation dialog, driven through its tabs ----------------------
+    def fm_marks():
+        """Where the burn marks are in the FM frame: the difference between a
+        reflection frame with the marks in the scene and one without, at the
+        pose and objective position the stack was taken at."""
+        scene = h.ui.microscope._sample_scene
+        fm.objective.insert()
+        fm.objective.move_absolute(lamellae[0].fluorescence_pose.objective_position)
+        fm.set_channel(channels[0])
+        with_marks = fm.camera.acquire_image().astype(np.float32)
+        kept, scene.milled = scene.milled, []
+        try:
+            without = fm.camera.acquire_image().astype(np.float32)
+        finally:
+            scene.milled = kept
+        fm.objective.retract()
+        diff = ndi.gaussian_filter(without - with_marks, 1.0)
+        # the marks against the frame noise, not against the brightest mark:
+        # one under a bright cell differs far more than the others
+        centre = float(np.median(diff))
+        sigma = 1.4826 * float(np.median(np.abs(diff - centre))) + 1e-6
+        labels, n = ndi.label(diff > centre + 8 * sigma)
+        if os.environ.get("FIBSEM_GUIDE_DEBUG"):
+            from PIL import Image as _Image
+
+            for name, arr in (
+                ("with", with_marks),
+                ("without", without),
+                ("diff", diff),
+            ):
+                lo, hi = np.percentile(arr, (0.5, 99.5))
+                img8 = np.clip((arr - lo) / max(hi - lo, 1e-6) * 255, 0, 255)
+                _Image.fromarray(img8.astype(np.uint8)).save(
+                    os.path.join(os.environ["FIBSEM_GUIDE_DEBUG"], f"fm-{name}.png")
+                )
+        found = []
+        for k in range(1, n + 1):
+            component = labels == k
+            if component.sum() < 4:
+                continue
+            cy, cx = ndi.center_of_mass(component)
+            found.append((float(cx), float(cy)))
+        return found
+
+    def pair(fib_points, candidates):
+        """Which FM candidates are the burn marks, in FIB order: the subset
+        and order that an affine map from the FIB points fits best. Affine,
+        not similarity: the FIB view is foreshortened along one axis."""
+        p = np.array(fib_points, dtype=float)
+        A = np.hstack([p, np.ones((len(p), 1))])
+        best = None
+        for combo in itertools.combinations(range(len(candidates)), len(p)):
+            for perm in itertools.permutations(combo):
+                q = np.array([candidates[k] for k in perm], dtype=float)
+                coeff, *_ = np.linalg.lstsq(A, q, rcond=None)
+                residual = float(np.abs(A @ coeff - q).sum())
+                if best is None or residual < best[0]:
+                    best = (residual, [candidates[k] for k in perm])
+        return best[1]
+
+    def drive(dialog):
+        widget = dialog.widget
+        dialog.show()
+        h.pump(1200)
+        h.shot("correlation-images", target=dialog)
+        widget._tabs.setCurrentIndex(1)
+        h.pump(400)
+        widget._coords_tab.set_channel_selection("Reflection", "GFP")
+        fm_image = widget.fm_image if hasattr(widget, "fm_image") else led.fm_image
+        # the FIB fiducials are seeded from the burn coordinates; the FM side is
+        # picked here, on the marks in the reflection channel at the middle plane
+        seeded = [
+            (c.point.x, c.point.y) for c in widget._coords_tab.fib_list.coordinates
+        ]
+        arr = fm_image.data
+        while arr.ndim > 4:
+            arr = arr[0]
+        z = widget._fm_display.current_z
+        candidates = fm_marks()
+        if len(candidates) < len(seeded):
+            raise RuntimeError(
+                f"found {len(candidates)} burn marks in the FM reflection"
+            )
+        for x, y in pair(seeded, candidates):
+            widget._on_canvas_add_requested(x, y, PointType.FM)
+        # the point of interest: the brightest cell in the GFP channel, away
+        # from the edges
+        gfp = ndi.gaussian_filter(arr[1, z].astype(np.float32), 3)
+        margin = gfp.shape[0] // 6
+        inner = gfp[margin:-margin, margin:-margin]
+        cy, cx = np.unravel_index(np.argmax(inner), inner.shape)
+        widget._on_canvas_add_requested(
+            float(cx + margin), float(cy + margin), PointType.POI
+        )
+        h.pump(800)
+        h.shot("correlation-coordinates", target=dialog)
+        widget._btn_run.click()
+        waited = 0
+        while widget.result is None and waited < 60000:
+            h.pump(250)
+            waited += 250
+        if widget.result is None:
+            raise RuntimeError("correlation did not finish")
+        h.pump(800)
+        widget._tabs.setCurrentIndex(2)
+        h.pump(500)
+        h.shot("correlation-results", target=dialog)
+        widget._tabs.setCurrentIndex(3)
+        h.pump(500)
+        h.shot("correlation-refractive-index", target=dialog)
+        widget._tabs.setCurrentIndex(2)
+        h.pump(300)
+        if widget._btn_continue.isEnabled():
+            widget._btn_continue.click()
+        else:
+            dialog.accept()
+        h.pump(500)
+        return dialog.Accepted
+
+    original_exec = ctw.CorrelationTabDialog.exec_
+    original_question = ctw.QMessageBox.question
+    ctw.CorrelationTabDialog.exec_ = drive
+    # Continue confirms with a modal Yes/No ("Continue with correlation result
+    # and close?"); answered Yes here
+    ctw.QMessageBox.question = staticmethod(
+        lambda *_a, **_k: ctw.QMessageBox.StandardButton.Yes
+    )
+    try:
+        led.pushButton_open_correlation.click()
+        h.pump(1000)
+    finally:
+        ctw.CorrelationTabDialog.exec_ = original_exec
+        ctw.QMessageBox.question = original_question
+
+    # the accepted point of interest on the Lamella tab
+    led.listWidget_selected_task.select("Rough Milling")
+    h.pump(800)
+    h.shot(
+        "lamella-after-correlation",
+        callouts=[Box(led.view_controller.widget)],
+        numbered=True,
+    )
+
+
 # -- entry point --------------------------------------------------------------
 
 
 def main(argv: Optional[List[str]] = None) -> int:
+    # `kill -USR1 <pid>` prints every thread's stack: where a run is stuck
+    import faulthandler
+    import signal
+
+    faulthandler.register(signal.SIGUSR1, all_threads=True)
     parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     parser.add_argument("pages", nargs="*", help="pages to render (default: all)")
     parser.add_argument(

--- a/docs/developers/render_user_guide.py
+++ b/docs/developers/render_user_guide.py
@@ -2012,7 +2012,7 @@ def render_correlation(h: Harness) -> None:
     )
     from fibsem.correlation.structures import PointType
     from fibsem.fm.structures import ChannelSettings, ZParameters
-    from fibsem.structures import Point
+    from fibsem.structures import BeamType, ImageSettings, Point
     from fibsem.ui.correlation.widgets import correlation_tab_widget as ctw
 
     h.first_run(False)
@@ -2035,11 +2035,13 @@ def render_correlation(h: Harness) -> None:
             name="Reflection",
             excitation_wavelength=nearest(550),
             emission_wavelength=None,
+            color="gray",
         ),
         ChannelSettings(
             name="GFP",
             excitation_wavelength=nearest(488),
             emission_wavelength="Fluorescence",
+            color="green",
         ),
     ]
     # an asymmetric layout, so the pairs are unambiguous when the FM view is
@@ -2062,17 +2064,18 @@ def render_correlation(h: Harness) -> None:
                 lamella.task_config[config.task_name] = copy.deepcopy(config)
         # after the setup task, before the milling: burn, then image
         tasks = protocol.workflow_config.tasks
-        setup = tasks[0].name
+        setup, fiducial = tasks[0].name, tasks[1].name
         tasks.insert(
             1,
             AutoLamellaTaskDescription(
                 name=SPOT, supervise=True, required=False, requires=[setup]
             ),
         )
+        # the fluorescence stack after the fiducial, so both are in it
         tasks.insert(
-            2,
+            3,
             AutoLamellaTaskDescription(
-                name=FMTASK, supervise=False, required=False, requires=[SPOT]
+                name=FMTASK, supervise=False, required=False, requires=[fiducial]
             ),
         )
         experiment.save()
@@ -2106,31 +2109,12 @@ def render_correlation(h: Harness) -> None:
         numbered=True,
     )
 
-    # -- a burn by hand: the Spot Burn tab outside a workflow -----------------
-    from fibsem.imaging.spot import SpotBurnSettings
-
-    h.show_main_tab("Microscope")
-    sbw = h.ui.spot_burn_widget
-    h.ui.set_spot_burn_widget_active(True)
-    h.ui.tabWidget.setCurrentWidget(sbw)
-    sbw.set_workflow_mode(False)
-    sbw.set_settings(SpotBurnSettings(coordinates=points))
-    h.pump(600)
-    fib_panel = h.window.view_controller.widget._all_panels[2]
-    h.shot(
-        "spot-burn-by-hand",
-        callouts=[Box(fib_panel), Box(sbw.coord_editor), sbw.pushButton_run_spot_burn],
-        numbered=True,
-    )
-    sbw.clear_points_layer()
-    h.pump(300)
-
     # -- the run: setup, burn (supervised), fluorescence stack ---------------
     ww = h.window.lamella_workflow_widget
     ww.lamella_list.set_all_selected(False)
     ww.lamella_list._row(0).checkbox.setChecked(True)
     ww.workflow.set_all_selected(False)
-    for i in range(3):
+    for i in range(4):
         ww.workflow._row(i).checkbox.setChecked(True)
     h.pump(300)
     h.show_main_tab("Workflow")
@@ -2147,6 +2131,7 @@ def render_correlation(h: Harness) -> None:
         raise RuntimeError("workflow did not start")
     burn_shot_taken = False
     burn_ran = False
+    milled = set()
     waited = 0
     while (h.ui.is_workflow_running or waited < 2000) and waited < 1200000:
         h.pump(250)
@@ -2194,12 +2179,40 @@ def render_correlation(h: Harness) -> None:
                 h.ui.pushButton_yes.click()  # Run Spot Burn; re-asks when done
             else:
                 h.ui.pushButton_no.click()  # Continue
+        elif kind == "RunMillingTask":
+            # Run Milling once per task, then Continue when it re-asks
+            key = getattr(getattr(question, "config", None), "name", None)
+            if key in milled:
+                h.ui.pushButton_no.click()
+            else:
+                milled.add(key)
+                h.ui.pushButton_yes.click()
         else:
             h.ui.pushButton_yes.click()
         h.pump(800)
     if h.ui.is_workflow_running:
         raise RuntimeError("workflow did not finish")
     h.pump(1500)
+
+    # -- a burn by hand: the Spot Burn tab outside a workflow, on the last
+    # image the run took -----------------------------------------------------
+    from fibsem.imaging.spot import SpotBurnSettings
+
+    h.show_main_tab("Microscope")
+    sbw = h.ui.spot_burn_widget
+    h.ui.set_spot_burn_widget_active(True)
+    h.ui.tabWidget.setCurrentWidget(sbw)
+    sbw.set_workflow_mode(False)
+    sbw.set_settings(SpotBurnSettings(coordinates=points))
+    h.pump(600)
+    fib_panel = h.window.view_controller.widget._all_panels[2]
+    h.shot(
+        "spot-burn-by-hand",
+        callouts=[Box(fib_panel), Box(sbw.coord_editor), sbw.pushButton_run_spot_burn],
+        numbered=True,
+    )
+    sbw.clear_points_layer()
+    h.pump(300)
 
     # -- the Lamella tab: the marks in the FIB reference, the FM stack -------
     h.show_main_tab("Lamella")
@@ -2208,13 +2221,18 @@ def render_correlation(h: Harness) -> None:
     h.pump(800)
     led.listWidget_selected_task.select(SPOT)
     h.pump(600)
-    # the reference taken after the burn, so the marks are in it
+    # the reference taken after the burn at the field the points were placed
+    # in: the final set is numbered largest field first, so the burn's field
+    # (field of view 1, the smaller) is the last of them
     fib_combo = led.combobox_fib_filenames
-    for i in range(fib_combo.count()):
-        data = str(fib_combo.itemData(i))
-        if "Spot Burn" in data and "final" in data:
-            fib_combo.setCurrentIndex(i)
-            break
+    finals = [
+        i
+        for i in range(fib_combo.count())
+        if "Spot Burn" in str(fib_combo.itemData(i))
+        and "final" in str(fib_combo.itemData(i))
+    ]
+    if finals:
+        fib_combo.setCurrentIndex(max(finals))
     h.pump(800)
     h.shot(
         "lamella-after-burn",
@@ -2241,9 +2259,12 @@ def render_correlation(h: Harness) -> None:
         """Where the burn marks are in the FM frame: the difference between a
         reflection frame with the marks in the scene and one without, at the
         pose and objective position the stack was taken at."""
-        scene = h.ui.microscope._sample_scene
+        microscope = h.ui.microscope
+        scene = microscope._sample_scene
+        pose = lamellae[0].fluorescence_pose
+        microscope.safe_absolute_stage_movement(pose.stage_position)
         fm.objective.insert()
-        fm.objective.move_absolute(lamellae[0].fluorescence_pose.objective_position)
+        fm.objective.move_absolute(pose.objective_position)
         fm.set_channel(channels[0])
         with_marks = fm.camera.acquire_image().astype(np.float32)
         kept, scene.milled = scene.milled, []
@@ -2280,6 +2301,74 @@ def render_correlation(h: Harness) -> None:
             found.append((float(cx), float(cy)))
         return found
 
+    def fib_marks(reference):
+        """Where the burn marks are in the FIB reference: the difference
+        between a frame with the marks in the scene and one without, at the
+        pose and field the reference was taken at."""
+        microscope = h.ui.microscope
+        scene = microscope._sample_scene
+        microscope.move_stage_absolute(lamellae[0].milling_pose.stage_position)
+        settings = ImageSettings(
+            hfw=float(reference.metadata.image_settings.hfw),
+            resolution=tuple(reference.metadata.image_settings.resolution),
+            dwell_time=1e-6,
+            beam_type=BeamType.ION,
+            save=False,
+            autocontrast=False,
+        )
+        with_marks = microscope.acquire_image(image_settings=settings).data.astype(
+            np.float32
+        )
+        kept, scene.milled = scene.milled, []
+        try:
+            without = microscope.acquire_image(image_settings=settings).data.astype(
+                np.float32
+            )
+        finally:
+            scene.milled = kept
+        diff = ndi.gaussian_filter(without - with_marks, 1.0)
+        centre = float(np.median(diff))
+        sigma = 1.4826 * float(np.median(np.abs(diff - centre))) + 1e-6
+        labels, n = ndi.label(diff > centre + 8 * sigma)
+        found = []
+        for k in range(1, n + 1):
+            component = labels == k
+            if component.sum() < 6:
+                continue
+            cy, cx = ndi.center_of_mass(component)
+            found.append((float(cx), float(cy)))
+        if os.environ.get("FIBSEM_GUIDE_DEBUG"):
+            from PIL import Image as _Image
+
+            out = os.environ["FIBSEM_GUIDE_DEBUG"]
+            for name, arr in (
+                ("with", with_marks),
+                ("reference", reference.data.astype(np.float32)),
+                ("diff", diff),
+            ):
+                lo, hi = np.percentile(arr, (0.5, 99.5))
+                img8 = np.clip((arr - lo) / max(hi - lo, 1e-6) * 255, 0, 255)
+                _Image.fromarray(img8.astype(np.uint8)).save(
+                    os.path.join(out, f"fib-{name}.png")
+                )
+            import logging as _logging
+
+            _logging.warning(
+                {
+                    "msg": "guide_fib_marks",
+                    "marks": [(round(x), round(y)) for x, y in found],
+                    "reference_hfw": float(reference.metadata.image_settings.hfw),
+                    "reference_px": float(reference.metadata.pixel_size.x),
+                    "reference_shape": tuple(reference.data.shape),
+                    "beam_hfw": float(microscope.get("hfw", BeamType.ION)),
+                    "scan_rotation": float(
+                        microscope.get("scan_rotation", BeamType.ION) or 0.0
+                    ),
+                    "stage": str(microscope.get_stage_position()),
+                }
+            )
+        return found
+
     def pair(fib_points, candidates):
         """Which FM candidates are the burn marks, in FIB order: the subset
         and order that an affine map from the FIB points fits best. Affine,
@@ -2307,9 +2396,45 @@ def render_correlation(h: Harness) -> None:
         fm_image = widget.fm_image if hasattr(widget, "fm_image") else led.fm_image
         # the FIB fiducials are seeded from the burn coordinates; the FM side is
         # picked here, on the marks in the reflection channel at the middle plane
-        seeded = [
-            (c.point.x, c.point.y) for c in widget._coords_tab.fib_list.coordinates
-        ]
+        # The FIB fiducials are seeded from the coordinates the burn was asked
+        # for. The burn runs at another current, and the beam shifts with the
+        # current (what the milling-current alignment corrects), so the marks
+        # land a little off the points. Refine each seed onto its mark in the
+        # reference image, as the dialog asks the user to.
+        from fibsem.correlation.structures import Coordinate, PointXYZ
+
+        fib_list = widget._coords_tab.fib_list
+        marks = fib_marks(led.image)
+        if os.environ.get("FIBSEM_GUIDE_DEBUG"):
+            import logging as _logging
+
+            _logging.warning(
+                {
+                    "msg": "guide_fib_seeds",
+                    "seeds": [
+                        (round(c.point.x), round(c.point.y))
+                        for c in fib_list.coordinates
+                    ],
+                    "fib_file": led.combobox_fib_filenames.currentData(),
+                }
+            )
+        refined = []
+        for c in fib_list.coordinates:
+            d, (mx, my) = min(
+                (np.hypot(x - c.point.x, y - c.point.y), (x, y)) for x, y in marks
+            )
+            if d * float(led.image.metadata.pixel_size.x) > 5e-6:
+                raise RuntimeError(
+                    f"no burn mark near FIB point {c.point.x, c.point.y}"
+                )
+            refined.append(
+                Coordinate(PointXYZ(float(mx), float(my), 0.0), PointType.FIB)
+            )
+        fib_list.coordinates = refined
+        widget._refresh_canvas(widget._point_specs[PointType.FIB].adapter)
+        widget._coords_tab.update_headers()
+        widget.data_changed.emit(widget.data)
+        seeded = [(c.point.x, c.point.y) for c in refined]
         arr = fm_image.data
         while arr.ndim > 4:
             arr = arr[0]
@@ -2319,8 +2444,25 @@ def render_correlation(h: Harness) -> None:
             raise RuntimeError(
                 f"found {len(candidates)} burn marks in the FM reflection"
             )
-        for x, y in pair(seeded, candidates):
+        fm_points = pair(seeded, candidates)
+        for x, y in fm_points:
             widget._on_canvas_add_requested(x, y, PointType.FM)
+
+        def fm_rects(size=34):
+            """Boxes round the burn marks in the FM canvas, in dialog coords:
+            matplotlib's display pixels are y-up and at device resolution."""
+            canvas = widget._fm_display.canvas
+            dpr = canvas.devicePixelRatioF()
+            rects = []
+            for x, y in fm_points:
+                dx, dy = canvas._ax.transData.transform((x, y))
+                local = QPoint(int(dx / dpr), int(canvas.height() - dy / dpr))
+                centre = canvas.mapTo(dialog, local)
+                rects.append(
+                    QRect(centre.x() - size // 2, centre.y() - size // 2, size, size)
+                )
+            return rects
+
         # the point of interest: the brightest cell in the GFP channel, away
         # from the edges
         gfp = ndi.gaussian_filter(arr[1, z].astype(np.float32), 3)
@@ -2331,7 +2473,7 @@ def render_correlation(h: Harness) -> None:
             float(cx + margin), float(cy + margin), PointType.POI
         )
         h.pump(800)
-        h.shot("correlation-coordinates", target=dialog)
+        h.shot("correlation-coordinates", target=dialog, callout_rects=fm_rects())
         widget._btn_run.click()
         waited = 0
         while widget.result is None and waited < 60000:
@@ -2370,8 +2512,12 @@ def render_correlation(h: Harness) -> None:
         ctw.CorrelationTabDialog.exec_ = original_exec
         ctw.QMessageBox.question = original_question
 
-    # the accepted point of interest on the Lamella tab
+    # the accepted point of interest on the Lamella tab, on the reference at
+    # the milling task's own field (the larger of the burn task's two)
     led.listWidget_selected_task.select("Rough Milling")
+    h.pump(400)
+    if finals:
+        fib_combo.setCurrentIndex(min(finals))
     h.pump(800)
     h.shot(
         "lamella-after-correlation",

--- a/fibsem/applications/autolamella/workflows/tasks/select_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_position.py
@@ -50,13 +50,13 @@ class SelectMillingPositionTaskConfig(AutoLamellaTaskConfig):
         ),
     )
     sync_fluorescence_pose: bool = field(
-        default=True,
+        default=False,
         metadata=field_meta(
             label="Sync Fluorescence Pose",
             tooltip="Move the lamella's fluorescence pose to follow the milling "
             "position recorded here, so a fluorescence task images the site as "
-            "set up rather than where the lamella was first marked. Off keeps "
-            "a fluorescence pose chosen by hand.",
+            "set up rather than where the lamella was first marked. Off (the "
+            "default) leaves the fluorescence pose as it was.",
         ),
     )
     task_type: ClassVar[str] = "SELECT_MILLING_POSITION"
@@ -177,8 +177,8 @@ class SelectMillingPositionTask(AutoLamellaTask):
         # centring), so the fluorescence pose derived when it was marked now
         # describes where it used to be. Every UI path that moves a lamella
         # syncs it; a fluorescence stack taken from the stale pose lands tens
-        # of microns off the marks it is meant to show (FIB-954). Optional,
-        # for a fluorescence pose that was chosen by hand and should stay.
+        # of microns off the marks it is meant to show (FIB-954). Opt-in: the
+        # default leaves the pose alone, as the task always has.
         if self.config.sync_fluorescence_pose:
             sync_fluorescence_pose(self.microscope, self.lamella)
 

--- a/fibsem/applications/autolamella/workflows/tasks/select_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_position.py
@@ -49,6 +49,16 @@ class SelectMillingPositionTaskConfig(AutoLamellaTaskConfig):
             tooltip="Whether to ask the user to select a point of interest in the FIB image",
         ),
     )
+    sync_fluorescence_pose: bool = field(
+        default=True,
+        metadata=field_meta(
+            label="Sync Fluorescence Pose",
+            tooltip="Move the lamella's fluorescence pose to follow the milling "
+            "position recorded here, so a fluorescence task images the site as "
+            "set up rather than where the lamella was first marked. Off keeps "
+            "a fluorescence pose chosen by hand.",
+        ),
+    )
     task_type: ClassVar[str] = "SELECT_MILLING_POSITION"
     display_name: ClassVar[str] = "Select Milling Position"
 
@@ -167,8 +177,10 @@ class SelectMillingPositionTask(AutoLamellaTask):
         # centring), so the fluorescence pose derived when it was marked now
         # describes where it used to be. Every UI path that moves a lamella
         # syncs it; a fluorescence stack taken from the stale pose lands tens
-        # of microns off the marks it is meant to show (FIB-954).
-        sync_fluorescence_pose(self.microscope, self.lamella)
+        # of microns off the marks it is meant to show (FIB-954). Optional,
+        # for a fluorescence pose that was chosen by hand and should stay.
+        if self.config.sync_fluorescence_pose:
+            sync_fluorescence_pose(self.microscope, self.lamella)
 
     def _align_coincident_for_milling(
         self, milling_angle: float, is_close: bool

--- a/fibsem/applications/autolamella/workflows/tasks/select_position.py
+++ b/fibsem/applications/autolamella/workflows/tasks/select_position.py
@@ -7,6 +7,7 @@ from typing import ClassVar, Type
 import numpy as np
 
 from fibsem import constants
+from fibsem.applications.autolamella.poses import sync_fluorescence_pose
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
 from fibsem.applications.autolamella.workflows.tasks.base import AutoLamellaTask
 from fibsem.applications.autolamella.workflows.ui import ask_user, select_poi_ui
@@ -162,6 +163,12 @@ class SelectMillingPositionTask(AutoLamellaTask):
         # store milling pose and angle
         self.lamella.milling_pose = self.microscope.get_microscope_state()
         self.lamella.update_milling_angle(self.microscope)
+        # the task moved the lamella (the coincidence walk, the operator's own
+        # centring), so the fluorescence pose derived when it was marked now
+        # describes where it used to be. Every UI path that moves a lamella
+        # syncs it; a fluorescence stack taken from the stale pose lands tens
+        # of microns off the marks it is meant to show (FIB-954).
+        sync_fluorescence_pose(self.microscope, self.lamella)
 
     def _align_coincident_for_milling(
         self, milling_angle: float, is_close: bool

--- a/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
+++ b/fibsem/applications/autolamella/workflows/tasks/spot_burn.py
@@ -25,7 +25,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
     task_type: ClassVar[str] = "SPOT_BURN_FIDUCIAL"
     display_name: ClassVar[str] = "Spot Burn Fiducial"
     milling_current: float = field(
-        default=60.0e-12,  # in Amperes
+        default=100.0e-12,  # in Amperes; below this the marks are too faint to find
         metadata=field_meta(tooltip="Milling current in Amperes", unit="A", scale=1e12),
     )
     exposure_time: int = field(
@@ -98,7 +98,7 @@ class SpotBurnFiducialTaskConfig(AutoLamellaTaskConfig):
             milling=cfg.milling,
             reference_imaging=cfg.reference_imaging,
             # coerce numeric params: older protocols may have stored these as strings
-            milling_current=float(params.get("milling_current", 60.0e-12)),
+            milling_current=float(params.get("milling_current", 100.0e-12)),
             exposure_time=int(float(params.get("exposure_time", 10))),
             autofocus=bool(params.get("autofocus", False)),
             coordinates=coordinates,

--- a/fibsem/imaging/spot.py
+++ b/fibsem/imaging/spot.py
@@ -26,7 +26,7 @@ class SpotBurnSettings:
     """
 
     coordinates: List[Point] = field(default_factory=list)
-    milling_current: float = 60e-12  # amperes
+    milling_current: float = 100e-12  # amperes
     exposure_time: float = 10.0  # seconds
 
     def to_dict(self) -> dict:
@@ -40,7 +40,7 @@ class SpotBurnSettings:
     def from_dict(cls, ddict: dict) -> "SpotBurnSettings":
         return cls(
             coordinates=[Point.from_dict(pt) for pt in ddict.get("coordinates", [])],
-            milling_current=ddict.get("milling_current", 60e-12),
+            milling_current=ddict.get("milling_current", 100e-12),
             exposure_time=ddict.get("exposure_time", 10.0),
         )
 

--- a/fibsem/microscopes/sim_scene.py
+++ b/fibsem/microscopes/sim_scene.py
@@ -1553,11 +1553,6 @@ class SampleScene:
             # in reflection the holes and rips read dark, the rim bright
             canvas[holes] -= bars * HOLE_DEPTH
             canvas[rips] -= bars * RIP_DEPTH
-            if self.milled:
-                canvas[self.milled_mask(xs_world, ys_world)] = -bars * MILL_DEPTH
-                halo = self.halo_mask(xs_world, ys_world, pixel_size)
-                if halo is not None:
-                    canvas[halo] += bars * FM_HALO
         # ice reflects strongly and barely fluoresces
         ice = 0.9 if bars >= 1.0 else 0.04
 
@@ -1593,6 +1588,14 @@ class SampleScene:
             u = cx + (f.x + ax) / pixel_size
             v = cy + (f.y * fs + ay) / pixel_size
             self._stamp_feature(canvas, f, u, v, pixel_size, fs, 0.0, intensity=weight)
+        # milled regions after the features: a trench or a burn removes the
+        # material, so in reflection it reads dark through whatever cell was
+        # there, and a burn's rim stays visible on top of it (FIB-954)
+        if bars > 0 and self.milled:
+            canvas[self.milled_mask(xs_world, ys_world)] = -bars * MILL_DEPTH
+            halo = self.halo_mask(xs_world, ys_world, pixel_size)
+            if halo is not None:
+                canvas[halo] += bars * FM_HALO
         canvas[rim] = RIM_INTENSITY if bars >= 1.0 else 0.0
         canvas[beyond] = 0.0
 

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -695,6 +695,12 @@ class DemoMicroscope(FibsemMicroscope):
 
         logging.info(f"acquiring new {effective_beam_type.name} image.")
 
+        # set the imaging hfw, as the hardware drivers do: an acquisition leaves
+        # the beam at the field it imaged, so anything that follows in image
+        # coordinates - a spot burn parked at a normalised point - lands where
+        # the reference image says (FIB-954)
+        self.set("hfw", effective_image_settings.hfw, effective_beam_type)
+
         # get state for image metadata
         microscope_state = self.get_microscope_state(beam_type=effective_beam_type)
 

--- a/fibsem/microscopes/simulator.py
+++ b/fibsem/microscopes/simulator.py
@@ -1458,6 +1458,16 @@ class DemoMicroscope(FibsemMicroscope):
         dx = (float(point.x) - 0.5) * hfw
         dy = (0.5 - float(point.y)) * hfw * (height / width)
         shift = self.get_beam_shift(beam_type)
+        logging.info(
+            {
+                "msg": "sim_spot_burn",
+                "point": (float(point.x), float(point.y)),
+                "hfw": hfw,
+                "resolution": (width, height),
+                "view_offset_m": (dx, dy),
+                "beam_shift": (float(shift.x), float(shift.y)),
+            }
+        )
         scene.burn(
             [(dx, dy)],
             beam_type,

--- a/fibsem/ui/FibsemSpotBurnWidget.py
+++ b/fibsem/ui/FibsemSpotBurnWidget.py
@@ -28,7 +28,7 @@ from fibsem.ui.widgets.progress_widget import FibsemProgressWidget, ProgressUpda
 from fibsem.ui.widgets.spot_burn_coordinates_widget import SpotBurnCoordinatesWidget
 from fibsem.utils import format_value
 
-DEFAULT_BEAM_CURRENT = 60e-12  # 60 pA
+DEFAULT_BEAM_CURRENT = 100e-12  # 100 pA
 HIDE_PROGRESS_DELAY_MS = 2000  # how long the "Done" bar stays up before hiding
 
 

--- a/tests/autolamella/test_select_position_records_pose.py
+++ b/tests/autolamella/test_select_position_records_pose.py
@@ -63,8 +63,8 @@ def test_the_task_records_pose_and_reference_either_way(
 def test_the_fluorescence_pose_follows_the_milling_pose(tmp_path, sync):
     """On an instrument with a fluorescence microscope, the task leaves the
     fluorescence pose describing the position it recorded the milling pose
-    at, not the one the lamella was marked at (FIB-954). Off, a fluorescence
-    pose chosen by hand stays where it was."""
+    at, not the one the lamella was marked at (FIB-954), when asked to. Off,
+    the default, leaves the fluorescence pose where it was."""
     from fibsem.applications.autolamella.poses import (
         _to_fluorescence,
         build_lamella_poses,
@@ -116,5 +116,6 @@ def test_the_fluorescence_pose_follows_the_milling_pose(tmp_path, sync):
             assert got.x == pytest.approx(stale.x, abs=1e-9)
             assert got.y == pytest.approx(stale.y, abs=1e-9)
         assert lamella.fluorescence_pose.objective_position is not None
+        assert SelectMillingPositionTaskConfig().sync_fluorescence_pose is False
     finally:
         microscope.disconnect()

--- a/tests/autolamella/test_select_position_records_pose.py
+++ b/tests/autolamella/test_select_position_records_pose.py
@@ -57,3 +57,55 @@ def test_the_task_records_pose_and_reference_either_way(
     assert os.path.exists(
         os.path.join(lamella.path, ALIGNMENT_REFERENCE_IMAGE_FILENAME)
     ), "the alignment reference was acquired"
+
+
+def test_the_fluorescence_pose_follows_the_milling_pose(tmp_path):
+    """On an instrument with a fluorescence microscope, the task leaves the
+    fluorescence pose describing the position it recorded the milling pose
+    at, not the one the lamella was marked at (FIB-954)."""
+    from fibsem.applications.autolamella.poses import (
+        _to_fluorescence,
+        build_lamella_poses,
+    )
+    from fibsem.structures import FibsemStagePosition
+
+    microscope, _ = utils.setup_session(
+        manufacturer="Demo",
+        config_path=os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml"),
+    )
+    try:
+        marked = microscope.get_stage_position()
+        poses = build_lamella_poses(microscope=microscope, position=marked)
+        lamella = Lamella(path=tmp_path / "lam", number=0, petname="test")
+        lamella.path.mkdir(parents=True, exist_ok=True)
+        lamella.milling_pose = poses.milling
+        lamella.fluorescence_pose = poses.fluorescence
+        assert lamella.fluorescence_pose is not None
+        stale = lamella.fluorescence_pose.stage_position
+
+        # the operator centres the site 20 um away before the task records it
+        moved = FibsemStagePosition(
+            x=marked.x + 20e-6,
+            y=marked.y,
+            z=marked.z,
+            r=marked.r,
+            t=marked.t,
+            coordinate_system=marked.coordinate_system,
+        )
+        microscope.move_stage_absolute(moved)
+        lamella.milling_pose = microscope.get_microscope_state()
+        config = SelectMillingPositionTaskConfig(
+            auto_milling_alignment=False, use_autofocus=False, select_poi=False
+        )
+        SelectMillingPositionTask(
+            microscope=microscope, config=config, lamella=lamella
+        )._run()
+
+        expected = _to_fluorescence(microscope, lamella.milling_pose.stage_position)
+        got = lamella.fluorescence_pose.stage_position
+        assert got.x == pytest.approx(expected.x, abs=1e-9)
+        assert got.y == pytest.approx(expected.y, abs=1e-9)
+        assert abs(got.x - stale.x) > 10e-6, "the pose moved with the lamella"
+        assert lamella.fluorescence_pose.objective_position is not None
+    finally:
+        microscope.disconnect()

--- a/tests/autolamella/test_select_position_records_pose.py
+++ b/tests/autolamella/test_select_position_records_pose.py
@@ -59,10 +59,12 @@ def test_the_task_records_pose_and_reference_either_way(
     ), "the alignment reference was acquired"
 
 
-def test_the_fluorescence_pose_follows_the_milling_pose(tmp_path):
+@pytest.mark.parametrize("sync", [True, False])
+def test_the_fluorescence_pose_follows_the_milling_pose(tmp_path, sync):
     """On an instrument with a fluorescence microscope, the task leaves the
     fluorescence pose describing the position it recorded the milling pose
-    at, not the one the lamella was marked at (FIB-954)."""
+    at, not the one the lamella was marked at (FIB-954). Off, a fluorescence
+    pose chosen by hand stays where it was."""
     from fibsem.applications.autolamella.poses import (
         _to_fluorescence,
         build_lamella_poses,
@@ -95,17 +97,24 @@ def test_the_fluorescence_pose_follows_the_milling_pose(tmp_path):
         microscope.move_stage_absolute(moved)
         lamella.milling_pose = microscope.get_microscope_state()
         config = SelectMillingPositionTaskConfig(
-            auto_milling_alignment=False, use_autofocus=False, select_poi=False
+            auto_milling_alignment=False,
+            use_autofocus=False,
+            select_poi=False,
+            sync_fluorescence_pose=sync,
         )
         SelectMillingPositionTask(
             microscope=microscope, config=config, lamella=lamella
         )._run()
 
-        expected = _to_fluorescence(microscope, lamella.milling_pose.stage_position)
         got = lamella.fluorescence_pose.stage_position
-        assert got.x == pytest.approx(expected.x, abs=1e-9)
-        assert got.y == pytest.approx(expected.y, abs=1e-9)
-        assert abs(got.x - stale.x) > 10e-6, "the pose moved with the lamella"
+        if sync:
+            expected = _to_fluorescence(microscope, lamella.milling_pose.stage_position)
+            assert got.x == pytest.approx(expected.x, abs=1e-9)
+            assert got.y == pytest.approx(expected.y, abs=1e-9)
+            assert abs(got.x - stale.x) > 10e-6, "the pose moved with the lamella"
+        else:
+            assert got.x == pytest.approx(stale.x, abs=1e-9)
+            assert got.y == pytest.approx(stale.y, abs=1e-9)
         assert lamella.fluorescence_pose.objective_position is not None
     finally:
         microscope.disconnect()

--- a/tests/test_sim_scene_realism.py
+++ b/tests/test_sim_scene_realism.py
@@ -670,10 +670,11 @@ def test_spot_burns_leave_marks_in_every_view(microscope):
         ice_density=0.0,
         fiducial=False,
     )
+    # the reference image sets the field the points are placed in: an
+    # acquisition leaves the beam at its field, as on hardware
     settings = _settings(BeamType.ION, hfw=40e-6)
-    microscope.set("hfw", settings.hfw, BeamType.ION)
-    microscope.set("resolution", settings.resolution, BeamType.ION)
     before = microscope.acquire_image(image_settings=settings)
+    assert microscope.get("hfw", BeamType.ION) == pytest.approx(40e-6)
 
     # two points, normalised image coordinates: a quarter in from the left
     # and right edges, on the horizontal centre line and a quarter down


### PR DESCRIPTION
Second half of FIB-954: the user guide's Spot burns and correlation page (site PR #11) and what writing it found on the simulator and in the app.

**Spot burns land where the reference was taken.** `run_spot_burn` parks the beam at a normalised point at whatever field the beam has. The hardware drivers set the field of view during acquisition, so on hardware the reference image and the burn agree; the simulator's `acquire_image` did not, so the burn used the beam's previous field. `acquire_image` now sets the beam's hfw, and the spot-burn test asserts it. The simulator logs each burn's field and offsets.

**A burn shows through a cell.** `render_fm` painted the milled regions before the features, so a mark under a cell was covered by it. Milled regions and rims are now applied after the features.

**Setup Lamella Position can sync the fluorescence pose.** The task re-records the milling pose after the coincidence walk and the operator's centring, but leaves the fluorescence pose where the lamella was marked, so a fluorescence stack is taken tens of microns from the marks. A new task option `sync_fluorescence_pose` (default **off**, no behaviour change) makes it call `sync_fluorescence_pose` as the UI paths that move a lamella do. Test covers both settings and the default.

**Spot burn default current 100 pA** (task config, run payload, widget). Below that the marks are too faint to find in the fluorescence image.

**Harness**: `render_correlation` in `render_user_guide.py`. It adds the two tasks to the protocol (burn after setup, stack after the fiducial) with the pose sync on, runs setup → burn (supervised) → fiducial → stack, photographs the Spot Burn tab used by hand, then drives the correlation dialog from the Lamella tab: selects Mill Fiducial's post-milling reference at its smaller field so the FIB image carries the fiducial the stack shows, pairs the seeded FIB points to the marks found in a with/without-marks difference frame (the seeds are at the burn image's scale), does the same on the FM side at the fluorescence pose and boxes the marks, runs, and accepts. Also a SIGUSR1 stack dump for a hung run.

Seven files: the app fixes with their tests are what the page needed to render truthfully, and the harness page is what needed them.