### PR TITLE
[autolamella] Rebuilding the lamella and task lists keeps the operator's ticks

### DIFF
--- a/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
+++ b/fibsem/applications/autolamella/ui/AutoLamellaMainUI.py
@@ -3387,9 +3387,10 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         if not hasattr(self, "lamella_list_widget"):
             return
         experiment = self.autolamella_ui.experiment if self.autolamella_ui else None
-        self.lamella_list_widget.clear()
+        # The ticks and the selected card are the operator's, and this runs on every
+        # insert or removal: rebuild around them rather than through them (FIB-966).
+        selected = getattr(self, "_selected_card_lamella", None)
         self.lamella_card_container.clear()
-        self._on_lamella_card_selected(None)
         # The overview canvases are further displays of the same set, so they are
         # rebuilt here rather than from subscriptions of their own -- one handler for
         # "the lamellae changed" means the displays cannot end up disagreeing about what
@@ -3398,10 +3399,23 @@ class AutoLamellaSingleWindowUI(QMainWindow):
         # fill them.
         self._refresh_overview_positions()
         if experiment is None:
+            self.lamella_list_widget.clear()
+            self._on_lamella_card_selected(None)
             return
+        self.lamella_list_widget.set_lamellae(list(experiment.positions))
         for lamella in experiment.positions:
-            self.lamella_list_widget.add_lamella(lamella)
             self.lamella_card_container.add_lamella(lamella)
+        still_there = next(
+            (
+                lamella
+                for lamella in experiment.positions
+                if selected is not None and lamella.id == selected.id
+            ),
+            None,
+        )
+        if still_there is not None:
+            self.lamella_card_container.select_lamella(still_there.name)
+        self._on_lamella_card_selected(still_there)
         self._on_workflow_selection_changed()
         self._update_lamella_tab_enabled()
 

--- a/fibsem/applications/autolamella/ui/lamella_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_list_widget.py
@@ -41,7 +41,6 @@ _ROW_HEIGHT = 40
 _BTN_SPACER_WIDTH = _BTN_SIZE.width() * 3 + 8 * 2  # 3 buttons + 2 gaps
 
 
-
 class _LamellaTooltip(QWidget):
     """Frameless popup showing a thumbnail image when hovering a lamella name."""
 
