### PR TITLE
[ui] FM channels panel: drag to move, close button, hides with its host

### DIFF
--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -16,9 +16,10 @@ from dataclasses import replace
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
-from PyQt5.QtCore import QPoint, QSize, Qt, pyqtSignal
+from PyQt5.QtCore import QPoint, QRect, QSize, Qt, pyqtSignal
 from PyQt5.QtGui import QColor, QIcon, QPainter, QPixmap
 from PyQt5.QtWidgets import (
+    QApplication,
     QComboBox,
     QFrame,
     QHBoxLayout,
@@ -102,6 +103,8 @@ QFrame#channelRow {{ border-radius: 7px; background: transparent; }}
 QFrame#channelRow:hover {{ background: {ROW_ALT_COLOR}; }}
 QFrame#channelRow[selected="true"] {{ background: {BORDER_COLOR}; }}
 QToolButton#eyeBtn {{ border: none; background: transparent; padding: 0; }}
+QToolButton#closeBtn {{ border: none; background: transparent; border-radius: 9px; padding: 0; }}
+QToolButton#closeBtn:hover {{ background: {BORDER_COLOR}; }}
 #chName {{ color: {TEXT_STRONG_COLOR}; font-size: 13px; }}
 QComboBox {{ background: {PANEL_COLOR}; color: {TEXT_STRONG_COLOR}; border: 1px solid {BORDER_COLOR};
             border-radius: 6px; padding: 4px 8px; font-size: 12px; }}
@@ -316,6 +319,8 @@ class FMCanvasWidget(QWidget):
 
         self._panel = FMLayersPanel(self)
         self._panel.changed.connect(self._restyle)
+        self._panel.moved.connect(self._on_panel_moved)
+        self._panel.close_requested.connect(self._close_layers_panel)
         self._panel.hide()
 
     # ── public API ────────────────────────────────────────────────────────
@@ -654,16 +659,43 @@ class FMCanvasWidget(QWidget):
         else:
             self._panel.hide()
 
+    # Where the user last dragged the panel to, as an offset from the canvas's
+    # top-right corner. Class-level on purpose: the correlation dialog builds a fresh
+    # FM canvas per site, and the panel should reopen where it was left, not snap
+    # back to the corner every site. None = never moved = the default spot.
+    _panel_offset: Optional[QPoint] = None
+
+    def _panel_anchor(self) -> QPoint:
+        """The canvas's top-right corner in global coordinates (the toolbar lives there)."""
+        return self.canvas.mapToGlobal(QPoint(self.canvas.width() - 8, 44))
+
     def _position_panel(self) -> None:
         self._panel.adjustSize()
-        # top-level window → anchor near the canvas top-right in global coordinates
-        anchor = self.canvas.mapToGlobal(QPoint(self.canvas.width() - 8, 44))
-        self._panel.move(anchor.x() - self._panel.width(), anchor.y())
+        anchor = self._panel_anchor()
+        if FMCanvasWidget._panel_offset is None:
+            pos = QPoint(anchor.x() - self._panel.width(), anchor.y())
+        else:
+            pos = anchor + FMCanvasWidget._panel_offset
+        self._panel.move(_clamp_to_screen(pos, self._panel.size(), anchor))
+
+    def _on_panel_moved(self) -> None:
+        FMCanvasWidget._panel_offset = self._panel.pos() - self._panel_anchor()
+
+    def _close_layers_panel(self) -> None:
+        self._panel.hide()
+        self._btn_layers.setChecked(False)
 
     def resizeEvent(self, event) -> None:
         super().resizeEvent(event)
         if self._panel.isVisible():
             self._position_panel()
+
+    def hideEvent(self, event) -> None:
+        # The panel is a top-level tool window, so it does not go away with this
+        # widget on its own: closing the correlation dialog for one site left it
+        # floating over whatever came next (FIB-962).
+        self._close_layers_panel()
+        super().hideEvent(event)
 
 
 class FMRealSpaceCanvasWidget(FMCanvasWidget):
@@ -1010,12 +1042,29 @@ class FMRealSpaceCanvasWidget(FMCanvasWidget):
         self._pixel_size = pixel_size
 
 
+def _clamp_to_screen(pos: QPoint, size: QSize, near: QPoint) -> QPoint:
+    """Keep a top-level panel fully on the screen that holds *near*.
+
+    A remembered offset can point off-screen once the window moves to a smaller
+    display, and a frameless window with its header off-screen cannot be dragged back.
+    """
+    screen = QApplication.screenAt(near) or QApplication.primaryScreen()
+    if screen is None:
+        return pos
+    avail: QRect = screen.availableGeometry()
+    x = min(max(pos.x(), avail.left()), avail.right() - size.width() + 1)
+    y = min(max(pos.y(), avail.top()), avail.bottom() - size.height() + 1)
+    return QPoint(x, y)
+
+
 class FMLayersPanel(QFrame):
     """Floating per-channel controls — a dark channel list (eye toggle + colour chip
     + name) over a detail panel (colormap / opacity / gamma / contrast) for the
     selected channel. Emits :attr:`changed` whenever an edit needs a re-composite."""
 
     changed = pyqtSignal()
+    moved = pyqtSignal()  # the user finished dragging the panel somewhere
+    close_requested = pyqtSignal()  # the × in the header
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
@@ -1023,6 +1072,8 @@ class FMLayersPanel(QFrame):
         # matplotlib canvas, and as a child widget its native sliders were forced
         # to repaint (and flicker) on every canvas redraw during a slider drag.
         self.setWindowFlags(Qt.Tool | Qt.FramelessWindowHint)
+        # Cursor-to-window offset while the header is being dragged; None otherwise.
+        self._drag_origin: Optional[QPoint] = None
         self.setAttribute(Qt.WA_StyledBackground, True)
         self.setObjectName("fmPanel")
         self.setStyleSheet(_PANEL_QSS)
@@ -1053,7 +1104,29 @@ class FMLayersPanel(QFrame):
         header.addWidget(hicon)
         header.addWidget(title)
         header.addStretch()
-        root.addLayout(header)
+        grip = QLabel()
+        grip.setToolTip("Drag to move")
+        grip.setPixmap(
+            fibsem_icon("mdi:drag-horizontal-variant", color=TEXT_MUTED_COLOR).pixmap(
+                QSize(16, 16)
+            )
+        )
+        header.addWidget(grip)
+        self._btn_close = QToolButton()
+        self._btn_close.setObjectName("closeBtn")
+        self._btn_close.setToolTip("Close")
+        self._btn_close.setIcon(fibsem_icon("mdi:close", color=TEXT_MUTED_COLOR))
+        self._btn_close.setIconSize(QSize(14, 14))
+        self._btn_close.setFixedSize(18, 18)
+        self._btn_close.setCursor(Qt.PointingHandCursor)
+        self._btn_close.clicked.connect(self.close_requested)
+        header.addWidget(self._btn_close)
+        # The whole header row is the drag handle; kept as a widget so the mouse
+        # handlers below can tell a drag from a click on the controls beneath it.
+        self._header = QWidget()
+        self._header.setLayout(header)
+        self._header.setCursor(Qt.OpenHandCursor)
+        root.addWidget(self._header)
         root.addSpacing(12)
 
         # channel list
@@ -1144,6 +1217,34 @@ class FMLayersPanel(QFrame):
         self.btn_reset.setCursor(Qt.PointingHandCursor)
         self.btn_reset.clicked.connect(self._on_reset)
         root.addWidget(self.btn_reset)
+
+    # ── drag to move ──────────────────────────────────────────────────────
+
+    def mousePressEvent(self, event) -> None:
+        if event.button() == Qt.LeftButton and self._header.geometry().contains(
+            event.pos()
+        ):
+            self._drag_origin = event.globalPos() - self.frameGeometry().topLeft()
+            self._header.setCursor(Qt.ClosedHandCursor)
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event) -> None:
+        if self._drag_origin is not None:
+            self.move(event.globalPos() - self._drag_origin)
+            event.accept()
+            return
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:
+        if self._drag_origin is not None:
+            self._drag_origin = None
+            self._header.setCursor(Qt.OpenHandCursor)
+            self.moved.emit()
+            event.accept()
+            return
+        super().mouseReleaseEvent(event)
 
     def _slider_row(self, root, label: str, lo: int, hi: int, val: int):
         head = QHBoxLayout()

