### PR TITLE
[ui] Correlation canvas: one Delete removes one point; manual FM contrast survives a z-scrub

### DIFF
--- a/fibsem/ui/correlation/widgets/coordinate_list_widget.py
+++ b/fibsem/ui/correlation/widgets/coordinate_list_widget.py
@@ -7,6 +7,7 @@ operate on the currently selected coordinate.
 Operates on a flat List[Coordinate]. Callers are responsible for
 flattening/reconstructing CorrelationInputData.
 """
+
 from __future__ import annotations
 
 from typing import Dict, List, Optional
@@ -53,10 +54,10 @@ _FITTED_ICON_COLOR = stylesheets.WHITE_ICON_COLOR
 _UNFITTED_ICON_COLOR = "#6b6f76"
 
 _POINT_TYPE_COLORS: Dict[PointType, str] = {
-    PointType.FIB:        "lime",
-    PointType.FM:         "cyan",
-    PointType.POI:        "magenta",
-    PointType.SURFACE:    "red",
+    PointType.FIB: "lime",
+    PointType.FM: "cyan",
+    PointType.POI: "magenta",
+    PointType.SURFACE: "red",
     PointType.SURFACE_FM: "yellow",
 }
 
@@ -88,7 +89,7 @@ def _name_col_width(point_type: Optional[PointType]) -> int:
     """
     label = f"{point_type.value if point_type else 'POINT'} 99"
     font = QApplication.font()  # the app-default family the label inherits...
-    font.setPixelSize(11)       # ...at the row/name label font-size
+    font.setPixelSize(11)  # ...at the row/name label font-size
     text_w = QFontMetrics(font).horizontalAdvance(label)
     return max(48, min(text_w + 14, _NAME_FIXED_WIDTH))  # +padding, clamped
 
@@ -96,6 +97,7 @@ def _name_col_width(point_type: Optional[PointType]) -> int:
 # ---------------------------------------------------------------------------
 # Draggable list
 # ---------------------------------------------------------------------------
+
 
 class _DraggableCoordinateList(QListWidget):
     """QListWidget with InternalMove drag-and-drop.
@@ -125,6 +127,7 @@ class _DraggableCoordinateList(QListWidget):
 # ---------------------------------------------------------------------------
 # Header
 # ---------------------------------------------------------------------------
+
 
 class _CoordinateListHeader(QWidget):
     """Sticky dark header with column labels, a color indicator for the
@@ -206,12 +209,13 @@ class _CoordinateListHeader(QWidget):
 # Row widget
 # ---------------------------------------------------------------------------
 
+
 class CoordinateRowWidget(QWidget):
     """Single row: read-only name, xyz spinboxes, trash button."""
 
-    row_clicked        = pyqtSignal(object)              # Coordinate
+    row_clicked = pyqtSignal(object)  # Coordinate
     coordinate_changed = pyqtSignal(object, str, float)  # Coordinate, field, value
