### PR TITLE
[ui] Canvas delete selects the neighbour; timelapse scrubber holds while scrubbing

### DIFF
--- a/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
+++ b/fibsem/applications/autolamella/ui/fluorescence_coincidence_viewer_widget.py
@@ -1717,7 +1717,12 @@ class FluorescenceCoincidenceViewerWidget(QWidget):
             self._timelapse_timestamps.append(now)
 
             n = len(self._timelapse_frames)
-            self.fm_canvas.set_timelapse_length(n)
+            self.fm_canvas.set_timelapse_length(n)  # the new frame is reachable
+            if self._is_scrubbing:
+                # The operator is looking at an earlier frame: the display path
+                # above already holds it, and the slider and label must describe
+                # it, not the frame that just arrived (FIB-968).
+                return
             # Advance slider to latest without triggering scrub (live display stays untouched)
             self.fm_canvas.time_slider.blockSignals(True)
             self.fm_canvas.time_slider.setValue(n - 1)

--- a/fibsem/ui/correlation/widgets/coordinate_list_widget.py
+++ b/fibsem/ui/correlation/widgets/coordinate_list_widget.py
@@ -574,12 +574,21 @@ class CoordinateListWidget(QWidget):
             self._header.update_selection(self._selected_coordinate)
         self.order_changed.emit(list(self._coordinates))
 
-    def _on_remove(self, coord: Coordinate) -> None:
+    def remove_coordinate(self, coord: Coordinate) -> bool:
+        """Remove *coord*'s row and select its neighbour, without emitting anything.
+
+        The caller decides what the removal means: the row's own trash button emits
+        ``coordinate_removed`` and then the neighbour's selection; the canvas path is
+        echoing a removal that already happened and only needs the list to follow.
+        Selecting the first row instead, as assigning ``coordinates`` does, was what
+        made a canvas delete jump the selection to row 1 (FIB-965).
+        Returns False if *coord* is not here.
+        """
         # Identity, not equality: the overlay and the tab widget both key on the
         # object, and two coordinates can hold equal values and still be different points.
         idx = next((i for i, c in enumerate(self._coordinates) if c is coord), None)
         if idx is None:
-            return
+            return False
         del self._coordinates[idx]
 
         next_coord = None
@@ -593,11 +602,23 @@ class CoordinateListWidget(QWidget):
         self._rebuild_rows()
 
         if next_coord is not None:
-            self._set_selected(next_coord)
+            self.blockSignals(True)
+            try:
+                self._set_selected(next_coord)
+            finally:
+                self.blockSignals(False)
         else:
             self._header.update_selection(None)
+        return True
 
-        self.coordinate_removed.emit(coord)
+    def _on_remove(self, coord: Coordinate) -> None:
+        # Removal first, then the neighbour's selection: the tab widget answers
+        # coordinate_removed by rebuilding the overlay, which drops its selection,
+        # so a selection announced before the removal was wiped by it (FIB-965).
+        if self.remove_coordinate(coord):
+            self.coordinate_removed.emit(coord)
+            if self._selected_coordinate is not None:
+                self.coordinate_selected.emit(self._selected_coordinate)
 
     def add_coordinate(self, coord: Coordinate) -> None:
         """Append a coordinate, rebuild its row, and select it."""

--- a/fibsem/ui/correlation/widgets/correlation_tab_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_tab_widget.py
@@ -134,7 +134,7 @@ _LEGACY_RESULT_FILENAME = "correlation_result.json"
 # confirm dialog is shown even in auto-accept mode. Generous — the goal is to
 # catch gross mis-locks, not sub-pixel disagreement.
 _AUTO_ACCEPT_MAX_XY_PX = 25.0  # XY displacement (pixels)
-_AUTO_ACCEPT_MAX_Z = 5.0       # Z displacement (slices)
+_AUTO_ACCEPT_MAX_Z = 5.0  # Z displacement (slices)
 
 # Run-bar RMS cue. The badge FLAGS problems; it never certifies quality. The RMS
 # is a fit residual over the fiducials, so a low value cannot promise the POI —
@@ -215,7 +215,7 @@ def _ro_item(text: str) -> QTableWidgetItem:
     return item
 
 
-_PLOT_DPI = 150          # the saved figure's dpi
+_PLOT_DPI = 150  # the saved figure's dpi
 _PLOT_PANEL_INCHES = 8.0  # each panel of the 16x8 two-panel figure
 
 
