### PR TITLE
[ui] Configuration v1 (9/9): a Defaults panel — read from the instrument, edit, save

### DIFF
--- a/fibsem/structures.py
+++ b/fibsem/structures.py
@@ -2407,6 +2407,21 @@ class StageSystemSettings:
         )
 
 
+def _detector_block_from(settings: dict) -> dict:
+    """The detector keys of a beam block, in the names `FibsemDetectorSettings` reads.
+
+    The prefixed spelling wins when both are present, because it is the one the
+    writer produces and the one every shipped file uses.
+    """
+    block = {}
+    for name in ("type", "mode", "brightness", "contrast"):
+        if f"detector_{name}" in settings:
+            block[name] = settings[f"detector_{name}"]
+        elif name in settings:
+            block[name] = settings[name]
+    return block
+
+
 def _split_defaults(beam: dict) -> dict:
     """Move the session defaults out of a written beam block, in place.
 
@@ -2498,7 +2513,13 @@ class BeamSystemSettings:
             beam_type=beam_type,
             enabled=settings.get("enabled", True),
             beam=BeamSettings.from_dict(settings),
-            detector=FibsemDetectorSettings.from_dict(settings),
+            # The file spells the detector keys with a `detector_` prefix -- that is
+            # what `to_dict` writes -- and `FibsemDetectorSettings.from_dict` reads
+            # the bare names, so for as long as both existed every shipped
+            # `detector_type: ETD` loaded as "Unknown", and a saved file lost its
+            # detector on the next load. Mapped here, at the one seam where the
+            # prefixed spelling meets the record.
+            detector=FibsemDetectorSettings.from_dict(_detector_block_from(settings)),
             eucentric_height=settings.get("eucentric_height", 0.0),
             column_tilt=settings.get("column_tilt", default_column_tilt),
             plasma_gas=_plasma_gas_from(settings),

--- a/fibsem/ui/FibsemSystemSetupWidget.py
+++ b/fibsem/ui/FibsemSystemSetupWidget.py
@@ -20,8 +20,10 @@ from fibsem.ui.tokens import (
 )
 from fibsem.ui.utils import message_box_ui, open_existing_file_dialog
 from fibsem.ui.widgets.custom_widgets import (
+    TitledPanel,
     ValueComboBox,
 )
+from fibsem.ui.widgets.microscope_defaults_widget import MicroscopeDefaultsWidget
 
 
 class FibsemSystemSetupWidget(QtWidgets.QWidget):
@@ -62,13 +64,22 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
         self.gridLayout.addWidget(self.toolButton_import_configuration, 1, 2, 1, 1)
         self.gridLayout.addWidget(self.pushButton_connect_to_microscope, 2, 0, 1, 3)
         self.gridLayout.addWidget(self.pushButton_apply_configuration, 3, 0, 1, 3)
-        self.gridLayout.addWidget(self.label_connection_status, 4, 0, 1, 3)
-        self.gridLayout.addWidget(self.label_connection_information, 5, 0, 1, 3)
+        # The defaults a session starts from: read off the instrument, edited, saved
+        # into the configuration. Beside Apply, which is what consumes them.
+        self.defaultsWidget = MicroscopeDefaultsWidget()
+        self.defaultsPanel = TitledPanel(
+            "Defaults", content=self.defaultsWidget, collapsible=True
+        )
+        self.defaultsPanel.collapse()
+        self.defaultsPanel.setVisible(False)
+        self.gridLayout.addWidget(self.defaultsPanel, 4, 0, 1, 3)
+        self.gridLayout.addWidget(self.label_connection_status, 5, 0, 1, 3)
+        self.gridLayout.addWidget(self.label_connection_information, 6, 0, 1, 3)
         self.gridLayout.addItem(
             QtWidgets.QSpacerItem(
                 20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding
             ),
-            6,
+            7,
             0,
             1,
             3,
@@ -476,6 +487,8 @@ class FibsemSystemSetupWidget(QtWidgets.QWidget):
         self.pushButton_apply_configuration.setEnabled(
             is_microscope_connected and cfg.APPLY_CONFIGURATION_ENABLED
         )
+        self.defaultsPanel.setVisible(is_microscope_connected)
+        self.defaultsWidget.set_microscope(self.microscope or None)
 
         if is_microscope_connected:
             self.pushButton_connect_to_microscope.setVisible(False)

--- a/fibsem/ui/widgets/microscope_defaults_widget.py
+++ b/fibsem/ui/widgets/microscope_defaults_widget.py
@@ -1,0 +1,247 @@
+"""The beam defaults a session starts from, read from the instrument and edited here.
+
+`defaults:` in the microscope configuration holds what the columns start at -- voltage,
+current, field of view, resolution, dwell time, detector. Nobody wants to type those
+into a file, and somebody who does will type what they believe the instrument is doing.
+So the panel reads them off the instrument ("it is set up how I like it, remember
+this"), lets them be adjusted, and writes them into the configuration file the session
+was started from -- that section and nothing else.
+
+Nothing here touches the column. Apply, beside this panel, is what pushes the
+defaults to the instrument; this panel only decides what they are.
+"""
+
+import logging
+from typing import List, Optional, Tuple
+
+from PyQt5.QtWidgets import (
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from fibsem import utils
+from fibsem.constants import METRE_TO_MICRON, MICRON_TO_METRE
+from fibsem.microscope import FibsemMicroscope
+from fibsem.structures import BeamSystemSettings, BeamType
+from fibsem.ui import notification_service, stylesheets
+from fibsem.ui.widgets.custom_widgets import ValueComboBox, ValueSpinBox
+
+# Offered when the instrument cannot list its own; the current value is always
+# added beside them so a file's setting is never silently snapped to a neighbour.
+STANDARD_RESOLUTIONS: List[Tuple[int, int]] = [
+    (768, 512),
+    (1536, 1024),
+    (3072, 2048),
+    (6144, 4096),
+]
+
+
+def _format_voltage(v) -> str:
+    return f"{float(v) / 1e3:.2f} kV"
+
+
+def _format_current(a) -> str:
+    a = float(a)
+    if a >= 1e-9:
+        return f"{a * 1e9:.2f} nA"
+    return f"{a * 1e12:.1f} pA"
+
+
+def _format_resolution(r) -> str:
+    return f"{int(r[0])} x {int(r[1])}"
+
+
+class BeamDefaultsForm(QGroupBox):
+    """One column's defaults: what `defaults.electron` / `defaults.ion` carries."""
+
+    def __init__(self, beam_type: BeamType, parent: Optional[QWidget] = None):
+        super().__init__(beam_type.name.title() + " Beam", parent)
+        self.beam_type = beam_type
+
+        self.voltage = ValueComboBox(format_fn=_format_voltage)
+        self.current = ValueComboBox(format_fn=_format_current)
+        self.hfw = ValueSpinBox(
+            suffix="µm", minimum=1.0, maximum=5000.0, decimals=1, step=10.0
+        )
+        self.resolution = ValueComboBox(format_fn=_format_resolution)
+        self.dwell_time = ValueSpinBox(
+            suffix="µs", minimum=0.01, maximum=1000.0, decimals=2, step=0.1
+        )
+        self.detector_type = ValueComboBox()
+        self.detector_mode = ValueComboBox()
+
+        form = QFormLayout()
+        form.addRow("Voltage", self.voltage)
+        form.addRow("Current", self.current)
+        form.addRow("Field of view", self.hfw)
+        form.addRow("Resolution", self.resolution)
+        form.addRow("Dwell time", self.dwell_time)
+        form.addRow("Detector", self.detector_type)
+        form.addRow("Mode", self.detector_mode)
+        form.setContentsMargins(6, 6, 6, 6)
+        self.setLayout(form)
+
+    def populate_choices(self, microscope: FibsemMicroscope) -> None:
+        """The values this instrument can be set to, with the current one kept."""
+        beam = self.beam_type
+
+        def available(key: str) -> list:
+            try:
+                return list(microscope.get_available_values_cached(key, beam) or [])
+            except Exception as e:  # a backend that cannot list this key
+                logging.debug(f"No available values for {key} ({beam.name}): {e}")
+                return []
+
+        record = getattr(microscope.system, beam.name.lower())
+        self._set_choices(self.voltage, available("voltage"), record.beam.voltage)
+        self._set_choices(self.current, available("current"), record.beam.beam_current)
+        resolutions = [tuple(r) for r in STANDARD_RESOLUTIONS]
+        self._set_choices(
+            self.resolution,
+            resolutions,
+            tuple(record.beam.resolution) if record.beam.resolution else None,
+        )
+        self._set_choices(
+            self.detector_type, available("detector_type"), record.detector.type
+        )
+        self._set_choices(
+            self.detector_mode, available("detector_mode"), record.detector.mode
+        )
+
+    @staticmethod
+    def _set_choices(combo: ValueComboBox, choices: list, current) -> None:
+        items = list(choices)
+        if current is not None and current not in items:
+            items.append(current)
+        combo.set_values(items, value=current)
+
+    def show_settings(self, record: BeamSystemSettings) -> None:
+        beam, detector = record.beam, record.detector
+        if beam.voltage is not None:
+            self.voltage.set_value(beam.voltage)
+        if beam.beam_current is not None:
+            self.current.set_value(beam.beam_current)
+        if beam.hfw is not None:
+            self.hfw.setValue(beam.hfw * METRE_TO_MICRON)
+        if beam.resolution is not None:
+            self.resolution.set_value(tuple(beam.resolution))
+        if beam.dwell_time is not None:
+            self.dwell_time.setValue(beam.dwell_time * 1e6)
+        if detector.type is not None:
+            self.detector_type.set_value(detector.type)
+        if detector.mode is not None:
+            self.detector_mode.set_value(detector.mode)
+
+    def write_into(self, record: BeamSystemSettings) -> None:
+        """Copy the form into the record. Only the defaults; nothing about the column."""
+        record.beam.voltage = self.voltage.value()
+        record.beam.beam_current = self.current.value()
+        record.beam.hfw = self.hfw.value() * MICRON_TO_METRE
+        resolution = self.resolution.value()
+        record.beam.resolution = tuple(resolution) if resolution else None
+        record.beam.dwell_time = self.dwell_time.value() * 1e-6
+        record.detector.type = self.detector_type.value()
+        record.detector.mode = self.detector_mode.value()
+
+
+class MicroscopeDefaultsWidget(QWidget):
+    """Read the defaults from the instrument, edit them, save them to the configuration."""
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.microscope: Optional[FibsemMicroscope] = None
+
+        self.electron = BeamDefaultsForm(BeamType.ELECTRON)
+        self.ion = BeamDefaultsForm(BeamType.ION)
+        self.pushButton_read = QPushButton("Read from Microscope")
+        self.pushButton_read.setToolTip(
+            "Take what the instrument is doing now as the defaults."
+        )
+        self.pushButton_read.setStyleSheet(stylesheets.SECONDARY_BUTTON_STYLESHEET)
+        self.pushButton_save = QPushButton("Save to Configuration")
+        self.pushButton_save.setToolTip(
+            "Write these defaults into the configuration file this session was "
+            "started from. Nothing else in the file is changed."
+        )
+        self.pushButton_save.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+
+        forms = QHBoxLayout()
+        forms.addWidget(self.electron)
+        forms.addWidget(self.ion)
+        buttons = QHBoxLayout()
+        buttons.addWidget(self.pushButton_read)
+        buttons.addWidget(self.pushButton_save)
+        layout = QVBoxLayout()
+        layout.addLayout(forms)
+        layout.addLayout(buttons)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
+
+        self.pushButton_read.clicked.connect(self.read_from_microscope)
+        self.pushButton_save.clicked.connect(self.save_to_configuration)
+        self.setEnabled(False)
+
+    def set_microscope(self, microscope: Optional[FibsemMicroscope]) -> None:
+        self.microscope = microscope
+        self.setEnabled(microscope is not None)
+        if microscope is None:
+            return
+        for form in (self.electron, self.ion):
+            form.populate_choices(microscope)
+        self.show_system()
+
+    def show_system(self) -> None:
+        """The form shows what `system.electron` / `system.ion` currently hold."""
+        if self.microscope is None:
+            return
+        self.electron.show_settings(self.microscope.system.electron)
+        self.ion.show_settings(self.microscope.system.ion)
+
+    def read_from_microscope(self) -> None:
+        if self.microscope is None:
+            return
+        self.microscope.capture_defaults()
+        self.show_system()
+        notification_service.show_toast(
+            "Defaults read from the microscope. Save to keep them.", "info"
+        )
+
+    def write_form_into_system(self) -> None:
+        if self.microscope is None:
+            return
+        self.electron.write_into(self.microscope.system.electron)
+        self.ion.write_into(self.microscope.system.ion)
+
+    def save_to_configuration(self) -> None:
+        if self.microscope is None:
+            return
+        path = getattr(self.microscope, "configuration_path", None)
+        if not path:
+            notification_service.show_toast(
+                "This session was not started from a configuration file, so there is "
+                "nowhere to save the defaults.",
+                "warning",
+            )
+            return
+        self.write_form_into_system()
+        # The beam halves of what `SystemSettings.to_dict` writes under `defaults:`.
+        # The imaging defaults are the acquire tab's, and `apply_on_connect` is not
+        # this panel's to change, so neither is written from here.
+        defaults = self.microscope.system.to_dict()["defaults"]
+        updates = {
+            "defaults": {"electron": defaults["electron"], "ion": defaults["ion"]}
+        }
+        try:
+            utils.write_configuration(path, updates)
+        except Exception as e:
+            logging.error(f"Could not save the defaults: {e}")
+            notification_service.show_toast(
+                f"Could not save the defaults: {e}", "error"
+            )
+            return
+        logging.info(f"Beam defaults saved to {path}")
+        notification_service.show_toast("Defaults saved to the configuration.", "info")

--- a/fibsem/ui/widgets/microscope_defaults_widget.py
+++ b/fibsem/ui/widgets/microscope_defaults_widget.py
@@ -147,6 +147,19 @@ class BeamDefaultsForm(QGroupBox):
         if detector.mode is not None:
             self.detector_mode.set_value(detector.mode)
 
+    def defaults_to_dict(self) -> dict:
+        """The form's seven values, in the file's spelling."""
+        key = self.resolution.value()
+        return {
+            "voltage": self.voltage.value(),
+            "current": self.current.value(),
+            "hfw": self.hfw.value() * MICRON_TO_METRE,
+            "resolution": list(_resolution_from_key(key)) if key else None,
+            "dwell_time": self.dwell_time.value() * 1e-6,
+            "detector_type": self.detector_type.value(),
+            "detector_mode": self.detector_mode.value(),
+        }
+
     def write_into(self, record: BeamSystemSettings) -> None:
         """Copy the form into the record. Only the defaults; nothing about the column."""
         record.beam.voltage = self.voltage.value()
@@ -239,12 +252,16 @@ class MicroscopeDefaultsWidget(QWidget):
             )
             return
         self.write_form_into_system()
