### PR TITLE
[fix] AutoLamellaTaskConfigWidget takes its microscope from the host

### DIFF
--- a/fibsem/applications/autolamella/ui/autolamella_task_config_widget.py
+++ b/fibsem/applications/autolamella/ui/autolamella_task_config_widget.py
@@ -28,8 +28,8 @@ from PyQt5.QtWidgets import (
 )
 from superqt import QCollapsible
 
-from fibsem import utils
 from fibsem.applications.autolamella.structures import AutoLamellaTaskConfig
+from fibsem.microscope import FibsemMicroscope
 from fibsem.ui.widgets.custom_widgets import TitledPanel, align_form
 from fibsem.ui.widgets.form_builder import Control, FormDefaults, build_control
 from fibsem.ui.widgets.milling_task_viewer_widget import MillingTaskViewerWidget
@@ -121,20 +121,32 @@ def build_parameter_rows(
 
 
 class AutoLamellaTaskConfigWidget(QWidget):
-    """Widget for configuring AutoLamella task parameters."""
+    """Widget for configuring AutoLamella task parameters.
+
+    The milling section needs a microscope, and the host hands one in. It used
+    to open a session of its own at construction -- `utils.setup_session()` with
+    no arguments, so whatever the default configuration named -- which is a
+    connection side effect from building a widget. With no microscope the
+    parameters section is built and the milling section is left out.
+
+    No tab hosts this widget today; the Protocol and Lamella tabs build the
+    parameters form and the milling viewer separately.
+    """
 
     config_changed = pyqtSignal(AutoLamellaTaskConfig)
 
     def __init__(
         self,
         task_config: Optional[AutoLamellaTaskConfig] = None,
+        microscope: Optional[FibsemMicroscope] = None,
         parent: Optional[QWidget] = None,
     ):
         super().__init__(parent)
         self.task_config = task_config
+        self.microscope = microscope
         self._rows: List[_Row] = []
         self._advanced_visible = False
-        self.milling_task_widget: MillingTaskViewerWidget
+        self.milling_task_widget: Optional[MillingTaskViewerWidget] = None
 
         self._setup_ui()
         if self.task_config:
@@ -155,28 +167,21 @@ class AutoLamellaTaskConfigWidget(QWidget):
 
         self.task_params_collapsible.addWidget(self.params_widget)
 
-        # Create collapsible section for milling parameters
-        self.milling_params_collapsible = QCollapsible("Milling Task Parameters", self)
-
-        # initialise milling_task_widget
-        microscope, settings = (
-            utils.setup_session()
-        )  # TODO: pass in from the parent if available...
-        self.milling_task_widget = MillingTaskViewerWidget(
-            microscope=microscope,
-            milling_enabled=False,
-            parent=self,
-        )
-        self.milling_task_widget.setMinimumHeight(600)
-        self.milling_params_collapsible.addWidget(self.milling_task_widget)
-
         self.main_layout.addWidget(self.task_params_collapsible)  # type: ignore
-        self.main_layout.addWidget(self.milling_params_collapsible)  # type: ignore
 
-        # Connect milling widget signals
-        self.milling_task_widget.settings_changed.connect(
-            self._on_milling_config_updated
-        )
+        # The milling section, only with a microscope to drive it
+        self.milling_params_collapsible = QCollapsible("Milling Task Parameters", self)
+        if self.microscope is not None:
+            self.milling_task_widget = MillingTaskViewerWidget(
+                microscope=self.microscope,
+                milling_enabled=False,
+                parent=self,
+            )
+            self.milling_params_collapsible.addWidget(self.milling_task_widget)
+            self.milling_task_widget.settings_changed.connect(
+                self._on_milling_config_updated
+            )
+            self.main_layout.addWidget(self.milling_params_collapsible)  # type: ignore
 
         self.main_layout.addStretch()
 
@@ -206,8 +211,10 @@ class AutoLamellaTaskConfigWidget(QWidget):
         else:
             self.task_params_collapsible.hide()
 
-        # Show/hide milling parameters section
-        if self.task_config.milling:
+        # Show/hide milling parameters section (absent without a microscope)
+        if self.milling_task_widget is None:
+            self._current_milling_key = None
+        elif self.task_config.milling:
             self._current_milling_key = next(iter(self.task_config.milling))
             self.milling_task_widget.set_config(
                 self.task_config.milling[self._current_milling_key]

--- a/tests/ui/test_task_config_parameter_widgets.py
+++ b/tests/ui/test_task_config_parameter_widgets.py
@@ -88,7 +88,9 @@ class SampleTaskConfig(AutoLamellaTaskConfig):
     with_items: str = field(default="b", metadata={"items": ["a", "b", "c"]})
     # The two that used to be silently destroyed.
     nested: NestedSettings = field(default_factory=NestedSettings)
-    nested_list: List[NestedSettings] = field(default_factory=lambda: [NestedSettings()])
+    nested_list: List[NestedSettings] = field(
+        default_factory=lambda: [NestedSettings()]
+    )
 
 
 # Both forms in the module share one dispatch; run every test against both so a
@@ -242,7 +244,11 @@ def test_a_literal_field_offers_its_allowed_values(qapp, form_cls):
     combo = param_widget.widget
 
     assert isinstance(combo, ValueComboBox)
-    assert [combo.itemData(i) for i in range(combo.count())] == ["cells", "hpf", "other"]
+    assert [combo.itemData(i) for i in range(combo.count())] == [
+        "cells",
+        "hpf",
+        "other",
+    ]
     assert combo.currentData() == "hpf"
 
     combo.setCurrentIndex(0)
@@ -409,7 +415,9 @@ def test_an_unset_optional_string_reads_back_as_none(qapp, form_cls):
         ("a_literal", lambda w: w.setCurrentIndex(0), "cells"),
     ],
 )