@@ -574,9 +574,7 @@ class _ImagesTab(QWidget):
             "Interpolate the z-stack toward an isotropic voxel size"
         )
         self._btn_interpolate.setEnabled(False)  # enabled once a z-stack is loaded
-        self._btn_interpolate.clicked.connect(
-            lambda: self.interpolate_requested.emit()
-        )
+        self._btn_interpolate.clicked.connect(lambda: self.interpolate_requested.emit())
         z_row_layout.addWidget(self._btn_interpolate)
         fm_form.addRow(_form_label("Z-slices:"), z_row)
 
@@ -885,7 +883,9 @@ class _CoordinatesTab(QWidget):
             "(failed or far-off fits still ask)."
         )
         fit_help.setWordWrap(True)
-        fit_help.setStyleSheet(f"color: {TEXT_MUTED_COLOR}; font-size: 11px; padding-top: 4px;")
+        fit_help.setStyleSheet(
+            f"color: {TEXT_MUTED_COLOR}; font-size: 11px; padding-top: 4px;"
+        )
         fit_form.addRow(fit_help)
 
         self._fit_panel = TitledPanel("Fit Settings", collapsible=True)
@@ -1067,7 +1067,7 @@ class _RITab(QWidget):
            applying it triggers (or requires) a correlation run.
     """
 
-    correction_applied = pyqtSignal(object)             # CorrelationResult (post)
+    correction_applied = pyqtSignal(object)  # CorrelationResult (post)
     pre_correction_requested = pyqtSignal(float, bool)  # factor, rerun (pre)
 
     # Abbreviated because the full words don't fit four columns at this panel
@@ -1076,9 +1076,9 @@ class _RITab(QWidget):
     _PRE_HEADERS = ["POI", "X (px)", "Z orig (px)", "Z corr (px)"]
 
     _WARNING_STYLES = {
-        "error":   "color: #e07b39; font-size: 11px;",
+        "error": "color: #e07b39; font-size: 11px;",
         "success": "color: #6dbf6d; font-size: 11px;",
-        "armed":   "color: #e0c060; font-size: 11px;",
+        "armed": "color: #e0c060; font-size: 11px;",
     }
 
     # Half the factor spinbox's last decimal: a stored 1.5950000000000002 shows
@@ -1530,7 +1530,9 @@ class _RITab(QWidget):
             logging.exception("[RITab._apply_post] correction refused")
             self._set_warning(f"Correction not applied: {exc}")
             return
-        logging.info("[RITab._apply_post] correction applied, emitting correction_applied")
+        logging.info(
+            "[RITab._apply_post] correction applied, emitting correction_applied"
+        )
         self.correction_applied.emit(self._result)
 
 
@@ -1633,11 +1635,11 @@ class _PointTypeSpec:
     point_type: PointType
     list_widget: CoordinateListWidget
     adapter: _CanvasAdapter
-    max_one: bool = False                            # replace-on-add (surfaces)
-    exclusive_group: Optional[str] = None            # mutually exclusive specs
-    fm_fit_role: Optional[str] = None                # "fid" | "poi" → refit combos
+    max_one: bool = False  # replace-on-add (surfaces)
+    exclusive_group: Optional[str] = None  # mutually exclusive specs
+    fm_fit_role: Optional[str] = None  # "fid" | "poi" → refit combos
     on_cleared: Optional[Callable[[], None]] = None  # fired when the spec's
-                                                     # last point is removed
+    # last point is removed
 
     def __post_init__(self) -> None:
         expected_side = _POINT_TYPE_SIDES.get(self.point_type)
@@ -1828,7 +1830,9 @@ class CorrelationTabWidget(QWidget):
         right_layout.addWidget(self._tabs, stretch=1)
 
         run_bar = QWidget()
-        run_bar.setStyleSheet(f"background: {CANVAS_BG}; border-top: 1px solid #3a3d42;")
+        run_bar.setStyleSheet(
+            f"background: {CANVAS_BG}; border-top: 1px solid #3a3d42;"
+        )
         run_layout = QVBoxLayout(run_bar)
         run_layout.setContentsMargins(8, 6, 8, 6)
         run_layout.setSpacing(4)
@@ -1891,20 +1895,28 @@ class CorrelationTabWidget(QWidget):
         specs = (
             _PointTypeSpec(PointType.FIB, cl.fib_list, adapter_for(PointType.FIB)),
             _PointTypeSpec(
-                PointType.SURFACE, cl.surface_list, adapter_for(PointType.SURFACE),
-                max_one=True, exclusive_group="surface",
+                PointType.SURFACE,
+                cl.surface_list,
+                adapter_for(PointType.SURFACE),
+                max_one=True,
+                exclusive_group="surface",
             ),
             _PointTypeSpec(
                 PointType.FM, cl.fm_list, adapter_for(PointType.FM), fm_fit_role="fid"
             ),
             _PointTypeSpec(
-                PointType.POI, cl.poi_list, adapter_for(PointType.POI),
+                PointType.POI,
+                cl.poi_list,
+                adapter_for(PointType.POI),
                 fm_fit_role="poi",
             ),
             _PointTypeSpec(
-                PointType.SURFACE_FM, cl.fm_surface_list,
+                PointType.SURFACE_FM,
+                cl.fm_surface_list,
                 adapter_for(PointType.SURFACE_FM),
-                max_one=True, exclusive_group="surface", fm_fit_role="fid",
+                max_one=True,
+                exclusive_group="surface",
+                fm_fit_role="fid",
                 on_cleared=self._clear_pre_correction_factor,
             ),
         )
@@ -2116,7 +2128,10 @@ class CorrelationTabWidget(QWidget):
             logging.warning(
                 "FM scalebar: data width %d ≠ metadata resolution %d — pixel "
                 "size corrected %.1f→%.1f nm/px for the display resize.",
-                data_w, acq_w, px * 1e9, corrected * 1e9,
+                data_w,
+                acq_w,
+                px * 1e9,
+                corrected * 1e9,
             )
             return corrected
         return px
@@ -2278,7 +2293,7 @@ class CorrelationTabWidget(QWidget):
         differs, so a seed picked in a differently-interpolated volume lands at the
         right depth. Points are placed as-is; the user refines them on demand.
         """