--- a/fibsem/ui/widgets/canvas/fm_canvas.py
+++ b/fibsem/ui/widgets/canvas/fm_canvas.py
@@ -694,8 +694,21 @@ class FMCanvasWidget(QWidget):
         # The panel is a top-level tool window, so it does not go away with this
         # widget on its own: closing the correlation dialog for one site left it
         # floating over whatever came next (FIB-962).
-        self._close_layers_panel()
         super().hideEvent(event)
+        # Also reached from C++ while a parent window is being destroyed: Qt hides
+        # the children first. When that destruction is a Python garbage-collection
+        # pass, this wrapper's instance dict may already have been cleared, and an
+        # exception raised inside a Qt virtual is fatal under PyQt5 (the process
+        # aborts). So look the attributes up tolerantly and never raise here.
+        panel = self.__dict__.get("_panel")
+        button = self.__dict__.get("_btn_layers")
+        if panel is None or button is None:
+            return
+        try:
+            panel.hide()
+            button.setChecked(False)
+        except RuntimeError:  # wrapped C/C++ object already deleted
+            pass
 
 
 class FMRealSpaceCanvasWidget(FMCanvasWidget):

--- a/tests/ui/test_fm_layers_panel_floating.py
+++ b/tests/ui/test_fm_layers_panel_floating.py
@@ -1,0 +1,167 @@
+"""The FM channels panel can be moved, closes with its host, and reopens where it was left.
+
+FIB-961: the per-channel contrast/gamma popover opened over the FM image with no way to
+move it. FIB-962: it is a top-level tool window, so it outlived the correlation dialog it
+was opened from and stayed on top of whatever came next.
+
+Now the header is a drag handle with a close button, the dragged-to position is kept as an
+offset from the canvas's top-right corner (class-level, so a fresh FM canvas for the next
+site reopens the panel in the same place), and hiding the host widget hides the panel.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_fm_layers_panel_floating.py
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtCore import QEvent, QPoint, QRect, QSize, Qt
+from PyQt5.QtGui import QMouseEvent
+from PyQt5.QtTest import QTest
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.fm_canvas import (
+    FMCanvasWidget,
+    FMRealSpaceCanvasWidget,
+    _clamp_to_screen,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+@pytest.fixture(autouse=True)
+def _forget_panel_position():
+    FMCanvasWidget._panel_offset = None
+    yield
+    FMCanvasWidget._panel_offset = None
+
+
+def _widget():
+    w = FMRealSpaceCanvasWidget()
+    w.resize(600, 500)
+    w.show()
+    _app.processEvents()
+    stack = (np.random.default_rng(0).random((3, 64, 64)) * 1000).astype(np.uint16)
+    w._stacks = {"GFP": stack}
+    w._upsert_layer("GFP", stack.max(axis=0), "green")
+    return w
+
+
+def _open_panel(w):
+    w._btn_layers.setChecked(True)
+    w._toggle_layers_panel()
+    _app.processEvents()
+    assert w._panel.isVisible()
+
+
+def _move(widget, pos: QPoint):
+    # QTest.mouseMove only warps the cursor on the offscreen platform; the drag
+    # handler needs the actual move event, so deliver one by hand.
+    ev = QMouseEvent(
+        QEvent.MouseMove,
+        pos,
+        widget.mapToGlobal(pos),
+        Qt.NoButton,
+        Qt.LeftButton,
+        Qt.NoModifier,
+    )
+    _app.sendEvent(widget, ev)
+
+
+def _drag(widget, start: QPoint, dx: int, dy: int):
+    end = start + QPoint(dx, dy)
+    QTest.mousePress(widget, Qt.LeftButton, Qt.NoModifier, start)
+    _move(widget, end)
+    QTest.mouseRelease(widget, Qt.LeftButton, Qt.NoModifier, end)
+    _app.processEvents()
+
+
+def _drag_header(w, dx: int, dy: int):
+    _drag(w._panel, w._panel._header.geometry().center(), dx, dy)
+
+
+def test_default_position_is_canvas_top_right():
+    w = _widget()
+    _open_panel(w)
+    anchor = w._panel_anchor()
+    assert w._panel.pos().x() == anchor.x() - w._panel.width()
+    assert w._panel.pos().y() == anchor.y()
+    assert FMCanvasWidget._panel_offset is None
+    w.close()
+
+
+def test_drag_moves_the_panel_and_records_the_offset():
+    w = _widget()
+    _open_panel(w)
+    before = w._panel.pos()
+
+    _drag_header(w, -40, 30)
+
+    after = w._panel.pos()
+    assert after == before + QPoint(-40, 30)
+    assert FMCanvasWidget._panel_offset == after - w._panel_anchor()
+    w.close()
+
+
+def test_drag_below_the_header_does_not_move_the_panel():
+    w = _widget()
+    _open_panel(w)
+    before = w._panel.pos()
+    panel = w._panel
+    body = QPoint(panel.width() // 2, panel.height() - 20)  # over the reset button
+    _drag(panel, body, 30, 30)
+    assert w._panel.pos() == before
+    assert FMCanvasWidget._panel_offset is None
+    w.close()
+
+
+def test_a_fresh_widget_reopens_the_panel_where_it_was_left():
+    first = _widget()
+    _open_panel(first)
+    _drag_header(first, -50, 60)
+    offset = FMCanvasWidget._panel_offset
+    first.close()
+
+    second = _widget()  # the next correlation site builds a new FM canvas
+    _open_panel(second)
+    assert second._panel.pos() == second._panel_anchor() + offset
+    second.close()
+
+
+def test_close_button_hides_the_panel_and_unchecks_the_button():
+    w = _widget()
+    _open_panel(w)
+    w._panel._btn_close.click()
+    _app.processEvents()
+    assert not w._panel.isVisible()
+    assert not w._btn_layers.isChecked()
+    w.close()
+
+
+def test_hiding_the_host_hides_the_panel():
+    w = _widget()
+    _open_panel(w)
+    w.hide()  # the correlation dialog closing for this site
+    _app.processEvents()
+    assert not w._panel.isVisible()
+    assert not w._btn_layers.isChecked()
+    w.close()
+
+
+def test_clamp_keeps_a_remembered_position_on_screen():
+    screen = _app.primaryScreen().availableGeometry()
+    size = QSize(268, 500)
+    near = screen.center()
+    far = QPoint(screen.right() + 400, screen.bottom() + 400)
+    kept = _clamp_to_screen(far, size, near)
+    assert QRect(kept, size).intersected(screen) == QRect(kept, size)
+    inside = QPoint(screen.left() + 10, screen.top() + 10)
+    assert _clamp_to_screen(inside, size, near) == inside


### PR DESCRIPTION
Fixes FIB-961 and FIB-962, the two popover items from the September correlation feedback batch.

## FIB-961: the contrast/gamma popover covers the image

The header row of `FMLayersPanel` is now a drag handle (grip icon, open-hand cursor) with a close ×. The panel stays a frameless `Qt.Tool` window, which is what keeps its sliders from flickering over the matplotlib canvas during a drag.

Where the user drags it to is remembered as an offset from the FM canvas's top-right corner, so it follows the dialog if that is moved or resized. It is class-level on purpose: the correlation dialog builds a fresh FM canvas per site, and the panel should reopen where it was left rather than snap back to the corner every site. The offset is clamped to the screen so a spot remembered on a larger display cannot leave the header off-screen where it could never be dragged back.

Default placement is unchanged (top-right of the FM canvas, beside the button that opens it). Session-only for now; persisting to user-preferences can follow if anyone asks.

Not done: the users' alternative of a gamma strip above the z-slider. A movable panel answers both requests without a second control for one value.

## FIB-962: the popover stays on top after moving to the next site

`FMCanvasWidget.hideEvent` now hides the panel and unchecks the toolbar button, so closing the dialog, switching tab, or advancing to the next site takes the panel with it.

## Verification

- `tests/ui/test_fm_layers_panel_floating.py`: default position, drag moves the panel and records the offset, a drag below the header does nothing, a fresh widget reopens where the last one left off, close button, hide-with-host, and the screen clamp. 64 tests across the FM area pass offscreen.
- Tried by hand in the `test_correlation_tab_widget` launcher on a real project directory.