### PR TITLE
[ui] Point overlay finishes its drag bookkeeping before it emits

### DIFF
--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -57,6 +57,7 @@ OBJECTIVE_START_LABELS = {
     ObjectiveStartPosition.FOCUS: "Saved focus position",
 }
 
+
 def format_objective_start(start, position: Optional[float]) -> str:
     """Label one start option, with what it currently means in millimetres.
 
@@ -101,7 +102,7 @@ class FMOverviewSettingsWidget(QWidget):
         parent: Optional[QWidget] = None,
     ):
         super().__init__(parent)
-        self._tile_fov: Optional[tuple] = None   # (fov_x, fov_y) metres, set externally
+        self._tile_fov: Optional[tuple] = None  # (fov_x, fov_y) metres, set externally
         # What the start options currently mean. None until a host says -- the standalone
         # settings widget has no microscope to ask.
         self._objective_current: Optional[float] = None
@@ -246,7 +247,9 @@ class FMOverviewSettingsWidget(QWidget):
         self.path_edit.lineEdit.textChanged.connect(self._refresh_destination)
         self._refresh_destination()
         self.check_zstack.stateChanged.connect(self._on_zstack_toggled)
-        self.combo_autofocus_mode.currentIndexChanged.connect(self._on_autofocus_changed)
+        self.combo_autofocus_mode.currentIndexChanged.connect(
+            self._on_autofocus_changed
+        )
         self.combo_objective_start.currentIndexChanged.connect(self._on_any_change)
         self.autofocus_widget.settings_changed.connect(self._on_any_change)
 
@@ -463,15 +466,19 @@ class FMOverviewSettingsWidget(QWidget):
 
     @parameters.setter
     def parameters(self, value: OverviewParameters) -> None:
-        widgets = (self.check_zstack, self.combo_autofocus_mode,
-                   self.combo_objective_start)
+        widgets = (
+            self.check_zstack,
+            self.combo_autofocus_mode,
+            self.combo_objective_start,
+        )
         for widget in widgets:
             widget.blockSignals(True)
         try:
             # The grid panel does its own blocking, so it is loaded outside this one --
             # `blockSignals` on the panel would not reach the boxes inside it anyway.
-            self.grid.apply(value.rows, value.cols, value.overlap,
-                            value.tile_order, value.tile_mask)
+            self.grid.apply(
+                value.rows, value.cols, value.overlap, value.tile_order, value.tile_mask
+            )
             self.check_zstack.setChecked(value.use_zstack)
             self.combo_autofocus_mode.set_value(value.autofocus_mode)
             self.combo_objective_start.set_value(value.objective_start)

--- a/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
+++ b/fibsem/ui/fm/widgets/fm_overview_settings_widget.py
@@ -375,15 +375,6 @@ class FMOverviewSettingsWidget(QWidget):
 
     # ── value ────────────────────────────────────────────────────────────
 
-    def set_channel_names(self, names: List[str]) -> None:
-        current = self.combo_autofocus_channel.value()
-        self.combo_autofocus_channel.blockSignals(True)
-        self.combo_autofocus_channel.clear()
-        self.combo_autofocus_channel.add_values(list(names))
-        if current in names:
-            self.combo_autofocus_channel.set_value(current)
-        self.combo_autofocus_channel.blockSignals(False)
-
     def set_channel_settings(self, channels: List[ChannelSettings]) -> None:
         """Keep the focus-channel choices in step with the channels being acquired."""
         self.autofocus_widget.update_channels(list(channels))

--- a/fibsem/ui/widgets/canvas/overlays/point_overlay.py
+++ b/fibsem/ui/widgets/canvas/overlays/point_overlay.py
@@ -882,8 +882,11 @@ class PointOverlay(QObject):
             if old_sel is not None and old_sel != hit:
                 self._update_artist_appearance(old_sel)
             self._update_artist_appearance(hit)
-            self.point_selected.emit(hit, self._points[hit][0], self._points[hit][1])
+            # Drag state first, emit last: a listener may rebuild this overlay
+            # (set_points) while handling the signal, and the drag has to have
+            # captured its artist and blit background before that can happen.
             self._start_drag(hit, event)
+            self.point_selected.emit(hit, self._points[hit][0], self._points[hit][1])
         elif self._selected is not None:
             # left-click empty → deselect
             old_sel = self._selected
@@ -901,8 +904,8 @@ class PointOverlay(QObject):
         )
         self._points[self._drag_idx] = [x, y]
         self._update_artist_position(self._drag_idx)
-        self.point_dragging.emit(self._drag_idx, x, y)
         self._blit()
+        self.point_dragging.emit(self._drag_idx, x, y)
 
     def _on_release(self, event):
         if self._canvas is None:

--- a/tests/ui/test_point_overlay_emit_order.py
+++ b/tests/ui/test_point_overlay_emit_order.py
@@ -1,0 +1,100 @@
+"""A point overlay finishes its own bookkeeping before it announces anything.
+
+FIB-958 was one instance of a general trap: emit a signal, and a synchronously
+connected listener may rebuild the overlay (set_points) before control comes back.
+Anything the emitting method still does with indices or artists afterwards then
+runs against the rebuilt lists. remove_point was fixed there; these pin the two
+remaining emit-before-mutate sites (FIB-972) so a listener that rebuilds on
+point_selected or point_dragging cannot leave a drag pointing at a dead artist.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_point_overlay_emit_order.py
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.ui.widgets.canvas.image_canvas import FibsemImageCanvas
+from fibsem.ui.widgets.canvas.overlays.point_overlay import PointOverlay
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _overlay():
+    canvas = FibsemImageCanvas()
+    canvas.resize(300, 300)
+    overlay = PointOverlay()
+    canvas.add_overlay(overlay)
+    canvas.set_array(np.zeros((100, 100), np.uint8))
+    canvas.show()
+    _app.processEvents()
+    overlay.set_points([(20.0, 20.0), (60.0, 60.0)])
+    canvas.draw()
+    _app.processEvents()
+    return canvas, overlay
+
+
+def _event(overlay, x: float, y: float, button=1):
+    sx, sy = overlay._ax.transData.transform((x, y))
+    return SimpleNamespace(
+        button=button,
+        x=sx,
+        y=sy,
+        xdata=x,
+        ydata=y,
+        inaxes=overlay._ax,
+        key=None,
+        dblclick=False,
+    )
+
+
+def _press_on(overlay, idx: int):
+    x, y = overlay._points[idx]
+    overlay._on_press(_event(overlay, x, y))
+
+
+def test_drag_state_is_established_before_point_selected_is_emitted():
+    canvas, overlay = _overlay()
+    seen = []
+
+    def on_selected(idx, x, y):
+        # What a model-owning listener sees at the moment of the emit. If the drag
+        # had not started yet, a rebuild here would leave it holding dead artists.
+        seen.append((idx, overlay._drag_idx, overlay._blit_bg is not None))
+        overlay.set_points(overlay.get_points())
+
+    overlay.point_selected.connect(on_selected)
+    _press_on(overlay, 1)
+
+    assert seen == [(1, 1, True)]
+    canvas.close()
+
+
+def test_the_dragged_frame_is_blitted_before_point_dragging_is_emitted():
+    canvas, overlay = _overlay()
+    _press_on(overlay, 1)
+    order = []
+    real_blit = overlay._blit
+    overlay._blit = lambda: (order.append("blit"), real_blit())[1]
+
+    def on_dragging(idx, x, y):
+        order.append("emit")
+        overlay.set_points(overlay.get_points())
+
+    overlay.point_dragging.connect(on_dragging)
+    overlay._on_motion(_event(overlay, 70.0, 75.0))
+
+    assert order == ["blit", "emit"]
+    assert overlay.get_points()[1] == (70.0, 75.0)
+    canvas.close()


### PR DESCRIPTION
Fixes FIB-972, the hygiene follow-up from the 2026-09 audit for the FIB-958 defect shape (a method emits a signal, a synchronously connected listener rebuilds the emitter, and the method then keeps working on the rebuilt collection).

The audit scanned every emit site under `fibsem/ui` and `autolamella/ui` and found no further confirmed cases. These are the two latent ones in `PointOverlay`, correct today only because no connected listener rebuilds the overlay from these signals:

- `_on_press` emitted `point_selected` before `_start_drag` captured its artist and blit background. Now the drag is established first.
- `_on_motion` emitted `point_dragging` before blitting the moved frame. Now it blits first.

No behaviour change for existing listeners. `tests/ui/test_point_overlay_emit_order.py` observes the order from inside a listener and fails on the old ordering.

Also removes `FMOverviewSettingsWidget.set_channel_names`, which referenced a combo the widget never creates and had no callers.

Two commits: a whitespace-only `[format]` of the two touched files (AST-identical, for the lint job's format-on-touch check), then the change.