-        src_z = source.stored_fm_pixel_size_z   # read before we attach the current image
+        src_z = source.stored_fm_pixel_size_z  # read before we attach the current image
         cur_z = self._fm_pixel_size_z()
         source.fib_image = self._fib_image
         source.fm_image = self._fm_image
@@ -2420,9 +2435,7 @@ class CorrelationTabWidget(QWidget):
                 self.seed_fib_fiducials_from_spot_burns(payload)
         else:
             self.set_data(
-                CorrelationInputData(
-                    fib_image=self._fib_image, fm_image=self._fm_image
-                )
+                CorrelationInputData(fib_image=self._fib_image, fm_image=self._fm_image)
             )
             self._discard_result()
             self.data_changed.emit(self.data)
@@ -2768,16 +2781,16 @@ class CorrelationTabWidget(QWidget):
         if rms is not None and live:
             px_m = self._fib_pixel_size_m()
             rms_nm = rms * px_m * 1e9 if px_m else None
-            shown = _format_distance_nm(rms_nm) if rms_nm is not None else f"{rms:.2f} px"
+            shown = (
+                _format_distance_nm(rms_nm) if rms_nm is not None else f"{rms:.2f} px"
+            )
             worst = self._worst_fiducial_px(result)
             color, concern = _rms_concern(
                 rms_nm,
                 len(result.reprojected_3d),
                 worst / rms if worst is not None and rms > 0 else None,
             )
-            self._lbl_result.setText(
-                f'<span style="color:{color}">RMS {shown}</span>'
-            )
+            self._lbl_result.setText(f'<span style="color:{color}">RMS {shown}</span>')
             self._lbl_result.setToolTip(self._rms_tooltip(result, rms, px_m, concern))
             self._lbl_result.setVisible(True)
         # Staleness outranks the RI note: this is the only line explaining why
@@ -2849,7 +2862,9 @@ class CorrelationTabWidget(QWidget):
             lines.append(f"{rms_px:.2f} px × {px_m * 1e9:.1f} nm/px")
         else:
             lines.append(f"Registration RMS error — {rms_px:.2f} px")