-        # The beam halves of what `SystemSettings.to_dict` writes under `defaults:`.
-        # The imaging defaults are the acquire tab's, and `apply_on_connect` is not
-        # this panel's to change, so neither is written from here.
-        defaults = self.microscope.system.to_dict()["defaults"]
+        # Exactly the seven keys the form shows, for each beam. Not the whole beam
+        # record: that also carries the beam shift, stigmation, scan rotation and
+        # working distance, which are alignment state -- written here they would be
+        # pushed back by Apply. The imaging defaults are the acquire tab's, and
+        # `apply_on_connect` is not this panel's to change.
         updates = {
-            "defaults": {"electron": defaults["electron"], "ion": defaults["ion"]}
+            "defaults": {
+                "electron": self.electron.defaults_to_dict(),
+                "ion": self.ion.defaults_to_dict(),
+            }
         }
         try:
             utils.write_configuration(path, updates)

--- a/fibsem/ui/widgets/microscope_defaults_widget.py
+++ b/fibsem/ui/widgets/microscope_defaults_widget.py
@@ -51,8 +51,20 @@ def _format_current(a) -> str:
     return f"{a * 1e12:.1f} pA"
 
 
-def _format_resolution(r) -> str:
-    return f"{int(r[0])} x {int(r[1])}"
+# Resolutions travel through the combo box as "WxH" strings: a tuple does not survive
+# the QVariant round trip `findData` uses to select an item, so `set_value` fell
+# back to its closest-numeric rule, which cannot compare tuples and picked index 0.
+def _resolution_key(r) -> str:
+    return f"{int(r[0])}x{int(r[1])}"
+
+
+def _resolution_from_key(key: str) -> Tuple[int, int]:
+    w, h = key.split("x")
+    return int(w), int(h)
+
+
+def _format_resolution(key: str) -> str:
+    return key.replace("x", " x ")
 
 
 class BeamDefaultsForm(QGroupBox):
