### PR TITLE
[ui] Protocol tab: a status strip says when an edited task has not been applied

### DIFF
--- a/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_editor.py
@@ -3,6 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import (
     QComboBox,
     QDialog,
@@ -20,6 +21,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from fibsem.applications.autolamella.structures import AutoLamellaTaskProtocol
 from fibsem.applications.autolamella.ui.autolamella_fluorescence_acquisition_task_config_widget import (
     AutoLamellaFluorescenceAcquisitionTaskConfigWidget,
 )
@@ -47,6 +49,9 @@ from fibsem.applications.autolamella.workflows.tasks.tasks import (
 from fibsem.structures import BeamType, FibsemImage
 from fibsem.ui import stylesheets
 from fibsem.ui.tokens import (
+    BORDER_COLOR,
+    NEUTRAL_200,
+    SEMANTIC_WARNING_COLOR,
     TEXT_MUTED_COLOR,
 )
 from fibsem.ui.widgets.canvas.quad_view import (
@@ -187,6 +192,111 @@ class AddTaskDialog(QDialog):
         return task_type, task_name
 
 
+def _task_tooltips(protocol: AutoLamellaTaskProtocol) -> Dict[str, str]:
+    """What each task is, and how the workflow runs it -- read here, edited elsewhere.
+
+    The Protocol tab edits task definitions; the Workflow tab composes them into a
+    run. The list rows stay plain so nothing on them looks editable that is not,
+    and the tooltip says which tab owns each line.
+    """
+    workflow = {t.name: t for t in protocol.workflow_config.tasks}
+    tips: Dict[str, str] = {}
+    for name, config in protocol.task_config.items():
+        # The base config class carries no task_type; a bare one reads as its class.
+        raw = getattr(config, "task_type", None) or type(config).__name__
+        kind = " ".join(w.capitalize() for w in str(raw).lower().split("_"))
+        task = workflow.get(name)
+        if task is None:
+            run = "not included"
+        else:
+            parts = ["supervised" if task.supervise else "unsupervised"]
+            parts.append("required" if task.required else "optional")
+            if task.requires:
+                parts.append("after " + ", ".join(task.requires))
+            run = ", ".join(parts)
+        tips[name] = f"{name}\nType: {kind}\nWorkflow: {run}"
+    return tips
+
+
+class _DirtyBanner(QWidget):
+    """The strip above the editor: quiet while the lamellae carry the current
+    settings, lit with an Apply button once an edited task has not reached them.
+
+    One fixed height in both states, so switching between them moves nothing
+    underneath; and a widget that is always laid out, rather than one that floats,
+    so it covers nothing either.
+    """
+
+    apply_clicked = pyqtSignal()
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("dirtyBanner")
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setFixedHeight(32)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(10, 0, 6, 0)
+        layout.setSpacing(10)
+        self.label = QLabel("")
+        self.apply_button = QPushButton("Apply")
+        self.apply_button.setStyleSheet(stylesheets.PRIMARY_BUTTON_STYLESHEET)
+        self.apply_button.setFixedHeight(24)
+        self.apply_button.clicked.connect(self.apply_clicked)
+        layout.addWidget(self.label, 1)
+        layout.addWidget(self.apply_button)
+        self.show_for("", 0)
+
+    def show_for(self, task_name: str, lamellae: int) -> None:
+        """Lit for an edited *task_name* that has not been applied; quiet otherwise.
+
+        Says only what the edit flag knows: that this task was edited here and
+        Apply has not run since. Whether each lamella actually matches is not
+        tracked, and the wording does not claim it.
+        """
+        rgb = QColor(SEMANTIC_WARNING_COLOR)
+        plural = "lamella" if lamellae == 1 else "lamellae"
+        if task_name and lamellae:
+            self.label.setText(
+                f"'{task_name}' was edited but has not been applied to the "
+                f"{lamellae} existing {plural} yet."
+            )
+            self.label.setStyleSheet(
+                f"color: {NEUTRAL_200}; background: transparent; border: none;"
+            )
+            self.apply_button.setText("Apply now")
+            self.apply_button.setToolTip(
+                f"Overwrite '{task_name}' on all {lamellae} existing {plural} with "
+                "the protocol's settings, including any edited individually."
+            )
+            self.apply_button.setVisible(True)
+            self.setStyleSheet(
+                "#dirtyBanner { background: rgba(%d, %d, %d, 0.12);"
+                " border-top: 1px solid rgba(%d, %d, %d, 0.5); }"
+                % (
+                    rgb.red(),
+                    rgb.green(),
+                    rgb.blue(),
+                    rgb.red(),
+                    rgb.green(),
+                    rgb.blue(),
+                )
+            )
+            return
+        self.label.setText(
+            "Task edits reach existing lamellae only when applied; new lamellae "
+            "take the current settings."
+        )
+        self.label.setStyleSheet(
+            f"color: {TEXT_MUTED_COLOR}; font-size: 11px;"
+            " background: transparent; border: none;"
+        )
+        self.apply_button.setVisible(False)
+        self.setStyleSheet(
+            f"#dirtyBanner {{ background: transparent;"
+            f" border-top: 1px solid {BORDER_COLOR}; }}"
+        )
+
+
 class AutoLamellaProtocolTaskConfigEditor(QWidget):
     """A widget to edit the AutoLamella protocol."""
 
@@ -208,6 +318,7 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
         self._main_layout = QVBoxLayout(self)
         self._main_layout.setContentsMargins(0, 0, 0, 0)
+        self._main_layout.setSpacing(0)
 
         self._try_initialize()
 
@@ -415,9 +526,19 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
         splitter.setSizes([280, 580, 580])
 
         self._main_layout.addWidget(splitter)
+        # The status strip below the columns is always there, at one height, so
+        # nothing moves when it changes state: quiet while the lamellae carry the
+        # current settings, lit with the Apply button once a task is edited. At the
+        # bottom, where status lives and where the existing Apply button already
+        # is, rather than at the top where a quiet sentence would be the first
+        # thing read. That button stays, for now, as the second route to the action.
+        self.dirty_banner = _DirtyBanner(parent=self)
+        self.dirty_banner.apply_clicked.connect(self._on_sync_to_lamella_clicked)
+        self._main_layout.addWidget(self.dirty_banner)
 
     def _set_protocol_dirty(self, dirty: bool):
         self._protocol_dirty = dirty
+        self._refresh_status_strip()
         if dirty and self.pushButton_sync_to_lamella.isEnabled():
             self.pushButton_sync_to_lamella.setStyleSheet(
                 stylesheets.PRIMARY_BUTTON_STYLESHEET
@@ -432,6 +553,16 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
             self.pushButton_sync_to_lamella.setToolTip(
                 "Update all existing lamella with the current task configuration"
             )
+
+    def _refresh_status_strip(self) -> None:
+        banner = getattr(self, "dirty_banner", None)
+        if banner is None or self.experiment is None:
+            return  # the widgets are still being built
+        lamellae = len(self.experiment.positions)
+        banner.show_for(
+            self.task_list_widget.selected_task if self._protocol_dirty else "",
+            lamellae,
+        )
 
     def _setup_connections(self):
         """Setup signal connections - called once during initialization."""
@@ -477,6 +608,9 @@ class AutoLamellaProtocolTaskConfigEditor(QWidget):
 
         task_names = list(self.experiment.task_protocol.task_config.keys())
         self.task_list_widget.set_tasks(task_names)
+        self.task_list_widget.set_task_tooltips(
+            _task_tooltips(self.experiment.task_protocol)
+        )
 
     def refresh_if_showing_task(self, task_name: str) -> None:
         """Rebuild the panel if it is displaying ``task_name``.

--- a/fibsem/ui/widgets/custom_widgets.py
+++ b/fibsem/ui/widgets/custom_widgets.py
@@ -866,8 +866,10 @@ class TaskNameListWidget(QWidget):
         self._list.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         outer.addWidget(self._list)
 
-        # Per-task status chips, by task name; reapplied when the list repopulates.
+        # Per-task status chips and tooltips, by task name; reapplied when the
+        # list repopulates.
         self._states: Dict[str, Tuple[str, str]] = {}
+        self._tooltips: Dict[str, str] = {}
 
         # Wire signals
         self._list.itemSelectionChanged.connect(
@@ -934,6 +936,16 @@ class TaskNameListWidget(QWidget):
         self._list.blockSignals(False)
         if self._states:
             self.set_task_states(self._states)
+        if self._tooltips:
+            self.set_task_tooltips(self._tooltips)
+
+    def set_task_tooltips(self, tooltips: Mapping[str, str]) -> None:
+        """A tooltip per named row. The row itself stays plain text: what a task is
+        and how the workflow runs it are read here, edited elsewhere."""
+        self._tooltips = dict(tooltips)
+        for i in range(self._list.count()):
+            item = self._list.item(i)
+            item.setToolTip(self._tooltips.get(item.text(), ""))
 
     def select(self, name: str) -> None:
         """Select the item with the given name (exact match)."""

--- a/tests/ui/test_protocol_editor_dirty_banner.py
+++ b/tests/ui/test_protocol_editor_dirty_banner.py
@@ -1,0 +1,129 @@
+"""The Protocol tab's status strip and its task tooltips.
+
+Editing a task lit up a primary button under the task list that nobody looked at.
+The strip below the columns says the same thing on the tab where the editing
+happens. It is
+always there at one height -- quiet while the lamellae carry the current settings,
+lit with Apply once a task is edited -- so changing state moves and covers nothing.
+The buttons stay for now as the second route to the same action.
+
+The task rows stay plain text: what a task is and how the workflow runs it are
+read in the tooltip and edited elsewhere.
+"""
+
+import copy
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from psygnal.containers import EventedDict  # noqa: E402
+from PyQt5.QtWidgets import QApplication, QSplitter, QWidget  # noqa: E402
+
+from fibsem import utils  # noqa: E402
+from fibsem.applications.autolamella.structures import (  # noqa: E402
+    AutoLamellaTaskProtocol,
+    Experiment,
+)
+from fibsem.applications.autolamella.ui.autolamella_task_config_editor import (  # noqa: E402
+    AutoLamellaProtocolTaskConfigEditor,
+    _task_tooltips,
+)
+from fibsem.structures import MicroscopeState  # noqa: E402
+
+
+@pytest.fixture
+def qapp():
+    yield QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def editor(qapp):
+    import fibsem.applications.autolamella.protocol as protodir
+
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    exp = Experiment(path=pathlib.Path(tempfile.mkdtemp()), name="banner")
+    os.makedirs(exp.path, exist_ok=True)
+    exp.task_protocol = AutoLamellaTaskProtocol.load(
+        os.path.join(os.path.dirname(protodir.__file__), "task-protocol.yaml")
+    )
+    # lamellae created the way the app does it: carrying the protocol's configs
+    for _ in range(2):
+        exp.add_new_lamella(
+            MicroscopeState(),
+            EventedDict(copy.deepcopy(dict(exp.task_protocol.task_config))),
+        )
+    host = QWidget()
+    host.experiment, host.microscope = exp, microscope
+    widget = AutoLamellaProtocolTaskConfigEditor(parent=host)
+    widget._host = host
+    host.resize(1200, 700)
+    host.show()
+    qapp.processEvents()
+    yield widget
+    host.close()
+
+
+def test_the_strip_is_always_there_and_changing_state_moves_nothing(editor, qapp):
+    splitter = editor.findChild(QSplitter)
+    strip = editor.dirty_banner
+    assert not strip.isHidden()
+    assert strip.apply_button.isHidden(), "nothing edited: no button"
+    quiet_height, before = strip.height(), splitter.geometry()
+
+    editor.task_list_widget.select("Rough Milling")
+    editor._set_protocol_dirty(True)
+    qapp.processEvents()
+
+    assert not strip.apply_button.isHidden()
+    assert strip.height() == quiet_height
+    assert splitter.geometry() == before, "lighting the strip shifted the columns"
+    assert strip.y() > splitter.y(), "the strip sits below the columns"
+
+    editor._set_protocol_dirty(False)
+    qapp.processEvents()
+    assert strip.apply_button.isHidden()
+
+
+def test_the_strip_says_only_what_the_edit_flag_knows(editor, qapp):
+    """It says the task was edited and not applied. It does not claim which
+    lamellae match, because nothing tracks that."""
+    editor.task_list_widget.select("Rough Milling")
+    editor._set_protocol_dirty(True)
+
+    text = editor.dirty_banner.label.text()
+    assert text == (
+        "'Rough Milling' was edited but has not been applied to the 2 existing "
+        "lamellae yet."
+    )
+    assert editor.dirty_banner.apply_button.text() == "Apply now"
+
+
+def test_with_no_lamellae_the_strip_stays_quiet(editor, qapp):
+    editor.experiment.positions.clear()
+    editor._set_protocol_dirty(True)
+    assert editor.dirty_banner.apply_button.isHidden()
+
+
+def test_tooltips_say_what_a_task_is_and_how_the_workflow_runs_it(editor):
+    protocol = editor.experiment.task_protocol
+    tips = _task_tooltips(protocol)
+
+    assert tips["Rough Milling"] == (
+        "Rough Milling\nType: Mill Rough\nWorkflow: supervised, required, after Mill Fiducial"
+    )
+    assert editor.task_list_widget._list.item(2).toolTip() == tips["Rough Milling"]
+
+
+def test_a_task_the_workflow_does_not_run_says_so():
+    from fibsem.applications.autolamella.workflows.tasks.base import (
+        AutoLamellaTaskConfig,
+    )
+
+    protocol = AutoLamellaTaskProtocol()
+    protocol.task_config = {"Orphan": AutoLamellaTaskConfig(task_name="Orphan")}
+    tips = _task_tooltips(protocol)
+    assert tips["Orphan"].endswith("Workflow: not included")

--- a/tests/ui/test_task_name_list_widget.py
+++ b/tests/ui/test_task_name_list_widget.py
@@ -67,3 +67,15 @@ def test_the_chip_does_not_change_the_row_text_or_selection(qapp):
     assert widget._list.item(1).text() == "Polishing"
     row = widget._list.itemWidget(widget._list.item(1))
     assert row.testAttribute(Qt.WA_TransparentForMouseEvents)
+
+
+def test_tooltips_are_per_row_and_survive_a_repopulate(qapp):
+    widget = TaskNameListWidget()
+    widget.set_tasks(["Setup", "Polishing"])
+
+    widget.set_task_tooltips({"Setup": "Setup\nType: Select Milling Position"})
+    assert widget._list.item(0).toolTip().startswith("Setup\nType:")
+    assert widget._list.item(1).toolTip() == ""
+
+    widget.set_tasks(["Setup", "Polishing", "Extra"])
+    assert widget._list.item(0).toolTip().startswith("Setup\nType:")


### PR DESCRIPTION
## Summary

Stacked on #834. Editing a task on the Protocol tab lit up the primary button under the task list, and nobody looked down there. A status strip below the three columns now says it where the editing happens.

- **Quiet state**, muted: "Task edits reach existing lamellae only when applied; new lamellae take the current settings."
- **Lit state**, warning tint with an **Apply now** button, once a task was edited and Apply has not run: "'Rough Milling' was edited but has not been applied to the 6 existing lamellae yet." The button runs the existing sync with its confirmation. Its tooltip says it overwrites the task on every lamella, including any edited individually.
- The strip is always present at one height, so changing state moves nothing and covers nothing. A floating overlay was tried first and covered the panel headers.
- The button under the list stays for now as the second route to the same action. Global Edit and Lamella Template are untouched.

It says only what the edit flag knows. It does not claim which lamellae match the protocol, because nothing tracks that. A per-lamella comparison was built and dropped: a lamella's copy of a config carries its own image path, so the comparison needed to know which keys are noise, and the cost was not worth a claim the flag can't back.

**Task tooltips.** The rows stay plain text. Hovering a row shows the task's type and how the workflow runs it, "supervised, required, after Mill Fiducial", or "not included", under a "Workflow:" label so it is clearly the other tab's business. The Protocol tab edits task definitions; the Workflow tab composes them.

## Verification

- New `tests/ui/test_protocol_editor_dirty_banner.py` (on CI): the strip is always present, lighting it leaves the splitter geometry unchanged and sits below the columns, the wording is exact, no lamellae keeps it quiet, tooltips are exact and cover the not-included case.
- `TaskNameListWidget.set_task_tooltips` covered in the task-list suite, including survival across a repopulate.
- 34 tests pass across those and the spot-burn and responder suites that build the real editor.
- Rendered on the real editor in both states with a real protocol; lint and format-check clean.