-def test_editing_a_control_reaches_the_config(qapp, form_cls, field_name, drive, expected):
+def test_editing_a_control_reaches_the_config(
+    qapp, form_cls, field_name, drive, expected
+):
     """Drive the widget's own signal, not the handler.
 
     The tests around this one called `form._on_parameter_changed(name)` directly,
@@ -469,3 +477,31 @@ def test_an_edit_survives_switching_task_and_coming_back(qapp, form_cls):
 
     assert config.a_float == 9.0
     assert _control(form, "a_float").widget.value() == 9.0
+
+
+def test_the_config_form_opens_no_session_and_takes_the_hosts_microscope(
+    qapp, monkeypatch
+):
+    """Building the widget used to call utils.setup_session() -- a connection to
+    whatever the default configuration named. Now a host hands the microscope in,
+    and without one the milling section is simply not built."""
+    from fibsem import utils
+
+    def _forbidden(*_args, **_kwargs):
+        raise AssertionError("the widget must not open a session of its own")
+
+    monkeypatch.setattr(utils, "setup_session", _forbidden)
+
+    form = AutoLamellaTaskConfigWidget(task_config=SampleTaskConfig())
+    assert form.milling_task_widget is None
+
+
+def test_with_a_microscope_the_config_form_builds_its_milling_section(qapp):
+    from fibsem import utils
+
+    microscope, _ = utils.setup_session(manufacturer="Demo")
+    form = AutoLamellaTaskConfigWidget(
+        task_config=SampleTaskConfig(), microscope=microscope
+    )
+    assert form.milling_task_widget is not None
+    assert form.milling_task_widget.microscope is microscope


### PR DESCRIPTION
## Summary

Stacked on #865. `AutoLamellaTaskConfigWidget` opened a session of its own at construction, `utils.setup_session()` with no arguments, to give its milling section a microscope. That is a connection to whatever the default configuration names, as a side effect of building a widget, and it was marked with a TODO to take the microscope from the parent.

- The constructor takes `microscope: Optional[FibsemMicroscope]`. The milling section is built only when one is given; the config sync code handles its absence.
- Without a microscope the parameters form builds with no session at all, which is the half the existing tests exercise.
- No tab hosts this widget today: the Protocol and Lamella tabs build the parameters form and the milling viewer separately. The docstring records that, so the next reader knows it is a candidate for removal rather than a live path.

## Verification

- A test monkeypatches `utils.setup_session` to raise and builds the widget: no session is opened, and `milling_task_widget` is `None`.
- A test builds it with a Demo microscope and checks the milling section exists and holds that microscope.
- 71 tests pass across the task-config parameter and form-writeback suites. Lint and format-check clean.