@@ -99,11 +111,10 @@ class BeamDefaultsForm(QGroupBox):
         record = getattr(microscope.system, beam.name.lower())
         self._set_choices(self.voltage, available("voltage"), record.beam.voltage)
         self._set_choices(self.current, available("current"), record.beam.beam_current)
-        resolutions = [tuple(r) for r in STANDARD_RESOLUTIONS]
         self._set_choices(
             self.resolution,
-            resolutions,
-            tuple(record.beam.resolution) if record.beam.resolution else None,
+            [_resolution_key(r) for r in STANDARD_RESOLUTIONS],
+            _resolution_key(record.beam.resolution) if record.beam.resolution else None,
         )
         self._set_choices(
             self.detector_type, available("detector_type"), record.detector.type
@@ -128,7 +139,7 @@ class BeamDefaultsForm(QGroupBox):
         if beam.hfw is not None:
             self.hfw.setValue(beam.hfw * METRE_TO_MICRON)
         if beam.resolution is not None:
-            self.resolution.set_value(tuple(beam.resolution))
+            self.resolution.set_value(_resolution_key(beam.resolution))
         if beam.dwell_time is not None:
             self.dwell_time.setValue(beam.dwell_time * 1e6)
         if detector.type is not None:
@@ -141,8 +152,8 @@ class BeamDefaultsForm(QGroupBox):
         record.beam.voltage = self.voltage.value()
         record.beam.beam_current = self.current.value()
         record.beam.hfw = self.hfw.value() * MICRON_TO_METRE
-        resolution = self.resolution.value()
-        record.beam.resolution = tuple(resolution) if resolution else None
+        key = self.resolution.value()
+        record.beam.resolution = _resolution_from_key(key) if key else None
         record.beam.dwell_time = self.dwell_time.value() * 1e-6
         record.detector.type = self.detector_type.value()
         record.detector.mode = self.detector_mode.value()

--- a/fibsem/utils.py
+++ b/fibsem/utils.py
@@ -640,24 +640,76 @@ def report_unrecognised_configuration_keys(config: dict, source: str = "") -> Li
     return unknown
 
 
+def _deep_update(target: dict, updates: dict) -> dict:
+    for key, value in updates.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            _deep_update(target[key], value)
+        else:
+            target[key] = value
+    return target
+
+
+def write_configuration(path: Union[str, Path], updates: dict) -> None:
+    """Write *updates* into the configuration file at *path*, and nothing else.
+
+    The file is read, the nested keys in *updates* are set (a dict merges into the
+    block it names; anything else replaces the value there), and it is written back.
+    The rest of the file -- including whatever a person wrote there by hand -- is
+    preserved at the parsed level. This is the one writer of the file from the
+    application: a calibration action writes `calibration.*`, the defaults panel
+    writes `defaults.*`, and neither can disturb the other's section.
+    """
+    config = load_yaml(os.path.join(path)) or {}
+    _deep_update(config, updates)
+    _retire_legacy_duplicates(config)
+    _write_configuration_file(path, config)
+
+
+def _retire_legacy_duplicates(config: dict) -> None:
+    """Drop a key from an old flat block once its new home states it.
+
+    A file written before the sections existed keeps its flat blocks, and the
+    reader accepts them. Writing `defaults.electron.voltage` into such a file
+    would otherwise leave `electron.voltage` beside it -- two homes for one value,
+    the reader silently preferring the new one, and the warning suppressed by the
+    legacy alias. Here the old copy goes, and an emptied block goes with it.
+    """
+    for block, aliases in LEGACY_CONFIGURATION_BLOCKS.items():
+        old = config.get(block)
+        if not isinstance(old, dict):
+            continue
+        for alias in aliases:
+            new_home = config
+            for part in alias.split("."):
+                new_home = new_home.get(part) if isinstance(new_home, dict) else None
+                if new_home is None:
+                    break
+            if not isinstance(new_home, dict):
+                continue
+            for key in list(old):
+                if key in new_home:
+                    del old[key]
+        if not old:
+            del config[block]
+
+
 def write_objective_calibration(
     path: Union[str, Path],
     focus_position: Optional[float],
     limit_position: Optional[float],
 ) -> None:
-    """Record the objective's calibration in the configuration file at *path*.
-
-    Touches `calibration.objective` and nothing else: the file is read, that one
-    block is replaced, and it is written back. The rest of the file -- including
-    whatever a person wrote there by hand -- is preserved at the parsed level. The
-    only writer of a calibration is a calibration action, which is what this is.
-    """
-    config = load_yaml(os.path.join(path)) or {}
-    config.setdefault("calibration", {})["objective"] = {
-        "focus_position": focus_position,
-        "limit_position": limit_position,
-    }
-    _write_configuration_file(path, config)
+    """Record the objective's calibration in the configuration file at *path*."""
+    write_configuration(
+        path,
+        {
+            "calibration": {
+                "objective": {
+                    "focus_position": focus_position,
+                    "limit_position": limit_position,
+                }
+            }
+        },
+    )
 
 
 def _plain(value):

--- a/tests/test_configuration_defaults.py
+++ b/tests/test_configuration_defaults.py
@@ -314,20 +314,20 @@ def test_capturing_leaves_the_hardware_description_alone(microscope):
     assert microscope.system.electron.eucentric_height == before_eucentric
 
 
-def test_the_detector_keys_in_every_shipped_file_are_read_by_nothing():
-    """A defect this change surfaced without causing, recorded rather than fixed.
+def test_the_detector_keys_in_every_shipped_file_are_read():
+    """A defect older than the schema work, fixed here because the Defaults panel
+    made it destructive.
 
     Every shipped configuration states `detector_type: ETD` and
     `detector_mode: SecondaryElectrons`. `BeamSystemSettings.to_dict` writes those
-    names, but `FibsemDetectorSettings.from_dict` reads `type` and `mode`, so nothing
-    ever reads them back -- the detector loads as `Unknown` on every system. Confirmed
-    on stock `origin/main`, so it predates the schema work.
+    names, but `FibsemDetectorSettings.from_dict` read `type` and `mode`, so nothing
+    ever read them back: the detector loaded as "Unknown" on every system, and a
+    file saved from the application lost its detector on the next load. With a
+    panel that reads the record and writes it back, "Unknown" would have replaced
+    every site's ETD on the first Save.
 
-    Not fixed here on purpose. `set_beam_system_settings` pushes
-    `settings.detector` to the instrument, so making the keys readable changes what
-    Apply sends to real hardware. That belongs in its own change with a bench check,
-    not inside a refactor whose whole claim is that it changes no configuration's
-    meaning.
+    What changes on hardware: Apply now pushes the detector the file names rather
+    than "Unknown". That is what the file always intended.
     """
     config = _load("microscope-configuration.yaml")
     defaults = config["defaults"]["electron"]
@@ -336,5 +336,17 @@ def test_the_detector_keys_in_every_shipped_file_are_read_by_nothing():
 
     settings = MicroscopeSettings.from_dict(config)
 
-    assert settings.system.electron.detector.type == "Unknown"
-    assert settings.system.electron.detector.mode == "Unknown"
+    assert settings.system.electron.detector.type == "ETD"
+    assert settings.system.electron.detector.mode == "SecondaryElectrons"
+
+
+def test_the_detector_round_trips_through_a_saved_file():
+    """Brightness and contrast too: written as `detector_brightness`, they were read
+    as `brightness` and came back as the default."""
+    settings = MicroscopeSettings.from_dict(_load("microscope-configuration.yaml"))
+    settings.system.ion.detector.brightness = 0.37
+    settings.system.ion.detector.contrast = 0.62
+
+    reloaded = MicroscopeSettings.from_dict(copy.deepcopy(settings.to_dict()))
+
+    assert reloaded.system.ion.detector == settings.system.ion.detector

--- a/tests/test_write_configuration.py
+++ b/tests/test_write_configuration.py
@@ -1,0 +1,67 @@
+"""The one writer of the configuration file from the application.
+
+`write_configuration` sets nested keys and preserves everything else at the parsed
+level, so a calibration action and the defaults panel can each write their own
+section without disturbing the other's, or anything a person wrote by hand.
+"""
+
+import copy
+import os
+
+import yaml
+
+import fibsem.config as cfg
+from fibsem import utils
+from fibsem.structures import MicroscopeSettings
+
+SHIPPED = os.path.join(cfg.CONFIG_PATH, "microscope-configuration.yaml")
+
+
+def _site_file(tmp_path):
+    original = utils.load_yaml(SHIPPED)
+    original["info"]["name"] = "Bay 2"  # something a person wrote
+    path = tmp_path / "site.yaml"
+    path.write_text(yaml.safe_dump(original))
+    return path, original
+
+
+def test_a_nested_update_touches_only_the_keys_it_names(tmp_path):
+    path, original = _site_file(tmp_path)
+
+    utils.write_configuration(path, {"defaults": {"electron": {"voltage": 5000}}})
+
+    written = utils.load_yaml(str(path))
+    expected = copy.deepcopy(original)
+    expected["defaults"]["electron"]["voltage"] = 5000
+    assert written == expected
+
+
+def test_a_dict_merges_and_a_value_replaces(tmp_path):
+    path, original = _site_file(tmp_path)
+
+    utils.write_configuration(
+        path, {"calibration": {"objective": {"focus_position": 1.0}}, "version": 1}
+    )
+
+    written = utils.load_yaml(str(path))
+    assert written["calibration"]["objective"] == {"focus_position": 1.0}
+    assert (
+        written["calibration"]["shuttle_pre_tilt"]
+        == original["calibration"]["shuttle_pre_tilt"]
+    )
+    assert written["hardware"] == original["hardware"]
+
+
+def test_two_sections_written_separately_do_not_disturb_each_other(tmp_path):
+    path, _ = _site_file(tmp_path)
+
+    utils.write_objective_calibration(path, 7.0e-3, 8.0e-3)
+    utils.write_configuration(path, {"defaults": {"ion": {"voltage": 8000}}})
+
+    written = utils.load_yaml(str(path))
+    assert written["calibration"]["objective"]["focus_position"] == 7.0e-3
+    assert written["defaults"]["ion"]["voltage"] == 8000
+    assert written["defaults"]["electron"]["voltage"] == 2000
+    # and it still loads with nothing unrecognised
+    assert utils.unrecognised_configuration_keys(written) == []
+    assert MicroscopeSettings.from_dict(written).system.ion.beam.voltage == 8000

--- a/tests/test_write_configuration.py
+++ b/tests/test_write_configuration.py
@@ -52,6 +52,46 @@ def test_a_dict_merges_and_a_value_replaces(tmp_path):
     assert written["hardware"] == original["hardware"]
 
 
+def test_writing_into_an_old_flat_file_retires_the_old_copy(tmp_path):
+    """A file from before the sections keeps its flat blocks, and the reader
+    accepts them. Writing `defaults.electron.voltage` must not leave
+    `electron.voltage` beside it -- two homes for one value, the new one silently
+    winning and the legacy alias hiding the warning."""
+    path = tmp_path / "old.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "electron": {"voltage": 2000, "column_tilt": 0, "hfw": 150e-6},
+                "imaging": {"hfw": 150e-6, "beam_type": "ELECTRON"},
+            }
+        )
+    )
+
+    utils.write_configuration(
+        path,
+        {"defaults": {"electron": {"voltage": 5000}, "imaging": {"hfw": 80e-6}}},
+    )
+
+    written = utils.load_yaml(str(path))
+    assert written["defaults"]["electron"]["voltage"] == 5000
+    assert "voltage" not in written["electron"], "two homes for one value"
+    assert written["electron"] == {
+        "column_tilt": 0,
+        "hfw": 150e-6,
+    }  # untouched keys stay
+    assert written["imaging"] == {"beam_type": "ELECTRON"}
+    assert MicroscopeSettings.from_dict(written).system.electron.beam.voltage == 5000
+
+
+def test_an_emptied_legacy_block_is_removed(tmp_path):
+    path = tmp_path / "old.yaml"
+    path.write_text(yaml.safe_dump({"imaging": {"hfw": 150e-6}}))
+
+    utils.write_configuration(path, {"defaults": {"imaging": {"hfw": 80e-6}}})
+
+    assert "imaging" not in utils.load_yaml(str(path))
+
+
 def test_two_sections_written_separately_do_not_disturb_each_other(tmp_path):
     path, _ = _site_file(tmp_path)
 

--- a/tests/ui/test_microscope_defaults_widget.py
+++ b/tests/ui/test_microscope_defaults_widget.py
@@ -1,0 +1,108 @@
+"""The Defaults panel: read from the instrument, edit, save to the configuration."""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication  # noqa: E402
+
+import fibsem.config as cfg  # noqa: E402
+from fibsem import utils  # noqa: E402
+from fibsem.structures import MicroscopeSettings  # noqa: E402
+from fibsem.ui.widgets.microscope_defaults_widget import (  # noqa: E402
+    MicroscopeDefaultsWidget,
+)
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture()
+def microscope(tmp_path):
+    import yaml
+
+    path = tmp_path / "site.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            utils.load_yaml(
+                os.path.join(cfg.CONFIG_PATH, "microscope-configuration.yaml")
+            )
+        )
+    )
+    microscope, _ = utils.setup_session(config_path=str(path), manufacturer="Demo")
+    yield microscope
+    microscope.disconnect()
+
+
+@pytest.fixture()
+def widget(qapp, microscope):
+    w = MicroscopeDefaultsWidget()
+    w.set_microscope(microscope)
+    yield w
+    w.close()
+    w.deleteLater()
+
+
+def test_disabled_until_there_is_a_microscope(qapp):
+    w = MicroscopeDefaultsWidget()
+    assert not w.isEnabled()
+    w.deleteLater()
+
+
+def test_the_form_shows_the_configured_defaults(widget, microscope):
+    assert widget.electron.voltage.value() == microscope.system.electron.beam.voltage
+    assert widget.ion.voltage.value() == microscope.system.ion.beam.voltage
+    assert widget.electron.hfw.value() == pytest.approx(
+        microscope.system.electron.beam.hfw * 1e6
+    )
+
+
+def test_reading_from_the_microscope_takes_the_live_values(widget, microscope):
+    live = microscope.get_microscope_state().electron_beam.voltage
+    microscope.system.electron.beam.voltage = (live or 0) + 4321  # stale
+    widget.show_system()
+    assert widget.electron.voltage.value() != live
+
+    widget.read_from_microscope()
+
+    assert microscope.system.electron.beam.voltage == live
+    assert widget.electron.voltage.value() == live
+
+
+def test_saving_writes_the_defaults_section_and_nothing_else(widget, microscope):
+    path = microscope.configuration_path
+    before = utils.load_yaml(path)
+    widget.ion.voltage.set_value(8000)
+    widget.electron.hfw.setValue(80.0)
+
+    widget.save_to_configuration()
+
+    written = utils.load_yaml(path)
+    assert written["defaults"]["ion"]["voltage"] == 8000
+    assert written["defaults"]["electron"]["hfw"] == pytest.approx(80.0e-6)
+    assert written["hardware"] == before["hardware"]
+    assert written["calibration"] == before["calibration"]
+    assert written["defaults"]["imaging"] == before["defaults"]["imaging"]
+    assert written["defaults"]["apply_on_connect"] is False
+    assert utils.unrecognised_configuration_keys(written) == []
+    reloaded = MicroscopeSettings.from_dict(written)
+    assert reloaded.system.ion.beam.voltage == 8000
+
+
+def test_saving_does_not_touch_the_column(widget, microscope):
+    """Save decides what the defaults are; Apply is what pushes them."""
+    live_before = microscope.get_beam_settings(microscope.system.ion.beam_type).voltage
+    widget.ion.voltage.set_value(8000)
+
+    widget.save_to_configuration()
+
+    assert (
+        microscope.get_beam_settings(microscope.system.ion.beam_type).voltage
+        == live_before
+    )

--- a/tests/ui/test_microscope_defaults_widget.py
+++ b/tests/ui/test_microscope_defaults_widget.py
@@ -57,6 +57,10 @@ def test_disabled_until_there_is_a_microscope(qapp):
 
 def test_the_form_shows_the_configured_defaults(widget, microscope):
     assert widget.electron.voltage.value() == microscope.system.electron.beam.voltage
+    # The shipped 1536x1024, not the first item in the list: a tuple did not
+    # survive the combo box and the form showed 768x512 for every configuration.
+    assert widget.electron.resolution.value() == "1536x1024"
+    assert widget.electron.detector_type.value() == "ETD"
     assert widget.ion.voltage.value() == microscope.system.ion.beam.voltage
     assert widget.electron.hfw.value() == pytest.approx(
         microscope.system.electron.beam.hfw * 1e6

--- a/tests/ui/test_microscope_defaults_widget.py
+++ b/tests/ui/test_microscope_defaults_widget.py
@@ -23,6 +23,28 @@ def qapp():
     return QApplication.instance() or QApplication([])
 
 
+@pytest.fixture(autouse=True)
+def toasts(monkeypatch):
+    """Toasts go to a list, not to the notification service.
+
+    The service is a module-level QObject owned by whichever QApplication first
+    created it; a later test module's teardown can delete it, and the next toast
+    raises "wrapped C/C++ object has been deleted" from inside the widget under
+    test. The widgets' own behaviour is what these tests are about.
+    """
+    from fibsem.ui import notification_service
+
+    shown = []
+    monkeypatch.setattr(
+        notification_service,
+        "show_toast",
+        lambda message, notification_type="info": shown.append(
+            (message, notification_type)
+        ),
+    )
+    return shown
+
+
 @pytest.fixture()
 def microscope(tmp_path):
     import yaml
@@ -97,6 +119,26 @@ def test_saving_writes_the_defaults_section_and_nothing_else(widget, microscope)
     assert utils.unrecognised_configuration_keys(written) == []
     reloaded = MicroscopeSettings.from_dict(written)
     assert reloaded.system.ion.beam.voltage == 8000
+
+
+def test_saving_writes_the_seven_keys_and_no_alignment_state(widget, microscope):
+    """Not the beam shift, stigmation, scan rotation or working distance -- those
+    are alignment state, and written here Apply would push them back."""
+    microscope.system.electron.beam.working_distance = 0.0042
+    microscope.system.electron.beam.scan_rotation = 1.5
+
+    widget.save_to_configuration()
+
+    written = utils.load_yaml(microscope.configuration_path)["defaults"]["electron"]
+    assert set(written) == {
+        "voltage",
+        "current",
+        "hfw",
+        "resolution",
+        "dwell_time",
+        "detector_type",
+        "detector_mode",
+    }
 
 
 def test_saving_does_not_touch_the_column(widget, microscope):

--- a/tests/ui/test_objective_calibration_widget.py
+++ b/tests/ui/test_objective_calibration_widget.py
@@ -33,6 +33,28 @@ def qapp():
     return QApplication.instance() or QApplication([])
 
 
+@pytest.fixture(autouse=True)
+def toasts(monkeypatch):
+    """Toasts go to a list, not to the notification service.
+
+    The service is a module-level QObject owned by whichever QApplication first
+    created it; a later test module's teardown can delete it, and the next toast
+    raises "wrapped C/C++ object has been deleted" from inside the widget under
+    test. The widgets' own behaviour is what these tests are about.
+    """
+    from fibsem.ui import notification_service
+
+    shown = []
+    monkeypatch.setattr(
+        notification_service,
+        "show_toast",
+        lambda message, notification_type="info": shown.append(
+            (message, notification_type)
+        ),
+    )
+    return shown
+
+
 @pytest.fixture()
 def widget(qapp):
     from fibsem.ui.fm.overview_app import build_microscope


### PR DESCRIPTION
Stack: … → objective calibration (#855) → **this**. The UI half of rule 4 (the UI is the editor). Plan: *Microscope Configuration, from First Principles* §8.

`defaults:` holds what the columns start at, and until now the only way to set it was to type into the file. The setup tab gains a collapsible **Defaults** panel, shown once connected, beside the Apply button that consumes it:

- **Read from Microscope** — `capture_defaults()`, then the form shows it. Set the instrument up how you like it, press this.
- **The form** — electron and ion side by side: voltage and current from the instrument's own available values, field of view, resolution, dwell time, detector type and mode. Imaging defaults are left to the acquire tab, which already edits them live.
- **Save to Configuration** — writes `defaults.electron` and `defaults.ion` into the file the session was started from, and nothing else in it.

Nothing here touches the column; Apply is what pushes the defaults. `utils.write_configuration(path, updates)` is the one writer of the file from the application — a deep merge that preserves the rest at the parsed level; the objective calibration (#855) now goes through it.

**Two defects surfaced by building it, fixed in the second commit — one is a behaviour change on hardware:**

- **The detector keys were never read.** `to_dict` writes `detector_type` / `detector_mode` / `detector_brightness` / `detector_contrast`; `FibsemDetectorSettings.from_dict` read the bare names, so every shipped `detector_type: ETD` loaded as "Unknown" and a saved file lost its detector on the next load. Pre-existing on `main`, recorded rather than fixed until now because fixing it changes what Apply pushes. This panel made it destructive (the first Save would have written "Unknown" over every site's ETD), so it is fixed at the one seam where the prefixed spelling meets the record. **Apply now pushes the detector the file names.** Worth one look on a bench.
- Resolution tuples did not survive the combo box (`findData` on a tuple → index 0 → 768×512 shown for every file). Now "WxH" strings.

Gates: non-UI `1 failed / 5036 passed` (the pre-existing correlation failure); UI `2724 passed, 1 skipped`.