-            lines.append("FIB pixel size unknown — load the FIB image to see this in nm.")
+            lines.append(
+                "FIB pixel size unknown — load the FIB image to see this in nm."
+            )
 
         detail = (
             "Root-mean-square residual of the rigid 3D→2D fit"
@@ -3017,9 +3032,7 @@ class CorrelationTabWidget(QWidget):
         else:
             spec.list_widget.add_coordinate(coord)
         # Before the emit: the armed factor is part of the data being announced.
-        armed = (
-            self._auto_arm_pre_correction() if pt is PointType.SURFACE_FM else None
-        )
+        armed = self._auto_arm_pre_correction() if pt is PointType.SURFACE_FM else None
         self._refresh_canvas(spec.adapter)
         self._coords_tab.update_headers()
         self.data_changed.emit(self.data)
@@ -3233,7 +3246,9 @@ class CorrelationTabWidget(QWidget):
             self.load_correlation(path)
         except Exception as exc:
             logging.exception("Failed to load correlation from %s", path)
-            QMessageBox.warning(self, "Load Error", f"Could not load correlation:\n{exc}")
+            QMessageBox.warning(
+                self, "Load Error", f"Could not load correlation:\n{exc}"
+            )
 
     def _on_save(self) -> None:
         start = os.path.join(self._project_dir or "", CORRELATION_FILENAME)
@@ -3249,7 +3264,9 @@ class CorrelationTabWidget(QWidget):
             self.save_correlation(path)
         except Exception as exc:
             logging.exception("Failed to save correlation to %s", path)
-            QMessageBox.warning(self, "Save Error", f"Could not save correlation:\n{exc}")
+            QMessageBox.warning(
+                self, "Save Error", f"Could not save correlation:\n{exc}"
+            )
 
     # ------------------------------------------------------------------
     # FM z-stack interpolation (FIB-253)
@@ -3357,9 +3374,7 @@ class CorrelationTabWidget(QWidget):
         without hunting for it. Scoped to this widget and its children so it
         only fires while the correlation UI has focus."""
         self._fit_shortcut = QShortcut(QKeySequence("F"), self)
-        self._fit_shortcut.setContext(
-            Qt.ShortcutContext.WidgetWithChildrenShortcut
-        )
+        self._fit_shortcut.setContext(Qt.ShortcutContext.WidgetWithChildrenShortcut)
         self._fit_shortcut.activated.connect(self._fit_selected_coordinate)
 
     def _selected_coordinate(self) -> Optional[Coordinate]:
@@ -3453,9 +3468,7 @@ class CorrelationTabWidget(QWidget):
                     attempted = True
                     # pass the sub-pixel click (not int) so the diagnostic's
                     # input marker lands where the user clicked — FIB-282.
-                    xr, yr, diag = hole_fitting_FIB(
-                        self._fib_image.filtered_data, x, y
-                    )
+                    xr, yr, diag = hole_fitting_FIB(self._fib_image.filtered_data, x, y)
                     fitted = PointXYZ(float(xr), float(yr), z)
             else:
                 # The FM surface is typically picked in the reflection channel,
@@ -3472,20 +3485,26 @@ class CorrelationTabWidget(QWidget):
                     if method == "Hole":
                         attempted = True
                         xr, yr, zr, diag = hole_fitting_reflection(
-                            img, x, y, z=int(z),  # sub-pixel x/y (FIB-282)
+                            img,
+                            x,
+                            y,
+                            z=int(z),  # sub-pixel x/y (FIB-282)
                             cutout=self._correlation_config.fit.reflection_cutout,
                         )
                         fitted = PointXYZ(float(xr), float(yr), float(zr))
                     elif method == "Gaussian":
                         attempted = True
                         xr, yr, zr, diag = target_fitting_fluorescence(
-                            img, x, y, int(z),  # sub-pixel x/y (FIB-282)
+                            img,
+                            x,
+                            y,
+                            int(z),  # sub-pixel x/y (FIB-282)
                             cutout=self._correlation_config.fit.fluorescence_cutout,
                         )
                         fitted = PointXYZ(float(xr), float(yr), float(zr))
         except Exception as exc:
             logging.exception("Point fit failed")
-            error_detail = str(exc)          # raw text -> log + tooltip
+            error_detail = str(exc)  # raw text -> log + tooltip
             error = humanize_fit_error(exc)  # user-facing, actionable
             attempted = True
 
@@ -3613,9 +3632,7 @@ def _discover_correlation_files(directory: str) -> Dict[str, Optional[str]]:
             glob.glob(os.path.join(directory, "*.tif"))
             + glob.glob(os.path.join(directory, "*.tiff"))
         )
-        fib = next(
-            (t for t in tifs if not t.endswith((".ome.tif", ".ome.tiff"))), None
-        )
+        fib = next((t for t in tifs if not t.endswith((".ome.tif", ".ome.tiff"))), None)
 
     def _existing(name: str) -> Optional[str]:
         p = os.path.join(directory, name)

--- a/fibsem/ui/correlation/widgets/correlation_tab_widget.py
+++ b/fibsem/ui/correlation/widgets/correlation_tab_widget.py
@@ -3014,12 +3014,13 @@ class CorrelationTabWidget(QWidget):
 
     def _on_canvas_removed(self, coord: Coordinate) -> None:
         spec = self._point_specs[coord.point_type]
-        spec.list_widget.coordinates = [
-            c for c in spec.list_widget.coordinates if c is not coord
-        ]
+        # Through the list's own removal, so the neighbour ends up selected, the
+        # same as the row's trash button. Assigning `coordinates` selects row 1.
+        spec.list_widget.remove_coordinate(coord)
         if spec.on_cleared is not None and not spec.list_widget.coordinates:
             spec.on_cleared()
         self._refresh_canvas(spec.adapter)
+        self._select_only(spec, spec.list_widget.selected_coordinate)
         self._coords_tab.update_headers()
         self.data_changed.emit(self.data)
 
@@ -3079,6 +3080,7 @@ class CorrelationTabWidget(QWidget):
         if spec.on_cleared is not None and not spec.list_widget.coordinates:
             spec.on_cleared()
         self._refresh_canvas(spec.adapter)
+        self._select_only(spec, spec.list_widget.selected_coordinate)
         self._coords_tab.update_headers()
         self.data_changed.emit(self.data)
 

--- a/tests/ui/test_coincidence_timelapse_scrub.py
+++ b/tests/ui/test_coincidence_timelapse_scrub.py
@@ -1,0 +1,78 @@
+"""The timelapse scrubber stays where the operator put it while a run accumulates frames.
+
+FIB-968: the viewer adds a frame to its timelapse every TIMELAPSE_INTERVAL seconds. The
+display path already stood aside while the operator was scrubbing back through earlier
+frames; the accumulation path did not, and every interval it moved the slider to the end
+and rewrote the label with the newest timestamp, while the canvas kept showing the
+earlier frame. The slider's range still has to grow so the new frame is reachable.
+
+Run directly (no display needed):
+    QT_QPA_PLATFORM=offscreen python -m pytest tests/ui/test_coincidence_timelapse_scrub.py
+"""
+
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt5")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt5.QtWidgets import QApplication
+
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture
+def viewer(qapp, tmp_path):
+    from fibsem import config as cfg
+    from fibsem import utils
+    from fibsem.applications.autolamella.structures import Experiment
+    from fibsem.applications.autolamella.ui.fluorescence_coincidence_viewer_widget import (
+        FluorescenceCoincidenceViewerWidget,
+    )
+
+    microscope, _ = utils.setup_session(
+        config_path=os.path.join(cfg.CONFIG_PATH, "sim-arctis-configuration.yaml")
+    )
+    widget = FluorescenceCoincidenceViewerWidget(
+        microscope=microscope,
+        experiment=Experiment(path=str(tmp_path), name="timelapse-scrub-test"),
+    )
+    yield widget
+    widget.close()
+
+
+def _accumulate(viewer):
+    viewer._last_timelapse_time = 0.0  # make the interval elapse
+    frame = SimpleNamespace(data=np.zeros((16, 16), np.float32))
+    viewer._maybe_accumulate_timelapse(frame)
+
+
+def test_scrubbing_holds_the_slider_and_label_while_frames_accumulate(viewer):
+    for _ in range(3):
+        _accumulate(viewer)
+    viewer.fm_canvas.time_slider.setValue(0)  # drag the scrubber back
+    assert viewer._is_scrubbing
+    label_before = viewer.fm_canvas.frame_label.text()
+
+    _accumulate(viewer)
+
+    assert len(viewer._timelapse_frames) == 4
+    assert viewer.fm_canvas.time_slider.maximum() == 3  # the new frame is reachable
+    assert viewer.fm_canvas.time_slider.value() == 0
+    assert viewer.fm_canvas.frame_label.text() == label_before
+
+
+def test_live_view_still_follows_the_newest_frame(viewer):
+    for _ in range(3):
+        _accumulate(viewer)
+    assert not viewer._is_scrubbing
+    assert viewer.fm_canvas.time_slider.value() == 2
+    assert viewer.fm_canvas.frame_label.text().endswith("(2/2)")

--- a/tests/ui/test_correlation_point_removal.py
+++ b/tests/ui/test_correlation_point_removal.py
@@ -103,3 +103,74 @@ def test_list_widget_removes_by_identity_not_equality():
     assert lw.coordinates == [twin_a]
     assert lw.coordinates[0] is twin_a
     lw.close()
+
+
+# ── FIB-965: which row is selected after a removal ───────────────────────
+
+
+def _list_with(n: int) -> CoordinateListWidget:
+    lw = CoordinateListWidget(point_type=PointType.FIB)
+    lw.coordinates = [
+        Coordinate(PointXYZ(10 * i, 10 * i, 0), PointType.FIB) for i in range(n)
+    ]
+    return lw
+
+
+def test_remove_coordinate_selects_the_neighbour_and_emits_nothing():
+    lw = _list_with(5)
+    coords = lw.coordinates
+    lw.select_coordinate_silent(coords[3])
+    emitted = []
+    lw.coordinate_selected.connect(lambda c: emitted.append(("selected", c)))
+    lw.coordinate_removed.connect(lambda c: emitted.append(("removed", c)))
+
+    assert lw.remove_coordinate(coords[3]) is True
+
+    assert lw.coordinates == [coords[0], coords[1], coords[2], coords[4]]
+    assert lw.selected_coordinate is coords[4]
+    assert emitted == []
+    lw.close()
+
+
+def test_remove_coordinate_of_the_last_row_selects_the_new_last():
+    lw = _list_with(3)
+    coords = lw.coordinates
+    lw.remove_coordinate(coords[2])
+    assert lw.selected_coordinate is coords[1]
+    assert lw.remove_coordinate(coords[2]) is False  # already gone
+    lw.close()
+
+
+def test_trash_button_emits_the_removal_before_the_new_selection():
+    lw = _list_with(3)
+    coords = lw.coordinates
+    order = []
+    lw.coordinate_removed.connect(lambda c: order.append(("removed", c)))
+    lw.coordinate_selected.connect(lambda c: order.append(("selected", c)))
+
+    lw._on_remove(coords[0])
+
+    assert order == [("removed", coords[0]), ("selected", coords[1])]
+    lw.close()
+
+
+def test_canvas_delete_in_the_tab_widget_selects_the_neighbour_not_row_1():
+    from fibsem.ui.correlation.widgets.correlation_tab_widget import (
+        CorrelationTabWidget,
+    )
+
+    tab = CorrelationTabWidget()
+    spec = tab._point_specs[PointType.FIB]
+    spec.list_widget.coordinates = [
+        Coordinate(PointXYZ(10 * i, 10 * i, 0), PointType.FIB) for i in range(5)
+    ]
+    coords = spec.list_widget.coordinates
+    tab._refresh_canvas(spec.adapter)
+    spec.list_widget.select_coordinate_silent(coords[3])
+
+    tab._on_canvas_removed(coords[3])  # what the canvas's Delete key reaches
+
+    assert spec.list_widget.coordinates == [coords[0], coords[1], coords[2], coords[4]]
+    assert spec.list_widget.selected_coordinate is coords[4]
+    assert spec.adapter._surface.picking.points.selected_coordinate() is coords[4]
+    tab.close()


### PR DESCRIPTION
Fixes FIB-965 and FIB-968, two of the audit follow-ups.

## FIB-965: deleting a point on the canvas jumped the list selection to row 1

Two paths deleted a point. The row's trash button went through `_on_remove`, which removes the row and selects its neighbour. The canvas's Delete key went through the tab widget, which assigned a filtered list through the `coordinates` setter, and that setter always selects the first row. The canvas highlight followed it.

Now `CoordinateListWidget.remove_coordinate` carries the remove-and-select-neighbour behaviour without emitting anything, both entry points go through it, and the tab widget re-applies the list's selection to the canvas afterwards. The trash slot also emits the removal before the neighbour's selection: the tab widget's removal handler rebuilds the overlay, which dropped a selection announced first, so after a trash click the list showed the next row selected while the canvas showed no highlight.

## FIB-968: the timelapse scrubber snapped to the newest frame while scrubbing

The coincidence viewer's timelapse accumulation path moved the slider to the end and rewrote the label every interval, even while the operator was scrubbing an earlier frame. The display path in the same slot already stood aside for scrubbing. The slider's range still grows so the new frame is reachable; its position and the label now hold until the operator moves it or presses Live.

## Verification

- `tests/ui/test_correlation_point_removal.py` gains four tests: the helper selects the neighbour and emits nothing, last-row removal, trash-button emit order, and the tab-widget canvas path selecting the neighbour on both list and overlay.
- `tests/ui/test_coincidence_timelapse_scrub.py`: scrubbing holds slider and label while a frame accumulates; live view still follows the newest frame.
- All new tests fail on `main` and pass here.

Two commits: a whitespace-only `[format]` of `correlation_tab_widget.py` (AST-identical, for the lint job's format-on-touch check), then the change.