-    remove_clicked     = pyqtSignal(object)              # Coordinate
+    remove_clicked = pyqtSignal(object)  # Coordinate
 
     def __init__(
         self,
@@ -238,17 +242,23 @@ class CoordinateRowWidget(QWidget):
         layout.addWidget(self.name_label)
 
         # XYZ spinboxes
-        self.x_spin = ValueSpinBox(decimals=3, minimum=-1e6, maximum=1e6, step=0.001, no_buttons=True)
+        self.x_spin = ValueSpinBox(
+            decimals=3, minimum=-1e6, maximum=1e6, step=0.001, no_buttons=True
+        )
         self.x_spin.setFixedWidth(_SPIN_FIXED_WIDTH)
         self.x_spin.setToolTip("X coordinate")
         layout.addWidget(self.x_spin)
 
-        self.y_spin = ValueSpinBox(decimals=3, minimum=-1e6, maximum=1e6, step=0.001, no_buttons=True)
+        self.y_spin = ValueSpinBox(
+            decimals=3, minimum=-1e6, maximum=1e6, step=0.001, no_buttons=True
+        )
         self.y_spin.setFixedWidth(_SPIN_FIXED_WIDTH)
         self.y_spin.setToolTip("Y coordinate")
         layout.addWidget(self.y_spin)
 
-        self.z_spin = ValueSpinBox(decimals=3, minimum=-1e6, maximum=1e6, step=0.001, no_buttons=True)
+        self.z_spin = ValueSpinBox(
+            decimals=3, minimum=-1e6, maximum=1e6, step=0.001, no_buttons=True
+        )
         self.z_spin.setFixedWidth(_SPIN_FIXED_WIDTH)
         self.z_spin.setToolTip("Z coordinate")
         layout.addWidget(self.z_spin)
@@ -263,9 +273,9 @@ class CoordinateRowWidget(QWidget):
         # status column; the colour encodes the state (white = auto-fit and
         # confirmed, grey = manually placed). coord.fitted clears on a manual
         # edit. Pixmaps are pre-rendered once and swapped on refresh.
-        self._icon_fitted = fibsem_icon(
-            "mdi:target", color=_FITTED_ICON_COLOR
-        ).pixmap(QSize(14, 14))
+        self._icon_fitted = fibsem_icon("mdi:target", color=_FITTED_ICON_COLOR).pixmap(
+            QSize(14, 14)
+        )
         self._icon_unfitted = fibsem_icon(
             "mdi:target", color=_UNFITTED_ICON_COLOR
         ).pixmap(QSize(14, 14))
@@ -352,9 +362,7 @@ class CoordinateRowWidget(QWidget):
     def _update_fitted_icon(self) -> None:
         """Colour the always-visible indicator by fit state (green vs grey)."""
         fitted = bool(getattr(self.coord, "fitted", False))
-        self.fitted_icon.setPixmap(
-            self._icon_fitted if fitted else self._icon_unfitted
-        )
+        self.fitted_icon.setPixmap(self._icon_fitted if fitted else self._icon_unfitted)
         self.fitted_icon.setToolTip(
             "Auto-fit and confirmed" if fitted else "Manually placed (not auto-fit)"
         )
@@ -389,6 +397,7 @@ class CoordinateRowWidget(QWidget):
 # Main list widget
 # ---------------------------------------------------------------------------
 
+
 class CoordinateListWidget(QWidget):
     """Reorderable list of Coordinate objects.
 
@@ -404,11 +413,11 @@ class CoordinateListWidget(QWidget):
     refit_requested      : Coordinate — header refit button clicked
     """
 
-    coordinate_selected  = pyqtSignal(object)              # Coordinate
-    coordinate_changed   = pyqtSignal(object, str, float)  # Coordinate, field, value
-    coordinate_removed   = pyqtSignal(object)              # Coordinate
-    order_changed        = pyqtSignal(list)                # List[Coordinate]
-    refit_requested      = pyqtSignal(object)              # Coordinate
+    coordinate_selected = pyqtSignal(object)  # Coordinate
+    coordinate_changed = pyqtSignal(object, str, float)  # Coordinate, field, value
+    coordinate_removed = pyqtSignal(object)  # Coordinate
+    order_changed = pyqtSignal(list)  # List[Coordinate]
+    refit_requested = pyqtSignal(object)  # Coordinate
 
     def __init__(
         self,
@@ -422,7 +431,9 @@ class CoordinateListWidget(QWidget):
         self._x_max: Optional[float] = None
         self._y_max: Optional[float] = None
         self._z_max: Optional[float] = None
-        self._default_header_color = _POINT_TYPE_COLORS.get(point_type) if point_type else None
+        self._default_header_color = (
+            _POINT_TYPE_COLORS.get(point_type) if point_type else None
+        )
         self._name_width = _name_col_width(point_type)
 
         self._setup_ui()
@@ -454,7 +465,9 @@ class CoordinateListWidget(QWidget):
 
         self._empty_label = QLabel("No coordinates")
         self._empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self._empty_label.setStyleSheet("color: #666; font-style: italic; padding: 8px;")
+        self._empty_label.setStyleSheet(
+            "color: #666; font-style: italic; padding: 8px;"
+        )
         self._empty_label.setVisible(True)
         layout.addWidget(self._empty_label)
 

--- a/fibsem/ui/correlation/widgets/coordinate_list_widget.py
+++ b/fibsem/ui/correlation/widgets/coordinate_list_widget.py
@@ -575,10 +575,12 @@ class CoordinateListWidget(QWidget):
         self.order_changed.emit(list(self._coordinates))
 
     def _on_remove(self, coord: Coordinate) -> None:
-        if coord not in self._coordinates:
+        # Identity, not equality: the overlay and the tab widget both key on the
+        # object, and two coordinates can hold equal values and still be different points.
+        idx = next((i for i, c in enumerate(self._coordinates) if c is coord), None)
+        if idx is None:
             return
-        idx = self._coordinates.index(coord)
-        self._coordinates.remove(coord)
+        del self._coordinates[idx]
 
         next_coord = None
         if self._coordinates:

--- a/fibsem/ui/correlation/widgets/correlation_point_overlay.py
+++ b/fibsem/ui/correlation/widgets/correlation_point_overlay.py
@@ -35,6 +35,7 @@ reordering. Index bookkeeping on removal — including shifting ``_selected`` �
 stays in the base, which is precisely the part a translation layer would have
 had to reimplement.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -57,17 +58,17 @@ if TYPE_CHECKING:
 # rather than to match the app palette — the same reasoning that keeps the
 # NEUTRAL_* ramp out of the tinted tokens.
 POINT_COLORS: Dict[PointType, str] = {
-    PointType.FIB:        "#00ff00",
-    PointType.FM:         "#00e5ff",
-    PointType.POI:        "#ff00ff",
-    PointType.SURFACE:    ORANGE_COLOR,
+    PointType.FIB: "#00ff00",
+    PointType.FM: "#00e5ff",
+    PointType.POI: "#ff00ff",
+    PointType.SURFACE: ORANGE_COLOR,
     PointType.SURFACE_FM: "#ffea00",
 }
 POINT_MARKERS: Dict[PointType, str] = {
-    PointType.FIB:        "o",
-    PointType.FM:         "o",
-    PointType.POI:        "o",
-    PointType.SURFACE:    "+",
+    PointType.FIB: "o",
+    PointType.FM: "o",
+    PointType.POI: "o",
+    PointType.SURFACE: "+",
     PointType.SURFACE_FM: "+",
 }
 MARKER_SIZE = 5.0  # the base draws the selected marker at size * 1.4 = 7.0
@@ -110,7 +111,8 @@ def legend_handle(
 
     edge_color, edge_width = marker_edge(color, marker, hollow)
     return Line2D(
-        [], [],
+        [],
+        [],
         marker=marker,
         markersize=7,
         color=color,
@@ -196,7 +198,9 @@ class CorrelationPointOverlay(PointOverlay):
 
     def selected_coordinate(self) -> Optional[Coordinate]:
         idx = self._selected
-        return self._coords[idx] if idx is not None and idx < len(self._coords) else None
+        return (
+            self._coords[idx] if idx is not None and idx < len(self._coords) else None
+        )
 
     def set_selected_coordinate(self, coord: Optional[Coordinate]) -> None:
         """Select by identity. Silent, like the base's ``set_selected``."""
@@ -634,7 +638,8 @@ class CorrelationResultOverlay(CanvasOverlay):
         edge_color, edge_width = marker_edge(group.color, group.marker, group.hollow)
         for i, (x, y) in enumerate(group.points, start=1):
             (line,) = self._ax.plot(
-                x, y,
+                x,
+                y,
                 marker=group.marker,
                 markersize=group.size,
                 color=group.color,

--- a/fibsem/ui/correlation/widgets/correlation_point_overlay.py
+++ b/fibsem/ui/correlation/widgets/correlation_point_overlay.py
@@ -145,7 +145,7 @@ class CorrelationPointOverlay(PointOverlay):
     # ones still fire; consumers here should use these.
     coordinate_selected = pyqtSignal(object)  # Coordinate
     coordinate_moved = pyqtSignal(object)  # Coordinate (drag finished)
-    coordinate_removed = pyqtSignal(object)  # Coordinate (before removal)
+    coordinate_removed = pyqtSignal(object)  # Coordinate (emitted after removal)
     # The view decides which PointType a new point gets (it owns the menu), so
     # the overlay only reports where the user asked for one.
     add_requested = pyqtSignal(float, float)  # x, y
@@ -162,7 +162,6 @@ class CorrelationPointOverlay(PointOverlay):
         self._surface_coord: Optional[Coordinate] = None
         self.point_selected.connect(self._emit_selected)
         self.point_moved.connect(self._emit_moved)
-        self.point_removed.connect(self._emit_removed)
 
     # ── model ─────────────────────────────────────────────────────────────
 
@@ -227,12 +226,15 @@ class CorrelationPointOverlay(PointOverlay):
     def remove_point(self, index: int) -> None:
         if index < 0 or index >= len(self._coords):
             return
-        # super() emits point_removed(index) before it pops, so _emit_removed can
-        # still read _coords[index]; pop only once it returns.
-        super().remove_point(index)
-        self._coords.pop(index)
+        # Pop our side first so _coords stays index-aligned with the base's
+        # _points while super() redraws, then announce the Coordinate only once
+        # the overlay is fully consistent: the tab widget answers by rebuilding
+        # us from its model, which must not race a half-finished removal.
+        coord = self._coords.pop(index)
         self._names = generate_names(self._coords)
+        super().remove_point(index)
         self._refresh_chrome()
+        self.coordinate_removed.emit(coord)
 
     def clear_points(self) -> None:
         super().clear_points()
@@ -457,10 +459,6 @@ class CorrelationPointOverlay(PointOverlay):
         coord = self._coords[idx]
         coord.point.x, coord.point.y = float(x), float(y)
         self.coordinate_moved.emit(coord)
-
-    def _emit_removed(self, idx: int) -> None:
-        if idx < len(self._coords):
-            self.coordinate_removed.emit(self._coords[idx])
 
     def _refresh_chrome(self) -> None:
         """Re-derive the labels and the legend after the coordinate set changes.

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -9,6 +9,7 @@ contrast — the napari layer-controls equivalent, on matplotlib.
 Display only (Phase 6a); FM canvas interactions (position select, relative move)
 are Phase 6b.
 """
+
 from __future__ import annotations
 
 from dataclasses import replace
@@ -72,7 +73,7 @@ _ACCENT = ACCENT_COLOR
 # ACCENT_COLOR carries the pill with it; a hand-picked hex would silently fall
 # out of step.
 _ACCENT_WASH = "rgba({}, {}, {}, 0.16)".format(
-    *(int(ACCENT_COLOR[i:i + 2], 16) for i in (1, 3, 5))
+    *(int(ACCENT_COLOR[i : i + 2], 16) for i in (1, 3, 5))
 )
 
 # The ‹ › buttons flanking the z-slider. Outside _PANEL_QSS because that stylesheet
@@ -131,7 +132,9 @@ def _color_icon(color: str, size: int = 14) -> QIcon:
 
 
 def _chip_css(color: str) -> str:
-    return "background: %s; border-radius: 3px;" % ("white" if color == "gray" else color)
+    return "background: %s; border-radius: 3px;" % (
+        "white" if color == "gray" else color
+    )
 
 
 class _ContrastSlider(QRangeSlider):
@@ -165,7 +168,9 @@ class _ChannelRow(QFrame):
     selected = pyqtSignal(int)
     visibility_changed = pyqtSignal(int, bool)
 
-    def __init__(self, index: int, layer: FMLayer, parent: Optional[QWidget] = None) -> None:
+    def __init__(
+        self, index: int, layer: FMLayer, parent: Optional[QWidget] = None
+    ) -> None:
         super().__init__(parent)
         self._index = index
         self.setObjectName("channelRow")
@@ -250,13 +255,17 @@ class FMCanvasWidget(QWidget):
         # rather than absent -- an AttributeError inside a paint aborts the process
         # under PyQt5 rather than raising (FIB-329).
         self._blended_planes: Dict[str, np.ndarray] = {}
-        self._shape: Optional[Tuple[int, int]] = None  # composite target shape (last upserted layer)
+        self._shape: Optional[Tuple[int, int]] = (
+            None  # composite target shape (last upserted layer)
+        )
         # z-stack scrubbing: keep the full ZYX stack per channel + display state
-        self._stacks: Dict[str, np.ndarray] = {}   # channel name -> ZYX stack
-        self._mip_clim: Dict[str, Tuple[float, float]] = {}  # fixed clim while scrubbing
+        self._stacks: Dict[str, np.ndarray] = {}  # channel name -> ZYX stack
+        self._mip_clim: Dict[
+            str, Tuple[float, float]
+        ] = {}  # fixed clim while scrubbing
         self._z_index: int = 0
-        self._z_max: int = 0                        # nz - 1
-        self._max_projection: bool = True           # default: MIP (behaviour-preserving)
+        self._z_max: int = 0  # nz - 1
+        self._max_projection: bool = True  # default: MIP (behaviour-preserving)
 
         lay = QVBoxLayout(self)
         lay.setContentsMargins(0, 0, 0, 0)
@@ -291,10 +300,15 @@ class FMCanvasWidget(QWidget):
         )
         # max-projection toggle (checked = MIP; uncheck to scrub the z-slider)
         self._btn_mip = self.canvas.add_toolbar_button(
-            "mdi:arrow-collapse-vertical", "Max projection", self._on_mip_button, checkable=True
+            "mdi:arrow-collapse-vertical",
+            "Max projection",
+            self._on_mip_button,
+            checkable=True,
         )
         self._btn_mip.setChecked(True)
-        self._btn_mip.setVisible(False)  # shown only once a multi-plane z-stack is loaded
+        self._btn_mip.setVisible(
+            False
+        )  # shown only once a multi-plane z-stack is loaded
         # FM contrast/gamma is per-channel (layers popover); the canvas's built-in
         # grayscale contrast button does nothing on the RGB composite — hide it.
         self.canvas.btn_contrast.hide()
@@ -306,7 +320,9 @@ class FMCanvasWidget(QWidget):
 
     # ── public API ────────────────────────────────────────────────────────
 
-    def _upsert_layer(self, name: str, data: np.ndarray, color: Optional[str]) -> FMLayer:
+    def _upsert_layer(
+        self, name: str, data: np.ndarray, color: Optional[str]
+    ) -> FMLayer:
         """Create or update a channel's layer (2-D data + colour); display props preserved.
 
         Rebuilds the panel list only when a channel is added — a data-only update (live
@@ -366,7 +382,9 @@ class FMCanvasWidget(QWidget):
         """
         return False
 
-    def set_channel(self, name: str, data: np.ndarray, color: Optional[str] = None) -> None:
+    def set_channel(
+        self, name: str, data: np.ndarray, color: Optional[str] = None
+    ) -> None:
         """Upsert a channel's 2-D image (live path — no z-stack); display props preserved.
 
         Setting several channels? Use :meth:`set_channels`. Each call here recomposites,
@@ -423,11 +441,11 @@ class FMCanvasWidget(QWidget):
         self._mip_clim = {}
         self._z_index = 0
         for ci, channel in enumerate(md.channels):
-            if data.ndim >= 4:        # CZYX
+            if data.ndim >= 4:  # CZYX
                 stack = np.asarray(data[ci])
-            elif data.ndim == 3:      # ZYX (single channel)
+            elif data.ndim == 3:  # ZYX (single channel)
                 stack = np.asarray(data)
-            else:                      # 2-D single plane
+            else:  # 2-D single plane
                 stack = np.asarray(data)[None]
             self._stacks[channel.name] = stack
             self._upsert_layer(channel.name, stack.max(axis=0), channel.color)
@@ -684,7 +702,9 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         self._held: Dict[str, Dict[str, np.ndarray]] = {}
         # Auto contrast limits per placed image per channel, as
         # ``{key: {channel: (source_plane, (lo, hi))}}``. See `_auto_clim`.
-        self._held_clim: Dict[str, Dict[str, Tuple[np.ndarray, Tuple[float, float]]]] = {}
+        self._held_clim: Dict[
+            str, Dict[str, Tuple[np.ndarray, Tuple[float, float]]]
+        ] = {}
 
     def _make_canvas(self) -> FibsemCanvasBase:
         return FibsemRealSpaceCanvas()
@@ -742,9 +762,13 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         """
         self._placement = (float(centre[0]), float(centre[1]))
 
-    def set_world_extent(self, width: Optional[float], height: Optional[float] = None,
-                         centre: Tuple[float, float] = (0.0, 0.0),
-                         refit: bool = True) -> None:
+    def set_world_extent(
+        self,
+        width: Optional[float],
+        height: Optional[float] = None,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        refit: bool = True,
+    ) -> None:
         """Declare the working area the canvas represents — see the canvas method."""
         self.canvas.set_world_extent(width, height, centre, refit)
 
@@ -771,7 +795,10 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         # inferring placed a mosaic reduced 10x at a tenth of its size.
         covers = None
         if self._shape:
-            covers = (self._shape[1] * self._pixel_size, self._shape[0] * self._pixel_size)
+            covers = (
+                self._shape[1] * self._pixel_size,
+                self._shape[0] * self._pixel_size,
+            )
         # Keep this image's planes at *acquisition* resolution: they are what `_patch`
         # slices, so how far a zoom can go is set by what is kept here. No reduction is
         # cached beside them -- the canvas holds the patch it last fetched and refetches
@@ -870,7 +897,9 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
             x0 / width, x1 / width, y0 / height, y1 / height
         )
 
-    def _auto_clim(self, key: str, name: str, source: np.ndarray) -> Tuple[float, float]:
+    def _auto_clim(
+        self, key: str, name: str, source: np.ndarray
+    ) -> Tuple[float, float]:
         """Auto contrast limits for one channel of one placed image, computed once.
 
         **Pinned to the whole image, not to what is drawn of it.** `composite_fm_layers`
@@ -950,7 +979,8 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         key = self._composite_key
         reduced = [
             self._pinned(key, layer, layer.data, self._reduce(layer.data))
-            if layer.data is not None else layer
+            if layer.data is not None
+            else layer
             for layer in self._layers
         ]
         first = next((layer.data for layer in reduced if layer.data is not None), None)
@@ -1008,42 +1038,62 @@ class FMLayersPanel(QFrame):
         root.setSpacing(0)
 
         # header
-        header = QHBoxLayout(); header.setSpacing(8)
+        header = QHBoxLayout()
+        header.setSpacing(8)
         hicon = QLabel()
         hicon.setPixmap(
-            fibsem_icon("mdi:layers-triple-outline", color=TEXT_MUTED_COLOR).pixmap(QSize(16, 16))
+            fibsem_icon("mdi:layers-triple-outline", color=TEXT_MUTED_COLOR).pixmap(
+                QSize(16, 16)
+            )
         )
-        title = QLabel("FM CHANNELS"); title.setObjectName("panelTitle")
-        header.addWidget(hicon); header.addWidget(title); header.addStretch()
+        title = QLabel("FM CHANNELS")
+        title.setObjectName("panelTitle")
+        header.addWidget(hicon)
+        header.addWidget(title)
+        header.addStretch()
         root.addLayout(header)
         root.addSpacing(12)
 
         # channel list
-        self._list_box = QVBoxLayout(); self._list_box.setSpacing(2)
+        self._list_box = QVBoxLayout()
+        self._list_box.setSpacing(2)
         root.addLayout(self._list_box)
         root.addSpacing(12)
 
-        div = QFrame(); div.setObjectName("divider"); div.setFixedHeight(1)
+        div = QFrame()
+        div.setObjectName("divider")
+        div.setFixedHeight(1)
         root.addWidget(div)
         root.addSpacing(12)
 
         # detail header (selected channel)
-        dh = QHBoxLayout(); dh.setSpacing(8)
-        self.sel_chip = QLabel(); self.sel_chip.setFixedSize(11, 11)
-        self.sel_name = QLabel("—"); self.sel_name.setObjectName("selName")
-        sel_tag = QLabel("selected"); sel_tag.setObjectName("selTag")
-        dh.addWidget(self.sel_chip); dh.addWidget(self.sel_name); dh.addStretch(); dh.addWidget(sel_tag)
+        dh = QHBoxLayout()
+        dh.setSpacing(8)
+        self.sel_chip = QLabel()
+        self.sel_chip.setFixedSize(11, 11)
+        self.sel_name = QLabel("—")
+        self.sel_name.setObjectName("selName")
+        sel_tag = QLabel("selected")
+        sel_tag.setObjectName("selTag")
+        dh.addWidget(self.sel_chip)
+        dh.addWidget(self.sel_name)
+        dh.addStretch()
+        dh.addWidget(sel_tag)
         root.addLayout(dh)
         root.addSpacing(14)
 
         # colormap
         cm_row = QHBoxLayout()
-        cm_lbl = QLabel("Colormap"); cm_lbl.setObjectName("ctrlLbl")
-        self.colormap = QComboBox(); self.colormap.setFixedWidth(132)
+        cm_lbl = QLabel("Colormap")
+        cm_lbl.setObjectName("ctrlLbl")
+        self.colormap = QComboBox()
+        self.colormap.setFixedWidth(132)
         for c in AVAILABLE_COLORS:
             self.colormap.addItem(_color_icon(c), c)
         self.colormap.currentTextChanged.connect(self._on_colormap)
-        cm_row.addWidget(cm_lbl); cm_row.addStretch(); cm_row.addWidget(self.colormap)
+        cm_row.addWidget(cm_lbl)
+        cm_row.addStretch()
+        cm_row.addWidget(self.colormap)
         root.addLayout(cm_row)
         root.addSpacing(13)
 
@@ -1055,41 +1105,58 @@ class FMLayersPanel(QFrame):
 
         # contrast header (label + Auto pill)
         ch = QHBoxLayout()
-        ct_lbl = QLabel("Contrast"); ct_lbl.setObjectName("ctrlLbl")
-        self.autocontrast_cb = QPushButton("Auto"); self.autocontrast_cb.setObjectName("autoPill")
-        self.autocontrast_cb.setCheckable(True); self.autocontrast_cb.setChecked(True)
+        ct_lbl = QLabel("Contrast")
+        ct_lbl.setObjectName("ctrlLbl")
+        self.autocontrast_cb = QPushButton("Auto")
+        self.autocontrast_cb.setObjectName("autoPill")
+        self.autocontrast_cb.setCheckable(True)
+        self.autocontrast_cb.setChecked(True)
         self.autocontrast_cb.setCursor(Qt.PointingHandCursor)
         self.autocontrast_cb.toggled.connect(self._on_autocontrast)
-        ch.addWidget(ct_lbl); ch.addStretch(); ch.addWidget(self.autocontrast_cb)
+        ch.addWidget(ct_lbl)
+        ch.addStretch()
+        ch.addWidget(self.autocontrast_cb)
         root.addLayout(ch)
         root.addSpacing(8)
 
         self.contrast = _ContrastSlider(Qt.Horizontal)
-        self.contrast.setRange(0, 1000); self.contrast.setValue((0, 1000))
+        self.contrast.setRange(0, 1000)
+        self.contrast.setValue((0, 1000))
         self.contrast.valueChanged.connect(self._on_contrast)
         root.addWidget(self.contrast)
         root.addSpacing(8)
 
         cv = QHBoxLayout()
-        self.cmin_val = QLabel("0"); self.cmin_val.setObjectName("valSm")
-        self.cmax_val = QLabel("0"); self.cmax_val.setObjectName("valSm")
-        cv.addWidget(self.cmin_val); cv.addStretch(); cv.addWidget(self.cmax_val)
+        self.cmin_val = QLabel("0")
+        self.cmin_val.setObjectName("valSm")
+        self.cmax_val = QLabel("0")
+        self.cmax_val.setObjectName("valSm")
+        cv.addWidget(self.cmin_val)
+        cv.addStretch()
+        cv.addWidget(self.cmax_val)
         root.addLayout(cv)
         root.addSpacing(14)
 
-        self.btn_reset = QPushButton("Reset adjustments"); self.btn_reset.setObjectName("resetBtn")
+        self.btn_reset = QPushButton("Reset adjustments")
+        self.btn_reset.setObjectName("resetBtn")
         self.btn_reset.setCursor(Qt.PointingHandCursor)
         self.btn_reset.clicked.connect(self._on_reset)
         root.addWidget(self.btn_reset)
 
     def _slider_row(self, root, label: str, lo: int, hi: int, val: int):
         head = QHBoxLayout()
-        lbl = QLabel(label); lbl.setObjectName("ctrlLbl")
-        valw = QLabel(); valw.setObjectName("valLbl")
-        head.addWidget(lbl); head.addStretch(); head.addWidget(valw)
+        lbl = QLabel(label)
+        lbl.setObjectName("ctrlLbl")
+        valw = QLabel()
+        valw.setObjectName("valLbl")
+        head.addWidget(lbl)
+        head.addStretch()
+        head.addWidget(valw)
         root.addLayout(head)
         root.addSpacing(7)
-        s = QSlider(Qt.Horizontal); s.setRange(lo, hi); s.setValue(val)
+        s = QSlider(Qt.Horizontal)
+        s.setRange(lo, hi)
+        s.setValue(val)
         root.addWidget(s)
         root.addSpacing(13)
         return s, valw
@@ -1128,7 +1195,11 @@ class FMLayersPanel(QFrame):
             row.set_selected(i == self._selected)
 
     def _current(self) -> Optional[FMLayer]:
-        return self._layers[self._selected] if 0 <= self._selected < len(self._layers) else None
+        return (
+            self._layers[self._selected]
+            if 0 <= self._selected < len(self._layers)
+            else None
+        )
 
     def _sync_detail(self) -> None:
         layer = self._current()
@@ -1146,7 +1217,9 @@ class FMLayersPanel(QFrame):
             self.gamma.setValue(int(layer.gamma * 100))
             self.gamma_val.setText("%.2f" % layer.gamma)
             self.autocontrast_cb.setChecked(layer.autocontrast)
-            self.contrast.setEnabled(not layer.autocontrast)  # manual edits only when off
+            self.contrast.setEnabled(
+                not layer.autocontrast
+            )  # manual edits only when off
             if layer.data is not None:
                 d = np.asarray(layer.data, dtype=np.float32)
                 lo_d, hi_d = float(d.min()), float(d.max())
@@ -1156,10 +1229,12 @@ class FMLayersPanel(QFrame):
                 else:
                     clo, chi = layer.clim
                 self._data_lo, self._data_span = lo_d, span
-                self.contrast.setValue((
-                    int((clo - lo_d) / span * 1000),
-                    int((chi - lo_d) / span * 1000),
-                ))
+                self.contrast.setValue(
+                    (
+                        int((clo - lo_d) / span * 1000),
+                        int((chi - lo_d) / span * 1000),
+                    )
+                )
                 self.cmin_val.setText("%d" % round(clo))
                 self.cmax_val.setText("%d" % round(chi))
         self._updating = prev_updating
@@ -1216,7 +1291,9 @@ class FMLayersPanel(QFrame):
         if self._updating or layer is None:
             return
         layer.autocontrast = checked
-        layer.manual = not checked  # explicit user choice — survives live frames / MIP toggles
+        layer.manual = (
+            not checked
+        )  # explicit user choice — survives live frames / MIP toggles
         if not checked and layer.clim is None and layer.data is not None:
             # seed manual limits from the current auto values so the image doesn't jump
             layer.clim = auto_clim(np.asarray(layer.data, dtype=np.float32))

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -582,7 +582,9 @@ class FMCanvasWidget(QWidget):
                 if not layer.manual:
                     layer.autocontrast = True
                     layer.clim = None
-            else:
+            elif not layer.manual:
+                # Same guard as above: a z-scrub holds one MIP-derived clim across
+                # planes, but never over a contrast range the user set by hand.
                 clim = self._mip_clim.get(layer.name)
                 if clim is None:
                     clim = auto_clim(stack.max(axis=0))

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -379,7 +379,7 @@ class PointOverlay(QObject):
     point_selected = pyqtSignal(int, float, float)  # index, x, y
     point_dragging = pyqtSignal(int, float, float)  # index, x, y  (each motion step)
     point_moved = pyqtSignal(int, float, float)  # index, x, y  (on release)
-    point_removed = pyqtSignal(int)  # index (before removal)
+    point_removed = pyqtSignal(int)  # index the point held (emitted after removal)
 
     def __init__(
         self,
@@ -508,7 +508,6 @@ class PointOverlay(QObject):
         """Remove the point at *index*."""
         if index < 0 or index >= len(self._points):
             return
-        self.point_removed.emit(index)
         for lst in (self._artists, self._anns):
             a = lst.pop(index)
             if a is not None:
@@ -525,6 +524,10 @@ class PointOverlay(QObject):
             self._refresh_ann_text()
         if self._canvas is not None:
             self._canvas.draw_idle()
+        # Emit LAST. A direct-connected listener may rebuild this overlay from its
+        # own model (set_points) while handling the signal; emitting before the pop
+        # made the pop below run on the rebuilt lists and remove a second point.
+        self.point_removed.emit(index)
 
     def clear_points(self) -> None:
         self._selected = None

--- a/tests/ui/test_correlation_point_removal.py
+++ b/tests/ui/test_correlation_point_removal.py
@@ -1,0 +1,105 @@
+"""Deleting one point on the correlation canvas removes exactly one point (FIB-958).
+
+`PointOverlay.remove_point` used to emit `point_removed(index)` before popping its own
+lists. The tab widget answers that signal by filtering its list model and rebuilding
+the overlay from it (`set_coordinates`), so by the time the base method resumed and
+popped `index`, the lists had already been rebuilt without the point and the pop took
+whichever point now sat there. One Delete removed two markers from the canvas while
+the list widget -- the source of truth for the run button -- still held the second.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_correlation_point_removal.py
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.correlation.structures import Coordinate, PointType, PointXYZ
+from fibsem.ui.correlation.widgets.coordinate_list_widget import CoordinateListWidget
+from fibsem.ui.correlation.widgets.correlation_canvas_widget import (
+    CorrelationCanvasWidget,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _make_canvas(n: int = 5):
+    w = CorrelationCanvasWidget()
+    w.set_image(np.zeros((200, 200), np.uint8))
+    ov = w.picking.points
+    model = [
+        Coordinate(PointXYZ(20 + i * 30, 20 + i * 30, 0), PointType.FIB)
+        for i in range(n)
+    ]
+    ov.set_coordinates(model)
+
+    removed = []
+
+    def on_removed(c):  # mirrors CorrelationTabWidget._on_canvas_removed
+        removed.append(c)
+        model[:] = [x for x in model if x is not c]
+        ov.set_coordinates(model)  # == _refresh_canvas
+
+    w.point_removed.connect(on_removed)
+    return w, ov, model, removed
+
+
+def _assert_in_sync(ov, model):
+    assert len(model) == len(ov.coordinates()) == len(ov._points) == len(ov._artists)
+    assert [c.point.x for c in ov.coordinates()] == [c.point.x for c in model]
+    assert [p[0] for p in ov._points] == [c.point.x for c in model]
+
+
+@pytest.mark.parametrize("index", [0, 1, 3, 4])
+def test_remove_via_canvas_removes_exactly_one_point(index):
+    w, ov, model, removed = _make_canvas(5)
+    target = model[index]
+
+    ov.remove_point(index)
+
+    assert removed == [target]
+    assert target not in model
+    _assert_in_sync(ov, model)
+    assert len(model) == 4
+    w.close()
+
+
+def test_remove_every_point_one_at_a_time_stays_in_sync():
+    w, ov, model, removed = _make_canvas(5)
+    while model:
+        ov.remove_point(0)
+        _assert_in_sync(ov, model)
+    assert len(removed) == 5
+    w.close()
+
+
+def test_remove_coordinate_by_identity_emits_that_coordinate():
+    w, ov, model, removed = _make_canvas(3)
+    ov.remove_coordinate(model[2])
+    assert len(removed) == 1 and removed[0].point.x == 80
+    _assert_in_sync(ov, model)
+    w.close()
+
+
+def test_list_widget_removes_by_identity_not_equality():
+    lw = CoordinateListWidget(point_type=PointType.FIB)
+    twin_a = Coordinate(PointXYZ(10, 10, 0), PointType.FIB)
+    twin_b = Coordinate(PointXYZ(10, 10, 0), PointType.FIB)
+    assert twin_a == twin_b and twin_a is not twin_b
+    lw.coordinates = [twin_a, twin_b]
+
+    lw._on_remove(twin_b)
+
+    assert lw.coordinates == [twin_a]
+    assert lw.coordinates[0] is twin_a
+    lw.close()

--- a/tests/ui/test_fm_canvas_manual_contrast_survives_z.py
+++ b/tests/ui/test_fm_canvas_manual_contrast_survives_z.py
@@ -1,0 +1,73 @@
+"""A contrast range the user set by hand survives a z-slice change (FIB-959).
+
+`FMCanvasWidget._apply_z_mode` runs on every z-slider move. Its MIP / single-plane
+branch already honoured `layer.manual` (FIB-743); the z-scrub branch did not, and
+unconditionally wrote the MIP-derived auto clim back. The correlation FM display
+defaults to planes rather than MIP, so every scrub there reverted a manual contrast
+edit. Gamma is not touched by `_apply_z_mode`, which is why the reset looked
+intermittent to users: gamma-only edits persisted, contrast edits did not.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_fm_canvas_manual_contrast_survives_z.py
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.correlation.widgets.correlation_fm_canvas_widget import (
+    CorrelationFMCanvasWidget,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _make_widget():
+    w = CorrelationFMCanvasWidget()
+    rng = np.random.default_rng(0)
+    stack = (rng.random((3, 64, 64)) * 1000).astype(np.uint16)
+    w._stacks = {"GFP": stack}
+    layer = w._upsert_layer("GFP", stack.max(axis=0), "green")
+    w._max_projection = False
+    w._z_index = 0
+    w._apply_z_mode()
+    return w, layer
+
+
+def test_manual_clim_and_gamma_survive_z_change():
+    w, layer = _make_widget()
+    layer.manual = True
+    layer.autocontrast = False
+    layer.clim = (100.0, 200.0)
+    layer.gamma = 0.5
+
+    w._on_z_changed(1)
+    assert layer.clim == (100.0, 200.0)
+    assert layer.gamma == 0.5
+    assert layer.manual is True
+
+    w._on_z_changed(2)
+    assert layer.clim == (100.0, 200.0)
+    w.close()
+
+
+def test_auto_clim_is_held_constant_across_planes():
+    w, layer = _make_widget()
+    assert layer.manual is False
+    first = layer.clim
+    assert first is not None
+
+    w._on_z_changed(1)
+    assert layer.clim == first
+    w._on_z_changed(2)
+    assert layer.clim == first
+    w.close()


### PR DESCRIPTION
Fixes FIB-958 and FIB-959, the two High bugs from the September correlation feedback batch.

## FIB-958: deleting a point on the canvas removed a second one from the display but not the list

`PointOverlay.remove_point` emitted `point_removed(index)` **before** popping its own artists and points. The correlation tab answers that signal synchronously by filtering its list model and rebuilding the overlay from it, so by the time the base method resumed, its lists had already been rebuilt without the point and the pop took whichever point now sat at that index. One Delete removed two markers from the canvas while the list widget (the source of truth for Run) still held the second. Deleting the *last* point raised `IndexError` instead, which is why it looked intermittent.

- Base overlay now pops first and emits last.
- `CorrelationPointOverlay` captures the `Coordinate`, pops `_coords` before calling super so the two lists stay index-aligned through the redraw, and emits `coordinate_removed` itself once consistent. The pre-pop `_emit_removed` slot is gone.
- `CoordinateListWidget._on_remove` matches by identity like the overlay and tab widget, so two equal-valued coordinates cannot remove the wrong row.

## FIB-959: manual contrast reverted to auto on every z-slice change

`FMCanvasWidget._apply_z_mode` runs on every z-slider move. Its MIP / single-plane branch already checked `layer.manual` (FIB-743); the z-scrub branch did not and wrote the MIP-derived clim back unconditionally. The correlation FM display defaults to planes, so every scrub there reverted a contrast edit. Gamma is not touched by `_apply_z_mode`, hence "it resets only sometimes": gamma-only edits persisted, contrast edits did not.

The z-scrub branch now carries the same guard. Auto-on behaviour is unchanged.

## Commits

1. `[format]` whitespace-only reformat of the three touched files (AST-identical), so the lint job's format-on-touch check passes and the review is not buried in wrapping.
2. FIB-958 fix + `tests/ui/test_correlation_point_removal.py`
3. FIB-959 fix + `tests/ui/test_fm_canvas_manual_contrast_survives_z.py`

## Verification

- New tests fail on `main`, pass here. 68 tests across the touched areas pass offscreen.
- Before/after screenshots from one script run against `main` and this branch: deleting point 2 of 5 left 3 on the canvas and 4 in the list before, 4 and 4 after; a manual clim of (900, 1000) became (223, 996) after a z-scrub before, and holds after.
- Tried by hand in the `test_correlation_tab_widget` launcher on a real project directory; log clean.