@@ -64,11 +63,17 @@ class _LamellaTooltip(QWidget):
         h, w, c = arr.shape
         qimg = QImage(arr.data, w, h, w * c, QImage.Format_RGB888)
         self._img_label.setPixmap(
-            QPixmap.fromImage(qimg).scaled(256, 170, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
+            QPixmap.fromImage(qimg).scaled(
+                256,
+                170,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
         )
 
     def show_near_cursor(self) -> None:
         from PyQt5.QtWidgets import QApplication
+
         cursor = QCursor.pos()
         self.adjustSize()
         w, h = self.width(), self.height()
@@ -88,7 +93,10 @@ def _status_text(lamella: Lamella) -> tuple[str, str]:
     """Return (text, stylesheet) for the status column."""
     ts = lamella.task_state
     if ts and ts.status == AutoLamellaTaskStatus.InProgress:
-        return f"{ts.name}", f"color: {stylesheets.PRIMARY_COLOR}; background: transparent;"
+        return (
+            f"{ts.name}",
+            f"color: {stylesheets.PRIMARY_COLOR}; background: transparent;",
+        )
     last = lamella.last_completed_task
     if last:
         return last.completed, f"color: {NEUTRAL_550}; background: transparent;"
@@ -101,15 +109,23 @@ def _defect_icon(lamella: Lamella) -> tuple[str, str, str]:
     if d.state == DefectType.NONE:
         return "mdi:check-circle", stylesheets.GREEN_COLOR, "No defect"
     if d.state == DefectType.REWORK:
-        return "mdi:refresh-circle", stylesheets.DEFECT_ORANGE_COLOR, f"Rework required{': ' + d.description if d.description else ''}"
-    return "mdi:close-circle", stylesheets.DEFECT_RED_COLOR, f"Failure{': ' + d.description if d.description else ''}"
+        return (
+            "mdi:refresh-circle",
+            stylesheets.DEFECT_ORANGE_COLOR,
+            f"Rework required{': ' + d.description if d.description else ''}",
+        )
+    return (
+        "mdi:close-circle",
+        stylesheets.DEFECT_RED_COLOR,
+        f"Failure{': ' + d.description if d.description else ''}",
+    )
 
 
 class LamellaRowWidget(QWidget):
-    move_to_clicked = pyqtSignal(object)       # Lamella
-    edit_clicked = pyqtSignal(object)          # Lamella
-    remove_clicked = pyqtSignal(object)        # Lamella
-    defect_changed = pyqtSignal(object)        # Lamella
+    move_to_clicked = pyqtSignal(object)  # Lamella
+    edit_clicked = pyqtSignal(object)  # Lamella
+    remove_clicked = pyqtSignal(object)  # Lamella
+    defect_changed = pyqtSignal(object)  # Lamella
     selection_changed = pyqtSignal(object, bool)  # Lamella, checked
 
     def __init__(
@@ -145,15 +161,21 @@ class LamellaRowWidget(QWidget):
         layout.addWidget(self.status_label, 1)
 
         self.btn_defect = QToolButton()
-        self.btn_defect.setIcon(fibsem_icon("mdi:circle", color=stylesheets.GREEN_COLOR))
+        self.btn_defect.setIcon(
+            fibsem_icon("mdi:circle", color=stylesheets.GREEN_COLOR)
+        )
         self.btn_defect.setFixedSize(_BTN_SIZE)
         self.btn_defect.setStyleSheet(stylesheets.TOOLBUTTON_ICON_STYLESHEET)
         layout.addWidget(self.btn_defect)
 
-        self.btn_edit = IconToolButton(icon="mdi:pencil", tooltip="Edit Lamella", size=_BTN_SIZE.width())
+        self.btn_edit = IconToolButton(
+            icon="mdi:pencil", tooltip="Edit Lamella", size=_BTN_SIZE.width()
+        )
         layout.addWidget(self.btn_edit)
 
-        self.btn_remove = IconToolButton(icon="mdi:trash-can-outline", tooltip="Remove", size=_BTN_SIZE.width())
+        self.btn_remove = IconToolButton(
+            icon="mdi:trash-can-outline", tooltip="Remove", size=_BTN_SIZE.width()
+        )
         layout.addWidget(self.btn_remove)
 
         self.checkbox.stateChanged.connect(
@@ -196,8 +218,8 @@ class LamellaRowWidget(QWidget):
         # type: ignore because @evented adds .events dynamically and pyright can't see it.
         # lamella.task_state.events.name.connect(self.refresh)    # DISABLED: FIB-604
         # lamella.task_state.events.status.connect(self.refresh)  # DISABLED: FIB-604
-        lamella.events.defect.connect(self.refresh)             # type: ignore[union-attr]
-        lamella.events.description.connect(self.refresh)        # type: ignore[union-attr]
+        lamella.events.defect.connect(self.refresh)  # type: ignore[union-attr]
+        lamella.events.description.connect(self.refresh)  # type: ignore[union-attr]
 
         self.refresh()
 
@@ -207,15 +229,17 @@ class LamellaRowWidget(QWidget):
             fibsem_icon("mdi:check-circle", color=stylesheets.GREEN_COLOR), "No defect"
         )
         action_rework = menu.addAction(
-            fibsem_icon("mdi:refresh-circle", color=stylesheets.DEFECT_ORANGE_COLOR), "Rework required"
+            fibsem_icon("mdi:refresh-circle", color=stylesheets.DEFECT_ORANGE_COLOR),
+            "Rework required",
         )
         action_failure = menu.addAction(
-            fibsem_icon("mdi:close-circle", color=stylesheets.DEFECT_RED_COLOR), "Failure"
+            fibsem_icon("mdi:close-circle", color=stylesheets.DEFECT_RED_COLOR),
+            "Failure",
         )
 
-        chosen = menu.exec_(self.btn_defect.mapToGlobal(
-            self.btn_defect.rect().bottomLeft()
-        ))
+        chosen = menu.exec_(
+            self.btn_defect.mapToGlobal(self.btn_defect.rect().bottomLeft())
+        )
 
         if chosen == action_none:
             self.lamella.defect = DefectState(state=DefectType.NONE)
@@ -306,11 +330,11 @@ class _LamellaListHeader(QWidget):
 class LamellaListWidget(QWidget):
     """List widget displaying Lamella objects with name, defect, status and actions."""
 
-    move_to_requested = pyqtSignal(object)   # Lamella
-    edit_requested = pyqtSignal(object)      # Lamella
-    remove_requested = pyqtSignal(object)    # Lamella
-    defect_changed = pyqtSignal(object)      # Lamella
-    selection_changed = pyqtSignal(list)     # List[Lamella]
+    move_to_requested = pyqtSignal(object)  # Lamella
+    edit_requested = pyqtSignal(object)  # Lamella
+    remove_requested = pyqtSignal(object)  # Lamella
+    defect_changed = pyqtSignal(object)  # Lamella
+    selection_changed = pyqtSignal(list)  # List[Lamella]
 
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
@@ -460,10 +484,7 @@ class LamellaListWidget(QWidget):
         count = self._list.count()
         if count == 0:
             return
-        n_checked = sum(
-            self._row(i).checkbox.isChecked()
-            for i in range(count)
-        )
+        n_checked = sum(self._row(i).checkbox.isChecked() for i in range(count))
         cb = self._header.checkbox_all
         cb.blockSignals(True)
         if n_checked == 0:

--- a/fibsem/applications/autolamella/ui/lamella_list_widget.py
+++ b/fibsem/applications/autolamella/ui/lamella_list_widget.py
@@ -439,6 +439,20 @@ class LamellaListWidget(QWidget):
             if self._row(i).checkbox.isChecked()
         ]
 
+    def set_lamellae(self, lamellae: List[Lamella]) -> None:
+        """Rebuild the rows from *lamellae*, keeping the ticks the user already has.
+
+        The host rebuilds on every insert or removal in the experiment, and the
+        ticked rows are its run selection. Rebuilding them unticked emptied that
+        selection, and silently disabled Run, every time a position was added
+        (FIB-966). Ticks are matched by lamella id, so a lamella that is gone is
+        simply not re-ticked.
+        """
+        checked = {lamella.id for lamella in self.get_selected()}
+        self.clear()
+        for lamella in lamellae:
+            self.add_lamella(lamella, checked=lamella.id in checked)
+
     def clear(self) -> None:
         self._list.clear()
 

--- a/fibsem/applications/autolamella/ui/workflow_config_widget.py
+++ b/fibsem/applications/autolamella/ui/workflow_config_widget.py
@@ -358,10 +358,17 @@ class WorkflowConfigWidget(QWidget):
     # ------------------------------------------------------------------
 
     def set_config(self, config: AutoLamellaWorkflowConfig) -> None:
-        """Populate the list from an AutoLamellaWorkflowConfig."""
+        """Populate the list from an AutoLamellaWorkflowConfig, keeping the ticks.
+
+        Reached on every protocol edit (``workflow_config_changed``), not only when
+        the task set changes, and the ticked rows are the run selection. Rebuilding
+        them unticked emptied that selection on any field edit (FIB-967). Ticks are
+        matched by task name, so a task that is gone is simply not re-ticked.
+        """
+        checked = {task.name for task in self.get_selected()}
         self.clear()
         for task in config.tasks:
-            self.add_task(task)
+            self.add_task(task, checked=task.name in checked)
 
     def add_task(
         self, task: AutoLamellaTaskDescription, checked: bool = False

--- a/tests/ui/test_fm_overview_widget.py
+++ b/tests/ui/test_fm_overview_widget.py
@@ -3652,6 +3652,12 @@ class _ListStub:
     def add_lamella(self, lamella):
         self.lamellae.append(lamella)
 
+    def set_lamellae(self, lamellae):
+        self.lamellae[:] = list(lamellae)
+
+    def select_lamella(self, name):
+        pass
+
 
 def _list_host(qapp, tmp_path, experiment=None):
     """A `_StubHost` that can run the real `_rebuild_lamella_list`."""
@@ -3747,6 +3753,53 @@ def test_closing_an_experiment_clears_the_canvas(qapp, tmp_path):
 
     assert host.fm_overview_widget._positions == []
 
+    host._teardown_fm_overview_widget()
+
+
+def test_a_rebuild_keeps_the_ticks_and_the_selected_card(qapp, tmp_path):
+    """FIB-966: the rebuild runs on every insert, and the ticks are the run selection.
+
+    Real list and card widgets here rather than the stubs, because the claim is about
+    what they hold across the clear-and-re-add, not about what the canvas draws.
+    """
+    from fibsem.applications.autolamella.ui.lamella_card_widget import (
+        LamellaCardContainer,
+    )
+    from fibsem.applications.autolamella.ui.lamella_list_widget import (
+        LamellaListWidget,
+    )
+
+    experiment = _real_experiment(tmp_path)
+    host = _list_host(qapp, tmp_path, experiment)
+    host.lamella_list_widget = LamellaListWidget()
+    host.lamella_card_container = LamellaCardContainer(columns=1)
+    reselected = []
+    host._on_lamella_card_selected = reselected.append
+    microscope = host.autolamella_ui.microscope
+    first = _real_lamella("Lamella-01", microscope, tmp_path)
+    second = _real_lamella("Lamella-02", microscope, tmp_path)
+    experiment.positions.extend([first, second])
+    host._rebuild_lamella_list()
+    host.lamella_list_widget._row(1).checkbox.setChecked(True)
+    host.lamella_card_container.select_lamella(second.name)
+    host._selected_card_lamella = second
+
+    experiment.positions.append(_real_lamella("Lamella-03", microscope, tmp_path))
+    host._rebuild_lamella_list()
+
+    assert host.lamella_list_widget.get_selected() == [second]
+    assert host.lamella_card_container._selected_id == second.id
+    assert reselected[-1] is second
+
+    experiment.positions.remove(second)
+    host._rebuild_lamella_list()
+
+    assert host.lamella_list_widget.get_selected() == []
+    assert host.lamella_card_container._selected_id is None
+    assert reselected[-1] is None
+
+    host.lamella_list_widget.close()
+    host.lamella_card_container.close()
     host._teardown_fm_overview_widget()
 
 

--- a/tests/ui/test_rebuild_keeps_ticks.py
+++ b/tests/ui/test_rebuild_keeps_ticks.py
@@ -1,0 +1,133 @@
+"""Rebuilding the run-selection lists keeps the operator's ticks (FIB-966, FIB-967).
+
+Both lists are the run selection, and both are rebuilt on routine events: the lamella
+list on every insert or removal in the experiment, the task list on every protocol
+edit. Rebuilding them unticked emptied the selection and silently disabled Run. The
+grid workflow widget already preserved its ticks across its own rebuild; these two now
+do the same.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_rebuild_keeps_ticks.py
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+from PyQt5.QtWidgets import QApplication
+
+from fibsem.applications.autolamella.structures import (
+    AutoLamellaTaskDescription,
+    AutoLamellaWorkflowConfig,
+    Lamella,
+)
+from fibsem.applications.autolamella.ui.lamella_list_widget import LamellaListWidget
+from fibsem.applications.autolamella.ui.workflow_config_widget import (
+    WorkflowConfigWidget,
+)
+
+_app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _lamellae(n: int):
+    return [
+        Lamella(path="", number=i + 1, petname=f"lamella-{i + 1}") for i in range(n)
+    ]
+
+
+def _tasks(names):
+    return [
+        AutoLamellaTaskDescription(name=n, supervise=False, required=False)
+        for n in names
+    ]
+
+
+def _tick(widget, rows):
+    for i in rows:
+        widget._row(i).checkbox.setChecked(True)
+
+
+# ── lamella list ──────────────────────────────────────────────────────────
+
+
+def test_set_lamellae_keeps_the_ticks_when_a_lamella_is_added():
+    widget = LamellaListWidget()
+    lamellae = _lamellae(3)
+    widget.set_lamellae(lamellae)
+    _tick(widget, [0, 2])
+
+    widget.set_lamellae(lamellae + _lamellae(1))
+
+    assert widget.get_selected() == [lamellae[0], lamellae[2]]
+    widget.close()
+
+
+def test_set_lamellae_drops_the_tick_of_a_removed_lamella_only():
+    widget = LamellaListWidget()
+    lamellae = _lamellae(3)
+    widget.set_lamellae(lamellae)
+    _tick(widget, [0, 1])
+
+    widget.set_lamellae([lamellae[0], lamellae[2]])
+
+    assert widget.get_selected() == [lamellae[0]]
+    widget.close()
+
+
+def test_set_lamellae_matches_by_id_not_by_name():
+    widget = LamellaListWidget()
+    old = _lamellae(1)
+    widget.set_lamellae(old)
+    _tick(widget, [0])
+    twin = Lamella(path="", number=1, petname=old[0].petname)  # same name, new id
+
+    widget.set_lamellae([twin])
+
+    assert widget.get_selected() == []
+    widget.close()
+
+
+def test_set_lamellae_from_empty_starts_unticked():
+    widget = LamellaListWidget()
+    widget.set_lamellae(_lamellae(2))
+    assert widget.get_selected() == []
+    widget.close()
+
+
+# ── task list ─────────────────────────────────────────────────────────────
+
+
+def test_set_config_keeps_the_ticks_across_a_field_edit():
+    widget = WorkflowConfigWidget()
+    widget.set_config(AutoLamellaWorkflowConfig(tasks=_tasks(["a", "b", "c"])))
+    _tick(widget, [0, 2])
+
+    # A protocol edit hands over fresh task objects with the same names.
+    widget.set_config(AutoLamellaWorkflowConfig(tasks=_tasks(["a", "b", "c"])))
+
+    assert [t.name for t in widget.get_selected()] == ["a", "c"]
+    widget.close()
+
+
+def test_set_config_drops_the_tick_of_a_removed_task_only():
+    widget = WorkflowConfigWidget()
+    widget.set_config(AutoLamellaWorkflowConfig(tasks=_tasks(["a", "b", "c"])))
+    _tick(widget, [0, 1])
+
+    widget.set_config(AutoLamellaWorkflowConfig(tasks=_tasks(["a", "c"])))
+
+    assert [t.name for t in widget.get_selected()] == ["a"]
+    widget.close()
+
+
+def test_set_config_from_empty_starts_unticked():
+    widget = WorkflowConfigWidget()
+    widget.set_config(AutoLamellaWorkflowConfig(tasks=_tasks(["a", "b"])))
+    assert widget.get_selected() == []
+    widget.close()


### PR DESCRIPTION
Fixes FIB-966 and FIB-967, the two High items from the 2026-09 audit for the FIB-959 defect shape (a routine path silently reverts state the user set).

Both lists are the run selection, and both were rebuilt unticked on routine events.

## FIB-966: adding or removing a lamella clears every tick and the selected card

`AutoLamellaMainUI._rebuild_lamella_list` runs on every psygnal insert or removal in the experiment. It cleared the list, the card container and the selected card, then re-added everything unticked. Adding a position on the Overview tab, or a running workflow adding one, emptied the selection and silently disabled Run.

Now `LamellaListWidget.set_lamellae` rebuilds around the ticks, matched by lamella id, and the main UI re-selects the card the operator had if that lamella is still present. The `GridWorkflowWidget._rebuild` sibling already did this for grids.

## FIB-967: any protocol edit unticks every task

`WorkflowConfigWidget.set_config` is reached from `workflow_config_changed` on every field edit, not only when the task set changes. It cleared and re-added every task unticked. Now it keeps the ticks, matched by task name, since a protocol edit hands over fresh task objects.

A task or lamella that is gone is simply not re-ticked. A list populated from empty starts unticked, as before.

## Verification

- `tests/ui/test_rebuild_keeps_ticks.py`: add, remove, id-vs-name matching, and from-empty for both widgets. `test_selection_clearing.py` (the FIB-577/578 clear paths) still passes.
- The main-UI rebuild is not unit-tested here; there is no headless harness for `AutoLamellaMainUI` in the tree. Its change is a snapshot before the clear and a `select_lamella` after the re-add.

Two commits: a whitespace-only `[format]` of `lamella_list_widget.py` (AST-identical, for the lint job's format-on-touch check), then the change.